### PR TITLE
timescaledb-parallel-copy: 0.9.0 -> 0.12.0

### DIFF
--- a/pkgs/by-name/ti/timescaledb-parallel-copy/package.nix
+++ b/pkgs/by-name/ti/timescaledb-parallel-copy/package.nix
@@ -7,16 +7,24 @@
 
 buildGoModule (finalAttrs: {
   pname = "timescaledb-parallel-copy";
-  version = "0.9.0";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "timescale";
     repo = "timescaledb-parallel-copy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vd+2KpURyVhcVf2ESHcyZLJCw+z+WbnTJX9Uy4ZAPoE=";
+    name = "timescaledb-parallel-copy-v0.12.0-source";
+    hash = "sha256-ICy1Z3ePydHN7yTNwL+Zj9tlK2L/w1xa1mPFTZzlmFY=";
   };
 
-  vendorHash = "sha256-MRso2uihMUc+rLwljwZZR1+1cXADCNg+JUpRcRU918g=";
+  vendorHash = "sha256-EB/9U2RROC9IFDkVXe5fPm+pOQUKlse262OQdhZrtn8=";
+
+  #Upstream forgot to bump the hardcoded version string in 0.12.0.
+  #This hack can be removed once they update the version in cmd/timescaledb-parallel-copy/main.go.
+  postPatch = ''
+    substituteInPlace cmd/timescaledb-parallel-copy/main.go \
+      --replace-fail 'version    = "v0.11.0"' 'version    = "v${finalAttrs.version}"'
+  '';
 
   checkFlags =
     let
@@ -24,13 +32,14 @@ buildGoModule (finalAttrs: {
       skippedTests = [
         "TestWriteDataToCSV"
         "TestErrorAtRow"
-        "TestErrorAtRowWithHeader"
         "TestWriteReportProgress"
         "TestFailedBatchHandler"
-        "TestFailedBatchHandlerFailure"
+        "TestTransaction"
+        "TestAtomicity"
+        "TestBatchConflict"
       ];
     in
-    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+    [ "-skip=^(${builtins.concatStringsSep "|" skippedTests})" ];
 
   doInstallCheck = true;
 


### PR DESCRIPTION
Diff: [timescaledb/timescaledb-parallel-copy@v0.9.0...v0.12.0](https://github.com/timescale/timescaledb-parallel-copy/compare/v0.9.0...v0.12.0)

timescaledb-parallel-copy didnt bump the hardcoded version in `/cmd/timescaledb-parallel-copy/main.go` so added a post patch `substituteInPlace cmd/timescaledb-parallel-copy/main.go \
      --replace-fail 'version    = "v0.11.0"' 'version    = "v${finalAttrs.version}"'`

/main.go

## Things done


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
