### PR TITLE
rt-cli: init at 0.1.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27792,6 +27792,11 @@
     github = "unrooted";
     githubId = 30440603;
   };
+  unvalley = {
+    name = "unvalley";
+    github = "unvalley";
+    githubId = 38400669;
+  };
   unsolvedcypher = {
     name = "Matthew M";
     github = "UnsolvedCypher";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27792,15 +27792,15 @@
     github = "unrooted";
     githubId = 30440603;
   };
-  unvalley = {
-    name = "unvalley";
-    github = "unvalley";
-    githubId = 38400669;
-  };
   unsolvedcypher = {
     name = "Matthew M";
     github = "UnsolvedCypher";
     githubId = 3170853;
+  };
+  unvalley = {
+    name = "unvalley";
+    github = "unvalley";
+    githubId = 38400669;
   };
   uralbash = {
     email = "root@uralbash.ru";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27797,6 +27797,11 @@
     github = "UnsolvedCypher";
     githubId = 3170853;
   };
+  unvalley = {
+    name = "unvalley";
+    github = "unvalley";
+    githubId = 38400669;
+  };
   uralbash = {
     email = "root@uralbash.ru";
     github = "uralbash";

--- a/pkgs/by-name/rt/rt-cli/package.nix
+++ b/pkgs/by-name/rt/rt-cli/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-LN/5qSLpFZqiZrMPufPbCvjb9dRTewxROb03thPXVhk=";
 
   meta = {
-    description = "Run tasks across different task runners";
+    description = "Run tasks interactively, no matter task runners";
     homepage = "https://github.com/unvalley/rt";
     changelog = "https://github.com/unvalley/rt/releases/tag/v${version}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/rt/rt-cli/package.nix
+++ b/pkgs/by-name/rt/rt-cli/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rt-cli";
-  version = "0.1.8";
+  version = "0.1.9";
 
   src = fetchFromGitHub {
     owner = "unvalley";
     repo = "rt";
     rev = "v${version}";
-    hash = "sha256-VO3WaKbKwHCZCxKr40oNWRO5+fN0D9JBtKzPuDvoKuU=";
+    hash = "sha256-Y3QWpYrAkWymI+s24YJFtpIXy9QGAksU68OOlgp0DdA=";
   };
 
-  cargoHash = "sha256-GwTJPX60vrWzFfVuwwnO6/s0AvPY2HJSw9rAvW/EIsU=";
+  cargoHash = "sha256-LN/5qSLpFZqiZrMPufPbCvjb9dRTewxROb03thPXVhk=";
 
   meta = {
     description = "Run tasks across different task runners";

--- a/pkgs/by-name/rt/rt-cli/package.nix
+++ b/pkgs/by-name/rt/rt-cli/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rt-cli";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "unvalley";
+    repo = "rt";
+    rev = "v${version}";
+    hash = "sha256-VO3WaKbKwHCZCxKr40oNWRO5+fN0D9JBtKzPuDvoKuU=";
+  };
+
+  cargoHash = "sha256-GwTJPX60vrWzFfVuwwnO6/s0AvPY2HJSw9rAvW/EIsU=";
+
+  meta = {
+    description = "Run tasks across different task runners";
+    homepage = "https://github.com/unvalley/rt";
+    changelog = "https://github.com/unvalley/rt/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ unvalley ];
+    mainProgram = "rt";
+  };
+}

--- a/pkgs/by-name/rt/rt-cli/package.nix
+++ b/pkgs/by-name/rt/rt-cli/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rt-cli";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "unvalley";
+    repo = "rt";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Y3QWpYrAkWymI+s24YJFtpIXy9QGAksU68OOlgp0DdA=";
+  };
+
+  cargoHash = "sha256-LN/5qSLpFZqiZrMPufPbCvjb9dRTewxROb03thPXVhk=";
+
+  meta = {
+    description = "Run tasks interactively, no matter task runners";
+    homepage = "https://github.com/unvalley/rt";
+    changelog = "https://github.com/unvalley/rt/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ unvalley ];
+    mainProgram = "rt";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add new package [rt-cli](https://github.com/unvalley/rt) v0.1.9 and maintainer me @unvalley 

`rt` is a CLI to run tasks interactively across different task runners (Makefile, justfile, taskfile, others). 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
