### PR TITLE
daggerfall-unity: fix build

### DIFF
--- a/pkgs/by-name/da/daggerfall-unity/package.nix
+++ b/pkgs/by-name/da/daggerfall-unity/package.nix
@@ -18,6 +18,7 @@
   nix-update-script,
   stdenv,
   vulkan-loader,
+  zlib,
   pname ? "daggerfall-unity",
   includeUnfree ? false,
 }:
@@ -65,6 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpulseaudio
     libudev0-shim
     vulkan-loader
+    zlib
   ];
 
   strictDeps = true;


### PR DESCRIPTION
`libMonoPosixHelper.so` requires `libz.so.1` at runtime, but `zlib` was missing from `buildInputs`, causing `autoPatchelfHook` to fail during the build. This adds `zlib` to fix it.

<details>
<summary>Build failure</summary>

<pre>
error: auto-patchelf could not satisfy dependency libz.so.1 wanted by
.../DaggerfallUnity_Data/MonoBleedingEdge/x86_64/libMonoPosixHelper.so
auto-patchelf failed to find all the required dependencies.
Add the missing dependencies to --libs or use --ignore-missing="foo.so.1 bar.so etc.so".
</pre>

</details>

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.