### PR TITLE
python3Packages.devpi-common: 4.1.0 -> 4.1.1

### DIFF
--- a/pkgs/development/python-modules/devpi-common/default.nix
+++ b/pkgs/development/python-modules/devpi-common/default.nix
@@ -47,6 +47,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/devpi/devpi/blob/common-${version}/common/CHANGELOG";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      confus
       lewo
       makefu
     ];

--- a/pkgs/development/python-modules/devpi-common/default.nix
+++ b/pkgs/development/python-modules/devpi-common/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   lazy,
   packaging-legacy,
   pytestCheckHook,
@@ -12,16 +12,19 @@
   nix-update-script,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "devpi-common";
-  version = "4.1.0";
+  version = "4.1.1";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "devpi-common";
-    inherit version;
-    hash = "sha256-WNf3YeP+f9/kScSmqeI1DU3fvrZssPbSCAJRQpQwMNM=";
+  src = fetchFromGitHub {
+    owner = "devpi";
+    repo = "devpi";
+    tag = "common-${finalAttrs.version}";
+    hash = "sha256-YFY2iLnORzFxnfGYU2kCpJL8CZi+lALIkL1bRpfd4NE=";
   };
+
+  sourceRoot = "${finalAttrs.src.name}/common";
 
   build-system = [
     setuptools
@@ -44,7 +47,7 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/devpi/devpi";
     description = "Utilities jointly used by devpi-server and devpi-client";
-    changelog = "https://github.com/devpi/devpi/blob/common-${version}/common/CHANGELOG";
+    changelog = "https://github.com/devpi/devpi/blob/common-${finalAttrs.version}/common/CHANGELOG";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       confus
@@ -52,4 +55,4 @@ buildPythonPackage rec {
       makefu
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/devpi-ldap/default.nix
+++ b/pkgs/development/python-modules/devpi-ldap/default.nix
@@ -6,7 +6,6 @@
   ldap3,
   mock,
   pytest-cov-stub,
-  pytest-flake8,
   pytestCheckHook,
   pythonOlder,
   pythonAtLeast,
@@ -46,7 +45,6 @@ buildPythonPackage (finalAttrs: {
     devpi-server
     mock
     pytest-cov-stub
-    pytest-flake8
     pytestCheckHook
     webtest
   ];


### PR DESCRIPTION
Bump devpi-common 4.1.0 -> 4.1.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
