### PR TITLE
dasel: 2.8.1 -> 3.3.0

### DIFF
--- a/pkgs/by-name/da/dasel/package.nix
+++ b/pkgs/by-name/da/dasel/package.nix
@@ -3,43 +3,33 @@
   stdenv,
   buildGoModule,
   fetchFromGitHub,
-  installShellFiles,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "dasel";
-  version = "2.8.1";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "TomWright";
     repo = "dasel";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-vq4lRCsqD2hmQw0yH84Wji5LeJ/aiMGJJIyCDvATA+I=";
+    hash = "sha256-3gLOAca5C4HfLqmF+1c1fDytA58JNml+18FYsWUhIQ0=";
   };
 
-  vendorHash = "sha256-edyFs5oURklkqsTF7JA1in3XteSBx/6YEVu4MjIcGN4=";
+  vendorHash = "sha256-hHxEE0xNSP4wnT5B13BAxUPpdIWs8v7KF1MuISfaYBE=";
 
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/tomwright/dasel/v2/internal.Version=${finalAttrs.version}"
+    "-X github.com/tomwright/dasel/v3/internal.Version=v${finalAttrs.version}"
   ];
-
-  nativeBuildInputs = [ installShellFiles ];
-
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    installShellCompletion --cmd dasel \
-      --bash <($out/bin/dasel completion bash) \
-      --fish <($out/bin/dasel completion fish) \
-      --zsh <($out/bin/dasel completion zsh)
-  '';
 
   doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   installCheckPhase = ''
     runHook preInstallCheck
-    if [[ $($out/bin/dasel --version) == "dasel version ${finalAttrs.version}" ]]; then
+    if [[ $($out/bin/dasel version) == "v${finalAttrs.version}" ]]; then
       echo '{ "my": { "favourites": { "colour": "blue" } } }' \
-        | $out/bin/dasel put -t json -r json -t string -v "red" "my.favourites.colour" \
+        | $out/bin/dasel -i json 'my.favourites.colour = "red"' \
         | grep "red"
     else
       return 1


### PR DESCRIPTION
This is a major version bump with breaking changes.

The interface changed a lot, so I fixed the `installCheckPhase` script.

I removed shell completions since they have been dropped upstream, there's an issue to bring them back:
https://github.com/TomWright/dasel/issues/497


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
