### PR TITLE
Revert "python3Packages.pycookiecheat: 0.8.0 -> 0.11"

### DIFF
--- a/pkgs/development/python-modules/pycookiecheat/default.nix
+++ b/pkgs/development/python-modules/pycookiecheat/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "pycookiecheat";
-  version = "0.11";
+  version = "0.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "n8henrie";
     repo = "pycookiecheat";
-    tag = version;
-    hash = "sha256-hP4J41ctAkrC6HIeKu6ITzK3W0PB7/tCz0cjP42I/J8=";
+    tag = "v${version}";
+    hash = "sha256-jOyTfh2ZhKW/pMU7T5tfxaM0l/g59N+mirnbc0FLPbQ=";
   };
 
   pythonRelaxDeps = [
@@ -64,7 +64,7 @@ buildPythonPackage rec {
   meta = {
     description = "Borrow cookies from your browser's authenticated session for use in Python scripts";
     homepage = "https://github.com/n8henrie/pycookiecheat";
-    changelog = "https://github.com/n8henrie/pycookiecheat/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/n8henrie/pycookiecheat/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       fab


### PR DESCRIPTION
That is really a downgrade to a way older version. 

@mweinelt how to ignore that update the next time?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
