### PR TITLE
llvmPackages_opencilk: init at 19.1.7 (OpenCilk v3.0)

### DIFF
--- a/pkgs/development/compilers/llvm/common/cheetah/default.nix
+++ b/pkgs/development/compilers/llvm/common/cheetah/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  llvm_meta,
+  release_version,
+  version,
+  monorepoSrc,
+  runCommand,
+  cmake,
+  ninja,
+  python3,
+  libllvm,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cheetah";
+  inherit version;
+
+  src = runCommand "cheetah-src-${version}" { } ''
+    mkdir -p "$out"
+    cp -r ${monorepoSrc}/cmake "$out"
+    cp -r ${monorepoSrc}/cheetah "$out"
+  '';
+
+  sourceRoot = "${finalAttrs.src.name}/cheetah";
+
+  nativeBuildInputs = [
+    cmake
+    python3
+    libllvm.dev
+    ninja
+  ];
+
+  meta = llvm_meta // {
+    homepage = "https://opencilk.org/";
+    description = "OpenCilk Runtime (Cheetah)";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/development/compilers/llvm/common/cilktools/default.nix
+++ b/pkgs/development/compilers/llvm/common/cilktools/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  llvm_meta,
+  release_version,
+  version,
+  monorepoSrc,
+  runCommand,
+  cmake,
+  ninja,
+  python3,
+  libllvm,
+  cheetah,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cilktools";
+  inherit version;
+
+  src = runCommand "cilktools-src-${version}" { } ''
+    mkdir -p "$out"
+    cp -r ${monorepoSrc}/cmake "$out"
+    cp -r ${monorepoSrc}/cilktools "$out"
+  '';
+
+  sourceRoot = "${finalAttrs.src.name}/cilktools";
+
+  nativeBuildInputs = [
+    cmake
+    python3
+    libllvm.dev
+    ninja
+  ];
+
+  buildInputs = [
+    cheetah
+  ];
+
+  cmakeFlags = [
+    "-DCILKTOOLS_INCLUDE_DIRS=${cheetah}/include"
+  ];
+
+  meta = llvm_meta // {
+    homepage = "https://opencilk.org/";
+    description = "OpenCilk Productivity Tools";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -31,12 +31,14 @@ stdenv.mkDerivation (
 
     src =
       if monorepoSrc != null then
-        runCommand "clang-src-${version}" { inherit (monorepoSrc) passthru; } ''
-          mkdir -p "$out"
-          cp -r ${monorepoSrc}/cmake "$out"
-          cp -r ${monorepoSrc}/clang "$out"
-          ${lib.optionalString enableClangToolsExtra "cp -r ${monorepoSrc}/clang-tools-extra \"$out\""}
-        ''
+        runCommand "clang-src-${version}"
+          (lib.optionalAttrs (monorepoSrc ? passthru) { inherit (monorepoSrc) passthru; })
+          ''
+            mkdir -p "$out"
+            cp -r ${monorepoSrc}/cmake "$out"
+            cp -r ${monorepoSrc}/clang "$out"
+            ${lib.optionalString enableClangToolsExtra "cp -r ${monorepoSrc}/clang-tools-extra \"$out\""}
+          ''
       else
         src;
 

--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -50,19 +50,21 @@ stdenv.mkDerivation (finalAttrs: {
 
   src =
     if monorepoSrc != null then
-      runCommand "compiler-rt-src-${version}" { inherit (monorepoSrc) passthru; } (
-        ''
-          mkdir -p "$out"
-          cp -r ${monorepoSrc}/cmake "$out"
-        ''
-        + lib.optionalString (lib.versionAtLeast release_version "21") ''
-          cp -r ${monorepoSrc}/third-party "$out"
-        ''
-        + ''
-          cp -r ${monorepoSrc}/compiler-rt "$out"
-          cp -r ${monorepoSrc}/llvm "$out"
-        ''
-      )
+      runCommand "compiler-rt-src-${version}"
+        (lib.optionalAttrs (monorepoSrc ? passthru) { inherit (monorepoSrc) passthru; })
+        (
+          ''
+            mkdir -p "$out"
+            cp -r ${monorepoSrc}/cmake "$out"
+          ''
+          + lib.optionalString (lib.versionAtLeast release_version "21") ''
+            cp -r ${monorepoSrc}/third-party "$out"
+          ''
+          + ''
+            cp -r ${monorepoSrc}/compiler-rt "$out"
+            cp -r ${monorepoSrc}/llvm "$out"
+          ''
+        )
     else
       src;
 

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -22,6 +22,7 @@
   monorepoSrc ? null,
   version ? null,
   patchesFn ? lib.id,
+  isOpenCilk ? false,
   cmake,
   cmakeMinimal,
   python3,
@@ -158,6 +159,29 @@ makeScopeWithSplicing' {
         + ''
           ln -s "${targetLlvmPackages.compiler-rt.out}/lib" "$rsrc/lib"
           ln -s "${targetLlvmPackages.compiler-rt.out}/share" "$rsrc/share"
+        ''
+        + lib.optionalString isOpenCilk ''
+          # Merge cheetah runtime and headers into resource root for -fopencilk support
+          rm "$rsrc/lib"
+          mkdir -p "$rsrc/lib"
+          for d in ${targetLlvmPackages.compiler-rt.out}/lib/*/; do
+            subdir=$(basename "$d")
+            mkdir -p "$rsrc/lib/$subdir"
+            ln -s "$d"* "$rsrc/lib/$subdir/"
+          done
+          ln -sf ${targetLlvmPackages.compiler-rt.out}/lib/*.* "$rsrc/lib/" 2>/dev/null || true
+          for d in ${targetLlvmPackages.cheetah}/lib/*/; do
+            subdir=$(basename "$d")
+            mkdir -p "$rsrc/lib/$subdir"
+            ln -s "$d"* "$rsrc/lib/$subdir/"
+          done
+          ln -sf ${targetLlvmPackages.cheetah}/lib/*.* "$rsrc/lib/" 2>/dev/null || true
+
+          # Merge cheetah cilk headers into clang resource include directory
+          rm "$rsrc/include"
+          mkdir -p "$rsrc/include"
+          ln -s ${lib.getLib cc}/lib/clang/${clangVersion}/include/* "$rsrc/include/"
+          cp -rs ${targetLlvmPackages.cheetah}/include/* "$rsrc/include/"
         '';
 
       bintoolsNoLibc' = if bootBintoolsNoLibc == null then self.bintoolsNoLibc else bootBintoolsNoLibc;
@@ -224,14 +248,20 @@ makeScopeWithSplicing' {
         cc = self.clang-unwrapped;
         # libstdcxx is taken from gcc in an ad-hoc way in cc-wrapper.
         libcxx = null;
-        extraPackages = [ targetLlvmPackages.compiler-rt ];
+        extraPackages = [
+          targetLlvmPackages.compiler-rt
+        ]
+        ++ lib.optional isOpenCilk targetLlvmPackages.cheetah;
         extraBuildCommands = mkExtraBuildCommands cc;
       };
 
       libcxxClang = wrapCCWith rec {
         cc = self.clang-unwrapped;
         libcxx = targetLlvmPackages.libcxx;
-        extraPackages = [ targetLlvmPackages.compiler-rt ];
+        extraPackages = [
+          targetLlvmPackages.compiler-rt
+        ]
+        ++ lib.optional isOpenCilk targetLlvmPackages.cheetah;
         extraBuildCommands = mkExtraBuildCommands cc;
       };
 
@@ -293,6 +323,7 @@ makeScopeWithSplicing' {
         extraPackages = [
           targetLlvmPackages.compiler-rt
         ]
+        ++ lib.optional isOpenCilk targetLlvmPackages.cheetah
         ++ lib.optionals (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD) [
           targetLlvmPackages.libunwind
         ];
@@ -472,6 +503,20 @@ makeScopeWithSplicing' {
       mlir = callPackage ./mlir { };
 
       libclc = callPackage ./libclc { };
+    }
+    // lib.optionalAttrs isOpenCilk {
+      cheetah = callPackage ./cheetah {
+        monorepoSrc = metadata.monorepoSrc;
+        # Cheetah must be compiled with clang (GCC rejects always_inline + setjmp).
+        # Use clangWithLibcAndBasicRt to avoid circular dependency with cheetah-including wrappers.
+        stdenv = overrideCC args.stdenv buildLlvmPackages.clangWithLibcAndBasicRt;
+      };
+
+      cilktools = callPackage ./cilktools {
+        monorepoSrc = metadata.monorepoSrc;
+        stdenv = overrideCC args.stdenv buildLlvmPackages.clangWithLibcAndBasicRt;
+        inherit (self) cheetah;
+      };
     }
     // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "19") {
       bolt = callPackage ./bolt { };

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -87,21 +87,31 @@ stdenv.mkDerivation (
 
     src =
       if monorepoSrc != null then
-        runCommand "llvm-src-${version}" { inherit (monorepoSrc) passthru; } (
-          ''
-            mkdir -p "$out"
-            cp -r ${monorepoSrc}/llvm "$out"
-            cp -r ${monorepoSrc}/cmake "$out"
-            cp -r ${monorepoSrc}/third-party "$out"
-          ''
-          + lib.optionalString enablePolly ''
-            chmod u+w "$out/llvm/tools"
-            cp -r ${monorepoSrc}/polly "$out/llvm/tools"
-          ''
-          + lib.optionalString (lib.versionAtLeast release_version "21") ''
-            cp -r ${monorepoSrc}/libc "$out"
-          ''
-        )
+        runCommand "llvm-src-${version}"
+          (lib.optionalAttrs (monorepoSrc ? passthru) { inherit (monorepoSrc) passthru; })
+          (
+            ''
+              mkdir -p "$out"
+              cp -r ${monorepoSrc}/llvm "$out"
+              cp -r ${monorepoSrc}/cmake "$out"
+              cp -r ${monorepoSrc}/third-party "$out"
+            ''
+            + lib.optionalString enablePolly ''
+              chmod u+w "$out/llvm/tools"
+              cp -r ${monorepoSrc}/polly "$out/llvm/tools"
+            ''
+            + lib.optionalString (lib.versionAtLeast release_version "21") ''
+              cp -r ${monorepoSrc}/libc "$out"
+            ''
+            # OpenCilk's CMakeLists.txt references LICENSE files at the monorepo root
+            + ''
+              for f in LICENSE.TXT MIT_LICENSE.TXT; do
+                if [ -e ${monorepoSrc}/$f ]; then
+                  cp ${monorepoSrc}/$f "$out"
+                fi
+              done
+            ''
+          )
       else
         src;
 

--- a/pkgs/development/compilers/llvm/common/opencilk-source.nix
+++ b/pkgs/development/compilers/llvm/common/opencilk-source.nix
@@ -1,0 +1,39 @@
+{
+  fetchFromGitHub,
+  runCommand,
+}:
+
+let
+  version = "v3.0";
+
+  opencilkProject = fetchFromGitHub {
+    owner = "OpenCilk";
+    repo = "opencilk-project";
+    rev = "opencilk/${version}";
+    hash = "sha256-QIBpCsdDVbXh35VGVDymI9CvAnTo1SA0UxZvJ0LUy0k=";
+  };
+
+  cheetah = fetchFromGitHub {
+    owner = "OpenCilk";
+    repo = "cheetah";
+    rev = "opencilk/${version}";
+    hash = "sha256-qBjYuCqw7Dk3IFrf9nEkGMjdveev2WiX9zSDHoSpnDc=";
+  };
+
+  productivityTools = fetchFromGitHub {
+    owner = "OpenCilk";
+    repo = "productivity-tools";
+    rev = "opencilk/${version}";
+    hash = "sha256-E59xva3+TFo7VCUO7/qVgHr0ZSiZq1cByRzCVfrQlP8=";
+  };
+
+in
+runCommand "opencilk-source-${version}" { } ''
+  mkdir -p $out
+  cp -r ${opencilkProject}/* $out/
+  chmod -R u+w $out
+
+  rm -rf $out/cheetah $out/cilktools
+  cp -r ${cheetah} $out/cheetah
+  cp -r ${productivityTools} $out/cilktools
+''

--- a/pkgs/development/compilers/llvm/common/tblgen.nix
+++ b/pkgs/development/compilers/llvm/common/tblgen.nix
@@ -38,15 +38,25 @@ let
 
   src' =
     if monorepoSrc != null then
-      runCommand "${pname}-src-${version}" { } ''
-        mkdir -p "$out"
-        cp -r ${monorepoSrc}/cmake "$out"
-        cp -r ${monorepoSrc}/third-party "$out"
-        cp -r ${monorepoSrc}/llvm "$out"
-        cp -r ${monorepoSrc}/clang "$out"
-        cp -r ${monorepoSrc}/clang-tools-extra "$out"
-        cp -r ${monorepoSrc}/mlir "$out"
-      ''
+      runCommand "${pname}-src-${version}" { } (
+        ''
+          mkdir -p "$out"
+          cp -r ${monorepoSrc}/cmake "$out"
+          cp -r ${monorepoSrc}/third-party "$out"
+          cp -r ${monorepoSrc}/llvm "$out"
+          cp -r ${monorepoSrc}/clang "$out"
+          cp -r ${monorepoSrc}/clang-tools-extra "$out"
+          cp -r ${monorepoSrc}/mlir "$out"
+        ''
+        # OpenCilk's CMakeLists.txt references LICENSE files at the monorepo root
+        + ''
+          for f in LICENSE.TXT MIT_LICENSE.TXT; do
+            if [ -e ${monorepoSrc}/$f ]; then
+              cp ${monorepoSrc}/$f "$out"
+            fi
+          done
+        ''
+      )
     else
       src;
 

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -32,6 +32,14 @@ let
       rev-version = "23.0.0-unstable-2026-02-23";
       sha256 = "sha256-0ap9AFwouOuhVqeRzLaS7mYkBBCGFIakNbgv/VVrRns=";
     };
+    "opencilk" = {
+      monorepoSrc = callPackage ./common/opencilk-source.nix { };
+      officialRelease.version = "19.1.7";
+      officialRelease.sha256 = null;
+      version = "19.1.7";
+      name = "opencilk";
+      isOpenCilk = true;
+    };
   }
   // llvmVersions;
 
@@ -42,6 +50,7 @@ let
       gitRelease ? null,
       monorepoSrc ? null,
       version ? null,
+      isOpenCilk ? false,
     }@args:
     let
       inherit
@@ -68,6 +77,7 @@ let
               patchesFn
               bootBintools
               bootBintoolsNoLibc
+              isOpenCilk
               ;
 
             otherSplices = generateSplicesForMkScope "llvmPackages_${attrName}";
@@ -77,6 +87,6 @@ let
       )
     );
 
-  llvmPackages = lib.mapAttrs' (version: args: mkPackage (args // { inherit version; })) versions;
+  llvmPackages = lib.mapAttrs' (version: args: mkPackage ({ inherit version; } // args)) versions;
 in
 llvmPackages // { inherit mkPackage versions; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4530,6 +4530,8 @@ with pkgs;
       bolt_22 = llvmPackages_22.bolt;
       flang_22 = llvmPackages_22.flang;
 
+      llvmPackages_opencilk = llvmPackagesSet."opencilk";
+
       mkLLVMPackages = llvmPackagesSet.mkPackage;
     })
     llvmPackages_18
@@ -4564,6 +4566,7 @@ with pkgs;
     llvm_22
     bolt_22
     flang_22
+    llvmPackages_opencilk
     mkLLVMPackages
     ;
 


### PR DESCRIPTION
Add [OpenCilk](https://opencilk.org/) as an LLVM variant package set (`llvmPackages_opencilk`).

OpenCilk is a fork of LLVM 19.1.7 that extends C/C++ with task-parallel Cilk primitives (`cilk_spawn`, `cilk_sync`, `cilk_for`) via the `-fopencilk` compiler flag. It includes the Cheetah runtime library and productivity tools (cilksan race detector, cilkscale scalability analyzer).

New packages:
- `llvmPackages_opencilk.cheetah` — OpenCilk runtime library
- `llvmPackages_opencilk.cilktools` — productivity tools (cilksan, cilkscale)
The monorepo source is assembled from three GitHub repos (`opencilk-project`, `cheetah`, `productivity-tools`).
 Changes to shared LLVM packaging are minimal: guarding `monorepoSrc` passthru behind `? passthru` checks, and conditionally copying LICENSE files referenced by OpenCilk's CMakeLists.txt.
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test")