### PR TITLE
supabase-py: 2.27.2 -> 2.28.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15974,6 +15974,11 @@
     githubId = 401263;
     keys = [ { fingerprint = "1147 43F1 E707 6F3E 6F4B  2C96 B9A8 B592 F126 F8E8"; } ];
   };
+  macbucheron = {
+    name = "Nathan Deprat";
+    github = "Macbucheron1";
+    githubId = 95475157;
+  };
   macronova = {
     name = "Sicheng Pan";
     email = "trivial@invariantspace.com";

--- a/pkgs/development/python-modules/postgrest/default.nix
+++ b/pkgs/development/python-modules/postgrest/default.nix
@@ -1,61 +1,68 @@
 {
-  lib,
   buildPythonPackage,
   fetchFromGitHub,
-  deprecation,
-  h2,
+  lib,
+  uv-build,
   httpx,
-  poetry-core,
   pydantic,
+  yarl,
+  strenum,
+  deprecation,
+  pytest-asyncio,
+  pytest-cov-stub,
   pytestCheckHook,
-  pythonPackages,
+  unasync,
 }:
 
 buildPythonPackage rec {
   pname = "postgrest";
-  version = "1.1.1";
+  version = "2.28.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
-    repo = "postgrest-py";
+    repo = "supabase-py";
     tag = "v${version}";
-    hash = "sha256-WTS8J8XhHPSe6N1reY3j2QYHaRY1goiVoqQCUKSgbVY=";
+    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
   };
 
-  build-system = [ poetry-core ];
+  sourceRoot = "${src.name}/src/postgrest";
+
+  build-system = [ uv-build ];
 
   dependencies = [
-    deprecation
     httpx
+    deprecation
     pydantic
-  ];
+    strenum
+    yarl
+  ]
+  ++ httpx.optional-dependencies.http2;
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.8.3,<0.9.0' 'uv_build>=0.8.3'
+  '';
 
   nativeCheckInputs = [
     pytestCheckHook
-    h2
-  ];
-
-  # Lots of tests fail without network access
-  disabledTestPaths = [
-    "tests/_async/test_client.py"
-    "tests/_async/test_filter_request_builder.py"
-    "tests/_async/test_filter_request_builder_integration.py"
-    "tests/_async/test_query_request_builder.py"
-    "tests/_async/test_request_builder.py"
-    "tests/_sync/test_filter_request_builder_integration.py"
-  ];
-  disabledTests = [
-    "test_params_purged_after_execute"
+    pytest-asyncio
+    pytest-cov-stub
+    unasync
   ];
 
   pythonImportsCheck = [ "postgrest" ];
 
+  disabledTestPaths = [
+    "tests/_sync/"
+    "tests/_async/"
+  ];
+
   meta = {
-    description = "PostgREST client for Python, provides an ORM interface to PostgREST";
-    homepage = "https://github.com/supabase/postgrest-py";
-    changelog = "https://github.com/supabase/postgrest-py/releases/tag/v${version}";
+    description = "Client library for Supabase Functions";
+    homepage = "https://github.com/supabase/supabase-py";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [ macbucheron ];
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ jherland ];
   };
 }

--- a/pkgs/development/python-modules/realtime/default.nix
+++ b/pkgs/development/python-modules/realtime/default.nix
@@ -1,58 +1,65 @@
 {
-  lib,
   buildPythonPackage,
   fetchFromGitHub,
+  lib,
   poetry-core,
-  pydantic,
-  typing-extensions,
-  websockets,
   aiohttp,
+  websockets,
+  typing-extensions,
+  pydantic,
   pytest-asyncio,
-  pytestCheckHook,
+  pytest-cov-stub,
   python-dotenv,
+  pytestCheckHook,
+  pythonRelaxDepsHook,
 }:
 
 buildPythonPackage rec {
-  pname = "realtime-py";
-  version = "2.7.0";
+  pname = "realtime";
+  version = "2.28.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
-    repo = "realtime-py";
+    repo = "supabase-py";
     tag = "v${version}";
-    hash = "sha256-cWWgVs+ZNRvBje3kuDQS5L5utkY3z7MluGFNmjf9LFc=";
+    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
   };
 
+  sourceRoot = "${src.name}/src/realtime";
+
+  build-system = [ poetry-core ];
+
   dependencies = [
-    pydantic
-    typing-extensions
     websockets
+    typing-extensions
+    pydantic
   ];
 
-  pythonRelaxDeps = [
-    "websockets"
-  ];
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+
+  pythonRelaxDeps = [ "websockets" ];
 
   nativeCheckInputs = [
     aiohttp
-    pytest-asyncio
     pytestCheckHook
+    pytest-cov-stub
     python-dotenv
+    pytest-asyncio
   ];
 
   pythonImportsCheck = [ "realtime" ];
 
-  build-system = [ poetry-core ];
-
-  # requires running Supabase
-  doCheck = false;
+  disabledTestPaths = [
+    "tests/test_connection.py"
+    "tests/test_presence.py"
+  ];
 
   meta = {
-    changelog = "https://github.com/supabase/realtime-py/blob/${src.tag}/CHANGELOG.md";
-    homepage = "https://github.com/supabase/realtime-py";
-    license = lib.licenses.mit;
-    description = "Python Realtime Client for Supabase";
+    description = "Client library for Supabase Functions";
+    homepage = "https://github.com/supabase/supabase-py";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ siegema ];
+    license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/storage3/default.nix
+++ b/pkgs/development/python-modules/storage3/default.nix
@@ -1,43 +1,68 @@
 {
-  lib,
   buildPythonPackage,
   fetchFromGitHub,
-  poetry-core,
-  python-dateutil,
+  lib,
+  uv-build,
   httpx,
-  h2,
+  pydantic,
+  yarl,
+  pyiceberg,
   deprecation,
+  pytest-asyncio,
+  pytest-cov-stub,
+  python-dotenv,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "storage3";
-  version = "0.12.2";
+  version = "2.28.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
-    repo = "storage-py";
+    repo = "supabase-py";
     tag = "v${version}";
-    hash = "sha256-ACilbwSCNEsXyr2lUTkhOgfw/SiTnwj+rA07tnuFy5A=";
+    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
   };
 
-  dependencies = [
-    python-dateutil
-    httpx
-    h2
-    deprecation
-  ];
+  sourceRoot = "${src.name}/src/storage";
 
-  build-system = [ poetry-core ];
+  build-system = [ uv-build ];
+
+  dependencies = [
+    httpx
+    pydantic
+    yarl
+    pyiceberg
+    deprecation
+  ]
+  ++ httpx.optional-dependencies.http2;
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.8.3,<0.9.0' 'uv_build>=0.8.3'
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-cov-stub
+    python-dotenv
+  ];
 
   pythonImportsCheck = [ "storage3" ];
 
-  # tests fail due to mock server not starting
+  disabledTestPaths = [
+    "tests/_sync/"
+    "tests/_async/"
+  ];
 
   meta = {
-    homepage = "https://github.com/supabase/storage-py";
-    license = lib.licenses.mit;
-    description = "Supabase Storage client for Python.";
+    description = "Client library for Supabase Functions";
+    homepage = "https://github.com/supabase/supabase-py";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ siegema ];
+    license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/supabase-auth/default.nix
+++ b/pkgs/development/python-modules/supabase-auth/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  uv-build,
+  httpx,
+  pydantic,
+  pyjwt,
+  pytestCheckHook,
+  faker,
+  respx,
+  pytest-mock,
+  pytest-asyncio,
+}:
+buildPythonPackage rec {
+  pname = "supabase-auth";
+  version = "2.28.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = "supabase-py";
+    tag = "v${version}";
+    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
+  };
+
+  sourceRoot = "${src.name}/src/auth";
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    httpx
+    pydantic
+    pyjwt
+  ]
+  ++ httpx.optional-dependencies.http2
+  ++ pyjwt.optional-dependencies.crypto;
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.8.3,<0.9.0' 'uv_build>=0.8.3'
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    faker
+    respx
+    pytest-mock
+    pytest-asyncio
+  ];
+
+  disabledTestPaths = [
+    "tests/_sync/"
+    "tests/_async/"
+  ];
+
+  pythonImportsCheck = [ "supabase_auth" ];
+
+  meta = {
+    description = "Client library for Supabase Auth";
+    homepage = "https://github.com/supabase/supabase-py/";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ macbucheron ];
+  };
+}

--- a/pkgs/development/python-modules/supabase-functions/default.nix
+++ b/pkgs/development/python-modules/supabase-functions/default.nix
@@ -1,0 +1,60 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  httpx,
+  lib,
+  pyjwt,
+  pytest-asyncio,
+  pytestCheckHook,
+  strenum,
+  uv-build,
+  yarl,
+}:
+
+buildPythonPackage rec {
+  pname = "supabase-functions";
+  version = "2.28.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = "supabase-py";
+    tag = "v${version}";
+    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
+  };
+
+  sourceRoot = "${src.name}/src/functions";
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    strenum
+    yarl
+    httpx
+  ]
+  ++ httpx.optional-dependencies.http2;
+
+  # Upstream pins `uv_build>=0.8.3,<0.9.0`, but nixpkgs ships `uv-build` 0.9.x.
+  # Relax the upper bound to accept the 0.9 series, consistent with uv’s documentation examples:
+  # https://docs.astral.sh/uv/concepts/build-backend/#using-the-uv-build-backend
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.8.3,<0.9.0' 'uv_build>=0.8.3'
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pyjwt
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [ "supabase_functions" ];
+
+  meta = {
+    description = "Client library for Supabase Functions";
+    homepage = "https://github.com/supabase/supabase-py";
+    changelog = "https://github.com/supabase/supabase-py/blob/v${src.tag}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [ macbucheron ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/supabase/default.nix
+++ b/pkgs/development/python-modules/supabase/default.nix
@@ -2,49 +2,59 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  poetry-core,
-  gotrue,
-  postgrest,
+  uv-build,
   realtime,
-  storage3,
-  supafunc,
+  supabase-functions,
+  supabase-auth,
+  postgrest,
   httpx,
+  yarl,
+  storage3,
   pytestCheckHook,
   python-dotenv,
   pytest-asyncio,
+  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
   pname = "supabase";
-  version = "2.27.2";
+  version = "2.28.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${version}";
-    hash = "sha256-TRATa+lDRm2MDuARXfBRWnWYUak8i1fW7rr5ujWN8TY=";
+    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
   };
 
-  build-system = [ poetry-core ];
+  sourceRoot = "${src.name}/src/supabase";
 
-  # FIXME remove for supabase >= 2.18.0
-  pythonRelaxDeps = true;
+  build-system = [ uv-build ];
+
+  doCheck = true;
 
   dependencies = [
-    postgrest
     realtime
-    gotrue
+    supabase-auth
+    supabase-functions
+    postgrest
     httpx
+    yarl
     storage3
-    supafunc
   ];
 
   nativeBuildInputs = [
     pytestCheckHook
     python-dotenv
     pytest-asyncio
+    pytest-cov-stub
   ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.8.3,<0.9.0' 'uv_build>=0.8.3'
+  '';
 
   pythonImportsCheck = [ "supabase" ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18529,7 +18529,9 @@ self: super: with self; {
 
   supabase = callPackage ../development/python-modules/supabase { };
 
-  supabase-functions = self.supafunc;
+  supabase-auth = callPackage ../development/python-modules/supabase-auth { };
+
+  supabase-functions = callPackage ../development/python-modules/supabase-functions { };
 
   supafunc = callPackage ../development/python-modules/supafunc { };
 


### PR DESCRIPTION
Updates the Supabase Python client stack to **v2.28.0**, aligning nixpkgs with upstream’s `supabase/supabase-py` monorepo.

Fixes #480059
Related: #476392

Packaging changes:
- Fetch from `supabase/supabase-py` at `v2.28.0` and build individual subprojects via `sourceRoot` (`src/<project>`).
- Relax upstream’s pinned `uv_build` upper bound (`<0.9.0`) to allow nixpkgs’ `uv-build` 0.9.x.

Changelog:
- https://github.com/supabase/supabase-py/blob/v2.28.0/CHANGELOG.md
- https://github.com/supabase/supabase-py/releases/tag/v2.28.0

nixpkgs-review note:
- `python3Packages.exegol` is already failing on `master` due to `storage3` runtime dependency checks (missing `pydantic`). This PR updates the Supabase stack and fixes the `storage3` issue, but `exegol` (in version `5.1.2` still fails due to a strict `pydantic~=2.11.1` constraint vs nixpkgs `pydantic 2.12.x`. This should be handled in a follow-up PR (update `exegol` to version `5.1.8`).

## Things done

- Built on platform:
  - [x] x86_64-linux (NixOS)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

  Commands run:
  - `nix build -L .#python3Packages.postgrest`
  - `nix build -L .#python3Packages.supabase`
  - `nix build -L .#python3Packages.realtime`
  - `nix build -L .#python3Packages.storage3`
  - `nix build -L .#python3Packages.supabase-auth`
  - `nix build -L .#python3Packages.supabase-functions`

- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.