### PR TITLE
ddev: make docker-buildx available

### DIFF
--- a/pkgs/by-name/dd/ddev/cli-system-plugin-dir-from-env.patch
+++ b/pkgs/by-name/dd/ddev/cli-system-plugin-dir-from-env.patch
@@ -1,0 +1,31 @@
+diff --git a/cli-plugins/manager/manager_unix.go b/cli-plugins/manager/manager_unix.go
+index f546dc3849..5e3ae08dbc 100644
+--- a/cli-plugins/manager/manager_unix.go
++++ b/cli-plugins/manager/manager_unix.go
+@@ -2,6 +2,11 @@
+ 
+ package manager
+ 
++import (
++	"os"
++	"path/filepath"
++)
++
+ // defaultSystemPluginDirs are the platform-specific locations to search
+ // for plugins in order of preference.
+ //
+@@ -12,9 +17,8 @@
+ // 3. Platform-specific defaultSystemPluginDirs (as defined below).
+ //
+ // [ConfigFile.CLIPluginsExtraDirs]: https://pkg.go.dev/github.com/docker/cli@v26.1.4+incompatible/cli/config/configfile#ConfigFile.CLIPluginsExtraDirs
+-var defaultSystemPluginDirs = []string{
+-	"/usr/local/lib/docker/cli-plugins",
+-	"/usr/local/libexec/docker/cli-plugins",
+-	"/usr/lib/docker/cli-plugins",
+-	"/usr/libexec/docker/cli-plugins",
++var defaultSystemPluginDirs []string
++
++func init() {
++	defaultSystemPluginDirs = filepath.SplitList(os.Getenv("DOCKER_CLI_PLUGIN_DIRS"))
+ }
+

--- a/pkgs/by-name/dd/ddev/package.nix
+++ b/pkgs/by-name/dd/ddev/package.nix
@@ -2,12 +2,22 @@
   lib,
   stdenv,
   buildGoModule,
+  docker-buildx,
   fetchFromGitHub,
   installShellFiles,
+  makeBinaryWrapper,
   versionCheckHook,
   writableTmpDirAsHomeHook,
 }:
 
+let
+  dockerCliPlugins = [
+    docker-buildx
+  ];
+  dockerCliPluginsDirs = lib.strings.concatStringsSep ":" (
+    map (p: "${p}/libexec/docker/cli-plugins") dockerCliPlugins
+  );
+in
 buildGoModule (finalAttrs: {
   pname = "ddev";
   version = "1.25.0";
@@ -19,7 +29,12 @@ buildGoModule (finalAttrs: {
     hash = "sha256-vRhFj2/lV34sDIDUxi2/zF9VJimhi6By6TQndl0O/Xg=";
   };
 
+  postPatch = ''
+    (cd vendor/github.com/docker/cli && patch ${./cli-system-plugin-dir-from-env.patch})
+  '';
+
   nativeBuildInputs = [
+    makeBinaryWrapper
     installShellFiles
   ];
 
@@ -34,7 +49,13 @@ buildGoModule (finalAttrs: {
   # Tests need docker.
   doCheck = false;
 
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+  postInstall = ''
+    # make buildx available, it is a docker plugin which docker-compose uses and thus DDEV requires
+    # https://github.com/NixOS/nixpkgs/blob/43fc054052db6ca5df042dcbe823740aa6c9a7c2/pkgs/applications/virtualization/docker/default.nix#L339
+    wrapProgram $out/bin/ddev \
+      --prefix DOCKER_CLI_PLUGIN_DIRS : "${dockerCliPluginsDirs}"
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     # DDEV will try to create $HOME/.ddev, so we set $HOME to a temporary
     # directory.
     export HOME=$(mktemp -d)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes issue discussed on ddev discord server:
https://discord.com/channels/664580571770388500/1476227131615875195
(docker-compose requires buildx - not an issue so far; but ddev now validates that buildx is correctly installed, but because it uses docker as a library the patch for docker cli plugins on nixos is missing)

Seems to be introduced with the update to ddev v1.25 or v1.25.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
