### PR TITLE
pratdiff: init at 1.0.0

### DIFF
--- a/pkgs/by-name/pr/pratdiff/package.nix
+++ b/pkgs/by-name/pr/pratdiff/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  testers,
+  pratdiff,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pratdiff";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "fowles";
+    repo = "pratdiff";
+    tag = finalAttrs.version;
+    hash = "sha256-DuCCbozMXj/iboZyPoB8WQzEQREavBFkiVIBUH1GiLk=";
+  };
+
+  cargoHash = "sha256-sD6KwYLDD63YasVeyZ3tOBPm/GZz7zUOWJTyNmS4MH0=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd pratdiff \
+      --bash <($out/bin/pratdiff --completions bash) \
+      --fish <($out/bin/pratdiff --completions fish) \
+      --zsh <($out/bin/pratdiff --completions zsh)
+  '';
+
+  passthru.tests.version = testers.testVersion { package = pratdiff; };
+
+  meta = {
+    description = "Colorful diff tool based on the patience diff algorithm";
+    homepage = "https://github.com/fowles/pratdiff";
+    changelog = "https://github.com/fowles/pratdiff/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.siriobalmelli ];
+    mainProgram = "pratdiff";
+  };
+})


### PR DESCRIPTION
Colorful diff tool based on the patience diff algorithm: https://github.com/fowles/pratdiff

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [N/A] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [N/A] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [N/A] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [N/A] Module addition: when adding a new NixOS module.
  - [N/A] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test