### PR TITLE
claude-mergetool: init at 1.1.0

### DIFF
--- a/pkgs/by-name/cl/claude-mergetool/package.nix
+++ b/pkgs/by-name/cl/claude-mergetool/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+  versionCheckHook,
+}:
+let
+  version = "1.1.0";
+in
+rustPlatform.buildRustPackage {
+  pname = "claude-mergetool";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "9999years";
+    repo = "claude-mergetool";
+    tag = "v${version}";
+    hash = "sha256-MqAtr7SxbarllzDgOWvzUooiRNf08aAVaLdZHJzMnRI=";
+  };
+
+  cargoHash = "sha256-RawDKKx+O79+TnLZRdatEcNDd4vLzTqHF2w1/D5zPjA=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/claude-mergetool";
+
+  meta = {
+    homepage = "https://github.com/9999years/claude-mergetool";
+    changelog = "https://github.com/9999years/claude-mergetool/releases/tag/v${version}";
+    description = "Resolve Git/jj merge conflicts automatically with claude-code";
+    license = [ lib.licenses.mit ];
+    maintainers = [ lib.maintainers._9999years ];
+    mainProgram = "claude-mergetool";
+  };
+
+  passthru.updateScript = nix-update-script { };
+}


### PR DESCRIPTION
[`claude-mergetool`][1] is exactly what it sounds like: a git/jj conflict resolution tool which resolves conflicts by asking Claude to resolve the conflicts. It works very well if someone else is paying your Claude bill.

[1]: https://github.com/9999years/claude-mergetool


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
