### PR TITLE
python3Packages.sklearn2pmml: init at 0.129.2

### DIFF
--- a/pkgs/development/python-modules/sklearn2pmml/default.nix
+++ b/pkgs/development/python-modules/sklearn2pmml/default.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  dill,
+  jre_minimal,
+  joblib,
+  pandas,
+  scikit-learn,
+
+  # tests
+  pytestCheckHook,
+  statsmodels,
+}:
+
+let
+  jre = jre_minimal.override {
+    modules = [
+      "java.base"
+      "java.desktop"
+      "java.instrument"
+      "java.logging"
+      "java.net.http"
+      "java.sql"
+      "java.xml"
+    ];
+  };
+in
+buildPythonPackage (finalAttrs: {
+  pname = "sklearn2pmml";
+  version = "0.129.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jpmml";
+    repo = "sklearn2pmml";
+    tag = finalAttrs.version;
+    hash = "sha256-xntm+AUwylJuMhTAYi6o2tIxlzzeo8lkwtSvgeuQpQU=";
+  };
+
+  postPatch = ''
+    substituteInPlace sklearn2pmml/__init__.py \
+      --replace-fail 'result.extend(["java"])' 'result.extend(["${lib.getExe jre}"])'
+
+    # Fix deprecated dash-separated key in setup.cfg
+    substituteInPlace setup.cfg \
+      --replace-fail "description-file" "description_file"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    dill
+    joblib
+    pandas
+    scikit-learn
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    statsmodels
+  ];
+
+  pytestFlagsArray = [
+    # Only run the main test suite; subpackage tests require
+    # sklearn-pandas which is not available in nixpkgs
+    "sklearn2pmml/tests"
+  ];
+
+  pythonImportsCheck = [ "sklearn2pmml" ];
+
+  meta = {
+    description = "Python library for converting Scikit-Learn pipelines to PMML";
+    homepage = "https://github.com/jpmml/sklearn2pmml";
+    changelog = "https://github.com/jpmml/sklearn2pmml/blob/${finalAttrs.version}/NEWS.md";
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # bundled JAR files
+    ];
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ b-rodrigues ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17753,6 +17753,8 @@ self: super: with self; {
 
   sklearn-deap = callPackage ../development/python-modules/sklearn-deap { };
 
+  sklearn2pmml = callPackage ../development/python-modules/sklearn2pmml { };
+
   skodaconnect = callPackage ../development/python-modules/skodaconnect { };
 
   skops = callPackage ../development/python-modules/skops { };


### PR DESCRIPTION
Add [sklearn2pmml](https://github.com/jpmml/sklearn2pmml), a Python library for converting Scikit-Learn pipelines to PMML (Predictive Model Markup Language).

### Notes

* sklearn2pmml shells out to java
*`sourceProvenance`*: Marked as `fromSource` + `binaryBytecode` since the package bundles pre-compiled .jar files
- Only the main `sklearn2pmml/tests` suite is run. Subpackage tests (e.g. `preprocessing/tests`, `decoration/tests`) require `sklearn-pandas`, which is not currently available in nixpkgs.
- Patched `description-file` → `description_file` to silence a setuptools deprecation warning.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
