### PR TITLE
git-credential-1password: init at v1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18545,6 +18545,12 @@
     githubId = 1222539;
     name = "Roman Naumann";
   };
+  nanamiiiii = {
+    email = "sk@myuu.dev";
+    github = "Nanamiiiii";
+    githubId = 52265804;
+    name = "Akihiro Saiki";
+  };
   nanotwerp = {
     email = "nanotwerp@gmail.com";
     github = "nanotwerp";

--- a/pkgs/by-name/gi/git-credential-1password/package.nix
+++ b/pkgs/by-name/gi/git-credential-1password/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "git-credential-1password";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "ethrgeist";
+    repo = pname;
+    tag = "v${version}";
+    hash = "sha256-KiMpBQ4jEm2pXRitfZLEyGjkKJHC2KNKIX8tfenVTAw=";
+  };
+
+  vendorHash = null;
+
+  meta = {
+    description = "A git credential helper for 1Password";
+    homepage = "https://github.com/ethrgeist/git-credential-1password";
+    changelog = "https://github.com/ethrgeist/git-credential-1password/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nanamiiiii ];
+    mainProgram = "git-credential-1password";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

git credential helper for 1Password.
This is a different implementation from the previously deleted one (#313054).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
