### PR TITLE
crosspipe: init at 0.1.1

### DIFF
--- a/pkgs/by-name/cr/crosspipe/package.nix
+++ b/pkgs/by-name/cr/crosspipe/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  vala,
+  gtk4,
+  libadwaita,
+  libgee,
+  pipewire,
+  libxml2,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "crosspipe";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "dp0sk";
+    repo = "crosspipe";
+    tag = finalAttrs.version;
+    hash = "sha256-W3OKYdei/4l1uTQIXfzq6aaw2NF7dOBaAFkPTUFOLzA=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    vala
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    libgee
+    pipewire
+    libxml2
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    description = "PipeWire graph GTK4/Libadwaita GUI";
+    homepage = "https://github.com/dp0sk/crosspipe";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ qweered ];
+    mainProgram = "crosspipe";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Replacement for helvium that will be dropped in #493796

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
