### PR TITLE
avro-cpp: build failure due to boost 1.89

### DIFF
--- a/pkgs/by-name/av/avro-cpp/0004-remove-boost-system-component.patch
+++ b/pkgs/by-name/av/avro-cpp/0004-remove-boost-system-component.patch
@@ -1,0 +1,15 @@
+Remove boost_system component from find_package
+
+Boost 1.89.0 removed the separate boost_system compiled library.
+The boost::system headers are still available through the core Boost package.
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -79,7 +79,7 @@ endif ()
+
+
+ find_package (Boost 1.38 REQUIRED
+-    COMPONENTS filesystem iostreams program_options regex system)
++    COMPONENTS filesystem iostreams program_options regex)
+
+ include(FetchContent)
+ FetchContent_Declare(

--- a/pkgs/by-name/av/avro-cpp/package.nix
+++ b/pkgs/by-name/av/avro-cpp/package.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./0001-get-rid-of-fmt-fetchcontent.patch
     ./0002-fix-fmt-name-formatter.patch
     ./0003-fix-fmt-type-formatter.patch
+    ./0004-remove-boost-system-component.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
 Boost 1.89.0 removed the separate system component (it was header-only for a while and now the cmake target is gone). The avro-cpp CMakeLists.txt at line 82 requests system which no longer exists as a compiled library
 
 Resolves #494312

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
