### PR TITLE
tlaplus-toolbox: fix crash when opening file dialog

### DIFF
--- a/pkgs/by-name/tl/tlaplus-toolbox/package.nix
+++ b/pkgs/by-name/tl/tlaplus-toolbox/package.nix
@@ -60,6 +60,9 @@ stdenv.mkDerivation (finalAttrs: {
     patchelf --set-interpreter ${bintools.dynamicLinker} \
       "$(find "$out/libexec/toolbox" -name jspawnhelper)"
 
+    # Populate gappsWrapperArgs now instead of in a preFixupPhase.
+    gappsWrapperArgsHook
+
     makeShellWrapper $out/libexec/toolbox/toolbox $out/bin/tla-toolbox \
       --chdir "$out/libexec/toolbox" \
       --add-flags "-data ~/.tla-toolbox" \


### PR DESCRIPTION
This is re-applying the fix from https://github.com/NixOS/nixpkgs/pull/129042, which I think was accidentally partially reverted in https://github.com/NixOS/nixpkgs/pull/441183.

In particular, the application can't find gsettings schemas to open the file dialog and prints this error message:

    No GSettings schemas are installed on the system

The search paths for these schemas is normally set up by gappsWrapperArgsHook in a preFixupPhase, but this package creates the wrapper in the installPhase, so gappsWrapperArgs isn't fully initialized yet. I believe this hook normally runs after install so the glib postInstall hook can also detect schemas in $out, but this package doesn't have any.

It's sufficient to just call gappsWrapperArgsHook and not call fixupPhase like in the original PR. gappsWrapperArgsHook is one of the preFixupPhases, not part of preFixup, so calling fixupPhase won't run it.

@svalaskevicius
@kyehn


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
