### PR TITLE
git: fix rust cross-compilation

### DIFF
--- a/pkgs/by-name/gi/git/package.nix
+++ b/pkgs/by-name/gi/git/package.nix
@@ -166,6 +166,11 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace "$x" \
         --subst-var-by ssh "${openssh}/bin/ssh"
     done
+  ''
+  + lib.optionalString (rustSupport && (stdenv.buildPlatform != stdenv.hostPlatform)) ''
+    substituteInPlace Makefile \
+      --replace-fail "RUST_TARGET_DIR = target/" \
+                     "RUST_TARGET_DIR = target/${stdenv.hostPlatform.rust.rustcTargetSpec}/"
   '';
 
   nativeBuildInputs = [
@@ -207,10 +212,16 @@ stdenv.mkDerivation (finalAttrs: {
     libsecret
   ];
 
-  # required to support pthread_cancel()
-  env.NIX_LDFLAGS =
-    lib.optionalString (stdenv.cc.isGNU && stdenv.hostPlatform.libc == "glibc") "-lgcc_s"
-    + lib.optionalString (stdenv.hostPlatform.isFreeBSD) "-lthr";
+  env = {
+    # required to support pthread_cancel()
+    NIX_LDFLAGS =
+      lib.optionalString (stdenv.cc.isGNU && stdenv.hostPlatform.libc == "glibc") "-lgcc_s"
+      + lib.optionalString (stdenv.hostPlatform.isFreeBSD) "-lthr";
+  }
+  // lib.attrsets.optionalAttrs (rustSupport && (stdenv.buildPlatform != stdenv.hostPlatform)) {
+    # Rust cross-compilation
+    CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
+  };
 
   configureFlags = [
     "ac_cv_prog_CURL_CONFIG=${lib.getDev curl}/bin/curl-config"


### PR DESCRIPTION
... while trying to avoid triggering rebuilds in the non-cross case.

It feels like there is surely a better way to do this?

Tagging @wmertens @kashw2 @me-and @philiptaron @zivarah for opinions more than approval. :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] powerpc64le-linux, cross to aarch64-linux and armv7l-linux 
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
