### PR TITLE
ocamlPackages.earlybird: 1.3.4 → 1.3.5

### DIFF
--- a/pkgs/development/ocaml-modules/earlybird/default.nix
+++ b/pkgs/development/ocaml-modules/earlybird/default.nix
@@ -21,7 +21,7 @@
 
 buildDunePackage (finalAttrs: {
   pname = "earlybird";
-  version = "1.3.4";
+  version = "1.3.5";
 
   minimalOCamlVersion = "4.12";
 
@@ -29,7 +29,7 @@ buildDunePackage (finalAttrs: {
     owner = "hackwaly";
     repo = "ocamlearlybird";
     tag = finalAttrs.version;
-    hash = "sha256-uwx8N4GDs7NT2fEmNlvdBe2cIZGVPQpoaiiKROFa+kk=";
+    hash = "sha256-QDRtuphOb02L75JyCF9K1NqvIdtWlfefeLG3HmJVHW4=";
   };
 
   nativeBuildInputs = [ menhir ];
@@ -56,6 +56,5 @@ buildDunePackage (finalAttrs: {
     description = "OCaml debug adapter";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.romildo ];
-    broken = ocaml.version == "4.14.3";
   };
 })


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
