### PR TITLE
etesync-dav: fix compatibility with Radicale 3.6

### DIFF
--- a/pkgs/by-name/et/etesync-dav/package.nix
+++ b/pkgs/by-name/et/etesync-dav/package.nix
@@ -18,6 +18,11 @@ python3Packages.buildPythonApplication (finalAttrs: {
     hash = "sha256-y4BhU2kSn+RWqc5+pJQFhbwfat9cMWD0ED0EXJp25cY=";
   };
 
+  patches = [
+    # https://github.com/etesync/etesync-dav/pull/365
+    ./radicale-3-6-compat.patch
+  ];
+
   build-system = with python3Packages; [ setuptools ];
 
   pythonRelaxDeps = [ "radicale" ];

--- a/pkgs/by-name/et/etesync-dav/radicale-3-6-compat.patch
+++ b/pkgs/by-name/et/etesync-dav/radicale-3-6-compat.patch
@@ -1,0 +1,72 @@
+diff --git a/etesync_dav/radicale/storage.py b/etesync_dav/radicale/storage.py
+index d6312b1..8d4b0e1 100644
+--- a/etesync_dav/radicale/storage.py
++++ b/etesync_dav/radicale/storage.py
+@@ -22,6 +22,8 @@ from contextlib import contextmanager
+ 
+ import etesync as api
+ import vobject
++import radicale
++from packaging.version import Version
+ from radicale import pathutils
+ from radicale.item import Item, get_etag
+ from radicale.storage import (
+@@ -421,7 +423,10 @@ class Collection(BaseCollection):
+             href_mapper = HrefMapper(content=etesync_item._cache_obj, href=href)
+             href_mapper.save(force_insert=True)
+ 
+-        return self._get(href)
++        uploaded = self._get(href)
++        if Version(radicale.VERSION) >= Version("3.5.5"):
++            return (uploaded, item)
++        return uploaded
+ 
+     def delete(self, href=None):
+         """Delete an item.
+diff --git a/etesync_dav/radicale/storage_etebase_collection.py b/etesync_dav/radicale/storage_etebase_collection.py
+index 1ccc6dd..0f68561 100644
+--- a/etesync_dav/radicale/storage_etebase_collection.py
++++ b/etesync_dav/radicale/storage_etebase_collection.py
+@@ -1,6 +1,8 @@
+ import re
+ 
+ import vobject
++import radicale
++from packaging.version import Version
+ from radicale import pathutils
+ from radicale.item import Item
+ from radicale.storage import (
+@@ -294,7 +296,10 @@ class Collection(BaseCollection):
+             href_mapper = HrefMapper(content=etesync_item.cache_item, href=href)
+             href_mapper.save(force_insert=True)
+ 
+-        return self._get(href)
++        uploaded = self._get(href)
++        if Version(radicale.VERSION) >= Version("3.5.5"):
++            return (uploaded, item)
++        return uploaded
+ 
+     def delete(self, href=None):
+         """Delete an item.
+diff --git a/etesync_dav/radicale/web.py b/etesync_dav/radicale/web.py
+index 869624f..6b4c515 100644
+--- a/etesync_dav/radicale/web.py
++++ b/etesync_dav/radicale/web.py
+@@ -12,6 +12,8 @@
+ # You should have received a copy of the GNU General Public License
+ # along with this program. If not, see <http://www.gnu.org/licenses/>.
+ 
++import radicale
++from packaging.version import Version
+ from radicale import web
+ 
+ from etesync_dav.mac_helpers import has_ssl
+@@ -31,6 +33,8 @@ class Web(web.BaseWeb):
+             environ["wsgi.url_scheme"] = "https"
+         body = list(app(environ, start_response))[0]
+         ret_response.append(body)
++        if Version(radicale.VERSION) >= Version("3.5.10"):
++            ret_response.append(None)  # xml_request field
+         return tuple(ret_response)
+ 
+     def get(self, environ, base_prefix, path, user):


### PR DESCRIPTION
Radicale 3.5.5 changed the upload() return type to a 2-tuple and Radicale 3.5.10 changed WSGIResponse from a 3-tuple to a 4-tuple. Proposed for upstreaming in https://github.com/etesync/etesync-dav/pull/365

The [test was broken since december](https://hydra.nixos.org/build/322093776) but passes now

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
