### PR TITLE
[staging-next-25.11] python314Packages.msrest: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/msrest/default.nix
+++ b/pkgs/development/python-modules/msrest/default.nix
@@ -70,6 +70,13 @@ buildPythonPackage {
     "test_eventgrid_domain_auth"
   ];
 
+  disabledTestPaths = [
+    # 2 AssertionErrors... See:
+    # https://github.com/Azure/msrest-for-python/issues/267
+    "tests/asynctests/test_async_client.py::TestServiceClient::test_client_send"
+    "tests/test_client.py::TestServiceClient::test_client_send"
+  ];
+
   pythonImportsCheck = [ "msrest" ];
 
   meta = {


### PR DESCRIPTION
Manual backport of f3e179d71020a7386d77464ed0fd212c5173a310 from https://github.com/NixOS/nixpkgs/pull/491007.

(Despite the commit message, `python313Packages.msrest` is actually also affected.)

Hydra: https://hydra.nixos.org/build/322937899/nixlog/1
Upstream issue: https://github.com/Azure/msrest-for-python/issues/267

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13}Packages.msrest`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
