### PR TITLE
kellnr6: init at 6.0.3

### DIFF
--- a/pkgs/by-name/ke/kellnr6/package.nix
+++ b/pkgs/by-name/ke/kellnr6/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  stdenv,
+  cmake,
+  pkg-config,
+  openssl,
+  libiconv,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "kellnr6";
+  version = "6.0.3";
+
+  src = fetchCrate {
+    inherit version;
+    pname = "kellnr";
+    hash = "sha256-Eo3KhmX6BCL+Cc0eKMMJKAuDv/LTWnczIQGl+eJInAE=";
+  };
+
+  cargoHash = "sha256-PNWJjM++88FDH1HV/XVh1ruQnRsMNJr+IJiiUn6PYM0=";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    openssl.dev
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    libiconv
+  ];
+
+  OPENSSL_DIR = "${openssl.dev}";
+  OPENSSL_INCLUDE_DIR = "${openssl.dev}/include";
+  OPENSSL_LIB_DIR = "${openssl.out}/lib";
+  OPENSSL_NO_VENDOR = "1";
+
+  meta = {
+    description = "Host your private Rust crates on your own infrastructure. Full control. Complete privacy. Zero dependencies on external services.";
+    mainProgram = "kellnr";
+    homepage = "kellnr.io";
+    license = with lib.licenses; [
+      mit # or
+      asl20
+    ];
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
Add Kellnr, which is an open-source [Rust](https://www.rust-lang.org) registry for crates. Think of [crates.io](https://crates.io) but on your own hardware.

Homepage: [kellnr.io](https://kellnr.io)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
