### PR TITLE
python3Packages.uhooapi: init at 1.2.6

### DIFF
--- a/pkgs/development/python-modules/uhooapi/default.nix
+++ b/pkgs/development/python-modules/uhooapi/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-cov-stub,
+  aioresponses,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "uhooapi";
+  version = "1.2.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "getuhoo";
+    repo = "uhooapi";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DEb54ZoYe9CaxpCoQVpqbQlaZkDLuqRAjiu8SqiI6b0=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ aiohttp ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-cov-stub
+    aioresponses
+  ];
+
+  pythonImportsCheck = [ "uhooapi" ];
+
+  meta = {
+    description = "Python client for uHoo APIs";
+    homepage = "https://github.com/getuhoo/uhooapi";
+    changelog = "https://github.com/getuhoo/uhooapi/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -6495,7 +6495,8 @@
       ];
     "uhoo" =
       ps: with ps; [
-      ]; # missing inputs: uhooapi
+        uhooapi
+      ];
     "uk_transport" =
       ps: with ps; [
       ];
@@ -8103,6 +8104,7 @@
     "twilio"
     "twinkly"
     "twitch"
+    "uhoo"
     "uk_transport"
     "ukraine_alarm"
     "unifi"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20201,6 +20201,8 @@ self: super: with self; {
 
   uhi = callPackage ../development/python-modules/uhi { };
 
+  uhooapi = callPackage ../development/python-modules/uhooapi { };
+
   uiprotect = callPackage ../development/python-modules/uiprotect { };
 
   ujson = callPackage ../development/python-modules/ujson { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/uhooapi/
- https://github.com/getuhoo/uhooapi
- https://www.home-assistant.io/integrations/uhoo/  

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
