### PR TITLE
nixos/taskchampion-sync-server: use DynamicUser after 26.05

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -171,6 +171,8 @@
 
 - `vimPlugins.nvim-treesitter` has been updated to `main` branch, which is a full and incompatible rewrite. If you can't or don't want to update, you should use `vimPlugins.nvim-treesitter-legacy`.
 
+- `services.taskchampion-sync-server` module have been added an option `services.taskchampion-sync-server.dynamicUser` to use systemd's DynamicUser feature. This is enabled by default when stateVersion is at least 26.05, and disabled otherwise. If you need this feature, you need to set `services.taskchampion-sync-server.dynamicUser` to `true` and migrate `/var/lib/taskchampion-sync-server` to `/var/lib/private/taskchampion-sync-server`.
+
 ## Other Notable Changes {#sec-nixpkgs-release-26.05-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/misc/taskchampion-sync-server.nix
+++ b/nixos/modules/services/misc/taskchampion-sync-server.nix
@@ -59,14 +59,20 @@ in
       type = types.listOf types.str;
       default = [ ];
     };
+    dynamicUser = lib.mkOption {
+      description = "Whether to use dynamic user";
+      type = types.bool;
+      default = lib.versionAtLeast config.system.stateVersion "26.05";
+    };
   };
 
   config = lib.mkIf cfg.enable {
-    users.users.${cfg.user} = lib.mkIf (cfg.user == defaultUser) {
+    users.users.${cfg.user} = lib.mkIf (!cfg.dynamicUser && cfg.user == defaultUser) {
       isSystemUser = true;
       inherit (cfg) group;
     };
-    users.groups.${cfg.group} = lib.mkIf (cfg.group == defaultGroup) { };
+    users.groups.${cfg.group} = lib.mkIf (!cfg.dynamicUser && cfg.group == defaultGroup) { };
+
     networking.firewall.allowedTCPPorts = lib.mkIf (cfg.openFirewall) [ cfg.port ];
 
     systemd.services.taskchampion-sync-server = {
@@ -75,12 +81,7 @@ in
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;
-        # If we enable DynamicUser, users need to move
-        # /var/lib/taskchampion-sync-server to
-        # /var/lib/private/taskchampion-sync-server manually, which is a
-        # breakage. So we keep the old behavior and we'll do the migration in
-        # another PR.
-        DynamicUser = false;
+        DynamicUser = cfg.dynamicUser;
         StateDirectory = lib.mkIf (cfg.dataDir == defaultDir) "taskchampion-sync-server";
         ExecStart = ''
           ${lib.getExe cfg.package} \


### PR DESCRIPTION
This PR makes taskchampion-sync-server use DynamicUser after 26.05.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
