### PR TITLE
various: migrate fetchPnpmDeps from fetcherVersion = 1 to fetcherVersion = 3 (part 3)

### DIFF
--- a/pkgs/by-name/ov/overlayed/package.nix
+++ b/pkgs/by-name/ov/overlayed/package.nix
@@ -36,8 +36,8 @@ rustPlatform.buildRustPackage rec {
   pnpmDeps = fetchPnpmDeps {
     inherit pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-+yyxoodcDfqJ2pkosd6sMk77/71RDsGthedo1Oigwto=";
+    fetcherVersion = 3;
+    hash = "sha256-KJZuucXB7BEMnqPmgytveG/IBEzq4mgMo9ZJHPe/gVs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pa/parca/package.nix
+++ b/pkgs/by-name/pa/parca/package.nix
@@ -27,8 +27,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname src version;
       pnpm = pnpm_9;
-      fetcherVersion = 1;
-      hash = "sha256-MRzM3CrfJmmIHBcqHKuaEwmCm9a2RFXKJXtwY2v1SuI=";
+      fetcherVersion = 3;
+      hash = "sha256-RGIwJELFVUvDnci/uobnwhMBlCM4eEt2SHtuiZwF4BI=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/pg/pgrok/package.nix
+++ b/pkgs/by-name/pg/pgrok/package.nix
@@ -41,8 +41,8 @@ buildGoModule {
       src
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-o6wxO8EGRmhcYggJnfxDkH+nbt+isc8bfHji8Hu9YKg=";
+    fetcherVersion = 3;
+    hash = "sha256-gVwwLTOA8rXsy8xg4uGPJyBdQ8yUqkiul9W5oKw6kGI=";
   };
 
   vendorHash = "sha256-l/tUO7fevi+zUmUp6CQoVNrzMF7LIzbo2Qsa/ez6LiA=";

--- a/pkgs/by-name/pi/piped/package.nix
+++ b/pkgs/by-name/pi/piped/package.nix
@@ -38,8 +38,8 @@ buildNpmPackage rec {
       src
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-WtZfRZFRV9I1iBlAoV69GGFjdiQhTSBG/iiEadPVcys=";
+    fetcherVersion = 3;
+    hash = "sha256-IB/suR1I1hNip1qpIcUCP0YyUEDV2EwE5F2WXW8OhmU=";
   };
 
   passthru.updateScript = unstableGitUpdater { };

--- a/pkgs/by-name/po/porn-vault/package.nix
+++ b/pkgs/by-name/po/porn-vault/package.nix
@@ -54,8 +54,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm';
-    fetcherVersion = 1;
-    hash = "sha256-Xr9tRiP1hW+aFs9FnPvPkeJ0/LtJI57cjWY5bZQaRTQ=";
+    fetcherVersion = 3;
+    hash = "sha256-CAsUP+bLrTkbUd3h/FP4gBVwZECyqQg0nnmap4zsRTs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pr/prisma_6/package.nix
+++ b/pkgs/by-name/pr/prisma_6/package.nix
@@ -35,8 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-y0gxeOeQNZZu3/UEI/DmdhVD8kSrUnK5G/n/WLhiLZ4=";
+    fetcherVersion = 3;
+    hash = "sha256-BnluGYEVQbhVdEL/RvJTTGEQT1XrLjaTm2iI7Sqd3ZE=";
   };
 
   patchPhase = ''

--- a/pkgs/by-name/rm/rmfakecloud/package.nix
+++ b/pkgs/by-name/rm/rmfakecloud/package.nix
@@ -34,8 +34,8 @@ buildGoModule rec {
     sourceRoot = "${src.name}/ui";
     pnpmLock = "${src}/ui/pnpm-lock.yaml";
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-uywmHN9HWKi0CaqTg9uEio2XCu6ap9v2xtbodW/6b4Q=";
+    fetcherVersion = 3;
+    hash = "sha256-YhcPR7aObZiV0FibcogjrOGNo2+syUuusaW+yx1HRv8=";
   };
   preBuild = lib.optionals enableWebui ''
     # using sass-embedded fails at executing node_modules/sass-embedded-linux-x64/dart-sass/src/dart

--- a/pkgs/by-name/rq/rquickshare/package.nix
+++ b/pkgs/by-name/rq/rquickshare/package.nix
@@ -50,8 +50,8 @@ rustPlatform.buildRustPackage rec {
       ;
     pnpm = pnpm_9;
     postPatch = "cd ${pnpmRoot}";
-    fetcherVersion = 1;
-    hash = "sha256-VbdMaIEL1e+0U+ny4qbk1Mmkuc3cahKakKKYowCBK5Q=";
+    fetcherVersion = 3;
+    hash = "sha256-ESm7YVVbsfjpgYeNf3aVhJawpWhbeNdo0u7cBzLmEMw=";
   };
 
   cargoRoot = "app/main/src-tauri";

--- a/pkgs/by-name/rs/rsshub/package.nix
+++ b/pkgs/by-name/rs/rsshub/package.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-zTsJZnhX7xUOsKST6S3TQUV8M1Tewcs9fZgrDSf5ba8=";
+    fetcherVersion = 3;
+    hash = "sha256-jV+MpdNeaVHut0eUP7F9SmJZuLDGQE8ULR8LsiOE7Ug=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -99,8 +99,8 @@ stdenv.mkDerivation (finalAttrs: {
       postPatch
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-GLwREEnDf3NIbQsX+LA/n6zZYvTlyiJaozfKyk04go8=";
+    fetcherVersion = 3;
+    hash = "sha256-Dp684KKAb8Ge2PyPhBFgIB17Fs6swAF/Fw2z9SN4Aio=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/app";

--- a/pkgs/by-name/sl/slimevr/package.nix
+++ b/pkgs/by-name/sl/slimevr/package.nix
@@ -41,8 +41,8 @@ rustPlatform.buildRustPackage rec {
     pname = "${pname}-pnpm-deps";
     inherit version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-ExjEAr38GX2iZThVj3C3N/9mPgf0Bs7J5OAwtDdmn6I=";
+    fetcherVersion = 3;
+    hash = "sha256-deVfRZcMFkOVWXmNUiixmd5WBfIFKxG2Gw3CfshspYo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -31,8 +31,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-PVA6sXbiuxqvi9u3sPoeVIJSSpSbFQHQQnTFO3w31WE=";
+    fetcherVersion = 3;
+    hash = "sha256-qzUvA00ujnIibQAONOPlp5BsXcwQb/gQvOPp83hMT5A=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/sy/synchrony/package.nix
+++ b/pkgs/by-name/sy/synchrony/package.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-+hS4UK7sncCxv6o5Yl72AeY+LSGLnUTnKosAYB6QsP0=";
+    fetcherVersion = 3;
+    hash = "sha256-c6wtu/3tNCobLqJaB3hB9HP34ObijBQ/9ZcIzGetaT0=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/sy/syncyomi/package.nix
+++ b/pkgs/by-name/sy/syncyomi/package.nix
@@ -49,8 +49,8 @@ buildGoModule (finalAttrs: {
         sourceRoot
         ;
       pnpm = pnpm_9;
-      fetcherVersion = 1;
-      hash = "sha256-Gg4nOxqWb692GvvwE7AJKQzGrrLLW7haaooEkUZW7FQ=";
+      fetcherVersion = 3;
+      hash = "sha256-hRMHvfzfjOzvcCHFhDLxuq2qZ3mi4/333nEcQANbJ/o=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/ta/tabby-agent/package.nix
+++ b/pkgs/by-name/ta/tabby-agent/package.nix
@@ -52,8 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-SiJJxRzmKQxqw3UESN7q+3qkU1nK+7z6K5RpIMRRces=";
+    fetcherVersion = 3;
+    hash = "sha256-xx45vudeW6OnUgyH0N+gQI5GPT8k5B4x0HdCvHF+f9A=";
   };
 
   passthru.updateScript = nix-update-script {


### PR DESCRIPTION
Migrate various packages using `fetchPnpmDeps` from `fetcherVersion = 1` to `fetcherVersion = 3` and update their hashes accordingly.

`fetcherVersion = 1` is deprecated and will be removed. Version 3 uses a more robust fetching strategy.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test