### PR TITLE
various: migrate fetchPnpmDeps from fetcherVersion = 1 to fetcherVersion = 3 (part 1)

### DIFF
--- a/pkgs/by-name/ao/aonsoku/package.nix
+++ b/pkgs/by-name/ao/aonsoku/package.nix
@@ -29,8 +29,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_8;
-    fetcherVersion = 1;
-    hash = "sha256-h1rcM+H2c0lk7bpGeQT5ue9bQIggrCFHkj4o7KxnH08=";
+    fetcherVersion = 3;
+    hash = "sha256-gOPjNZCljr8OvU/xLs9ZQ27dl3RatscXddOyPfSVdoE=";
   };
 
   cargoRoot = "src-tauri";

--- a/pkgs/by-name/ap/apache-airflow/python-package.nix
+++ b/pkgs/by-name/ap/apache-airflow/python-package.nix
@@ -111,8 +111,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       pname = "airflow-ui";
       inherit sourceRoot src version;
-      fetcherVersion = 1;
-      hash = "sha256-UcEFQkDZ9Ye+VfyJ9rdZKe0wilTgO4dMsULABWfL2Co=";
+      fetcherVersion = 3;
+      hash = "sha256-ccLGYaAYJWSgegO+IfVZv1WdZ5YjhYYTZivqtDjdoOk=";
     };
 
     buildPhase = ''
@@ -140,8 +140,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       pname = "simple-auth-manager-ui";
       inherit sourceRoot src version;
-      fetcherVersion = 1;
-      hash = "sha256-8nZdWnhERUkiaY8USyy/a/j+dMksjmEzCabSkysndSE=";
+      fetcherVersion = 3;
+      hash = "sha256-ccLGYaAYJWSgegO+IfVZv1WdZ5YjhYYTZivqtDjdoOk=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/ap/apache-answer/package.nix
+++ b/pkgs/by-name/ap/apache-answer/package.nix
@@ -29,8 +29,8 @@ buildGoModule (finalAttrs: {
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) src version pname;
       sourceRoot = "${finalAttrs.src.name}/ui";
-      fetcherVersion = 1;
-      hash = "sha256-6IeLOwsEqchCwe0GGj/4v9Q4/Hm16K+ve2X+8QHztQM=";
+      fetcherVersion = 3;
+      hash = "sha256-0Jqe0wig28Vb9y0/tZHDfE49MehNR7kJTpChz616tzU=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/ar/artalk/package.nix
+++ b/pkgs/by-name/ar/artalk/package.nix
@@ -37,8 +37,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       pnpm = pnpm_9;
-      fetcherVersion = 1;
-      hash = "sha256-QIfadS2gNPtH006O86EndY/Hx2ml2FoKfUXJF5qoluw=";
+      fetcherVersion = 3;
+      hash = "sha256-HypDGYb0MRCIDBHY8pVgwFoZQWC8us44cunORZRk3RM=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/au/authelia/sources.nix
+++ b/pkgs/by-name/au/authelia/sources.nix
@@ -10,5 +10,5 @@ rec {
     hash = "sha256-u7TIhOGXfvWdAXvpL5qa43jaoa7PNAVL2MtGEuWBDPc=";
   };
   vendorHash = "sha256-7RoPv4OvOhiv+TmYOJuW95h/uh2LuTrpUSAZiTvbh7g=";
-  pnpmDepsHash = "sha256-uRwSpy/aZA4hG2rEY8hlD8pXJ7lvNoIa6a3VSZuZgcs=";
+  pnpmDepsHash = "sha256-Ck2nqFwDv3OxN0ONA3A+h4Rli1te+EYqKivcqrAInKw=";
 }

--- a/pkgs/by-name/au/authelia/web.nix
+++ b/pkgs/by-name/au/authelia/web.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
       sourceRoot
       ;
     inherit pnpm; # This may be different than pkgs.pnpm
-    fetcherVersion = 1;
+    fetcherVersion = 3;
     hash = pnpmDepsHash;
   };
 

--- a/pkgs/by-name/au/autoprefixer/package.nix
+++ b/pkgs/by-name/au/autoprefixer/package.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-fyygZMpRMm5tL5/kpERKXUNA9qqDt6ZkzT4zWtqQSv8=";
+    fetcherVersion = 3;
+    hash = "sha256-PPYyEsc0o5ufBexUdiX9EJLEsQZ0wX7saBzxJGsnseU=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -39,8 +39,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       pnpm = pnpm_9;
-      fetcherVersion = 1;
-      hash = "sha256-vJgsU0OXyAKjUJsPOyIY8o3zfNW1BUZ5IL814wmJr3o=";
+      fetcherVersion = 3;
+      hash = "sha256-9wzPNZxLE0l/AJ8SyE0SkhkBImiibhqJgsG3UrGj3aA=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/ca/cargo-tauri/test-app.nix
+++ b/pkgs/by-name/ca/cargo-tauri/test-app.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_9;
 
-    fetcherVersion = 1;
-    hash = "sha256-gHniZv847JFrmKnTUZcgyWhFl/ovJ5IfKbbM5I21tZc=";
+    fetcherVersion = 3;
+    hash = "sha256-/g+2jZQq3nTJnKpj0PlT6zB3UcUBE2ND8797XRwVZ0s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cl/clash-verge-rev/package.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/package.nix
@@ -21,7 +21,7 @@ let
     hash = "sha256-GmoeOLKxdW1x6PHtslwNPVq8wDWA413NHA/VeDRb4mA=";
   };
 
-  pnpm-hash = "sha256-qDwXPTfh1yOlugZe1UPUMKRyZOSagG4lX2eiFACgHRw=";
+  pnpm-hash = "sha256-o3VPb+D74bjwEex7UFmwfx8N1yGolPqNaIeJ7/cjB0c=";
   vendor-hash = "sha256-z5xVbqh+CiaTDtAx2VPQ4UjliYnV44tdp3pS8vzb1K4=";
 
   service = callPackage ./service.nix {

--- a/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage {
       src
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
+    fetcherVersion = 3;
     hash = pnpm-hash;
   };
 

--- a/pkgs/by-name/da/daed/package.nix
+++ b/pkgs/by-name/da/daed/package.nix
@@ -34,8 +34,8 @@ let
         src
         ;
       pnpm = pnpm_9;
-      fetcherVersion = 1;
-      hash = "sha256-+yLpSbDzr1OV/bmUUg6drOvK1ok3cBd+RRV7Qrrlp+Q=";
+      fetcherVersion = 3;
+      hash = "sha256-FBZk7qeYNi7JX99Sk1qe52YUE8GUYINJKid0mEBXMjU=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/do/dorion/package.nix
+++ b/pkgs/by-name/do/dorion/package.nix
@@ -72,8 +72,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       patches
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-fX48yZKntte4OxLjXqepZQyGdN/bv4o+n+v5ZT5lXMo=";
+    fetcherVersion = 3;
+    hash = "sha256-qSmIyLv8A+JDbTVG+Qcvq3gqBXBGtfbH4/tN+CvEmd8=";
   };
 
   # CMake (webkit extension)

--- a/pkgs/by-name/em/emmet-language-server/package.nix
+++ b/pkgs/by-name/em/emmet-language-server/package.nix
@@ -22,8 +22,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-sMOC5MQmJKwXZoUZnOmBy2I83SNMdrPc6WQKmeVGiCc=";
+    fetcherVersion = 3;
+    hash = "sha256-livnY/iwd7gqy6SKFBMF2MSIs7LVFec4BFqMBVasGWE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/eq/equicord/package.nix
+++ b/pkgs/by-name/eq/equicord/package.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-um8CmR4H+sck6sOpIpnISPhYn/rvXNfSn6i/EgQFvk0=";
+    fetcherVersion = 3;
+    hash = "sha256-L4qy3zMM6ksYcBT7gB6qCzfZIELVe+KZZxTSnfI3Rkk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/et/etherpad-lite/package.nix
+++ b/pkgs/by-name/et/etherpad-lite/package.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-/GqRoGWIQhOwKlbe4I6yTuGs+IOn4crPhwHt4ALJ97E=";
+    fetcherVersion = 3;
+    hash = "sha256-y5T7yerCK9MtTri3eZ+Iih7/DK9IMDC+d7ej746g47E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fe/fedistar/package.nix
+++ b/pkgs/by-name/fe/fedistar/package.nix
@@ -37,8 +37,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-xXVsjAXmrsOp+mXrYAxSKz4vX5JApLZ+Rh6hrYlnJDI=";
+    fetcherVersion = 3;
+    hash = "sha256-IznO8PJZCr6MR3mShD+Uqk2ACx8mrxTVWRTbk81zFEc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fi/firezone-gui-client/package.nix
+++ b/pkgs/by-name/fi/firezone-gui-client/package.nix
@@ -43,8 +43,8 @@ let
       inherit pname version;
       pnpm = pnpm_9;
       src = "${src}/rust/gui-client";
-      fetcherVersion = 1;
-      hash = "sha256-ttbTYBuUv0vyiYzrFATF4x/zngsRXjuLPfL3qW2HEe4=";
+      fetcherVersion = 3;
+      hash = "sha256-akanXiWehhQRx6WHN75PjYvFxFiSsJ5dJaguJBTM9J0=";
     };
     pnpmRoot = "rust/gui-client";
 

--- a/pkgs/by-name/fi/firezone-server/package.nix
+++ b/pkgs/by-name/fi/firezone-server/package.nix
@@ -36,8 +36,8 @@ beam27Packages.mixRelease rec {
     inherit pname version;
     pnpm = pnpm_9;
     src = "${src}/apps/web/assets";
-    fetcherVersion = 1;
-    hash = "sha256-40vtQIBhJNnzdxkAOVAcPN57IuD0IB6LFxGICo68AbQ=";
+    fetcherVersion = 3;
+    hash = "sha256-tB0y3T/dZBe8BHz7AV913zQ4oQu7VLyqHCnzBycNg18=";
   };
   pnpmRoot = "apps/web/assets";
 

--- a/pkgs/by-name/fl/flood/package.nix
+++ b/pkgs/by-name/fl/flood/package.nix
@@ -30,8 +30,8 @@ buildNpmPackage rec {
       src
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-ukhZ1SCejwi0n3PubBo5qIRE/8snjHSZaGVIbHKvwdI=";
+    fetcherVersion = 3;
+    hash = "sha256-v6uur47TmS09H3hzqsxwq3dvPK6TD8aRLPOcPG8wwC4=";
   };
 
   passthru = {

--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -38,8 +38,8 @@ stdenv.mkDerivation rec {
       src
       ;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-6I10NSmTDd/wmL/HfAgLH+G2MDfuPmrTePNDDy08nRA=";
+    fetcherVersion = 3;
+    hash = "sha256-EP7bpbJUcKmHm7KMlKc0Fz2u0niQ3jC7YN/9pp7vucE=";
   };
 
   env = {

--- a/pkgs/by-name/fr/froide/package.nix
+++ b/pkgs/by-name/fr/froide/package.nix
@@ -121,8 +121,8 @@ python.pkgs.buildPythonApplication rec {
 
   pnpmDeps = fetchPnpmDeps {
     inherit pname version src;
-    fetcherVersion = 1;
-    hash = "sha256-g7YX2fVXGmb3Qq9NNCb294bk4/0khcIZVSskYbE8Mdw=";
+    fetcherVersion = 3;
+    hash = "sha256-NbfCVD+gmtoxuYUCumTKj9P72utK787VdlnuU4lMMGc=";
   };
 
   postBuild = ''

--- a/pkgs/by-name/ga/gale/package.nix
+++ b/pkgs/by-name/ga/gale/package.nix
@@ -40,8 +40,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       patches
       ;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-ILhAhpY9a50a0KKWs5Y+G3jDyWuySHw8QcOJlYePzmc=";
+    fetcherVersion = 3;
+    hash = "sha256-11ga9j/5QYovpd23MMjnRzdD5Ri19nrFAotHpMV3mgU=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/go/goaway/package.nix
+++ b/pkgs/by-name/go/goaway/package.nix
@@ -28,8 +28,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/client";
-      fetcherVersion = 1;
-      hash = "sha256-cJLJMJNDPr73w5IiB1/zIloIdsUhqI+o/JqoKNwNweI=";
+      fetcherVersion = 3;
+      hash = "sha256-1YZf32lDwX3e9EC0Uixyo+yDczfU4/ZSlG+jFZwf+38=";
     };
 
     pnpmRoot = "client";

--- a/pkgs/by-name/go/goofcord/package.nix
+++ b/pkgs/by-name/go/goofcord/package.nix
@@ -46,8 +46,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 1;
-    hash = "sha256-8dSyU9arSvISc2kDWbg/CP6L4sZjZi/Zv7TZN4ONOjQ=";
+    fetcherVersion = 3;
+    hash = "sha256-NKind57XDW7I5XNmjAu4cqkK5UVNAaKewpfOTNzF2BM=";
   };
 
   env = {

--- a/pkgs/by-name/ho/homebox/package.nix
+++ b/pkgs/by-name/ho/homebox/package.nix
@@ -41,8 +41,8 @@ buildGoModule {
     inherit pname version;
     src = "${src}/frontend";
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-5AEwgI5rQzp/36USr+QEzjgllZkKhhIvlzl+9ZVfGM4=";
+    fetcherVersion = 3;
+    hash = "sha256-RYHm6I3MajwSWrL9tgRzYMXd7EzytsYnyYg/SKmMJJI=";
   };
   pnpmRoot = "../frontend";
 

--- a/pkgs/by-name/it/it-tools/package.nix
+++ b/pkgs/by-name/it/it-tools/package.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
       src
       ;
     pnpm = pnpm_8;
-    fetcherVersion = 1;
-    hash = "sha256-m1eXBE5rakcq8NGnPC9clAAvNJQrN5RuSQ94zfgGZxw=";
+    fetcherVersion = 3;
+    hash = "sha256-dsjf2TyLAqPzR8OXJgNcoOdDZj2t+H+tLfRhfPsu1G8=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/je/jellyseerr/package.nix
+++ b/pkgs/by-name/je/jellyseerr/package.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 1;
-    hash = "sha256-3df72m/ARgfelBLE6Bhi8+ThHytowVOBL2Ndk7auDgg=";
+    fetcherVersion = 3;
+    hash = "sha256-kCM6oNfBlVsjItzBDxSbeLu0+53I5XzxcerpCTEvZ0M=";
   };
 
   buildInputs = [ sqlite ];

--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -47,8 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 1;
-    hash = "sha256-9sdN5tbCCe/euTo8zRkU0C3yQ8sAufPyN8a4GeJW/Us=";
+    fetcherVersion = 3;
+    hash = "sha256-MgUOOr188t+t/4sTXVpbr+xYT/1qf7/B0ZG0w+QkVxc=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/me/memos/package.nix
+++ b/pkgs/by-name/me/memos/package.nix
@@ -24,8 +24,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/web";
-      fetcherVersion = 1;
-      hash = "sha256-k+pykzAiZ72cMMH+6qtnNxjaq4m4QyCQuWvQPbZSZho=";
+      fetcherVersion = 3;
+      hash = "sha256-xEOnxCgBD4uLypcZzCO+31S4r0sSfz8PpgEmZASeRZ4=";
     };
     pnpmRoot = "web";
     nativeBuildInputs = [

--- a/pkgs/by-name/me/metacubexd/package.nix
+++ b/pkgs/by-name/me/metacubexd/package.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-ItO9/+OU5zWI/J78dZoxmAMVNCb4wnbSjo1JBI8obZA=";
+    fetcherVersion = 3;
+    hash = "sha256-FbWEcq0Im01L0xW0UttW+3oorF7ZZJGp/niHt3D96yM=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
+++ b/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
@@ -76,8 +76,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-+/PGCoHAC9Hsl2YEdjvUBzDJi9iBf+ZxT/6yjDE3yBo=";
+    fetcherVersion = 3;
+    hash = "sha256-1ZBIMqG6YPZ8++jG6qzhHEgFx1Y6JR8BBLB3JfuNyNU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mo/moonfire-nvr/package.nix
+++ b/pkgs/by-name/mo/moonfire-nvr/package.nix
@@ -36,8 +36,8 @@ let
       inherit (finalAttrs) pname version src;
       pnpm = pnpm_9;
       sourceRoot = "${finalAttrs.src.name}/ui";
-      fetcherVersion = 1;
-      hash = "sha256-7fMhUFlV5lz+A9VG8IdWoc49C2CTdLYQlEgBSBqJvtw=";
+      fetcherVersion = 3;
+      hash = "sha256-1bkuou8jfWqdev4ZlpqvC4BRrFj//LK6ImVvSeMUEuM=";
     };
     installPhase = ''
       runHook preInstall

--- a/pkgs/by-name/oc/ocis/package.nix
+++ b/pkgs/by-name/oc/ocis/package.nix
@@ -58,8 +58,8 @@ buildGoModule rec {
       ;
     pnpm = pnpm_9;
     sourceRoot = "${src.name}/services/idp";
-    fetcherVersion = 1;
-    hash = "sha256-gNlN+u/bobnTsXrsOmkDcWs67D/trH3inT5AVQs3Brs=";
+    fetcherVersion = 3;
+    hash = "sha256-EsoGio2D8HZmbe+uuzsOhhwaLMSbJcfV4iUJUaqtA0M=";
   };
   pnpmRoot = "services/idp";
 

--- a/pkgs/by-name/oc/ocis/web.nix
+++ b/pkgs/by-name/oc/ocis/web.nix
@@ -44,8 +44,8 @@ stdenvNoCC.mkDerivation rec {
       src
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-3Erva6srdkX1YQ727trx34Ufx524nz19MUyaDQToz6M=";
+    fetcherVersion = 3;
+    hash = "sha256-EsoGio2D8HZmbe+uuzsOhhwaLMSbJcfV4iUJUaqtA0M=";
   };
 
   meta = {

--- a/pkgs/by-name/op/opencloud/web.nix
+++ b/pkgs/by-name/op/opencloud/web.nix
@@ -22,8 +22,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-v2XOBO1/BWaJslj2Z2k9RanSS2CsW2Yx72o/lX7Eo2I=";
+    fetcherVersion = 3;
+    hash = "sha256-tPU16r0hc0DYwGnvnukivUz3a+Bz6urUZPtokN/lbuA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ov/overlayed/package.nix
+++ b/pkgs/by-name/ov/overlayed/package.nix
@@ -36,8 +36,8 @@ rustPlatform.buildRustPackage rec {
   pnpmDeps = fetchPnpmDeps {
     inherit pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-+yyxoodcDfqJ2pkosd6sMk77/71RDsGthedo1Oigwto=";
+    fetcherVersion = 3;
+    hash = "sha256-KJZuucXB7BEMnqPmgytveG/IBEzq4mgMo9ZJHPe/gVs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pa/parca/package.nix
+++ b/pkgs/by-name/pa/parca/package.nix
@@ -27,8 +27,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname src version;
       pnpm = pnpm_9;
-      fetcherVersion = 1;
-      hash = "sha256-3egNSL62TyuRg6JDMMptjT0vLlwYdDLnJC2rYzaPE1w=";
+      fetcherVersion = 3;
+      hash = "sha256-KKkTIaTSDHyodXx5OMm/NmuR5sNCSn2IxZsmWzXNak0=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pg/pgrok/package.nix
+++ b/pkgs/by-name/pg/pgrok/package.nix
@@ -41,8 +41,8 @@ buildGoModule {
       src
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-o6wxO8EGRmhcYggJnfxDkH+nbt+isc8bfHji8Hu9YKg=";
+    fetcherVersion = 3;
+    hash = "sha256-gVwwLTOA8rXsy8xg4uGPJyBdQ8yUqkiul9W5oKw6kGI=";
   };
 
   vendorHash = "sha256-l/tUO7fevi+zUmUp6CQoVNrzMF7LIzbo2Qsa/ez6LiA=";

--- a/pkgs/by-name/pi/piped/package.nix
+++ b/pkgs/by-name/pi/piped/package.nix
@@ -38,8 +38,8 @@ buildNpmPackage rec {
       src
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-WtZfRZFRV9I1iBlAoV69GGFjdiQhTSBG/iiEadPVcys=";
+    fetcherVersion = 3;
+    hash = "sha256-IB/suR1I1hNip1qpIcUCP0YyUEDV2EwE5F2WXW8OhmU=";
   };
 
   passthru.updateScript = unstableGitUpdater { };

--- a/pkgs/by-name/po/porn-vault/package.nix
+++ b/pkgs/by-name/po/porn-vault/package.nix
@@ -54,8 +54,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm';
-    fetcherVersion = 1;
-    hash = "sha256-Xr9tRiP1hW+aFs9FnPvPkeJ0/LtJI57cjWY5bZQaRTQ=";
+    fetcherVersion = 3;
+    hash = "sha256-CAsUP+bLrTkbUd3h/FP4gBVwZECyqQg0nnmap4zsRTs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pr/prisma_6/package.nix
+++ b/pkgs/by-name/pr/prisma_6/package.nix
@@ -35,8 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-y0gxeOeQNZZu3/UEI/DmdhVD8kSrUnK5G/n/WLhiLZ4=";
+    fetcherVersion = 3;
+    hash = "sha256-BnluGYEVQbhVdEL/RvJTTGEQT1XrLjaTm2iI7Sqd3ZE=";
   };
 
   patchPhase = ''

--- a/pkgs/by-name/qu/quantframe/package.nix
+++ b/pkgs/by-name/qu/quantframe/package.nix
@@ -41,8 +41,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-ncoxliXnLxWEXL1Z7ixOULI/uYkxmfLiDWu1tDSRsrM=";
+    fetcherVersion = 3;
+    hash = "sha256-2p5o611IQCDk/rzlPSjtigdTCBvkzbpnysuR2GaKdg8=";
   };
 
   cargoHash = "sha256-0IgQK0jMVN6u5i4lBKK8njbMyRQCLguTdDcSBnFnyso=";

--- a/pkgs/by-name/rm/rmfakecloud/package.nix
+++ b/pkgs/by-name/rm/rmfakecloud/package.nix
@@ -34,8 +34,8 @@ buildGoModule rec {
     sourceRoot = "${src.name}/ui";
     pnpmLock = "${src}/ui/pnpm-lock.yaml";
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-uywmHN9HWKi0CaqTg9uEio2XCu6ap9v2xtbodW/6b4Q=";
+    fetcherVersion = 3;
+    hash = "sha256-YhcPR7aObZiV0FibcogjrOGNo2+syUuusaW+yx1HRv8=";
   };
   preBuild = lib.optionals enableWebui ''
     # using sass-embedded fails at executing node_modules/sass-embedded-linux-x64/dart-sass/src/dart

--- a/pkgs/by-name/rq/rquickshare/package.nix
+++ b/pkgs/by-name/rq/rquickshare/package.nix
@@ -50,8 +50,8 @@ rustPlatform.buildRustPackage rec {
       ;
     pnpm = pnpm_9;
     postPatch = "cd ${pnpmRoot}";
-    fetcherVersion = 1;
-    hash = "sha256-VbdMaIEL1e+0U+ny4qbk1Mmkuc3cahKakKKYowCBK5Q=";
+    fetcherVersion = 3;
+    hash = "sha256-ESm7YVVbsfjpgYeNf3aVhJawpWhbeNdo0u7cBzLmEMw=";
   };
 
   cargoRoot = "app/main/src-tauri";

--- a/pkgs/by-name/rs/rsshub/package.nix
+++ b/pkgs/by-name/rs/rsshub/package.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-zTsJZnhX7xUOsKST6S3TQUV8M1Tewcs9fZgrDSf5ba8=";
+    fetcherVersion = 3;
+    hash = "sha256-jV+MpdNeaVHut0eUP7F9SmJZuLDGQE8ULR8LsiOE7Ug=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -72,8 +72,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname src version;
       inherit pnpm;
-      fetcherVersion = 1;
-      hash = "sha256-m/JxsKnVhcya7dUz1MBMQKwEdqoV3xQiGOoT4egh3K4=";
+      fetcherVersion = 3;
+      hash = "sha256-WbdYcI5y01gdS9AIzy4VZZ6eFaTHaVPscTawLSsHzlc=";
     };
 
     strictDeps = true;
@@ -160,12 +160,12 @@ stdenv.mkDerivation (finalAttrs: {
       patches
       ;
     inherit pnpm;
-    fetcherVersion = 1;
+    fetcherVersion = 3;
     hash =
       if withAppleEmojis then
-        "sha256-sXDAAbrRFgOT+wRZqHAjEudmcUdBEbpkPWJpiB+MqDw="
+        "sha256-bxV1OUKL5FGriN4zH1iGDdLcQwFJqG/HfCXvSTwseWc="
       else
-        "sha256-uEXm4lFTJ7U9I/I1UiETy1fIHzAPP7tr9SsPQ5lWsFw=";
+        "sha256-hfJ7qt6y6Q8QpBJsdpALd9Yi6uI4Z2MwigyYVvok/rg=";
   };
 
   env = {

--- a/pkgs/by-name/si/signal-desktop/signal-sqlcipher.nix
+++ b/pkgs/by-name/si/signal-desktop/signal-sqlcipher.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm; # may be different than top-level pnpm
-    fetcherVersion = 1;
-    hash = "sha256-regaYG+SDvIgdnHQVR1GG1A1FSBXpzFfLuyTEdMt1kQ=";
+    fetcherVersion = 3;
+    hash = "sha256-/EcPuqTXXGw1dEN6l1x84cUGyx890/rujjT+zJouIvM=";
   };
 
   cargoRoot = "deps/extension";

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -99,8 +99,8 @@ stdenv.mkDerivation (finalAttrs: {
       postPatch
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-i11Hr/KA7Q27Z26AOmc6GNwSW/ZcwSyaNtNBJii5r2A=";
+    fetcherVersion = 3;
+    hash = "sha256-n5JEFnKvHdruu9HOhHKwEhN9kKnvCXftHrD5XkAkMRs=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/app";

--- a/pkgs/by-name/sl/slimevr/package.nix
+++ b/pkgs/by-name/sl/slimevr/package.nix
@@ -41,8 +41,8 @@ rustPlatform.buildRustPackage rec {
     pname = "${pname}-pnpm-deps";
     inherit version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-ExjEAr38GX2iZThVj3C3N/9mPgf0Bs7J5OAwtDdmn6I=";
+    fetcherVersion = 3;
+    hash = "sha256-deVfRZcMFkOVWXmNUiixmd5WBfIFKxG2Gw3CfshspYo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -31,8 +31,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-PVA6sXbiuxqvi9u3sPoeVIJSSpSbFQHQQnTFO3w31WE=";
+    fetcherVersion = 3;
+    hash = "sha256-qzUvA00ujnIibQAONOPlp5BsXcwQb/gQvOPp83hMT5A=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/sy/synchrony/package.nix
+++ b/pkgs/by-name/sy/synchrony/package.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-+hS4UK7sncCxv6o5Yl72AeY+LSGLnUTnKosAYB6QsP0=";
+    fetcherVersion = 3;
+    hash = "sha256-c6wtu/3tNCobLqJaB3hB9HP34ObijBQ/9ZcIzGetaT0=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/sy/syncyomi/package.nix
+++ b/pkgs/by-name/sy/syncyomi/package.nix
@@ -49,8 +49,8 @@ buildGoModule (finalAttrs: {
         sourceRoot
         ;
       pnpm = pnpm_9;
-      fetcherVersion = 1;
-      hash = "sha256-Gg4nOxqWb692GvvwE7AJKQzGrrLLW7haaooEkUZW7FQ=";
+      fetcherVersion = 3;
+      hash = "sha256-hRMHvfzfjOzvcCHFhDLxuq2qZ3mi4/333nEcQANbJ/o=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/ta/tabby-agent/package.nix
+++ b/pkgs/by-name/ta/tabby-agent/package.nix
@@ -52,8 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-SiJJxRzmKQxqw3UESN7q+3qkU1nK+7z6K5RpIMRRces=";
+    fetcherVersion = 3;
+    hash = "sha256-xx45vudeW6OnUgyH0N+gQI5GPT8k5B4x0HdCvHF+f9A=";
   };
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/by-name/ta/tailwindcss-language-server/package.nix
+++ b/pkgs/by-name/ta/tailwindcss-language-server/package.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
       pnpmWorkspaces
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-1F4DeqJWJs3L1hDzNn7PJr9sSBv2TcN8QfV8/pwAKuU=";
+    fetcherVersion = 3;
+    hash = "sha256-3pHEmYMgQuHFFMyGeFzo9BWRFt6yvWzFFMJEdRhwS2w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ta/taler-wallet-core/package.nix
+++ b/pkgs/by-name/ta/taler-wallet-core/package.nix
@@ -61,8 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm';
-    fetcherVersion = 1;
-    hash = "sha256-jwoSvqE0hqRxu76vDtUOpZxvi4SsmKukfpmp5G6ZV/I=";
+    fetcherVersion = 3;
+    hash = "sha256-a1ym/UpUufUPTGL3dozZ9Jb0eX1XVB7Hahek25eLvc4=";
   };
 
   buildInputs = [ nodejs_20 ];

--- a/pkgs/by-name/ta/taze/package.nix
+++ b/pkgs/by-name/ta/taze/package.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-SV8dHPydTOz/cbOY3p4npp0uMjh3hSXH9ZNk4BtHb4w=";
+    fetcherVersion = 3;
+    hash = "sha256-y4aR7bz8c+JPc2LgLxnB4JJceqSy9NyQbJE+ARbNNdY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/te/textlint/package.nix
+++ b/pkgs/by-name/te/textlint/package.nix
@@ -58,8 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
       patches
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-TyKtH4HjCDTydVd/poG05Yh5nRSfcrSPzFLEE3Oq2uo=";
+    fetcherVersion = 3;
+    hash = "sha256-TYMhAcmfWHbj/0yLNYiJXWd1GiYb+zqBLj2/83cGbzg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ts/tsx/package.nix
+++ b/pkgs/by-name/ts/tsx/package.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       ;
     pnpm = pnpm';
-    fetcherVersion = 1;
-    hash = "sha256-6ZizQtZC43yXrz634VXksRCKGkDKryICvT3Q+JCuIEw=";
+    fetcherVersion = 3;
+    hash = "sha256-7JdL2qz663+y3tzeK0LLn57vSsQ0P0d+FofRimWVjrM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -39,8 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
       sourceRoot
       pnpmInstallFlags
       ;
-    fetcherVersion = 1;
-    hash = "sha256-9KPQaRLep4n+2b9mk8KQoK22zdlMFrCb1VT6SEHxanQ=";
+    fetcherVersion = 3;
+    hash = "sha256-Auex4GrETKlQ8AONzdLZkroWoQmy+PPF8aMKW27Dlo8=";
   };
 
   env = {

--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -36,8 +36,8 @@ let
         sourceRoot
         ;
       pnpm = pnpm_10;
-      fetcherVersion = 1;
-      hash = "sha256-ME9sGKGRY3vaOTFwbFyzsDT20HnEnrfq3Z5nrL19k0A=";
+      fetcherVersion = 3;
+      hash = "sha256-NrysokKNmKAUdiC0o4qEPvsHr7KH7mMrcrEjxwmgb+g=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/vt/vtsls/package.nix
+++ b/pkgs/by-name/vt/vtsls/package.nix
@@ -46,8 +46,8 @@ stdenv.mkDerivation (finalAttrs: {
       version
       ;
     pnpm = pnpm';
-    fetcherVersion = 1;
-    hash = "sha256-SdqeTYRH60CyU522+nBo0uCDnzxDP48eWBAtGTL/pqg=";
+    fetcherVersion = 3;
+    hash = "sha256-1P2ph8ZX6/KptkLP4wk0dZzuvnYCLOWorM1b9+otKsE=";
   };
 
   # Patches to get submodule sha from file instead of 'git submodule status'

--- a/pkgs/by-name/vu/vue-language-server/package.nix
+++ b/pkgs/by-name/vu/vue-language-server/package.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 1;
-    hash = "sha256-QLey523pqhjOBn4xhN9mZTKRAC96imVka+li7C4BXQY=";
+    fetcherVersion = 3;
+    hash = "sha256-TqOqwdVs2FsmyCXlu9mde+ZKTE7E30HCZtwgAV3KTds=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/we/wealthfolio/package.nix
+++ b/pkgs/by-name/we/wealthfolio/package.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) src pname version;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-TcoyNIVb/aDgXIsNDvzTMfsewmefU9ck+uSHv/tbH/k=";
+    fetcherVersion = 3;
+    hash = "sha256-fGihjg2CxCuiFGLHu3V/DGc26PQdjiQTNWuX+iUL72o=";
   };
 
   cargoRoot = "src-tauri";

--- a/pkgs/by-name/za/zammad/package.nix
+++ b/pkgs/by-name/za/zammad/package.nix
@@ -92,8 +92,8 @@ stdenvNoCC.mkDerivation {
     inherit pname src;
     pnpm = pnpm_9;
 
-    fetcherVersion = 1;
-    hash = "sha256-mfdzb/LXQYL8kaQpWi9wD3OOroOOonDlJrhy9Dwl1no";
+    fetcherVersion = 3;
+    hash = "sha256-xEyTi0PUs3tWQuAOs9BW/muQvUyv1BdJrCTCRzVW7mc=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/ze/zenn-cli/package.nix
+++ b/pkgs/by-name/ze/zenn-cli/package.nix
@@ -40,8 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
       pnpmWorkspaces
       ;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-WXsS5/J08n/dWV5MbyX4vK7j1mfiUoLdzwmzyqoX3FA=";
+    fetcherVersion = 3;
+    hash = "sha256-uxeZnYZzwyNOZN1x1f6tzcYgPbJhSc3gTdsfaE+967w=";
   };
 
   preBuild = ''

--- a/pkgs/by-name/zi/zigbee2mqtt/package.nix
+++ b/pkgs/by-name/zi/zigbee2mqtt/package.nix
@@ -26,8 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-USpzlTtNlRI+xOJ37ZEohjNjtSBrq+bIqTNFH1IpObE=";
+    fetcherVersion = 3;
+    hash = "sha256-AYaP3KEFW5LP07irbl5CPUqJ1f5dkPTgidjQUspv2I8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/django-filingcabinet/default.nix
+++ b/pkgs/development/python-modules/django-filingcabinet/default.nix
@@ -97,8 +97,8 @@ buildPythonPackage rec {
 
   pnpmDeps = fetchPnpmDeps {
     inherit pname version src;
-    fetcherVersion = 1;
-    hash = "sha256-kvLV/pCX/wQHG0ttrjSro7/CoQ5K1T0aFChafQOwvNw=";
+    fetcherVersion = 3;
+    hash = "sha256-p+RpEDVbdYmeSD4bB0oUMrTpsVDGYkqME13awnoTNd0=";
   };
 
   postBuild = ''

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/custom-sidebar/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/custom-sidebar/package.nix
@@ -21,8 +21,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 1;
-    hash = "sha256-VbmbqTwuXfJQVSaQHGVwIZJf7350HsH+TGeVCtCXL38=";
+    fetcherVersion = 3;
+    hash = "sha256-gUVETXrl5rcXvn0YeKLfM+eErUpMxCuVlAOoyqQkLXs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -305,8 +305,8 @@ let
       pname = "discourse-assets";
       inherit version src;
       pnpm = pnpm_9;
-      fetcherVersion = 1;
-      hash = "sha256-/GJQqbmBXn5SSdxQ3TBQEUGe6Qm7aJ1ogoYqOFD5Pm0=";
+      fetcherVersion = 3;
+      hash = "sha256-xRB2byLQeN27kualQnyhLGHyuFbSePcu0xvpr2+kQq8=";
     };
 
     nativeBuildInputs = runtimeDeps ++ [

--- a/pkgs/servers/web-apps/lemmy/pin.json
+++ b/pkgs/servers/web-apps/lemmy/pin.json
@@ -4,5 +4,5 @@
   "serverHash": "sha256-8j18F0I7GnZ4OxIvWM9N4CEe9TnRJKAqukb1160ygv8=",
   "serverCargoHash": "sha256-8I3ZoMhfxdfhOF/cmtNZew3QgjuIgKLbuftS9Y7FHhw=",
   "uiHash": "sha256-vynfOAi7sRBJbA9y/2RULq79PP0YkgvlUZz6jOxPlhs=",
-  "uiPNPMDepsHash": "sha256-tuarUG1uKx6Q1O+rF6DHyK8MEseF9lKk34qtRWWScAg="
+  "uiPNPMDepsHash": "sha256-UOovErxC060rAVTERdNdZRg+zP2RHL6Hii8RqVe5ye8="
 }

--- a/pkgs/servers/web-apps/lemmy/ui.nix
+++ b/pkgs/servers/web-apps/lemmy/ui.nix
@@ -43,7 +43,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
+    fetcherVersion = 3;
     hash = pinData.uiPNPMDepsHash;
   };
 


### PR DESCRIPTION
Migrate various packages using `fetchPnpmDeps` from `fetcherVersion = 1` to `fetcherVersion = 3` and update their hashes accordingly.

`fetcherVersion = 1` is deprecated and will be removed. Version 3 uses a more robust fetching strategy.

**Note:** Three packages have `lib.fakeHash` placeholders that need manual resolution:
- `modrinth-app-unwrapped` — hash TBD
- `signal-desktop` — the `withAppleEmojis = true` conditional hash
- `opencloud/idp-web.nix` — skipped (upstream build failure with corrupt tarball)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test