### PR TITLE
various: migrate fetchPnpmDeps from fetcherVersion = 1 to fetcherVersion = 3 (part 4)

### DIFF
--- a/pkgs/by-name/fl/flood/package.nix
+++ b/pkgs/by-name/fl/flood/package.nix
@@ -30,8 +30,8 @@ buildNpmPackage rec {
       src
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-CT0e/IaAhFqRG+FdlA6ZIXOcmy1IzDdd677XV81SgHY=";
+    fetcherVersion = 3;
+    hash = "sha256-OqaRlqL08W8V35TYBk2mvgPDl58rLQV/avnSQGBvdNY=";
   };
 
   passthru = {

--- a/pkgs/by-name/oc/ocis/web.nix
+++ b/pkgs/by-name/oc/ocis/web.nix
@@ -44,8 +44,8 @@ stdenvNoCC.mkDerivation rec {
       src
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-3Erva6srdkX1YQ727trx34Ufx524nz19MUyaDQToz6M=";
+    fetcherVersion = 3;
+    hash = "sha256-EsoGio2D8HZmbe+uuzsOhhwaLMSbJcfV4iUJUaqtA0M=";
   };
 
   meta = {

--- a/pkgs/by-name/ta/tailwindcss-language-server/package.nix
+++ b/pkgs/by-name/ta/tailwindcss-language-server/package.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
       pnpmWorkspaces
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-1F4DeqJWJs3L1hDzNn7PJr9sSBv2TcN8QfV8/pwAKuU=";
+    fetcherVersion = 3;
+    hash = "sha256-3pHEmYMgQuHFFMyGeFzo9BWRFt6yvWzFFMJEdRhwS2w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ta/taler-wallet-core/package.nix
+++ b/pkgs/by-name/ta/taler-wallet-core/package.nix
@@ -61,8 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm';
-    fetcherVersion = 1;
-    hash = "sha256-jwoSvqE0hqRxu76vDtUOpZxvi4SsmKukfpmp5G6ZV/I=";
+    fetcherVersion = 3;
+    hash = "sha256-a1ym/UpUufUPTGL3dozZ9Jb0eX1XVB7Hahek25eLvc4=";
   };
 
   buildInputs = [ nodejs_20 ];

--- a/pkgs/by-name/ta/taze/package.nix
+++ b/pkgs/by-name/ta/taze/package.nix
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-cLh9iiDLW3CDg8R+I3TSEMdnyv1KaHelubvF31oGrWk=";
+    fetcherVersion = 3;
+    hash = "sha256-x9XPnvyrAmFqIMhjBFQYQE1qKDG6uxzd0NnxIjdOXio=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/te/textlint/package.nix
+++ b/pkgs/by-name/te/textlint/package.nix
@@ -58,8 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
       patches
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-TyKtH4HjCDTydVd/poG05Yh5nRSfcrSPzFLEE3Oq2uo=";
+    fetcherVersion = 3;
+    hash = "sha256-TYMhAcmfWHbj/0yLNYiJXWd1GiYb+zqBLj2/83cGbzg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ts/tsx/package.nix
+++ b/pkgs/by-name/ts/tsx/package.nix
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
       src
       ;
     pnpm = pnpm';
-    fetcherVersion = 1;
-    hash = "sha256-6ZizQtZC43yXrz634VXksRCKGkDKryICvT3Q+JCuIEw=";
+    fetcherVersion = 3;
+    hash = "sha256-7JdL2qz663+y3tzeK0LLn57vSsQ0P0d+FofRimWVjrM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vt/vtsls/package.nix
+++ b/pkgs/by-name/vt/vtsls/package.nix
@@ -46,8 +46,8 @@ stdenv.mkDerivation (finalAttrs: {
       version
       ;
     pnpm = pnpm';
-    fetcherVersion = 1;
-    hash = "sha256-SdqeTYRH60CyU522+nBo0uCDnzxDP48eWBAtGTL/pqg=";
+    fetcherVersion = 3;
+    hash = "sha256-1P2ph8ZX6/KptkLP4wk0dZzuvnYCLOWorM1b9+otKsE=";
   };
 
   # Patches to get submodule sha from file instead of 'git submodule status'

--- a/pkgs/by-name/vu/vue-language-server/package.nix
+++ b/pkgs/by-name/vu/vue-language-server/package.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 1;
-    hash = "sha256-unlZBLcDGP6laU2smtOP+hVrvp8HDPBqEk3MmmhO8sE=";
+    fetcherVersion = 3;
+    hash = "sha256-koRJkT/JloptmtQKLprqms53TL/Q4XHaktIl/6PIasw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/we/wealthfolio/package.nix
+++ b/pkgs/by-name/we/wealthfolio/package.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) src pname version;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-feM1jQsUDKVX4+x4Otdwx6AEM+FO7fiaJjmMbU6GDf8=";
+    fetcherVersion = 3;
+    hash = "sha256-PnKQthd36HiomYIsjB+TQqVNUX5Wocgnrz0SeHfhEyY=";
   };
 
   cargoRoot = ".";

--- a/pkgs/by-name/ze/zenn-cli/package.nix
+++ b/pkgs/by-name/ze/zenn-cli/package.nix
@@ -40,8 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
       pnpmWorkspaces
       ;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-WXsS5/J08n/dWV5MbyX4vK7j1mfiUoLdzwmzyqoX3FA=";
+    fetcherVersion = 3;
+    hash = "sha256-uxeZnYZzwyNOZN1x1f6tzcYgPbJhSc3gTdsfaE+967w=";
   };
 
   preBuild = ''

--- a/pkgs/by-name/zi/zigbee2mqtt/package.nix
+++ b/pkgs/by-name/zi/zigbee2mqtt/package.nix
@@ -26,8 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-8ioe9/gSI9u9ehrnj3L1j+vPS9p+nJGs2d8TdZTEsk4=";
+    fetcherVersion = 3;
+    hash = "sha256-uYzY1ixKTughpc6JfoMmp4/RKdgP1cKBuMMLZspSx18=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/django-filingcabinet/default.nix
+++ b/pkgs/development/python-modules/django-filingcabinet/default.nix
@@ -97,8 +97,8 @@ buildPythonPackage rec {
 
   pnpmDeps = fetchPnpmDeps {
     inherit pname version src;
-    fetcherVersion = 1;
-    hash = "sha256-kvLV/pCX/wQHG0ttrjSro7/CoQ5K1T0aFChafQOwvNw=";
+    fetcherVersion = 3;
+    hash = "sha256-p+RpEDVbdYmeSD4bB0oUMrTpsVDGYkqME13awnoTNd0=";
   };
 
   postBuild = ''

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/custom-sidebar/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/custom-sidebar/package.nix
@@ -21,8 +21,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    fetcherVersion = 1;
-    hash = "sha256-VbmbqTwuXfJQVSaQHGVwIZJf7350HsH+TGeVCtCXL38=";
+    fetcherVersion = 3;
+    hash = "sha256-gUVETXrl5rcXvn0YeKLfM+eErUpMxCuVlAOoyqQkLXs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -305,8 +305,8 @@ let
       pname = "discourse-assets";
       inherit version src;
       pnpm = pnpm;
-      fetcherVersion = 1;
-      hash = "sha256-/vPNHEB/ZuHWnSLqfz2NM/scSRH9wzotzjunDAw5Imc=";
+      fetcherVersion = 3;
+      hash = "sha256-xft/2x0iti0yJ53uI9q2+FSvKgWWfKQzlMlPFz3RZsE=";
     };
 
     nativeBuildInputs = runtimeDeps ++ [


### PR DESCRIPTION
Migrate various packages using `fetchPnpmDeps` from `fetcherVersion = 1` to `fetcherVersion = 3` and update their hashes accordingly.

`fetcherVersion = 1` is deprecated and will be removed. Version 3 uses a more robust fetching strategy.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test