### PR TITLE
documenso: pin nodejs, use npmDepsFetcherVersion = 2

### DIFF
--- a/pkgs/by-name/do/documenso/package.nix
+++ b/pkgs/by-name/do/documenso/package.nix
@@ -34,7 +34,8 @@ buildNpmPackage (finalAttrs: {
     ./turbo.json.patch
   ];
 
-  npmDepsHash = "sha256-ZddRSBDasa3mMAS2dqXgXRMOc1nvspdXsuTZ7c+einw=";
+  npmDepsFetcherVersion = 2;
+  npmDepsHash = "sha256-Up/P1ZHW+Drlig8lXKVH1/TFNF48fi46yCboOxfMzsk=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/do/documenso/package.nix
+++ b/pkgs/by-name/do/documenso/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  nodejs,
+  nodejs_22,
   node-gyp,
   node-pre-gyp,
   pixman,
@@ -18,6 +18,7 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "documenso";
+  nodejs = nodejs_22;
   version = "1.12.6";
 
   src = fetchFromGitHub {
@@ -84,7 +85,7 @@ buildNpmPackage (finalAttrs: {
     export PRISMA_SCHEMA_ENGINE_BINARY=${prisma-engines_6}
     cd $out/apps/remix
     ${lib.getExe prisma_6} migrate deploy --schema ../../packages/prisma/schema.prisma
-    ${lib.getExe nodejs} build/server/main.js
+    ${lib.getExe nodejs_22} build/server/main.js
     EOF
           chmod +x $out/bin/documenso
 


### PR DESCRIPTION
Split from #494401

- Pin nodejs to nodejs_22 to fix build
- Migrate to npmDepsFetcherVersion = 2

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test