### PR TITLE
stuntrally: fix build with boost 1.89

### DIFF
--- a/pkgs/by-name/st/stuntrally/package.nix
+++ b/pkgs/by-name/st/stuntrally/package.nix
@@ -51,6 +51,11 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace src/vdrift/paths.cpp \
       --replace-fail "@GAME_DATA_DIR@" "$out/share/stuntrally3/data" \
       --replace-fail "@GAME_CONFIG_DIR@" "$out/share/stuntrally3/config"
+
+    # Fix build with boost 1.89
+    substituteInPlace CMake/AddMissingTargets.cmake --replace-fail \
+      'find_package(Boost REQUIRED COMPONENTS system thread filesystem)' \
+      'find_package(Boost REQUIRED COMPONENTS thread filesystem)'
   '';
 
   strictDeps = true;


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/485826

closes https://github.com/NixOS/nixpkgs/issues/494254
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
