### PR TITLE
various: migrate fetchPnpmDeps from fetcherVersion = 1 to fetcherVersion = 3 (part 2)

### DIFF
--- a/pkgs/by-name/fi/firezone-gui-client/package.nix
+++ b/pkgs/by-name/fi/firezone-gui-client/package.nix
@@ -43,8 +43,8 @@ let
       inherit pname version;
       pnpm = pnpm_9;
       src = "${src}/rust/gui-client";
-      fetcherVersion = 1;
-      hash = "sha256-ttbTYBuUv0vyiYzrFATF4x/zngsRXjuLPfL3qW2HEe4=";
+      fetcherVersion = 3;
+      hash = "sha256-akanXiWehhQRx6WHN75PjYvFxFiSsJ5dJaguJBTM9J0=";
     };
     pnpmRoot = "rust/gui-client";
 

--- a/pkgs/by-name/fi/firezone-server/package.nix
+++ b/pkgs/by-name/fi/firezone-server/package.nix
@@ -36,8 +36,8 @@ beam27Packages.mixRelease rec {
     inherit pname version;
     pnpm = pnpm_9;
     src = "${src}/apps/web/assets";
-    fetcherVersion = 1;
-    hash = "sha256-40vtQIBhJNnzdxkAOVAcPN57IuD0IB6LFxGICo68AbQ=";
+    fetcherVersion = 3;
+    hash = "sha256-tB0y3T/dZBe8BHz7AV913zQ4oQu7VLyqHCnzBycNg18=";
   };
   pnpmRoot = "apps/web/assets";
 

--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -38,8 +38,8 @@ stdenv.mkDerivation rec {
       src
       ;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-6I10NSmTDd/wmL/HfAgLH+G2MDfuPmrTePNDDy08nRA=";
+    fetcherVersion = 3;
+    hash = "sha256-EP7bpbJUcKmHm7KMlKc0Fz2u0niQ3jC7YN/9pp7vucE=";
   };
 
   env = {

--- a/pkgs/by-name/fr/froide/package.nix
+++ b/pkgs/by-name/fr/froide/package.nix
@@ -121,8 +121,8 @@ python.pkgs.buildPythonApplication rec {
 
   pnpmDeps = fetchPnpmDeps {
     inherit pname version src;
-    fetcherVersion = 1;
-    hash = "sha256-g7YX2fVXGmb3Qq9NNCb294bk4/0khcIZVSskYbE8Mdw=";
+    fetcherVersion = 3;
+    hash = "sha256-NbfCVD+gmtoxuYUCumTKj9P72utK787VdlnuU4lMMGc=";
   };
 
   postBuild = ''

--- a/pkgs/by-name/go/goaway/package.nix
+++ b/pkgs/by-name/go/goaway/package.nix
@@ -28,8 +28,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/client";
-      fetcherVersion = 1;
-      hash = "sha256-cJLJMJNDPr73w5IiB1/zIloIdsUhqI+o/JqoKNwNweI=";
+      fetcherVersion = 3;
+      hash = "sha256-1YZf32lDwX3e9EC0Uixyo+yDczfU4/ZSlG+jFZwf+38=";
     };
 
     pnpmRoot = "client";

--- a/pkgs/by-name/go/goofcord/package.nix
+++ b/pkgs/by-name/go/goofcord/package.nix
@@ -46,8 +46,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 1;
-    hash = "sha256-8dSyU9arSvISc2kDWbg/CP6L4sZjZi/Zv7TZN4ONOjQ=";
+    fetcherVersion = 3;
+    hash = "sha256-NKind57XDW7I5XNmjAu4cqkK5UVNAaKewpfOTNzF2BM=";
   };
 
   env = {

--- a/pkgs/by-name/ho/homebox/package.nix
+++ b/pkgs/by-name/ho/homebox/package.nix
@@ -41,8 +41,8 @@ buildGoModule {
     inherit pname version;
     src = "${src}/frontend";
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-MG2IzSOjdGIjuKOtbDlI6UY+67+6/AAsnBscFvs2V4o=";
+    fetcherVersion = 3;
+    hash = "sha256-105HgNiC7QCsUn6mcYyRCqhOuMl8bZQlwoaOavi3dkk=";
   };
   pnpmRoot = "../frontend";
 

--- a/pkgs/by-name/it/it-tools/package.nix
+++ b/pkgs/by-name/it/it-tools/package.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
       src
       ;
     pnpm = pnpm_8;
-    fetcherVersion = 1;
-    hash = "sha256-m1eXBE5rakcq8NGnPC9clAAvNJQrN5RuSQ94zfgGZxw=";
+    fetcherVersion = 3;
+    hash = "sha256-dsjf2TyLAqPzR8OXJgNcoOdDZj2t+H+tLfRhfPsu1G8=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/je/jellyseerr/package.nix
+++ b/pkgs/by-name/je/jellyseerr/package.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 1;
-    hash = "sha256-3df72m/ARgfelBLE6Bhi8+ThHytowVOBL2Ndk7auDgg=";
+    fetcherVersion = 3;
+    hash = "sha256-kCM6oNfBlVsjItzBDxSbeLu0+53I5XzxcerpCTEvZ0M=";
   };
 
   buildInputs = [ sqlite ];

--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -47,8 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 1;
-    hash = "sha256-9sdN5tbCCe/euTo8zRkU0C3yQ8sAufPyN8a4GeJW/Us=";
+    fetcherVersion = 3;
+    hash = "sha256-MgUOOr188t+t/4sTXVpbr+xYT/1qf7/B0ZG0w+QkVxc=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/me/memos/package.nix
+++ b/pkgs/by-name/me/memos/package.nix
@@ -24,8 +24,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/web";
-      fetcherVersion = 1;
-      hash = "sha256-k+pykzAiZ72cMMH+6qtnNxjaq4m4QyCQuWvQPbZSZho=";
+      fetcherVersion = 3;
+      hash = "sha256-xEOnxCgBD4uLypcZzCO+31S4r0sSfz8PpgEmZASeRZ4=";
     };
     pnpmRoot = "web";
     nativeBuildInputs = [

--- a/pkgs/by-name/me/metacubexd/package.nix
+++ b/pkgs/by-name/me/metacubexd/package.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-UVf9ti4Cu4IACQQ16g7R6pIArJUUVn2XOC7CjXMMS9I=";
+    fetcherVersion = 3;
+    hash = "sha256-i6MSmv6dS/bkpKvId6oroKPAtFYk5OUIvUWyfFa/NJU=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
+++ b/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
@@ -76,8 +76,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-+/PGCoHAC9Hsl2YEdjvUBzDJi9iBf+ZxT/6yjDE3yBo=";
+    fetcherVersion = 3;
+    hash = "sha256-1ZBIMqG6YPZ8++jG6qzhHEgFx1Y6JR8BBLB3JfuNyNU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mo/moonfire-nvr/package.nix
+++ b/pkgs/by-name/mo/moonfire-nvr/package.nix
@@ -36,8 +36,8 @@ let
       inherit (finalAttrs) pname version src;
       pnpm = pnpm_9;
       sourceRoot = "${finalAttrs.src.name}/ui";
-      fetcherVersion = 1;
-      hash = "sha256-7fMhUFlV5lz+A9VG8IdWoc49C2CTdLYQlEgBSBqJvtw=";
+      fetcherVersion = 3;
+      hash = "sha256-1bkuou8jfWqdev4ZlpqvC4BRrFj//LK6ImVvSeMUEuM=";
     };
     installPhase = ''
       runHook preInstall

--- a/pkgs/by-name/op/opencloud/web.nix
+++ b/pkgs/by-name/op/opencloud/web.nix
@@ -22,8 +22,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-v2XOBO1/BWaJslj2Z2k9RanSS2CsW2Yx72o/lX7Eo2I=";
+    fetcherVersion = 3;
+    hash = "sha256-tPU16r0hc0DYwGnvnukivUz3a+Bz6urUZPtokN/lbuA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Migrate various packages using `fetchPnpmDeps` from `fetcherVersion = 1` to `fetcherVersion = 3` and update their hashes accordingly.

`fetcherVersion = 1` is deprecated and will be removed. Version 3 uses a more robust fetching strategy.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test