### PR TITLE
gradia: 1.11.3 -> 1.12.0

### DIFF
--- a/pkgs/by-name/gr/gradia/package.nix
+++ b/pkgs/by-name/gr/gradia/package.nix
@@ -18,18 +18,20 @@
   webp-pixbuf-loader,
   libsoup_3,
   bash,
+  glib-networking,
+  tesseract,
   nix-update-script,
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gradia";
-  version = "1.11.3";
+  version = "1.12.0";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "AlexanderVanhee";
     repo = "Gradia";
-    rev = "472a970e10c3a85f9db938719ebba121321c1d90";
-    hash = "sha256-2PSpFmojAIyDNx5yYrLE3CjO/q5iBArmIRikxCGW1HM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iYqMuqq2AmrdNMa7dkDUGg1+gCG7wL/rDEdWAPfcQnw=";
   };
 
   nativeBuildInputs = [
@@ -49,7 +51,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
     libportal-gtk4
     libsoup_3
     bash
+    glib-networking
+    tesseract
   ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "/app/bin/tesseract" "${lib.getExe tesseract}"
+  '';
 
   dependencies = with python3Packages; [
     pygobject3


### PR DESCRIPTION
Update gradia to v1.12.0
Gradia releases are tagged again so we can use these tags (#489845)

[Changelog](https://github.com/AlexanderVanhee/Gradia/releases/tag/v1.12.0)
Diff: [https://github.com/AlexanderVanhee/Gradia/compare/v1.11.1...v1.12.0](https://github.com/AlexanderVanhee/Gradia/compare/v1.11.1...v1.12.0) (since v.1.11.1)

The OCR button is not visible (should be beside the crop button).
In the builds logs I saw `DEPRECATION: Variable substitution with boolean value 'ENABLE_OCR' is deprecated.` so maybe we have to enable OCR? I’ll have to check it out.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
