### PR TITLE
xmlbird: migrate to by-name, modernize derivation

### DIFF
--- a/pkgs/by-name/xm/xmlbird/package.nix
+++ b/pkgs/by-name/xm/xmlbird/package.nix
@@ -9,13 +9,13 @@
   gobject-introspection,
 }:
 
-gccStdenv.mkDerivation rec {
+gccStdenv.mkDerivation (finalAttrs: {
   pname = "xmlbird";
   version = "1.2.15";
 
   src = fetchurl {
-    url = "https://birdfont.org/${pname}-releases/lib${pname}-${version}.tar.xz";
-    sha256 = "sha256-8GX4ijF+AxaGGFlSxRPOAoUezRG6592jOrifz/mWTRM=";
+    url = "https://birdfont.org/xmlbird-releases/libxmlbird-${finalAttrs.version}.tar.xz";
+    hash = "sha256-8GX4ijF+AxaGGFlSxRPOAoUezRG6592jOrifz/mWTRM=";
   };
 
   nativeBuildInputs = [
@@ -43,4 +43,4 @@ gccStdenv.mkDerivation rec {
     license = lib.licenses.lgpl3;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/xm/xmlbird/package.nix
+++ b/pkgs/by-name/xm/xmlbird/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gccStdenv,
   fetchurl,
   python3,
   pkg-config,
@@ -9,7 +9,7 @@
   gobject-introspection,
 }:
 
-stdenv.mkDerivation rec {
+gccStdenv.mkDerivation rec {
   pname = "xmlbird";
   version = "1.2.15";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1953,7 +1953,6 @@ with pkgs;
   binlore = callPackage ../development/tools/analysis/binlore { };
 
   birdfont = callPackage ../tools/misc/birdfont { };
-  xmlbird = callPackage ../tools/misc/birdfont/xmlbird.nix { stdenv = gccStdenv; };
 
   bmrsa = callPackage ../tools/security/bmrsa/11.nix { };
 


### PR DESCRIPTION
This pull request reorganizes and modernizes the packaging of the `xmlbird` library. The package definition has been moved to a new location and updated to follow current best practices, including improvements to the build environment and source fetching.

**Package relocation and modernization:**

* Moved the `xmlbird` package from `pkgs/tools/misc/birdfont/xmlbird.nix` to `pkgs/by-name/xm/xmlbird/package.nix` to align with the new package organization scheme.
* Updated the package definition to use `gccStdenv` (now aliased as `stdenv` within the file) and modernized the use of `mkDerivation` to accept an attribute set argument (`finalAttrs`).
* Updated the source URL and hash attribute from `sha256` to `hash` for consistency with current Nixpkgs conventions, and used the `finalAttrs.version` variable for better maintainability.

**Top-level package reference update:**

* Removed the old reference to `xmlbird` in `all-packages.nix` to reflect the new package location and prevent duplicate or outdated definitions.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
