### PR TITLE
meson: fix postPatch for pypy; pypy3Packages.sphinx: update pypy test paths; pypy3Packages.zopfli: replace setuptools version pin for pypy

### DIFF
--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -72,11 +72,11 @@ python3.pkgs.buildPythonApplication rec {
     if python3.isPyPy then
       ''
         substituteInPlace mesonbuild/modules/python.py \
-          --replace-fail "PythonExternalProgram('python3', mesonlib.python_command)" \
-                         "PythonExternalProgram('${python3.meta.mainProgram}', mesonlib.python_command)"
+          --replace-fail "PythonExternalProgram('python3', mesonlib.python_command" \
+                         "PythonExternalProgram('${python3.meta.mainProgram}', mesonlib.python_command"
         substituteInPlace mesonbuild/modules/python3.py \
-          --replace-fail "state.environment.lookup_binary_entry(mesonlib.MachineChoice.HOST, 'python3')" \
-                         "state.environment.lookup_binary_entry(mesonlib.MachineChoice.HOST, '${python3.meta.mainProgram}')"
+          --replace-fail "state.environment.lookup_binary_entry(mesonlib.MachineChoice.HOST, 'python3'" \
+                         "state.environment.lookup_binary_entry(mesonlib.MachineChoice.HOST, '${python3.meta.mainProgram}'"
         substituteInPlace "test cases"/*/*/*.py "test cases"/*/*/*/*.py \
           --replace-quiet '#!/usr/bin/env python3' '#!/usr/bin/env pypy3' \
           --replace-quiet '#! /usr/bin/env python3' '#!/usr/bin/env pypy3'
@@ -141,6 +141,8 @@ python3.pkgs.buildPythonApplication rec {
       ++ lib.optionals python3.isPyPy [
         # fails for unknown reason
         "test cases/python/4 custom target depends extmodule"
+        # we patch the path to the binary...
+        "test cases/common/26 find program"
       ]
     ))
     ++ [

--- a/pkgs/development/python-modules/sphinx/default.nix
+++ b/pkgs/development/python-modules/sphinx/default.nix
@@ -95,11 +95,11 @@ buildPythonPackage rec {
 
   disabledTestPaths = lib.optionals isPyPy [
     # internals are asserted which are sightly different in PyPy
-    "tests/test_extensions/test_ext_autodoc.py"
-    "tests/test_extensions/test_ext_autodoc_autoclass.py"
-    "tests/test_extensions/test_ext_autodoc_autofunction.py"
-    "tests/test_extensions/test_ext_autodoc_automodule.py"
-    "tests/test_extensions/test_ext_autodoc_preserve_defaults.py"
+    "tests/test_ext_autodoc/test_ext_autodoc.py"
+    "tests/test_ext_autodoc/test_ext_autodoc_autoclass.py"
+    "tests/test_ext_autodoc/test_ext_autodoc_autofunction.py"
+    "tests/test_ext_autodoc/test_ext_autodoc_automodule.py"
+    "tests/test_ext_autodoc/test_ext_autodoc_preserve_defaults.py"
     "tests/test_util/test_util_inspect.py"
     "tests/test_util/test_util_typing.py"
   ];

--- a/pkgs/development/python-modules/zopfli/default.nix
+++ b/pkgs/development/python-modules/zopfli/default.nix
@@ -17,6 +17,11 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-qO6ZKyVJ4JDNPwF4v2Bt1Bop4GE6BM31BUIkZixy3OY=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools<72.2.0" "setuptools"
+  '';
+
   build-system = [ setuptools-scm ];
 
   buildInputs = [ zopfli ];


### PR DESCRIPTION
There is still some other things missing but this gets us somewhere.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
