### PR TITLE
birdfont: migrate to by-name, fix gcc15 error

### DIFF
--- a/pkgs/by-name/bi/birdfont/package.nix
+++ b/pkgs/by-name/bi/birdfont/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "birdfont";
-  version = "2.33.6-unstable-2025-11-23";
+  version = "2.33.6-unstable-2025-11-23"; # For gcc15 error fix, remove unstable versioning in next release
 
   src = fetchFromGitHub {
     owner = "johanmattssonm";

--- a/pkgs/by-name/bi/birdfont/package.nix
+++ b/pkgs/by-name/bi/birdfont/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "birdfont";
-  version = "2.33.6";
+  version = "2.33.6-unstable-2025-11-23";
 
   src = fetchFromGitHub {
     owner = "johanmattssonm";
     repo = "birdfont";
-    tag = "v${finalAttrs.version}";
-    sha256 = "sha256-7xVjY/yH7pMlUBpQc5Gb4t4My24Mx5KkARVp2KSr+Iw=";
+    rev = "9865e6611e0bf00cbc5742ae1aab6eca4d04f072";
+    hash = "sha256-ZKnMBLjjoEHGKWGT3gJZ2BId48rOAYjygv3JeS9VKro=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/misc/birdfont/default.nix
+++ b/pkgs/tools/misc/birdfont/default.nix
@@ -64,7 +64,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = "./install.py";
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
+  };
 
   meta = {
     description = "Font editor which can generate fonts in TTF, EOT, SVG and BIRDFONT format";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1962,7 +1962,6 @@ with pkgs;
 
   binlore = callPackage ../development/tools/analysis/binlore { };
 
-  birdfont = callPackage ../tools/misc/birdfont { };
   xmlbird = callPackage ../tools/misc/birdfont/xmlbird.nix { stdenv = gccStdenv; };
 
   bmrsa = callPackage ../tools/security/bmrsa/11.nix { };


### PR DESCRIPTION
This pull request updates the packaging for `birdfont` by moving its package definition, updating its source and versioning scheme, and improving the update script configuration. The most important changes are grouped below:

**Package relocation and versioning:**
* Renamed and moved the package file from `pkgs/tools/misc/birdfont/default.nix` to `pkgs/by-name/bi/birdfont/package.nix` to follow the new directory structure.
* Updated the version to `2.33.6-unstable-2025-11-23` and switched to fetching a specific git revision instead of a tagged release, with the corresponding hash updated.

**Update script improvements:**
* Modified the `passthru.updateScript` to use an attribute set, adding `extraArgs = [ "--version=branch" ]` to better handle version updates from branches.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
