### PR TITLE
nixtamal: 1.1.1 → 1.1.2 (cherry-pick from staging)

### DIFF
--- a/pkgs/by-name/ni/nixtamal/package.nix
+++ b/pkgs/by-name/ni/nixtamal/package.nix
@@ -17,7 +17,7 @@
 
 ocamlPackages.buildDunePackage (finalAttrs: {
   pname = "nixtamal";
-  version = "1.1.1";
+  version = "1.1.2";
   release_year = 2026;
 
   minimalOCamlVersion = "5.3";
@@ -26,7 +26,7 @@ ocamlPackages.buildDunePackage (finalAttrs: {
     url = "https://darcs.toastal.in.th/nixtamal/stable/";
     mirrors = [ "https://smeder.ee/~toastal/nixtamal.darcs" ];
     rev = finalAttrs.version;
-    hash = "sha256-VYK6ZqEutlVA8ASegLfqnJhLSU5jc2dIL3YOrXrGT0I=";
+    hash = "sha256-Sgr3FGMjo/eETc6DA+rnBHKIQ3yUPkFKRRbf4O1Ns/o=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/491867 was merged into staging before https://github.com/NixOS/nixpkgs/pull/484655 made it to `staging-next`—which has now been in the default branch for 4 days leaving Nixtamal _broken_ for as many days, while https://github.com/NixOS/nixpkgs/pull/491867 is waiting in `staging` still. I would like to just cherry-pick that commit onto the default branch to get Nixtamal unbroken. That commit had already been reviewed/merged.

```console
$ nix-build -A nixtamal.tests
this derivation will be built:
  /nix/store/7nvl2xkdhhfch7aq23brda4k660b2pfz-ocaml5.4.0-nixtamal-1.1.2-test-version.drv
building '/nix/store/7nvl2xkdhhfch7aq23brda4k660b2pfz-ocaml5.4.0-nixtamal-1.1.2-test-version.drv' on 'ssh://olisbokollix-builder'...
copying 0 paths...
1.1.2
copying 1 paths...
copying path '/nix/store/r35hycx8nl2s3niph47rq1rndknsajsm-ocaml5.4.0-nixtamal-1.1.2-test-version' from 'ssh://olisbokollix-builder'...
/nix/store/r35hycx8nl2s3niph47rq1rndknsajsm-ocaml5.4.0-nixtamal-1.1.2-test-version
```

Tests still run.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
