### PR TITLE
python3Packages.pysaunum: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/pysaunum/default.nix
+++ b/pkgs/development/python-modules/pysaunum/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pymodbus,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-timeout,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pysaunum";
+  version = "0.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mettolen";
+    repo = "pysaunum";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0O/U79265YCr3iauVxXL0NRjVy7TZhlfUV3idfYa3fc=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pymodbus ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-timeout
+  ];
+
+  pythonImportsCheck = [ "pysaunum" ];
+
+  meta = {
+    description = "Python library for controlling Saunum sauna controllers via Modbus TCP";
+    homepage = "https://github.com/mettolen/pysaunum";
+    changelog = "https://github.com/mettolen/pysaunum/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -5392,7 +5392,8 @@
       ];
     "saunum" =
       ps: with ps; [
-      ]; # missing inputs: pysaunum
+        pysaunum
+      ];
     "scene" =
       ps: with ps; [
       ];
@@ -8013,6 +8014,7 @@
     "samsungtv"
     "sanix"
     "satel_integra"
+    "saunum"
     "scene"
     "schedule"
     "schlage"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14839,6 +14839,8 @@ self: super: with self; {
 
   pysatochip = callPackage ../development/python-modules/pysatochip { };
 
+  pysaunum = callPackage ../development/python-modules/pysaunum { };
+
   pysbd = callPackage ../development/python-modules/pysbd { };
 
   pysc2 = callPackage ../development/python-modules/pysc2 { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/pysaunum/
- https://github.com/mettolen/pysaunum
- https://www.home-assistant.io/integrations/saunum/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
