### PR TITLE
python3Packages.psycopg: skip failing test

### DIFF
--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -198,6 +198,9 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
+    # error connecting in 'pool-35': connection failed: connection to server at "127.0.0.1",
+    # port 53809 failed: server closed the connection unexpectedly
+    "test_stats_connect"
     # don't depend on mypy for tests
     "test_version"
     "test_package_version"


### PR DESCRIPTION
## Things done

Currently broken on all platforms on `master`.

```
=================================== FAILURES ===================================
_________________________ test_stats_connect[asyncio] __________________________

proxy = <tests.fix_proxy.Proxy object at 0x7ffff485e520>
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7fff8848c3e0>

    @pytest.mark.slow
    @skip_free_threaded("timing not accurate under the free-threaded build")
    async def test_stats_connect(proxy, monkeypatch):
        proxy.start()
        delay_connection(monkeypatch, 0.2)
        async with pool.AsyncConnectionPool(proxy.client_dsn, min_size=3) as p:
            await p.wait()
            stats = p.get_stats()
>           assert stats["connections_num"] == 3
E           assert 4 == 3

tests/pool/test_pool_async.py:872: AssertionError
----------------------------- Captured stderr call -----------------------------
/nix/store/xfrzqp13ilq0zjr1kk0knmcpv8y4vlnc-python3.13-pproxy-2.7.9/lib/python3.13/site-packages/pproxy/__doc__.py:14: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution
/build/source/tools/pproxy_fix.py:18: DeprecationWarning: There is no current event loop
  asyncio.get_event_loop()
Task was destroyed but it is pending!
task: <Task pending name='Task-14' coro=<BaseProtocol.channel() done, defined at /nix/store/xfrzqp13ilq0zjr1kk0knmcpv8y4vlnc-python3.13-pproxy-2.7.9/lib/python3.13/site-packages/pproxy/proto.py:56> wait_for=<Future pending cb=[Task.task_wakeup()]>>
Task was destroyed but it is pending!
task: <Task pending name='Task-15' coro=<BaseProtocol.channel() done, defined at /nix/store/xfrzqp13ilq0zjr1kk0knmcpv8y4vlnc-python3.13-pproxy-2.7.9/lib/python3.13/site-packages/pproxy/proto.py:56> wait_for=<Future pending cb=[Task.task_wakeup()]>>
------------------------------ Captured log call -------------------------------
WARNING  psycopg.pool:pool_async.py:739 error connecting in 'pool-35': connection failed: connection to server at "127.0.0.1", port 53809 failed: server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
______________________________ test_stats_connect ______________________________

proxy = <tests.fix_proxy.Proxy object at 0x7ffff36dbaf0>
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7fff86974c90>

    @pytest.mark.slow
    @skip_free_threaded("timing not accurate under the free-threaded build")
    def test_stats_connect(proxy, monkeypatch):
        proxy.start()
        delay_connection(monkeypatch, 0.2)
        with pool.ConnectionPool(proxy.client_dsn, min_size=3) as p:
            p.wait()
            stats = p.get_stats()
>           assert stats["connections_num"] == 3
E           assert 5 == 3

tests/pool/test_pool.py:871: AssertionError
----------------------------- Captured stderr call -----------------------------
/nix/store/xfrzqp13ilq0zjr1kk0knmcpv8y4vlnc-python3.13-pproxy-2.7.9/lib/python3.13/site-packages/pproxy/__doc__.py:14: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution
/build/source/tools/pproxy_fix.py:18: DeprecationWarning: There is no current event loop
  asyncio.get_event_loop()
Task was destroyed but it is pending!
task: <Task pending name='Task-13' coro=<BaseProtocol.channel() done, defined at /nix/store/xfrzqp13ilq0zjr1kk0knmcpv8y4vlnc-python3.13-pproxy-2.7.9/lib/python3.13/site-packages/pproxy/proto.py:56> wait_for=<Future pending cb=[Task.task_wakeup()]>>
Task was destroyed but it is pending!
task: <Task pending name='Task-14' coro=<BaseProtocol.channel() done, defined at /nix/store/xfrzqp13ilq0zjr1kk0knmcpv8y4vlnc-python3.13-pproxy-2.7.9/lib/python3.13/site-packages/pproxy/proto.py:56> wait_for=<Future pending cb=[Task.task_wakeup()]>>
Task was destroyed but it is pending!
task: <Task pending name='Task-17' coro=<BaseProtocol.channel() done, defined at /nix/store/xfrzqp13ilq0zjr1kk0knmcpv8y4vlnc-python3.13-pproxy-2.7.9/lib/python3.13/site-packages/pproxy/proto.py:56> wait_for=<Future pending cb=[Task.task_wakeup()]>>
Task was destroyed but it is pending!
task: <Task pending name='Task-18' coro=<BaseProtocol.channel() done, defined at /nix/store/xfrzqp13ilq0zjr1kk0knmcpv8y4vlnc-python3.13-pproxy-2.7.9/lib/python3.13/site-packages/pproxy/proto.py:56> wait_for=<Future pending cb=[Task.task_wakeup()]>>
------------------------------ Captured log call -------------------------------
WARNING  psycopg.pool:pool.py:683 error connecting in 'pool-172': connection failed: connection to server at "127.0.0.1", port 36473 failed: server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
WARNING  psycopg.pool:pool.py:683 error connecting in 'pool-172': connection failed: connection to server at "127.0.0.1", port 36473 failed: server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
```

cc @mweinelt

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
