### PR TITLE
[25.11] librewolf: add hythera as maintainer

### DIFF
--- a/pkgs/by-name/li/librewolf-unwrapped/package.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/package.nix
@@ -31,6 +31,7 @@ in
     maintainers = with lib.maintainers; [
       dwrege
       fpletz
+      hythera
     ];
     platforms = lib.platforms.unix;
     broken = stdenv.buildPlatform.is32bit;

--- a/pkgs/by-name/li/librewolf-unwrapped/package.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/package.nix
@@ -31,7 +31,6 @@ in
     maintainers = with lib.maintainers; [
       dwrege
       fpletz
-      grimmauld
     ];
     platforms = lib.platforms.unix;
     broken = stdenv.buildPlatform.is32bit;


### PR DESCRIPTION
Manual backport of #493065 and #475727

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
