### PR TITLE
octavePackages.{buildOctavePackage: allow specifying inputs for package tests, image: fix tests}

### DIFF
--- a/doc/languages-frameworks/octave.section.md
+++ b/doc/languages-frameworks/octave.section.md
@@ -76,6 +76,17 @@ See [Symbolic](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/oct
 `requiredOctavePackages`
 : This is a special dependency that ensures the specified Octave packages are dependent on others, and are made available simultaneously when loading them in Octave.
 
+### Testing Octave packages {#sssec-testing-octave-packages}
+
+Octave packages built using the `buildOctavePackage` function do not have a `checkPhase` or `installCheckPhase`.
+Instead, the tests `testOctaveBuildEnv` and `testOctavePkgTests` are added to the package's `passthru.tests`.
+
+`passthru.tests.testOctaveBuildEnv` tests whether the package can be used by `octave.withPackages` successfully.
+
+`passthru.tests.testOctavePkgTests` runs a `pkg test` command for the package.
+If the package needs additional inputs to successfully run the tests, the `nativeOctavePkgTestInputs` attribute can be specified.
+If the package needs environment variables to be set to successfully run the tests, ensure that `__structuredAttrs = true;` in the package, then set the environment variables you need in `octavePkgTestEnv` (which should be an attrset where the key is the name of the variable and the value is its value (as a string)).
+
 ### Installing Octave Packages {#sssec-installing-octave-packages}
 
 By default, the `buildOctavePackage` function does _not_ install the requested package into Octave for use.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -695,6 +695,9 @@
   "footnote-stdenv-find-inputs-location.__back.0": [
     "index.html#footnote-stdenv-find-inputs-location.__back.0"
   ],
+  "sssec-testing-octave-packages": [
+    "index.html#sssec-testing-octave-packages"
+  ],
   "strictflexarrays1": [
     "index.html#strictflexarrays1"
   ],

--- a/pkgs/development/interpreters/octave/build-octave-package.nix
+++ b/pkgs/development/interpreters/octave/build-octave-package.nix
@@ -46,6 +46,11 @@
   # requiredOctavePackages are ALSO installed into octave.
   requiredOctavePackages ? [ ],
 
+  # Dependencies and `env` for octave package tests,
+  # which are run with .passthru.tests.testOctavePkgTests
+  nativeOctavePkgTestInputs ? [ ],
+  octavePkgTestEnv ? { },
+
   preBuild ? "",
 
   meta ? { },
@@ -74,6 +79,7 @@ let
   # itself, causing everything to fail.
   attrs' = removeAttrs attrs [
     "nativeBuildInputs"
+    "nativeOctavePkgTestInputs"
     "passthru"
   ];
 in
@@ -143,7 +149,9 @@ stdenv.mkDerivation (
         testOctaveBuildEnv = (octave.withPackages (os: [ finalAttrs.finalPackage ])).overrideAttrs (old: {
           name = "${finalAttrs.name}-pkg-install";
         });
-        testOctavePkgTests = callPackage ./run-pkg-test.nix { } finalAttrs.finalPackage;
+        testOctavePkgTests = callPackage ./run-pkg-test.nix {
+          inherit nativeOctavePkgTestInputs octavePkgTestEnv;
+        } finalAttrs.finalPackage;
       }
       // passthru.tests or { };
     };

--- a/pkgs/development/interpreters/octave/run-pkg-test.nix
+++ b/pkgs/development/interpreters/octave/run-pkg-test.nix
@@ -1,6 +1,8 @@
 {
   octave,
   runCommand,
+  nativeOctavePkgTestInputs,
+  octavePkgTestEnv,
 }:
 package:
 
@@ -8,7 +10,10 @@ runCommand "${package.name}-pkg-test"
   {
     nativeBuildInputs = [
       (octave.withPackages (os: [ package ]))
-    ];
+    ]
+    ++ nativeOctavePkgTestInputs;
+
+    env = octavePkgTestEnv;
   }
   ''
     { octave-cli --eval 'pkg test ${package.pname}' || touch FAILED_ERRCODE; } \

--- a/pkgs/development/octave-modules/image/default.nix
+++ b/pkgs/development/octave-modules/image/default.nix
@@ -2,6 +2,10 @@
   buildOctavePackage,
   lib,
   fetchurl,
+  mesa,
+  gnuplot,
+  makeFontsConf,
+  writableTmpDirAsHomeHook,
 }:
 
 buildOctavePackage rec {
@@ -12,6 +16,16 @@ buildOctavePackage rec {
     url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
     sha256 = "sha256-pYY8E5LZd+pPNwzFVH4EsXY8K3fXs6Hyz2zYweXkmRk=";
   };
+
+  nativeOctavePkgTestInputs = [
+    mesa
+    gnuplot
+    writableTmpDirAsHomeHook
+  ];
+
+  octavePkgTestEnv.FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://gnu-octave.github.io/packages/image/";

--- a/pkgs/top-level/octave-packages.nix
+++ b/pkgs/top-level/octave-packages.nix
@@ -116,7 +116,14 @@ makeScope newScope (
       inherit (pkgs) gsl;
     };
 
-    image = callPackage ../development/octave-modules/image { };
+    image = callPackage ../development/octave-modules/image {
+      inherit (pkgs)
+        mesa
+        gnuplot
+        makeFontsConf
+        writableTmpDirAsHomeHook
+        ;
+    };
 
     image-acquisition = callPackage ../development/octave-modules/image-acquisition { };
 


### PR DESCRIPTION
Some Octave packages require OpenGL for their unit tests, e.g. `octavePackages.image`. Previously, this test script would have erroneous failures because OpenGL could not be found. [1] suggested that we add these to the test environment to remove these incorrect failures.

Fixing OpenGL being missing actually meant that gnuplot needed to be pulled in, because these unit tests were plotting AND doing graphics. And because gnuplot needs fonts, we need fontconfig too.

[1] https://github.com/NixOS/nixpkgs/pull/491992#issuecomment-3944950414

Pinging @NickCao, since they were the one to suggest the change.

Skipping the tests will be hard, since the tests may change from release to release. It's easier for us to just add the missing dependencies to the test environment.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
