### PR TITLE
python3Packages.mitmproxy: move aioquic v1.2.0 to top-level definitions

### DIFF
--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  aioquic,
+  aioquic_1_2,
   argon2-cffi,
   asgiref,
   bcrypt,
@@ -9,7 +9,6 @@
   certifi,
   cryptography,
   fetchFromGitHub,
-  fetchPypi,
   flask,
   h11,
   h2,
@@ -29,7 +28,6 @@
   pytest-timeout,
   pytest-xdist,
   pytestCheckHook,
-  pythonRelaxDepsHook,
   requests,
   ruamel-yaml,
   setuptools,
@@ -40,18 +38,6 @@
   zstandard,
 }:
 
-let
-  # Workaround for https://github.com/mitmproxy/mitmproxy/pull/7953
-  # nixpkgs' aioquic was updated to 1.3.0, which contains breaking changes that are unpatched in mitmproxy as of right now
-  aioquic' = aioquic.overrideAttrs (old: rec {
-    version = "1.2.0";
-    src = fetchPypi {
-      pname = "aioquic";
-      inherit version;
-      hash = "sha256-+RJjuz9xlIxciRW01Q7jcABPIKQW9n+rPcyQVWx+cZk=";
-    };
-  });
-in
 buildPythonPackage rec {
   pname = "mitmproxy";
   version = "12.2.1";
@@ -81,7 +67,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
-    aioquic'
+    aioquic_1_2
     argon2-cffi
     asgiref
     brotli

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -458,6 +458,16 @@ self: super: with self; {
 
   aioquic = callPackage ../development/python-modules/aioquic { };
 
+  aioquic_1_2 = self.aioquic.overrideAttrs rec {
+    version = "1.2.0";
+
+    src = pkgs.fetchPypi {
+      pname = "aioquic";
+      inherit version;
+      hash = "sha256-+RJjuz9xlIxciRW01Q7jcABPIKQW9n+rPcyQVWx+cZk=";
+    };
+  };
+
   aioraven = callPackage ../development/python-modules/aioraven { };
 
   aiorecollect = callPackage ../development/python-modules/aiorecollect { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Moves aioquic v1.2.0 to the top-level python module definition file.
This is in accordance to #421201, as discussed in https://github.com/NixOS/nixpkgs/pull/494138#discussion_r2860618502

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
