### PR TITLE
python313Packages.bgutil-ytdlp-pot-provider: package server

### DIFF
--- a/pkgs/development/python-modules/bgutil-ytdlp-pot-provider/default.nix
+++ b/pkgs/development/python-modules/bgutil-ytdlp-pot-provider/default.nix
@@ -1,8 +1,16 @@
 {
   lib,
   buildPythonPackage,
+  cairo,
   fetchFromGitHub,
+  fetchNpmDeps,
+  giflib,
   hatchling,
+  nodejs,
+  npmHooks,
+  pango,
+  pixman,
+  pkg-config,
   yt-dlp,
 }:
 
@@ -18,7 +26,27 @@ buildPythonPackage rec {
     hash = "sha256-dhpataQ1HSCRPnm4k3K/NMaQPQdNrx8C4q855l7kbbQ=";
   };
 
-  sourceRoot = "${src.name}/plugin";
+  npmDeps = fetchNpmDeps {
+    name = "${pname}-${version}-npm-deps";
+    src = src + "/server";
+    npmDepsFetcherVersion = 2;
+    hash = "sha256-Qwwi6W+Oeu6ZeLmZP5vEfAKOJyivbULR5mlk7tcVIE8=";
+  };
+
+  npmRoot = "server";
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    cairo
+    giflib
+    pango
+    pixman
+  ];
 
   build-system = [ hatchling ];
 
@@ -26,10 +54,29 @@ buildPythonPackage rec {
 
   doCheck = false; # no tests
 
+  preBuild = ''
+    cd server
+    npx tsc
+    npm prune --omit=dev
+    cd ../plugin
+  '';
+
+  postInstall = ''
+    cd ..
+
+    mkdir -p $out/share/bgutil-ytdlp-pot-provider/
+    cp -r server/{build,node_modules} $out/share/bgutil-ytdlp-pot-provider/
+    makeWrapper ${lib.getExe nodejs} $out/bin/bgutil-ytdlp-pot-provider \
+      --add-flags $out/share/bgutil-ytdlp-pot-provider/build/main.js
+
+    cd plugin
+  '';
+
   meta = {
     description = "Proof-of-origin token provider plugin for yt-dlp";
     homepage = "https://github.com/Brainicism/bgutil-ytdlp-pot-provider";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ hexa ];
+    mainProgram = "bgutil-ytdlp-pot-provider";
   };
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
