### PR TITLE
brave: fix VA-API feature flags renamed in Chromium 131+

### DIFF
--- a/pkgs/by-name/br/brave/make-brave.nix
+++ b/pkgs/by-name/br/brave/make-brave.nix
@@ -64,7 +64,7 @@
   # For GPU acceleration support on Wayland (without the lib it doesn't seem to work)
   libGL,
 
-  # For video acceleration via VA-API (--enable-features=VaapiVideoDecoder,VaapiVideoEncoder)
+  # For video acceleration via VA-API (--enable-features=AcceleratedVideoDecodeLinuxGL,AcceleratedVideoEncoder)
   libvaSupport ? stdenv.hostPlatform.isLinux,
   libva,
   enableVideoAcceleration ? libvaSupport,
@@ -146,8 +146,8 @@ let
 
   enableFeatures =
     optionals enableVideoAcceleration [
-      "VaapiVideoDecoder"
-      "VaapiVideoEncoder"
+      "AcceleratedVideoDecodeLinuxGL"
+      "AcceleratedVideoEncoder"
     ]
     ++ optional enableVulkan "Vulkan";
 


### PR DESCRIPTION
## Description

The `VaapiVideoDecoder` and `VaapiVideoEncoder` Chromium feature flags were renamed to `AcceleratedVideoDecodeLinuxGL` and `AcceleratedVideoEncoder` in Chromium 131. Brave 1.87+ is based on Chromium 145, so the old flags passed by the wrapper are silently ignored, leaving hardware video encode completely disabled and video decode potentially falling back to software.

The same rename was needed in other Chromium-based projects:
- [Vencord/Vesktop#1007](https://github.com/Vencord/Vesktop/pull/1007)

## Testing

Tested on AMD Radeon 860M (RDNA 3.5), Mesa 25.2.6, kernel 6.19.3:

- `vainfo` confirms VA-API encode entrypoints (H.264, HEVC, AV1)
- **Before (old flags):** `brave://gpu` shows "Video Encode: Software only. Hardware acceleration disabled", Encoding section empty
- **After (new flags):** `brave://gpu` shows "Video Encode: Hardware accelerated" with H.264 (baseline/main/high) and AV1 encode profiles listed

## Note

The `google-chrome` and `microsoft-edge` packages have similar outdated comments referencing `VaapiVideoDecoder` but don't actually pass these feature flags in their wrappers, so they are not affected.