### PR TITLE
python3Packages.python-openevse-http: init at 0.2.4

### DIFF
--- a/pkgs/development/python-modules/python-openevse-http/default.nix
+++ b/pkgs/development/python-modules/python-openevse-http/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  aiohttp,
+  aioresponses,
+  awesomeversion,
+  buildPythonPackage,
+  fetchFromGitHub,
+  freezegun,
+  pytestCheckHook,
+  pytest-asyncio,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "python-openevse-http";
+  version = "0.2.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "firstof9";
+    repo = "python-openevse-http";
+    tag = finalAttrs.version;
+    hash = "sha256-aI1IU9mGThg9tNAqdgKAG5miuVDQozWJoBaoy3cFhwY=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    awesomeversion
+  ];
+
+  nativeCheckInputs = [
+    aioresponses
+    freezegun
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [ "openevsehttp" ];
+
+  meta = {
+    description = "Python wrapper for OpenEVSE HTTP API";
+    homepage = "https://github.com/firstof9/python-openevse-http";
+    changelog = "https://github.com/firstof9/python-openevse-http/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -4388,8 +4388,9 @@
     "openevse" =
       ps: with ps; [
         ifaddr
+        python-openevse-http
         zeroconf
-      ]; # missing inputs: python-openevse-http
+      ];
     "openexchangerates" =
       ps: with ps; [
         aioopenexchangerates
@@ -7801,6 +7802,7 @@
     "openai_conversation"
     "openalpr_cloud"
     "openerz"
+    "openevse"
     "openexchangerates"
     "opengarage"
     "openhardwaremonitor"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15654,6 +15654,8 @@ self: super: with self; {
 
   python-openems = callPackage ../development/python-modules/python-openems { };
 
+  python-openevse-http = callPackage ../development/python-modules/python-openevse-http { };
+
   python-opensky = callPackage ../development/python-modules/python-opensky { };
 
   python-openstackclient = callPackage ../development/python-modules/python-openstackclient { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/python-openevse-http/
- https://github.com/firstof9/python-openevse-http
- https://www.home-assistant.io/integrations/openevse/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
