### PR TITLE
vunnel: 0.48.0 -> 0.55.1, python3Packages.yardstick: init at 0.16.1

### DIFF
--- a/pkgs/by-name/vu/vunnel/package.nix
+++ b/pkgs/by-name/vu/vunnel/package.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "vunnel";
-  version = "0.48.0";
+  version = "0.55.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "anchore";
     repo = "vunnel";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-D0/DoYmmLeAvGnr6ljE8p0B6dmFi4UHwcWCQRb85OkM=";
+    hash = "sha256-D3f+r+FGcdetE8kwSddVRE9qQ+LiwUHaJaUqUS086cs=";
     leaveDotGit = true;
   };
 
@@ -55,6 +55,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       sqlalchemy
       xsdata
       xxhash
+      yardstick
       zstandard
     ]
     ++ xsdata.optional-dependencies.cli

--- a/pkgs/development/python-modules/omitempty/default.nix
+++ b/pkgs/development/python-modules/omitempty/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "omitempty";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bfontaine";
+    repo = "omitempty";
+    tag = finalAttrs.version;
+    hash = "sha256-XQ887ArfxXnPJcCksgS5Zkg9VAfGRxu0wapewsnqdpY=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "omitempty" ];
+
+  # Tests are outdated
+  doCheck = false;
+
+  meta = {
+    description = "Go's omitempty for Python";
+    homepage = "https://github.com/bfontaine/omitempty";
+    changelog = "https://github.com/bfontaine/omitempty/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/development/python-modules/yardstick/default.nix
+++ b/pkgs/development/python-modules/yardstick/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildPythonPackage,
+  click,
+  dataclass-wizard,
+  dataclasses-json,
+  fetchFromGitHub,
+  gitpython,
+  hatchling,
+  importlib-metadata,
+  mergedeep,
+  omitempty,
+  prompt-toolkit,
+  pygments,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytest-mock,
+  pytestCheckHook,
+  pyyaml,
+  requests,
+  tabulate,
+  uv-dynamic-versioning,
+  xxhash,
+  zstandard,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "yardstick";
+  version = "0.16.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "anchore";
+    repo = "yardstick";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4Kwgm2gmgOam7AVzlGYT3QhAyJf14h3pZohrhbzprpg=";
+  };
+
+  build-system = [
+    hatchling
+    uv-dynamic-versioning
+  ];
+
+  dependencies = [
+    click
+    dataclass-wizard
+    dataclasses-json
+    gitpython
+    importlib-metadata
+    mergedeep
+    omitempty
+    prompt-toolkit
+    pygments
+    pyyaml
+    requests
+    tabulate
+    xxhash
+    zstandard
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov-stub
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "yardstick" ];
+
+  meta = {
+    description = "Module to compare vulnerability scanners results";
+    homepage = "https://github.com/anchore/yardstick";
+    changelog = "https://github.com/anchore/yardstick/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11307,6 +11307,8 @@ self: super: with self; {
 
   omemo-dr = callPackage ../development/python-modules/omemo-dr { };
 
+  omitempty = callPackage ../development/python-modules/omitempty { };
+
   omnikinverter = callPackage ../development/python-modules/omnikinverter { };
 
   omnilogic = callPackage ../development/python-modules/omnilogic { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21175,6 +21175,8 @@ self: super: with self; {
 
   yaramod = callPackage ../development/python-modules/yaramod { };
 
+  yardstick = callPackage ../development/python-modules/yardstick { };
+
   yarg = callPackage ../development/python-modules/yarg { };
 
   yargy = callPackage ../development/python-modules/yargy { };


### PR DESCRIPTION
Changelog: https://github.com/anchore/vunnel/releases/tag/v0.55.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
