### PR TITLE
lmstudio: add aarch64-linux support

### DIFF
--- a/pkgs/by-name/lm/lmstudio/package.nix
+++ b/pkgs/by-name/lm/lmstudio/package.nix
@@ -11,6 +11,8 @@ let
   hash_aarch64-darwin = "sha256-JadulYyHiXK+sQdp7Y6m5lQkkPkzut9O9Lc9kcW7bR4=";
   version_x86_64-linux = "0.4.2-2";
   hash_x86_64-linux = "sha256-JxGlqgsuLcW81mOIcntVFSHv19zSFouIChgz/egc+J0=";
+  version_aarch64-linux = "0.4.2-2";
+  hash_aarch64-linux = "sha256-+mGLFC3w2EPbFM8nV5Ft4QyAeVgCa+856lTaJrvD/IE=";
 
   meta = {
     description = "LM Studio is an easy to use desktop app for experimenting with local and open-source Large Language Models (LLMs)";
@@ -20,6 +22,7 @@ let
     maintainers = with lib.maintainers; [ crertel ];
     platforms = [
       "x86_64-linux"
+      "aarch64-linux"
       "aarch64-darwin"
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
@@ -35,6 +38,16 @@ if stdenv.hostPlatform.isDarwin then
       args.url
         or "https://installers.lmstudio.ai/darwin/arm64/${version_aarch64-darwin}/LM-Studio-${version_aarch64-darwin}-arm64.dmg";
     hash = args.hash or hash_aarch64-darwin;
+  }
+else if stdenv.hostPlatform.isAarch64 then
+  callPackage ./linux.nix {
+    inherit pname meta;
+    passthru.updateScript = ./update.sh;
+    version = version_aarch64-linux;
+    url =
+      args.url
+        or "https://installers.lmstudio.ai/linux/arm64/${version_aarch64-linux}/LM-Studio-${version_aarch64-linux}-arm64.AppImage";
+    hash = args.hash or hash_aarch64-linux;
   }
 else
   callPackage ./linux.nix {

--- a/pkgs/by-name/lm/lmstudio/update.sh
+++ b/pkgs/by-name/lm/lmstudio/update.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-for system in "aarch64-darwin darwin/arm64" "x86_64-linux linux/x64"; do
+for system in "aarch64-darwin darwin/arm64" "x86_64-linux linux/x64" "aarch64-linux linux/arm64"; do
   # shellcheck disable=SC2086
   set -- ${system} # split string into variables $1 and $2
 


### PR DESCRIPTION
I have added support for the aarch64-linux platform to the package lmstudio.

I downloaded the same version of LM Studio the package contains (0.4.2-2) for arm64, calculated the checksum, added the corresponding download link and hash to package.nix and updated the update.sh script to include the extra platform as well.

I then built the package on my arm64 device, confirming that LM Studio runs as expected.

At the time of writing, version 0.4.5-2 is available. I am not sure if it is a good idea to update the version in the same PR where I extend platform support, would be happy for any feedback in regards to potential future contributions. If wanted, I can add an extra commit updating the version. 

EDIT: I just realized #491906 covers this platform addition, there is a only tiny difference in platform determination.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
