### PR TITLE
various: migrate fetchPnpmDeps from fetcherVersion = 1 to fetcherVersion = 3 (part 1)

### DIFF
--- a/pkgs/by-name/ao/aonsoku/package.nix
+++ b/pkgs/by-name/ao/aonsoku/package.nix
@@ -29,8 +29,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_8;
-    fetcherVersion = 1;
-    hash = "sha256-h1rcM+H2c0lk7bpGeQT5ue9bQIggrCFHkj4o7KxnH08=";
+    fetcherVersion = 3;
+    hash = "sha256-gOPjNZCljr8OvU/xLs9ZQ27dl3RatscXddOyPfSVdoE=";
   };
 
   cargoRoot = "src-tauri";

--- a/pkgs/by-name/ap/apache-airflow/python-package.nix
+++ b/pkgs/by-name/ap/apache-airflow/python-package.nix
@@ -111,8 +111,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       pname = "airflow-ui";
       inherit sourceRoot src version;
-      fetcherVersion = 1;
-      hash = "sha256-UcEFQkDZ9Ye+VfyJ9rdZKe0wilTgO4dMsULABWfL2Co=";
+      fetcherVersion = 3;
+      hash = "sha256-jpv47+DAAoMB4pJBcv5G6zTGQ+/qdg86iQ/H22gwpro=";
     };
 
     buildPhase = ''
@@ -140,8 +140,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       pname = "simple-auth-manager-ui";
       inherit sourceRoot src version;
-      fetcherVersion = 1;
-      hash = "sha256-8nZdWnhERUkiaY8USyy/a/j+dMksjmEzCabSkysndSE=";
+      fetcherVersion = 3;
+      hash = "sha256-ccLGYaAYJWSgegO+IfVZv1WdZ5YjhYYTZivqtDjdoOk=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/ap/apache-answer/package.nix
+++ b/pkgs/by-name/ap/apache-answer/package.nix
@@ -29,8 +29,8 @@ buildGoModule (finalAttrs: {
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) src version pname;
       sourceRoot = "${finalAttrs.src.name}/ui";
-      fetcherVersion = 1;
-      hash = "sha256-6IeLOwsEqchCwe0GGj/4v9Q4/Hm16K+ve2X+8QHztQM=";
+      fetcherVersion = 3;
+      hash = "sha256-0Jqe0wig28Vb9y0/tZHDfE49MehNR7kJTpChz616tzU=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/ar/artalk/package.nix
+++ b/pkgs/by-name/ar/artalk/package.nix
@@ -37,8 +37,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       pnpm = pnpm_9;
-      fetcherVersion = 1;
-      hash = "sha256-QIfadS2gNPtH006O86EndY/Hx2ml2FoKfUXJF5qoluw=";
+      fetcherVersion = 3;
+      hash = "sha256-HypDGYb0MRCIDBHY8pVgwFoZQWC8us44cunORZRk3RM=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/au/authelia/sources.nix
+++ b/pkgs/by-name/au/authelia/sources.nix
@@ -10,5 +10,5 @@ rec {
     hash = "sha256-u7TIhOGXfvWdAXvpL5qa43jaoa7PNAVL2MtGEuWBDPc=";
   };
   vendorHash = "sha256-7RoPv4OvOhiv+TmYOJuW95h/uh2LuTrpUSAZiTvbh7g=";
-  pnpmDepsHash = "sha256-uRwSpy/aZA4hG2rEY8hlD8pXJ7lvNoIa6a3VSZuZgcs=";
+  pnpmDepsHash = "sha256-Ck2nqFwDv3OxN0ONA3A+h4Rli1te+EYqKivcqrAInKw=";
 }

--- a/pkgs/by-name/au/authelia/web.nix
+++ b/pkgs/by-name/au/authelia/web.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
       sourceRoot
       ;
     inherit pnpm; # This may be different than pkgs.pnpm
-    fetcherVersion = 1;
+    fetcherVersion = 3;
     hash = pnpmDepsHash;
   };
 

--- a/pkgs/by-name/au/autoprefixer/package.nix
+++ b/pkgs/by-name/au/autoprefixer/package.nix
@@ -29,8 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-fyygZMpRMm5tL5/kpERKXUNA9qqDt6ZkzT4zWtqQSv8=";
+    fetcherVersion = 3;
+    hash = "sha256-PPYyEsc0o5ufBexUdiX9EJLEsQZ0wX7saBzxJGsnseU=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -39,8 +39,8 @@ let
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
       pnpm = pnpm_9;
-      fetcherVersion = 1;
-      hash = "sha256-vJgsU0OXyAKjUJsPOyIY8o3zfNW1BUZ5IL814wmJr3o=";
+      fetcherVersion = 3;
+      hash = "sha256-9wzPNZxLE0l/AJ8SyE0SkhkBImiibhqJgsG3UrGj3aA=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/ca/cargo-tauri/test-app.nix
+++ b/pkgs/by-name/ca/cargo-tauri/test-app.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_9;
 
-    fetcherVersion = 1;
-    hash = "sha256-gHniZv847JFrmKnTUZcgyWhFl/ovJ5IfKbbM5I21tZc=";
+    fetcherVersion = 3;
+    hash = "sha256-/g+2jZQq3nTJnKpj0PlT6zB3UcUBE2ND8797XRwVZ0s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cl/clash-verge-rev/package.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/package.nix
@@ -21,7 +21,7 @@ let
     hash = "sha256-GmoeOLKxdW1x6PHtslwNPVq8wDWA413NHA/VeDRb4mA=";
   };
 
-  pnpm-hash = "sha256-qDwXPTfh1yOlugZe1UPUMKRyZOSagG4lX2eiFACgHRw=";
+  pnpm-hash = "sha256-o3VPb+D74bjwEex7UFmwfx8N1yGolPqNaIeJ7/cjB0c=";
   vendor-hash = "sha256-z5xVbqh+CiaTDtAx2VPQ4UjliYnV44tdp3pS8vzb1K4=";
 
   service = callPackage ./service.nix {

--- a/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage {
       src
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
+    fetcherVersion = 3;
     hash = pnpm-hash;
   };
 

--- a/pkgs/by-name/da/daed/package.nix
+++ b/pkgs/by-name/da/daed/package.nix
@@ -34,8 +34,8 @@ let
         src
         ;
       pnpm = pnpm_9;
-      fetcherVersion = 1;
-      hash = "sha256-+yLpSbDzr1OV/bmUUg6drOvK1ok3cBd+RRV7Qrrlp+Q=";
+      fetcherVersion = 3;
+      hash = "sha256-FBZk7qeYNi7JX99Sk1qe52YUE8GUYINJKid0mEBXMjU=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/do/dorion/package.nix
+++ b/pkgs/by-name/do/dorion/package.nix
@@ -72,8 +72,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       patches
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-fX48yZKntte4OxLjXqepZQyGdN/bv4o+n+v5ZT5lXMo=";
+    fetcherVersion = 3;
+    hash = "sha256-qSmIyLv8A+JDbTVG+Qcvq3gqBXBGtfbH4/tN+CvEmd8=";
   };
 
   # CMake (webkit extension)

--- a/pkgs/by-name/em/emmet-language-server/package.nix
+++ b/pkgs/by-name/em/emmet-language-server/package.nix
@@ -22,8 +22,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-sMOC5MQmJKwXZoUZnOmBy2I83SNMdrPc6WQKmeVGiCc=";
+    fetcherVersion = 3;
+    hash = "sha256-livnY/iwd7gqy6SKFBMF2MSIs7LVFec4BFqMBVasGWE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/eq/equicord/package.nix
+++ b/pkgs/by-name/eq/equicord/package.nix
@@ -32,8 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-um8CmR4H+sck6sOpIpnISPhYn/rvXNfSn6i/EgQFvk0=";
+    fetcherVersion = 3;
+    hash = "sha256-L4qy3zMM6ksYcBT7gB6qCzfZIELVe+KZZxTSnfI3Rkk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/et/etherpad-lite/package.nix
+++ b/pkgs/by-name/et/etherpad-lite/package.nix
@@ -31,8 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-/GqRoGWIQhOwKlbe4I6yTuGs+IOn4crPhwHt4ALJ97E=";
+    fetcherVersion = 3;
+    hash = "sha256-y5T7yerCK9MtTri3eZ+Iih7/DK9IMDC+d7ej746g47E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fe/fedistar/package.nix
+++ b/pkgs/by-name/fe/fedistar/package.nix
@@ -37,8 +37,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-xXVsjAXmrsOp+mXrYAxSKz4vX5JApLZ+Rh6hrYlnJDI=";
+    fetcherVersion = 3;
+    hash = "sha256-IznO8PJZCr6MR3mShD+Uqk2ACx8mrxTVWRTbk81zFEc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/si/signal-desktop/signal-sqlcipher.nix
+++ b/pkgs/by-name/si/signal-desktop/signal-sqlcipher.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm; # may be different than top-level pnpm
-    fetcherVersion = 1;
-    hash = "sha256-regaYG+SDvIgdnHQVR1GG1A1FSBXpzFfLuyTEdMt1kQ=";
+    fetcherVersion = 3;
+    hash = "sha256-/EcPuqTXXGw1dEN6l1x84cUGyx890/rujjT+zJouIvM=";
   };
 
   cargoRoot = "deps/extension";

--- a/pkgs/servers/web-apps/lemmy/pin.json
+++ b/pkgs/servers/web-apps/lemmy/pin.json
@@ -4,5 +4,5 @@
   "serverHash": "sha256-8j18F0I7GnZ4OxIvWM9N4CEe9TnRJKAqukb1160ygv8=",
   "serverCargoHash": "sha256-8I3ZoMhfxdfhOF/cmtNZew3QgjuIgKLbuftS9Y7FHhw=",
   "uiHash": "sha256-vynfOAi7sRBJbA9y/2RULq79PP0YkgvlUZz6jOxPlhs=",
-  "uiPNPMDepsHash": "sha256-tuarUG1uKx6Q1O+rF6DHyK8MEseF9lKk34qtRWWScAg="
+  "uiPNPMDepsHash": "sha256-UOovErxC060rAVTERdNdZRg+zP2RHL6Hii8RqVe5ye8="
 }

--- a/pkgs/servers/web-apps/lemmy/ui.nix
+++ b/pkgs/servers/web-apps/lemmy/ui.nix
@@ -43,7 +43,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
+    fetcherVersion = 3;
     hash = pinData.uiPNPMDepsHash;
   };
 


### PR DESCRIPTION
Migrate various packages using `fetchPnpmDeps` from `fetcherVersion = 1` to `fetcherVersion = 3` and update their hashes accordingly.

`fetcherVersion = 1` is deprecated and will be removed. Version 3 uses a more robust fetching strategy.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test