### PR TITLE
emacs: bump elisp packages

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "a68-mode";
       ename = "a68-mode";
-      version = "1.2.0.20251231.12038";
+      version = "1.2.0.20260129.20653";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/a68-mode-1.2.0.20251231.12038.tar";
-        sha256 = "0hb9j7hfng2scjw43jhh0899wa1765ix3mfylrh33xpdi6y2dk4c";
+        url = "https://elpa.gnu.org/devel/a68-mode-1.2.0.20260129.20653.tar";
+        sha256 = "03b4608ij5jiijasy41vndwcnzl92gwc0frh2pxs6112p7xk2sf0";
       };
       packageRequires = [ ];
       meta = {
@@ -333,10 +333,10 @@
     elpaBuild {
       pname = "altcaps";
       ename = "altcaps";
-      version = "1.3.0.0.20260111.105148";
+      version = "1.3.0.0.20260210.221352";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/altcaps-1.3.0.0.20260111.105148.tar";
-        sha256 = "1ps97855lps0vpw3h0saxx7z0ckdr0fn3zwlvxmh3fbl29w3c9jr";
+        url = "https://elpa.gnu.org/devel/altcaps-1.3.0.0.20260210.221352.tar";
+        sha256 = "1m97icn58an0a1x9lhby7870g5m4i7rgkmi61nz24qmrc5pcmqmw";
       };
       packageRequires = [ ];
       meta = {
@@ -461,10 +461,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.1.2.0.20260117.200713";
+      version = "14.1.2.0.20260219.153633";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-14.1.2.0.20260117.200713.tar";
-        sha256 = "064xvk5pwpnxlxxrgqhiv5r1cmmfcmqlpqnyzn71njslyf3z0321";
+        url = "https://elpa.gnu.org/devel/auctex-14.1.2.0.20260219.153633.tar";
+        sha256 = "1cd3av3rbjqa25fs6zgxp9nqwj1q67fgigm7qypx38apwc58zmy2";
       };
       packageRequires = [ ];
       meta = {
@@ -612,10 +612,10 @@
     elpaBuild {
       pname = "autocrypt";
       ename = "autocrypt";
-      version = "0.4.2.0.20250415.115030";
+      version = "0.4.2.0.20260126.200740";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/autocrypt-0.4.2.0.20250415.115030.tar";
-        sha256 = "1lf52r37ik8y8chc047k6mya560q4ybbbq82brdm088rabl81khx";
+        url = "https://elpa.gnu.org/devel/autocrypt-0.4.2.0.20260126.200740.tar";
+        sha256 = "15xqvi9j2jg1hya0gprif4wsxhwmi4l1fa0fpr7phzbjh0qhc90r";
       };
       packageRequires = [ ];
       meta = {
@@ -719,10 +719,10 @@
     elpaBuild {
       pname = "beframe";
       ename = "beframe";
-      version = "1.4.0.0.20260111.104742";
+      version = "1.5.0.0.20260204.145843";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/beframe-1.4.0.0.20260111.104742.tar";
-        sha256 = "04v315xmppvd0jv2dwmyj9679dwkiwkil3r6sfb6i48wc3b0ryzj";
+        url = "https://elpa.gnu.org/devel/beframe-1.5.0.0.20260204.145843.tar";
+        sha256 = "1jkirpjfxzxspbz1whf5yjzdzxx10abr9aymks40hh72xyjgida6";
       };
       packageRequires = [ ];
       meta = {
@@ -993,10 +993,10 @@
     elpaBuild {
       pname = "bufferlo";
       ename = "bufferlo";
-      version = "1.2.0.20251126.101032";
+      version = "1.2.0.20260213.95350";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bufferlo-1.2.0.20251126.101032.tar";
-        sha256 = "178qq7rvwn3601xw1f0vpgq6k0fjq854r907rncbx866s1427kai";
+        url = "https://elpa.gnu.org/devel/bufferlo-1.2.0.20260213.95350.tar";
+        sha256 = "097w4ixggawaj9l076bm9y1ahf0bdcmqhcsqwvnxgq2xqfgwbs9n";
       };
       packageRequires = [ ];
       meta = {
@@ -1015,10 +1015,10 @@
     elpaBuild {
       pname = "buframe";
       ename = "buframe";
-      version = "0.2.0.20260106.114915";
+      version = "0.3.0.20260120.162350";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/buframe-0.2.0.20260106.114915.tar";
-        sha256 = "169q9hl2l3axzs9x4w8gy65r21rzpswh25whi3bwvllcmkskf6k8";
+        url = "https://elpa.gnu.org/devel/buframe-0.3.0.20260120.162350.tar";
+        sha256 = "1kh6h6rqg3j4rbbcr5m1ch5gvcsyllxg78l549ay5hhyi06j2y7a";
       };
       packageRequires = [ timeout ];
       meta = {
@@ -1106,10 +1106,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.5.0.20260117.195328";
+      version = "2.6.0.20260124.92441";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cape-2.5.0.20260117.195328.tar";
-        sha256 = "0j8h5hl8d7nlwi5dnngjzp48d11z2mlkyhg5l1f9h4sz7lss9rc2";
+        url = "https://elpa.gnu.org/devel/cape-2.6.0.20260124.92441.tar";
+        sha256 = "1qxa7y27jy67g0wwryp4d74vp7ass5anskpjq9ak7spxiq54f3a1";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1387,10 +1387,10 @@
     elpaBuild {
       pname = "company";
       ename = "company";
-      version = "1.0.2.0.20260108.3608";
+      version = "1.0.2.0.20260220.15631";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20260108.3608.tar";
-        sha256 = "0py7kj5470b5i7mq7kfnbqh90q487nj4dnvk50yji1pdw5x6s9wj";
+        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20260220.15631.tar";
+        sha256 = "0wj07iqpjigzqdy8y1i7x3nzg9cgammjcyv872hxzx9dr4xb0i88";
       };
       packageRequires = [ ];
       meta = {
@@ -1483,10 +1483,10 @@
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "30.1.0.1.0.20260104.150319";
+      version = "30.1.0.1.0.20260131.205608";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/compat-30.1.0.1.0.20260104.150319.tar";
-        sha256 = "0p714qzrbk9nix3n2fhd6gqkm0zcx7yykrx9fq1p6iq90y894pzb";
+        url = "https://elpa.gnu.org/devel/compat-30.1.0.1.0.20260131.205608.tar";
+        sha256 = "0kyy296448mczwhxzpa2n34xi9zdvwj30vshhylfskr22wblr7i5";
       };
       packageRequires = [ seq ];
       meta = {
@@ -1504,10 +1504,10 @@
     elpaBuild {
       pname = "cond-star";
       ename = "cond-star";
-      version = "1.0.0.20260101.125434";
+      version = "1.0.0.20260219.94521";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cond-star-1.0.0.20260101.125434.tar";
-        sha256 = "0gmnc3vzid3w49m6j35kg2i2rzg7x2v8yl7c678ldh841rzmvmqz";
+        url = "https://elpa.gnu.org/devel/cond-star-1.0.0.20260219.94521.tar";
+        sha256 = "0anifdinhx8z85l3sfqiiy2i7xih5l7bxil6b2xxynvg4w4g1m76";
       };
       packageRequires = [ ];
       meta = {
@@ -1547,10 +1547,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "3.3.0.20260118.74435";
+      version = "3.3.0.20260205.205149";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-3.3.0.20260118.74435.tar";
-        sha256 = "1vb3bn9lv9drw43x2272aavdi019wccmz132r5ywlx540dr9lmm1";
+        url = "https://elpa.gnu.org/devel/consult-3.3.0.20260205.205149.tar";
+        sha256 = "1x3mds6qpls5ybhw1q7qzl5yc9kd6gg6wnqd9irq8pcb3yvg9ap4";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1570,10 +1570,10 @@
     elpaBuild {
       pname = "consult-denote";
       ename = "consult-denote";
-      version = "0.4.2.0.20260111.182520";
+      version = "0.4.2.0.20260122.100152";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-denote-0.4.2.0.20260111.182520.tar";
-        sha256 = "1z7dhkp7yy6qn0dr1r5ziwc3p1wbx6cvrh5cr5h8czh6prhswwx4";
+        url = "https://elpa.gnu.org/devel/consult-denote-0.4.2.0.20260122.100152.tar";
+        sha256 = "1d8dq183sc5sc3ki5z602w29f541cs6ljhyx5fwl7rwnj22w6yxx";
       };
       packageRequires = [
         consult
@@ -1660,10 +1660,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "2.8.0.20260118.74606";
+      version = "2.8.0.20260210.91503";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/corfu-2.8.0.20260118.74606.tar";
-        sha256 = "1fbvaiycmj1mpncxmmzyprqrymzn09b6zdldcbay6xywmvvdvcml";
+        url = "https://elpa.gnu.org/devel/corfu-2.8.0.20260210.91503.tar";
+        sha256 = "0kzrqzlz5n7z0cdkxnmc9c3wp6i5fpkz9h77rl1kn774063digap";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1705,10 +1705,10 @@
     elpaBuild {
       pname = "counsel";
       ename = "counsel";
-      version = "0.15.1.0.20250329.151454";
+      version = "0.15.1.0.20260214.101027";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/counsel-0.15.1.0.20250329.151454.tar";
-        sha256 = "0fnxgf08dkq16d65xcaa822vasdqzixmd7ihw48hncx80jzqk1s6";
+        url = "https://elpa.gnu.org/devel/counsel-0.15.1.0.20260214.101027.tar";
+        sha256 = "18p8sdlnva98vfzz8zdb9yp647r47q7gxxh2w1hqjvaw4802hxjv";
       };
       packageRequires = [
         ivy
@@ -1941,10 +1941,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.25.0.0.20260107.224854";
+      version = "0.26.0.0.20260204.173332";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dape-0.25.0.0.20260107.224854.tar";
-        sha256 = "1z3xms1jzhdx0m3r4i9a7nlwrcz1agdlxb92f7gqc8rh9jpvlvmh";
+        url = "https://elpa.gnu.org/devel/dape-0.26.0.0.20260204.173332.tar";
+        sha256 = "00lha8zgkwkl235lmppmma3wrh76qflkg2rbzy2baxywz3mjy5iv";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -1984,10 +1984,10 @@
     elpaBuild {
       pname = "dash";
       ename = "dash";
-      version = "2.20.0.0.20251016.104741";
+      version = "2.20.0.0.20260221.134621";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dash-2.20.0.0.20251016.104741.tar";
-        sha256 = "1d7lqzk7qwrkmxmydkk5a9mbi42zngn00ll42avhamsinld959g6";
+        url = "https://elpa.gnu.org/devel/dash-2.20.0.0.20260221.134621.tar";
+        sha256 = "09829jmfnlchyqqmisiy6j4jkzm8vv05mmzyyfhm6vy0rymfxdc0";
       };
       packageRequires = [ ];
       meta = {
@@ -2028,10 +2028,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.46.0.20260101.132314";
+      version = "0.46.0.20260222.93040";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/debbugs-0.46.0.20260101.132314.tar";
-        sha256 = "1rg2dmbrm9135mfpdwim50r37frpm0k24fxl80h79iyilzqhbgmy";
+        url = "https://elpa.gnu.org/devel/debbugs-0.46.0.20260222.93040.tar";
+        sha256 = "0karljqdimm1jcplyjrisjcy4sgmv1a6pr236327dwl14md7vp21";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -2075,10 +2075,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "4.1.3.0.20260118.70827";
+      version = "4.1.3.0.20260223.155039";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-4.1.3.0.20260118.70827.tar";
-        sha256 = "0mgkmzjqgfr4rlfib0sa9jkqmbzg5q1hgifdg1xadiga24g8krk2";
+        url = "https://elpa.gnu.org/devel/denote-4.1.3.0.20260223.155039.tar";
+        sha256 = "15lrs0h6fkrqspbmg805jk2ccfflbgqpq5zpzjg2br6n7fd05j1w";
       };
       packageRequires = [ ];
       meta = {
@@ -2175,6 +2175,28 @@
       };
     }
   ) { };
+  denote-review = callPackage (
+    {
+      denote,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "denote-review";
+      ename = "denote-review";
+      version = "1.0.5.0.20260224.153338";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/denote-review-1.0.5.0.20260224.153338.tar";
+        sha256 = "0jvsahaih68yx3n9gwbvxmqw7p7dpjk6cmnxnji9qnybh9yvqy20";
+      };
+      packageRequires = [ denote ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/denote-review.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   denote-search = callPackage (
     {
       denote,
@@ -2207,10 +2229,10 @@
     elpaBuild {
       pname = "denote-sequence";
       ename = "denote-sequence";
-      version = "0.2.0.0.20260111.183716";
+      version = "0.2.0.0.20260207.135941";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-sequence-0.2.0.0.20260111.183716.tar";
-        sha256 = "0i0krqc9hncsnbbp2bjqkpsi16ia57kbqw0p7x3v2g217jq4anvj";
+        url = "https://elpa.gnu.org/devel/denote-sequence-0.2.0.0.20260207.135941.tar";
+        sha256 = "1iabngf9rpjshcxb7lg9l8cqadkak8mhz066qp0mayxf08z70yq9";
       };
       packageRequires = [ denote ];
       meta = {
@@ -2365,10 +2387,10 @@
     elpaBuild {
       pname = "diff-hl";
       ename = "diff-hl";
-      version = "1.10.0.0.20251216.24245";
+      version = "1.10.0.0.20260223.155319";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20251216.24245.tar";
-        sha256 = "0h127hbdhvzhf1c03674pf831fvnnnb7agag84580id2mjijilkn";
+        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20260223.155319.tar";
+        sha256 = "0akrxgakxpvdvdrmfsfsgf8jmww7i2yn406bavv5qdi2ly915mmv";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2599,10 +2621,10 @@
     elpaBuild {
       pname = "do-at-point";
       ename = "do-at-point";
-      version = "0.1.2.0.20250501.125137";
+      version = "0.2.0.0.20260203.162636";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/do-at-point-0.1.2.0.20250501.125137.tar";
-        sha256 = "1sszwgf740yklj2cm47rzc5ia8ygn8vzfagpadcsv38mpcxpdzz0";
+        url = "https://elpa.gnu.org/devel/do-at-point-0.2.0.0.20260203.162636.tar";
+        sha256 = "04cqr9a2rbca4v2pmy863s19m1awvwk61mr3097brhylv0bz04mx";
       };
       packageRequires = [ ];
       meta = {
@@ -2683,10 +2705,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "0.6.0.0.20260117.121125";
+      version = "1.0.0.0.20260220.71354";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/doric-themes-0.6.0.0.20260117.121125.tar";
-        sha256 = "1lzwv1hypgcyzxd0aj0ilm5lkbszpl8g96k2mmfd59pkn3fxvbmz";
+        url = "https://elpa.gnu.org/devel/doric-themes-1.0.0.0.20260220.71354.tar";
+        sha256 = "1qvaf9aalbdbfahl6s5xpd44xgzx0wv4b36p4vhg2m0z9g4pm7n7";
       };
       packageRequires = [ ];
       meta = {
@@ -2769,10 +2791,10 @@
     elpaBuild {
       pname = "easy-kill";
       ename = "easy-kill";
-      version = "0.9.5.0.20260112.113033";
+      version = "0.9.5.0.20260121.75216";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/easy-kill-0.9.5.0.20260112.113033.tar";
-        sha256 = "0889d9hri58hfxj03ga98ji7m6z3jdpi23r72jcf7wmks1546j24";
+        url = "https://elpa.gnu.org/devel/easy-kill-0.9.5.0.20260121.75216.tar";
+        sha256 = "1x0adprjak14b9s2rkmlmmxgaszw2nqsd527pgi9da46wa5x55zy";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2885,10 +2907,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20251219.0.20251219.222550";
+      version = "20260126.0.20260126.21331";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eev-20251219.0.20251219.222550.tar";
-        sha256 = "1d22bvd7230i7847bsh7yni9nw02my181jvgf8l5hl2isd1fanwf";
+        url = "https://elpa.gnu.org/devel/eev-20260126.0.20260126.21331.tar";
+        sha256 = "03mqjza8y86cf9s8lav26digybz3wy1h0b73lp6a0vfngbc8i796";
       };
       packageRequires = [ ];
       meta = {
@@ -2907,10 +2929,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "2.0.1.0.20260119.182016";
+      version = "2.1.0.0.20260219.64738";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ef-themes-2.0.1.0.20260119.182016.tar";
-        sha256 = "0vz1v02jdxyyq4ia6i28avxkvhfasynjp9mzz3a3fmj3aqa5k86y";
+        url = "https://elpa.gnu.org/devel/ef-themes-2.1.0.0.20260219.64738.tar";
+        sha256 = "0nkjacpyvfnibbyvrsi2qfh0idnphv26ihwc5gkfjjiwynhspws4";
       };
       packageRequires = [ modus-themes ];
       meta = {
@@ -2935,10 +2957,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.21.0.20260117.150219";
+      version = "1.21.0.20260221.132913";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eglot-1.21.0.20260117.150219.tar";
-        sha256 = "00wqgprz4dav11k6qds5mpac8v553gww96ik9h5pp8m70hpayah5";
+        url = "https://elpa.gnu.org/devel/eglot-1.21.0.20260221.132913.tar";
+        sha256 = "0fffs64rl2mbhcqfxz31ayxvn5ngd38gd7amsagw8p2ixbw6n7kf";
       };
       packageRequires = [
         eldoc
@@ -2964,10 +2986,10 @@
     elpaBuild {
       pname = "el-job";
       ename = "el-job";
-      version = "2.6.1.0.20251202.235353";
+      version = "2.7.3.0.20260222.100909";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/el-job-2.6.1.0.20251202.235353.tar";
-        sha256 = "1g29s8i49y8p2nyajdi9p30py3h26x67y8llvrvkn3cxv30n23s2";
+        url = "https://elpa.gnu.org/devel/el-job-2.7.3.0.20260222.100909.tar";
+        sha256 = "0cqx9grvdij7xrj3xs6f62h548sc36k61p53gia8sd910v5mqks1";
       };
       packageRequires = [ ];
       meta = {
@@ -3104,20 +3126,22 @@
       llm,
       plz,
       transient,
+      yaml,
     }:
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "1.10.10.0.20260115.215017";
+      version = "1.12.18.0.20260223.202929";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ellama-1.10.10.0.20260115.215017.tar";
-        sha256 = "0465all7jia8q1ls9aqpn8hqjyprmzx4k5dr7i5fx8zhmxa8pigp";
+        url = "https://elpa.gnu.org/devel/ellama-1.12.18.0.20260223.202929.tar";
+        sha256 = "1yii4yzqla28z4gm9pmazqcl3fm6qcb1qyh32c6zm0xxfp52wrah";
       };
       packageRequires = [
         compat
         llm
         plz
         transient
+        yaml
       ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/ellama.html";
@@ -3146,6 +3170,48 @@
       };
     }
   ) { };
+  emacs-lisp-intro-es = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "emacs-lisp-intro-es";
+      ename = "emacs-lisp-intro-es";
+      version = "0.0.20260217.163329";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/emacs-lisp-intro-es-0.0.20260217.163329.tar";
+        sha256 = "18zjh5b1z929lsb6nfya817ni32avm45qc1cmn9q3caz07ry0ayz";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/emacs-lisp-intro-es.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  emacs-lisp-intro-nl = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "emacs-lisp-intro-nl";
+      ename = "emacs-lisp-intro-nl";
+      version = "0.0.20260221.202025";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/emacs-lisp-intro-nl-0.0.20260221.202025.tar";
+        sha256 = "1jz2pyldl1fw6y3q6s0fxb9ijlfi5032ak9003fi1rjff22zldzr";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/emacs-lisp-intro-nl.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   embark = callPackage (
     {
       compat,
@@ -3156,10 +3222,10 @@
     elpaBuild {
       pname = "embark";
       ename = "embark";
-      version = "1.1.0.20251117.191148";
+      version = "1.1.0.20260223.105831";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/embark-1.1.0.20251117.191148.tar";
-        sha256 = "0km0f7pk6frarfsdh4lz47vpq5d2ryfsxmb8lnksrhw5g7s3zhkw";
+        url = "https://elpa.gnu.org/devel/embark-1.1.0.20260223.105831.tar";
+        sha256 = "0kcwp51brjxmhnm04ml7qhl0ijadq0y6asyfjbrvqpw5lk8sdjkv";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3180,10 +3246,10 @@
     elpaBuild {
       pname = "embark-consult";
       ename = "embark-consult";
-      version = "1.1.0.20251117.191148";
+      version = "1.1.0.20260223.105831";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/embark-consult-1.1.0.20251117.191148.tar";
-        sha256 = "09710k4d5g7rp179mll9a056x9af9ckpsdjl8kcil0rfb7pc5s4r";
+        url = "https://elpa.gnu.org/devel/embark-consult-1.1.0.20260223.105831.tar";
+        sha256 = "030h5cn7567z193kngbnbmm4xdwq0gbd4cngp5yz1ch86n3wbj1y";
       };
       packageRequires = [
         compat
@@ -3244,10 +3310,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "25.0.20260113.142250";
+      version = "25.0.20260213.170929";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/emms-25.0.20260113.142250.tar";
-        sha256 = "1qg6nicdg49qzpq0bcc3drh7ags63izxpsjrwbfh7x7mw4lazp68";
+        url = "https://elpa.gnu.org/devel/emms-25.0.20260213.170929.tar";
+        sha256 = "1lrwhhaqbf09lwfk65gr7hpwc5z5sigpmna48fjmrmsp8aj99rzq";
       };
       packageRequires = [
         cl-lib
@@ -3333,10 +3399,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.6.2snapshot0.20260111.52503";
+      version = "5.6.2snapshot0.20260221.132913";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/erc-5.6.2snapshot0.20260111.52503.tar";
-        sha256 = "1s2n8gab2m97wmqanzvqxqzr2l25zwaczrgfhk23l2xr9rqq2x16";
+        url = "https://elpa.gnu.org/devel/erc-5.6.2snapshot0.20260221.132913.tar";
+        sha256 = "0dch8qbyxq0bhdsx0m3a9lzlym5jz6aljnwak9vw81p8qymsmdbr";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3380,10 +3446,10 @@
     elpaBuild {
       pname = "ess";
       ename = "ess";
-      version = "25.1.0.0.20251230.111114";
+      version = "25.1.0.0.20260203.103302";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20251230.111114.tar";
-        sha256 = "1ybpalv1868brh0y6c1kx1vvqhxbbpw5066448vrnylsjrz99y7c";
+        url = "https://elpa.gnu.org/devel/ess-25.1.0.0.20260203.103302.tar";
+        sha256 = "1r4m4m1x2z9zm28v577gp19603h51z59la7d4w67wjfpmb9mgky5";
       };
       packageRequires = [ ];
       meta = {
@@ -3496,10 +3562,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.34.0.20260101.133557";
+      version = "0.34.0.20260204.122929";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20260101.133557.tar";
-        sha256 = "0f84qsamhhrg71qfs4s3klf61idg8kfs40b0fw9kbd5hm1y9jcrc";
+        url = "https://elpa.gnu.org/devel/exwm-0.34.0.20260204.122929.tar";
+        sha256 = "1bmn6d7pjgjrh265y4w0g1ip8n21sx5z6xsl0vhfhvdf6h2w3c0b";
       };
       packageRequires = [
         compat
@@ -3630,10 +3696,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.4.3.0.20260111.34201";
+      version = "1.4.3.0.20260221.132913";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-1.4.3.0.20260111.34201.tar";
-        sha256 = "18l49lgq8856zl1gjqakv8q18wp5k93lfyaxlay15szpcb3nimrk";
+        url = "https://elpa.gnu.org/devel/flymake-1.4.3.0.20260221.132913.tar";
+        sha256 = "1wrwlgb0iz6bnl0jzw2r5z4x2q7bnf3jmjf5zi36a6b2x4vsjvr9";
       };
       packageRequires = [
         eldoc
@@ -3718,10 +3784,10 @@
     elpaBuild {
       pname = "fontaine";
       ename = "fontaine";
-      version = "3.0.1.0.20260111.105528";
+      version = "3.0.1.0.20260203.152338";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/fontaine-3.0.1.0.20260111.105528.tar";
-        sha256 = "121cm1fjp3simkkql85lf3l03k5amn5fxphcm2c693h5dqldmdkl";
+        url = "https://elpa.gnu.org/devel/fontaine-3.0.1.0.20260203.152338.tar";
+        sha256 = "13q3p2j81a1g5182iz30ibjcqcxp2p9wlwafgivphmrhz744cg5p";
       };
       packageRequires = [ ];
       meta = {
@@ -3816,6 +3882,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/ftable.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  futur = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "futur";
+      ename = "futur";
+      version = "1.0.0.20260218.172833";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/futur-1.0.0.20260218.172833.tar";
+        sha256 = "0sdds9maws20r6isfp0b4xwfj56621yydhav5c2lnvicyz2kgm3c";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/futur.html";
         license = lib.licenses.free;
       };
     }
@@ -3958,10 +4045,10 @@
     elpaBuild {
       pname = "gnome-dark-style";
       ename = "gnome-dark-style";
-      version = "0.2.3.0.20250325.182321";
+      version = "0.2.4.0.20260217.95837";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/gnome-dark-style-0.2.3.0.20250325.182321.tar";
-        sha256 = "1kk6pgl79zgd2jvnh011177080w7vz2561mqi88s1rpv43lf4qxa";
+        url = "https://elpa.gnu.org/devel/gnome-dark-style-0.2.4.0.20260217.95837.tar";
+        sha256 = "1pb86bww72vkm86424wqc2d1kvw2pkq4w3s9cr9r3pn9cqgn1r7h";
       };
       packageRequires = [ ];
       meta = {
@@ -3988,6 +4075,36 @@
       packageRequires = [ cl-lib ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/gnorb.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  gnosis = callPackage (
+    {
+      compat,
+      elpaBuild,
+      emacsql,
+      fetchurl,
+      lib,
+      org-gnosis,
+      transient,
+    }:
+    elpaBuild {
+      pname = "gnosis";
+      ename = "gnosis";
+      version = "0.7.0.0.20260224.120212";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/gnosis-0.7.0.0.20260224.120212.tar";
+        sha256 = "1dwybdq0099364xz7np812xyqzl0vh0xmic76sihaznbpf3ip3qx";
+      };
+      packageRequires = [
+        compat
+        emacsql
+        org-gnosis
+        transient
+      ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/gnosis.html";
         license = lib.licenses.free;
       };
     }
@@ -4165,10 +4282,10 @@
     elpaBuild {
       pname = "graphql";
       ename = "graphql";
-      version = "0.1.2.0.20221202.2453";
+      version = "0.1.2.0.20260206.151038";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/graphql-0.1.2.0.20221202.2453.tar";
-        sha256 = "0wh1lnn85nj026iln02b7p5hgrwd3dmqjkv48gc33ypyd4afh31z";
+        url = "https://elpa.gnu.org/devel/graphql-0.1.2.0.20260206.151038.tar";
+        sha256 = "0rg729h0hkdzfwk8nvp0zfagsbwfzha1ami0mlx935qpvviwjymc";
       };
       packageRequires = [ ];
       meta = {
@@ -4450,10 +4567,10 @@
     elpaBuild {
       pname = "hyperbole";
       ename = "hyperbole";
-      version = "9.0.2pre0.20260111.164604";
+      version = "9.0.2pre0.20260219.214719";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20260111.164604.tar";
-        sha256 = "1f23ai3xhcpf0ka8djpjxc7f2mm3fxb3xvnfma8dgyggw5hgq7lf";
+        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20260219.214719.tar";
+        sha256 = "00mxbqhhiwz9ri0ykcqf58wvn8y1qic6dkfygfr847v44gqzhj12";
       };
       packageRequires = [ ];
       meta = {
@@ -4514,10 +4631,10 @@
     elpaBuild {
       pname = "indent-bars";
       ename = "indent-bars";
-      version = "1.0.0.0.20260118.100043";
+      version = "1.0.0.0.20260120.94117";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/indent-bars-1.0.0.0.20260118.100043.tar";
-        sha256 = "0mc85hal6vsfbw69mzwpn2n9nnqyhzga91vk5b9vdipn616h1w07";
+        url = "https://elpa.gnu.org/devel/indent-bars-1.0.0.0.20260120.94117.tar";
+        sha256 = "11ffwvv8zmkxbc74ny30cgjpwzv6v0mbdcdr1laadhbhwkdlk8am";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4641,10 +4758,10 @@
     elpaBuild {
       pname = "ivy";
       ename = "ivy";
-      version = "0.15.1.0.20251123.103239";
+      version = "0.15.1.0.20260213.120315";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ivy-0.15.1.0.20251123.103239.tar";
-        sha256 = "1cymqwcgql6mra622rmpp62yq81mwfmfvh1fgqvn7sryqndz5hnl";
+        url = "https://elpa.gnu.org/devel/ivy-0.15.1.0.20260213.120315.tar";
+        sha256 = "1s1r32r9pwbxpw19hn53d6mv53dfl96q6zyhfsmfdqawrq2qwzwy";
       };
       packageRequires = [ ];
       meta = {
@@ -4664,10 +4781,10 @@
     elpaBuild {
       pname = "ivy-avy";
       ename = "ivy-avy";
-      version = "0.15.1.0.20250329.150930";
+      version = "0.15.1.0.20260212.144350";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ivy-avy-0.15.1.0.20250329.150930.tar";
-        sha256 = "0zqjfv86p52nr5vfmnliw5awsrzxalhlqwkninnp9sxgdib59z0k";
+        url = "https://elpa.gnu.org/devel/ivy-avy-0.15.1.0.20260212.144350.tar";
+        sha256 = "08fajvzrcgax467alz8gb6x8f6dch5npmgisjwa28pwi32chlqf5";
       };
       packageRequires = [
         avy
@@ -4712,10 +4829,10 @@
     elpaBuild {
       pname = "ivy-hydra";
       ename = "ivy-hydra";
-      version = "0.15.1.0.20250329.151244";
+      version = "0.15.1.0.20260213.120432";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ivy-hydra-0.15.1.0.20250329.151244.tar";
-        sha256 = "19a9bs0hynz203zw6f1y3khgyd3nv7mf3pp2da5gd6h0012j3k5s";
+        url = "https://elpa.gnu.org/devel/ivy-hydra-0.15.1.0.20260213.120432.tar";
+        sha256 = "1b81brh6ys3ra19p1jacpmxxy37yfg712sy5ax81ijzqxfd8bzbx";
       };
       packageRequires = [
         hydra
@@ -4738,10 +4855,10 @@
     elpaBuild {
       pname = "ivy-posframe";
       ename = "ivy-posframe";
-      version = "0.6.3.0.20241023.25839";
+      version = "0.6.4.0.20260127.5004";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ivy-posframe-0.6.3.0.20241023.25839.tar";
-        sha256 = "01wiviygb0c5kjdds1fk10jf9rcf6f59iychqp42yk2lghhw9k1z";
+        url = "https://elpa.gnu.org/devel/ivy-posframe-0.6.4.0.20260127.5004.tar";
+        sha256 = "0fsn7gjg7dvhanlw5h7jp62zjjqdscjm8k64i52423pgj3rydbwz";
       };
       packageRequires = [
         ivy
@@ -4804,10 +4921,10 @@
     elpaBuild {
       pname = "javaimp";
       ename = "javaimp";
-      version = "0.9.1.0.20241129.211411";
+      version = "0.9.1.0.20260220.205136";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/javaimp-0.9.1.0.20241129.211411.tar";
-        sha256 = "1i7jga44n7rdfb51y72x6c3j0k2pwb90x1xz3m0j0iq4avy89dj9";
+        url = "https://elpa.gnu.org/devel/javaimp-0.9.1.0.20260220.205136.tar";
+        sha256 = "1ccfzvn89yi79ayf791iqnl09643z89yyqs2ccvr0ddhjqb7fm9l";
       };
       packageRequires = [ ];
       meta = {
@@ -4848,10 +4965,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "2.6.0.20260117.165000";
+      version = "2.6.0.20260206.84758";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jinx-2.6.0.20260117.165000.tar";
-        sha256 = "1yn9rprxwzvhp5aifz3chxd62jgrr3d174f0frrg2f1hc8dr4gb5";
+        url = "https://elpa.gnu.org/devel/jinx-2.6.0.20260206.84758.tar";
+        sha256 = "0156k1vdd16050q3qbacy5m3nz4k66y5ima40lfhmbh6rh06rfrc";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4934,10 +5051,10 @@
     elpaBuild {
       pname = "jsonrpc";
       ename = "jsonrpc";
-      version = "1.0.27.0.20260111.34201";
+      version = "1.0.27.0.20260126.225709";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.27.0.20260111.34201.tar";
-        sha256 = "0c1lv0lzrx72qfzjrp7zvmz7iqzlic282hc9g9rgxwg03kp2jq4m";
+        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.27.0.20260126.225709.tar";
+        sha256 = "0s96nrzcmkxiszcashz6qjvwmnba0hpr20m2iphawv4yik6jb6gg";
       };
       packageRequires = [ ];
       meta = {
@@ -5041,10 +5158,10 @@
     elpaBuild {
       pname = "kubed";
       ename = "kubed";
-      version = "0.5.0.0.20251212.124255";
+      version = "0.5.1.0.20260213.144943";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/kubed-0.5.0.0.20251212.124255.tar";
-        sha256 = "0jabr52qqa8m4gn4wi9aajv8vf0ycjcxhlx2ldlmpidbwhrihhl2";
+        url = "https://elpa.gnu.org/devel/kubed-0.5.1.0.20260213.144943.tar";
+        sha256 = "1ymddlg4vd5flpg76mpy4md9545vfc5bgfa9ywy5dm6l4f3kw5hq";
       };
       packageRequires = [ ];
       meta = {
@@ -5085,10 +5202,10 @@
     elpaBuild {
       pname = "latex-table-wizard";
       ename = "latex-table-wizard";
-      version = "1.5.4.0.20230903.170436";
+      version = "1.5.5.0.20260212.172924";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/latex-table-wizard-1.5.4.0.20230903.170436.tar";
-        sha256 = "1y1crsd29fvqabzwzki7jqziarycix6bib0cmxlrfsqs95y7dr5w";
+        url = "https://elpa.gnu.org/devel/latex-table-wizard-1.5.5.0.20260212.172924.tar";
+        sha256 = "0n2zvy43lmyvygy3npfgh3897gpwdvxpjd35n6011hbnm3b05s55";
       };
       packageRequires = [
         auctex
@@ -5224,10 +5341,10 @@
     elpaBuild {
       pname = "lin";
       ename = "lin";
-      version = "1.1.0.0.20260111.104855";
+      version = "2.0.0.0.20260215.81346";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/lin-1.1.0.0.20260111.104855.tar";
-        sha256 = "0q6h6xdkf4lhmnib3c9yy2rqil731dpfqn4fpc39br7cmzwzhibj";
+        url = "https://elpa.gnu.org/devel/lin-2.0.0.0.20260215.81346.tar";
+        sha256 = "12mfawgz0pxfnxlkcd6vnjywjwx82nxy7myfd93bzqd2j8sgj53w";
       };
       packageRequires = [ ];
       meta = {
@@ -5300,10 +5417,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.28.5.0.20260110.215927";
+      version = "0.29.0.0.20260221.195402";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/llm-0.28.5.0.20260110.215927.tar";
-        sha256 = "1pljk62skgv02fv18gs0dvkq6wy7z6aya2qxhlgrh41hifb14837";
+        url = "https://elpa.gnu.org/devel/llm-0.29.0.0.20260221.195402.tar";
+        sha256 = "0jpjxmckc6cp56i44yx3f91k1bp30sibmpqns5n4fdi31z0jq0nz";
       };
       packageRequires = [
         compat
@@ -5540,10 +5657,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.8.0.20260117.165105";
+      version = "2.9.0.20260220.114937";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/marginalia-2.8.0.20260117.165105.tar";
-        sha256 = "0y5cmg778w0mik4pkbb2l9x7qp456dhrhcbyapr5g4ym2jl1id25";
+        url = "https://elpa.gnu.org/devel/marginalia-2.9.0.20260220.114937.tar";
+        sha256 = "0l8spkn49mxzid72zi9g26wp8jmzc4a4pvhi068jyixd3mr6sip6";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5646,10 +5763,10 @@
     elpaBuild {
       pname = "matlab-mode";
       ename = "matlab-mode";
-      version = "7.4.2.0.20251229.125049";
+      version = "8.1.1.0.20260224.73923";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/matlab-mode-7.4.2.0.20251229.125049.tar";
-        sha256 = "1rff2njap1ymgmydhsjif1i09x3rnj6xa1xz7x3pp8jyvg5vkzwp";
+        url = "https://elpa.gnu.org/devel/matlab-mode-8.1.1.0.20260224.73923.tar";
+        sha256 = "0q1lfanrdqbx7h3kcb2ldz0ffzm87jx2ymghj6kzy03y8p9k7fqc";
       };
       packageRequires = [ ];
       meta = {
@@ -5667,10 +5784,10 @@
     elpaBuild {
       pname = "mct";
       ename = "mct";
-      version = "1.1.0.0.20260110.55916";
+      version = "1.1.0.0.20260204.175531";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/mct-1.1.0.0.20260110.55916.tar";
-        sha256 = "1721nlynl8qq610zczqbjvbj6bgb4pvm9gqqayg3sn5ns2zs71q1";
+        url = "https://elpa.gnu.org/devel/mct-1.1.0.0.20260204.175531.tar";
+        sha256 = "1fd1nd013g3ayd3ckkjp4b6b2nf96rxfjgcs16w0f5x2zxrbkhw0";
       };
       packageRequires = [ ];
       meta = {
@@ -5860,10 +5977,10 @@
     elpaBuild {
       pname = "minuet";
       ename = "minuet";
-      version = "0.7.1.0.20251218.173414";
+      version = "0.7.1.0.20260202.224249";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/minuet-0.7.1.0.20251218.173414.tar";
-        sha256 = "0zy7rgl75ckaiibsmb0h09vrkmi9cz6svazfc8z20l0xnrkm10lr";
+        url = "https://elpa.gnu.org/devel/minuet-0.7.1.0.20260202.224249.tar";
+        sha256 = "0qd8h8aicmxqq7y9whgvapi0vlfgrhplrmzn2bpq4pxgk2d62zyn";
       };
       packageRequires = [
         dash
@@ -5927,10 +6044,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "5.2.0.0.20260113.43126";
+      version = "5.2.0.0.20260222.64339";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/modus-themes-5.2.0.0.20260113.43126.tar";
-        sha256 = "18wyzmpqax2zy37nm6naf8j059690ghxqkqa9qlqi6297wva229z";
+        url = "https://elpa.gnu.org/devel/modus-themes-5.2.0.0.20260222.64339.tar";
+        sha256 = "052h6agrbjz5agm25ymwd6gnfizdkm0s62257cawcqzxwd9c192m";
       };
       packageRequires = [ ];
       meta = {
@@ -6461,10 +6578,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.5.0.20260117.174956";
+      version = "1.6.0.20260127.172602";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/orderless-1.5.0.20260117.174956.tar";
-        sha256 = "1qrriyzh3gxd8w2v70njlf85yx6m6krkpdmigngbz1zlaw0axnrg";
+        url = "https://elpa.gnu.org/devel/orderless-1.6.0.20260127.172602.tar";
+        sha256 = "1arpnkw49vhrdgp7b9mpxbbv6q3mwnimn1d79cr3jjs97ngii980";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6482,10 +6599,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.8pre0.20260113.104754";
+      version = "10.0pre0.20260223.193918";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-9.8pre0.20260113.104754.tar";
-        sha256 = "161gp3vgl4i99l1z3dc9afs5gigdlflnpxsy78axh35bkli4b1ky";
+        url = "https://elpa.gnu.org/devel/org-10.0pre0.20260223.193918.tar";
+        sha256 = "0vpi9p9qspcdr4qzjxhb4nnck792hglqfdch0p7bir3305kcv7yv";
       };
       packageRequires = [ ];
       meta = {
@@ -6504,10 +6621,10 @@
     elpaBuild {
       pname = "org-contacts";
       ename = "org-contacts";
-      version = "1.2.0.20260114.75421";
+      version = "1.3.0.20260221.85240";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-contacts-1.2.0.20260114.75421.tar";
-        sha256 = "0x84lmaq5xr8i03hn0k5yvlmv79k6vhgdczavii5pbz6n3ggdhfs";
+        url = "https://elpa.gnu.org/devel/org-contacts-1.3.0.20260221.85240.tar";
+        sha256 = "1kvz0lhcq7mscraqb1np2r6sh8hincxr5k2n1iz037x8w5wdfqh9";
       };
       packageRequires = [ org ];
       meta = {
@@ -6553,10 +6670,10 @@
     elpaBuild {
       pname = "org-gnosis";
       ename = "org-gnosis";
-      version = "0.1.1.0.20260111.154709";
+      version = "0.2.2.0.20260224.203152";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-gnosis-0.1.1.0.20260111.154709.tar";
-        sha256 = "0il5nqmd6qj3ypglsdfcc4rxpzfrqdp8s4rg7f4jjd5qy2l3kwnw";
+        url = "https://elpa.gnu.org/devel/org-gnosis-0.2.2.0.20260224.203152.tar";
+        sha256 = "1ls3wnd4brn3aadafyfn4m4lkav5v5sm77irlijnm90rg2jdk7xc";
       };
       packageRequires = [
         compat
@@ -6601,10 +6718,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.12.0.20260117.165215";
+      version = "1.12.0.20260125.143845";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-modern-1.12.0.20260117.165215.tar";
-        sha256 = "1izgb25clhfm94091bkw7qb0lanx07d5757w5a7m0z1qcdqpfayw";
+        url = "https://elpa.gnu.org/devel/org-modern-1.12.0.20260125.143845.tar";
+        sha256 = "06kgflqfq3pifhr9442rpk2ik0jha9w7brla55lkxg0ips8822hw";
       };
       packageRequires = [
         compat
@@ -6781,10 +6898,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "2.1.0.20260118.165714";
+      version = "2.2.0.20260125.120005";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/osm-2.1.0.20260118.165714.tar";
-        sha256 = "177f9ygbfyxb5vghp5c1cq6qy9fjz0ryf0srp3zla42zjfjnd4al";
+        url = "https://elpa.gnu.org/devel/osm-2.2.0.20260125.120005.tar";
+        sha256 = "0ckw3ffkwykkzx435raypkblhvg91ls221qfvzpdc5jrwzygdfhn";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6866,10 +6983,10 @@
     elpaBuild {
       pname = "package-x";
       ename = "package-x";
-      version = "1.0.0.20251206.95854";
+      version = "1.0.0.20260219.70820";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/package-x-1.0.0.20251206.95854.tar";
-        sha256 = "0xbrmjk3yz05r196fy42yrxv52qc3ajdapdx3vkqxbqh4f5pcmmm";
+        url = "https://elpa.gnu.org/devel/package-x-1.0.0.20260219.70820.tar";
+        sha256 = "09c2hjisggl8x23z3yq08rhy8k8rg6y1zqil81c7dapcjk1bcznq";
       };
       packageRequires = [ ];
       meta = {
@@ -7157,6 +7274,27 @@
       };
     }
   ) { };
+  po-mode = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "po-mode";
+      ename = "po-mode";
+      version = "2.32.0.20260217.95607";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/po-mode-2.32.0.20260217.95607.tar";
+        sha256 = "16dkn7k3kkrv1n7c9qnvpzbrywgq4cwgry7szcsgyglrf6dq89y9";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/po-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   poke = callPackage (
     {
       elpaBuild,
@@ -7271,10 +7409,10 @@
     elpaBuild {
       pname = "posframe";
       ename = "posframe";
-      version = "1.5.0.0.20251125.84642";
+      version = "1.5.1.0.20260127.5158";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/posframe-1.5.0.0.20251125.84642.tar";
-        sha256 = "1cydrjx1i7l2aqv96gi7qdaa0d7cnv9b71xn0c9hdmigkdj7wdxh";
+        url = "https://elpa.gnu.org/devel/posframe-1.5.1.0.20260127.5158.tar";
+        sha256 = "17rxfbxwf89psi36fqfcwazk63pbrrv7xpg84d5hk6l8cvb7rhpn";
       };
       packageRequires = [ ];
       meta = {
@@ -7335,10 +7473,10 @@
     elpaBuild {
       pname = "preview-auto";
       ename = "preview-auto";
-      version = "0.4.1.0.20251222.150444";
+      version = "0.4.2.0.20260205.43257";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/preview-auto-0.4.1.0.20251222.150444.tar";
-        sha256 = "1lrj5053zndswqy914ngxvprcvrgdrrvwr6vlwgjdvmlpk1fyk5i";
+        url = "https://elpa.gnu.org/devel/preview-auto-0.4.2.0.20260205.43257.tar";
+        sha256 = "0dibby96qk7bv2rxgz3yviwdp61znq9qac72n5lqx07vg6hki486";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -7379,10 +7517,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.2.0.20260115.65220";
+      version = "0.11.2.0.20260223.152156";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/project-0.11.2.0.20260115.65220.tar";
-        sha256 = "0aah8nssxagr5znf08fs5zzdzin8iipk9chhhfv5l1dpqdi200r1";
+        url = "https://elpa.gnu.org/devel/project-0.11.2.0.20260223.152156.tar";
+        sha256 = "1z3ahlw0197qj3br609hz00cc4n44x3yh1pv8jg20c1b54clsjr8";
       };
       packageRequires = [ xref ];
       meta = {
@@ -7442,10 +7580,10 @@
     elpaBuild {
       pname = "pulsar";
       ename = "pulsar";
-      version = "1.3.2.0.20260111.105226";
+      version = "1.3.2.0.20260218.80724";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pulsar-1.3.2.0.20260111.105226.tar";
-        sha256 = "0lj8slzakg34f66ig4lq91hvqq92ja2vapwm9af8d1rphpz6qnil";
+        url = "https://elpa.gnu.org/devel/pulsar-1.3.2.0.20260218.80724.tar";
+        sha256 = "11f0c0qqzjqp92y1jwzckz25dv2ny04dm0rljg5kr4b9zs6y7sq9";
       };
       packageRequires = [ ];
       meta = {
@@ -7507,25 +7645,17 @@
       compat,
       elpaBuild,
       fetchurl,
-      flymake ? null,
       lib,
-      project,
-      seq,
     }:
     elpaBuild {
       pname = "python";
       ename = "python";
-      version = "0.30.0.20260117.160903";
+      version = "0.30.0.20260221.145128";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/python-0.30.0.20260117.160903.tar";
-        sha256 = "04m2p8054yfd0152dr7m08b4jszb15j91v3l97ailcasqfvwk80s";
+        url = "https://elpa.gnu.org/devel/python-0.30.0.20260221.145128.tar";
+        sha256 = "0hq170dzda5i08r8njm5ql8x10495xwa2sqq586f8wk48cczph5c";
       };
-      packageRequires = [
-        compat
-        flymake
-        project
-        seq
-      ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/python.html";
         license = lib.licenses.free;
@@ -7713,10 +7843,10 @@
     elpaBuild {
       pname = "realgud";
       ename = "realgud";
-      version = "1.6.0.0.20260111.74248";
+      version = "1.6.0.0.20260128.34106";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/realgud-1.6.0.0.20260111.74248.tar";
-        sha256 = "1ma8nahs8gy8wmjwmdazbnfwc52kcgy3pwbnawmp3sycz8kvdpqq";
+        url = "https://elpa.gnu.org/devel/realgud-1.6.0.0.20260128.34106.tar";
+        sha256 = "1cp7gq50fls2qzq4i34g6alcghjfmf2mj7i5lk8c1a5s9k3d4ma3";
       };
       packageRequires = [
         load-relative
@@ -7993,10 +8123,10 @@
     elpaBuild {
       pname = "relint";
       ename = "relint";
-      version = "2.1.0.20250904.163151";
+      version = "2.2.0.20260205.105130";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/relint-2.1.0.20250904.163151.tar";
-        sha256 = "11abw06nwq50xpin61qnmka3zdlkdmpljl34gs3ahf0b7p4w1g9b";
+        url = "https://elpa.gnu.org/devel/relint-2.2.0.20260205.105130.tar";
+        sha256 = "06k83c8ldxrdh9ncq5f3s4r84l6j367bcivv4y1gr0g5yhf92dgf";
       };
       packageRequires = [ xr ];
       meta = {
@@ -8834,10 +8964,10 @@
     elpaBuild {
       pname = "standard-themes";
       ename = "standard-themes";
-      version = "3.0.2.0.20260111.90308";
+      version = "3.0.2.0.20260219.64809";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/standard-themes-3.0.2.0.20260111.90308.tar";
-        sha256 = "17nkzfq0cfk0rylrqwfxmlyhk6l8csdvhk99s741d9vlzbmas1x0";
+        url = "https://elpa.gnu.org/devel/standard-themes-3.0.2.0.20260219.64809.tar";
+        sha256 = "0kll4xdizkyggmsjjg8v23vmff24fcmwvy486q01yyh3rwx7g68l";
       };
       packageRequires = [ modus-themes ];
       meta = {
@@ -8876,10 +9006,10 @@
     elpaBuild {
       pname = "substitute";
       ename = "substitute";
-      version = "0.5.0.0.20260105.62903";
+      version = "0.5.0.0.20260223.124554";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/substitute-0.5.0.0.20260105.62903.tar";
-        sha256 = "13bgq1niji5nxy1f543nhwlvpa00n00ypg519fm6s9ylmg9gza4z";
+        url = "https://elpa.gnu.org/devel/substitute-0.5.0.0.20260223.124554.tar";
+        sha256 = "1n4lcs12vn4ndsiwzhh80hadkgnvfagimf3lrixlwwzhi1j9vrdk";
       };
       packageRequires = [ ];
       meta = {
@@ -8984,10 +9114,10 @@
     elpaBuild {
       pname = "swiper";
       ename = "swiper";
-      version = "0.15.1.0.20250329.151337";
+      version = "0.15.1.0.20260212.144752";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/swiper-0.15.1.0.20250329.151337.tar";
-        sha256 = "08glyqqvj3m9bph1i53m32wg58xvxzglc44gidmg2b1gf2w3gl82";
+        url = "https://elpa.gnu.org/devel/swiper-0.15.1.0.20260212.144752.tar";
+        sha256 = "1v1lhxmann8c5jd9qnskvzkfl3bpjd9d1lh8dw7v3d89f8xh9p11";
       };
       packageRequires = [ ivy ];
       meta = {
@@ -9006,10 +9136,10 @@
     elpaBuild {
       pname = "switchy-window";
       ename = "switchy-window";
-      version = "1.3.0.20230411.180529";
+      version = "1.4.0.20260208.102948";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/switchy-window-1.3.0.20230411.180529.tar";
-        sha256 = "1h3jib0qr8wj3xk3qha5yrw2vqhidnqhj4jhw2smrfk61vyfs83b";
+        url = "https://elpa.gnu.org/devel/switchy-window-1.4.0.20260208.102948.tar";
+        sha256 = "1s70jnsbqa37arq4czmzbn4r2ba9s6k8k7iz2i6bz0pqmbdrmp84";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9207,10 +9337,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.9.0.20260119.133441";
+      version = "1.11.0.20260220.115732";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tempel-1.9.0.20260119.133441.tar";
-        sha256 = "1a642c0rasmyx94i7bjg9lpqj0sr624zi3vwz1jn2bxjfv3p3jpk";
+        url = "https://elpa.gnu.org/devel/tempel-1.11.0.20260220.115732.tar";
+        sha256 = "09gxz4irm50hszyiq6sz73r93qydahmdfvr7q8pp38vlp19w19ad";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9398,10 +9528,10 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.2.1.0.20260119.190816";
+      version = "1.3.0.0.20260125.74805";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tmr-1.2.1.0.20260119.190816.tar";
-        sha256 = "0c331q79fgvm0rhp2am836mqv70grzrdjvs10x8a74hmn9f0qr79";
+        url = "https://elpa.gnu.org/devel/tmr-1.3.0.0.20260125.74805.tar";
+        sha256 = "1pbl233p38nhdivrr9yh5k4i87mmdyf10rczv8v5mc0vvv68v4c7";
       };
       packageRequires = [ ];
       meta = {
@@ -9487,10 +9617,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.1.0.20260111.85658";
+      version = "2.8.1.1.0.20260130.95525";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-2.8.1.0.20260111.85658.tar";
-        sha256 = "0ya9jdsd2h91rc37qxm15aniivlrnmlmqzmk2hlrqdy0qpkismw8";
+        url = "https://elpa.gnu.org/devel/tramp-2.8.1.1.0.20260130.95525.tar";
+        sha256 = "0dvacg1jhz527incsfk6zprgjp7aswcf5zg28rfyi2gh7rqql176";
       };
       packageRequires = [ ];
       meta = {
@@ -9596,10 +9726,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.12.0.0.20260118.132220";
+      version = "0.12.0.0.20260223.94608";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-0.12.0.0.20260118.132220.tar";
-        sha256 = "1b0x7ljqgxdc9dw63v7jvqzhs7vkck54xjvyfx9fhsiq2ijnw3yp";
+        url = "https://elpa.gnu.org/devel/transient-0.12.0.0.20260223.94608.tar";
+        sha256 = "1vyr3k30jdw18ban3qhr30k36gq9xxh1ycnahivm0i8wwvav9kzy";
       };
       packageRequires = [
         compat
@@ -9888,10 +10018,10 @@
     elpaBuild {
       pname = "use-package";
       ename = "use-package";
-      version = "2.4.6.0.20260101.125434";
+      version = "2.4.6.0.20260221.132913";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20260101.125434.tar";
-        sha256 = "1i460law39bbfsy2y55jirnab3yv2g88qgx4n88lygq1drvc3qrg";
+        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20260221.132913.tar";
+        sha256 = "0rxzzf8j93dwlsrll6kfdbbs1kk7h033rmispl28hn3drccvy2k6";
       };
       packageRequires = [ bind-key ];
       meta = {
@@ -10021,10 +10151,10 @@
     elpaBuild {
       pname = "vc-jj";
       ename = "vc-jj";
-      version = "0.5.0.20260119.103313";
+      version = "0.5.0.20260214.163529";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vc-jj-0.5.0.20260119.103313.tar";
-        sha256 = "0h4lz3mr7iwd2ik17my467pa7k47xz5y67ccwmgkgyq2wkr2s4dm";
+        url = "https://elpa.gnu.org/devel/vc-jj-0.5.0.20260214.163529.tar";
+        sha256 = "1v5dv8ck76l76z0bjm92p8g4vxxi19rxlci934r4qmcgfb06bx0p";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10154,10 +10284,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "2.7.0.20260119.65523";
+      version = "2.7.0.20260210.102152";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-2.7.0.20260119.65523.tar";
-        sha256 = "131534qw0g88fyr4klk226abywm0vxzvwmq06pp4zf4k4114d2hy";
+        url = "https://elpa.gnu.org/devel/vertico-2.7.0.20260210.102152.tar";
+        sha256 = "0797n6lwgwrxk92s1q0l9wn0dw1siz5jxayvvwfwzm6d9lprhzf8";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10177,10 +10307,10 @@
     elpaBuild {
       pname = "vertico-posframe";
       ename = "vertico-posframe";
-      version = "0.9.0.0.20250910.92713";
+      version = "0.9.2.0.20260201.41512";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-posframe-0.9.0.0.20250910.92713.tar";
-        sha256 = "17lzg4w68rws0824dm1qn1fv9a63pwscvhabfqlfvicnkrpz7rzb";
+        url = "https://elpa.gnu.org/devel/vertico-posframe-0.9.2.0.20260201.41512.tar";
+        sha256 = "1alirwmf1x1m9h8amsbjvx6x1hh0cc0f83r2nay8vp2rr20jrgvp";
       };
       packageRequires = [
         posframe
@@ -10392,10 +10522,10 @@
     elpaBuild {
       pname = "websocket";
       ename = "websocket";
-      version = "1.15.0.20230808.230535";
+      version = "1.16.0.20260201.101702";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/websocket-1.15.0.20230808.230535.tar";
-        sha256 = "15xry8bv9vcc470j3an5ks9z2hg7ia4nl7x4xvqb77rpbkq53rb9";
+        url = "https://elpa.gnu.org/devel/websocket-1.16.0.20260201.101702.tar";
+        sha256 = "1hw5phwfi4gjicbad4bd1l7701xm8zixl1y563ip6v7g9k92pgf0";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -10699,10 +10829,10 @@
     elpaBuild {
       pname = "xr";
       ename = "xr";
-      version = "2.1.0.20250904.163110";
+      version = "2.2.0.20260205.105100";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xr-2.1.0.20250904.163110.tar";
-        sha256 = "1xa4y8dlkcskxhvd3gyfpfibkhgxfx25lf89km33wwz4d7vibzc9";
+        url = "https://elpa.gnu.org/devel/xr-2.2.0.20260205.105100.tar";
+        sha256 = "0zxm42k85h5xycn9j3xxdr950506r4kkx30i0jppj08lkk7dkdnb";
       };
       packageRequires = [ ];
       meta = {
@@ -10720,10 +10850,10 @@
     elpaBuild {
       pname = "xref";
       ename = "xref";
-      version = "1.7.0.0.20260101.125434";
+      version = "1.7.0.0.20260206.35652";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20260101.125434.tar";
-        sha256 = "0rp9r6s7k20jhhq2nbd0n8i42i5j0cjgni8b8xf7v22f4mksl5pk";
+        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20260206.35652.tar";
+        sha256 = "0sn1l2q5ka3qz066lz1gh9nbil8nzmyra8rbbd1h7ga4m9xhjs9g";
       };
       packageRequires = [ ];
       meta = {
@@ -10741,10 +10871,10 @@
     elpaBuild {
       pname = "xref-union";
       ename = "xref-union";
-      version = "0.2.0.0.20231225.162837";
+      version = "0.2.0.0.20260222.131318";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xref-union-0.2.0.0.20231225.162837.tar";
-        sha256 = "0is4r12r30drq1msa5143bgnwam1kgbf2iia30fbqv0l0rhvqd9x";
+        url = "https://elpa.gnu.org/devel/xref-union-0.2.0.0.20260222.131318.tar";
+        sha256 = "143kmlnmpgkv52a7yya0sy4r51vi838fvcjwjiczczydwxam59iz";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -698,10 +698,10 @@
     elpaBuild {
       pname = "beframe";
       ename = "beframe";
-      version = "1.4.0";
+      version = "1.5.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/beframe-1.4.0.tar";
-        sha256 = "1766y7jwhsccmndd30v7hyh3i8gacvzwb73ix7g0zynp12m6x6kb";
+        url = "https://elpa.gnu.org/packages/beframe-1.5.0.tar";
+        sha256 = "0cx7jxlfzqaldswnk2wg5z4zb7lv24x5by9h20y4vpf973nclj0r";
       };
       packageRequires = [ ];
       meta = {
@@ -994,10 +994,10 @@
     elpaBuild {
       pname = "buframe";
       ename = "buframe";
-      version = "0.2";
+      version = "0.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/buframe-0.2.tar";
-        sha256 = "0bnj4xvwmda62j9i7a9pnd0x20wa6g3il8cl55df26qpgqmjjpkq";
+        url = "https://elpa.gnu.org/packages/buframe-0.3.tar";
+        sha256 = "1lhbs13f1kky4f7ylfl4ki7gqi51x2rgmipmwx3w9b8hx8d8s6h1";
       };
       packageRequires = [ timeout ];
       meta = {
@@ -1085,10 +1085,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "2.5";
+      version = "2.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/cape-2.5.tar";
-        sha256 = "1xfrz3pvryp0b5x14dy04s97j3ir0iqxaij77a64gqvpmfjg154i";
+        url = "https://elpa.gnu.org/packages/cape-2.6.tar";
+        sha256 = "0n4j70w1q9ix9d8s276g4shkn1k7hv8d6wqpx65wchgilwbjx07z";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1900,10 +1900,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.25.0";
+      version = "0.26.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dape-0.25.0.tar";
-        sha256 = "1ffmmaqadgrc0h51zk1j8c5whrzi7c63l069jl74xmczvphh7zl4";
+        url = "https://elpa.gnu.org/packages/dape-0.26.0.tar";
+        sha256 = "0arid8qwaf7ic76hsjzj7grn41krsphnzvihmjbgm4im6b7zzb37";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -2130,6 +2130,28 @@
       packageRequires = [ denote ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/denote-org.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  denote-review = callPackage (
+    {
+      denote,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "denote-review";
+      ename = "denote-review";
+      version = "1.0.5";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/denote-review-1.0.5.tar";
+        sha256 = "0ss3mkir4x3k6f9fsg2z8w87dm2ny6a8yj4lf2hqkb1fsp9cl5wb";
+      };
+      packageRequires = [ denote ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/denote-review.html";
         license = lib.licenses.free;
       };
     }
@@ -2536,10 +2558,10 @@
     elpaBuild {
       pname = "do-at-point";
       ename = "do-at-point";
-      version = "0.1.2";
+      version = "0.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/do-at-point-0.1.2.tar";
-        sha256 = "0kirhg78ra6311hx1f1kpqhpxjxxg61gnzsh9j6id10f92h6m5gz";
+        url = "https://elpa.gnu.org/packages/do-at-point-0.2.0.tar";
+        sha256 = "028vpz6xss6k5wh3p6pigd47r5vrpl8fgai0spmz22ldawy61dfg";
       };
       packageRequires = [ ];
       meta = {
@@ -2620,10 +2642,10 @@
     elpaBuild {
       pname = "doric-themes";
       ename = "doric-themes";
-      version = "0.6.0";
+      version = "1.0.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/doric-themes-0.6.0.tar";
-        sha256 = "0rfdlzxg5xsmx4qzv9ffsp82immwaj44q2kmqr9lrrzqw185gwxy";
+        url = "https://elpa.gnu.org/packages/doric-themes-1.0.0.tar";
+        sha256 = "0bgbqa8j5yi23b7k447q5sffr1vk8pg23qk0a56vayz62y7ga8xa";
       };
       packageRequires = [ ];
       meta = {
@@ -2822,10 +2844,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20251219";
+      version = "20260126";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/eev-20251219.tar";
-        sha256 = "00q9yrcyd74nkqv32s1917s1qvgx6rg9lja5bka6i0jkwpw1rxzn";
+        url = "https://elpa.gnu.org/packages/eev-20260126.tar";
+        sha256 = "10n8fs61casjx7p64jvghwc15b09mmwp06af9s32z9bj73r4hyfk";
       };
       packageRequires = [ ];
       meta = {
@@ -2844,10 +2866,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "2.0.1";
+      version = "2.1.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ef-themes-2.0.1.tar";
-        sha256 = "039jhc3lwwp7s420078zr65k4l611n5x9bxhj2klqyzixsw4w64n";
+        url = "https://elpa.gnu.org/packages/ef-themes-2.1.0.tar";
+        sha256 = "09rb5pkqz63mc86f8n7969f8x27jdrhz51rh6vl0v3j4nvivv3dx";
       };
       packageRequires = [ modus-themes ];
       meta = {
@@ -2901,10 +2923,10 @@
     elpaBuild {
       pname = "el-job";
       ename = "el-job";
-      version = "2.6.1";
+      version = "2.7.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/el-job-2.6.1.tar";
-        sha256 = "1ghpi0hgvvbqq18c0f6n4pgajjdhad8gr03xg51byablkahfwwsz";
+        url = "https://elpa.gnu.org/packages/el-job-2.7.3.tar";
+        sha256 = "0fvamj342grhv9b1fl0p1n831sj5jvia4sd4n17i80z20yjydn8l";
       };
       packageRequires = [ ];
       meta = {
@@ -3041,20 +3063,22 @@
       llm,
       plz,
       transient,
+      yaml,
     }:
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "1.10.10";
+      version = "1.12.18";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ellama-1.10.10.tar";
-        sha256 = "1j04fmkhrdj5xnvh1c3x2s2fdn6mv2q2gckjgpi4n2wnyd87mdgg";
+        url = "https://elpa.gnu.org/packages/ellama-1.12.18.tar";
+        sha256 = "1r05xa4hzv3pw6b015nyaazqpj50n4b10z0vs5r4g8gxwhz5bz7p";
       };
       packageRequires = [
         compat
         llm
         plz
         transient
+        yaml
       ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/ellama.html";
@@ -3755,6 +3779,27 @@
       };
     }
   ) { };
+  futur = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "futur";
+      ename = "futur";
+      version = "1.0";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/futur-1.0.tar";
+        sha256 = "1pi7r87lddhf6fnvj78had1s9rpzfddcsw0ws8gc6czwly3n8vxg";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/futur.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   gcmh = callPackage (
     {
       elpaBuild,
@@ -3893,10 +3938,10 @@
     elpaBuild {
       pname = "gnome-dark-style";
       ename = "gnome-dark-style";
-      version = "0.2.3";
+      version = "0.2.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/gnome-dark-style-0.2.3.tar";
-        sha256 = "04cp31252svf5pkkkmx9b6nlcv3v4xffn739bna77jjyrw98mhv5";
+        url = "https://elpa.gnu.org/packages/gnome-dark-style-0.2.4.tar";
+        sha256 = "0smdgd68ha155lc4mmv1ix8y8mk1il081cx4gap49kny5ybx3538";
       };
       packageRequires = [ ];
       meta = {
@@ -3923,6 +3968,36 @@
       packageRequires = [ cl-lib ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/gnorb.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  gnosis = callPackage (
+    {
+      compat,
+      elpaBuild,
+      emacsql,
+      fetchurl,
+      lib,
+      org-gnosis,
+      transient,
+    }:
+    elpaBuild {
+      pname = "gnosis";
+      ename = "gnosis";
+      version = "0.7.0";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/gnosis-0.7.0.tar";
+        sha256 = "1l0dkwjgzh9by5hn6kfhcmjbbxyvdhfadwn104iny9ikgr9qsfih";
+      };
+      packageRequires = [
+        compat
+        emacsql
+        org-gnosis
+        transient
+      ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/gnosis.html";
         license = lib.licenses.free;
       };
     }
@@ -4677,10 +4752,10 @@
     elpaBuild {
       pname = "ivy-posframe";
       ename = "ivy-posframe";
-      version = "0.6.3";
+      version = "0.6.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ivy-posframe-0.6.3.tar";
-        sha256 = "027lbddg4rc44jpvxsqyw9n9pi1bnsssfislg2il3hbr86v88va9";
+        url = "https://elpa.gnu.org/packages/ivy-posframe-0.6.4.tar";
+        sha256 = "1lpfbr4baxha66g0pwgh3x0sgil2mrhify896raj4zal4zmbp0fk";
       };
       packageRequires = [
         ivy
@@ -4980,10 +5055,10 @@
     elpaBuild {
       pname = "kubed";
       ename = "kubed";
-      version = "0.5.0";
+      version = "0.5.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/kubed-0.5.0.tar";
-        sha256 = "00j0yx7bknjdl6mcfimlwp7plxgn7al3fl4rfxw7s4pgqgyyslsw";
+        url = "https://elpa.gnu.org/packages/kubed-0.5.1.tar";
+        sha256 = "1mfb9961xi7b7a4g3687y4hhlq37j98qsvq8cl4gsgy3x8j7vs2p";
       };
       packageRequires = [ ];
       meta = {
@@ -5024,10 +5099,10 @@
     elpaBuild {
       pname = "latex-table-wizard";
       ename = "latex-table-wizard";
-      version = "1.5.4";
+      version = "1.5.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/latex-table-wizard-1.5.4.tar";
-        sha256 = "1999kh5yi0cg1k0al3np3zi2qhrmcpzxqsfvwg0mgrg3mww4gqlw";
+        url = "https://elpa.gnu.org/packages/latex-table-wizard-1.5.5.tar";
+        sha256 = "1fffbaqiz3f1f2ki26b8x0cmisqhaijpw5vrh73k769wqdv09g43";
       };
       packageRequires = [
         auctex
@@ -5163,10 +5238,10 @@
     elpaBuild {
       pname = "lin";
       ename = "lin";
-      version = "1.1.0";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/lin-1.1.0.tar";
-        sha256 = "1rf81r8ylq2cccx4svdkiy2rvz1rq6cw0dakrcd4jrrscww52d7c";
+        url = "https://elpa.gnu.org/packages/lin-2.0.0.tar";
+        sha256 = "1ga1wb0fqv2abm95ymz1ki4dy0qlbi3cliz6mbkbk6gbdd1vhmaw";
       };
       packageRequires = [ ];
       meta = {
@@ -5239,10 +5314,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.28.5";
+      version = "0.29.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/llm-0.28.5.tar";
-        sha256 = "0imqqp95knnjx9c2x0ipgpr82j23jiqldldkff9qx19qkp66jq9l";
+        url = "https://elpa.gnu.org/packages/llm-0.29.0.tar";
+        sha256 = "0pybl4wxirsi00blx18gy1786n4324mb2fvr7n1a0bfyljz2rm6k";
       };
       packageRequires = [
         compat
@@ -5477,10 +5552,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "2.8";
+      version = "2.9";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/marginalia-2.8.tar";
-        sha256 = "0gshbibjpzi1cxvyg1jvxgp9a1n7pgizf8nibx6kmj10liilcjmk";
+        url = "https://elpa.gnu.org/packages/marginalia-2.9.tar";
+        sha256 = "1a6hnqfnfyd25vk1qgcqflj4x1hcd4whn0hwkpbhnfnsmdkxzpra";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5583,10 +5658,10 @@
     elpaBuild {
       pname = "matlab-mode";
       ename = "matlab-mode";
-      version = "7.4.2";
+      version = "8.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/matlab-mode-7.4.2.tar";
-        sha256 = "03dfhmcmd7c5iyzv6p5p56cr88nx10jvkvmlan7953g2w10nh836";
+        url = "https://elpa.gnu.org/packages/matlab-mode-8.1.1.tar";
+        sha256 = "0d0zq1fhx8dn0j2b4b62zpa2y301y2gg79msrybj4bm42hsqfx8x";
       };
       packageRequires = [ ];
       meta = {
@@ -6374,10 +6449,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.5";
+      version = "1.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/orderless-1.5.tar";
-        sha256 = "188mksjaazf1rxvyqrcybya4a53j6c1xwvcbfh8s1sgv0jqxlv8z";
+        url = "https://elpa.gnu.org/packages/orderless-1.6.tar";
+        sha256 = "15gif01ivwg03h45azrj3kw2lgj7xnkr6p9r95m36fmfbg31csdh";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6395,10 +6470,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.7.39";
+      version = "9.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-9.7.39.tar";
-        sha256 = "1yg50h84sqd2wfpcyxkwyvrvr30cqdqdvcl6kcsja22si19yjbxw";
+        url = "https://elpa.gnu.org/packages/org-9.8.tar";
+        sha256 = "1xfv6jk8gx0jv809cgpag5hcmw6n9gic2rxchb62qcnjiz4sl0q4";
       };
       packageRequires = [ ];
       meta = {
@@ -6417,10 +6492,10 @@
     elpaBuild {
       pname = "org-contacts";
       ename = "org-contacts";
-      version = "1.2";
+      version = "1.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-contacts-1.2.tar";
-        sha256 = "1icdwijxii3f14f8w1wh8pcg9xy4r1hlii7lzgb7jjswxn303gaj";
+        url = "https://elpa.gnu.org/packages/org-contacts-1.3.tar";
+        sha256 = "052j0d81fw6ppw7l8h0dj4jiar45skmwr3li058alxrqpgkxhxfh";
       };
       packageRequires = [ org ];
       meta = {
@@ -6466,10 +6541,10 @@
     elpaBuild {
       pname = "org-gnosis";
       ename = "org-gnosis";
-      version = "0.1.1";
+      version = "0.2.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-gnosis-0.1.1.tar";
-        sha256 = "0165bv6ky7zg9km7h63qzqg7rxnjdcpks4xyv0l2sidgmzimdyg5";
+        url = "https://elpa.gnu.org/packages/org-gnosis-0.2.2.tar";
+        sha256 = "1cdksxwq7wswmgdjdi3akdiljryxk3vw4yqfpjl1a2xzjqmvjxq7";
       };
       packageRequires = [
         compat
@@ -6694,10 +6769,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "2.1";
+      version = "2.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/osm-2.1.tar";
-        sha256 = "1nwr32n7cmfa2ckym0srs0fn3426slrhxiykx971s9sgjxydlqq2";
+        url = "https://elpa.gnu.org/packages/osm-2.2.tar";
+        sha256 = "0xq5gzhgxgv52kxprik15b5ijrdw7c5262ifzdcjg3vv3qv0hwy8";
       };
       packageRequires = [ compat ];
       meta = {
@@ -7070,6 +7145,27 @@
       };
     }
   ) { };
+  po-mode = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "po-mode";
+      ename = "po-mode";
+      version = "2.32";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/po-mode-2.32.tar";
+        sha256 = "0s83gjzmjqn3b80wrha7g9jp329df9qrzs66h2v6dv2inkdasn42";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/po-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   poke = callPackage (
     {
       elpaBuild,
@@ -7163,10 +7259,10 @@
     elpaBuild {
       pname = "posframe";
       ename = "posframe";
-      version = "1.5.0";
+      version = "1.5.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/posframe-1.5.0.tar";
-        sha256 = "0yk38fc08fgxwai6dn6da9yykcmq3bd4x7msfnlrg081b15q9a32";
+        url = "https://elpa.gnu.org/packages/posframe-1.5.1.tar";
+        sha256 = "1g1pcf83w4fv299ykvx7b93kxkc58fkr6yk39sxny5g16d4gl80g";
       };
       packageRequires = [ ];
       meta = {
@@ -7206,10 +7302,10 @@
     elpaBuild {
       pname = "preview-auto";
       ename = "preview-auto";
-      version = "0.4.1";
+      version = "0.4.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/preview-auto-0.4.1.tar";
-        sha256 = "0wdjka1wixhlzi1sksswa2jnialpna0gj770z0gl6faxdi310p9l";
+        url = "https://elpa.gnu.org/packages/preview-auto-0.4.2.tar";
+        sha256 = "1fg4nxzqjk13q9yvhrjmm9qqrszf9xd2n9jfji2v31f0rphlkc3p";
       };
       packageRequires = [ auctex ];
       meta = {
@@ -7837,10 +7933,10 @@
     elpaBuild {
       pname = "relint";
       ename = "relint";
-      version = "2.1";
+      version = "2.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/relint-2.1.tar";
-        sha256 = "0ikml87y0k85qd92m3l1gkzjd9ng3mhjfk19w15ln0w801351cq0";
+        url = "https://elpa.gnu.org/packages/relint-2.2.tar";
+        sha256 = "01x0134f3z7vh7b730lfrsnpwqqjj65z291gpm8qyai9fimljsn3";
       };
       packageRequires = [ xr ];
       meta = {
@@ -8808,10 +8904,10 @@
     elpaBuild {
       pname = "switchy-window";
       ename = "switchy-window";
-      version = "1.3";
+      version = "1.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/switchy-window-1.3.tar";
-        sha256 = "0ym5cy6czsrd15f8rgh3dad8fwn8pb2xrvhlmdikc59cc29zamrv";
+        url = "https://elpa.gnu.org/packages/switchy-window-1.4.tar";
+        sha256 = "1y8a791d1qmmvsjj39fs4rr3zx77xbxc7z21fchwqr5hjhs5gxc9";
       };
       packageRequires = [ compat ];
       meta = {
@@ -8984,10 +9080,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.9";
+      version = "1.11";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tempel-1.9.tar";
-        sha256 = "128yfnfnd0nd7ck39d9inr3vcbg2w2a5kms5a2l8aba2cb6valnb";
+        url = "https://elpa.gnu.org/packages/tempel-1.11.tar";
+        sha256 = "1gg91q755nk4f17d3av4ss55wxx87kzg7h37drkng6zvmi9c8k4i";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9175,10 +9271,10 @@
     elpaBuild {
       pname = "tmr";
       ename = "tmr";
-      version = "1.2.1";
+      version = "1.3.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tmr-1.2.1.tar";
-        sha256 = "1jx3j9pgr4z5f70jr5byq9b27z4l6q7r4pjzq9dzw6q30wk2kv8p";
+        url = "https://elpa.gnu.org/packages/tmr-1.3.0.tar";
+        sha256 = "0sv0kaz8z0lldkcplyzh7k99s4jqj3bzr9gb5mqjwpp747hj0qlq";
       };
       packageRequires = [ ];
       meta = {
@@ -9264,10 +9360,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.8.1";
+      version = "2.8.1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-2.8.1.tar";
-        sha256 = "0c0k9a69m1li6z1k36q0gmkwks106ghsmz4iz3k9c18979jmn0y1";
+        url = "https://elpa.gnu.org/packages/tramp-2.8.1.1.tar";
+        sha256 = "177297mj3qyj23s6g4x8c960vvbsbzkqy6xzfngi3ghsj55injk4";
       };
       packageRequires = [ ];
       meta = {
@@ -9954,10 +10050,10 @@
     elpaBuild {
       pname = "vertico-posframe";
       ename = "vertico-posframe";
-      version = "0.9.0";
+      version = "0.9.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vertico-posframe-0.9.0.tar";
-        sha256 = "16vnacmz52d1rwdmddsr1rm1zki1p3bw10ngpw39a3dszbwqkl3m";
+        url = "https://elpa.gnu.org/packages/vertico-posframe-0.9.2.tar";
+        sha256 = "1xq30aj2jkk1g4gnniixg0rzh03irf7vci551fwd6gg50sphaqj4";
       };
       packageRequires = [
         posframe
@@ -10168,10 +10264,10 @@
     elpaBuild {
       pname = "websocket";
       ename = "websocket";
-      version = "1.15";
+      version = "1.16";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/websocket-1.15.tar";
-        sha256 = "0cm3x6qzr4zqj46w0qfpn7n9g5z80figcv824869snvc74465h1g";
+        url = "https://elpa.gnu.org/packages/websocket-1.16.tar";
+        sha256 = "0an37jb4zalfl27gg731yg33cpic34g3fqsc0b8987dcn0szf7xi";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -10475,10 +10571,10 @@
     elpaBuild {
       pname = "xr";
       ename = "xr";
-      version = "2.1";
+      version = "2.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/xr-2.1.tar";
-        sha256 = "1yssl7av2rpanzmm93iw74acnb3pbrnh0b51kr64wcj6hwb26cy2";
+        url = "https://elpa.gnu.org/packages/xr-2.2.tar";
+        sha256 = "0d2hwn73g51gzm8ank41sfcyk87ys2s1cl9zk0h763yjd48r6jqf";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -3788,10 +3788,10 @@
     elpaBuild {
       pname = "futur";
       ename = "futur";
-      version = "1.0";
+      version = "1.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/futur-1.0.tar";
-        sha256 = "1pi7r87lddhf6fnvj78had1s9rpzfddcsw0ws8gc6czwly3n8vxg";
+        url = "https://elpa.gnu.org/packages/futur-1.1.tar";
+        sha256 = "1q72dd6hnq3d5si9jr15nhqf5j6zk2k3c6dd3xv3k80cbfvwj9rx";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "adoc-mode";
       ename = "adoc-mode";
-      version = "0.8.0snapshot0.20250206.83825";
+      version = "0.8.0.0.20260221.220754";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/adoc-mode-0.8.0snapshot0.20250206.83825.tar";
-        sha256 = "0b9lbxk5q0hr7j86wpxrkbg626srkc9jhycqi7qb3yqsn1pr4khc";
+        url = "https://elpa.nongnu.org/nongnu-devel/adoc-mode-0.8.0.0.20260221.220754.tar";
+        sha256 = "19cn5vm963pygzi42r7zw0n7g1adipa0k8f8chwlwibhzwmx3vyz";
       };
       packageRequires = [ ];
       meta = {
@@ -333,10 +333,10 @@
     elpaBuild {
       pname = "bash-completion";
       ename = "bash-completion";
-      version = "3.2.1snapshot0.20250721.202603";
+      version = "3.2.1snapshot0.20260206.145951";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.1snapshot0.20250721.202603.tar";
-        sha256 = "0vx9d3216n3p39fkch1z3kmsbszqcdhf1j4wiqp15y034j2g5gk1";
+        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.1snapshot0.20260206.145951.tar";
+        sha256 = "08ffm5d4b9d553q49zgnp00wf5a3cvzshwqv3kqfgb9wp29wqpja";
       };
       packageRequires = [ ];
       meta = {
@@ -580,6 +580,7 @@
   cider = callPackage (
     {
       clojure-mode,
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -593,13 +594,14 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.21.0snapshot0.20260116.151439";
+      version = "1.22.0snapshot0.20260221.61239";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.21.0snapshot0.20260116.151439.tar";
-        sha256 = "0llq2w0calxzcqh6pf23cp7fwl2pzj117hd9fawmq0lrbxkxqpk2";
+        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.22.0snapshot0.20260221.61239.tar";
+        sha256 = "03sazabqwy7hizs3dj6vwarkhl4l6jqil1dg5w77pv4f250sk3z8";
       };
       packageRequires = [
         clojure-mode
+        compat
         parseedn
         queue
         seq
@@ -622,10 +624,10 @@
     elpaBuild {
       pname = "clojure-mode";
       ename = "clojure-mode";
-      version = "5.20.0.0.20260116.81811";
+      version = "5.21.0.0.20260220.185145";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.20.0.0.20260116.81811.tar";
-        sha256 = "0bymqysm90zxz09mrljyrihk255kmisfz48mbrc0z267gj26zz00";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.21.0.0.20260220.185145.tar";
+        sha256 = "0vzi5bd60wz6my44yiq5g8xdgk6rv09nr034gf0qgql3ww34ggsy";
       };
       packageRequires = [ ];
       meta = {
@@ -643,10 +645,10 @@
     elpaBuild {
       pname = "clojure-ts-mode";
       ename = "clojure-ts-mode";
-      version = "0.6.0.0.20251202.152125";
+      version = "0.6.0.0.20260223.181343";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0.0.20251202.152125.tar";
-        sha256 = "16agzwvi3wlhiagff0v160kvgif5j30a0i7nkqhhx322l7198wfi";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-ts-mode-0.6.0.0.20260223.181343.tar";
+        sha256 = "0yrbddm4qv5xdn9vj3k9h0j62v5rv7l1yrdl0idw9094ln25k418";
       };
       packageRequires = [ ];
       meta = {
@@ -685,10 +687,10 @@
     elpaBuild {
       pname = "cond-let";
       ename = "cond-let";
-      version = "0.2.1.0.20260118.133210";
+      version = "0.2.2.0.20260201.150042";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cond-let-0.2.1.0.20260118.133210.tar";
-        sha256 = "0wmj57krcv3k9lvj2a9lzg155rfg5vvzl518mfx08bn5ycb6w9ra";
+        url = "https://elpa.nongnu.org/nongnu-devel/cond-let-0.2.2.0.20260201.150042.tar";
+        sha256 = "0fy4kji48wj5v1jf78kmd011v5v4q5b5n32mhhixv83243hng2fb";
       };
       packageRequires = [ ];
       meta = {
@@ -1057,10 +1059,10 @@
     elpaBuild {
       pname = "dracula-theme";
       ename = "dracula-theme";
-      version = "1.8.3.0.20250626.195550";
+      version = "1.8.3.0.20260224.145537";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.3.0.20250626.195550.tar";
-        sha256 = "14zlkirydnlydivmccg5129amnjmy6238m1b8b7gq68qz95spjxz";
+        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.3.0.20260224.145537.tar";
+        sha256 = "0g83cgcackysjh5x35j0vniqyysk1lgijk0mhmgnwnhm2fji1b74";
       };
       packageRequires = [ ];
       meta = {
@@ -1164,10 +1166,10 @@
     elpaBuild {
       pname = "editorconfig";
       ename = "editorconfig";
-      version = "0.11.0.0.20260117.231845";
+      version = "0.11.0.0.20260122.182806";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20260117.231845.tar";
-        sha256 = "1ys0m58c19598l6cakzl8m3931fcbs9f4c2fk76qhc5142np20w8";
+        url = "https://elpa.nongnu.org/nongnu-devel/editorconfig-0.11.0.0.20260122.182806.tar";
+        sha256 = "0vncm8w0vcqzjh28fglf6s7ryxa0kgfy5n3kkxkyksbczyndwprj";
       };
       packageRequires = [ ];
       meta = {
@@ -1229,10 +1231,10 @@
     elpaBuild {
       pname = "eldoc-mouse";
       ename = "eldoc-mouse";
-      version = "3.0.2.0.20251228.31655";
+      version = "3.0.3.0.20260130.135227";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/eldoc-mouse-3.0.2.0.20251228.31655.tar";
-        sha256 = "0wjk8wxsf8l4sxp9xbmi0ihq8d6z5m60789hiyv4whhy67cwlwk8";
+        url = "https://elpa.nongnu.org/nongnu-devel/eldoc-mouse-3.0.3.0.20260130.135227.tar";
+        sha256 = "0damazadfsr04q3vwgll2mfh67nixbfkf40ix213k45dlf399gqb";
       };
       packageRequires = [
         eglot
@@ -1274,10 +1276,10 @@
     elpaBuild {
       pname = "elpher";
       ename = "elpher";
-      version = "3.6.6.0.20250929.142203";
+      version = "3.7.0.0.20260221.92032";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/elpher-3.6.6.0.20250929.142203.tar";
-        sha256 = "03p5z3r79303vxxs0q5cxhfmnjc18yr76pnfrsga11my6c9j7lza";
+        url = "https://elpa.nongnu.org/nongnu-devel/elpher-3.7.0.0.20260221.92032.tar";
+        sha256 = "0s9akzwg59v97895kn941iqiqvw5p6mnqg3fxjydklssg7691ng5";
       };
       packageRequires = [ ];
       meta = {
@@ -1295,10 +1297,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.4.0.20260104.4346";
+      version = "4.3.5.0.20260201.151238";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.4.0.20260104.4346.tar";
-        sha256 = "1gpbv5plfcjzvf03gwgq0b2n0kff9xqwk32jpdl9209d8fmiw2q8";
+        url = "https://elpa.nongnu.org/nongnu-devel/emacsql-4.3.5.0.20260201.151238.tar";
+        sha256 = "0fb7538qanp4dr8mgm17x0vvyyzn9dy50ymphhj21zy9almjrlsj";
       };
       packageRequires = [ ];
       meta = {
@@ -1422,6 +1424,28 @@
       packageRequires = [ evil ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/evil-args.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  evil-emacs-cursor-model-mode = callPackage (
+    {
+      elpaBuild,
+      evil,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "evil-emacs-cursor-model-mode";
+      ename = "evil-emacs-cursor-model-mode";
+      version = "0.1.3.0.20260225.15950";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-emacs-cursor-model-mode-0.1.3.0.20260225.15950.tar";
+        sha256 = "0xx8vzkmggvvhanxq9xyrsrqiby0054agwpjmflqgvkvyrfvxzyc";
+      };
+      packageRequires = [ evil ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/evil-emacs-cursor-model-mode.html";
         license = lib.licenses.free;
       };
     }
@@ -1766,10 +1790,10 @@
     elpaBuild {
       pname = "fedi";
       ename = "fedi";
-      version = "0.2.0.20250812.64538";
+      version = "0.3.0.20260223.132625";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/fedi-0.2.0.20250812.64538.tar";
-        sha256 = "11s2l27vkzyrng931r5835xvh7jkq0vp30fpwihzsgq17g53h3i6";
+        url = "https://elpa.nongnu.org/nongnu-devel/fedi-0.3.0.20260223.132625.tar";
+        sha256 = "15cvwfyvixac3vvfjnmz0fvfzk5iq9sndnryzi3zlp3njjjds0wv";
       };
       packageRequires = [ markdown-mode ];
       meta = {
@@ -1791,10 +1815,10 @@
     elpaBuild {
       pname = "fj";
       ename = "fj";
-      version = "0.28.0.20251030.134543";
+      version = "0.32.0.20260225.163009";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/fj-0.28.0.20251030.134543.tar";
-        sha256 = "1fihl80jlsyb9w1f6dwd5rsrzaaxazb1cj8cp8yj4cajh4gmf8ms";
+        url = "https://elpa.nongnu.org/nongnu-devel/fj-0.32.0.20260225.163009.tar";
+        sha256 = "0vjqihc0bj0zizl3mjzsrvj09pzkv6lpp83157ppb6vfirs1vv4g";
       };
       packageRequires = [
         fedi
@@ -1866,10 +1890,10 @@
     elpaBuild {
       pname = "flycheck";
       ename = "flycheck";
-      version = "35.0.0.20251205.82912";
+      version = "36.0.0.20260224.192350";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0.0.20251205.82912.tar";
-        sha256 = "175y7spmj63v0pz7j9jd692ls23z2nicik14kl8m7ik4g2vhq0gp";
+        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-36.0.0.20260224.192350.tar";
+        sha256 = "1lcly3ip5n788q0a64yzd0gnlndxnqqg7dbwf0ypq04zjnakwr3x";
       };
       packageRequires = [ seq ];
       meta = {
@@ -2368,10 +2392,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.5.8.0.20260114.45444";
+      version = "0.7.0.0.20260224.120212";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.5.8.0.20260114.45444.tar";
-        sha256 = "17w44h3rsk5l8h48mgxz7wsmn3856zkqdiwzy4f1s8x55riqq7k3";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.7.0.0.20260224.120212.tar";
+        sha256 = "1znf3ilss269f9h8l5bh3yfhm7kyyqb83ia296vw4n728gmy7bb7";
       };
       packageRequires = [
         compat
@@ -2437,10 +2461,10 @@
     elpaBuild {
       pname = "gnuplot";
       ename = "gnuplot";
-      version = "0.11.0.20260117.175416";
+      version = "0.11.0.20260122.130054";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnuplot-0.11.0.20260117.175416.tar";
-        sha256 = "06hx09gk1l6z67n5djryw2h9dvp7d9drcq5xawcrxbvbx836fwir";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnuplot-0.11.0.20260122.130054.tar";
+        sha256 = "1qprpdry88b318774l26z7qddmnbf9nidzmc0bnhdgcxrbz3hnnk";
       };
       packageRequires = [ compat ];
       meta = {
@@ -2544,10 +2568,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.9.3.0.20260115.231046";
+      version = "0.9.9.4.0.20260221.172046";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.9.3.0.20260115.231046.tar";
-        sha256 = "05bjx9458zx5la3s16z2j7m69aapwmpf7vcfkhwsgnh52703qzxv";
+        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.9.4.0.20260221.172046.tar";
+        sha256 = "0hnnr6idzw1x990ggnj35rmw20316v2q5jxb1ymgsi88ii20i074";
       };
       packageRequires = [
         compat
@@ -2568,10 +2592,10 @@
     elpaBuild {
       pname = "graphql-mode";
       ename = "graphql-mode";
-      version = "1.0.0.0.20260102.175142";
+      version = "1.0.0.0.20260214.124443";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/graphql-mode-1.0.0.0.20260102.175142.tar";
-        sha256 = "0bpjij54jnn4jamcdvdxbsmza0g6c3h41300sn5yk4p8g8x85fcr";
+        url = "https://elpa.nongnu.org/nongnu-devel/graphql-mode-1.0.0.0.20260214.124443.tar";
+        sha256 = "141z96ax3kqy2b046v2c7k5sb2mw27hr5x7zi58r1yfyhqi4x3a9";
       };
       packageRequires = [ ];
       meta = {
@@ -2675,10 +2699,10 @@
     elpaBuild {
       pname = "haskell-mode";
       ename = "haskell-mode";
-      version = "17.5.0.20251121.55413";
+      version = "17.5.0.20260206.105045";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20251121.55413.tar";
-        sha256 = "191bcwnj5bf1yvg7a6cwhhjljzkgrbis56gq3jn9c79dm4zffmkq";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-mode-17.5.0.20260206.105045.tar";
+        sha256 = "012w356crya0ik9p16xlkykk1xv9yk4w3k029xrmjhjw1jqvkybd";
       };
       packageRequires = [ ];
       meta = {
@@ -2741,10 +2765,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.6.0.20260108.71401";
+      version = "4.0.6.0.20260214.143216";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.6.0.20260108.71401.tar";
-        sha256 = "03sxqk99cxvvm2mwhb8wj81ixgv5cc692k29kni3zm5g6n4p18wl";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.6.0.20260214.143216.tar";
+        sha256 = "0v1j7vvpw5m6cjrbmzbjssw8n7r4ipxkzwl13z351lqx81q27p9b";
       };
       packageRequires = [
         helm-core
@@ -2766,10 +2790,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.6.0.20260108.71401";
+      version = "4.0.6.0.20260214.143216";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.6.0.20260108.71401.tar";
-        sha256 = "1z6ka0dbjgw8i9brl26miivddiwgbw641zqd27mxqlmhb3xq5n28";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.6.0.20260214.143216.tar";
+        sha256 = "09rmliclxhzbai5cgy3f1bg1y9nk6a3xig79iz6yxfc26qs1kkh2";
       };
       packageRequires = [ async ];
       meta = {
@@ -2977,10 +3001,10 @@
     elpaBuild {
       pname = "idris-mode";
       ename = "idris-mode";
-      version = "1.1.0.0.20251203.154827";
+      version = "1.1.0.0.20260209.110723";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/idris-mode-1.1.0.0.20251203.154827.tar";
-        sha256 = "1vdyd551nbadsxkyy9zi2247rn8yz3fyxp8nrdcc19vkdx895wdi";
+        url = "https://elpa.nongnu.org/nongnu-devel/idris-mode-1.1.0.0.20260209.110723.tar";
+        sha256 = "19rw6k40qkn4b11vhr95w71rdfqdmrr27ga8vdj7imb812wcdqyy";
       };
       packageRequires = [
         cl-lib
@@ -3023,10 +3047,10 @@
     elpaBuild {
       pname = "inf-clojure";
       ename = "inf-clojure";
-      version = "3.3.0.0.20250525.205532";
+      version = "3.4.0snapshot0.20260220.143715";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/inf-clojure-3.3.0.0.20250525.205532.tar";
-        sha256 = "1q4cibg107pcg1cirqmmzhvbyyzlm76aqfyqad8m6ds76jv3kkcg";
+        url = "https://elpa.nongnu.org/nongnu-devel/inf-clojure-3.4.0snapshot0.20260220.143715.tar";
+        sha256 = "1m0jah1rfd6csqafiqq44d8l3g97d51a1gwyhr8pxc7d82ng8sfn";
       };
       packageRequires = [ clojure-mode ];
       meta = {
@@ -3086,10 +3110,10 @@
     elpaBuild {
       pname = "isl";
       ename = "isl";
-      version = "1.6.0.20260105.45206";
+      version = "1.6.0.20260225.43822";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/isl-1.6.0.20260105.45206.tar";
-        sha256 = "07srq23d165cbk2c31ibi5snh113qg387ycdfkndffc7s1n3jr7f";
+        url = "https://elpa.nongnu.org/nongnu-devel/isl-1.6.0.20260225.43822.tar";
+        sha256 = "05fq6l8c8w4bkfkh2cmmmdnjwa6hmfpv00avkp6r5fz4v9fnkvwq";
       };
       packageRequires = [ ];
       meta = {
@@ -3175,10 +3199,10 @@
     elpaBuild {
       pname = "javelin";
       ename = "javelin";
-      version = "0.2.3.0.20260105.173516";
+      version = "0.2.3.0.20260215.104721";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/javelin-0.2.3.0.20260105.173516.tar";
-        sha256 = "0vv0kk0pvdmyr7arargdxrldkk4m8b43i2jb0w4lia5pfn66h6kl";
+        url = "https://elpa.nongnu.org/nongnu-devel/javelin-0.2.3.0.20260215.104721.tar";
+        sha256 = "18w050yhf4avkmynyd80gf39bg5bhj7r8p09cflsaa16zni5169y";
       };
       packageRequires = [ ];
       meta = {
@@ -3217,10 +3241,10 @@
     elpaBuild {
       pname = "julia-mode";
       ename = "julia-mode";
-      version = "1.0.2.0.20250428.81943";
+      version = "1.1.0.0.20260204.80729";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/julia-mode-1.0.2.0.20250428.81943.tar";
-        sha256 = "05sx6pwwrvxwrpd1fskhqnr8yvzav7yafk7im5iscxic061xggpv";
+        url = "https://elpa.nongnu.org/nongnu-devel/julia-mode-1.1.0.0.20260204.80729.tar";
+        sha256 = "1xx4vc8j2s0d3l6jby164kwwm90pxk3igd9xcbxblgdqspd5g5cw";
       };
       packageRequires = [ ];
       meta = {
@@ -3308,10 +3332,10 @@
     elpaBuild {
       pname = "llama";
       ename = "llama";
-      version = "1.0.3.0.20260101.183011";
+      version = "1.0.3.0.20260217.210434";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.3.0.20260101.183011.tar";
-        sha256 = "1z3j7rg8v7hrgjhz914gqms6566hvxrhs3ylxg3ljbrz1rql23a2";
+        url = "https://elpa.nongnu.org/nongnu-devel/llama-1.0.3.0.20260217.210434.tar";
+        sha256 = "072q29wxq1jnhbiva7sw4kxi2j5rsbpp1zsyii9phk28h6hwb2h4";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3332,10 +3356,10 @@
     elpaBuild {
       pname = "logview";
       ename = "logview";
-      version = "0.19.4snapshot0.20251104.172505";
+      version = "0.19.4snapshot0.20260218.201306";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/logview-0.19.4snapshot0.20251104.172505.tar";
-        sha256 = "1j1sy2z3w9k6h5b9dszshfy2l34v73qyr3y9l11zf2yzzm90lwz1";
+        url = "https://elpa.nongnu.org/nongnu-devel/logview-0.19.4snapshot0.20260218.201306.tar";
+        sha256 = "1f49zs4w4wmn7famsc3ay8n7834c8zk2z3xmw74sk3744ygrc8d3";
       };
       packageRequires = [
         compat
@@ -3361,10 +3385,10 @@
     elpaBuild {
       pname = "loopy";
       ename = "loopy";
-      version = "0.15.0.0.20260110.235316";
+      version = "0.15.0.0.20260222.160925";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.15.0.0.20260110.235316.tar";
-        sha256 = "0kg0qszanbmfsdgakpdxaa9bp6jv44900slhk96kkip9r8im3yg5";
+        url = "https://elpa.nongnu.org/nongnu-devel/loopy-0.15.0.0.20260222.160925.tar";
+        sha256 = "11cwl779qgv9r3l5ajpki0zy3zycspdnlgjdvynpq9mqqqgsx3rx";
       };
       packageRequires = [
         compat
@@ -3488,10 +3512,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.5.0.0.20260116.172240";
+      version = "4.5.0.0.20260221.163408";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.5.0.0.20260116.172240.tar";
-        sha256 = "12y9glvz78dbziimfpfylskigg0qzhn09rlfiigbjhj3436pqp9p";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.5.0.0.20260221.163408.tar";
+        sha256 = "0w75prlzii0adc9ha3dia8g1x35nhg1g8v0mi34alclbimwmnxyg";
       };
       packageRequires = [
         compat
@@ -3521,10 +3545,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.5.0.0.20260116.172240";
+      version = "4.5.0.0.20260221.163408";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.5.0.0.20260116.172240.tar";
-        sha256 = "1jax2rfr5znpr4miscy8byx7yimzq1qizdb1ldv4dhv6vwbmaa3z";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.5.0.0.20260221.163408.tar";
+        sha256 = "108l2sgfximlcmp8m70qpmgzqhhj7njc2rz2dvw34ll88n6wpf57";
       };
       packageRequires = [
         compat
@@ -3547,10 +3571,10 @@
     elpaBuild {
       pname = "markdown-mode";
       ename = "markdown-mode";
-      version = "2.8alpha0.20251204.85213";
+      version = "2.8alpha0.20260209.45942";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.8alpha0.20251204.85213.tar";
-        sha256 = "01h8yxfi54691ph8idzlh80lnx1wjapv0hq0vbffcr5z6pk5s00l";
+        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.8alpha0.20260209.45942.tar";
+        sha256 = "1n26jwk0qfzw3gzb2h0f3c7606x6bj30l7gk3q71zxnvzzzd40rk";
       };
       packageRequires = [ ];
       meta = {
@@ -3687,10 +3711,10 @@
     elpaBuild {
       pname = "moe-theme";
       ename = "moe-theme";
-      version = "1.1.0.0.20251218.53629";
+      version = "1.1.0.0.20260211.61732";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/moe-theme-1.1.0.0.20251218.53629.tar";
-        sha256 = "09dgdxlcgvsssq9s6p2xkh1c3lyaaqcpgxgaicvvsv75h22mn8a0";
+        url = "https://elpa.nongnu.org/nongnu-devel/moe-theme-1.1.0.0.20260211.61732.tar";
+        sha256 = "0ids4skv6cyk36qww44kmds347l78kppaj96ra2d59ni2wl4jdbz";
       };
       packageRequires = [ ];
       meta = {
@@ -3927,10 +3951,10 @@
     elpaBuild {
       pname = "org-contrib";
       ename = "org-contrib";
-      version = "0.7.0.20251011.144539";
+      version = "0.8.0.20260221.192041";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-contrib-0.7.0.20251011.144539.tar";
-        sha256 = "02v12mhpfd7i0m7y5cij6zq8lqamrplc4ybdkya66zw8dwh5y1mn";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-contrib-0.8.0.20260221.192041.tar";
+        sha256 = "15mrdfmj4nxqh7ayyc2nyhxak5ymfsa9ym8dl8gwjsc8xym9jidd";
       };
       packageRequires = [ org ];
       meta = {
@@ -4114,10 +4138,10 @@
     elpaBuild {
       pname = "orgit";
       ename = "orgit";
-      version = "2.1.1.0.20260101.185122";
+      version = "2.1.1.0.20260201.145846";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.1.1.0.20260101.185122.tar";
-        sha256 = "04437y8svn6i05rwvlnna0cca2dnj1h59wlsiknpw4bfikx5svm6";
+        url = "https://elpa.nongnu.org/nongnu-devel/orgit-2.1.1.0.20260201.145846.tar";
+        sha256 = "0wgvhkfq0x876pw2lad9bq5xh5mla604wzvrh3l4zklqif18y7m4";
       };
       packageRequires = [
         compat
@@ -4363,10 +4387,10 @@
     elpaBuild {
       pname = "pg";
       ename = "pg";
-      version = "0.62.0.20251230.93152";
+      version = "0.63.0.20260208.141935";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.62.0.20251230.93152.tar";
-        sha256 = "1k0miw933f4526wikl6s22h286hilzmq322i17igsnzi0b1d3304";
+        url = "https://elpa.nongnu.org/nongnu-devel/pg-0.63.0.20260208.141935.tar";
+        sha256 = "1jkddkiv4izp64ad4gl4a335znds8vak9mly9vx00arzs9cg255r";
       };
       packageRequires = [ peg ];
       meta = {
@@ -4461,6 +4485,7 @@
   ) { };
   projectile = callPackage (
     {
+      compat,
       elpaBuild,
       fetchurl,
       lib,
@@ -4468,12 +4493,12 @@
     elpaBuild {
       pname = "projectile";
       ename = "projectile";
-      version = "2.9.1.0.20260109.133628";
+      version = "2.10.0snapshot0.20260216.65235";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.9.1.0.20260109.133628.tar";
-        sha256 = "0y7mf322fa533h2jc0hwwr1nh0m7bk6xzbcc1w4x7iiq520rs3mf";
+        url = "https://elpa.nongnu.org/nongnu-devel/projectile-2.10.0snapshot0.20260216.65235.tar";
+        sha256 = "0a79a85scyrpvrcbqb4n2cjjjgbhf61qm2ilkwk8mspym4g0b41v";
       };
-      packageRequires = [ ];
+      packageRequires = [ compat ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/projectile.html";
         license = lib.licenses.free;
@@ -4489,10 +4514,10 @@
     elpaBuild {
       pname = "proof-general";
       ename = "proof-general";
-      version = "4.6snapshot0.20260113.122819";
+      version = "4.6snapshot0.20260124.135141";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20260113.122819.tar";
-        sha256 = "0cwxfbad97py7lax387dv5drwmwgmi3qcy191fq1sdj8pc9c7b1v";
+        url = "https://elpa.nongnu.org/nongnu-devel/proof-general-4.6snapshot0.20260124.135141.tar";
+        sha256 = "0wjjip6pph8s8j613md5j6f5ba40cl88v44i88s6s11ixrmd73sl";
       };
       packageRequires = [ ];
       meta = {
@@ -4554,10 +4579,10 @@
     elpaBuild {
       pname = "radio";
       ename = "radio";
-      version = "0.4.1.0.20250305.101402";
+      version = "0.4.3.0.20260212.144358";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/radio-0.4.1.0.20250305.101402.tar";
-        sha256 = "0l71sgr2a3xpmq3s6ilzk89psjl2zymc15v2la3zd0iw1xbd97x6";
+        url = "https://elpa.nongnu.org/nongnu-devel/radio-0.4.3.0.20260212.144358.tar";
+        sha256 = "0bjxl75zi9fkz0wqx2b70rjkv5mngx5g7az4zx5jgim85qs2cpyg";
       };
       packageRequires = [ ];
       meta = {
@@ -4680,10 +4705,10 @@
     elpaBuild {
       pname = "rfc-mode";
       ename = "rfc-mode";
-      version = "1.4.2.0.20231013.135347";
+      version = "1.4.2.0.20260127.180740";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rfc-mode-1.4.2.0.20231013.135347.tar";
-        sha256 = "0jp5xamraan313nsgy8w7c91jjvqrxphzsm2wg8sgnj00zpr3jfb";
+        url = "https://elpa.nongnu.org/nongnu-devel/rfc-mode-1.4.2.0.20260127.180740.tar";
+        sha256 = "1i01x9k208zasil586q1jz28hdl5hpx964a6bgb6wwgf9ya79xlx";
       };
       packageRequires = [ ];
       meta = {
@@ -4743,10 +4768,10 @@
     elpaBuild {
       pname = "rust-mode";
       ename = "rust-mode";
-      version = "1.0.6.0.20260118.53640";
+      version = "1.0.6.0.20260207.42454";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20260118.53640.tar";
-        sha256 = "1lzaji5bxznmm55xnyz93q2rf3x7p3873z0gw3ml08mng0gj99w7";
+        url = "https://elpa.nongnu.org/nongnu-devel/rust-mode-1.0.6.0.20260207.42454.tar";
+        sha256 = "106pv49x0ivmxal1zn9raacrbnyncg2x7a3sf52g6ij5rdcixi18";
       };
       packageRequires = [ ];
       meta = {
@@ -4918,10 +4943,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.32snapshot0.20260119.50517";
+      version = "2.32snapshot0.20260224.183432";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.32snapshot0.20260119.50517.tar";
-        sha256 = "07nff1w56vv3qr6s2rx6ppwp9gc43pxnglgzanasygxs2fghn477";
+        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.32snapshot0.20260224.183432.tar";
+        sha256 = "1vad3zbjskfaypisby9fj2sy02ifva2bjsfy9ix0rw0mpq8ggnpb";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -4961,10 +4986,10 @@
     elpaBuild {
       pname = "smartparens";
       ename = "smartparens";
-      version = "1.11.0.0.20250612.105020";
+      version = "1.11.0.0.20260129.121419";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/smartparens-1.11.0.0.20250612.105020.tar";
-        sha256 = "1cdicjah7mbkcg43zm5la75zb7cgg15gxf9178zhd2qd71gqfl8m";
+        url = "https://elpa.nongnu.org/nongnu-devel/smartparens-1.11.0.0.20260129.121419.tar";
+        sha256 = "0c7cy08dk67d2fw3z24m9g598rqcf82ziwnkjgh45ywgbrrz52x1";
       };
       packageRequires = [ dash ];
       meta = {
@@ -5108,10 +5133,10 @@
     elpaBuild {
       pname = "subatomic-theme";
       ename = "subatomic-theme";
-      version = "1.8.2.0.20220128.161518";
+      version = "1.8.2.0.20260216.82619";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/subatomic-theme-1.8.2.0.20220128.161518.tar";
-        sha256 = "1h4rr2g6lhn186df2nk026xk1x6yhh441d6mjcdrfkii17n15552";
+        url = "https://elpa.nongnu.org/nongnu-devel/subatomic-theme-1.8.2.0.20260216.82619.tar";
+        sha256 = "0v5jv362kicjrygyf7dkjjg8sfczwx4g783h7l4ndxn5r1l7smb6";
       };
       packageRequires = [ ];
       meta = {
@@ -5129,10 +5154,10 @@
     elpaBuild {
       pname = "subed";
       ename = "subed";
-      version = "1.3.1.0.20260103.134523";
+      version = "1.4.1.0.20260216.184548";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/subed-1.3.1.0.20260103.134523.tar";
-        sha256 = "0m68rngydjpk2q0y766p0hbj1l6aixj3j3yl3dwmwwmbn03phfsp";
+        url = "https://elpa.nongnu.org/nongnu-devel/subed-1.4.1.0.20260216.184548.tar";
+        sha256 = "0fjnfxinr7lvhzd71xcvcpgq23fd57yawqhs40qy02mpq7d7h3ai";
       };
       packageRequires = [ ];
       meta = {
@@ -5413,10 +5438,10 @@
     elpaBuild {
       pname = "tp";
       ename = "tp";
-      version = "0.7.0.20250206.81229";
+      version = "0.8.0.20260219.143500";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/tp-0.7.0.20250206.81229.tar";
-        sha256 = "14zhky7jf0afmsxrhkyvgzqh4k2yf1p829j77ryw741swj75z3av";
+        url = "https://elpa.nongnu.org/nongnu-devel/tp-0.8.0.20260219.143500.tar";
+        sha256 = "15szb0li4ibsaja39699rc85nvk2s466g303dp0si62h9ipha68w";
       };
       packageRequires = [ transient ];
       meta = {
@@ -5519,10 +5544,10 @@
     elpaBuild {
       pname = "typst-ts-mode";
       ename = "typst-ts-mode";
-      version = "0.12.2.0.20251026.52820";
+      version = "0.12.2.0.20260130.110553";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.2.0.20251026.52820.tar";
-        sha256 = "002ry7lgc61w1appzw33xgavsgc34wxjahbpjqba3rp53qmkk0m8";
+        url = "https://elpa.nongnu.org/nongnu-devel/typst-ts-mode-0.12.2.0.20260130.110553.tar";
+        sha256 = "19v349nhr1km00w19rxv1g4vkhl2hk9sf0y9q0cg15682qc28jjz";
       };
       packageRequires = [ ];
       meta = {
@@ -5582,10 +5607,10 @@
     elpaBuild {
       pname = "undo-fu-session";
       ename = "undo-fu-session";
-      version = "0.7.0.20260108.131306";
+      version = "0.8.0.20260209.75408";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-session-0.7.0.20260108.131306.tar";
-        sha256 = "0ykdif99h5618nssnh24yqjhv47cci69x2c1g1fwb96j371ckwlj";
+        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-session-0.8.0.20260209.75408.tar";
+        sha256 = "1238b4i83sw5rylh73i4bd4qdm7g4hpwpas7ynyyq000zfj52jas";
       };
       packageRequires = [ ];
       meta = {
@@ -5667,10 +5692,10 @@
     elpaBuild {
       pname = "vm";
       ename = "vm";
-      version = "8.3.3snapshot0.20251229.112614";
+      version = "8.3.3snapshot0.20260225.71602";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.3snapshot0.20251229.112614.tar";
-        sha256 = "0j96fzmqljhyk0dxkwzs6y4j4x9clyslndbspcisx0qskqa3p0fg";
+        url = "https://elpa.nongnu.org/nongnu-devel/vm-8.3.3snapshot0.20260225.71602.tar";
+        sha256 = "1w6p8cygsvwzzci2fjjy4rysb6n888frsa1ay99p66x8kq5s7n50";
       };
       packageRequires = [ vcard ];
       meta = {
@@ -5909,10 +5934,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "28.11.20260106081151.0.20260106.81408";
+      version = "28.11.20260215192642.0.20260215.201333";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-28.11.20260106081151.0.20260106.81408.tar";
-        sha256 = "0bfjylai4ck3nb73h6863gbb0pka84gh7wys5h2dq1k5bhx8sfqi";
+        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-28.11.20260215192642.0.20260215.201333.tar";
+        sha256 = "08pdqfglkl150pw43llm5z3a2mpzdil315a732i7fa4a27qwkxfn";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -9,10 +9,10 @@
     elpaBuild {
       pname = "adoc-mode";
       ename = "adoc-mode";
-      version = "0.7.0";
+      version = "0.8.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/adoc-mode-0.7.0.tar";
-        sha256 = "1gdjgybpbw3qj9mfmq9ljx4xaam1f6rwyrav2y2f5fpv6z7w0i61";
+        url = "https://elpa.nongnu.org/nongnu/adoc-mode-0.8.0.tar";
+        sha256 = "16459ial82gybqjm8ib0cxry6daipak4baxiz2wnldgy5vpgjnrd";
       };
       packageRequires = [ ];
       meta = {
@@ -593,10 +593,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.20.0";
+      version = "1.21.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cider-1.20.0.tar";
-        sha256 = "1s1jw1dc8r7aqjc4vkgcsz193fnhrd6lrz54bim839sfyfv2rhb8";
+        url = "https://elpa.nongnu.org/nongnu/cider-1.21.0.tar";
+        sha256 = "0rfjq6fqvam9v7mcx1459p377ryzi9wf7p2dn68nd51f324hx0gj";
       };
       packageRequires = [
         clojure-mode
@@ -622,10 +622,10 @@
     elpaBuild {
       pname = "clojure-mode";
       ename = "clojure-mode";
-      version = "5.20.0";
+      version = "5.21.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/clojure-mode-5.20.0.tar";
-        sha256 = "16myla7yfknxf36w0n09xg2rr4z4374gs6iqb9spf9hmw0d6z800";
+        url = "https://elpa.nongnu.org/nongnu/clojure-mode-5.21.0.tar";
+        sha256 = "1jjnxhh5l0xvqczcpxj8vgrxwvv7wchwsy7anc8gl1p7wmm8kr79";
       };
       packageRequires = [ ];
       meta = {
@@ -708,10 +708,10 @@
     elpaBuild {
       pname = "cond-let";
       ename = "cond-let";
-      version = "0.2.1";
+      version = "0.2.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/cond-let-0.2.1.tar";
-        sha256 = "1q5gjb3v0xk6azrjbpyyxabrfd68i4gqw4r9dk2wnvbw0vcr21qf";
+        url = "https://elpa.nongnu.org/nongnu/cond-let-0.2.2.tar";
+        sha256 = "0ip5k8jhdgq1zkc6cj4ax8rv4236cxla2dapj83y526ra321gkzy";
       };
       packageRequires = [ ];
       meta = {
@@ -1253,10 +1253,10 @@
     elpaBuild {
       pname = "eldoc-mouse";
       ename = "eldoc-mouse";
-      version = "3.0.2";
+      version = "3.0.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/eldoc-mouse-3.0.2.tar";
-        sha256 = "0ljivs5wpmwc74l4w6fqn0j7ppyf9zc1v3ggx06z1w4jgx15q51d";
+        url = "https://elpa.nongnu.org/nongnu/eldoc-mouse-3.0.3.tar";
+        sha256 = "18bd84sllxilxw42g0qnyf997qxzsa321b60viyw1d9ipn5in2l2";
       };
       packageRequires = [
         eglot
@@ -1298,10 +1298,10 @@
     elpaBuild {
       pname = "elpher";
       ename = "elpher";
-      version = "3.6.6";
+      version = "3.7.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/elpher-3.6.6.tar";
-        sha256 = "0wb1d5cm2gsjarqb9z06hx7nry37la6g5s44bb8q7j2xfd11h764";
+        url = "https://elpa.nongnu.org/nongnu/elpher-3.7.0.tar";
+        sha256 = "1z12nb9a9gbksfnirnqv5fi6b7ygkjgyvrd7glp3ymbp765pjb2p";
       };
       packageRequires = [ ];
       meta = {
@@ -1319,10 +1319,10 @@
     elpaBuild {
       pname = "emacsql";
       ename = "emacsql";
-      version = "4.3.4";
+      version = "4.3.5";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/emacsql-4.3.4.tar";
-        sha256 = "0gf58p86qrysaq576yvz80zi9mmfzij8pcp5lh75v2y6xc4b9hpw";
+        url = "https://elpa.nongnu.org/nongnu/emacsql-4.3.5.tar";
+        sha256 = "150wrcknbcm9kid41qjwa84mn742pzk0g12k9zm7q8zb37d709zq";
       };
       packageRequires = [ ];
       meta = {
@@ -1440,6 +1440,28 @@
       packageRequires = [ evil ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/evil-args.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  evil-emacs-cursor-model-mode = callPackage (
+    {
+      elpaBuild,
+      evil,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "evil-emacs-cursor-model-mode";
+      ename = "evil-emacs-cursor-model-mode";
+      version = "0.1.3";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/evil-emacs-cursor-model-mode-0.1.3.tar";
+        sha256 = "03mn90kpn5lj1yxg5pl69wa01ms2xi9bj1w5dix5ac153iqlddjm";
+      };
+      packageRequires = [ evil ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/evil-emacs-cursor-model-mode.html";
         license = lib.licenses.free;
       };
     }
@@ -1784,10 +1806,10 @@
     elpaBuild {
       pname = "fedi";
       ename = "fedi";
-      version = "0.2";
+      version = "0.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/fedi-0.2.tar";
-        sha256 = "1vhv72s988xvwq14w9xhzqq7hpsjidh2hsii97q9bakh00k5zdra";
+        url = "https://elpa.nongnu.org/nongnu/fedi-0.3.tar";
+        sha256 = "1s1dn7n860b18cwyahc20lbl1bhv4y5h8jijs4iqbbgbk8w7hsjg";
       };
       packageRequires = [ markdown-mode ];
       meta = {
@@ -1809,10 +1831,10 @@
     elpaBuild {
       pname = "fj";
       ename = "fj";
-      version = "0.28";
+      version = "0.32";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/fj-0.28.tar";
-        sha256 = "0smmz9iig83yckcgmd9jd45kkklfywk7nw4jl98wxm4mqwmy1f5l";
+        url = "https://elpa.nongnu.org/nongnu/fj-0.32.tar";
+        sha256 = "16qbrri7z2q9zalmfgqcb5f62ljvpz1zacsh9x8xnbwhlyhavbgk";
       };
       packageRequires = [
         fedi
@@ -1879,16 +1901,17 @@
       elpaBuild,
       fetchurl,
       lib,
+      seq,
     }:
     elpaBuild {
       pname = "flycheck";
       ename = "flycheck";
-      version = "35.0";
+      version = "36.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/flycheck-35.0.tar";
-        sha256 = "1nrsnp5d2jfrg6k9qf55v9mlygkc3ln44j31qmirsp5ad5xrflhm";
+        url = "https://elpa.nongnu.org/nongnu/flycheck-36.0.tar";
+        sha256 = "0172y6qzkys77cbvdla1iiiznpxpscjzmsdr66m66s8g4bf7f1p2";
       };
-      packageRequires = [ ];
+      packageRequires = [ seq ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/flycheck.html";
         license = lib.licenses.free;
@@ -2384,10 +2407,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.5.8";
+      version = "0.7.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gnosis-0.5.8.tar";
-        sha256 = "00halz9fmgccgc7px2zqp6q2js4ab60fixqbr15sdqbygmlwvhh7";
+        url = "https://elpa.nongnu.org/nongnu/gnosis-0.7.0.tar";
+        sha256 = "0r8mblfdqzjbvcis1387yvgrcg2b47zld179dax9n4smbzvzc3gb";
       };
       packageRequires = [
         compat
@@ -2560,10 +2583,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.9.3";
+      version = "0.9.9.4";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.9.3.tar";
-        sha256 = "19wwjjlpfa5ngmfj8v3hzf2ndr355s5vg9nzg8qmx3ni61jb08n7";
+        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.9.4.tar";
+        sha256 = "0j410b0bynq91dxwakrrzp92m3p2lznzvmyq41viscjm0gjng4kn";
       };
       packageRequires = [
         compat
@@ -3232,10 +3255,10 @@
     elpaBuild {
       pname = "julia-mode";
       ename = "julia-mode";
-      version = "1.0.2";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/julia-mode-1.0.2.tar";
-        sha256 = "1wwnyanxbpzy4n8n3ixafdbx7badkl1krcnk0yf5923f2ahiqhlr";
+        url = "https://elpa.nongnu.org/nongnu/julia-mode-1.1.0.tar";
+        sha256 = "1r8xsn5j1gdr2izy6q1xs13v7wcabgdrn7f6x608406kbhd01rrv";
       };
       packageRequires = [ ];
       meta = {
@@ -3949,10 +3972,10 @@
     elpaBuild {
       pname = "org-contrib";
       ename = "org-contrib";
-      version = "0.7";
+      version = "0.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/org-contrib-0.7.tar";
-        sha256 = "1v9sphc2jwccdix74ry3wblkkp9majk7n7c9ic1bsq9caj4i9n5r";
+        url = "https://elpa.nongnu.org/nongnu/org-contrib-0.8.tar";
+        sha256 = "0bw6wrnkbx26k0zxgglyps2nnmgwr6yvkizxqnknds3y5r643j34";
       };
       packageRequires = [ org ];
       meta = {
@@ -4385,10 +4408,10 @@
     elpaBuild {
       pname = "pg";
       ename = "pg";
-      version = "0.62";
+      version = "0.63";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/pg-0.62.tar";
-        sha256 = "1fxg2irjbc85rr0czqj7cmy7pxh5l9sa69244dgr5ix6b7901dwd";
+        url = "https://elpa.nongnu.org/nongnu/pg-0.63.tar";
+        sha256 = "104f1c80cxzwb7z789igw2gvbmp8mirn213sp62jjwpyxfldm06q";
       };
       packageRequires = [ peg ];
       meta = {
@@ -4576,10 +4599,10 @@
     elpaBuild {
       pname = "radio";
       ename = "radio";
-      version = "0.4.1";
+      version = "0.4.3";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/radio-0.4.1.tar";
-        sha256 = "049j72m7f3a2naffpp8q4q0qrgqw0mnw5paqwabig417mwzzhqqr";
+        url = "https://elpa.nongnu.org/nongnu/radio-0.4.3.tar";
+        sha256 = "1xr10zhm8fk75h0i07jry5c05cds4xbb012wa943cbibxj0cma68";
       };
       packageRequires = [ ];
       meta = {
@@ -5147,10 +5170,10 @@
     elpaBuild {
       pname = "subed";
       ename = "subed";
-      version = "1.3.1";
+      version = "1.4.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/subed-1.3.1.tar";
-        sha256 = "04c7yzv5dif8rxxn1lkn2xhb614nw5mycjsihxvl21443539n9ic";
+        url = "https://elpa.nongnu.org/nongnu/subed-1.4.1.tar";
+        sha256 = "11rg436w2rdcpiix5hzmdb7r736nhiqpm4h8b18ac7dv6nnjjnwd";
       };
       packageRequires = [ ];
       meta = {
@@ -5454,10 +5477,10 @@
     elpaBuild {
       pname = "tp";
       ename = "tp";
-      version = "0.7";
+      version = "0.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/tp-0.7.tar";
-        sha256 = "048z3g0gv7brsl546s530b6si2rjhy3mm8y0jdcp14fza4srpliv";
+        url = "https://elpa.nongnu.org/nongnu/tp-0.8.tar";
+        sha256 = "1psa4sdia1vx3l2v1lklc8wy8nqbq6g83fyj46xii20rfm4db9hk";
       };
       packageRequires = [ transient ];
       meta = {
@@ -5623,10 +5646,10 @@
     elpaBuild {
       pname = "undo-fu-session";
       ename = "undo-fu-session";
-      version = "0.7";
+      version = "0.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/undo-fu-session-0.7.tar";
-        sha256 = "1gly9fl8kvfssh2h90j9qcqvxvmnckn0x1wfm4qbz9ax57xvms23";
+        url = "https://elpa.nongnu.org/nongnu/undo-fu-session-0.8.tar";
+        sha256 = "1l69q4g5f9dza0npw9sp2y398q142xzpfgrmhl3aa2fjq49d4bcf";
       };
       packageRequires = [ ];
       meta = {
@@ -5950,10 +5973,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "28.11.20260106081151";
+      version = "28.11.20260215192642";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-28.11.20260106081151.tar";
-        sha256 = "1xp3x69fxzv805wkiwl8fynpgzr4ap1fx67fqrmw5m0vi856qhbx";
+        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-28.11.20260215192642.tar";
+        sha256 = "0k0p60wirvp36ifaqkq6420rxfj1ys4cb8j34q7rhcbdfw1cp9dd";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -318,8 +318,8 @@
   "repo": "abstools/abs-mode",
   "unstable": {
    "version": [
-    20241217,
-    839
+    20260211,
+    1320
    ],
    "deps": [
     "erlang",
@@ -327,8 +327,8 @@
     "maude-mode",
     "yasnippet"
    ],
-   "commit": "debb48caef334870b4439609a9e818c7fd01f420",
-   "sha256": "0kicw2462pzhhrds2lws8s00d4xwmr7yaaskpj9r5rdr41qyxkxl"
+   "commit": "aaf97a11ef799d424f34de9a651dcbe601e85b63",
+   "sha256": "0gfn3q11gl2kl885vmcby0w5l7jsm58drq0ksm9qhr0nzjg000zl"
   },
   "stable": {
    "version": [
@@ -353,20 +353,20 @@
   "repo": "mgrbyte/emacs-abyss-theme",
   "unstable": {
    "version": [
-    20260103,
-    1924
+    20260125,
+    1959
    ],
-   "commit": "e8326ed9955d0897cc68fb38d488985a045c868c",
-   "sha256": "072ignp5ncj5xhjw1hrlkq9by7a0f96lak00c758b2malnxwaddp"
+   "commit": "6eb2b5735808ea96a36fc7abf741fc3bbf1b6ee4",
+   "sha256": "1fy1id4qvqs5ya3lig0galf0z54ym939cn3hzg4h5qg8jdcsj1nz"
   },
   "stable": {
    "version": [
     0,
     7,
-    1
+    2
    ],
-   "commit": "e8326ed9955d0897cc68fb38d488985a045c868c",
-   "sha256": "072ignp5ncj5xhjw1hrlkq9by7a0f96lak00c758b2malnxwaddp"
+   "commit": "6eb2b5735808ea96a36fc7abf741fc3bbf1b6ee4",
+   "sha256": "1fy1id4qvqs5ya3lig0galf0z54ym939cn3hzg4h5qg8jdcsj1nz"
   }
  },
  {
@@ -1009,8 +1009,8 @@
   "repo": "xcwen/ac-php",
   "unstable": {
    "version": [
-    20260114,
-    607
+    20260210,
+    846
    ],
    "deps": [
     "dash",
@@ -1020,8 +1020,8 @@
     "s",
     "xcscope"
    ],
-   "commit": "b7448b8bcdff20a2818a64d804cb3d14c1737b46",
-   "sha256": "005cv05dma6086x9qrwqqbcscdflyb1685azc700pcwzv0ggzr11"
+   "commit": "b053bd3723acf13a6c1a3e9cec221f4e0b24ea2c",
+   "sha256": "1zxk1r8a1p3pcn4xh727x490z0vwm0aljnm9vi018vh2012453wr"
   },
   "stable": {
    "version": [
@@ -1599,20 +1599,20 @@
   "repo": "xenodium/acp.el",
   "unstable": {
    "version": [
-    20260118,
-    1815
+    20260221,
+    2307
    ],
-   "commit": "9ab9b8f25cd7f42955171d471da5c3d016d1ef5a",
-   "sha256": "0lg5rli3xvkfp0gvpz1bmdv8m8h8abkn1zklxrpgfisxb5axyzii"
+   "commit": "49de56f0de328ad9022e2784f52acd73170f7e75",
+   "sha256": "081cjs8mvp8za8kxn1y908iwzarqdxx5pzx0b4wbas9ablqi8cp6"
   },
   "stable": {
    "version": [
     0,
-    8,
-    3
+    11,
+    1
    ],
-   "commit": "9ab9b8f25cd7f42955171d471da5c3d016d1ef5a",
-   "sha256": "0lg5rli3xvkfp0gvpz1bmdv8m8h8abkn1zklxrpgfisxb5axyzii"
+   "commit": "784b00017262260c2c718c98af98f16a2cc7bfdd",
+   "sha256": "1l1m5iwn15xp8h7q18fzmi0grr6cgyiy16dpkp1w8fsbd7n439pb"
   }
  },
  {
@@ -1859,11 +1859,11 @@
   "repo": "louabill/ado-mode",
   "unstable": {
    "version": [
-    20251201,
-    2259
+    20260210,
+    1431
    ],
-   "commit": "0bf66c877e5773ae8e86d4bee286f29a4abd56e9",
-   "sha256": "03vz59b81yg54z736mirkr5vxj5f47c2vhmwsv0irfhhzqvis59h"
+   "commit": "371441d27027fd4783a8c828458a5af098babca4",
+   "sha256": "09f8glzsln16kyhk4jiixhg2jcslxs989kq09pmhvxi4z1cvvchw"
   },
   "stable": {
    "version": [
@@ -1883,20 +1883,35 @@
   "repo": "bbatsov/adoc-mode",
   "unstable": {
    "version": [
-    20250206,
-    838
+    20260221,
+    2207
    ],
-   "commit": "20772277b8a5b8c08d49bd03043d5d4dd7a815e9",
-   "sha256": "0ln8xfvsdmr5p1axlk25gvnis2h8wh4ry74gglg02fwkrkqbs6w9"
+   "commit": "50b601dd92f99dd9534ff44de5f411480ca32b09",
+   "sha256": "1sgmhsvr0kbkv86zgp82r5bs3wpn4sn7mm15fdn7mv3dsjkngssv"
   },
   "stable": {
    "version": [
     0,
-    7,
+    8,
     0
    ],
-   "commit": "66b9adc97d8702de47140092cbae3a2f5563a297",
-   "sha256": "0bp2i66a9gp41r7nvbx8f4s334gd7lwjdxi3qw5yhgaav6gk3bkc"
+   "commit": "6fc5ebc9478de17b1971222485e7729f04fbcf57",
+   "sha256": "0hjhjg9kdx849qbdhzryfv8c21h2xq02991hixykmxf1b2xv1y69"
+  }
+ },
+ {
+  "ename": "advent-mode",
+  "commit": "2f3e9d6b61c61b9807434a443cdcc2d1b2dce65c",
+  "sha256": "076089qhrm80y83y088fydwx14c850a77f0zzvrr0mijafkfn5b4",
+  "fetcher": "github",
+  "repo": "vkazanov/advent-mode",
+  "unstable": {
+   "version": [
+    20260209,
+    1903
+   ],
+   "commit": "68c149aad8e5844d87fbf5f703479cded641ef49",
+   "sha256": "0cji1i2ixrqv348md1671fq558mg0spgw00wbmh17ii8m8ncb736"
   }
  },
  {
@@ -2001,7 +2016,7 @@
  },
  {
   "ename": "afternoon-theme",
-  "commit": "a5676fa2b3228cb56e38449c4573afdc37f3994b",
+  "commit": "bcccb562e0d35af65d57312f654d931db3964a4d",
   "sha256": "0lb7qia4fqdz9jbklx4jiy4820dmblmbg7qpnww0pkqrc0nychh3",
   "fetcher": "github",
   "repo": "ozanmakes/emacs-afternoon-theme",
@@ -2137,28 +2152,28 @@
   "repo": "xenodium/agent-shell",
   "unstable": {
    "version": [
-    20260119,
-    2116
+    20260224,
+    1533
    ],
    "deps": [
     "acp",
     "shell-maker"
    ],
-   "commit": "b47e18587a5215231dcc94c9e44a7bbdc96135fe",
-   "sha256": "05v064mikr8zbizb1mm2z5yjs3869nlaj84xrsd22xiajp4ak3n4"
+   "commit": "7f9e67da4593ed927901bbf2ae5025da25e98979",
+   "sha256": "1bybc78701r5m01vqkzw9v5h6ha9q82zxq7hbllqam227nzb22hj"
   },
   "stable": {
    "version": [
     0,
-    30,
+    41,
     1
    ],
    "deps": [
     "acp",
     "shell-maker"
    ],
-   "commit": "25c54b06dca83c5854896df5dac3c0cdab2ed7fe",
-   "sha256": "1bki2f04czm3rq3dpnmplw6gqvcx0i83n15g2llf4qswdxwrkz0w"
+   "commit": "a1803cd7848284e69f8d1379afc9b76fbea52383",
+   "sha256": "17ha385iafdyjmyljw52j63kq8jkh34q673jvb8wki5idhizxgzq"
   }
  },
  {
@@ -2304,27 +2319,27 @@
   "repo": "tninja/ai-code-interface.el",
   "unstable": {
    "version": [
-    20260116,
-    1534
+    20260224,
+    346
    ],
    "deps": [
     "magit",
     "transient"
    ],
-   "commit": "007fd8f7e19b37f1969035480823ef759215140c",
-   "sha256": "15fc2xaq7ldqrin2wn98k5f3sjk7ml9f7j723nlxp3lirgyyb04c"
+   "commit": "882c3b55bb5eb6911a92badfcd8845f940b6504a",
+   "sha256": "171drv7gk1bpg5mwkxib2snrymfdzqs48z10cch0a3gsxzv07lhr"
   },
   "stable": {
    "version": [
-    0,
-    91
+    1,
+    52
    ],
    "deps": [
     "magit",
     "transient"
    ],
-   "commit": "934763b559686fe6920a5fbcbae2df9d5647c15a",
-   "sha256": "0742rc6mvrr46w2h6vn6saq6br3hi8nqm681cb367kmwkd3wakv7"
+   "commit": "74fd1c0b2db8dcc1c228633e950c434f8dfa6aa8",
+   "sha256": "1k7x84w6cfb8x7g2kpdg5h8lj5i9fshk6aib563c955zw3ygx282"
   }
  },
  {
@@ -2446,11 +2461,11 @@
   "repo": "skeeto/emacs-aio",
   "unstable": {
    "version": [
-    20251117,
-    644
+    20260214,
+    1529
    ],
-   "commit": "58157e51e7eb7a4b954894ee4182564c507a2f01",
-   "sha256": "10m6kkcb2gk0vaj6z3d8kcf72zqmi8mw4bx39nvkx4c2ssx5k66g"
+   "commit": "0e94a06bb035953cbbb4242568b38ca15443ad4c",
+   "sha256": "1fwv0ajc0zbjiyna5zpixp5sal0g43vhk830xiijy91mvz9f7hs4"
   },
   "stable": {
    "version": [
@@ -2542,15 +2557,15 @@
   "repo": "alan-platform/AlanForEmacs",
   "unstable": {
    "version": [
-    20240309,
-    650
+    20260209,
+    1113
    ],
    "deps": [
     "flycheck",
     "s"
    ],
-   "commit": "df6c82f1a37a4bd6f18cb463c3f7ab7d087b91ab",
-   "sha256": "13fy6x7cs74zpqzix719jly01v5mzdwqhcq3m3kqrsxy1m9a0g49"
+   "commit": "87eed317ea7eac483a33680fd230ffc9f0eb3297",
+   "sha256": "1ky2znrnmsjl9vahlbkcrmab6cbjf5j7ja3iixb2wir3d712fifv"
   },
   "stable": {
    "version": [
@@ -3037,9 +3052,9 @@
  },
  {
   "ename": "almost-mono-themes",
-  "commit": "71ca87a0dd28f911dd988e1c208896b1ec5bfcc7",
-  "sha256": "1lv7c63lii8463mmsmxnldkwark2c6n46j9zvf990dhacwl4q1mg",
-  "fetcher": "github",
+  "commit": "048bd83bb0cef4efa5e40e2afe7c08452f97e550",
+  "sha256": "10599yjydcjbv9mghnavgav8l2m4yd60fd4vfryh6njz6kgvskwc",
+  "fetcher": "codeberg",
   "repo": "cryon/almost-mono-themes",
   "unstable": {
    "version": [
@@ -4062,20 +4077,20 @@
   "repo": "radian-software/apheleia",
   "unstable": {
    "version": [
-    20251223,
-    1924
+    20260221,
+    2001
    ],
-   "commit": "426616cf1799dbce89800ae2fe9f155311436503",
-   "sha256": "0kv879kv9xqp9gcdjvn1xs6lzy4ylhpi9xflvgpm2kmynjgs2hc6"
+   "commit": "2bc2bb4cc2caad111e6f2f1b9daf20ec388101ff",
+   "sha256": "1vs532hjkwj19laigqvvk11r0gwhv5vd8v6wh5598dzmfw3yh4bm"
   },
   "stable": {
    "version": [
     4,
     4,
-    2
+    3
    ],
-   "commit": "5e5969d7c8afa4c40948d95dc41fe66e30f3a282",
-   "sha256": "1ldj6cny88b7j0jspv68sw5z9jpfpqimavmbnhcbq7gmc6xlbmvz"
+   "commit": "2bc2bb4cc2caad111e6f2f1b9daf20ec388101ff",
+   "sha256": "1vs532hjkwj19laigqvvk11r0gwhv5vd8v6wh5598dzmfw3yh4bm"
   }
  },
  {
@@ -4556,6 +4571,30 @@
    ],
    "commit": "dc3c91feff6282303b66816bdcee9e031558ff77",
    "sha256": "1bigikx3q3vgj8y8bqp19yxdmgwkn0rmccyx88sjl0azsg4il5zk"
+  }
+ },
+ {
+  "ename": "asciidoc-mode",
+  "commit": "b64b4ec9529fb8e50cbf7f975147335e8d80e5c9",
+  "sha256": "09pnkgk3ggmav9zb7hjds9fl5w0cbd6m5qvc2wk8vvlrs4qmxnv8",
+  "fetcher": "github",
+  "repo": "bbatsov/asciidoc-mode",
+  "unstable": {
+   "version": [
+    20260222,
+    1804
+   ],
+   "commit": "4b5e89bedc0453e63147e08cdd759cbf2e31be26",
+   "sha256": "0gn8lcx2j6yrgh0wggnb6hjs5x1hwhvbc6g2f7vk42hsgz5skng4"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "4b5e89bedc0453e63147e08cdd759cbf2e31be26",
+   "sha256": "0gn8lcx2j6yrgh0wggnb6hjs5x1hwhvbc6g2f7vk42hsgz5skng4"
   }
  },
  {
@@ -5320,11 +5359,11 @@
   "repo": "dlobraico/auth-source-1password",
   "unstable": {
    "version": [
-    20230529,
-    1349
+    20260221,
+    2058
    ],
-   "commit": "7bb8ad3507c58cc642b2ebbd7e57a91efab80e14",
-   "sha256": "1ph9kg0v4xnc5ymcg71q9pvpp83qg67k788xkggk32xjriv5cq57"
+   "commit": "10961bdc8a3ed551dde29fde416843058bea2374",
+   "sha256": "19s59j2d8wdvpdd2yajmlbhm2ihf3jvf5ra8l2p9sn4db7ri95qb"
   }
  },
  {
@@ -5472,11 +5511,11 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20260101,
-    1821
+    20260219,
+    2245
    ],
-   "commit": "eaed414fa7dae04c7701dbc591de52fb3e81aa91",
-   "sha256": "02i7ak9sgzhfxyhil0w579d8xpa9p151l7x797pyv29ffi5brc4h"
+   "commit": "fa5a6f1c7f372005ac0f3511b59fa5b417b090e9",
+   "sha256": "0j23ggl68f1sv4d72wbpymx7kcfklcfwm1fq3i2nxg6ymb9svp9f"
   },
   "stable": {
    "version": [
@@ -5786,20 +5825,20 @@
   "repo": "LionyxML/auto-dark-emacs",
   "unstable": {
    "version": [
-    20251006,
-    358
+    20260218,
+    1317
    ],
-   "commit": "a71e791e47d09c5bf4bcbc2bbd7300b71ff72f1a",
-   "sha256": "1jmh27fkf1pivavv0qwwbb1fhdaycj3gpbbgsd917flsp6pfw55x"
+   "commit": "280d9a6e6ab0ccb833185761734585344ce22095",
+   "sha256": "1z4v3wvay6fyighqs7j28zydv2hifym5gmv63dzqvsmimccxcap9"
   },
   "stable": {
    "version": [
     0,
     13,
-    7
+    9
    ],
-   "commit": "a71e791e47d09c5bf4bcbc2bbd7300b71ff72f1a",
-   "sha256": "1jmh27fkf1pivavv0qwwbb1fhdaycj3gpbbgsd917flsp6pfw55x"
+   "commit": "280d9a6e6ab0ccb833185761734585344ce22095",
+   "sha256": "1z4v3wvay6fyighqs7j28zydv2hifym5gmv63dzqvsmimccxcap9"
   }
  },
  {
@@ -6110,6 +6149,21 @@
    ],
    "commit": "3ffa4e2a76a6dda949fdfd200f623a17c4796559",
    "sha256": "1d6dxzfgpwaidjys9jx6x368rih40lqyhrgx51rsjf68x4k24s3s"
+  }
+ },
+ {
+  "ename": "auto-space-mode",
+  "commit": "91d1608c3165fe234e97ad8d041ccc34d283af82",
+  "sha256": "0nymy5aa0kkrzyy5a7y3j6kgq2svsirmbqb9vbzwsnm5pnhwhlw7",
+  "fetcher": "github",
+  "repo": "wowhxj/auto-space-mode",
+  "unstable": {
+   "version": [
+    20260204,
+    255
+   ],
+   "commit": "38cd6bc259522250c1df88f24d0a3cc3727fb982",
+   "sha256": "0cz4m7nlspc24cm3dv7w98vkw7rlxa3g6vjx6c2hz5as7ri7aw2g"
   }
  },
  {
@@ -6495,15 +6549,15 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20250127,
-    1315
+    20260218,
+    624
    ],
    "deps": [
     "avy",
     "embark"
    ],
-   "commit": "755cb49b59801ff420193cc0e3b1a7aa12bf22e3",
-   "sha256": "0n8khkgk3mnm48b9426radzmrgda0k6zcc0c0ws8yl2gpnkblkxn"
+   "commit": "0bdfd38d281d6375e6e675ce6f1bd597a9e3b136",
+   "sha256": "0m9y2wraapi744fg7y6cgz6y2gx0xzaglnxqalynz44ca9z6m6y4"
   },
   "stable": {
    "version": [
@@ -7166,11 +7220,11 @@
   "repo": "tinted-theming/base16-emacs",
   "unstable": {
    "version": [
-    20260118,
-    148
+    20260222,
+    204
    ],
-   "commit": "1d9457c3940b42a7db586ee9b1249d86d1facbdb",
-   "sha256": "1mlhbpv3xbka8r2p9zxmnvsgvlpijiv4nyyj0z9zf9n33rq7rs19"
+   "commit": "639f5ff740ec5ec2d7debad1349fe1d130528ff1",
+   "sha256": "0n9anahkbf76mw7mrbc9xk1q1wpr9rkh5vwga8nrgp2vhsx17xs6"
   },
   "stable": {
    "version": [
@@ -7212,11 +7266,11 @@
   "repo": "szermatt/emacs-bash-completion",
   "unstable": {
    "version": [
-    20250721,
-    2026
+    20260206,
+    1459
    ],
-   "commit": "762f28fefba487e15d626691310f3194804eb71a",
-   "sha256": "1kf542389phlrjly5cjhhkv5534cc6lp93468aiaqnx2maaa982a"
+   "commit": "5b621db96efc549c64436011a81fd658c6dcf6a0",
+   "sha256": "160nswlhh7mbrkisy4aq9dybknjpkbvbqkhs4mq6n452p5r0l2kf"
   },
   "stable": {
    "version": [
@@ -8063,19 +8117,19 @@
   "repo": "kristjoc/bible-gateway",
   "unstable": {
    "version": [
-    20260105,
-    1259
+    20260223,
+    1906
    ],
-   "commit": "8616ccb52a370c0d4ffca441a4bc2410a869e3b0",
-   "sha256": "16drh2mqvrvgi1dyblk0kw8yzswhccwniqlgs734jjgkfpvk0qks"
+   "commit": "b4cf300c1335dfe8210da05af0a8f3bf18b8f5d3",
+   "sha256": "048mw5dfpmrdq4sxpci1jrazvlizy4dz7lk95kqhvf7zdp70lywi"
   },
   "stable": {
    "version": [
     1,
-    5
+    6
    ],
-   "commit": "8616ccb52a370c0d4ffca441a4bc2410a869e3b0",
-   "sha256": "16drh2mqvrvgi1dyblk0kw8yzswhccwniqlgs734jjgkfpvk0qks"
+   "commit": "b0fb2c0fcbb5f178061b5b4bbe6ea17adabe7c36",
+   "sha256": "0df3gmj1qcyqn14w33dhbm7wxikvwl38ws91h33dwl63q2zjb64n"
   }
  },
  {
@@ -9100,14 +9154,14 @@
   "repo": "lapislazuli/blue.el",
   "unstable": {
    "version": [
-    20251223,
-    1409
+    20260129,
+    2241
    ],
    "deps": [
     "magit-section"
    ],
-   "commit": "b2778111dba48b0d7db4c17cbe352b541e6e7707",
-   "sha256": "1wd4wg6mjsmxhxpx72hgqz9wnss0n060kdcf9i7llk1gsw4bcmjr"
+   "commit": "858b630b49a97030d5f828d1e7fddece4055a7a7",
+   "sha256": "03wbrdbq48jmqy1fgrrfd8291gbmgz9n6vzn16jfknizixijkpvq"
   }
  },
  {
@@ -9477,16 +9531,16 @@
   "repo": "jyp/boon",
   "unstable": {
    "version": [
-    20251212,
-    1343
+    20260215,
+    930
    ],
    "deps": [
     "dash",
     "expand-region",
     "multiple-cursors"
    ],
-   "commit": "28b3ff88673d73a4a907a47c22e82864a5c7a031",
-   "sha256": "0988lf0faqzkj3kh7jxac4xf5ffnwy9xa1gv8a7lzygv1kgvh99d"
+   "commit": "1aa2b2f8f6c0b32cd600355bbeabc036624d0566",
+   "sha256": "12jcwcisdkkxzzzm1a8fqha90h0x7vb3cy3k1d8ijm80rcs7r4sk"
   },
   "stable": {
    "version": [
@@ -9510,28 +9564,28 @@
   "repo": "emacscollective/borg",
   "unstable": {
    "version": [
-    20260114,
-    1146
+    20260217,
+    2111
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "9482e00eb06dfbc599eac58bb73ec53700793b3e",
-   "sha256": "0kxgai33b8irl08gbmfbrsqnvbfh702hvbrwi740a0zz7dwnq7iw"
+   "commit": "6edbdfc3ef39539e36dd91512e98637fb27f9e76",
+   "sha256": "1ap6wg9yl7w11rb1g4wnzm1khfrarpj8ag9gg3zj27s0aqaf1v2c"
   },
   "stable": {
    "version": [
     4,
     4,
-    0
+    1
    ],
    "deps": [
     "epkg",
     "magit"
    ],
-   "commit": "61f9e083b8d9f9ca196758729adce2c286841991",
-   "sha256": "18vnf0lkkribkinl0xr074vx1yhqmllxysbcgcf8p2vy92n4spzl"
+   "commit": "99933c616380fdcdf3732644d7d69b7c5d54d4bf",
+   "sha256": "1wkd8p6iwk3pvi115ml848gsxcc48ddl226kgd08awimgqidzhs1"
   }
  },
  {
@@ -9670,15 +9724,15 @@
   "repo": "museoa/bqn-mode",
   "unstable": {
    "version": [
-    20250705,
-    1223
+    20260208,
+    1145
    ],
    "deps": [
     "compat",
     "eros"
    ],
-   "commit": "7c04ca9009e72b48da307b41d6814df1e383609a",
-   "sha256": "0bah6xpmb86rgjd3irnalpdqsb6wbf5izq6h1di5hh9axk55acsr"
+   "commit": "7968023225c23ec63644a18ea613cb8cd2cd536e",
+   "sha256": "1m9l4if3a9i6r76v370gh6azgj2lwqcnpavfv2bkvm9ad56f3pa8"
   }
  },
  {
@@ -9874,16 +9928,16 @@
   "repo": "rmuslimov/browse-at-remote",
   "unstable": {
    "version": [
-    20251223,
-    2328
+    20260126,
+    608
    ],
    "deps": [
     "cl-lib",
     "f",
     "s"
    ],
-   "commit": "27b17cc63b9f9dca893425908373251eb9b10f44",
-   "sha256": "0kbxag8krbj1s50arc8axvkx0v62akqv2m8c2rkcjg5qh0670dkf"
+   "commit": "38e5ffd77493c17c821fd88f938dbf42705a5158",
+   "sha256": "0qfahv06wrandalrg4lpnj20g2vmlbl77vx5wlqp9qc3g9vq64ic"
   },
   "stable": {
    "version": [
@@ -10305,11 +10359,11 @@
   "repo": "jamescherti/buffer-terminator.el",
   "unstable": {
    "version": [
-    20260114,
-    1535
+    20260222,
+    340
    ],
-   "commit": "543c96ff73e38f51543747aee4665649525b0cf2",
-   "sha256": "15d6dw3hpwjz22cw9rv8a0cqx06nsxc1shwjx91r7d0s8v9fmhkg"
+   "commit": "eeaefca1860f62c5b7ff11f7a0550d7b11892151",
+   "sha256": "1pncz0iam7z7sf8zk4k4zwpd2c2daf5hg2xd5v5hgcm2v2mwwzd9"
   },
   "stable": {
    "version": [
@@ -10422,11 +10476,11 @@
   "repo": "jamescherti/bufferfile.el",
   "unstable": {
    "version": [
-    20260114,
-    1535
+    20260215,
+    2013
    ],
-   "commit": "6bcff99b4e78a83ffaa15f1ce95f4f0421db64b0",
-   "sha256": "0cxs6phsvm5dbfxvw36sv8av4n436rc9w9wv2245ba6m1kr7f9bv"
+   "commit": "6c3a089b3b25a26880f672a900402d59b638837d",
+   "sha256": "0q5ifzvqmjv0cbpwaxwvjy1f9dh4c934f8r1jrymv773c8ddgib7"
   },
   "stable": {
    "version": [
@@ -11132,14 +11186,25 @@
   "repo": "xwl/cal-china-x",
   "unstable": {
    "version": [
-    20200924,
-    1837
+    20260222,
+    1826
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "94005e678a1d2522b7a00299779f40c5c77286b8",
-   "sha256": "0dy9awy5y990wz925rdn95gn23ywarwbvkqq0l0xms1br1v8kxc6"
+   "commit": "e9e3067134b0606bfe2a6925d7488c4b24ce81d5",
+   "sha256": "1y662hvbbs745yy72ppicdp9ifcz5a9xj1qp3jsifiyhs138zklf"
+  },
+  "stable": {
+   "version": [
+    2,
+    7
+   ],
+   "deps": [
+    "cl-lib"
+   ],
+   "commit": "e9e3067134b0606bfe2a6925d7488c4b24ce81d5",
+   "sha256": "1y662hvbbs745yy72ppicdp9ifcz5a9xj1qp3jsifiyhs138zklf"
   }
  },
  {
@@ -11427,16 +11492,16 @@
   "repo": "beacoder/call-graph",
   "unstable": {
    "version": [
-    20251227,
-    222
+    20260212,
+    649
    ],
    "deps": [
     "beacon",
     "ivy",
     "tree-mode"
    ],
-   "commit": "95008f18991691fc117c12e84cde2b9dc04e4e4b",
-   "sha256": "0r06sixyj5s7gvy255bhbwcicc2xwcsklqrv65xbx4y1ycjls2r3"
+   "commit": "38cb7a4488af63208d7ee1766a141453518e0abc",
+   "sha256": "00yn00kgski6nyfxjjqr1cxyf725dnl81v6chy0kc94mxnww8ybr"
   },
   "stable": {
    "version": [
@@ -11589,25 +11654,25 @@
   "repo": "minad/cape",
   "unstable": {
    "version": [
-    20260117,
-    1953
+    20260124,
+    924
    ],
    "deps": [
     "compat"
    ],
-   "commit": "dfb3bca62238aab8f64ec319a77a125df86a0eee",
-   "sha256": "0bi81w8qpl9gwfj0423bcsnl2wady2jvsxbc5ai7mb9mc1qzyvgg"
+   "commit": "2b2a5c5bef16eddcce507d9b5804e5a0cc9481ae",
+   "sha256": "18pdm8dlvzjry7xxx3yyka7rmrx94cvwkhwiagxcfprk6yinx21z"
   },
   "stable": {
    "version": [
     2,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "96162aab2a22158ccc40b0f5c90f61e77b03c4f8",
-   "sha256": "12jk8jjk38mfldsgnimnsggxan5a5amzf2z17pwjq7dxhn87168j"
+   "commit": "2b2a5c5bef16eddcce507d9b5804e5a0cc9481ae",
+   "sha256": "18pdm8dlvzjry7xxx3yyka7rmrx94cvwkhwiagxcfprk6yinx21z"
   }
  },
  {
@@ -11917,28 +11982,28 @@
   "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20260107,
-    910
+    20260223,
+    2338
    ],
    "deps": [
     "csv-mode",
     "transient"
    ],
-   "commit": "1620d8ac1f555b4b4299fb7a852d59ddeaaae2e4",
-   "sha256": "0w3p5zdd1wbx8jyk22z0z952wpkfxlrzliihr6gcvid7d249pjhf"
+   "commit": "a68d05609cc40905618b72b8cadbbdde833e428e",
+   "sha256": "1cahqzz1r7lzbqk57ncikavkd4sbw4jcrl8mlb4i7chf575k0ipv"
   },
   "stable": {
    "version": [
     2,
-    12,
-    1
+    14,
+    2
    ],
    "deps": [
     "csv-mode",
     "transient"
    ],
-   "commit": "1620d8ac1f555b4b4299fb7a852d59ddeaaae2e4",
-   "sha256": "0w3p5zdd1wbx8jyk22z0z952wpkfxlrzliihr6gcvid7d249pjhf"
+   "commit": "a68d05609cc40905618b72b8cadbbdde833e428e",
+   "sha256": "1cahqzz1r7lzbqk57ncikavkd4sbw4jcrl8mlb4i7chf575k0ipv"
   }
  },
  {
@@ -12071,11 +12136,11 @@
   "repo": "catppuccin/emacs",
   "unstable": {
    "version": [
-    20250910,
-    2247
+    20260128,
+    702
    ],
-   "commit": "09b9b785014e74f8e2ba24f29f806f1c0a65ad54",
-   "sha256": "0v7wzmslnqadxja52ygxjwimrhk9l4vw8n21yvk4gpcb66whjyip"
+   "commit": "7cd71f94865674eccde8e3c17175e12942a9e047",
+   "sha256": "0wpvykz8gyb155ysm5skmqqmk58x54l096vj158jrjp4hk35gprb"
   },
   "stable": {
    "version": [
@@ -12356,14 +12421,14 @@
   "repo": "ema2159/centaur-tabs",
   "unstable": {
    "version": [
-    20260115,
-    2125
+    20260128,
+    950
    ],
    "deps": [
     "powerline"
    ],
-   "commit": "5ad22d9a6a5d056a07f08b6fe6253f2a71f94ad8",
-   "sha256": "1izf6kpsbr3zjb8cl17gs416yqr2sm4wcxs4bn6lhhym5vqcim3x"
+   "commit": "5ec350da6cacc34ac0efaac17d6ac5031ef82bd4",
+   "sha256": "0mxw727vnyfdy35gbwi37dflqnxg1y5cvcbmri2ai4jiknha4n78"
   },
   "stable": {
    "version": [
@@ -12560,7 +12625,7 @@
   "repo": "worr/cfn-mode",
   "unstable": {
    "version": [
-    20260118,
+    20260215,
     907
    ],
    "deps": [
@@ -12568,8 +12633,8 @@
     "s",
     "yaml-mode"
    ],
-   "commit": "e52b95671b6834395463096a9431149ecf0a1a20",
-   "sha256": "0553fw3fd7phk0bbmdysx3gxr513f2aqm83yhmpphzkj50w91wm8"
+   "commit": "1fdc8b07baf82ad57cbede472d999fd6e5223042",
+   "sha256": "0c36n9mw83xam3s8f1zf27a128ymxg8fg4wx44c4sy64by6x0nz4"
   },
   "stable": {
    "version": [
@@ -12833,15 +12898,15 @@
   "repo": "xenodium/chatgpt-shell",
   "unstable": {
    "version": [
-    20251217,
-    1818
+    20260221,
+    2246
    ],
    "deps": [
     "shell-maker",
     "transient"
    ],
-   "commit": "e240b1a9004c1452b8bcb5279b4fa79d9f60def7",
-   "sha256": "04bxrx48qsf3wfcyzfhdgbcik5ws3p5afj13kl50v3jw45ci0md3"
+   "commit": "cbad6ffc9cbde1962a7317cf6d1d4d50ac1c1ac2",
+   "sha256": "12frn5h8j94nn47586r5b0kn0rflvxbxwcbaak36fbc551vsnb71"
   },
   "stable": {
    "version": [
@@ -13244,14 +13309,14 @@
   "repo": "plandes/choice-program",
   "unstable": {
    "version": [
-    20260107,
-    1854
+    20260127,
+    2022
    ],
    "deps": [
     "dash"
    ],
-   "commit": "acacd3409d60b7aa5c53d07290a8dfc31b919971",
-   "sha256": "0z46pkwc15p1lag5i5n6hmfj9abb0bpk1m61knwls31rmqrq6cj4"
+   "commit": "9c027a54a97390ee4863d663be19b1a2aaa70c7b",
+   "sha256": "016n3930fj5vymmk3xkdiwfk9an5dslv812d1f3nzbasv2kwhx3x"
   },
   "stable": {
    "version": [
@@ -13521,11 +13586,12 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20260116,
-    1514
+    20260221,
+    612
    ],
    "deps": [
     "clojure-mode",
+    "compat",
     "parseedn",
     "queue",
     "seq",
@@ -13533,13 +13599,13 @@
     "spinner",
     "transient"
    ],
-   "commit": "31c05c0a417c2c3dec97135c3dab3cd9c8322e53",
-   "sha256": "1gc5rn0v81alpairwd07asaxmjc9bsh08nv0rdscy7prq9jfgd4n"
+   "commit": "75dc57aebed59212952595684b9aae60f95c94a6",
+   "sha256": "04h188rk3c5r56aa5jf65nh6q9wnfsi72nbpvl3l8a3pv15fqslf"
   },
   "stable": {
    "version": [
     1,
-    20,
+    21,
     0
    ],
    "deps": [
@@ -13551,8 +13617,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "8e3091e8c427cc18f1cc511d5d5aa15424cddb62",
-   "sha256": "08hd281ybskkhir170hr3xpga1b1hwpph7rd0fk6fvm0ngdgxazs"
+   "commit": "c71bc65af7709667b0cc77306f4e3d5befe86d27",
+   "sha256": "19wx9mc488qipm08s7hc0zrfmiylw577lmf3jpvqcjq7amx14jgc"
   }
  },
  {
@@ -13731,20 +13797,20 @@
   "repo": "guidoschmidt/circadian.el",
   "unstable": {
    "version": [
-    20250222,
-    1158
+    20260208,
+    2050
    ],
-   "commit": "73fa3fd8b63af04bab877209397e42b83fbb9534",
-   "sha256": "0kxa8hky56xmg8szii23yai0w8zfh3ql7mazn9ff77aa8lx6mplm"
+   "commit": "181bb35ba9416bdede255c9fa6b86a2d60115f94",
+   "sha256": "1bpgg8vli4kl49w60hmqy14ymsfy1aqx2axcqwhk1q2a2xlqb5h2"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
-   "commit": "73fa3fd8b63af04bab877209397e42b83fbb9534",
-   "sha256": "0kxa8hky56xmg8szii23yai0w8zfh3ql7mazn9ff77aa8lx6mplm"
+   "commit": "181bb35ba9416bdede255c9fa6b86a2d60115f94",
+   "sha256": "1bpgg8vli4kl49w60hmqy14ymsfy1aqx2axcqwhk1q2a2xlqb5h2"
   }
  },
  {
@@ -14097,20 +14163,20 @@
   "repo": "universal-ctags/citre",
   "unstable": {
    "version": [
-    20251015,
-    220
+    20260220,
+    1324
    ],
-   "commit": "300596a34b61b486530ce3759e8fb722d9534325",
-   "sha256": "0nhyshjiy7amncxisnm8ra462xhmq351zrrv0ah3ym3v99vlsgn7"
+   "commit": "72375aac87cb245b4f49a4737456f626091a0a42",
+   "sha256": "0gslc3xqdbwjyb0rci1877ihinp8zlvjgf7maxbbmdgjgqpdlmwh"
   },
   "stable": {
    "version": [
     0,
     4,
-    1
+    2
    ],
-   "commit": "7c9c77276cc7dfcb77640df7d589eaac3198cfee",
-   "sha256": "1x5kxlzhzr2x4cszcqaxcg2lc71nwmmfnm2vzx7iz7h74hn4f1ld"
+   "commit": "72375aac87cb245b4f49a4737456f626091a0a42",
+   "sha256": "0gslc3xqdbwjyb0rci1877ihinp8zlvjgf7maxbbmdgjgqpdlmwh"
   }
  },
  {
@@ -14962,20 +15028,20 @@
   "repo": "clojure-emacs/clojure-mode",
   "unstable": {
    "version": [
-    20250527,
-    840
+    20260220,
+    1418
    ],
-   "commit": "d336db623e7ae8cffff50aaaea3f1b05cc4ccecb",
-   "sha256": "123x8rwv4nb30h1rz7avshvr00xjfjjsmzrqsyxhgdm3f0rhac5w"
+   "commit": "4bccd24fc680238f8d29fee1629401f620d50ca6",
+   "sha256": "0jagkbm0qssxgj342rva9bcwya5r3w7ihzdsbyyqkdvi468vyq2d"
   },
   "stable": {
    "version": [
     5,
-    20,
+    21,
     0
    ],
-   "commit": "d336db623e7ae8cffff50aaaea3f1b05cc4ccecb",
-   "sha256": "123x8rwv4nb30h1rz7avshvr00xjfjjsmzrqsyxhgdm3f0rhac5w"
+   "commit": "f1cd680918d6e3c28247b54fb199e186ef9cfd9d",
+   "sha256": "0h9qcdvdcl72231wm4x31nbwsihj4bwd179y2gxi6mr2q9yzbm1z"
   }
  },
  {
@@ -14986,26 +15052,26 @@
   "repo": "clojure-emacs/clojure-mode",
   "unstable": {
    "version": [
-    20250527,
-    840
+    20260219,
+    2144
    ],
    "deps": [
     "clojure-mode"
    ],
-   "commit": "d336db623e7ae8cffff50aaaea3f1b05cc4ccecb",
-   "sha256": "123x8rwv4nb30h1rz7avshvr00xjfjjsmzrqsyxhgdm3f0rhac5w"
+   "commit": "b9a648b148487677323c853d1c600be4e65d9351",
+   "sha256": "1ya14scpv4yrjymy51x68r6m5wk58rzp5nm64g98xly0cfr5p91p"
   },
   "stable": {
    "version": [
     5,
-    20,
+    21,
     0
    ],
    "deps": [
     "clojure-mode"
    ],
-   "commit": "d336db623e7ae8cffff50aaaea3f1b05cc4ccecb",
-   "sha256": "123x8rwv4nb30h1rz7avshvr00xjfjjsmzrqsyxhgdm3f0rhac5w"
+   "commit": "f1cd680918d6e3c28247b54fb199e186ef9cfd9d",
+   "sha256": "0h9qcdvdcl72231wm4x31nbwsihj4bwd179y2gxi6mr2q9yzbm1z"
   }
  },
  {
@@ -15079,11 +15145,11 @@
   "repo": "clojure-emacs/clojure-ts-mode",
   "unstable": {
    "version": [
-    20251202,
-    1521
+    20260223,
+    1813
    ],
-   "commit": "96fdffcbe9e1b8ebf9ad14e23b06f62cc3422e22",
-   "sha256": "1j78j9ig2x3g8qgsdrs38r3v0rva48c074d7kyag1aa0p7s37kr0"
+   "commit": "f47fefb5d7d6fed24314ae317acf4d0fb96dccd6",
+   "sha256": "0pkhnz6c24bqdsavc61hpahn1m9h7nr8flyk0l9fl9i03dld77sh"
   },
   "stable": {
    "version": [
@@ -15334,20 +15400,20 @@
   "url": "https://gitlab.kitware.com/cmake/cmake.git",
   "unstable": {
    "version": [
-    20251208,
-    1833
+    20260127,
+    1603
    ],
-   "commit": "485f11a780435eb6495b79227d3237383778ac3e",
-   "sha256": "0qcnrrcdj4kbx76q73y5a0iiww5vc9ickyjp26f3l9dkrp41y9yw"
+   "commit": "53ae242d55f89bee1f44ecc6e2fc460ae0f92f20",
+   "sha256": "0p93lkbqcmsmrvpsa7xs8iagm9lv69x725l55yq6vqcq8jyikx7k"
   },
   "stable": {
    "version": [
     4,
     2,
-    1
+    3
    ],
-   "commit": "485f11a780435eb6495b79227d3237383778ac3e",
-   "sha256": "0qcnrrcdj4kbx76q73y5a0iiww5vc9ickyjp26f3l9dkrp41y9yw"
+   "commit": "53ae242d55f89bee1f44ecc6e2fc460ae0f92f20",
+   "sha256": "0p93lkbqcmsmrvpsa7xs8iagm9lv69x725l55yq6vqcq8jyikx7k"
   }
  },
  {
@@ -15507,21 +15573,6 @@
    ],
    "commit": "1ad9af6679d0294c3056eab9cad673f29c562721",
    "sha256": "0s0zakrmbx9gr7ippnyqngc09xj9f7bsv0mv11p062a8pkilg219"
-  }
- },
- {
-  "ename": "code-awareness",
-  "commit": "899d8bebad73b4d2d404d769a8c147b5984219ff",
-  "sha256": "1w5jvxk1ngiqr6q2zvrrmix73l95vsd4r0df2c7yvs4yws7idmqd",
-  "fetcher": "github",
-  "repo": "CodeAwareness/kawa.emacs",
-  "unstable": {
-   "version": [
-    20251117,
-    617
-   ],
-   "commit": "16b700570ea8902830607575f3418f970dffe4c0",
-   "sha256": "0qw337f7p6ckdzycaacfsn0k7iigc7bs1ahkmhh14w7za5x4glw7"
   }
  },
  {
@@ -15692,17 +15743,17 @@
  },
  {
   "ename": "codespaces",
-  "commit": "385b9c079904e3548dc9ecaf6daf78cd737349fd",
-  "sha256": "0iln27y69zz7d9ls5ddbhh8jax3spjg3pfclpajwfgwncwkl8qgz",
+  "commit": "d2dd3edc7a6579fe4d4a92d42bfa1beecf51e2cc",
+  "sha256": "139sl0h1vr75zf17pmm912ims2pd2qz82jr1hi0nbj0n7w050yvb",
   "fetcher": "github",
-  "repo": "patrickt/codespaces.el",
+  "repo": "f4ban/codespaces.el",
   "unstable": {
    "version": [
-    20221018,
-    1831
+    20260224,
+    403
    ],
-   "commit": "8e0843684ea685c2b25b8f5601cf02553bab4b08",
-   "sha256": "1w3ay58aq3hgibmigb6frr7w1q660fvzhapr7lzgfh8w2z4lq7l9"
+   "commit": "16e5fc290532847c1dc3ced23533376880e44267",
+   "sha256": "02izh145v7b05il9vqdqyi3lmacpimvvy4ihiwnfjmzddlvm5cra"
   },
   "stable": {
    "version": [
@@ -16031,11 +16082,11 @@
   "repo": "purcell/color-theme-sanityinc-tomorrow",
   "unstable": {
    "version": [
-    20260105,
-    1047
+    20260211,
+    1131
    ],
-   "commit": "22107d90816293c361b777b1f8dfd6ba0be00f7b",
-   "sha256": "0kplsngi22m7i7wy9crizfqbsc6kfmx6h6svr2kirdglabjsnakm"
+   "commit": "7aec77ed89402bebf0ed879848329ac336f44188",
+   "sha256": "04a0mvff2k9dg3flx953w1yfnwp345za7k8220zcwxmpi5rcnzz5"
   },
   "stable": {
    "version": [
@@ -16203,14 +16254,14 @@
   "repo": "NicholasBHubbard/comint-histories",
   "unstable": {
    "version": [
-    20251116,
-    1248
+    20260205,
+    106
    ],
    "deps": [
     "f"
    ],
-   "commit": "36f37760a85bc5e8535180d9481c856768ea356d",
-   "sha256": "1rh36m9d4pm4lhdlwyw77h6k2gnwz69bayh270aslv269j1g96xk"
+   "commit": "12cd14d64d7396def51397ca1f0756357afd41f3",
+   "sha256": "0ywnahzm0lvlz5z4yd43zi1m4bfmfsdnh85ainf106chwc5nl0p5"
   }
  },
  {
@@ -16518,11 +16569,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20260108,
-    36
+    20260220,
+    156
    ],
-   "commit": "fad9f207e00a851c0d96dd532c1b175326ac3e3d",
-   "sha256": "0c7wm5wkq94j64v7ivk2aq3172lg3cd4nn77l5k7aszh3rqlhrnm"
+   "commit": "42d3897308a992cd2268ba2d4e2ec013fc6c961e",
+   "sha256": "18l5r52hsw3w7wmpzvrcy542s541z7s8f3ma9hy186l4p22hwziv"
   },
   "stable": {
    "version": [
@@ -16743,8 +16794,8 @@
   "repo": "cpitclaudel/company-coq",
   "unstable": {
    "version": [
-    20250806,
-    1134
+    20260223,
+    1721
    ],
    "deps": [
     "cl-lib",
@@ -16753,8 +16804,8 @@
     "dash",
     "yasnippet"
    ],
-   "commit": "78ed04ce39e925232a556d2077718cc7b215469c",
-   "sha256": "02c4771ds6hm6hr12z5pw0lir43gjgba87wzrnda9gh5vbvflyc4"
+   "commit": "1fc1d8f2d56e460b33c6d41a659488dce7b214f9",
+   "sha256": "0jlsg6bm77lzyxpqz7h076991hvlmqhwvjhklsfi4aqbigncc9lv"
   },
   "stable": {
    "version": [
@@ -16883,15 +16934,15 @@
   "repo": "emacs-eask/company-eask",
   "unstable": {
    "version": [
-    20251231,
-    1607
+    20260224,
+    1651
    ],
    "deps": [
     "company",
     "eask"
    ],
-   "commit": "8011dc5c6c931760a80189d1695147cad674e568",
-   "sha256": "14v24rlw1h2101ps3ykmpa91pgmjkyf1d6zaz2d6pffdclp9ag7v"
+   "commit": "748c53fe1530c7b75682d78128f85326e41432d6",
+   "sha256": "1w0vj9ivm4lhxvrwfaarb2jqcc40n4nqysrzsdn9hwbzwz421caz"
   },
   "stable": {
    "version": [
@@ -18416,11 +18467,11 @@
   "repo": "jamescherti/compile-angel.el",
   "unstable": {
    "version": [
-    20260114,
-    1601
+    20260224,
+    27
    ],
-   "commit": "59b431c6a55b8aeb36f536756890adc3b70ee205",
-   "sha256": "0hkn932lbnq4dp7zkw6gvb23xcs3253hava738cdhbw2b2kj32rr"
+   "commit": "4d9d1db237189720eb72aff24c05ba18ebe06423",
+   "sha256": "1x1j0pz8lhlzbs1iarxh3xix6m93yjz4iidf9pmbqm0r1r6s6yd5"
   },
   "stable": {
    "version": [
@@ -18552,8 +18603,8 @@
   "repo": "mkcms/compiler-explorer.el",
   "unstable": {
    "version": [
-    20260113,
-    1505
+    20260203,
+    2217
    ],
    "deps": [
     "eldoc",
@@ -18561,8 +18612,8 @@
     "plz",
     "seq"
    ],
-   "commit": "79a4c4be96a3210ccc85d2e7f1acbc1a4bcf86d5",
-   "sha256": "0zapy5fjzfw7rxw7wkwvq27wbqsic7l7wjv0wlb5djyfjcax9g5q"
+   "commit": "269bd9d9d2cbc45c10b5f91f988dc39bf783a68d",
+   "sha256": "0l76y2vv16bf4ay68pmrgypcq7sxnmk4sgdhili96bqy8jxc4ryp"
   },
   "stable": {
    "version": [
@@ -18713,20 +18764,20 @@
   "repo": "tarsius/cond-let",
   "unstable": {
    "version": [
-    20260118,
-    1332
+    20260201,
+    1500
    ],
-   "commit": "e08a9ccf29e28aae43988458789dea04a562ccd1",
-   "sha256": "198yk7fr28n85mglmq41r8ir3vl1fk0000z1a79hb7xmplkk6c3d"
+   "commit": "8bf87d45e169ebc091103b2aae325aece3aa804d",
+   "sha256": "08ay78mbypfs1nl31dsv4b7bixnsl5kp1xkg0jkk7fvbsfv22679"
   },
   "stable": {
    "version": [
     0,
     2,
-    1
+    2
    ],
-   "commit": "0430bd1eb3493ea90d69feb6b7eb7dac3e10d0ba",
-   "sha256": "0611cz5warp6w4zvy4q1mkxkgypnlfwwz52h94n8mgqxa0r3rhvs"
+   "commit": "8bf87d45e169ebc091103b2aae325aece3aa804d",
+   "sha256": "08ay78mbypfs1nl31dsv4b7bixnsl5kp1xkg0jkk7fvbsfv22679"
   }
  },
  {
@@ -18960,14 +19011,14 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20260118,
-    744
+    20260205,
+    2051
    ],
    "deps": [
     "compat"
    ],
-   "commit": "312f2db1a23ef5428ab9553679147d5ff3a4e57d",
-   "sha256": "1q046nfhikklz137yccsxnak91hdh38gjpl1nbssh0nmqcfgkmvs"
+   "commit": "d1d39d52151a10f7ca29aa291886e99534cc94db",
+   "sha256": "1ck0g1l11knb9x13jmga1w67r7lfh5ajk6fnwdbd0yxfnkx44gqg"
   },
   "stable": {
    "version": [
@@ -19471,6 +19522,25 @@
   }
  },
  {
+  "ename": "consult-gumshoe",
+  "commit": "cae5094c143c1eb882edb423f6f2b6f5b5217259",
+  "sha256": "1p011ccyrifygcj7f48czc50m3pjwv0zcwr08dl1nqd238di8hy8",
+  "fetcher": "github",
+  "repo": "Overdr0ne/gumshoe",
+  "unstable": {
+   "version": [
+    20260217,
+    252
+   ],
+   "deps": [
+    "consult",
+    "gumshoe"
+   ],
+   "commit": "da71e889b5e890fecbacaeba0a4977c4657b4351",
+   "sha256": "0j5nnrn5ypj4i2ysdfayiky3iai30wjwhdbxakrj5bafcn5051ki"
+  }
+ },
+ {
   "ename": "consult-hatena-bookmark",
   "commit": "7a14748b58bba3d89324fd3e3ed7e50963fffa52",
   "sha256": "1km2wqy8jard8017a5qahrr5ghxgl0xshbycggfxdd2z6n6pxbyg",
@@ -19579,16 +19649,16 @@
   "repo": "mclear-tools/consult-notes",
   "unstable": {
    "version": [
-    20251117,
-    1511
+    20260222,
+    1928
    ],
    "deps": [
     "consult",
     "dash",
     "s"
    ],
-   "commit": "3c11379514718db365a377ac8e4503d1ea4674a8",
-   "sha256": "096ppagkdr8ji3cfkmgh0jnlwzccc89rcdqc1pp9mf2yq6phbxfh"
+   "commit": "94e5b19ec84363438eb7114e59c059a67f3d7c59",
+   "sha256": "1cvvmk3nf3fidcfc2x8wvsb1yc98cilhhcl7kgawzlwmy8r0libr"
   }
  },
  {
@@ -19631,15 +19701,15 @@
   "repo": "jgru/consult-org-roam",
   "unstable": {
    "version": [
-    20251116,
-    1230
+    20260209,
+    1805
    ],
    "deps": [
     "consult",
     "org-roam"
    ],
-   "commit": "7d825fffd6f990b800485376f62dd9b277991709",
-   "sha256": "1icr16lq7ns9ml8sl6zxbv68zvwb1b1w4vq0x7dr1qrcvgzpsgr8"
+   "commit": "781d9c1cfee8631bc125fa45bab92de320d3941e",
+   "sha256": "18gwyv6zbbh4kqf8g8gz2rdi4sihmv7z9cmlksyg5j41a2l6imjg"
   }
  },
  {
@@ -19738,6 +19808,24 @@
    ],
    "commit": "5c1dcf0182135cda4191d4ba206fe2f265100293",
    "sha256": "06wj2pixhjgqddl9g2wkv7cq9gz9yjb46cb1jrlbya3rdjyfb6h5"
+  }
+ },
+ {
+  "ename": "consult-spotlight",
+  "commit": "aadaf32f459d1d62b34a3d0bd4a2d630c8f38342",
+  "sha256": "0507f4x0y1zifdyfbaka21y3873pp903afr2p5candf2yr8gfjsy",
+  "fetcher": "github",
+  "repo": "guibor/consult-spotlight",
+  "unstable": {
+   "version": [
+    20260202,
+    2318
+   ],
+   "deps": [
+    "consult"
+   ],
+   "commit": "b60fef973c19e22225cae395217ff01bd32a0ef5",
+   "sha256": "0dsd12kj7blnd6mhs3kgww5x4bz7xl8qbj2xg3xra8jgdic03njk"
   }
  },
  {
@@ -20030,17 +20118,17 @@
   "repo": "copilot-emacs/copilot.el",
   "unstable": {
    "version": [
-    20251210,
-    1016
+    20260225,
+    538
    ],
    "deps": [
+    "compat",
     "editorconfig",
-    "f",
     "jsonrpc",
     "track-changes"
    ],
-   "commit": "7ee4758bb748beac7d29e62de5d2e752ebafb858",
-   "sha256": "0r8g1yv8csq9l069myiy57kak39dym3klqbxs08l693j9zmdyflg"
+   "commit": "0e1c017162f50dbceb32cd00d4d6d41ddde71b2b",
+   "sha256": "1p3dwn34cb8k6pw2y2dirnp2gymxin4njs0wdcm1n5l2ci1vhrzx"
   },
   "stable": {
    "version": [
@@ -20066,8 +20154,8 @@
   "repo": "chep/copilot-chat.el",
   "unstable": {
    "version": [
-    20260105,
-    858
+    20260123,
+    937
    ],
    "deps": [
     "aio",
@@ -20079,8 +20167,8 @@
     "shell-maker",
     "transient"
    ],
-   "commit": "9dd4b0c72e5e2af16b340a22a427105854f4e745",
-   "sha256": "0jlqf4mabynzwsl3s4vwha5lw1ipva9xkdin92qslmb8lkffr9r7"
+   "commit": "753ebc4ae466c8716be8de0d169393f730c999f6",
+   "sha256": "11f3i27yi5f9v61wmhwl35awidkv7jn285pq4jq9zrwzv8cp6zm6"
   },
   "stable": {
    "version": [
@@ -20251,14 +20339,14 @@
   "repo": "minad/corfu",
   "unstable": {
    "version": [
-    20260118,
-    746
+    20260210,
+    915
    ],
    "deps": [
     "compat"
    ],
-   "commit": "fbbcdf9578a8fbea4d6956fc3bdf2dcb776b8d8b",
-   "sha256": "0aliis64ifr17xyig99gbh0xczdkdlb4snq5pbrlnrjhzk1cksy4"
+   "commit": "abfe0003d71b61ffdcf23fc6e546643486daeb69",
+   "sha256": "1v8y941pf3q03pva9pma2pykmb8nl9sdl7ydcph798yfcsw0p6xr"
   },
   "stable": {
    "version": [
@@ -20428,15 +20516,15 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20250329,
-    1401
+    20260214,
+    1004
    ],
    "deps": [
     "ivy",
     "swiper"
    ],
-   "commit": "e33b028ed4b1258a211c87fd5fe801bed25de429",
-   "sha256": "1yv40k0swdywk0zwxs2s95s4y1pa9k2m3s25fx7gv9pnmf7yw8p1"
+   "commit": "ee79f68215ae7e2b8a38ba6bf7f82b3fe57dc16c",
+   "sha256": "0qs73g9d5c1rmjmmlkgx11qs25nb10azh841ybjllsyqa9ilch8l"
   },
   "stable": {
    "version": [
@@ -21391,11 +21479,11 @@
   "repo": "smallwat3r/emacs-creamy-theme",
   "unstable": {
    "version": [
-    20251030,
-    1829
+    20260130,
+    917
    ],
-   "commit": "3bceabac758378d91d07ba39b855e744be7e3c54",
-   "sha256": "135v8qcx2cwjj68q9zwxiy4jgmyl6pwvc4dkwi4z6r4wy7g306sl"
+   "commit": "d16902a91c28d616d01bb7bcfd7c6248415f5860",
+   "sha256": "0i3r58b6pyq2zhpyzkp6yb8rdwh2li1f1scshgz4wydsvsirqal6"
   }
  },
  {
@@ -21972,19 +22060,20 @@
   "repo": "radian-software/ctrlf",
   "unstable": {
    "version": [
-    20251212,
-    141
+    20260221,
+    1939
    ],
-   "commit": "3e1d4d74b201e45a2d471675f5fdae370f23f947",
-   "sha256": "0mcchmw7kc7676rmh2psmqmijwdkqrj8js7nk12g3y1ydyskypd2"
+   "commit": "452723c046c54f66f590900548d8eb4a7783e528",
+   "sha256": "05s1ardblrfj3jbwrini0v7b7ww5q6gzvgrx9jgncgvi4xci046s"
   },
   "stable": {
    "version": [
     1,
-    6
+    6,
+    1
    ],
-   "commit": "9b4cf6c79a961f2bfbb949805aa300fcf1eb40a6",
-   "sha256": "061id540spjycgy2xshj8kwgdngkjinznhx2qp5pmqzzx7z7rpfb"
+   "commit": "452723c046c54f66f590900548d8eb4a7783e528",
+   "sha256": "05s1ardblrfj3jbwrini0v7b7ww5q6gzvgrx9jgncgvi4xci046s"
   }
  },
  {
@@ -22925,8 +23014,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20260104,
-    1524
+    20260208,
+    1403
    ],
    "deps": [
     "bui",
@@ -22939,8 +23028,8 @@
     "posframe",
     "s"
    ],
-   "commit": "ded79ff0637f0ceb04380926a5ce4c40ef0a4f4c",
-   "sha256": "116wr8dvs7bcf5xc7kbmfdpzn4l3ck3gkjk711a2bhirqlrqjxww"
+   "commit": "b77d9bdb15d89e354b8a20906bebe7789e19fc9b",
+   "sha256": "1092xys5dx9k0rq3vgkrrgx6bfkpvq8lbhng8p8cvhspi2fi766s"
   },
   "stable": {
    "version": [
@@ -23197,11 +23286,11 @@
   "repo": "nameiwillforget/d-emacs",
   "unstable": {
    "version": [
-    20260105,
-    2019
+    20260224,
+    1036
    ],
-   "commit": "5bdba90f2600fbe4c0ddf75d8b190fc9218a5476",
-   "sha256": "10zr2xf4zfgx2z0pf2kv42jclg3c28kjsniwmcgqw0ldjlx89yl6"
+   "commit": "b3ceec1e31953b7925aceb4c081b48bc9a413000",
+   "sha256": "0z3gx15a63cnbfalazx8wjibgf277jrk0n1bpqm3n228dnqyswdl"
   }
  },
  {
@@ -23212,11 +23301,11 @@
   "repo": "magnars/dash.el",
   "unstable": {
    "version": [
-    20250312,
-    1307
+    20260221,
+    1346
    ],
-   "commit": "fcb5d831fc08a43f984242c7509870f30983c27c",
-   "sha256": "092kf61bi6dwl42yng69g3y55ni8afycqbpaqx9wzf8frx9myg6m"
+   "commit": "d3a84021dbe48dba63b52ef7665651e0cf02e915",
+   "sha256": "145zfh9y08k2rlnzim95lhwxx6qzihlmbrvxnhs38gkkgl0ljh2n"
   },
   "stable": {
    "version": [
@@ -23315,11 +23404,11 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20251231,
-    1631
+    20260221,
+    1336
    ],
-   "commit": "49de4c16624f6a86a5beb1196f68f02636a74d1b",
-   "sha256": "0p5v0bnvzngzz4jyr11jl44d1akywzwx3irbkbn6k0a5c4545caf"
+   "commit": "13fa459e8d60b83ff6134486d44888e3bdcf291a",
+   "sha256": "0fahi1afkv83swvbb2xh3zvmfzgp5wvnajlml0q7pvkfdgk9lzis"
   },
   "stable": {
    "version": [
@@ -23683,6 +23772,21 @@
    ],
    "commit": "ec3de36ae7bcf71829f03a5063ee9912fcca40bc",
    "sha256": "08sdhj4gs66dxv5fqpbp3vwm21rasw2qz0853056h19jiqkzz3a1"
+  }
+ },
+ {
+  "ename": "ddgr",
+  "commit": "565be7cc4daa04220b2e80cc32a6d39f311b3c61",
+  "sha256": "0g5z8jjxc2qlxmdkjlj9fvp0c0j6046n1xy9r3mg310ybfzwisq6",
+  "fetcher": "github",
+  "repo": "necaris/ddgr.el",
+  "unstable": {
+   "version": [
+    20260217,
+    345
+   ],
+   "commit": "55cba194c477f435221094d31798a588df4137e7",
+   "sha256": "0pmwpjn7n0h0z0gkiclccj4gw94y8hy093df181dm2w4njj6dql0"
   }
  },
  {
@@ -24081,8 +24185,8 @@
   "repo": "jcs-elpa/define-it",
   "unstable": {
    "version": [
-    20260101,
-    558
+    20260214,
+    1857
    ],
    "deps": [
     "define-word",
@@ -24093,8 +24197,8 @@
     "s",
     "wiki-summary"
    ],
-   "commit": "f33effcfcd4ef73cefd5d1c32991c5802269643e",
-   "sha256": "1645xxv7x93z4fj05imrddbmbn7qj152vbv5yh8implqwf0mnlyw"
+   "commit": "094c2dbe3fac7c19365fb952e821bdd5b558f51c",
+   "sha256": "1d32vhsbz829p4bjqzd9x5a1wapp9yyklp8h60lws988k8ykg690"
   },
   "stable": {
    "version": [
@@ -24518,15 +24622,15 @@
   "repo": "swflint/denote-sections",
   "unstable": {
    "version": [
-    20260112,
-    1809
+    20260120,
+    1542
    ],
    "deps": [
     "denote",
     "universal-sidecar"
    ],
-   "commit": "ea81318cf1c7d7281047a6b3a2ac8fb76c8535d7",
-   "sha256": "09qjwy90b5xpgzaplvw6vpwwhpa5484yjq9291b992h031gjvygw"
+   "commit": "dde6836a4663cb3fc23cdce8ea25834720711c8a",
+   "sha256": "0rrnr3my8w76zv99wlhhym0j5c3amlgjlamv8q3raglhbk683q3g"
   }
  },
  {
@@ -24743,6 +24847,21 @@
   }
  },
  {
+  "ename": "devcontainer",
+  "commit": "a3ee0e0fe865ff35e91678ce5577421477d27191",
+  "sha256": "0lcxqmqwdy1kwhinlqxc58q3ykip7rkrz7cyklsq3fbwdzfvyh4a",
+  "fetcher": "github",
+  "repo": "johannes-mueller/devcontainer.el",
+  "unstable": {
+   "version": [
+    20260221,
+    1522
+   ],
+   "commit": "6c28f50da80f8242bee90e43abacd9bced552114",
+   "sha256": "0gjbhh1dmq11x5f40qxhwdhppix24nnz5x8ph3pyil53jnsw5s6s"
+  }
+ },
+ {
   "ename": "devdocs",
   "commit": "19d1adfa91593cc32a3ce94d47f4c32102408488",
   "sha256": "1hizgj4fn3m986ri6zhx0a2dp0qkvm24farb4gcwf19p3ii70470",
@@ -24830,6 +24949,21 @@
    ],
    "commit": "fca383a9c4622c1d9a39dc977572b34c7fa0b719",
    "sha256": "12i3spjw5a74n7rfsnd93wvf496j3pp45rk85nxyij5vr1nxn3g7"
+  }
+ },
+ {
+  "ename": "dialog-mode",
+  "commit": "b07680fd918a44795876ee242d048a9eb184b19d",
+  "sha256": "1ig5s6g6ldxilxhwm90b25x4yih59ngz9a2q22fm1vilnhmakrdh",
+  "fetcher": "sourcehut",
+  "repo": "mew/dialog-mode",
+  "unstable": {
+   "version": [
+    20260221,
+    2125
+   ],
+   "commit": "c8f29d6cd7cd4363a7ae1b4912d26acc33fb536d",
+   "sha256": "077kx3vqz6c33pjxm56k4qxkfh6dkmwxxy72vzl02zv8whba7hv0"
   }
  },
  {
@@ -25052,14 +25186,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20251216,
-    242
+    20260223,
+    1553
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "e79aa49ad3cbbe85379cf6646db3aaacd3b04708",
-   "sha256": "0fvxngcbx36vqj72fllfp5iqwihcqd1dfhmqr3m1284191q83na3"
+   "commit": "bdb36417e3dc990326567803831241199e266844",
+   "sha256": "0yg6aq4vls7qmgk0aj6r4chrs8fh17gpj6zsajq7jz7pilvc7pk7"
   },
   "stable": {
    "version": [
@@ -25395,26 +25529,26 @@
   "repo": "dylan-lang/dylan-emacs-support",
   "unstable": {
    "version": [
-    20210613,
-    1431
+    20260212,
+    8
    ],
    "deps": [
     "dylan"
    ],
-   "commit": "d85409dc3cba57a390ca85da95822f8078ecbfa2",
-   "sha256": "1cm4l2ycaw47mfgc6ms021zxkas1jajgwpnykqlkcwcbakbczxjl"
+   "commit": "c22f339b5394d26af4961192825e58ae766965ec",
+   "sha256": "032ksqk2hwqw68nqjldhswxvmn41s9iiacabl4z0abcb5qc1l26g"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
     "dylan"
    ],
-   "commit": "d85409dc3cba57a390ca85da95822f8078ecbfa2",
-   "sha256": "1cm4l2ycaw47mfgc6ms021zxkas1jajgwpnykqlkcwcbakbczxjl"
+   "commit": "c22f339b5394d26af4961192825e58ae766965ec",
+   "sha256": "032ksqk2hwqw68nqjldhswxvmn41s9iiacabl4z0abcb5qc1l26g"
   }
  },
  {
@@ -25536,11 +25670,11 @@
   "repo": "jamescherti/dir-config.el",
   "unstable": {
    "version": [
-    20260114,
-    1604
+    20260215,
+    2013
    ],
-   "commit": "4ac26d4698b841f438c0896896f39db90c120571",
-   "sha256": "07l5g77j5dd4hfdyzd4rf3jgrw5sqqzdx2j6gzi6km5n7076qxbv"
+   "commit": "765a697d17dbd969c1bb5551f14c6d0524439097",
+   "sha256": "0gn4q8krbim3vlbcw1nzyhv91s2w4d58gqspywpni64i7i18ssmc"
   },
   "stable": {
    "version": [
@@ -25734,26 +25868,26 @@
   "repo": "meedstrom/dired-du-duc",
   "unstable": {
    "version": [
-    20251223,
-    1946
+    20260205,
+    1758
    ],
    "deps": [
     "dired-du"
    ],
-   "commit": "8b72d0a3c42332f23ca3c9fe7a940c9c0db2e474",
-   "sha256": "03bm2k4niwjkj5sy481qi5hzkr8bk1x15l7g7rzw5irrmrzv03gb"
+   "commit": "f7f1a915e5a39109c00cabc3ab2a38c77750c195",
+   "sha256": "1jg7lwnbslnax5x476szc5raifx6r4634pk4kyazrmjyl1xawyq0"
   },
   "stable": {
    "version": [
     0,
     1,
-    2
+    3
    ],
    "deps": [
     "dired-du"
    ],
-   "commit": "a90e13b6e4b7e39c9b7c57b9111bf33261431dc8",
-   "sha256": "18qaw3n9jgp5wky515kz4a15dz4xklha16yr7cdwpzgk3mlgrm13"
+   "commit": "f7f1a915e5a39109c00cabc3ab2a38c77750c195",
+   "sha256": "1jg7lwnbslnax5x476szc5raifx6r4634pk4kyazrmjyl1xawyq0"
   }
  },
  {
@@ -26339,15 +26473,15 @@
   "repo": "stsquad/dired-rsync",
   "unstable": {
    "version": [
-    20230822,
-    1350
+    20260204,
+    1424
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "5bcb851f3bf9c4f7c07299fcc25be7c408a68cda",
-   "sha256": "0lgqq7lh6pkg5mr9b2ilpkyw1gjrdr4frq26vjkmrl95wwphbc32"
+   "commit": "24ceb60b168c591d7e2d9440a7f1895880681f48",
+   "sha256": "0vrpwk91qrcnkr6cgmal7abi0cmykfr840l4cxvv5jzr8c1m1zhi"
   },
   "stable": {
    "version": [
@@ -26553,14 +26687,14 @@
   "repo": "Boruch-Baum/emacs-diredc",
   "unstable": {
    "version": [
-    20260106,
-    554
+    20260219,
+    637
    ],
    "deps": [
     "key-assist"
    ],
-   "commit": "812a0e1892a318cf6cfd69d1296480e810e5d790",
-   "sha256": "18qax2d1yj3yyp0alwh54w2zirf0hj0kzns0728axcgmi1h5l0hw"
+   "commit": "c702a9a1df3939424f6033bb8c948dbb163010f5",
+   "sha256": "038sql3chk8ywhryrbrlzsh937vh2wgx2vvkknwqpnxfwza28shk"
   },
   "stable": {
    "version": [
@@ -26582,20 +26716,20 @@
   "repo": "knu/diredfd.el",
   "unstable": {
    "version": [
-    20241209,
-    623
+    20260206,
+    337
    ],
-   "commit": "d789710c7e9699dae6ca87dcbfc27641a85fa3b6",
-   "sha256": "0xlgzmx089whmmnka0ngz7mdxvdplci3b4xvxjdmsydxx99gj3q6"
+   "commit": "a3eb656d2bd201a193fdb1ac547c075717ee7561",
+   "sha256": "06864z8zhv6vbamsx6iyazx6d808dpscv65v2sq0pj7p7cw8y8lg"
   },
   "stable": {
    "version": [
     2,
     0,
-    1
+    3
    ],
-   "commit": "e234c0bf91649bd13de984f6ef1b2354565fd4ce",
-   "sha256": "0yb7918kxja9lsri4ak3pkksvs32picw3yg3b8x9j6vp4zd7gd3j"
+   "commit": "a3eb656d2bd201a193fdb1ac547c075717ee7561",
+   "sha256": "06864z8zhv6vbamsx6iyazx6d808dpscv65v2sq0pj7p7cw8y8lg"
   }
  },
  {
@@ -27547,8 +27681,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20260115,
-    1341
+    20260126,
+    1212
    ],
    "deps": [
     "aio",
@@ -27557,13 +27691,13 @@
     "tablist",
     "transient"
    ],
-   "commit": "f69f331e767109bf456bf7780d2a8982f9d23b22",
-   "sha256": "1ha9j13l256dky0fgbzi8ndbb1yj996q1j4q42vbiidrfinxpfl5"
+   "commit": "916686b86e83a3bd2281fbc5e6f98962aa747429",
+   "sha256": "0yql0k5bw1vsqh44g5aq6ip6dn3c36k8gpljvbghsj01fcqdlvj6"
   },
   "stable": {
    "version": [
     2,
-    4,
+    5,
     0
    ],
    "deps": [
@@ -27573,8 +27707,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "375e0ed45bb1edc655d9ae2943a09864bec1fcba",
-   "sha256": "102hn0m91shyiz25x2c5ihhzbc8a3i9vnlkfcb3xm3w3nrqa5w64"
+   "commit": "916686b86e83a3bd2281fbc5e6f98962aa747429",
+   "sha256": "0yql0k5bw1vsqh44g5aq6ip6dn3c36k8gpljvbghsj01fcqdlvj6"
   }
  },
  {
@@ -27852,6 +27986,24 @@
   }
  },
  {
+  "ename": "doing",
+  "commit": "bd6b452ccbf1319394f47347dc1dc5e5a9a2310f",
+  "sha256": "14xm2cwfca0m5p22wh1zp4nfwmn3zbn559j3cln2bdh5dr4hl89r",
+  "fetcher": "github",
+  "repo": "xiaoxinghu/doing.el",
+  "unstable": {
+   "version": [
+    20260219,
+    234
+   ],
+   "deps": [
+    "org"
+   ],
+   "commit": "e3c39bf16f41637a0ef1c1512cb1417063dea956",
+   "sha256": "0kn4v64vhlhqiayn09w0z8s0pfjp9qrwmikk6zp820l0ibzkxmdh"
+  }
+ },
+ {
   "ename": "dokuwiki",
   "commit": "e608f40d00a3b2a80a6997da00e7d04f76d8ef0d",
   "sha256": "0d92il37z1m1hgcgb6c6zaifllznzk1na4yv4bfsfqg25l0mid75",
@@ -27895,20 +28047,32 @@
  },
  {
   "ename": "dollaro",
-  "commit": "b8195000cffa1913060266b17801eb7c1e472a83",
-  "sha256": "06kaqzb0nh8sndhk7p5n4acn5nc27dyxw3ldgcbp81wj6ipii26h",
+  "commit": "0c5d50f4925aca5d5b4ba68d8ba8c54b37bb5380",
+  "sha256": "18y4wcb8bslmrp844bw4wyi07fpqzvqx1bpqs97b7lda2mjv6il4",
   "fetcher": "github",
-  "repo": "laynor/dollaro",
+  "repo": "emacsattic/dollaro",
   "unstable": {
    "version": [
-    20151123,
-    1302
+    20260210,
+    1514
    ],
    "deps": [
     "s"
    ],
-   "commit": "500127f0172ac7a1eec627e026b59136580a74ac",
-   "sha256": "1xyqsnymgdd8ic3az2lgwv7s7vld6d4pcycb234bxm4in9fixgdj"
+   "commit": "d18b07fc6a63ce773b745714e135284b6eec7485",
+   "sha256": "1a0mnh8bkfh5x4pw74b2hn1nigy3v5jfnc3x7mmpj6kclwxmpcy6"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    1
+   ],
+   "deps": [
+    "s"
+   ],
+   "commit": "d18b07fc6a63ce773b745714e135284b6eec7485",
+   "sha256": "1a0mnh8bkfh5x4pw74b2hn1nigy3v5jfnc3x7mmpj6kclwxmpcy6"
   }
  },
  {
@@ -27948,16 +28112,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20260110,
-    517
+    20260223,
+    1035
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "9ac20488c56be0e88611881beb713cc58e02eff3",
-   "sha256": "1c22gyckinxhz3qixbh05i7qgnwpag9xy78mb6rf4hyr00b3yqpz"
+   "commit": "499a44c0333d70624b75e987029264e684418965",
+   "sha256": "08i9ld44bx60mj976vl8lchp662fsixaffk7mkmklbjbqg175a0k"
   },
   "stable": {
    "version": [
@@ -28358,11 +28522,11 @@
   "repo": "dracula/emacs",
   "unstable": {
    "version": [
-    20250625,
-    2011
+    20260224,
+    1455
    ],
-   "commit": "ad30f50e06c1b4c3e461c647e976cd00b9bc4869",
-   "sha256": "1vv00hgik7pvj1p0ii8g6bcyvfjzwhh33hjh0gfgsh8gxm1lfij8"
+   "commit": "b1a4d87ba1cf880143f4ab2ccd942cf556887fb1",
+   "sha256": "10yy3abny8iv74pxw2m94gnnszylpsqsf85lp7rla7lslmykhqys"
   },
   "stable": {
    "version": [
@@ -28706,6 +28870,30 @@
   }
  },
  {
+  "ename": "duckdb-query",
+  "commit": "9bd98c8bcfe743784ed24bdefc37e7f31fe6757d",
+  "sha256": "0ald6fzmiz03i4s5nrq936nvgy85cf72pb9w3rpw1ax97l40mnck",
+  "fetcher": "github",
+  "repo": "gggion/duckdb-query.el",
+  "unstable": {
+   "version": [
+    20260225,
+    354
+   ],
+   "commit": "b81c669859e201c4dcd1303033c0ee81134aca17",
+   "sha256": "0z48vrnv79z7zr579sf8zs4fmxhyv68bps4kx38x5jih1c0cvmdp"
+  },
+  "stable": {
+   "version": [
+    0,
+    8,
+    0
+   ],
+   "commit": "b81c669859e201c4dcd1303033c0ee81134aca17",
+   "sha256": "0z48vrnv79z7zr579sf8zs4fmxhyv68bps4kx38x5jih1c0cvmdp"
+  }
+ },
+ {
   "ename": "ducpel",
   "commit": "a6ff6bbfa11f08647bf17afe75bfb4dcafd86683",
   "sha256": "1jppm79d6b961ikm0w1hs4yj27dbqxd12581524pq2571hs2wcmw",
@@ -28713,14 +28901,11 @@
   "repo": "alezost/ducpel",
   "unstable": {
    "version": [
-    20140702,
-    1154
+    20260204,
+    1533
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "2f2ce2df269d99261c808a5c4ebc00d6d2cddabc",
-   "sha256": "19a8q9nakjzyzv7aryndifjr9c8jls9a2v7ilfjj8kscwxpjqlzb"
+   "commit": "bb0275a8aa7e8aa0895979711b037573544d50c1",
+   "sha256": "03dcr1wykany2r5ix576j1f36v67qyz1q2flmmccdcawv01kda08"
   },
   "stable": {
    "version": [
@@ -28757,16 +28942,14 @@
   "repo": "jacktasia/dumb-jump",
   "unstable": {
    "version": [
-    20260119,
-    2346
+    20260225,
+    556
    ],
    "deps": [
-    "dash",
-    "popup",
-    "s"
+    "dash"
    ],
-   "commit": "5bfea588a5f67ccf163bbe5084ee0c92e43869cf",
-   "sha256": "1bi69qb9w7x1w9irf2smv82jafy9z5fa4qlzqjrfcqv701kf67zf"
+   "commit": "d194c4777f0a8e970864cd316fc3b93cfc34e6b2",
+   "sha256": "042kd8g4wpvfcb1r43jk46y5hhigh03xj1c2k8w87w0ssnjzfhyf"
   },
   "stable": {
    "version": [
@@ -28825,20 +29008,20 @@
   "repo": "ocaml/dune",
   "unstable": {
    "version": [
-    20260112,
-    1835
+    20260120,
+    2128
    ],
-   "commit": "832d2384ce30cf98e32d797aecf81088d1bd354b",
-   "sha256": "12y6j141znv9k1hknavr8i19wlc5009cgz8d6xgw4w42ghsmcppf"
+   "commit": "ccdb380ab5714b81f1ba71f7f8acfd792e6200bf",
+   "sha256": "0b6xndnh8c27v84vbv0bl8x3062y9fvbrh92p2hm065qsaj8gr7s"
   },
   "stable": {
    "version": [
     3,
     21,
-    0
+    1
    ],
-   "commit": "832d2384ce30cf98e32d797aecf81088d1bd354b",
-   "sha256": "12y6j141znv9k1hknavr8i19wlc5009cgz8d6xgw4w42ghsmcppf"
+   "commit": "0b5863d9be475453b3cc2bd321fde222af2544d4",
+   "sha256": "1d8llv0ky4dv01bv4hdk57x33b38c28mbawshq3i4p8big3480xl"
   }
  },
  {
@@ -28992,11 +29175,11 @@
   "repo": "xenodium/dwim-shell-command",
   "unstable": {
    "version": [
-    20260112,
-    1233
+    20260123,
+    1157
    ],
-   "commit": "1227c014d08c116d8fd446cf5eeb27c566289644",
-   "sha256": "1vw09zsdjif2s7hb40l3j1akxw6gwin9rwfk460d1y7f0kgpgc8w"
+   "commit": "a408b7826bb4535e7a14e16848ad41820d63411f",
+   "sha256": "1a30h2ly34pplfnpxhnkdjwqlsfkjchx01wcnh1cnd9zlg05sinp"
   },
   "stable": {
    "version": [
@@ -29064,20 +29247,20 @@
   "repo": "dylan-lang/dylan-emacs-support",
   "unstable": {
    "version": [
-    20250319,
-    1925
+    20260212,
+    8
    ],
-   "commit": "342d86a58ad307a581fc95c0f271661444dbc13c",
-   "sha256": "1lpy03lzfpws828wn4f89cqnc0js4d65kk206xrb6rjlx55yv2a9"
+   "commit": "c22f339b5394d26af4961192825e58ae766965ec",
+   "sha256": "032ksqk2hwqw68nqjldhswxvmn41s9iiacabl4z0abcb5qc1l26g"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
-   "commit": "d85409dc3cba57a390ca85da95822f8078ecbfa2",
-   "sha256": "1cm4l2ycaw47mfgc6ms021zxkas1jajgwpnykqlkcwcbakbczxjl"
+   "commit": "c22f339b5394d26af4961192825e58ae766965ec",
+   "sha256": "032ksqk2hwqw68nqjldhswxvmn41s9iiacabl4z0abcb5qc1l26g"
   }
  },
  {
@@ -29505,26 +29688,26 @@
   "repo": "meedstrom/eager-state",
   "unstable": {
    "version": [
-    20251221,
-    1617
+    20260123,
+    751
    ],
    "deps": [
     "llama"
    ],
-   "commit": "7d34fc1f4f341a971ec165fd54b1f42eb9982971",
-   "sha256": "0h8xixld412nfbsqz59s51d5digfnqlhik1hq4vvpk6172a5z4jm"
+   "commit": "53282709833021dfbe8605c9eadaa0fffe5da349",
+   "sha256": "1ms6xwb96fjrrizxdpvb3rnqg4ch8s7qnqw5ca75vr5aqb1hli2y"
   },
   "stable": {
    "version": [
     0,
     2,
-    1
+    2
    ],
    "deps": [
     "llama"
    ],
-   "commit": "f9716129a17cca7a3f4271a9c822a9986457f229",
-   "sha256": "0x9nzxa5ff963cxfzaj2br577vllk5kccp8in5j93p8n46209mxr"
+   "commit": "53282709833021dfbe8605c9eadaa0fffe5da349",
+   "sha256": "1ms6xwb96fjrrizxdpvb3rnqg4ch8s7qnqw5ca75vr5aqb1hli2y"
   }
  },
  {
@@ -29565,20 +29748,20 @@
   "repo": "emacs-eask/eask",
   "unstable": {
    "version": [
-    20260117,
-    1610
+    20260222,
+    1247
    ],
-   "commit": "e8857600be6b9c3e40edbff6fd56fcfbc6286679",
-   "sha256": "1v9m78wxvjzw8k77gf3vffzla8r3bcgihdkr6sfmiqb7hz3z9v3n"
+   "commit": "664704775ce2318f7a76b65077e8559ada542814",
+   "sha256": "0w4m3sgsivp0kd95bs2bgfhm2zd3vm4mcvahghlgprrgc7dj089r"
   },
   "stable": {
    "version": [
     0,
     12,
-    2
+    9
    ],
-   "commit": "d5e665fcc63af17bf2177ecc371dda1f999788aa",
-   "sha256": "01y5bq6mmsla21i2656ran3vc3hyzry4yh0rs6vjyikg1f0vagk4"
+   "commit": "4ef950a951ef3a1b6c6f6f75f30c10576e4248e1",
+   "sha256": "1h4c1qcbz9cwq6yvzbk07g85nyswi3kasdvf260izp7i0x535r3v"
   }
  },
  {
@@ -29616,8 +29799,8 @@
   "repo": "emacs-eask/easky",
   "unstable": {
    "version": [
-    20251231,
-    1607
+    20260123,
+    1934
    ],
    "deps": [
     "ansi",
@@ -29626,8 +29809,8 @@
     "lv",
     "marquee-header"
    ],
-   "commit": "efe25f0c1ba483378854795fcfe7fa0367cebf27",
-   "sha256": "1zsn8p8lyik7ib5ks8jvglbi8f9lh8f3xfkz6x33711v1zygy985"
+   "commit": "2eb06188d2a134c23340421a53cc5bfa94286a4a",
+   "sha256": "123flhrpr2xbvsqk3121bjgfiajrz4r8q5hmb03gdnq6dkg5a5h5"
   },
   "stable": {
    "version": [
@@ -29769,14 +29952,14 @@
   "repo": "leoliu/easy-kill",
   "unstable": {
    "version": [
-    20260112,
-    1130
+    20260121,
+    752
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "3401ab7427e34f8913374311bf75d342462fc9b0",
-   "sha256": "1rxl0whamvyz0mkgd57s4kxjd9dyr38vx18brhfyr3icspxf8qx9"
+   "commit": "98cbae5d8c378ad14d612d7c88a78484c49a80b8",
+   "sha256": "16ad0p9yrqx60mscllnc58bawdpk7ghbmlbi9sbmbnfq38cclyfb"
   },
   "stable": {
    "version": [
@@ -29867,20 +30050,20 @@
   "repo": "jamescherti/easysession.el",
   "unstable": {
    "version": [
-    20260118,
-    36
+    20260222,
+    358
    ],
-   "commit": "314b167ce85807895a1025c692ed4e73e1709b77",
-   "sha256": "1wi44gpilq67x2aik3fg75rmnpw31jf8ngycagc391z44s301w7n"
+   "commit": "6198a7b212284600d24a72ff09b911b4f67217da",
+   "sha256": "13xfmalc5i011n427ivkaz52wk36y2lnk0qsv39al6kzzrsvc78f"
   },
   "stable": {
    "version": [
     1,
-    1,
-    7
+    2,
+    0
    ],
-   "commit": "f30ffdf6e270e0420df99b1265081800a36ca4d5",
-   "sha256": "1vv55xbvfir7x1iilsrwrxl1jgz1929zwqygwms48pf835rh24gl"
+   "commit": "bf2a989c8d990396784ae7e2a38ef9943465a967",
+   "sha256": "0h1jj58ncnhli4a1gpp0nvhxs6kkgg93bqr9xm462dis9fzxb9p1"
   }
  },
  {
@@ -30054,8 +30237,8 @@
   "repo": "editor-code-assistant/eca-emacs",
   "unstable": {
    "version": [
-    20260116,
-    1933
+    20260224,
+    1849
    ],
    "deps": [
     "compat",
@@ -30063,14 +30246,14 @@
     "f",
     "markdown-mode"
    ],
-   "commit": "ac426986a117e5c1ef3be1aae568991a152a5aa3",
-   "sha256": "0vn48cmyz8vm84i67rygimdmpq1a78ggiygziri9mrg4mhg1azls"
+   "commit": "625ddb5b8f8fe6dd70f88f53c4174158021f23d9",
+   "sha256": "022vw2hs41y1j6nvlbqhkzgfs45cj9h13l4l2pd75g0kjhkb48g8"
   },
   "stable": {
    "version": [
     0,
-    4,
-    1
+    5,
+    0
    ],
    "deps": [
     "compat",
@@ -30078,8 +30261,8 @@
     "f",
     "markdown-mode"
    ],
-   "commit": "d2a0a738e68c3d5ac8e4137de1e5bebf3637517d",
-   "sha256": "17a53j4pr4liyyf854x04xk4qrd38z45j3x4gqlfj8sp9c67r1l7"
+   "commit": "7ab3a482d0f53ad5cc06f380a96e8f318bab254b",
+   "sha256": "1liwi44d8ah6lryxzfyxl6wryhr4ck8ya0c5fyf4dgdsm23xz7sg"
   }
  },
  {
@@ -30420,6 +30603,25 @@
   }
  },
  {
+  "ename": "edit-metadata",
+  "commit": "ee1f876ca9a341640f6e3d0690fb4b9ef276a719",
+  "sha256": "0xwngggsmkb36cph5vzyv39gjnxf0icjyss1d1v9f03vic054cnq",
+  "fetcher": "codeberg",
+  "repo": "mxpi/edit-metadata",
+  "unstable": {
+   "version": [
+    20260210,
+    2022
+   ],
+   "deps": [
+    "compat",
+    "exiftool"
+   ],
+   "commit": "903b6c0d7d8f6550dd91a56cd1cf9d880b5cbded",
+   "sha256": "1xvy86mji2gd6vyjf6xsblzfrkmdz6f802pa2gcqfdaq5jcdrbgy"
+  }
+ },
+ {
   "ename": "edit-server",
   "commit": "d98d69008b5ca8b92fa7a6045b9d1af86f269386",
   "sha256": "0ffxcgmnz0f2c1i3vfwm8vlm6jyd7ibf4kq5z8c6n50zkwfdmns0",
@@ -30601,6 +30803,30 @@
    ],
    "commit": "bb035dcbeccccdb2c899d2cce8e81486764d0ad7",
    "sha256": "06v34l9dkykrrdfpnm3zi5wjm0fdvy76pbkfnk92wqkjp8fqimhd"
+  }
+ },
+ {
+  "ename": "edna-theme",
+  "commit": "9a93fbdb5f58be5c2d84db74d11303bda048d555",
+  "sha256": "0p6jdikbqkhgkqwpgbxn9h3s62a7lh0hx46ygyv3wmb00h8zsgs2",
+  "fetcher": "codeberg",
+  "repo": "golanv/edna-theme",
+  "unstable": {
+   "version": [
+    20260214,
+    2320
+   ],
+   "commit": "78da1fcde3d03f4ff65b310d19319dc26140566b",
+   "sha256": "0961c4w94697n3jnkc58sp0j3lmyk8h45y00m1kr04h9rzqhrasb"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    6
+   ],
+   "commit": "78da1fcde3d03f4ff65b310d19319dc26140566b",
+   "sha256": "0961c4w94697n3jnkc58sp0j3lmyk8h45y00m1kr04h9rzqhrasb"
   }
  },
  {
@@ -30859,11 +31085,11 @@
   "repo": "egison/egison",
   "unstable": {
    "version": [
-    20211218,
-    1115
+    20260104,
+    1519
    ],
-   "commit": "dbb395b41a4e4eb69f3f045cbfbe95a1575ac45b",
-   "sha256": "14g0dpn8j7kh3iiq7qlhaa1wdk6xvl60hkl3j87ncjwkh6h4imcg"
+   "commit": "4e796ee52785e052f3b10c6493fa484461bb4482",
+   "sha256": "0m4sp7ncf6d9maf1sm4p4rg4z140bdfvbxgd05fmly4pk1yz0yv8"
   },
   "stable": {
    "version": [
@@ -30981,14 +31207,14 @@
   "repo": "kennethloeffler/eglot-luau",
   "unstable": {
    "version": [
-    20241102,
-    1924
+    20260121,
+    919
    ],
    "deps": [
     "eglot"
    ],
-   "commit": "23335f45fb91de606e6971e93179df0fee0fd062",
-   "sha256": "1k43zsw82l07i9va9w9fxhl9cnz1vbpl90m6jvbnrl8fxhzw2kvh"
+   "commit": "6fd1ba044fd1f35785c8cb5fc831878993b0afbb",
+   "sha256": "0ksn3m6ihd0lp7ckldkcz1s7bdcdhkwjyv9mxrizyyllxs1ml4hk"
   },
   "stable": {
    "version": [
@@ -31131,11 +31357,11 @@
   "url": "https://forge.tedomum.net/hjuvi/eide.git",
   "unstable": {
    "version": [
-    20260107,
-    2102
+    20260202,
+    1853
    ],
-   "commit": "9918d623124fdb4111faf0cf6c3f55be43a6b070",
-   "sha256": "11wib1n3bix4qf5wl8kk1wf26afhxc8jyl324znq3aj5f1zx23kv"
+   "commit": "ea10bf1b3727087e78921a146a1d7d0bcaf4f8a5",
+   "sha256": "11apdb0c20dfg8qsii87kp8ikpsgzqw92m6klz0dsn8ci5fg5ixh"
   },
   "stable": {
    "version": [
@@ -31268,15 +31494,15 @@
   "repo": "ahyatt/ekg",
   "unstable": {
    "version": [
-    20260119,
-    1613
+    20260222,
+    2157
    ],
    "deps": [
     "llm",
     "triples"
    ],
-   "commit": "bbd94e571990a31ecc3ab8108a02dd3b3aac2757",
-   "sha256": "1ygx250zf2km5v1hii239xc6ffkpaql945xdhj9k0w6hpvv4cgpp"
+   "commit": "9358c6c71fd8d585c1fabd3612090f83f1526228",
+   "sha256": "0pygcdjzbhb42sjmv55w9jq2ljawmyvqxaq5xwrhrgrlyk26ls4c"
   },
   "stable": {
    "version": [
@@ -31362,11 +31588,11 @@
   "repo": "dimitri/el-get",
   "unstable": {
    "version": [
-    20251110,
-    758
+    20260215,
+    1117
    ],
-   "commit": "64112351b1f58c77463b8802ddd7f78964c9c5ca",
-   "sha256": "0lj83i7qxsy1lm5fc639y1mbxk1krhbhr1ig4gsfwxqyq2v4bqq0"
+   "commit": "911c252afe763a5cd1cbd188c476d44353cd5271",
+   "sha256": "094xlvqaj2crd405jhfk7raxdylw43k9f42wzc15miix6c98ldsz"
   },
   "stable": {
    "version": [
@@ -31455,20 +31681,20 @@
   "repo": "meedstrom/el-job",
   "unstable": {
    "version": [
-    20251202,
-    2353
+    20260222,
+    1009
    ],
-   "commit": "274f999ceee3db6c48e3550964c547161a3ee1bb",
-   "sha256": "1m4q0d8j55wgzbwqkwfh0a5dwlag7qcnfg1mjgmg8l8848q88w7q"
+   "commit": "5af4975c176477cfe5f864bb9b402d8a8f2a074a",
+   "sha256": "14hq3xc0q6knxdr3c19pi4g7j3s0l85nzbbg4vrhpbyfg6ix0zif"
   },
   "stable": {
    "version": [
     2,
-    6,
-    1
+    7,
+    3
    ],
-   "commit": "274f999ceee3db6c48e3550964c547161a3ee1bb",
-   "sha256": "1m4q0d8j55wgzbwqkwfh0a5dwlag7qcnfg1mjgmg8l8848q88w7q"
+   "commit": "5af4975c176477cfe5f864bb9b402d8a8f2a074a",
+   "sha256": "14hq3xc0q6knxdr3c19pi4g7j3s0l85nzbbg4vrhpbyfg6ix0zif"
   }
  },
  {
@@ -31834,11 +32060,11 @@
   "repo": "Mstrodl/elcord",
   "unstable": {
    "version": [
-    20250304,
-    1743
+    20260121,
+    1637
    ],
-   "commit": "deeb22f84378b382f09e78f1718bc4c39a3582b8",
-   "sha256": "1w9258vdl994l786vmhzx2xm8mb9rvc9v0fl12qib5fvfgk51d15"
+   "commit": "827dccbbdae038330f47e16ca189fd3e4ef25964",
+   "sha256": "15vfrb6vl1ycx2as051p8nqmfbcxhzcf2pqc52a5nq1lsdq1ybk0"
   }
  },
  {
@@ -31888,6 +32114,36 @@
    ],
    "commit": "5ec0f75a308ab8ae1f29bbb3c18b63514fc83c20",
    "sha256": "0aksjg9wrl0aifwdw4m41al1yqcp8nz2bmfxd5jvx89rl1a6ijpb"
+  }
+ },
+ {
+  "ename": "eldc",
+  "commit": "4010f32a2b0083d2cc7d6e18889be4eaa1677007",
+  "sha256": "0wsciaaa02yd2w8ji1z2n7jq0a9s1scpyx7nys68xj1xwj192qdk",
+  "fetcher": "github",
+  "repo": "gicrisf/eldc",
+  "unstable": {
+   "version": [
+    20260130,
+    1628
+   ],
+   "deps": [
+    "deferred"
+   ],
+   "commit": "acd9971c491331b9824be96b6190497b6ca5ed53",
+   "sha256": "0s38m3gc6vc3hsfpibq5p5k2j06j78gk5xllcr3v1l9d5y166lj7"
+  },
+  "stable": {
+   "version": [
+    0,
+    5,
+    0
+   ],
+   "deps": [
+    "deferred"
+   ],
+   "commit": "acd9971c491331b9824be96b6190497b6ca5ed53",
+   "sha256": "0s38m3gc6vc3hsfpibq5p5k2j06j78gk5xllcr3v1l9d5y166lj7"
   }
  },
  {
@@ -32014,28 +32270,28 @@
   "repo": "huangfeiyu/eldoc-mouse",
   "unstable": {
    "version": [
-    20251228,
-    316
+    20260130,
+    1352
    ],
    "deps": [
     "eglot",
     "posframe"
    ],
-   "commit": "de48a1af46617861d38d9f96984869c21c0d887e",
-   "sha256": "1zzxndzwn94cnlz9lwjkmw7pvmqm80gm1hia66qqsgb2i6qwg8qm"
+   "commit": "e66dba299ed381bfafeb0f430418fdd737ef6922",
+   "sha256": "1n99l37l8n2fdb1077161wvv22sxhyb5yisj0hcbffzn2pgrdwwd"
   },
   "stable": {
    "version": [
     3,
     0,
-    2
+    3
    ],
    "deps": [
     "eglot",
     "posframe"
    ],
-   "commit": "de48a1af46617861d38d9f96984869c21c0d887e",
-   "sha256": "1zzxndzwn94cnlz9lwjkmw7pvmqm80gm1hia66qqsgb2i6qwg8qm"
+   "commit": "e66dba299ed381bfafeb0f430418fdd737ef6922",
+   "sha256": "1n99l37l8n2fdb1077161wvv22sxhyb5yisj0hcbffzn2pgrdwwd"
   }
  },
  {
@@ -32312,11 +32568,11 @@
   "repo": "skeeto/elfeed",
   "unstable": {
    "version": [
-    20241202,
-    22
+    20260218,
+    1306
    ],
-   "commit": "a39fb78e34ee25dc8baea83376f929d7c128344f",
-   "sha256": "1rys5z7shn45z07dfcm5g06pnpx5kccdz94xkwizmrf882xzmmvh"
+   "commit": "bbb3cac27b0412d80b327b5cfaab83683c96a2a1",
+   "sha256": "1z1ig5h2mhy7zdz8vh003536mmpkrjr7jm84ih3wsx8krvhgc1lb"
   },
   "stable": {
    "version": [
@@ -32495,26 +32751,45 @@
   "repo": "sp1ff/elfeed-score",
   "unstable": {
    "version": [
-    20251012,
-    2253
+    20260125,
+    2028
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "9e9874dc4f2a6b01199e0834ba52665d8383ad9f",
-   "sha256": "14f5m81ik8w3yi2dc3mff88v63abkcjs5fcp5d2zbg35adbqrb7l"
+   "commit": "f6ef83c472e6f01d0f60130ecac768462c5a20b7",
+   "sha256": "1a2ymyb6l84jrphrfb8svrm78aq9dpp5k18y112pg19lc6wqwgbv"
   },
   "stable": {
    "version": [
     1,
     2,
-    10
+    11
    ],
    "deps": [
     "elfeed"
    ],
-   "commit": "9e9874dc4f2a6b01199e0834ba52665d8383ad9f",
-   "sha256": "14f5m81ik8w3yi2dc3mff88v63abkcjs5fcp5d2zbg35adbqrb7l"
+   "commit": "f6ef83c472e6f01d0f60130ecac768462c5a20b7",
+   "sha256": "1a2ymyb6l84jrphrfb8svrm78aq9dpp5k18y112pg19lc6wqwgbv"
+  }
+ },
+ {
+  "ename": "elfeed-summarize",
+  "commit": "0f7fb5e5dbd25bac2c4cbb730e8029d6736afcc8",
+  "sha256": "110wpsf7zrvb3zfayvxaf41sq274jhlxsdg9w3asnxdkrpa9an82",
+  "fetcher": "github",
+  "repo": "fritzgrabo/elfeed-summarize",
+  "unstable": {
+   "version": [
+    20260217,
+    1534
+   ],
+   "deps": [
+    "elfeed",
+    "llm"
+   ],
+   "commit": "b4d9f8a7bb72d9fd0db804eff535c42859d94cf8",
+   "sha256": "09f0v2mxrq01fjkpz6zk34c74hqy8y2z9qawv5lmm55sc91z2ajv"
   }
  },
  {
@@ -32838,26 +33113,26 @@
   "repo": "laurynas-biveinis/elisp-dev-mcp",
   "unstable": {
    "version": [
-    20260119,
-    1722
+    20260210,
+    434
    ],
    "deps": [
     "mcp-server-lib"
    ],
-   "commit": "8dc2dadd8b2590d8b0e6375325e6d09a7ca269bf",
-   "sha256": "1hi7dn0nvmy7lym23iz8zpl2i27hfnnng0fr0q14rd5psy52wpl1"
+   "commit": "acce467f667df06e8dd391d64c5a553997dabed5",
+   "sha256": "019b0yg1k1dknmw47wz9s8f9k6rzj7535g5alxrf4nw9j165n0i2"
   },
   "stable": {
    "version": [
     1,
-    1,
-    1
+    2,
+    0
    ],
    "deps": [
     "mcp-server-lib"
    ],
-   "commit": "62e811321329b60bd3d288b0601eda7eb69eaa29",
-   "sha256": "11mhyibf8fimc9a4x3irza725qva09gqclqshfh179wd5gwmqinr"
+   "commit": "acce467f667df06e8dd391d64c5a553997dabed5",
+   "sha256": "019b0yg1k1dknmw47wz9s8f9k6rzj7535g5alxrf4nw9j165n0i2"
   }
  },
  {
@@ -33109,32 +33384,34 @@
   "repo": "s-kostyaev/ellama",
   "unstable": {
    "version": [
-    20260119,
-    2229
+    20260223,
+    2029
    ],
    "deps": [
     "compat",
     "llm",
     "plz",
-    "transient"
+    "transient",
+    "yaml"
    ],
-   "commit": "c491bf4c5b6449751a55afa6772c8cdb0e167a41",
-   "sha256": "1sn6b8qfjgf8vx7sffzv8irhsk5ciy24q58ynfr354k5jpxxxkqm"
+   "commit": "c9cf0ae36cac6d4a65bafb8f947e3195e2e2f5fd",
+   "sha256": "13jnaxz4w2n4agyz5rg8jq35qs57arl06mib4lgx4z9q3vwvqd2z"
   },
   "stable": {
    "version": [
     1,
-    10,
-    11
+    12,
+    18
    ],
    "deps": [
     "compat",
     "llm",
     "plz",
-    "transient"
+    "transient",
+    "yaml"
    ],
-   "commit": "c491bf4c5b6449751a55afa6772c8cdb0e167a41",
-   "sha256": "1sn6b8qfjgf8vx7sffzv8irhsk5ciy24q58ynfr354k5jpxxxkqm"
+   "commit": "c9cf0ae36cac6d4a65bafb8f947e3195e2e2f5fd",
+   "sha256": "13jnaxz4w2n4agyz5rg8jq35qs57arl06mib4lgx4z9q3vwvqd2z"
   }
  },
  {
@@ -33491,11 +33768,11 @@
   "url": "https://thelambdalab.xyz/git/elpher.git",
   "unstable": {
    "version": [
-    20250929,
-    1422
+    20260221,
+    920
    ],
-   "commit": "dcdeb86f7ae633e252f9ef8a73d3458e87c1ab12",
-   "sha256": "15cgqzzfjikq4spsmf7mmhvrd6igcsv75d9mdsxl5j6zhq784hh8"
+   "commit": "d799c467a1f35934f96d33960d638ddf796f01ba",
+   "sha256": "0wzj4n8wc90mqzmd86rvq8g20mk44lvmqdvfan3pj3z3b1jnk82c"
   },
   "stable": {
    "version": [
@@ -33806,6 +34083,30 @@
   }
  },
  {
+  "ename": "elsqlite",
+  "commit": "9f73b97d355f9cd4373d831f18ccd6c66dd74bfb",
+  "sha256": "0la8v47b0pwqr0nx8707gzk5qphqjk0fznwczxyb7h50kqjm0jkz",
+  "fetcher": "github",
+  "repo": "dusanx/elsqlite",
+  "unstable": {
+   "version": [
+    20260206,
+    1949
+   ],
+   "commit": "394904b1cd80ceb665ae4e832043331c1b587b8d",
+   "sha256": "0gikamhv9k4i10xdahxwfq9wy7hiyfbikhjmi0p54m3xmnn3mdyq"
+  },
+  "stable": {
+   "version": [
+    0,
+    4,
+    0
+   ],
+   "commit": "394904b1cd80ceb665ae4e832043331c1b587b8d",
+   "sha256": "0gikamhv9k4i10xdahxwfq9wy7hiyfbikhjmi0p54m3xmnn3mdyq"
+  }
+ },
+ {
   "ename": "elune-theme",
   "commit": "f6eb088a263e150e190209ae437a608671e81bfc",
   "sha256": "0babdvn8ipxgivkl4ab3jdad6m7dy42m2mpk2p49xzpzwdc9w63y",
@@ -33950,11 +34251,11 @@
   "repo": "knu/emacsc",
   "unstable": {
    "version": [
-    20250710,
-    1637
+    20260125,
+    1050
    ],
-   "commit": "c0d51eea7c5cbef4ea49350dff8c721227635be6",
-   "sha256": "17k8xpcfir09wbhi7a98k4mcf7bfyrvgb8p6im3yjgmn8il94g4a"
+   "commit": "e3c8636d64d787eec876792288e99511d604eeec",
+   "sha256": "0d0jy1y75176v4akbw7690yqr5p0dsm18rjq3klimfrfc5vr6b62"
   },
   "stable": {
    "version": [
@@ -33989,20 +34290,20 @@
   "repo": "magit/emacsql",
   "unstable": {
    "version": [
-    20260101,
-    1849
+    20260201,
+    1512
    ],
-   "commit": "c6a9d2373cc15184e4e34414b8574a896d070323",
-   "sha256": "10h0zb8pp4zbmsrkp8kd4a0rnclh6arbyg4f7n5l5n8cn0w2pf8l"
+   "commit": "6ef7473248fce048c7daa00c3b2ae75af987c89c",
+   "sha256": "1abc9p2bajm9sfhhi7gc3vl8ivkic15ki0s25631aysjl2002apb"
   },
   "stable": {
    "version": [
     4,
     3,
-    4
+    5
    ],
-   "commit": "c6a9d2373cc15184e4e34414b8574a896d070323",
-   "sha256": "10h0zb8pp4zbmsrkp8kd4a0rnclh6arbyg4f7n5l5n8cn0w2pf8l"
+   "commit": "6ef7473248fce048c7daa00c3b2ae75af987c89c",
+   "sha256": "1abc9p2bajm9sfhhi7gc3vl8ivkic15ki0s25631aysjl2002apb"
   }
  },
  {
@@ -34109,14 +34410,14 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20251118,
-    111
+    20260221,
+    2325
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7b3b2fa239c34c2e304eab4367a4f5924c047e2b",
-   "sha256": "1hn4x5smylqviaqw35j9wccffsvfxp0q5jlnw0ynxny5c7pnp66l"
+   "commit": "cf0f0f0c29e7f30df23693b6380072a3b6733841",
+   "sha256": "0hlwl874ggvrjk27a57w4vc9hqlx174606jsiz87hq10h3g9nyw0"
   },
   "stable": {
    "version": [
@@ -34138,16 +34439,16 @@
   "repo": "oantolin/embark",
   "unstable": {
    "version": [
-    20250622,
-    535
+    20260223,
+    1658
    ],
    "deps": [
     "compat",
     "consult",
     "embark"
    ],
-   "commit": "a563786d0e07fc43601c1c83d1ffc801b86506b9",
-   "sha256": "05inj6mq5kjs33sz4r7qjs0z179b15g1zr9cxqr9jpnzf8dgzapi"
+   "commit": "e0238889b1c946514fd967d21d70599af9c4e887",
+   "sha256": "1addby8g65a1pbvbzanvcwpfzv13k89qj6m014xwr9qki0i49nss"
   },
   "stable": {
    "version": [
@@ -34380,16 +34681,16 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20260113,
-    1922
+    20260213,
+    2209
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "1d48a1133db2670d839f2cf2aff17d6c32aeb15f",
-   "sha256": "0pvlkybdpf1bfpjs0np89kfnxj3qjvyawk1g0b2l5jg21k6c20ww"
+   "commit": "002a8db0913c1780149eb4a9306e6f582efe8974",
+   "sha256": "0wn0ky1xpnb2hrlp48i6zr0f48gdnpsy3mzi7cdggx7wmp3cc2xq"
   },
   "stable": {
    "version": [
@@ -34557,7 +34858,7 @@
  },
  {
   "ename": "emms-soundcloud",
-  "commit": "952c7a383d39825805127bd709fa60ac77ef724d",
+  "commit": "5855698f1ed096cce7def653e7b0b73ef7f244a1",
   "sha256": "13vpcgqhhxhvgf22jpqidb9a1q4l1x9m8kfdv9ba9h009xf2a1pi",
   "fetcher": "github",
   "repo": "ozanmakes/emms-soundcloud",
@@ -34792,19 +35093,19 @@
   "repo": "isamert/empv.el",
   "unstable": {
    "version": [
-    20251214,
-    1032
+    20260201,
+    1258
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "7ef178763d3d3044fd030368d66e15a0bbeed160",
-   "sha256": "0x05gr6ficx3aw02akvgqy6jz5fhi2j07arc516bh50dxk99msnc"
+   "commit": "5287a71a6220acdb1716d47af183cee4c6094994",
+   "sha256": "1dym2x3mqfrn5h8p8c9mglxrb5idbq7l3ic3xh6whfji08wx1w4h"
   },
   "stable": {
    "version": [
-    5,
+    6,
     1,
     0
    ],
@@ -34812,8 +35113,8 @@
     "compat",
     "s"
    ],
-   "commit": "8de3e5abcdf99f76a339a386855d6c2ddd38b178",
-   "sha256": "0in9yyssahrp0qfbwziymg85bmysxlzr58vycb13k4m4g9i4s3r7"
+   "commit": "11245762388c03ecdfb550fb1b96978459d68a4f",
+   "sha256": "159s9hyn8z35ja3f297lb2335ihjyp60zkk7lsz8r3jc4vv0kgqs"
   }
  },
  {
@@ -35123,16 +35424,16 @@
   "repo": "cfclrk/environ",
   "unstable": {
    "version": [
-    20230518,
-    1310
+    20260130,
+    1135
    ],
    "deps": [
     "dash",
     "f",
     "s"
    ],
-   "commit": "9530e2f1ead5bd37aca4d298514800f73b3cc0a7",
-   "sha256": "188ww446qaqmyl3dxfkxn3yvh504jxwk07djw87gciwdz4ymf398"
+   "commit": "fae49380dd859c63c333b80c3bda7bd497e92d91",
+   "sha256": "1w695z5b1xyz498c9nbq49p5fqi74f222652nybli863ah99m7pk"
   },
   "stable": {
    "version": [
@@ -35157,15 +35458,15 @@
   "repo": "purcell/envrc",
   "unstable": {
    "version": [
-    20250917,
-    915
+    20260218,
+    842
    ],
    "deps": [
     "inheritenv",
     "seq"
    ],
-   "commit": "de1ae6e538764f74659f358b04af0d84fa0fef42",
-   "sha256": "0j5kwg6x1kr9ybzhc0rwrbmq35zmsk09svx39pmw2byl39d8fhb3"
+   "commit": "f44353c42c0794cdc6629c83a923d1689f33469f",
+   "sha256": "0ikswnkgdnhs5fl7w5ni71l1qy33pd2dk1jhvimswjhc9iwbk1ml"
   },
   "stable": {
    "version": [
@@ -35301,8 +35602,8 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20260105,
-    2201
+    20260217,
+    1917
    ],
    "deps": [
     "closql",
@@ -35310,14 +35611,14 @@
     "emacsql",
     "llama"
    ],
-   "commit": "522b00c64aaf230215c6dde8f992e79ed38b9e42",
-   "sha256": "0fw9qla52s8ca8kiy98nn9gpyjnnsr8m0aic7n3ir724fkr6r56n"
+   "commit": "f0ae7cd28d036850fe6cb18b47742b8e892e5c09",
+   "sha256": "1z3xgc1rsn7qg1yhxwryyk41xh1ac3wxxkcvysq8h7r05kcyahwn"
   },
   "stable": {
    "version": [
     4,
     1,
-    2
+    3
    ],
    "deps": [
     "closql",
@@ -35325,8 +35626,8 @@
     "emacsql",
     "llama"
    ],
-   "commit": "0dcab271d547736791e13be49cd6ee3630110eb1",
-   "sha256": "1hm6f73lwqsrn89f3s7dx79nc67qvqs8v1jb3wbyq7wdify5mja0"
+   "commit": "7758de6c8b6d56829b134be751562b1f885d311b",
+   "sha256": "1v7ln90529wqxvcwph7pyz21rr0l30pbfdjbcl4yyyqvza52wv8g"
   }
  },
  {
@@ -35337,30 +35638,30 @@
   "repo": "emacscollective/epkg-marginalia",
   "unstable": {
    "version": [
-    20260101,
-    1857
+    20260201,
+    1511
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "a42de3acf215bec1d3a06b63c98d0ad9182ce760",
-   "sha256": "14pbwh20vazrvxg4zmxvzpclpkkgrxd9qalrc1chgsr1zkdqff6s"
+   "commit": "1fda65cebc0d53319f2972ae52d182bdf5470702",
+   "sha256": "0mi0rgj5ivzam1ac70yiasr9hss47fmwh8dc683nlpdi18mv8vk8"
   },
   "stable": {
    "version": [
     1,
     1,
-    2
+    3
    ],
    "deps": [
     "compat",
     "epkg",
     "marginalia"
    ],
-   "commit": "a42de3acf215bec1d3a06b63c98d0ad9182ce760",
-   "sha256": "14pbwh20vazrvxg4zmxvzpclpkkgrxd9qalrc1chgsr1zkdqff6s"
+   "commit": "1fda65cebc0d53319f2972ae52d182bdf5470702",
+   "sha256": "0mi0rgj5ivzam1ac70yiasr9hss47fmwh8dc683nlpdi18mv8vk8"
   }
  },
  {
@@ -36078,20 +36379,20 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20260114,
-    1445
+    20260127,
+    1516
    ],
-   "commit": "28fef74d7a13556a2bbd12a90b19a30e939f72ce",
-   "sha256": "0msms2hjfldnr2f76hjfhh2baxprlkbdaa4gwb30bmjs9bdvyqsy"
+   "commit": "7f5eb9b686c16c2997358ba3052c234aedbeff33",
+   "sha256": "0mj0w674qrmzccp0h2y0z80f7ipfnw4l8x7kx2q05pv3mdlq1j22"
   },
   "stable": {
    "version": [
     28,
     3,
-    1
+    2
    ],
-   "commit": "aa5b1d3366762ff8f420f2aa6a52604b481530c9",
-   "sha256": "04wfdjacrar3x2xc7d28ld4dr24qx2nyf33pwfa5f1bd4nbgpicb"
+   "commit": "b74eae92e1dee97d57a9ab3ea3c36e8b701a9ca6",
+   "sha256": "0vg0m11rcaz2bv5f4fj7zskqdgppzgfpqjrwnnwfabf0k3q6f7pv"
   }
  },
  {
@@ -36390,8 +36691,8 @@
   "repo": "dakrone/es-mode",
   "unstable": {
    "version": [
-    20221026,
-    1103
+    20260220,
+    2147
    ],
    "deps": [
     "cl-lib",
@@ -36400,8 +36701,8 @@
     "s",
     "spark"
    ],
-   "commit": "e82465fd785688bb58918ea62ca4de06a2a23a1e",
-   "sha256": "0nb0nh651wnx8916j4ybhmadfk4ri6gnpfw9x58fv50nnmna9bc9"
+   "commit": "cf93c9900057a9f3c89f982f778f41f48285d076",
+   "sha256": "064jm7cdvh7z28vn8l3ndmdy9vg6snrzyxw8pkn6h9bp0zjkjpq0"
   },
   "stable": {
    "version": [
@@ -36493,6 +36794,30 @@
   }
  },
  {
+  "ename": "eselect-news",
+  "commit": "262d44137bc8e02ce44346d5a50c61344ddc354f",
+  "sha256": "16mgvz2ccz9b0snb8gs37r3cw1gk3s0yi95kakdjck2fr6x47dps",
+  "fetcher": "gitlab",
+  "repo": "cestrand/emacs-eselect-news",
+  "unstable": {
+   "version": [
+    20260222,
+    1216
+   ],
+   "commit": "562191c013a20348bd1adbf3be564c6e1d3c52b6",
+   "sha256": "1bwsmyk7faapq8vb3a66v49ca946nmxmsvz8fji3pmjfwwg5rd3j"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "ab4ecb45eef2a612fc24e4658289082eecddda60",
+   "sha256": "1mgh97xxlp38gkgb0gi5d9db7drdbbhlqzg5h7aqjhakiixbkaqb"
+  }
+ },
+ {
   "ename": "esh-autosuggest",
   "commit": "dc3776068d6928fc1661a27cccaeb8fb85577099",
   "sha256": "1rcng1dhy4yw95qg909ck33svpdxhv9v5k7226d29gp4y54dwyrx",
@@ -36575,14 +36900,14 @@
   "repo": "SqrtMinusOne/eshell-atuin",
   "unstable": {
    "version": [
-    20250301,
-    833
+    20260222,
+    802
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1ac4895529546839985c7f57c9858644f7be1e6a",
-   "sha256": "0zf62qdmqw7y7s1dg3d35abr9jaymyqfbrv4bplkrry2wwk0m4gx"
+   "commit": "142536a01a9d6d92d802e41474c290e0ca655deb",
+   "sha256": "1g4v9l755gvclggv33mk13vn7vw8sxivi3xgcmbgav1svim01v6q"
   }
  },
  {
@@ -36640,11 +36965,11 @@
   "repo": "jaeyeom/eshell-command-not-found",
   "unstable": {
    "version": [
-    20240708,
-    512
+    20260201,
+    715
    ],
-   "commit": "28427f0ca266fd75890ceafdd96997b5507e1bc4",
-   "sha256": "0cid9caklxbp4rfdpam42cmkxj1izzw84g9hpk7jabjmfgashrxg"
+   "commit": "0efda98051747183bd54cb021f4756bdf831bd8e",
+   "sha256": "1gxacp72pm9v9hdic9pv9iqp7kpi3x9pglfh4sa2i6dbm0ln8a56"
   }
  },
  {
@@ -37184,11 +37509,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20251230,
-    1711
+    20260203,
+    1633
    ],
-   "commit": "f8c464dc1b017b5397f8ec9955f7856493af1179",
-   "sha256": "1994cbs4zjsw2a66l9n2bvjdhm5223ybj9n8b35cqc1qjfi72mmf"
+   "commit": "bfe892db15e94387f70319efdc55710dc3660d2f",
+   "sha256": "0lrj27wf1rm6yi60dsmzy7c4533wk0xch1ww06y20b59hhnbccsj"
   },
   "stable": {
    "version": [
@@ -37455,10 +37780,10 @@
  },
  {
   "ename": "eta",
-  "commit": "6566b2cf5be53047db6d076d47f29932ba589d09",
-  "sha256": "06xfkcnjq5w56vbxaq23lqhw2fl2gx2b0wj8ddvii3q3c432y4hq",
+  "commit": "4a6f5322cf92cf6e99e741bc07d807113af1025c",
+  "sha256": "037lnz5pz7kgcnc12f1fmyxlcgyrjp5v91bg5kkr9gv7yg98hrxp",
   "fetcher": "github",
-  "repo": "zcaudate/eta",
+  "repo": "hoebat/eta",
   "unstable": {
    "version": [
     20210115,
@@ -37480,15 +37805,15 @@
   "repo": "mavit/etc-sudoers-mode",
   "unstable": {
    "version": [
-    20240417,
-    2126
+    20260224,
+    326
    ],
    "deps": [
     "sudo-edit",
     "with-editor"
    ],
-   "commit": "133f342e7a249ed4b3e3983e6d8bf541bae05c4b",
-   "sha256": "0lgw6x7p9rq334g97npbdq5zf7ws8a0gxx608dhai3g7lw47w84w"
+   "commit": "400b4d4d7281b33896d388e84dec6b7a2c39ea22",
+   "sha256": "09v6jyxc5gldra3974q2fjyn8af1gm4qzwzza326yfcy6ln9w99s"
   },
   "stable": {
    "version": [
@@ -37841,11 +38166,11 @@
   "repo": "mekeor/evenok",
   "unstable": {
    "version": [
-    20250606,
-    812
+    20260221,
+    2125
    ],
-   "commit": "eccc70e577bac3c9901e508fc06ae21b8364e6e9",
-   "sha256": "03qa62k1mi5nnkrvas1xf99vjg66gx3qdxzm2ddrixir8qszh3xz"
+   "commit": "6b5e3c10d3649be6ea9df5cc369d8a4d4a03f3aa",
+   "sha256": "0kj2jw90lndf1sjirxrs3v93kc43pz1hjxb0x7b50z9lpvz1rjz9"
   },
   "stable": {
    "version": [
@@ -38090,15 +38415,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20251226,
-    804
+    20260125,
+    1403
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "163792a823bcdb2dae7ac1bba4018adfac35dca2",
-   "sha256": "1vfhs1f4s0ygys9cs2iixv9f7rjf69gmvban68j92ndv6bvq31qg"
+   "commit": "d052ad2ec1f6a4b101f873f01517b295cd7dc4a9",
+   "sha256": "1q9w1wwlfcvw9xhpcv56qx9y6g2wrfrl1mcs2gzbds9qb2nszf7y"
   },
   "stable": {
    "version": [
@@ -38520,26 +38845,26 @@
   "repo": "yad-tahir/evil-insert-plus",
   "unstable": {
    "version": [
-    20260119,
-    926
+    20260127,
+    1015
    ],
    "deps": [
     "evil"
    ],
-   "commit": "d264c13585f3b282552a27fa6c0e77c2b17afa7c",
-   "sha256": "0413q2rhbxnfcpahfzjfp4sgxrm642a96xmvkn1y0a9fh0x10p5n"
+   "commit": "d584ed3ea2a49ed7f93fe176800e7a2f95dff6aa",
+   "sha256": "1fjrq54vfacxmmk1w1f35w9mdbrlld462nnqfappj6v4d14cq3fs"
   },
   "stable": {
    "version": [
     0,
     5,
-    3
+    5
    ],
    "deps": [
     "evil"
    ],
-   "commit": "d264c13585f3b282552a27fa6c0e77c2b17afa7c",
-   "sha256": "0413q2rhbxnfcpahfzjfp4sgxrm642a96xmvkn1y0a9fh0x10p5n"
+   "commit": "a43914e3d483685dc11d616f9fcd268779dd0258",
+   "sha256": "1ahnh30qimcfydwmdwblg3h1gmjlq5iibcr7h0r1s720fsb73fn7"
   }
  },
  {
@@ -40447,14 +40772,14 @@
   "repo": "rolandwalker/express",
   "unstable": {
    "version": [
-    20140508,
-    2041
+    20260202,
+    1155
    ],
    "deps": [
     "string-utils"
    ],
-   "commit": "6c301e8a4b6b58a5fe59ba607865238e38cee8fd",
-   "sha256": "1nhqaxagg3p26grjzg8089bmwpx2a3bbq1abw40wbqivybl6mgd5"
+   "commit": "f98932f43771eea3cadd36002670d2099a0258f8",
+   "sha256": "1xnhi94ywfffai1jbz7ip8npvkzqjjc5h1zirznmnf3k5n003qs8"
   },
   "stable": {
    "version": [
@@ -40583,8 +40908,8 @@
   "repo": "ananthakumaran/exunit.el",
   "unstable": {
    "version": [
-    20251101,
-    1233
+    20260127,
+    1521
    ],
    "deps": [
     "f",
@@ -40592,8 +40917,8 @@
     "s",
     "transient"
    ],
-   "commit": "632298249150f8e6cf83175edcb0a13158deabc2",
-   "sha256": "1bcrxzk9jpvj2wx3wx3z048xi2pplcay4ljg6bahmgf178lc36sv"
+   "commit": "bef971bde5634992fc2e4c8436b3feaddd8d7ed6",
+   "sha256": "1v1wd9r8hlv54363bcih7z9rl1f740mlg9zpm5zdf3qfg2q6vagk"
   }
  },
  {
@@ -41047,19 +41372,20 @@
   "repo": "WJCFerguson/emacs-faff-theme",
   "unstable": {
    "version": [
-    20251229,
-    2005
+    20260209,
+    2337
    ],
-   "commit": "234889b84663e066eb8755528e8c35e2dd210704",
-   "sha256": "1ir3jv7zg1k4k85khlkbs5gg9niyr5rsynzlim7vqy5f9304779c"
+   "commit": "216b52467e2fbbc61b746c28b5d0bc001345a8eb",
+   "sha256": "18brbllyv8vmnanjl382qpkyf4156n7vv43mhr472fjl4qvkr34l"
   },
   "stable": {
    "version": [
     3,
-    8
+    9,
+    1
    ],
-   "commit": "e8b6b4b5669fb41f0dd4fdcbcb88b5b9ab803f53",
-   "sha256": "0m4li4qhxp5ay0zs6dgsqj7llh8kv4gmcs5jbdswcr631b2a4ax7"
+   "commit": "216b52467e2fbbc61b746c28b5d0bc001345a8eb",
+   "sha256": "18brbllyv8vmnanjl382qpkyf4156n7vv43mhr472fjl4qvkr34l"
   }
  },
  {
@@ -41136,6 +41462,21 @@
    ],
    "commit": "cf4a2f7e3e43e07ab9aa9db16532a21010e9fc8c",
    "sha256": "04z9pwvl68hsisnyf9wlxmkwk8xag36jvcchwcwp4n9vp04z8745"
+  }
+ },
+ {
+  "ename": "fancy-fill-paragraph",
+  "commit": "17a907926688dbf4b2375f450dc2051c230fc6cd",
+  "sha256": "14lbm9x4pal8xp70zr8a05aca8cmkkvdsi28m59h9mf6mvg67lqs",
+  "fetcher": "codeberg",
+  "repo": "ideasman42/emacs-fancy-fill-paragraph",
+  "unstable": {
+   "version": [
+    20260218,
+    1058
+   ],
+   "commit": "68e3e903ec9406958151b3edbef3e96896be5c27",
+   "sha256": "0g5wjlyilljxzsh7b0ql3c09bq077z2swyclz7mg01q1frx11ng0"
   }
  },
  {
@@ -41550,25 +41891,25 @@
   "repo": "martianh/fedi.el",
   "unstable": {
    "version": [
-    20250812,
-    645
+    20260223,
+    1326
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "a9df02f835899d0a587d236b1fa4d16e53af9039",
-   "sha256": "0jdlhl3gjyk6alkkyhx3svqkwmfkddsh0qga6wwcc2irlv0gryad"
+   "commit": "74fab520f1d008f5a389a673616a617c03c74600",
+   "sha256": "0ldag8659nqphc2isw1n3xv8dqf468ppwf1q10zn03sdj4dc1i11"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "ffcb84bb132a72c9d787b4f6d8481d27da623d41",
-   "sha256": "0a5zq7axxh3khx6465s7ym9s7v2iw7ky9z486d0zg41k7926bm9d"
+   "commit": "74fab520f1d008f5a389a673616a617c03c74600",
+   "sha256": "0ldag8659nqphc2isw1n3xv8dqf468ppwf1q10zn03sdj4dc1i11"
   }
  },
  {
@@ -41647,11 +41988,11 @@
   "repo": "technomancy/fennel-mode",
   "unstable": {
    "version": [
-    20251028,
-    2216
+    20260210,
+    2300
    ],
-   "commit": "c1bccdec9e8923247c9b1a5ffcf14039d2ddb227",
-   "sha256": "0ylhffwiww03my7qaysklz7mx4jh530hgv5zgv78v4fbxsqwp02n"
+   "commit": "9c1dac3c39fcdbecbb9e963898cb353ec8ba6cc3",
+   "sha256": "1gvknvprlsm7p8kbl5aawngnwvswm40zm1llx59yscycb779dp3w"
   },
   "stable": {
    "version": [
@@ -42325,14 +42666,14 @@
   "repo": "Anoncheg1/firstly-search",
   "unstable": {
    "version": [
-    20250904,
-    5
+    20260220,
+    2320
    ],
    "deps": [
     "compat"
    ],
-   "commit": "509cb483e68caf8e6ecd0f171330b91eff430583",
-   "sha256": "01lkhbgb8a4hbzxiny3hfdxpg1qzpmxrp06bx9szw9yjf9qmbnw5"
+   "commit": "3d4599dcda4a2f761212ef5107260013ad73c101",
+   "sha256": "1h9pi3aa1yjkprnjblgcarrl4k3jmjhc3mk84dpyr8s8ydvgybbs"
   },
   "stable": {
    "version": [
@@ -42558,8 +42899,8 @@
   "repo": "martianh/fj.el",
   "unstable": {
    "version": [
-    20251030,
-    1345
+    20260224,
+    918
    ],
    "deps": [
     "fedi",
@@ -42567,13 +42908,13 @@
     "tp",
     "transient"
    ],
-   "commit": "79a1ef1006f6f8da6bbdcaf05ae8888a79f6887e",
-   "sha256": "0wjycqxknvim5x0xbwjkbpvzaplikzxpiw33dsv7ly8c71nbr4i4"
+   "commit": "835050814e6ab5bc68763793be86b6a99bdf247a",
+   "sha256": "1ih9ynjpb1z0jk4dy5g9zjdbl5wa1rqpbqi205qba8jg6vw17bvn"
   },
   "stable": {
    "version": [
     0,
-    27
+    31
    ],
    "deps": [
     "fedi",
@@ -42581,8 +42922,8 @@
     "tp",
     "transient"
    ],
-   "commit": "eeba4f379b957864e5b7b16f7f5b98c5f75614b5",
-   "sha256": "1hp8xaggb6fclgdjh7jz97rn248xbl8qy88a8c7xx3gvv2x7ahgx"
+   "commit": "835050814e6ab5bc68763793be86b6a99bdf247a",
+   "sha256": "1ih9ynjpb1z0jk4dy5g9zjdbl5wa1rqpbqi205qba8jg6vw17bvn"
   }
  },
  {
@@ -42628,6 +42969,21 @@
    ],
    "commit": "fac0011983251d5c44f4ed1eacac03f5de3caac4",
    "sha256": "191sdqaljxryslvwjgr38fhgxi0gg7v74m1rqxx3m740wr4qnx7s"
+  }
+ },
+ {
+  "ename": "flash",
+  "commit": "fd3db454652440bf1c5090320e2440ddbd74b360",
+  "sha256": "141dfk5zy9kqrbdzlf0f9ddlc4niwycjdfki7mm3i4iwfbjbhpfa",
+  "fetcher": "github",
+  "repo": "Prgebish/flash",
+  "unstable": {
+   "version": [
+    20260225,
+    801
+   ],
+   "commit": "faa32ab3486668b62b7f4bf86411fd694720dab5",
+   "sha256": "00bq95pqw1adlnhfg7sjpi07sq2pczkxsc5fa0slw0hg5mjd9ii8"
   }
  },
  {
@@ -43153,22 +43509,25 @@
   "repo": "flycheck/flycheck",
   "unstable": {
    "version": [
-    20251128,
-    1706
+    20260224,
+    1923
    ],
    "deps": [
     "seq"
    ],
-   "commit": "62570fafbedb8fa3f7d75a50a9364feca3b294ef",
-   "sha256": "18068n5mqb1k54hjgfifhvghkm3adbh498dbj8xms0i1bi1ld8c7"
+   "commit": "b714e2770f6a2d1f441557f7c14182ae4e3defef",
+   "sha256": "0d2qx5wa1m94jj61vhprq9i6cfi2h24kvij0k9v5pzm43l6bn440"
   },
   "stable": {
    "version": [
-    35,
+    36,
     0
    ],
-   "commit": "6e43c07e83406cdd3f75952ee988d61d7573ec11",
-   "sha256": "1jj9w1j1qgpj3cdihwkgaj7nd714a0sgsydh413j9rsv6a3d4cgg"
+   "deps": [
+    "seq"
+   ],
+   "commit": "ebddfd89b1eea91b8590f542908672569942fb82",
+   "sha256": "0gndi96ijxqj6k9qy5d4l0cwqh0ky7w1p27z90ipkn05xz4j3zp5"
   }
  },
  {
@@ -43269,14 +43628,14 @@
   "repo": "leotaku/flycheck-aspell",
   "unstable": {
    "version": [
-    20250118,
-    2052
+    20260105,
+    2025
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "0d9291fd3422de0eedbac387e8c1eb037904f808",
-   "sha256": "1fivvfrcdkdavpdv6hglzj5snwx97gw1zrb1abyc60p91fsqab1k"
+   "commit": "abbac0f6ccd94224f19c70d8545fddfe9c27351f",
+   "sha256": "1kxxzvamjcs3f5zd0cwd2aszxx2cfs0ywq7ywhkkzall43ird4y7"
   }
  },
  {
@@ -43982,15 +44341,15 @@
   "repo": "flycheck/flycheck-eglot",
   "unstable": {
    "version": [
-    20260109,
-    1536
+    20260225,
+    255
    ],
    "deps": [
     "eglot",
     "flycheck"
    ],
-   "commit": "87cc55936f843f8e0b9ab0b6b5ae5c6d7170f600",
-   "sha256": "1z9wdqqf482535jwmf3iyv5b92nbm9l4cy4v2z2nga9fj0sdr3vp"
+   "commit": "cd1dd78cec0ae1f566c765d98bbff322cc7b67ef",
+   "sha256": "19i2a33mpddd64mnvjk247ayn325p66lknm9pqjb0ccjfwi54sml"
   },
   "stable": {
    "version": [
@@ -44189,14 +44548,14 @@
   "repo": "weijiangan/flycheck-golangci-lint",
   "unstable": {
    "version": [
-    20251203,
-    2053
+    20260201,
+    1313
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "f7e36e19d6af39d098b94a2e7524dbd7b585ce67",
-   "sha256": "1h77vyrx0cswwmqww0ac75vfw9v8ylxfr715rfh3c30920gb2ip8"
+   "commit": "51aede797df89eeea5928df05d0f619530339152",
+   "sha256": "0xh628bhkw0f29k11i5b9z1xlcl53hhj4xh4vzqnad1j9hgyxsqc"
   }
  },
  {
@@ -44761,26 +45120,26 @@
   "repo": "emacs-languagetool/flycheck-languagetool",
   "unstable": {
    "version": [
-    20260101,
-    535
+    20260218,
+    1520
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "8889414ec50c3c4dfeef601900c63901a55a2237",
-   "sha256": "18133npi09ka6d8m0j4gg9m74l2j5fs5y5psfb1jj4j5wvydcxc4"
+   "commit": "59dc7467425bda99aeb7fb16b4b0926070701d60",
+   "sha256": "133szna5vxczrgvap6lg1s3x0wm41dh3qdx7nryvfm912j5z6cyx"
   },
   "stable": {
    "version": [
     0,
     4,
-    1
+    2
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "03d023c78cca177901afe7223ee57a8e396dcf49",
-   "sha256": "0s11sn0qbq3g6dwrr9r476c59zmp5fya89pf71pl02jijd4a3gr4"
+   "commit": "59dc7467425bda99aeb7fb16b4b0926070701d60",
+   "sha256": "133szna5vxczrgvap6lg1s3x0wm41dh3qdx7nryvfm912j5z6cyx"
   }
  },
  {
@@ -45988,11 +46347,11 @@
   "repo": "jamescherti/flymake-ansible-lint.el",
   "unstable": {
    "version": [
-    20260114,
-    1535
+    20260215,
+    2013
    ],
-   "commit": "8eadddad5fac18cb5625f70371890813ff9d5b87",
-   "sha256": "0zwmk4g54k4c4zyhp0b5ysj17ga5i5qgs9wj9anl8b8lddh701mk"
+   "commit": "580ae9b179aab4ee4b90c07be0b82a80f314ccf8",
+   "sha256": "1xzp56b4f9jia24a7wn4kv8ki38wi2962b0yw2r5xp7im2xm5izi"
   },
   "stable": {
    "version": [
@@ -46012,11 +46371,11 @@
   "repo": "leotaku/flycheck-aspell",
   "unstable": {
    "version": [
-    20250118,
-    2052
+    20260105,
+    2025
    ],
-   "commit": "0d9291fd3422de0eedbac387e8c1eb037904f808",
-   "sha256": "1fivvfrcdkdavpdv6hglzj5snwx97gw1zrb1abyc60p91fsqab1k"
+   "commit": "abbac0f6ccd94224f19c70d8545fddfe9c27351f",
+   "sha256": "1kxxzvamjcs3f5zd0cwd2aszxx2cfs0ywq7ywhkkzall43ird4y7"
   }
  },
  {
@@ -46027,14 +46386,14 @@
   "repo": "jamescherti/flymake-bashate.el",
   "unstable": {
    "version": [
-    20260114,
-    1535
+    20260215,
+    2013
    ],
    "deps": [
     "flymake-quickdef"
    ],
-   "commit": "91a687fd2c10c09e3509ea32e91209877affe379",
-   "sha256": "10y3pwp8r5849wlldcrya26vfq4wiblb9bif522ya25784f8bydx"
+   "commit": "128f24cbaae9e6bb749169bf5a8e0acfe179c3cb",
+   "sha256": "0qylzvx330klvadvdm60lihbl20yh1yfy7byj5w5n7549ckiz161"
   },
   "stable": {
    "version": [
@@ -47434,36 +47793,6 @@
   }
  },
  {
-  "ename": "flymake-x",
-  "commit": "015ab56dacbd76e023561d16dbb702ac651ca7df",
-  "sha256": "18y1g56w6a4mb1cgf32agvna26m8m8dkv3zycn0xm09yz3gksr2d",
-  "fetcher": "github",
-  "repo": "mkcms/flymake-x",
-  "unstable": {
-   "version": [
-    20251208,
-    1843
-   ],
-   "deps": [
-    "flymake"
-   ],
-   "commit": "0f50d49dff71a16a50e53619578a6c64fd6d6be1",
-   "sha256": "10nrr7sbf7fn2lz1zxjjbmh95rjzk0zl1f5lfhj1c5fdq71cfyl7"
-  },
-  "stable": {
-   "version": [
-    0,
-    2,
-    0
-   ],
-   "deps": [
-    "flymake"
-   ],
-   "commit": "0f50d49dff71a16a50e53619578a6c64fd6d6be1",
-   "sha256": "10nrr7sbf7fn2lz1zxjjbmh95rjzk0zl1f5lfhj1c5fdq71cfyl7"
-  }
- },
- {
   "ename": "flymake-yaml",
   "commit": "888bcbcb24866abd990abd5b467461a1e1fc13fa",
   "sha256": "17wghm797np4hlidf3wwb47w4klwc6qyk6ry1z05psl3nykws1g7",
@@ -47531,14 +47860,14 @@
   "repo": "konrad1977/flyover",
   "unstable": {
    "version": [
-    20260111,
-    1120
+    20260225,
+    626
    ],
    "deps": [
     "flymake"
    ],
-   "commit": "166da1cd3388c8dbbe0d514b3a1fe8397630d8d5",
-   "sha256": "03cily8i7zq860n7gf5qj68005jc1219m8rvd9m10snz8wrpdkkd"
+   "commit": "8815cb067ca0d3d32607c9ae5093673cb29663a0",
+   "sha256": "15va0m6dyypvq9llyk9mz2l6cam7ysrymaga8ycfr16pr7rrnx9d"
   }
  },
  {
@@ -48262,8 +48591,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20260117,
-    1710
+    20260208,
+    1639
    ],
    "deps": [
     "closql",
@@ -48278,8 +48607,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "3cde5fc0e17e9a30a0f3b49fcbc49b50a5ca49f3",
-   "sha256": "120ajxsdi2jm075d40ajsvv12vaq4w77d1jaxayanwfq8mppcld3"
+   "commit": "5c005c085dda7258696aded59983482e228654a3",
+   "sha256": "0qgy5pziq70mdjmg5vyzf9vbnyw6sf2xq8xyl4bvy1zyq5hhw20x"
   },
   "stable": {
    "version": [
@@ -49389,15 +49718,15 @@
   "repo": "jojojames/fussy",
   "unstable": {
    "version": [
-    20250820,
-    104
+    20260216,
+    27
    ],
    "deps": [
     "compat",
     "flx"
    ],
-   "commit": "163ded34be3e9230702201d0abe1e7b85e815c2d",
-   "sha256": "0gkgkg298qnk9yf1d9la5cnl3mrxvs41hxlgys5v36c4pg7v9yzp"
+   "commit": "17ca387c077f47553239816f41d6f0e351a21103",
+   "sha256": "1slbrqsi17zglqy229zggn094w8rckkpdnmnbw5gvhy6z40p5s5c"
   },
   "stable": {
    "version": [
@@ -49623,11 +49952,11 @@
   "repo": "bling/fzf.el",
   "unstable": {
    "version": [
-    20260111,
-    1853
+    20260121,
+    1418
    ],
-   "commit": "7bd12faa84f0ddcbc1e76ab416bb43e36fbf9c1f",
-   "sha256": "07zfb7771kwwv99z1fdk9zb51swyl5i07ps53748n9yskivf16kx"
+   "commit": "0f6a2fd644bedfbcc061f995c8c270d084da1cba",
+   "sha256": "1q6hs3kksr7lxj6w42gp6q16m86zmkc4r1mr8j5s3n0y8mw9gy2y"
   },
   "stable": {
    "version": [
@@ -49689,11 +50018,11 @@
   "repo": "ShiroTakeda/gams-mode",
   "unstable": {
    "version": [
-    20260119,
-    217
+    20260121,
+    924
    ],
-   "commit": "519c64f186515157b6a01143f438dc24148d8e58",
-   "sha256": "185r2x63cib0bjl68xxn52bvli7lfpy894l7n01wy3q05w4lfbws"
+   "commit": "eeb4cfcf98d113388a5d66b2fa65cb32563ef9af",
+   "sha256": "16cn4c2ma7ixb2r4bd04qyxf1g9wqzvma93b95x5zryn8n0k3lmx"
   },
   "stable": {
    "version": [
@@ -49811,11 +50140,11 @@
   "repo": "godotengine/emacs-gdscript-mode",
   "unstable": {
    "version": [
-    20251104,
-    1437
+    20260202,
+    556
    ],
-   "commit": "e94dfd9dc7a50261b2c41ae3daa05043331a54a8",
-   "sha256": "18f7y7cnsr0kc6h0f286x6557f6mp69v17b98i4mg4my2ah6gszi"
+   "commit": "dd44f1dfa541c73d41272adefd35017147dc9fcb",
+   "sha256": "1hf7gwzzl4k955z4qf6dnrjq6yyyw6lcfzc4ga78y0s4n10sy6f3"
   },
   "stable": {
    "version": [
@@ -50484,16 +50813,16 @@
   "repo": "twmr/gerrit.el",
   "unstable": {
    "version": [
-    20251105,
-    2119
+    20260208,
+    922
    ],
    "deps": [
     "dash",
     "magit",
     "s"
    ],
-   "commit": "e89b21d2f464ead98a60d8ecc79c359be886b232",
-   "sha256": "19wz4vgm0bjk87rn0x6ykj612rh4b3idaig6adn6yns77danrs60"
+   "commit": "317599943495da561a508b31e83ae55c800e5a52",
+   "sha256": "185q22afq281k6whhjrmikgr711xd7blv6ixir8pinv7d4m5psmd"
   }
  },
  {
@@ -50585,8 +50914,8 @@
   "repo": "sigma/gh.el",
   "unstable": {
    "version": [
-    20230825,
-    1217
+    20260210,
+    1535
    ],
    "deps": [
     "cl-lib",
@@ -50594,8 +50923,8 @@
     "marshal",
     "pcache"
    ],
-   "commit": "b5a8d8209340d49ad82dab22d23dae0434499fdf",
-   "sha256": "1vab2qdjyv4c3hfp09vbkqanfwj8ip7zi64gqbg93kf1aig1qgl9"
+   "commit": "b1551245d3404eac6394abaebe1a9e0b2c504235",
+   "sha256": "0aifrgsrycbv5c0xdmijbc276vif9n136c8fbf8lw4cxyrvmqyiw"
   },
   "stable": {
    "version": [
@@ -50774,8 +51103,8 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20260101,
-    1852
+    20260217,
+    1835
    ],
    "deps": [
     "compat",
@@ -50783,8 +51112,8 @@
     "llama",
     "treepy"
    ],
-   "commit": "278d9fb5f3f673a4ecfe551faeacc0dfd5de0783",
-   "sha256": "0bw8m3i05r6bm8drapxf8ldg71wgymkr15adl43lckp37kl7npyj"
+   "commit": "f87acd5c01f20d3d67ef5926b5e7230726ced835",
+   "sha256": "0l61hnc15s7q0s74xxfl7v3cdxnsalzpc6gr7jfj1hp12lmqa47p"
   },
   "stable": {
    "version": [
@@ -52714,8 +53043,8 @@
   "url": "https://git.thanosapollo.org/gnosis",
   "unstable": {
    "version": [
-    20260114,
-    454
+    20260224,
+    1202
    ],
    "deps": [
     "compat",
@@ -52723,14 +53052,14 @@
     "org-gnosis",
     "transient"
    ],
-   "commit": "6bd8f4e5a84387b51df961db9703e9801f3610f7",
-   "sha256": "1x8d0dw1s6qhhhv2f90372nk0zwi3m405cga706xzrffr86mydyr"
+   "commit": "efac49bb1c55779d41d1f0aa22a0fb18486b6722",
+   "sha256": "1fz7a08vfzw93gh6ikqpghk1b1pzllm8m5ryx3ng1r6lc4ql56ch"
   },
   "stable": {
    "version": [
     0,
-    5,
-    8
+    7,
+    0
    ],
    "deps": [
     "compat",
@@ -52738,8 +53067,8 @@
     "org-gnosis",
     "transient"
    ],
-   "commit": "43b8ba93a7173543d16e08ebc30ce8ed3f793b7f",
-   "sha256": "0zlcw3qqpxar9sapds38w38yhxmndv7zb59xh206c0fwvymjfc1d"
+   "commit": "54660aabfa3200663053dd0063f2c215ef674ddb",
+   "sha256": "0a8bsmvj6wckq9fjpnqa9ccml4fwbia7415j4wrqbza6a9svilrx"
   }
  },
  {
@@ -52847,11 +53176,11 @@
   "repo": "hexmode/gnus-alias",
   "unstable": {
    "version": [
-    20230818,
-    1830
+    20260224,
+    27
    ],
-   "commit": "cf1783a9294bc2f72bfafcaea288c159c4e3dee5",
-   "sha256": "0cs0cyi7hj7ga9aiqz4dafc07xrk3l5g9zzlbda9l90xbvyfssa0"
+   "commit": "cd7e3f92a12fe7948e2658d26bd0c53ca4a483bd",
+   "sha256": "15fpvwz2mxgn6jb6gvgfnp9snjiwxhw783lfkj8qxn12hcwz6c7m"
   }
  },
  {
@@ -53650,20 +53979,20 @@
   "repo": "rch/go-template-helper-mode",
   "unstable": {
    "version": [
-    20260102,
-    1449
+    20260124,
+    2229
    ],
-   "commit": "34ba1fa917da78f9926fa909056bd9e1e5dd2837",
-   "sha256": "179przj56648gxsqz0b0jzwj6b7d729ncabqzqgqfwyad9n2605b"
+   "commit": "e13b09d9176dd88e65c4bea5eb5c878242ea7e13",
+   "sha256": "07x19icrir88h6kxgx57rg8m6f48xvlqkrwncq92ff3m7jma1yhv"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    3
    ],
-   "commit": "34ba1fa917da78f9926fa909056bd9e1e5dd2837",
-   "sha256": "179przj56648gxsqz0b0jzwj6b7d729ncabqzqgqfwyad9n2605b"
+   "commit": "e13b09d9176dd88e65c4bea5eb5c878242ea7e13",
+   "sha256": "07x19icrir88h6kxgx57rg8m6f48xvlqkrwncq92ff3m7jma1yhv"
   }
  },
  {
@@ -54171,14 +54500,14 @@
   "repo": "chmouel/gotest-ts.el",
   "unstable": {
    "version": [
-    20250923,
-    702
+    20260127,
+    1547
    ],
    "deps": [
     "gotest"
    ],
-   "commit": "edbc8dcd14fa037cd91e08896027fcd6331aca7c",
-   "sha256": "1siaj2f7jbvkf5a5fk5h5j56sm27vkxp0913kjkygcjhigkdi0lw"
+   "commit": "b12e08d925bab705792f14b29acdca9af550d9a8",
+   "sha256": "053q4h0wd8rbrcdmn85v1530cvbx4ygwlr0yp8v5pji7wrgbbpd7"
   }
  },
  {
@@ -54213,20 +54542,20 @@
   "repo": "emacs-vs/goto-char-preview",
   "unstable": {
    "version": [
-    20260101,
-    549
+    20260204,
+    956
    ],
-   "commit": "b78fa6419466984b97459e95ffb77f3e9ae10a09",
-   "sha256": "0wz4ajn4d4b3rli1hvlh5vsdpm98m2wkdni6sw03m3wz4750brx6"
+   "commit": "d81c7186dc3c916ba84a5d8ce2f06c652c1186a8",
+   "sha256": "1h4lhhr2r6rngz1fba2fzaa4wj0dwqv5icn2ivzmcmgwbcmkay5i"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
-   "commit": "6209973933bec4081145dbcb8e3e442cb29a8c52",
-   "sha256": "1ckpdgfr7da37fwx9pw0vc8bdcmbpdpygfn8gkwwmz3yjk3021h7"
+   "commit": "13c9ab10b0a4f5be0b22158f6437a535a3f36240",
+   "sha256": "1fv75lrgfnpwpqcwsjr799bb1xda322rjrsyzj5mb2gjv57ia5mg"
   }
  },
  {
@@ -54300,20 +54629,20 @@
   "repo": "emacs-vs/goto-line-preview",
   "unstable": {
    "version": [
-    20260101,
-    549
+    20260204,
+    956
    ],
-   "commit": "ccc3c361da93f5bd44d697d22482f52fab735860",
-   "sha256": "08yw64chjd189is40yl9plxym35bb3zfmsb7k41h8rdgpcw7ib27"
+   "commit": "7c86228bc4f92b5129302824881f36d7ae39ee0a",
+   "sha256": "0nhgpdhjzvginq3adzfx67jwgv7ldvkcfqk09sbc7ii4ihj4m2fi"
   },
   "stable": {
    "version": [
     0,
-    1,
-    1
+    2,
+    0
    ],
-   "commit": "66817b66ce124b2961df3521faa3adc87943d0d9",
-   "sha256": "0w9cqp5xcqnncwpb90xvirvm05bknsaxhd51y2wkhqr7j5xi489i"
+   "commit": "f835428addbadc8af782b5ea511103c5f10b6dc5",
+   "sha256": "0ayy18wiakz33ylh6g7szvndgq9k0k6jh37s6yqhjzkg884aga3x"
   }
  },
  {
@@ -54339,7 +54668,7 @@
   "stable": {
    "version": [
     0,
-    52,
+    53,
     0
    ],
    "deps": [
@@ -54348,8 +54677,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "e53c30d0f0f3cdb97160b0263cda0126c070693a",
-   "sha256": "0n2yga2biipqh23bz1p7bz7cwz35wd055qwpjh5gr904sy3i7pqr"
+   "commit": "029d112e05adfc13fa458b99bab4260dd08376c1",
+   "sha256": "0av7fc15422kqx8yd38qv9828mi7y788q865qhmgb4wy26aamwzz"
   }
  },
  {
@@ -54441,11 +54770,11 @@
   "repo": "stuhlmueller/gpt.el",
   "unstable": {
    "version": [
-    20260111,
-    423
+    20260207,
+    633
    ],
-   "commit": "fb5b7a833116377f9aae05e3ddefec64805d7546",
-   "sha256": "15md8lpkkj1k9f0aaqqp98pzkklvc386i5ilawqq0mvq1kpzir2j"
+   "commit": "9d4752674e6cbf57aee0bc013d99b4c8652e9f60",
+   "sha256": "0dfaq0b0vk2j42f7j09lk8mxk32my3w0ll20nczy4746pbmf26zq"
   }
  },
  {
@@ -54512,29 +54841,29 @@
   "repo": "karthink/gptel",
   "unstable": {
    "version": [
-    20260116,
-    710
+    20260222,
+    120
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "7f15e57e1a5c7dcc504457708645aef2deceb425",
-   "sha256": "0ljylls6537rxgy0ywc7paxz4ccgxizv1lzlb02hnb1xwrd5pmyz"
+   "commit": "d221329ee3aa0198ad51c003a8d94b2af3a72dce",
+   "sha256": "1ffh2mwy9znjd0v9mh065lv122xg4nlnkbxwjfrsaqn1j1q2xc0c"
   },
   "stable": {
    "version": [
     0,
     9,
     9,
-    3
+    4
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "d0c392bbb0a1f7775d3a1e98220f4bdc043ab63b",
-   "sha256": "080dk0101imvfkxcqlqhy8wf1wc8p2vqyp3cwdi48wn44y1csqy9"
+   "commit": "d221329ee3aa0198ad51c003a8d94b2af3a72dce",
+   "sha256": "1ffh2mwy9znjd0v9mh065lv122xg4nlnkbxwjfrsaqn1j1q2xc0c"
   }
  },
  {
@@ -54545,8 +54874,8 @@
   "repo": "karthink/gptel-agent",
   "unstable": {
    "version": [
-    20260114,
-    2340
+    20260213,
+    750
    ],
    "deps": [
     "compat",
@@ -54554,8 +54883,8 @@
     "orderless",
     "yaml"
    ],
-   "commit": "ba4aed51fe4ae4ddf73dc538aeaec7fe9bc364be",
-   "sha256": "0476jbydk62f01vj9463c0h7fy4nibq351m4wy4dql04x6nhflx6"
+   "commit": "8ba9056da2341468192e6417d47cb50e26636e97",
+   "sha256": "1si6sxvcczpjcrzgig1030faxgkl34zkrn08b71hd807flmpyqik"
   }
  },
  {
@@ -55337,11 +55666,11 @@
   "repo": "seagle0128/grip-mode",
   "unstable": {
    "version": [
-    20250731,
-    213
+    20260213,
+    1756
    ],
-   "commit": "c965a344ab950c6b4ef788c7b9e8792a95a139d1",
-   "sha256": "0dbqcbsd891r7i267wvjswxn5x8qvc5379if0j91xvgznmzfwllv"
+   "commit": "b8b9e603edbb258ab38a94a0518c4a8c7a22e53c",
+   "sha256": "1y7vp6jsl62ijf01yvckm5d3w6jh4aj7bl0gv5dh81vrz8wlv5qy"
   },
   "stable": {
    "version": [
@@ -55791,20 +56120,20 @@
   "repo": "bormoge/guava-themes",
   "unstable": {
    "version": [
-    20260119,
-    2115
+    20260222,
+    1518
    ],
-   "commit": "983154f6922571b2cb34730808d6b396417b10ba",
-   "sha256": "0760bavqmbhjsd1ydiqm4h5c2kfmlvnn0mgf845k8qvghb9y14xx"
+   "commit": "1a8e3aa0f999a378344da0cf82ee843773526f9c",
+   "sha256": "1v562mb08nqhingdba4vcyjhqxwgqrmpaz3ai3j9mn1dwh6h6iak"
   },
   "stable": {
    "version": [
     0,
-    8,
+    11,
     0
    ],
-   "commit": "983154f6922571b2cb34730808d6b396417b10ba",
-   "sha256": "0760bavqmbhjsd1ydiqm4h5c2kfmlvnn0mgf845k8qvghb9y14xx"
+   "commit": "1a8e3aa0f999a378344da0cf82ee843773526f9c",
+   "sha256": "1v562mb08nqhingdba4vcyjhqxwgqrmpaz3ai3j9mn1dwh6h6iak"
   }
  },
  {
@@ -55952,11 +56281,11 @@
   "repo": "Overdr0ne/gumshoe",
   "unstable": {
    "version": [
-    20260110,
-    1840
+    20260217,
+    252
    ],
-   "commit": "2f4f54a584d4460b838ae8e366c07eb0f040d408",
-   "sha256": "0b4pprgqlbcl69whk7rwwdc5zqysxkgk74hmbbfp3r55mfi686ca"
+   "commit": "da71e889b5e890fecbacaeba0a4977c4657b4351",
+   "sha256": "0j5nnrn5ypj4i2ysdfayiky3iai30wjwhdbxakrj5bafcn5051ki"
   }
  },
  {
@@ -56106,14 +56435,14 @@
   "repo": "hhvm/hack-mode",
   "unstable": {
    "version": [
-    20251212,
-    2139
+    20260207,
+    559
    ],
    "deps": [
     "s"
    ],
-   "commit": "86a981bd7bc9929750abc7cea368d58c6ebb86fa",
-   "sha256": "12acw817jnisa68lx845vmnl582fi7bfg3qwqkm0cwn1s7fpa4mi"
+   "commit": "0b117e7f259439e7b5d961ec936d8718a727c13a",
+   "sha256": "0l89hvsdx0igqxj1vvxwry461r459qfs40bv3lhfl32h333n3pq9"
   },
   "stable": {
    "version": [
@@ -56451,6 +56780,21 @@
   }
  },
  {
+  "ename": "hanfix-mode",
+  "commit": "a4b7d982f963aaa6bd26c9ab8df392a9df785bd1",
+  "sha256": "0nv1hnbywkazibsv79z75yf7zqnygqvf2is10zbx7cygyr1qswvl",
+  "fetcher": "github",
+  "repo": "ntalbs/hanfix-mode",
+  "unstable": {
+   "version": [
+    20260202,
+    2111
+   ],
+   "commit": "41f3a942cf7531dcb003932138e00e9ab4fa8214",
+   "sha256": "1llq62havgqnbnx7ibcdxcjwxivyv9q14gc4ikjwg61shqjjd7ni"
+  }
+ },
+ {
   "ename": "haproxy-mode",
   "commit": "cda0e4b350611e60eb2ef5bdb3e660f9e707e503",
   "sha256": "1psvnyia3mcwndqap45356f9lr4iza2kn0snpc06rkhb16410bqh",
@@ -56720,11 +57064,11 @@
   "repo": "haskell/haskell-mode",
   "unstable": {
    "version": [
-    20250930,
-    1728
+    20260206,
+    1050
    ],
-   "commit": "bd89438b0e6e6b6877d635699e265da85e85ca06",
-   "sha256": "0mkxrizxnvl1xdxhxdv01bpqjancbw4vshp69rdhvsiv7gm27nwv"
+   "commit": "2dd755a5fa11577a9388af88f385d2a8e18f7a8d",
+   "sha256": "0p3xxzjfbhf14cp162iqy2jc9xn67lrj5c5wp29qd17bvk1akf7n"
   },
   "stable": {
    "version": [
@@ -56994,11 +57338,11 @@
   "repo": "hdf5-viewer/hdf5-viewer",
   "unstable": {
    "version": [
-    20250901,
-    33
+    20260216,
+    1940
    ],
-   "commit": "cd934811721a36e63cea45fffbf4b3459ad60e15",
-   "sha256": "0qzbcizc8s3izrpcscm478910i9v4iwpjb5pm305azfsfb0gnmq3"
+   "commit": "620abfea368c85e326108328c846a82fea490b77",
+   "sha256": "1s60rag11n260l83gcsdbph9fqyacha5d57q6myfq0xm48cr9nmx"
   }
  },
  {
@@ -57102,15 +57446,15 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20260108,
-    714
+    20260214,
+    1432
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "3065b5d7c42fd2ba23ebd73cb25dc028990fc0bb",
-   "sha256": "11b3z2l8ml4d21fh64gwlzqsk4k8pq4ak6jhck5dzkz6gq4ln469"
+   "commit": "9d8de1e0810ef5a5e1f3a46c9461b78b9e86167b",
+   "sha256": "1h6w4dbq8wvy55d2wlac62q0ljd79pc2ygvkkm1i08af427b5w2m"
   },
   "stable": {
    "version": [
@@ -57913,14 +58257,14 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20260104,
-    1441
+    20260201,
+    507
    ],
    "deps": [
     "async"
    ],
-   "commit": "cbbaff3c5a76b3ab91ba297844acce11980f55fd",
-   "sha256": "05zadb07hgsv4lphssawjsfdwi3c7rq2l6qf8yq5my6g6w372l88"
+   "commit": "dcaa8fb45d4f7d08390d80351a4204f848f2ec90",
+   "sha256": "1hiawmmqg1yvfi1mzjynjbjq2hs2xflzs40a84yk863hzbj056fd"
   },
   "stable": {
    "version": [
@@ -58224,6 +58568,24 @@
    ],
    "commit": "d7da090af0f63b92c5d735197992c732adbeef3d",
    "sha256": "0fs0i33di3liyx1f55xpg5nmac1b750n37g3pkxw2mil7fx7dz32"
+  }
+ },
+ {
+  "ename": "helm-emoji",
+  "commit": "14e1c43392dc8f33ded3c99771c7f9fddb6d421f",
+  "sha256": "1nq7xz71nmvkmf68zjak1042pp0iz28pld4yk4ndifsa856cikmc",
+  "fetcher": "codeberg",
+  "repo": "timmli/helm-emoji",
+  "unstable": {
+   "version": [
+    20260218,
+    1141
+   ],
+   "deps": [
+    "helm"
+   ],
+   "commit": "4c125d3fc42fad0576ff653c0a45ee265498a2c6",
+   "sha256": "0pmgfd3z96abh5lrw608ma8ss0vzpwzb94k5f3dsbhndw8vl0j5q"
   }
  },
  {
@@ -58858,14 +59220,14 @@
   "repo": "emacsorphanage/helm-gtags",
   "unstable": {
    "version": [
-    20260103,
-    1800
+    20260204,
+    1753
    ],
    "deps": [
     "helm"
    ],
-   "commit": "6278f138896585dd60cd954f991cffcc0ebf6440",
-   "sha256": "0471bkm8mv8qh4x69kvz3cayhlyjwg6zi1yxaxl2prs0h5dyn11x"
+   "commit": "bfafd3d4a7f028d42f3f46c3273eaed930269ec6",
+   "sha256": "0rf0ad5rp86xmlsn7hn1rqw1p0l1h2bkb8wrgk5943m6k49kpraf"
   },
   "stable": {
    "version": [
@@ -60261,28 +60623,28 @@
   "repo": "masutaka/emacs-helm-raindrop",
   "unstable": {
    "version": [
-    20250806,
-    1220
+    20260211,
+    606
    ],
    "deps": [
     "helm",
     "request"
    ],
-   "commit": "6c080b1acf51ada473a7252cca7e0a5d812be4b0",
-   "sha256": "1gzfyrj1lv58zlbh6bxaz7csbq6v80h9n7f8bamhsnzn2mdlafia"
+   "commit": "0c87eddc7f15c2046b9b03b83a8a7ee0551a0747",
+   "sha256": "0z3323fq0vvm2n8qy8q3n94k158pmznwxi820wdpl1scjc1rxrmp"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
    "deps": [
     "helm",
     "request"
    ],
-   "commit": "6c080b1acf51ada473a7252cca7e0a5d812be4b0",
-   "sha256": "1gzfyrj1lv58zlbh6bxaz7csbq6v80h9n7f8bamhsnzn2mdlafia"
+   "commit": "0c87eddc7f15c2046b9b03b83a8a7ee0551a0747",
+   "sha256": "0z3323fq0vvm2n8qy8q3n94k158pmznwxi820wdpl1scjc1rxrmp"
   }
  },
  {
@@ -61825,11 +62187,11 @@
   "repo": "DarthFennec/highlight-indent-guides",
   "unstable": {
    "version": [
-    20241229,
-    2012
+    20260202,
+    1243
    ],
-   "commit": "3205abe2721053416e354a1ff53947dd122a6941",
-   "sha256": "1w8qqgvviwd439llfpsmcihjx4dz5454r03957p2qi66f1a7g6vw"
+   "commit": "802fb2eaf67ead730d7e3483b9a1e9639705f267",
+   "sha256": "14clnkp9hvw7l4i2d0pswayvb0cgdls1ff677c07g72qq1qalczs"
   }
  },
  {
@@ -62111,11 +62473,11 @@
   "repo": "dantecatalfamo/himalaya-emacs",
   "unstable": {
    "version": [
-    20241209,
-    1501
+    20260219,
+    1107
    ],
-   "commit": "934e8f8741e3cfff577d7119eceb2cfdb7cff6f3",
-   "sha256": "1pwn91d7x39np5i9b0d0mi48bxqv7d7h4fmg4ifhwgvglzla3r96"
+   "commit": "e308694ef60b211bad2a70c46a1566ef0b985f2e",
+   "sha256": "0hgchf77zf1f4dd2rcdsc02mgmsclksslqp4c0j1hw38vqyf8qav"
   },
   "stable": {
    "version": [
@@ -62134,23 +62496,20 @@
   "repo": "mihaimaruseac/hindent",
   "unstable": {
    "version": [
-    20250909,
-    1613
+    20260124,
+    2208
    ],
-   "commit": "e841f55c37abf6865309083b93eb6214eb100cea",
-   "sha256": "1sp7dzrngn6jhcy020w1akph849cw1rihz1ql5vc48r7c3wrsyz8"
+   "commit": "57e769d48447c77da5a21d1923ba3634e3a605fe",
+   "sha256": "17vpffrrm6a1pfgbk97xl0d51h6141kpd1yqhvwwvzcr5qx5jvgc"
   },
   "stable": {
    "version": [
     6,
-    2,
-    1
+    3,
+    0
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "beafb2610fb9a724bdd78339375e6673d46c23fe",
-   "sha256": "1hx0sj5afy0glxr3lfr6hvnk0iphmfnfg3wilx2s013a5v0drmxc"
+   "commit": "57e769d48447c77da5a21d1923ba3634e3a605fe",
+   "sha256": "17vpffrrm6a1pfgbk97xl0d51h6141kpd1yqhvwwvzcr5qx5jvgc"
   }
  },
  {
@@ -63520,11 +63879,11 @@
   "url": "https://git.savannah.gnu.org/git/hyperbole.git",
   "unstable": {
    "version": [
-    20260111,
-    1646
+    20260220,
+    247
    ],
-   "commit": "b14310df58cc8bd33860e9bf548ee1497dc3fd20",
-   "sha256": "1xxzcr6v4qpmrz9380fil5bik0q45ww8iifgh2bl6ry7fnnpm3sc"
+   "commit": "8af4e68a25623dbe5134053cdadb0c5b06beec9f",
+   "sha256": "1w2h299v8z6gzcw91nl1gcb27p9mixkxqsxnkwgz8c0an1zz8i0j"
   },
   "stable": {
    "version": [
@@ -63693,20 +64052,19 @@
   "repo": "precompute/hyperstitional-themes",
   "unstable": {
    "version": [
-    20260112,
-    2116
+    20260215,
+    1305
    ],
-   "commit": "cc8c33a23116ed112ef9ca3a973597f03dc41459",
-   "sha256": "00mli6mdgrs49ckgq4qwmzgzlsax36harhhhwmb7ab87g5a9jadc"
+   "commit": "b4bf851ea46ad4ddc8c45afc3c2d000d7f13bc4b",
+   "sha256": "1zqcy2zhgp2qfj4k01ns8pc7ff449gyrx4gfwlzny8cgmbv01fkd"
   },
   "stable": {
    "version": [
     3,
-    2,
-    2
+    4
    ],
-   "commit": "cc8c33a23116ed112ef9ca3a973597f03dc41459",
-   "sha256": "00mli6mdgrs49ckgq4qwmzgzlsax36harhhhwmb7ab87g5a9jadc"
+   "commit": "b4bf851ea46ad4ddc8c45afc3c2d000d7f13bc4b",
+   "sha256": "1zqcy2zhgp2qfj4k01ns8pc7ff449gyrx4gfwlzny8cgmbv01fkd"
   }
  },
  {
@@ -64647,15 +65005,15 @@
   "repo": "idris-hackers/idris-mode",
   "unstable": {
    "version": [
-    20251203,
-    1548
+    20260209,
+    1107
    ],
    "deps": [
     "cl-lib",
     "prop-menu"
    ],
-   "commit": "85928dc4cc2c22010fa91661abd55e6bd3dbacee",
-   "sha256": "169a19x861yj18wrkjx4mxm12lvfdzw320f9lddsc2xcsdlrmm5v"
+   "commit": "d32b2396a8ad17820e308cd267f1b464a5235abc",
+   "sha256": "1vldwsmyaazrkcmff6qv5hlprsj37dvj7p01lphg6x20pv63c6av"
   },
   "stable": {
    "version": [
@@ -65129,14 +65487,14 @@
   "repo": "petergardfjall/emacs-immaterial-theme",
   "unstable": {
    "version": [
-    20251222,
-    1352
+    20260219,
+    749
    ],
    "deps": [
     "modus-themes"
    ],
-   "commit": "c478e875d9949a0b8341fa146ea9a408997623f5",
-   "sha256": "0q3462vg46qp03ac870lvg6jl1ri3z9h7gd4b9kazfaj88n13p52"
+   "commit": "4d2920d48f07a7681b9fb98cf27f60bd1611c265",
+   "sha256": "0rd3djmpns1d76i1xrrbaixhzbpnhjj2q7q1cvbxsg6pqc0agavy"
   },
   "stable": {
    "version": [
@@ -65388,11 +65746,11 @@
   "repo": "jcs-elpa/indent-control",
   "unstable": {
    "version": [
-    20260101,
-    600
+    20260128,
+    1027
    ],
-   "commit": "222fa01879c08adc5cc84cef6aa4fcff90c7c938",
-   "sha256": "0w5iq7mnyisa63f3rlcpaqbxy3h428ywxz7rkw5z0v2gbr480l11"
+   "commit": "8bd4a44c2ae51f781bc3b86f09869f71343ca1ff",
+   "sha256": "1371pzd82hyqmnil46kl75s4kq9sgi782gbaa8dl2invgccbs6r3"
   },
   "stable": {
    "version": [
@@ -65412,11 +65770,11 @@
   "repo": "zk-phi/indent-guide",
   "unstable": {
    "version": [
-    20210115,
-    400
+    20260211,
+    1005
    ],
-   "commit": "d388c3387781a370ca13233ff445d03f3c5cf12f",
-   "sha256": "0r303mzxj57l8rclzsmvhnx2p3lhf2k4zvn8a6145wb10jvcwfxi"
+   "commit": "f3455c6c798b568a6ea1013b7eea1153d2e092be",
+   "sha256": "18bmf426xbqlrz448i9aphw69zh8nki1zy1s59l9drz1h5h15n7r"
   },
   "stable": {
    "version": [
@@ -65622,14 +65980,14 @@
   "repo": "clojure-emacs/inf-clojure",
   "unstable": {
    "version": [
-    20250525,
-    2054
+    20260220,
+    1437
    ],
    "deps": [
     "clojure-mode"
    ],
-   "commit": "bdef6110a3d051c08179503207eadc43b1dd4d09",
-   "sha256": "0jcp8w4k37cfivwp1486znf7pz24fikic9qcc05ik0a31iqwna0h"
+   "commit": "be5e9bd90775b35c8bc2ecb118d6af9a521b2d81",
+   "sha256": "19idc5383h2m6ia4zc4mcrhxdh2zlshqm6wxwh9bxqn7gb0hag8b"
   },
   "stable": {
    "version": [
@@ -66024,11 +66382,11 @@
   "repo": "jamescherti/inhibit-mouse.el",
   "unstable": {
    "version": [
-    20260114,
-    1535
+    20260215,
+    2013
    ],
-   "commit": "448a86b679dc4d45ec74f94d1471b51850bfd6b8",
-   "sha256": "0vpcvw317sk5w6v5nwjnbb80lfs27nya186rfhpn2mgzrbg5h0md"
+   "commit": "cffda3c6fe4f662e1438a347259d914db410f2dd",
+   "sha256": "0zylxqiyywllljxjy13cxflnpnklhlx75fqgmdyw2qvf75sby4zy"
   },
   "stable": {
    "version": [
@@ -66190,11 +66548,11 @@
   "repo": "Kungsgeten/ink-mode",
   "unstable": {
    "version": [
-    20201105,
-    2242
+    20260212,
+    923
    ],
-   "commit": "71d215712067729eb92e766a3b2067e7f3254183",
-   "sha256": "00k2jihpk5xi3pnsdcdxhi570lw6acsdpc0impwvm9zq9mw3rik3"
+   "commit": "da2e7144837606f27ea6a5ea6d26229aeb0dd77e",
+   "sha256": "0xskqy4zdxan04kqqwrn8svnskcyswxlwg3smp8n2kpp36dfc284"
   },
   "stable": {
    "version": [
@@ -67244,11 +67602,11 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20251123,
-    1023
+    20260213,
+    1157
    ],
-   "commit": "ec9421340c88ebe08f05680e22308ed57ed68a3d",
-   "sha256": "1i3zpl8kldggvzbkzqmkld2j0cgdqc4wcid9gaz3l7dwmsanwbkp"
+   "commit": "11649c347107cba5f7ef8fd67ad8e77bc3b2472c",
+   "sha256": "0y78pj15yj08a3gndin91vf222wsbg7fzn01gng1cc6cd91hhhhx"
   },
   "stable": {
    "version": [
@@ -67268,15 +67626,15 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20250329,
-    1401
+    20260101,
+    2125
    ],
    "deps": [
     "avy",
     "ivy"
    ],
-   "commit": "e33b028ed4b1258a211c87fd5fe801bed25de429",
-   "sha256": "1yv40k0swdywk0zwxs2s95s4y1pa9k2m3s25fx7gv9pnmf7yw8p1"
+   "commit": "d489b4f0d48fd215119261d92de103c5b5580895",
+   "sha256": "1jady7337ws51y2r78n4mgnijsq8415ga3s5c47f4lpd3d74j2bj"
   },
   "stable": {
    "version": [
@@ -67635,15 +67993,15 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20250329,
-    1401
+    20260213,
+    941
    ],
    "deps": [
     "hydra",
     "ivy"
    ],
-   "commit": "e33b028ed4b1258a211c87fd5fe801bed25de429",
-   "sha256": "1yv40k0swdywk0zwxs2s95s4y1pa9k2m3s25fx7gv9pnmf7yw8p1"
+   "commit": "4defb814ce00fbbc2cf2ad626e630a39f4da1456",
+   "sha256": "0fk05w6fn1780by26hrb9d7hksm0gbfkjp8d9xg49va0y6cq2g28"
   },
   "stable": {
    "version": [
@@ -67792,28 +68150,28 @@
   "repo": "tumashu/ivy-posframe",
   "unstable": {
    "version": [
-    20241023,
-    258
+    20260127,
+    50
    ],
    "deps": [
     "ivy",
     "posframe"
    ],
-   "commit": "660c773f559ac37f29ccf626af0103817c8d5e30",
-   "sha256": "05p2n86a57mdkqkr554maa85n47w8ma0ygszhp9jgfczf9c8qm64"
+   "commit": "ede7b2121f176ab543ce6b73fd96e3eafd6d1505",
+   "sha256": "0v5wbh8jqcgp53h7lqwn9925p3pf8ds4gr1ys0xhqkg28jkynijz"
   },
   "stable": {
    "version": [
     0,
-    5,
-    5
+    6,
+    4
    ],
    "deps": [
     "ivy",
     "posframe"
    ],
-   "commit": "83047d440ff132d5a45acde5955f71853edeefb9",
-   "sha256": "03n1a9qzc53i3lx0ywayc2v8p0n4ydl7ly6niaj9dj15ik0nzxsp"
+   "commit": "ede7b2121f176ab543ce6b73fd96e3eafd6d1505",
+   "sha256": "0v5wbh8jqcgp53h7lqwn9925p3pf8ds4gr1ys0xhqkg28jkynijz"
   }
  },
  {
@@ -68214,15 +68572,15 @@
   "repo": "emacs-jabber/emacs-jabber",
   "unstable": {
    "version": [
-    20260119,
-    1421
+    20260203,
+    211
    ],
    "deps": [
     "fsm",
     "srv"
    ],
-   "commit": "745e5f1354e99bfcee1aa097fb9d198cd701b463",
-   "sha256": "09rz0b8jlw9xpyxx7qfhh5hg5glkxfl1yzmzq2j2bk00iprmx0k0"
+   "commit": "2b9dd87f8a182502383c9d4a72a140b1cc3ec8c2",
+   "sha256": "11a1jiqbyqc846jr271fhpyqg1q0jppmcr5fmy3mfdwry5214y52"
   },
   "stable": {
    "version": [
@@ -68455,11 +68813,11 @@
   "repo": "rudi/jastadd-ast-mode",
   "unstable": {
    "version": [
-    20200926,
-    1820
+    20260209,
+    816
    ],
-   "commit": "a98a5eef274d8eedabc7467874edf4338c9a012e",
-   "sha256": "1wxw36p6835a13ycc7vcj3w9k5zgwqydg0gs667934r502wd0xp9"
+   "commit": "b495089cd15876d5ac83289c5768d67dce3c28cd",
+   "sha256": "0qs4f5msbccyfarkcmyg03ywg9js7kq9b1abh6y54irb9k7wfysa"
   }
  },
  {
@@ -68565,11 +68923,11 @@
   "repo": "DamianB-BitFlipper/javelin.el",
   "unstable": {
    "version": [
-    20260105,
-    1728
+    20260215,
+    1847
    ],
-   "commit": "e58733d6dfb3282d5b6ad4d295e8c71a8e5abc71",
-   "sha256": "198kxmcchmfblxphmwcgki15ymzz0kgmllmkdbgvs48bycpzp8kr"
+   "commit": "e2f1ccad5a7ad0dd38f62773723353081d57bae8",
+   "sha256": "06iggf0l543wz0y6ba7q5l8q1mv0qi3pj5nwymfj7cv0v8jms6a1"
   },
   "stable": {
    "version": [
@@ -69078,14 +69436,14 @@
   "repo": "minad/jinx",
   "unstable": {
    "version": [
-    20260117,
-    1650
+    20260206,
+    847
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b412673dec759131fe0abb346998b55225fbe771",
-   "sha256": "1rkgp1j4pc9i2305fjs20nrvn11dg22rj5vmwf4520baj7asd8m3"
+   "commit": "75e8e4805fe6f4ab256bd59bec71464edbc23887",
+   "sha256": "10yrk5kd3ms27k48m8n8gwg83v557knamb9m1nyfgqhgb5h41vi8"
   },
   "stable": {
    "version": [
@@ -69107,8 +69465,8 @@
   "repo": "unmonoqueteclea/jira.el",
   "unstable": {
    "version": [
-    20251208,
-    1845
+    20260218,
+    721
    ],
    "deps": [
     "magit-section",
@@ -69116,13 +69474,13 @@
     "tablist",
     "transient"
    ],
-   "commit": "3b4b5260d6e6c14fe1fc2bcffe64f3a9b9f30245",
-   "sha256": "0wwzw84qrzzw1bywpfz81x4z9fb84dikxgb5dx4hji97j1s6w21k"
+   "commit": "b578426e7f4d6d4c41a41788053e88e6a5290f84",
+   "sha256": "0hiv8ynygnqv2b5d7s43zab8d75fc34n06jvlm0wscjkq8rkmnkm"
   },
   "stable": {
    "version": [
     2,
-    15,
+    21,
     0
    ],
    "deps": [
@@ -69131,8 +69489,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "3b4b5260d6e6c14fe1fc2bcffe64f3a9b9f30245",
-   "sha256": "0wwzw84qrzzw1bywpfz81x4z9fb84dikxgb5dx4hji97j1s6w21k"
+   "commit": "b578426e7f4d6d4c41a41788053e88e6a5290f84",
+   "sha256": "0hiv8ynygnqv2b5d7s43zab8d75fc34n06jvlm0wscjkq8rkmnkm"
   }
  },
  {
@@ -69946,26 +70304,20 @@
   "repo": "taku0/json-par",
   "unstable": {
    "version": [
-    20250720,
-    619
+    20260131,
+    913
    ],
-   "deps": [
-    "json-mode"
-   ],
-   "commit": "38a3f1f11dd2ab6d195a26818966a5a5e1f74448",
-   "sha256": "1nmkw76dzq5j5jvgdwql1sbzp1a5vl8hsb4pc1ic7ak8n51vqm4h"
+   "commit": "1c0e363a8d28bf66187d082c97370c2fa11adfcc",
+   "sha256": "00jig26gjvbfyiixlmbw2wxspnif73hwrwh9j2firj0kvvmq1zzc"
   },
   "stable": {
    "version": [
     5,
-    0,
+    1,
     0
    ],
-   "deps": [
-    "json-mode"
-   ],
-   "commit": "7b346b0f0db62d65f382ce48a9b2ecd9e180b0d7",
-   "sha256": "1rppp5yi3v3jf90di9jsil18fl00l4qlgandzb3bdrv0j9z2lfqc"
+   "commit": "1c0e363a8d28bf66187d082c97370c2fa11adfcc",
+   "sha256": "00jig26gjvbfyiixlmbw2wxspnif73hwrwh9j2firj0kvvmq1zzc"
   }
  },
  {
@@ -70265,11 +70617,11 @@
   "repo": "llemaitre19/jtsx",
   "unstable": {
    "version": [
-    20251018,
-    1908
+    20260130,
+    2058
    ],
-   "commit": "61df071a7f4761ddb30c33c8225e78f72e68f7ae",
-   "sha256": "0h1f5g44lviv6z7pcssxm9p21r4hl6qq4w3rhnljqawbvf7vq18v"
+   "commit": "f33efef5052b0757287abbea2b877cefca663bf2",
+   "sha256": "11bvxgip5kh3q5kk5xwvxcdl6h7gqaj1rqd5kxc4kzzbaz8msxdv"
   },
   "stable": {
    "version": [
@@ -70307,11 +70659,11 @@
   "repo": "JuliaEditorSupport/julia-emacs",
   "unstable": {
    "version": [
-    20250407,
-    841
+    20260204,
+    807
    ],
-   "commit": "7fc071eb2c383d44be6d61ea6cef73b0cc8ef9b7",
-   "sha256": "1dfls9ggn192xblfyjrbxi007hg4yd25s2cl8zh0v40akpqclhqc"
+   "commit": "aadf29523a120c666939cd7adac4b7dece5bd6ef",
+   "sha256": "0kw79pz3l40d533hhrrw21hskayr38nffnp0cnwjq0zv9fvxwin1"
   },
   "stable": {
    "version": [
@@ -70330,26 +70682,26 @@
   "repo": "tpapp/julia-repl",
   "unstable": {
    "version": [
-    20250719,
-    1449
+    20260211,
+    1502
    ],
    "deps": [
     "s"
    ],
-   "commit": "681efc14a72ece3390137b01c4ee67f317cd8324",
-   "sha256": "1f5wkxjc556vv3fvn0b9vz1kqlgn4438ya3d8cl6if11i6p7gvbg"
+   "commit": "0173237a43d9a42f0d69a5405283fabe1ac602a0",
+   "sha256": "0xq9cg7l4v85h9xwnss38k8j665zzn0kwf4zq8mkn6xxvcf2wq53"
   },
   "stable": {
    "version": [
     1,
-    3,
-    0
+    5,
+    2
    ],
    "deps": [
     "s"
    ],
-   "commit": "7ce38a9caf2a9c105afe66f464a2f30e816d69f3",
-   "sha256": "11vpqqnxqj9nxh8kccj4y6h3f8lib6jxnsk6vxc2j2fqw6alnafm"
+   "commit": "0173237a43d9a42f0d69a5405283fabe1ac602a0",
+   "sha256": "0xq9cg7l4v85h9xwnss38k8j665zzn0kwf4zq8mkn6xxvcf2wq53"
   }
  },
  {
@@ -70690,8 +71042,8 @@
   "repo": "psibi/justl.el",
   "unstable": {
    "version": [
-    20251111,
-    948
+    20260207,
+    411
    ],
    "deps": [
     "f",
@@ -70699,8 +71051,8 @@
     "s",
     "transient"
    ],
-   "commit": "3b11dd8ac7ebeaca5da6c80223254a9f0494b275",
-   "sha256": "1i5m8iqyw7pkc2cjkk6z0px6lqm0w0ad9r1f9i8dhi8v8v7lk70r"
+   "commit": "36e5d5194bfc1ae4bd10663a4533546f0cec6d90",
+   "sha256": "0az6pkjjqlrh6l8rqdrij0nx4bsb3haw3p6jdlvb0qn620rq5glr"
   },
   "stable": {
    "version": [
@@ -71248,6 +71600,21 @@
    ],
    "commit": "f4ee856e7f59649e9d9021c46f872f9b4f5b7e6e",
    "sha256": "0avcg307r4navvgj3hjkggk4gr7mzs4mljhxh223r8g69l9bm6m8"
+  }
+ },
+ {
+  "ename": "kawacode",
+  "commit": "f69990fe63c4e519a39cdc5b27ab31e7727a6884",
+  "sha256": "0nnfs3gl0d79vl655hh82bb38mr4ynn6bjzhfr9cqgr0hhkiyphn",
+  "fetcher": "github",
+  "repo": "CodeAwareness/kawa.emacs",
+  "unstable": {
+   "version": [
+    20260217,
+    2240
+   ],
+   "commit": "713cb959fe82bbc7ca6d96cce7d5779e74f7839c",
+   "sha256": "0wsav2pm095smbbzpvnbvswnsc0cn4fr01fxw4anj838psvhsnyq"
   }
  },
  {
@@ -71927,15 +72294,15 @@
   "repo": "khoj-ai/khoj",
   "unstable": {
    "version": [
-    20260102,
-    359
+    20260222,
+    1956
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "d55a00288bd6257d1b84f2a491ca24fb00530d43",
-   "sha256": "0rh0z021cw5199szvzdylpz6vi17j70l96mkrsmf3yyddgbm7n87"
+   "commit": "94bae4789aca60e5bea67e3f96fbeb2ed39fff72",
+   "sha256": "1242ydicxbr89ckm9igxk2zmz2n89kg4czx8sn0xy3vk9h5cl1d9"
   },
   "stable": {
    "version": [
@@ -72078,20 +72445,20 @@
   "repo": "jamescherti/kirigami.el",
   "unstable": {
    "version": [
-    20260114,
-    1604
+    20260219,
+    1821
    ],
-   "commit": "40ea6e38f3845a4dd081111df0404dd5aca956de",
-   "sha256": "08rg7ppdnhjvj4qcr3w75xk4hisl5991x1q5bn0pnf4cjqa5z2in"
+   "commit": "fa7a52aa87592b86ace66869099d4b34129136db",
+   "sha256": "1srmrjc48kswkwnmcgljhymiqsbl3immy8hc8gamrqsxbdp7rznw"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    4
    ],
-   "commit": "a73e2a79f267f185bb25807947a4a89cdee87164",
-   "sha256": "0qxs5bi97bw5p24znwilwc1ab2zhm571nwhj0qm23sdg4zzxs3w3"
+   "commit": "b2abb0c61a08bf7ecdc194daa3e1efc53947f344",
+   "sha256": "0qjskaqdgaf786v89jm3590vr2rjxqcp7mhjn8i8gha9chvhrsv9"
   }
  },
  {
@@ -72182,14 +72549,14 @@
   "repo": "mew/kixtart-mode",
   "unstable": {
    "version": [
-    20260115,
-    1810
+    20260203,
+    1935
    ],
    "deps": [
     "eldoc"
    ],
-   "commit": "a09f91c6dda7a5eda5f5f0cd382bdcef1519720f",
-   "sha256": "1kn74c1h4c10d7l3c55qnhjxf80cfzqmq9ryx0gbpmg7gvq9ysqf"
+   "commit": "5f5cb16dc76c22d80f69fb9413aa0d877bf13746",
+   "sha256": "06b7p2ka5crvhjifxn42jrchlj8yl545wqnv7cn6zl9jkzx574kb"
   },
   "stable": {
    "version": [
@@ -72330,11 +72697,11 @@
   "repo": "gynamics/koishi-theme.el",
   "unstable": {
    "version": [
-    20251222,
-    1209
+    20260212,
+    1605
    ],
-   "commit": "68e265b379c6d1790fa0dc4a9665cbc6c4df1ccf",
-   "sha256": "0v1nig63c3clcqk4cqqwf0ip100ariji7irz5mdb7ggdxrkympdp"
+   "commit": "e699d5181265981d28f1bd3c13446916c77aeb06",
+   "sha256": "110bxq56997srjmwpc8vb3jiblf3bgs8xc5585ksh6b9q1av1d3j"
   }
  },
  {
@@ -72393,11 +72760,11 @@
   "repo": "tttuuu888/korean-holidays",
   "unstable": {
    "version": [
-    20190102,
-    1558
+    20260131,
+    1013
    ],
-   "commit": "3f90ed86f46f8e5533f23baa40e2513ac497ca2b",
-   "sha256": "0y88b4mr73qcshr87750jkjzz1mc2wwra6ca3y8spv4qc6cadwls"
+   "commit": "9fffbad583cb1ad97bdc31ebf908cc663a1c4d29",
+   "sha256": "03czdiznmy7car43v0niwfyi4vh5piyqbi0pkg94dgzzv3z8iskc"
   }
  },
  {
@@ -72438,11 +72805,11 @@
   "repo": "bricka/emacs-kotlin-ts-mode",
   "unstable": {
    "version": [
-    20250617,
-    843
+    20260224,
+    1344
    ],
-   "commit": "051c9ef534956c235343fb41546623ff87a1695b",
-   "sha256": "03x9522fmfads4iknsgdj7b1f86cn4j4wly0y1vv162zscp8441m"
+   "commit": "b318a64a7f6b35fa5abf93b8e86cc42305fa7552",
+   "sha256": "0s4knich3naql7q0xr0yjdj7vxypczdvd9ndkj72p5wj8wa5a2kz"
   }
  },
  {
@@ -72598,8 +72965,8 @@
   "repo": "abrochard/kubel",
   "unstable": {
    "version": [
-    20251009,
-    310
+    20260223,
+    1935
    ],
    "deps": [
     "dash",
@@ -72607,8 +72974,8 @@
     "transient",
     "yaml-mode"
    ],
-   "commit": "48a2dabac24921c89e95039d1a8e5a52568baa02",
-   "sha256": "08y4jq0c7cql187bai1ws64icsiq91lfz1d0d1mvxs7yn2xmjvsq"
+   "commit": "e2664f040eb71dba8ba2cbd4fccfe64842f0efb5",
+   "sha256": "0s9dv3g0l5wqxhl5vaiqj1i2hm18f7pvmyq31gqzvkl9v2k5x4f9"
   },
   "stable": {
    "version": [
@@ -72906,8 +73273,8 @@
   "stable": {
    "version": [
     3,
-    0,
-    1
+    5,
+    0
    ],
    "deps": [
     "async-await",
@@ -72917,8 +73284,8 @@
     "request",
     "s"
    ],
-   "commit": "a29b3ccadeab31b6582fedd0e35e5bf46c96fc64",
-   "sha256": "1c8nmj7m0c3j1pdrp7dgcx0kfv9vrjsam0vw4b82k7pxl3k3dcc7"
+   "commit": "547d9dd773dd3747c4345cf0b9111ac0ed8c14b4",
+   "sha256": "0picg91kraym4b26ay9iy7bibmfvdpl6xlrgrm6x7jsnvsxi66xf"
   }
  },
  {
@@ -73007,16 +73374,16 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20250716,
-    1143
+    20260203,
+    1712
    ],
    "deps": [
     "eglot",
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "f73c64dbeebf850ecc3384d64f0dbf93a1ea6acd",
-   "sha256": "1rk6rmks1818rgl1jmvcs1j8ydm5sqbwlgmb9rp9jj4kx9njxs1a"
+   "commit": "4fd4704bf77395de8c6abace30b87e5aabbf8132",
+   "sha256": "1adw8pcqis55ffvzp60h8c1y011ix5qb1kszgjvvh0ksfs9i3qwy"
   },
   "stable": {
    "version": [
@@ -73242,8 +73609,8 @@
   "repo": "mihaiolteanu/lastfm.el",
   "unstable": {
    "version": [
-    20211018,
-    838
+    20260130,
+    1102
    ],
    "deps": [
     "anaphora",
@@ -73252,8 +73619,8 @@
     "request",
     "s"
    ],
-   "commit": "b4b19f0aadc5087febeeb3f59944a89c4cdcf325",
-   "sha256": "0yp6gzxs6hxfqhdwhp5vldjsxl1y6qvj4i3s5fdvcf0sjdjncvxw"
+   "commit": "d095474f2264174396e36148bac3ced80382d061",
+   "sha256": "0ksx0ssk20ymwh94nrc6907d4mc4wbm77xqhc3875ng3xlfqppc4"
   },
   "stable": {
    "version": [
@@ -73425,15 +73792,15 @@
   "repo": "enricoflor/latex-table-wizard",
   "unstable": {
    "version": [
-    20230903,
-    2104
+    20260212,
+    2229
    ],
    "deps": [
     "auctex",
     "transient"
    ],
-   "commit": "b55d215dbef321194dbf10553d4c0d3b244a50f0",
-   "sha256": "0ay07w6pvhh1r2zkyz8lzd71h2qkvcc58xd6sc0pcl0s2i7qfwy5"
+   "commit": "681c03010e38e8cb4089171be72d73e6d28cd472",
+   "sha256": "1v5dwidr9gvlqdspalr1iqw7gdcyl6lyji4cl8dddj9rmyf3x8rw"
   },
   "stable": {
    "version": [
@@ -73602,6 +73969,21 @@
   }
  },
  {
+  "ename": "lazy",
+  "commit": "c2e3f79ed1c0c3564757b2186df98b2843f1c6ad",
+  "sha256": "16x67w647jg6ss0gii6l1xw7mrjrikprnbyrlhz22hwpwrnf3h9n",
+  "fetcher": "github",
+  "repo": "conao3/lazy.el",
+  "unstable": {
+   "version": [
+    20260128,
+    1547
+   ],
+   "commit": "c9c70fb7f157148e9d08462e93240ada73e365ae",
+   "sha256": "03rncxbbx59zpfxpv18xc4bf70kfhn1a9czcyylhgg2y3djq6x2c"
+  }
+ },
+ {
   "ename": "lazy-ruff",
   "commit": "fa727e3b6572b6c5c6469e06b4b6083b87047823",
   "sha256": "07bp5ris4wr8dhbn55nj6zynd7dw5476dnjj1slz9z3yq15frmkh",
@@ -73692,14 +74074,14 @@
   "repo": "AnselmC/le-gpt.el",
   "unstable": {
    "version": [
-    20251203,
-    1304
+    20260202,
+    1935
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "a05675c3855fe9a5fd3e4a14b9737df22fcfddbe",
-   "sha256": "0dvfb1wlhi1y3dqqwl5wg4zp1iwiy865r7xwqvpn4xhx70mnmdi4"
+   "commit": "dd5e0cdec646adb3fb638d837e6d8fb61a2602f1",
+   "sha256": "0nh15ii69xpwxny2mc4bm77ka4wg9xagdi8ixxap5546zirqqbr1"
   }
  },
  {
@@ -74260,20 +74642,20 @@
   "repo": "fniessen/emacs-leuven-theme",
   "unstable": {
    "version": [
-    20251223,
-    1627
+    20260213,
+    1052
    ],
-   "commit": "1711662e934debdfa00884ebe23b8fc00f78a191",
-   "sha256": "074x226l2hscc82naqy9ws49mp038f6adn4r4b5x300nbzd8kjnl"
+   "commit": "c3546e6a84c138fd8cdbd33998fefcf834c45018",
+   "sha256": "0lrgbhqr8v59f6brcd21a9answgax7gii0pwqblf889x7js5jd0z"
   },
   "stable": {
    "version": [
     2,
-    5,
-    422
+    6,
+    213
    ],
-   "commit": "d84b1d8b435a517b7daf70d341784245fde1e8c0",
-   "sha256": "1y52vgfwy7qqyz1cnm82l9i0nr6658j3cnmwnnrzsj052272lyw6"
+   "commit": "c3546e6a84c138fd8cdbd33998fefcf834c45018",
+   "sha256": "0lrgbhqr8v59f6brcd21a9answgax7gii0pwqblf889x7js5jd0z"
   }
  },
  {
@@ -74617,25 +74999,25 @@
  },
  {
   "ename": "lichess",
-  "commit": "c5d9b5b9a3b682887441abbfbf966a4a4f1e2ce6",
-  "sha256": "1zxgwyb4yz16sxx45y3j1ss65fbb0m0pd4iqrn02a7z2ivlfky2x",
+  "commit": "cfae2a6280c182d0f24ef2e6c961793b841425d5",
+  "sha256": "0d3zbhnb3lx02ymg718lnl2b14fqw283bz0i78r1m5dx5qm2f0qf",
   "fetcher": "github",
-  "repo": "tmythicator/Lichess.el",
+  "repo": "tmythicator/lichess.el",
   "unstable": {
    "version": [
-    20260119,
-    946
+    20260203,
+    1027
    ],
-   "commit": "c0bd061a8759f436fb57a7f8a7ed379749dee6f0",
-   "sha256": "0lrc4rz9r7mh25jvb4b7jibxlq7mz2kcn16fd89b9yy8byx7bx87"
+   "commit": "1dd8a25ede7144c5d6be1f45f4ae3d07903783cd",
+   "sha256": "157l4crbz37x367m69sxwvnd1pd8cqa6w0lcvyyvs27cm021d2gr"
   },
   "stable": {
    "version": [
     0,
-    5
+    8
    ],
-   "commit": "c0bd061a8759f436fb57a7f8a7ed379749dee6f0",
-   "sha256": "0lrc4rz9r7mh25jvb4b7jibxlq7mz2kcn16fd89b9yy8byx7bx87"
+   "commit": "1dd8a25ede7144c5d6be1f45f4ae3d07903783cd",
+   "sha256": "157l4crbz37x367m69sxwvnd1pd8cqa6w0lcvyyvs27cm021d2gr"
   }
  },
  {
@@ -75133,6 +75515,21 @@
    ],
    "commit": "ff745a937f79df51cac0209b3cc3c35ce1d1fc61",
    "sha256": "0ffwjv5fpzia772iavn9ily5m7l73pxf0amgqizzmbx12rx3kkhg"
+  }
+ },
+ {
+  "ename": "lisp-semantic-hl",
+  "commit": "079b156919ffcef70ae7b63cd13127cbf9634c14",
+  "sha256": "0720fix1jc54pdknsjasizxgixh0mgrhy6b47xd0wrawrhg1vmki",
+  "fetcher": "github",
+  "repo": "calsys456/lisp-semantic-hl.el",
+  "unstable": {
+   "version": [
+    20260223,
+    521
+   ],
+   "commit": "0474bfab3ae6b0d76425e117e6ae4fe9b0f04b54",
+   "sha256": "015z8cidlqbi9mb3msa129lhcpr384gdajfifj3ypgv4fjj5a1hb"
   }
  },
  {
@@ -75658,20 +76055,20 @@
   "repo": "donkirkby/live-py-plugin",
   "unstable": {
    "version": [
-    20260101,
-    1741
+    20260222,
+    40
    ],
-   "commit": "dab6ce73500602a5230a0115a9531e5729ce88ef",
-   "sha256": "0xkrbb89z9g9j8m221cwhzxkja51l61lkg3cm6kfin7sspy0wip4"
+   "commit": "e3d1436a7c279084587b40534f96cfd33aff25b4",
+   "sha256": "0rvnanq6dslnkx6vyb20sn6hsbzqa2rfcabws9dy9dyig98ahnf9"
   },
   "stable": {
    "version": [
     4,
-    12,
-    0
+    13,
+    3
    ],
-   "commit": "b417ad93191e8eecaca347f5407dd4bb4c07b6f8",
-   "sha256": "101dd0b1czc28yjsdz0fdvkh8b76rd03a1br7sldlmsy3dfhk669"
+   "commit": "e7fdd3e28550e6983a301437e837836fecae3d3a",
+   "sha256": "0i8jdps02lwiniqlhdf1vgx6ddgx346ibyscyl1zphhvp6fv177f"
   }
  },
  {
@@ -75772,14 +76169,14 @@
   "repo": "tarsius/llama",
   "unstable": {
    "version": [
-    20260101,
-    1830
+    20260217,
+    2104
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2a89ba755b0459914a44b1ffa793e57f759a5b85",
-   "sha256": "1fcribk74shqz757b8i4cybpia7j3x886lxfa5vlzxc3wwlf3x37"
+   "commit": "de61773fc378d40f478f8daf67543a51889ecded",
+   "sha256": "12a7k3qkjycksni7cl99bx9fw6fglnxga4jzzgh942si1p31mmc2"
   },
   "stable": {
    "version": [
@@ -76271,16 +76668,16 @@
   "repo": "doublep/logview",
   "unstable": {
    "version": [
-    20251104,
-    1725
+    20260218,
+    2013
    ],
    "deps": [
     "compat",
     "datetime",
     "extmap"
    ],
-   "commit": "9c97221dd04d7398df098e9f942efff016b60bbf",
-   "sha256": "0rvm37j403x5ymd1n4s3xryl7cp7rpfsg11jbcajbpavdhk8nmq9"
+   "commit": "50cac3f726abd4e7872b8fa36ede72550ce66a64",
+   "sha256": "0wk8945b2drkc93paqb2p8gc1amy906dzndrlgyv4sc681fn111b"
   },
   "stable": {
    "version": [
@@ -76340,6 +76737,21 @@
    ],
    "commit": "280a47e0bf02ee3abc7c5b6b14345056f41981f9",
    "sha256": "1j51h2j0n6mkglalrp1mirpc1v7mgrfxfd1k43rhzg800rb4ahhr"
+  }
+ },
+ {
+  "ename": "lonelog",
+  "commit": "64acc728bddbda7cef36599e8c85ec4da7c05d5c",
+  "sha256": "1wl65lm5d01v86sldvwwsmsqsbmbvxc16b4w7rvvjnmncb8jk754",
+  "fetcher": "github",
+  "repo": "Enfors/lonelog",
+  "unstable": {
+   "version": [
+    20260225,
+    807
+   ],
+   "commit": "068b03d0047a4cba674dd3463b05fb5fd4a51e19",
+   "sha256": "1jgwa59ac5mrc80m8gybsqcxl22328nl37rl9yzxvb9vy169kp5s"
   }
  },
  {
@@ -76430,8 +76842,8 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20260110,
-    2353
+    20260222,
+    1609
    ],
    "deps": [
     "compat",
@@ -76439,8 +76851,8 @@
     "seq",
     "stream"
    ],
-   "commit": "7996ae466a321c1244903f2c579056d86a9db7a4",
-   "sha256": "03xa954pls07d9bvfcfyyhqd7q5n3jqk136yqrld6vz63c26zsvk"
+   "commit": "07ff6c900fbe9fd218a5602974507e81c3165f6d",
+   "sha256": "0s6znxib8fn7abj6wlhqlvqxam7r8cyrh2070b6kja3i52bjan43"
   },
   "stable": {
    "version": [
@@ -76588,8 +77000,8 @@
   "repo": "emacs-lsp/lsp-dart",
   "unstable": {
    "version": [
-    20250301,
-    2106
+    20260214,
+    2354
    ],
    "deps": [
     "dap-mode",
@@ -76601,8 +77013,8 @@
     "lsp-mode",
     "lsp-treemacs"
    ],
-   "commit": "2170823139269b77c39e3bf7600ff6c751a73b0d",
-   "sha256": "1g66pxq9cfhbk3gnp581y1frhmrraw8b4wcpvmw9xgimnf0k0y1p"
+   "commit": "166e4f2ba12403da5691d352b587c88d24ddb574",
+   "sha256": "177l32r1ns8rxq5z8qa5k5nv3v4l29zps9xn4ps196298phd253a"
   },
   "stable": {
    "version": [
@@ -77044,8 +77456,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20260119,
-    1235
+    20260224,
+    1434
    ],
    "deps": [
     "dash",
@@ -77056,8 +77468,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "7642778d595f0158d17740e40a47646cfecbe96a",
-   "sha256": "002402x4ba6fn6cdg2nh39c71hdwgvg0v9kq96d6a7k7gnafp9yh"
+   "commit": "3e55ca80712d66f2fc38bad514b5e2521751433d",
+   "sha256": "1mj015973i8s146cx93vni80wjqlvlr5is0qvzxin6s9vghfv1hl"
   },
   "stable": {
    "version": [
@@ -77867,14 +78279,14 @@
   "repo": "kmontag/macher",
   "unstable": {
    "version": [
-    20260107,
-    2043
+    20260203,
+    2055
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "eb9c108e400fe8bbb3c8724f45ef6bd0d2a2ae33",
-   "sha256": "17zm8apiyyb29xzqbgnqfqf82nlcfmx43sh7m413s23g584cnm6y"
+   "commit": "16672b88967c3ea452d8670285e2ab7fc705ce17",
+   "sha256": "10wz9rdyb3lx7g69wnf7gb305nzgjss9a0rln9ycy54dnhdcwzhp"
   },
   "stable": {
    "version": [
@@ -78104,15 +78516,15 @@
   "repo": "roadrunner1776/magik",
   "unstable": {
    "version": [
-    20251006,
-    1327
+    20260128,
+    1624
    ],
    "deps": [
     "compat",
     "yasnippet"
    ],
-   "commit": "069a1d630f63f6822607c59ae171ad7be6219631",
-   "sha256": "0mv12nihkwpqirmz5br1rczqnkr50ln4b3dw60kp0s4lc4054fkp"
+   "commit": "b1fc21f82e9d4bd3948589cee9491cf48a138934",
+   "sha256": "0aqq6qirzy9vjbabb4pqshi6iv45g7ryny7j1z1azdncb4a8rdlc"
   },
   "stable": {
    "version": [
@@ -78136,8 +78548,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20260116,
-    1722
+    20260221,
+    1634
    ],
    "deps": [
     "compat",
@@ -78148,8 +78560,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "fe0c43b6f5b3b20fce9ed30d203bf1267831b14f",
-   "sha256": "0nps2q7lfqvvjsca7vxvmk7j7crwvm18j08dy48yy4bn72h5nqhg"
+   "commit": "0376b01d7d2036666dc3e0bc318a235fd88a2686",
+   "sha256": "15llbr0nl4kk2p42wd702kaghdjym93hwwffkfx6c9dwi8vp6cm3"
   },
   "stable": {
    "version": [
@@ -78350,6 +78762,25 @@
   }
  },
  {
+  "ename": "magit-gh",
+  "commit": "c5ea23de161c9296577e7d083e05ca6a4d0e520c",
+  "sha256": "09pysax2fzv9fdcwj725pviidfdc63a9nrws6rp5m1k4zp9irvif",
+  "fetcher": "github",
+  "repo": "jonathanchu/magit-gh",
+  "unstable": {
+   "version": [
+    20260221,
+    522
+   ],
+   "deps": [
+    "magit",
+    "transient"
+   ],
+   "commit": "5b3cb8f367e3d9fbb5d9593683b492bd7b5399c7",
+   "sha256": "15nyflvr86cpd2ym57jfkg6fav2r4npvdri93gjbpfyhqxs9xyv6"
+  }
+ },
+ {
   "ename": "magit-gh-pulls",
   "commit": "9b54fe4f51820c2f707e1f5d8a1128fff19a319c",
   "sha256": "0qn9vjxi33pya9s8v3g95scmhwrn2yf5pjm7d24frq766wigjv8d",
@@ -78383,6 +78814,25 @@
    ],
    "commit": "d526f4c9ee1709c79f8a4630699ce1f25ae054e7",
    "sha256": "11fd3c7wnqy08khj6za8spbsm3k1rqqih21lbax2iwvxl8jv4dv0"
+  }
+ },
+ {
+  "ename": "magit-git-toolbelt",
+  "commit": "27e995c65b369c1dd0addba2c00f2e57313fb2d5",
+  "sha256": "0ns9bkffvc4fj0cqfhbjx7y3hz7n53b4hlbqp1kpdxa8qklz25d7",
+  "fetcher": "github",
+  "repo": "jonathanchu/magit-git-toolbelt",
+  "unstable": {
+   "version": [
+    20260202,
+    325
+   ],
+   "deps": [
+    "magit",
+    "transient"
+   ],
+   "commit": "acf0942bb95ec5c913c35415377d168e38e77e16",
+   "sha256": "0rm5ajhyg3vhsx8fx5fbgy2frqc04qaxr6njfbq3w76kdb3cdfyb"
   }
  },
  {
@@ -78678,6 +79128,38 @@
    ],
    "commit": "d8585fa39f88956963d877b921322530257ba9f5",
    "sha256": "0znp6gx6vpcsybg774ab06mdgxb7sfk3gki1yp2qhkanav13i6q1"
+  }
+ },
+ {
+  "ename": "magit-pre-commit",
+  "commit": "523e1d51a992d5313979520338534ec6b712d50a",
+  "sha256": "1kg0gcbii2ni04sj96bq49vscbmd0as4k8n1s0xil21ng0qd4vni",
+  "fetcher": "github",
+  "repo": "DamianB-BitFlipper/magit-pre-commit.el",
+  "unstable": {
+   "version": [
+    20260215,
+    1854
+   ],
+   "deps": [
+    "magit",
+    "yaml"
+   ],
+   "commit": "406d14e364b11a3a7f5240b2bcb904a3c9c10cc9",
+   "sha256": "06z8kdf1f4ybaxa24s0mp4i57jh45dpw2gipni4jxdzwhxxh2dq0"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "magit",
+    "yaml"
+   ],
+   "commit": "1b4056fc72c64b12aa2ac799d69a100aec253e39",
+   "sha256": "0955qpvj6dg3daqgl1j66swg3d5kgbnhpbwqhr35ysf8xi47svkk"
   }
  },
  {
@@ -79015,6 +79497,25 @@
    ],
    "commit": "605b01505ba30589c77ebb4c96834b5072ccbdd4",
    "sha256": "1hqz26zm4bdz5wavna4j9yia3ns4z19dnszl7k0lcpgbgmb0wh8y"
+  }
+ },
+ {
+  "ename": "magnus",
+  "commit": "281edae7ce887e370cc96175e4a2fde7ca09d62d",
+  "sha256": "1jj4m69k2al89131pgk6wgwf67cjpwva3cpc4fp5l13jzmxsj6cq",
+  "fetcher": "github",
+  "repo": "hrishikeshs/magnus",
+  "unstable": {
+   "version": [
+    20260225,
+    413
+   ],
+   "deps": [
+    "transient",
+    "vterm"
+   ],
+   "commit": "56cec058a0e368c77c727577d3e1453d0ae7b6bc",
+   "sha256": "1xzimslbf52vnc34gxhgl33949s5vr4x35hcs30ln3h5lmv427r0"
   }
  },
  {
@@ -79375,11 +79876,11 @@
   "repo": "choppsv1/emacs-mandm-theme",
   "unstable": {
    "version": [
-    20250726,
-    1920
+    20260208,
+    1754
    ],
-   "commit": "5b8ccb687b56ce143d3f60f59a681e6ca2e90956",
-   "sha256": "03mjn7dkh246w92aiw1f63wmkckjkk0kbvcp8xg8ha1wdgwq2cl0"
+   "commit": "217775591a4b2f8e531f745e6a9fb6cea6153bd7",
+   "sha256": "1shwijj2sak80pv9rs4qyyvxgnvm9jggzpqqnq038j1pg0fsd49s"
   }
  },
  {
@@ -79497,25 +79998,40 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20260119,
-    2125
+    20260220,
+    1149
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e980b562e5b5f6db0851675eb6576d4c4b228540",
-   "sha256": "12yik11xdsh4sl6g3vwpagz16bbahnlrfbqrjpiiqjvd51hzak4l"
+   "commit": "142e4da1bd76dc5bdbbfd15532571b8a271e680e",
+   "sha256": "18f58v9pa7sa3552jpwma1j9z0ypi3409byprxaisvbqsdwzq4xi"
   },
   "stable": {
    "version": [
     2,
-    8
+    9
    ],
    "deps": [
     "compat"
    ],
-   "commit": "79c1dc2c63f710f7aad900881da49930af43d729",
-   "sha256": "0fni7zs7az5ljpvd7ianbd26h9qwwsmmwwsc0b6l6ahy94sbza6p"
+   "commit": "0d08fbea0f1182627891240780081ba528c1348b",
+   "sha256": "0l77djsjamfnn8064gb2z9m3wxcyxcfnfyk5sjm8w82hqd73410f"
+  }
+ },
+ {
+  "ename": "mark-graf",
+  "commit": "665572faa09f3f04858d6d6e796a6fcac68e392a",
+  "sha256": "092g11fpgimw7gplbqkyy18qi66zxhyjyngrll40ww50fwlj4a2g",
+  "fetcher": "github",
+  "repo": "hyperZphere/mark-graf",
+  "unstable": {
+   "version": [
+    20260222,
+    753
+   ],
+   "commit": "0e1c502bd577f5b800c8bc04b15ac510d4c4b4a9",
+   "sha256": "0h3668s8i7qm0zahdy8y0vwqwg8gi80d24jf17r3k10wqfyqwwsp"
   }
  },
  {
@@ -79657,11 +80173,11 @@
   "repo": "jrblevin/markdown-mode",
   "unstable": {
    "version": [
-    20251204,
-    852
+    20260209,
+    459
    ],
-   "commit": "92802fae9ebbc8c2e4c281c06dcdbd74b8bca80e",
-   "sha256": "1qiy6pi7pl1a70axqrs86yysn3nglgjj63k7kdlrnhkwbs38fi6i"
+   "commit": "9de2df5a9f2f864c82ec112d3369154767a2bb49",
+   "sha256": "190ydqc3m9wyd5qpnic20axr3kbj0crwghn0gqjprq8b00qh7f3a"
   },
   "stable": {
    "version": [
@@ -79765,16 +80281,16 @@
   "repo": "ardumont/markdown-toc",
   "unstable": {
    "version": [
-    20251210,
-    2018
+    20260131,
+    1444
    ],
    "deps": [
     "dash",
     "markdown-mode",
     "s"
    ],
-   "commit": "29e5c0f33ed026a5f993e4211f52debd7c02b3ba",
-   "sha256": "12p9i6sah599lzpki4276g0lla137klnq796n11wkr0cas1rgbyg"
+   "commit": "d22633b654193bcab322ec51b6dd3bb98dd5f69f",
+   "sha256": "1f9is32gk8v5cf2212fpg0zsvlb741a0r0m4xbiyzmnfv0yv30rn"
   },
   "stable": {
    "version": [
@@ -80017,14 +80533,14 @@
   "repo": "deirn/mason.el",
   "unstable": {
    "version": [
-    20260107,
-    1801
+    20260209,
+    1847
    ],
    "deps": [
     "s"
    ],
-   "commit": "47b6e24820fb65bc934fca3ebc17d215e9db9893",
-   "sha256": "17l921aw8a145hbg0viwa7kafk8w4k20xfbyf17kkvdzwlgvv30i"
+   "commit": "fe149182385e1f4c957c783e7c78fa6dc837809f",
+   "sha256": "0ydijn049lwjnhfd558n5bpy0hxrg17cgav54d4pfbhk2xvcp97j"
   }
  },
  {
@@ -80194,20 +80710,20 @@
   "repo": "mathworks/Emacs-MATLAB-Mode",
   "unstable": {
    "version": [
-    20251229,
-    1750
+    20260222,
+    2111
    ],
-   "commit": "1e6ec79fa69d51c405000caef270a6944ef9cdc5",
-   "sha256": "0bd5i6609rczn4n3w1dgln6z6ii7crwj7zgdvn4dgkvchl57jrj2"
+   "commit": "67dad7af8a04723593fe096d416b21690ce65e31",
+   "sha256": "1v20rqzs24wz7jc5r3i8akw0cyqj47k3c20n769mb19xjrad8k4a"
   },
   "stable": {
    "version": [
-    7,
-    4,
-    0
+    8,
+    1,
+    1
    ],
-   "commit": "d49fa62458208140c67970e9c2ec7f5591f40b1c",
-   "sha256": "18akq8bwrxpcw5ajg0kqd3dq4qlv03j300spy6mw5cr66gfva2g9"
+   "commit": "e6923314f3ffb291e45ece6b1ce08a0961e31adb",
+   "sha256": "0x34gqpcx1k387h3kn3gam1n2x79idqiq44vcrr98ims2zix812g"
   }
  },
  {
@@ -80449,14 +80965,14 @@
   "repo": "lizqwerscott/mcp.el",
   "unstable": {
    "version": [
-    20251219,
-    314
+    20260222,
+    1058
    ],
    "deps": [
     "jsonrpc"
    ],
-   "commit": "125e0a4478ff1404880ea4e593f5e4ff0122cb83",
-   "sha256": "02rapj0vgnml518hr1vxvv7bljpa6ldcnxi676gysng2p1kn4f0q"
+   "commit": "5c105a8db470eb9777fdbd26251548dec42c03f0",
+   "sha256": "03npn50zfc3f0w30d47qqwxzky7ambd03arf94w025ilcfbc4dmm"
   }
  },
  {
@@ -81063,11 +81579,11 @@
   "repo": "abrochard/mermaid-mode",
   "unstable": {
    "version": [
-    20250718,
-    1858
+    20260217,
+    1737
    ],
-   "commit": "9535d513b41ed11bcd91f644815e2db6430c1560",
-   "sha256": "174xlsm316rpxm8sbxfnyhvy1bjkl0qbx71s1mfcyda737y3dsbl"
+   "commit": "3b972164bf6a20b2f51607791b1e593ffa1e63cc",
+   "sha256": "0v9z7a4g5s7b2wrc3105bfr6wzilczvzv14vrwa3cpjdhyd8gdbi"
   }
  },
  {
@@ -81206,16 +81722,16 @@
   "repo": "seblemaguer/metal-archives.el",
   "unstable": {
    "version": [
-    20260101,
-    1230
+    20260202,
+    1028
    ],
    "deps": [
     "alert",
     "ht",
     "request"
    ],
-   "commit": "da7c1efcc3d4859019de8fa030899fe191e33608",
-   "sha256": "16ic9i6dbxym4wnxjhd87wa0zp8ylwqwlknzrzzrmgg37fp4i0gq"
+   "commit": "eb1c4d84f04f4afc7a1c2a0f3c4f816f16fa85e6",
+   "sha256": "0za5a7w4yzwwz8qfj5fm3ga2k9x1q42k9f1ary72d5rr5zcqq70f"
   }
  },
  {
@@ -81226,8 +81742,8 @@
   "repo": "seblemaguer/metal-archives.el",
   "unstable": {
    "version": [
-    20251204,
-    1858
+    20260202,
+    1028
    ],
    "deps": [
     "alert",
@@ -81235,8 +81751,8 @@
     "metal-archives",
     "org-ml"
    ],
-   "commit": "b4924354481b853a6fee58b2817a6b0a3e1674b7",
-   "sha256": "1rpgiqylivcd22dvj8sr01b1wzq7zzc2gr8d9mscpdclzq6r54ib"
+   "commit": "eb1c4d84f04f4afc7a1c2a0f3c4f816f16fa85e6",
+   "sha256": "0za5a7w4yzwwz8qfj5fm3ga2k9x1q42k9f1ary72d5rr5zcqq70f"
   }
  },
  {
@@ -81440,20 +81956,20 @@
   "repo": "purpleidea/mgmt",
   "unstable": {
    "version": [
-    20251028,
-    2100
+    20260222,
+    1339
    ],
-   "commit": "7079121217a345c45a31f4f75f6f3b1c0d92a84e",
-   "sha256": "1adzafq6ifpm9d51qvy1b5nkrd39s0f1z4lhlyaajfn5dj8llbs2"
+   "commit": "2a08fa18cd3d0ba4a6433bdd9c4c0f3e85ed7528",
+   "sha256": "0576pmm5cya802p4kw0d1g0fv95ng8jzzgaiw6x9xb86p3vkifcw"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
-   "commit": "7079121217a345c45a31f4f75f6f3b1c0d92a84e",
-   "sha256": "1adzafq6ifpm9d51qvy1b5nkrd39s0f1z4lhlyaajfn5dj8llbs2"
+   "commit": "2a08fa18cd3d0ba4a6433bdd9c4c0f3e85ed7528",
+   "sha256": "0576pmm5cya802p4kw0d1g0fv95ng8jzzgaiw6x9xb86p3vkifcw"
   }
  },
  {
@@ -81494,20 +82010,20 @@
   "repo": "daut/miasma-theme.el",
   "unstable": {
    "version": [
-    20260113,
-    1800
+    20260124,
+    2048
    ],
-   "commit": "998aa50769722f1a92f99124d76a1689c2d9eaf1",
-   "sha256": "1zhs482f0j0wjg3mwps3g6nlrw67f2wyab2wcqxg41inxb7msm9v"
+   "commit": "313678cfe8cb386f2240ed62d91495bb65e1fc2b",
+   "sha256": "0zwgzahllf7hsvpx0p9bdfnxq076y8fsgrzwqmxygfm6w0vi2b3a"
   },
   "stable": {
    "version": [
     1,
     6,
-    6
+    7
    ],
-   "commit": "998aa50769722f1a92f99124d76a1689c2d9eaf1",
-   "sha256": "1zhs482f0j0wjg3mwps3g6nlrw67f2wyab2wcqxg41inxb7msm9v"
+   "commit": "313678cfe8cb386f2240ed62d91495bb65e1fc2b",
+   "sha256": "0zwgzahllf7hsvpx0p9bdfnxq076y8fsgrzwqmxygfm6w0vi2b3a"
   }
  },
  {
@@ -81658,25 +82174,19 @@
   "repo": "countvajhula/mindstream",
   "unstable": {
    "version": [
-    20250821,
-    2237
+    20260218,
+    312
    ],
-   "deps": [
-    "magit"
-   ],
-   "commit": "f76934cdda1c5aa3cf6e64c7ffab350ee97bc22d",
-   "sha256": "1rpclgn126dw1h86cx7zh181sc03ixa7pd9hzjhiw1p03kd0l45p"
+   "commit": "6b51036a069379d18538a7cca5274c21666a5979",
+   "sha256": "0j82dm2mj49fs2q6qklhfimv1gvy6q3l6bqaj1azxyh1hbg4d0vi"
   },
   "stable": {
    "version": [
-    1,
+    2,
     0
    ],
-   "deps": [
-    "magit"
-   ],
-   "commit": "f95e7fc2c6d529533709ae63a55e8ace9287ec0b",
-   "sha256": "08m5qlfbl0ilf0z0s6n3lgmjzwc5gh650jmxgl7a6rlzgw3rrh6a"
+   "commit": "6b51036a069379d18538a7cca5274c21666a5979",
+   "sha256": "0j82dm2mj49fs2q6qklhfimv1gvy6q3l6bqaj1azxyh1hbg4d0vi"
   }
  },
  {
@@ -82109,15 +82619,15 @@
   "repo": "milanglacier/minuet-ai.el",
   "unstable": {
    "version": [
-    20251218,
-    2234
+    20260203,
+    254
    ],
    "deps": [
     "dash",
     "plz"
    ],
-   "commit": "d3ce06dfd33f475a63544c1937868a907553afae",
-   "sha256": "1i99gx9h4idbc73lff14gl7bpp05wgk47wjr5ypnww26nn51a07y"
+   "commit": "dd8301f05dce2c5c536947a6b9bd262a81018e69",
+   "sha256": "12fsxwg6800954rf58ihnh7c3ka86yy4km0vs418m7b29fm5x7g3"
   },
   "stable": {
    "version": [
@@ -82211,11 +82721,11 @@
   "repo": "szermatt/mistty",
   "unstable": {
    "version": [
-    20250716,
-    1914
+    20260205,
+    1444
    ],
-   "commit": "bfb17611cff6c845270050a0756a38489cdf4ed6",
-   "sha256": "16pxd68g37d1knnw4i2y7dii3h95prfradl6y04jbz5hpjsq9122"
+   "commit": "bf0ddd077351001c56a4c754399d7ec025b93bab",
+   "sha256": "0j4m5ivbzkrp4jspcvbi3jy3dq4lqmm93p47pc1v9v0g54hym5nr"
   },
   "stable": {
    "version": [
@@ -82565,11 +83075,11 @@
   "repo": "sigma/mocker.el",
   "unstable": {
    "version": [
-    20220727,
-    1452
+    20260204,
+    1045
    ],
-   "commit": "4bd8d56eb4c3a1fcbbcdbf616f1b43e076b13eee",
-   "sha256": "15q3fccpmd2qd9gaqrf1dm391611b6bh4xn6d0ak3l9q5izl7385"
+   "commit": "462e4aa140db1f0589ab71dd07ee509e5425e2ff",
+   "sha256": "0hywjv86afza20masiy8v254d85rkq3dsrk9bf5gqs2asjzc2kpl"
   },
   "stable": {
    "version": [
@@ -82888,11 +83398,11 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20260113,
-    431
+    20260222,
+    643
    ],
-   "commit": "8a45a1393aa68cf93f1a973b00d87e3e9de4833d",
-   "sha256": "1wikmp0l438kicsy4w55xmdnmq6inizglclf79pa7qjsc4rd6bbd"
+   "commit": "b45b0d8a7c1e8b9679eea7ec366207280e4f89ed",
+   "sha256": "08wn814p3izbxg6cjdzczxvd44vc3d7kqx65pfaiwnya9iwply8n"
   },
   "stable": {
    "version": [
@@ -82912,11 +83422,11 @@
   "repo": "kuanyui/moe-theme.el",
   "unstable": {
    "version": [
-    20251218,
-    536
+    20260211,
+    617
    ],
-   "commit": "a7c8279e8e6160a52236a69ef1a3b2111be29693",
-   "sha256": "1c657z5pm6j6dyddzyjrbilsxzdm8sr3jkjrbf452fjyr697kzw5"
+   "commit": "4d779e8af108cd0b2867a9145453ce1dd46678df",
+   "sha256": "1fzn02w8997g6klq7xnr7pcschg1zj2jb44s1iaxbsq6ngvwivpj"
   },
   "stable": {
    "version": [
@@ -83681,21 +84191,20 @@
   "repo": "google/mozc",
   "unstable": {
    "version": [
-    20251022,
-    236
+    20260128,
+    821
    ],
-   "commit": "d9c3f195582de6b0baa07ecb81a04e8902acf9af",
-   "sha256": "12mpqlw7msmy62mwyxc1jyc30777iy5nyij2sn90pvz6x8n2n94b"
+   "commit": "8f92cd985cba2fd009545963698f4df7424bec56",
+   "sha256": "1kjh030ayyh4y7d3bmzdzgw0xba7lkiwrqdzfq78fhrd2hcjkkdw"
   },
   "stable": {
    "version": [
-    2,
-    32,
-    5994,
-    102
+    3,
+    33,
+    6089
    ],
-   "commit": "d9c3f195582de6b0baa07ecb81a04e8902acf9af",
-   "sha256": "12mpqlw7msmy62mwyxc1jyc30777iy5nyij2sn90pvz6x8n2n94b"
+   "commit": "8f92cd985cba2fd009545963698f4df7424bec56",
+   "sha256": "1kjh030ayyh4y7d3bmzdzgw0xba7lkiwrqdzfq78fhrd2hcjkkdw"
   }
  },
  {
@@ -84225,6 +84734,36 @@
    ],
    "commit": "cf19684d2333cb0cda7f6b62c7607144baa49310",
    "sha256": "02kyqd4ihliahkhirqqy7a8fi7s8haf9csaq95xi2hc9zkbd2nx5"
+  }
+ },
+ {
+  "ename": "mu4e-llm",
+  "commit": "237dc81b8903249820ca67e9f3e4a5ef54ffe6fd",
+  "sha256": "0qacqdg9rsmw3miqbqdpggq8cjph12ssdfmml8hvw6727fwccvfm",
+  "fetcher": "github",
+  "repo": "sillyfellow/mu4e-llm",
+  "unstable": {
+   "version": [
+    20260121,
+    1539
+   ],
+   "deps": [
+    "llm"
+   ],
+   "commit": "290657310d4041c23d627572d6fb780da8ed02f8",
+   "sha256": "1jj6jif4sjqb1rihqf5ckj11n7k40w79cngd81sqbbhrhxbdv0j6"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "deps": [
+    "llm"
+   ],
+   "commit": "80cd1e86f12bbbbe6c8f05406079e0955104a168",
+   "sha256": "1all3bv4pqdmm15hd6qb7lh6jw7m5rinvpdqb90yc18d68l4765i"
   }
  },
  {
@@ -85169,20 +85708,20 @@
   "repo": "mekeor/nael",
   "unstable": {
    "version": [
-    20260114,
-    2208
+    20260222,
+    33
    ],
-   "commit": "97114434492e3fa1b3c2795d3120ca78628d9765",
-   "sha256": "1mgd46z8a8nv5qd8lgd11c20iy6lhb0ww2mr5rfj1f8rd7avf37a"
+   "commit": "fbfb6757365cbde89d7ae0b56727315db15d31e4",
+   "sha256": "13pm7l895n8h7980l1prfcpcdl923dvkqvjf5gqz8kv95d5bb0fx"
   },
   "stable": {
    "version": [
     0,
     8,
-    0
+    2
    ],
-   "commit": "1a462a61a3599c436c9284a23cae4ff8815a84da",
-   "sha256": "1gck1p27vfl9rswbdpszxi3111wqx9f26ks3nh18cryd9v885cr1"
+   "commit": "fbfb6757365cbde89d7ae0b56727315db15d31e4",
+   "sha256": "13pm7l895n8h7980l1prfcpcdl923dvkqvjf5gqz8kv95d5bb0fx"
   }
  },
  {
@@ -85193,28 +85732,28 @@
   "repo": "mekeor/nael",
   "unstable": {
    "version": [
-    20260114,
-    1519
+    20260222,
+    33
    ],
    "deps": [
     "lsp-mode",
     "nael"
    ],
-   "commit": "1a462a61a3599c436c9284a23cae4ff8815a84da",
-   "sha256": "1gck1p27vfl9rswbdpszxi3111wqx9f26ks3nh18cryd9v885cr1"
+   "commit": "fbfb6757365cbde89d7ae0b56727315db15d31e4",
+   "sha256": "13pm7l895n8h7980l1prfcpcdl923dvkqvjf5gqz8kv95d5bb0fx"
   },
   "stable": {
    "version": [
     0,
     8,
-    0
+    2
    ],
    "deps": [
     "lsp-mode",
     "nael"
    ],
-   "commit": "1a462a61a3599c436c9284a23cae4ff8815a84da",
-   "sha256": "1gck1p27vfl9rswbdpszxi3111wqx9f26ks3nh18cryd9v885cr1"
+   "commit": "fbfb6757365cbde89d7ae0b56727315db15d31e4",
+   "sha256": "13pm7l895n8h7980l1prfcpcdl923dvkqvjf5gqz8kv95d5bb0fx"
   }
  },
  {
@@ -85832,6 +86371,30 @@
   }
  },
  {
+  "ename": "neocaml",
+  "commit": "67ad00bbbb0382a2e40472210ec3b3cabff9f160",
+  "sha256": "1ijx3lsc9ip52jklhfvbf39s9fsw1i0npp4h57g4f72j4pnhq0ig",
+  "fetcher": "github",
+  "repo": "bbatsov/neocaml",
+  "unstable": {
+   "version": [
+    20260224,
+    1902
+   ],
+   "commit": "410db808ad69516fd4314ea7ec6779eb9b6c6894",
+   "sha256": "07g82vxln7z80f3if5lq4xkiik1v2llgzws86s3ljab78mpvalrv"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    0
+   ],
+   "commit": "4218ba706816659708e2f9cc56fa224dac090e19",
+   "sha256": "148r4cacdxji3gch10ir835i3212i54v6dv30h6r8hrp6g50rwq8"
+  }
+ },
+ {
   "ename": "neon-mode",
   "commit": "c6b2a4898bf21413c4d9e6714af129bbb0a23e1a",
   "sha256": "0kgyc0rkxvvks5ykizfv82f2cx7ck17sk63plj7bld6khlcgv0y6",
@@ -85893,11 +86456,11 @@
   "repo": "rainstormstudio/nerd-icons.el",
   "unstable": {
    "version": [
-    20260117,
-    1631
+    20260129,
+    1655
    ],
-   "commit": "14b9fb4b48a08806836bc93f09cf44565aa9f152",
-   "sha256": "1b7sar1k206a89np69xsngr04km5cab20y4sassjh4bjr1fdmfr2"
+   "commit": "9a7f44db9a53567f04603bc88d05402cad49c64c",
+   "sha256": "10fij74c09jl0nxlid1fqgcnmzk2q7z3k9r40q3rc77q2brd4gfn"
   },
   "stable": {
    "version": [
@@ -85966,14 +86529,14 @@
   "repo": "rainstormstudio/nerd-icons-dired",
   "unstable": {
    "version": [
-    20251106,
-    1840
+    20260206,
+    1554
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "3265d6c4b552eae457d50d423adb10494113d70b",
-   "sha256": "1kkpw59xflz4i0jdg5rdw84lggjqjy2k03yilpa19a5allvar63s"
+   "commit": "929b62f01b93d30a3f42cc507fc45c84a2457b3f",
+   "sha256": "1z7nj89wm4w9c01p69wmxgj57nv4kwc4gkgbpycwv9avj2z4fad7"
   }
  },
  {
@@ -86124,11 +86687,11 @@
   "repo": "Feyorsh/nethack-el",
   "unstable": {
    "version": [
-    20251213,
-    1310
+    20260210,
+    119
    ],
-   "commit": "475d6113aa8a09fb81b581f3fb23fbfe76f7de22",
-   "sha256": "10p9jlb685ij3z45hsiybrf6zixibn66d0z444f2j8fimjbzh8wa"
+   "commit": "dfd8b26bac48b8c59d8bddf79eb9721ad06f98c6",
+   "sha256": "0n0ivks7zlqfanzn0yfb5rikaw3br4mxz2h2dc86xfyzcjprnh9y"
   }
  },
  {
@@ -86513,17 +87076,16 @@
   "repo": "nim-lang/nim-mode",
   "unstable": {
    "version": [
-    20240220,
-    1033
+    20260123,
+    1302
    ],
    "deps": [
     "commenter",
     "epc",
-    "flycheck-nimsuggest",
     "let-alist"
    ],
-   "commit": "625cc023bd75a741b7d4e629e5bec3a52f45b4be",
-   "sha256": "0jasg5qiha0y3zqh1q1knlhipnk11kqd1jxzgmpcsyc3ikq01brs"
+   "commit": "4502f83fbbd262a8a7e014db9affcbf05c8a1e79",
+   "sha256": "0r9xm02rwwddhvyrp5mzyj7v0clsz3anbdnp7rn6n5y4052j88wz"
   },
   "stable": {
    "version": [
@@ -86567,21 +87129,21 @@
  },
  {
   "ename": "ninetyfive",
-  "commit": "10c81234ec893a747379c266d566cc26733bfde7",
-  "sha256": "0a5m6v3iailj1camdi7z5iljj33fsgn9w73rbagxkhkhpy47q7y7",
+  "commit": "2cc1bd44b5bec3fd74336ff7a3689331dacd1106",
+  "sha256": "1njc240xl99vdxc088bzai7csf1vs09w35gb7m5dicnp8625sz81",
   "fetcher": "github",
-  "repo": "ninetyfive-gg/ninetyfive.el",
+  "repo": "numerataz/ninetyfive.el",
   "unstable": {
    "version": [
-    20251125,
-    2223
+    20260213,
+    1623
    ],
    "deps": [
     "async",
     "websocket"
    ],
-   "commit": "0d673ac905c68a91dadf7e9c2ff6fa9c6402034e",
-   "sha256": "1xxfgz97zcas50nsg848l1ish5fbj4xrmbd57slsrw02h7xm0m04"
+   "commit": "f2af587f97168e3544e770e74690cf0d7877c250",
+   "sha256": "0g8l7am3qd3cnk9fwblish5q8a14scabws2gsgb9fbanmfpnby5i"
   }
  },
  {
@@ -86760,11 +87322,11 @@
   "repo": "nix-community/nix-ts-mode",
   "unstable": {
    "version": [
-    20251114,
-    1500
+    20260215,
+    1421
    ],
-   "commit": "03c77fdbbd22d9b87a654169c26339b28c97d8cd",
-   "sha256": "1x8flq97vrxqvqmf25dr5wnmvwpa0l3zv5hyz2af3aj4yy1ic35n"
+   "commit": "319831712125e8c9e4f14b66def518d7a633685c",
+   "sha256": "0y2l1q3cvap7jjgl47wa78c5kagj6n2lpd3bilkhxn62aj3ahm0y"
   },
   "stable": {
    "version": [
@@ -87035,26 +87597,26 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20260101,
-    1839
+    20260205,
+    1529
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f854fc971df346b65d58a9aebb89f20cf0a6fc77",
-   "sha256": "0ps1hl8mygc9qi7qpmzd9jav2zm64i659xrmk1yx55r6hqk51f5z"
+   "commit": "ec8b6b76e6a8e53fa5e471949021dee68f3bc2e6",
+   "sha256": "0k5bwga4zja33xvqc7399bqizsx9npigdl00cgza4h40j371i4gv"
   },
   "stable": {
    "version": [
     1,
     8,
-    3
+    4
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f854fc971df346b65d58a9aebb89f20cf0a6fc77",
-   "sha256": "0ps1hl8mygc9qi7qpmzd9jav2zm64i659xrmk1yx55r6hqk51f5z"
+   "commit": "7d8fd72222b77ffaaaf8a32eedebb1f546d2441f",
+   "sha256": "1y30330vpqj1n5ylnmcl5kgp7c8r4mb80ilf9j2ip8x864shirpj"
   }
  },
  {
@@ -87531,19 +88093,19 @@
   "url": "https://git.notmuchmail.org/git/notmuch",
   "unstable": {
    "version": [
-    20260114,
-    2256
+    20260124,
+    2329
    ],
-   "commit": "97a2bad36a35399681f6c5f5a2b4390e6429d5ae",
-   "sha256": "0bnb19ikls0f9732z30zp5dig2ndv08sr2ly6ddhdm1lmvjkq6wb"
+   "commit": "ad789ba474581619be9f25838fa3d96d38a8d0c1",
+   "sha256": "083i587rjaasn3ffvpg38py2a41k8dgcqm3qyn77j40h30a35y3w"
   },
   "stable": {
    "version": [
     0,
-    39
+    40
    ],
-   "commit": "a5214eabb63ba78b84f4563942de1aa8763f0914",
-   "sha256": "1qq9bwhxrklkjysilmjmhzdwhxprc440krvml15mv8rind9xjll4"
+   "commit": "cee41bccc054617b0cffe12759b209ff66066563",
+   "sha256": "1cz3w35w189fy5zwvd4b11j47x4lz1kprl808v5lnvs994hzp51r"
   }
  },
  {
@@ -87742,11 +88304,11 @@
   "repo": "muirdm/emacs-nova-theme",
   "unstable": {
    "version": [
-    20240904,
-    2127
+    20260202,
+    501
    ],
-   "commit": "51b2899ac56c29638d11336d3b2a9894bb35b86e",
-   "sha256": "1bk5cg1kq62pg0gdw97vlfgjxkifj5xhr8ippyic04dv02b3kkz8"
+   "commit": "6daa91ff091653cae7a94345ca579084f954effc",
+   "sha256": "1m2hrg9nxc179v9zv4asr38wq4h1w5gk0ih1yfm0fhp8gknkjhw6"
   }
  },
  {
@@ -88258,19 +88820,19 @@
   "repo": "Anoncheg1/emacs-oai",
   "unstable": {
    "version": [
-    20260118,
-    1516
+    20260224,
+    39
    ],
-   "commit": "5f2ca47f35a52ebd8f7d6dab9deb463acaee62d4",
-   "sha256": "0l1c8vydjcvfikgp31c226d8kljsq13p20m5s40srh8ny8x7qzd9"
+   "commit": "ef1a4ee5b7737734482bb2c6d3a9800d89a6fbcb",
+   "sha256": "1sbiipikac2ganbh4h0hcd46baxypb80wrkw3f7k964aql4q14hp"
   },
   "stable": {
    "version": [
     0,
-    1
+    2
    ],
-   "commit": "268eda829b16b9000eebbcc30f021c47338a9757",
-   "sha256": "09bgnvg5rbja03qc7rnp280sqx3nkk4q94ma430wmksrxwn9g3sn"
+   "commit": "48831f36bf7262d33cec19fa6bcafad6b7edfb59",
+   "sha256": "1b4jp14zvxr3gi4qf3fvcimx24mh96x2nb4hpdjrbdl37wl2wcap"
   }
  },
  {
@@ -88823,11 +89385,11 @@
   "repo": "isamert/ob-deno",
   "unstable": {
    "version": [
-    20250913,
-    1628
+    20260213,
+    1023
    ],
-   "commit": "d9225ecf2e4e111d75b1a059ec04448bc044f3d2",
-   "sha256": "0w5k49iw5rz92v2qlgvl7bhh2h5kabc9wnbmwpfkd57kdjdz0ykj"
+   "commit": "77beef624ff21a3ee0b69b61265b427205b8031e",
+   "sha256": "1bimndvwnrr290il22hikw787wsdfc3cpjzl5ida017rmx405vsv"
   },
   "stable": {
    "version": [
@@ -89074,6 +89636,30 @@
    ],
    "commit": "933beadc754b108d541ccaa5bb0f017c41ef107a",
    "sha256": "1hys575y90rzhrwc8afc316wqmwxsaif5vjkk3cq2nn82zirl3z9"
+  }
+ },
+ {
+  "ename": "ob-gleam",
+  "commit": "c72a4e946e937d2fc361bb5c718d8acf28bcbc50",
+  "sha256": "1yp9j8b2w48l91914wf2f6l6f90x3nc73r7n44qdscqj76kh8803",
+  "fetcher": "github",
+  "repo": "takeokunn/ob-gleam",
+  "unstable": {
+   "version": [
+    20260221,
+    2046
+   ],
+   "commit": "31a521c165426954e565ea368da81c4500885f30",
+   "sha256": "1q2zln8m3bbl0dhi0cd4wjakiv1qqf7z826qmajxlkbvbrwm1r4n"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    1
+   ],
+   "commit": "22fae3e741647750a603fdac29eb61b5c052f3da",
+   "sha256": "101l8f061ng1igkj155il4620h9wha3nicq5q0vyl4qn8a0k4fni"
   }
  },
  {
@@ -89336,10 +89922,10 @@
  },
  {
   "ename": "ob-lurk",
-  "commit": "8399712211a0fb927970917aec906a97488d00fb",
-  "sha256": "0ajy98lzgq2k4dz4m03qlxndy38xqyr4whhd33v97mqwgzsdrf7c",
+  "commit": "23dfbed8e97bf922db3fc0fc51ddc7e8486cf071",
+  "sha256": "0k4qz5va5dwzf4wkljwvil2lh35avpn8dm1a08xgvwcj9afpvjnv",
   "fetcher": "github",
-  "repo": "argumentcomputer/lurk-emacs",
+  "repo": "lurk-lab/lurk-emacs",
   "unstable": {
    "version": [
     20221122,
@@ -89360,11 +89946,11 @@
   "repo": "arnm/ob-mermaid",
   "unstable": {
    "version": [
-    20250621,
-    1655
+    20260120,
+    601
    ],
-   "commit": "9b64cbc4b58a8e46ae7adbaa0cedc0e7d4c2eaf9",
-   "sha256": "1vnw5g05l88x3rrcy1j7qldaq743r2b1ifpkl81vilywg30s27zm"
+   "commit": "4f814ad5e1b96764af52d53799288ff3acc94b47",
+   "sha256": "0r9ky57w9d8lrqw3h9i1skp2ps5gjnf5nw4raqr1q6sg1imy5p7j"
   }
  },
  {
@@ -89931,25 +90517,25 @@
   "repo": "tmythicator/ob-ts-node",
   "unstable": {
    "version": [
-    20250929,
-    1013
+    20260123,
+    14
    ],
    "deps": [
     "org"
    ],
-   "commit": "11e25ba2f73b56af66824f67dac167a0d5ae129e",
-   "sha256": "04j9d213ly3gqvwnsgchq262r5r88rjki1g2zzclawnrvhly7ffi"
+   "commit": "a480e19fc204847c5b4c1808b07856bca68dae1e",
+   "sha256": "07jpd4aw6l5p3ma3pbyqikljysmdgvqpcwgs2qdh5nq8klvs9z1y"
   },
   "stable": {
    "version": [
     0,
-    3
+    4
    ],
    "deps": [
     "org"
    ],
-   "commit": "11e25ba2f73b56af66824f67dac167a0d5ae129e",
-   "sha256": "04j9d213ly3gqvwnsgchq262r5r88rjki1g2zzclawnrvhly7ffi"
+   "commit": "a480e19fc204847c5b4c1808b07856bca68dae1e",
+   "sha256": "07jpd4aw6l5p3ma3pbyqikljysmdgvqpcwgs2qdh5nq8klvs9z1y"
   }
  },
  {
@@ -90108,6 +90694,21 @@
   }
  },
  {
+  "ename": "oboe",
+  "commit": "038c955851d4e3e143925a70d62ee48fc512f52c",
+  "sha256": "1z6764fzcqdgmv4khsalpsp0529dls1p9b65i1smkc5kdcxf2gjl",
+  "fetcher": "github",
+  "repo": "gynamics/oboe.el",
+  "unstable": {
+   "version": [
+    20260217,
+    604
+   ],
+   "commit": "7829d308063b512531a32ac3dda9c31ef6eb68d2",
+   "sha256": "0ml3brzgpihvydhg344xp4ca5v1fih3cw40qzpdi7vvrnvnkdny3"
+  }
+ },
+ {
   "ename": "obsidian",
   "commit": "2c2a69a670206a4f06f69654278026564de6d5cd",
   "sha256": "0v3fc7pcgpdbpmcp6fp3lwc581jrr19agw2lnx8v72ca260vrvi2",
@@ -90172,11 +90773,11 @@
   "repo": "tarides/ocaml-eglot",
   "unstable": {
    "version": [
-    20260119,
-    1135
+    20260126,
+    1618
    ],
-   "commit": "5aff883db323c7b083964f286fe134e96b0c9458",
-   "sha256": "1adjg47qp52ngi5w50383icp8qb0i23f5xmr43qbn88knz9jb7gv"
+   "commit": "67d74e1d110e573926baae8e0b6878f645d87961",
+   "sha256": "06hll9dp8fziqqrzc44dcp5af6p92q7yxpnfwbdcf3gwkzpv8laq"
   },
   "stable": {
    "version": [
@@ -90390,9 +90991,9 @@
  },
  {
   "ename": "octo-mode",
-  "commit": "899ec190515d33f706e5279c8e3628514f733a12",
-  "sha256": "1xvpykdrkmxlk302kbqycasrq89f72xvhqlm14qrcd2lqnwhbi07",
-  "fetcher": "github",
+  "commit": "9fbeab3de84938acda84ef812110e54147111732",
+  "sha256": "1610jg7zpzmb3hs5xzcl0ls82p8axypks52lrsjwcnkw6z92gm99",
+  "fetcher": "codeberg",
   "repo": "cryon/octo-mode",
   "unstable": {
    "version": [
@@ -90641,11 +91242,11 @@
   "repo": "captainflasmr/ollama-buddy",
   "unstable": {
    "version": [
-    20251211,
-    1257
+    20260224,
+    1546
    ],
-   "commit": "3e5e38c2263f2ece0c276d79778fed01448b5446",
-   "sha256": "12day7zx2bvh3y51hz3dh3bhcwfxrncmyxrbsk1p37z5jlm4khcr"
+   "commit": "13ddf8ae8905e4c02a087f10806a9adf191d21e4",
+   "sha256": "00206dbyxqy1s0z0jrg3vbgcjbrmk3gqwnvg0smgj5jhafk2bxv1"
   },
   "stable": {
    "version": [
@@ -90954,20 +91555,26 @@
   "repo": "meedstrom/once",
   "unstable": {
    "version": [
-    20260105,
-    1940
+    20260218,
+    751
    ],
-   "commit": "65c654a18855df21a2f8f4721e2beabab4d29949",
-   "sha256": "0n5crsp9k029zb9hv9qmf4s72xhx5r3n2g1f6437h60v9a6as8x1"
+   "deps": [
+    "compat"
+   ],
+   "commit": "8bb03796ca7801bbd24dcc36f55a5a9d640326d4",
+   "sha256": "0x4jbi3qizydk0pcs5jcwqvmcwq7vs6fw23f2vzf6749yv0ax9vn"
   },
   "stable": {
    "version": [
     0,
-    1,
+    2,
     0
    ],
-   "commit": "b311e20ade96185176b02939a6e51fe61491e524",
-   "sha256": "05w4c5wb0yqa4wv7fx0gyxh7xrd3p7i85h88p3dxd5rdjmws4cm1"
+   "deps": [
+    "compat"
+   ],
+   "commit": "8bb03796ca7801bbd24dcc36f55a5a9d640326d4",
+   "sha256": "0x4jbi3qizydk0pcs5jcwqvmcwq7vs6fw23f2vzf6749yv0ax9vn"
   }
  },
  {
@@ -91400,25 +92007,25 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20260117,
-    1749
+    20260124,
+    1000
    ],
    "deps": [
     "compat"
    ],
-   "commit": "225dbcba32ab079f78e4146cbfd7d4dfb58840a3",
-   "sha256": "0hdb9q787889jmv1i0nkcbizrhqm4gqn7vl7bxnixlqfc3r0xlrg"
+   "commit": "6e3a09d6026fe7d7d5a3caf9a3d777cc9841fe80",
+   "sha256": "1r6sbyz8f3nkq5pr7iq3mm0q2dq3nq28xycf0x6xys7nsq2nink5"
   },
   "stable": {
    "version": [
     1,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "31812d9252c6cfa7eae8fa04cd40c8b2081e9936",
-   "sha256": "0cgklam29vsfrl70n3cqv1dxbsnpzjylfxabfs9v1yz02q27nggv"
+   "commit": "6e3a09d6026fe7d7d5a3caf9a3d777cc9841fe80",
+   "sha256": "1r6sbyz8f3nkq5pr7iq3mm0q2dq3nq28xycf0x6xys7nsq2nink5"
   }
  },
  {
@@ -91487,15 +92094,15 @@
   "repo": "hron/org-agenda-dock",
   "unstable": {
    "version": [
-    20250809,
-    703
+    20260206,
+    901
    ],
    "deps": [
     "dock",
     "org"
    ],
-   "commit": "1a0d37f471b6a8f5e9320b6bc97c5932ff83743b",
-   "sha256": "02p3fasfdvckp1r1bbcbs73p666bj6bf466qy2ayqcngfnjn5ch3"
+   "commit": "5b4f86a97c45f873ce41ce56ce398d9ef3e92dff",
+   "sha256": "1xf2ymkkismzxd62g7ydbli2nc968718kzjmvkzcf5ql3b3r39qy"
   }
  },
  {
@@ -91667,30 +92274,30 @@
   "repo": "eyeinsky/org-anki",
   "unstable": {
    "version": [
-    20250610,
-    911
+    20260209,
+    1249
    ],
    "deps": [
     "dash",
     "promise",
     "request"
    ],
-   "commit": "55724018316c76a9db4ce6a886bb2b563b26184e",
-   "sha256": "1dl69h5r1v42f9maqygq8v8mir04m80ff08k9f777q4fpf7jrajw"
+   "commit": "8cf3f5eb43cbe256ce892cfc867059e200a1b5bb",
+   "sha256": "1a41z676p41530vdg9kv3izc6mcnwjj7l3xbj245mvqdcyiyk7jz"
   },
   "stable": {
    "version": [
     4,
     0,
-    2
+    3
    ],
    "deps": [
     "dash",
     "promise",
     "request"
    ],
-   "commit": "55724018316c76a9db4ce6a886bb2b563b26184e",
-   "sha256": "1dl69h5r1v42f9maqygq8v8mir04m80ff08k9f777q4fpf7jrajw"
+   "commit": "8cf3f5eb43cbe256ce892cfc867059e200a1b5bb",
+   "sha256": "1a41z676p41530vdg9kv3izc6mcnwjj7l3xbj245mvqdcyiyk7jz"
   }
  },
  {
@@ -91945,28 +92552,28 @@
   "repo": "will-abb/org-aws-iam-role",
   "unstable": {
    "version": [
-    20251130,
-    2226
+    20260207,
+    1643
    ],
    "deps": [
     "async",
     "promise"
    ],
-   "commit": "f5dd83600fa1501e27d5b98beb41272cb3aa9021",
-   "sha256": "1h1yaamn0h0xai0jpirrjvjw13dxk1x3qfd5w4mmhl11mm4x71jn"
+   "commit": "4c6cdde1efd1f33a4e2434db7af7617ce590e90c",
+   "sha256": "16d92ckk4dk4dgpj0wcw79wnls4r8mfkx2j6pipphp8qr8fi8xmd"
   },
   "stable": {
    "version": [
     1,
     6,
-    4
+    5
    ],
    "deps": [
     "async",
     "promise"
    ],
-   "commit": "f5dd83600fa1501e27d5b98beb41272cb3aa9021",
-   "sha256": "1h1yaamn0h0xai0jpirrjvjw13dxk1x3qfd5w4mmhl11mm4x71jn"
+   "commit": "4c6cdde1efd1f33a4e2434db7af7617ce590e90c",
+   "sha256": "16d92ckk4dk4dgpj0wcw79wnls4r8mfkx2j6pipphp8qr8fi8xmd"
   }
  },
  {
@@ -92233,14 +92840,14 @@
   "repo": "dengste/org-caldav",
   "unstable": {
    "version": [
-    20250212,
-    334
+    20260222,
+    437
    ],
    "deps": [
     "org"
    ],
-   "commit": "44a6d463cee3c3be8acf7511db785ab55519b375",
-   "sha256": "0qxnms7libsq1q7hbvpbbza8g9kzyry0fi3ayhdv9sddnm2wx2d4"
+   "commit": "2afbeca982d6b0987b1566eba5a4efa871546955",
+   "sha256": "0f6pi583zb0i2323m5xdsh8w3f78a0f46nf3315mhdyrv74i7isv"
   },
   "stable": {
    "version": [
@@ -92292,14 +92899,14 @@
   "repo": "colonelpanic8/org-project-capture",
   "unstable": {
    "version": [
-    20260118,
-    807
+    20260127,
+    711
    ],
    "deps": [
     "org"
    ],
-   "commit": "4303dd869b0d638bd09014702803cde50f4e7fed",
-   "sha256": "10vxb0d6b31dmd7xqhr15syzlvzify6qmbz25ca6pp8rjkdkrxjv"
+   "commit": "0521cbb6bb371cbfd9b7b5688b82ac119af1bf30",
+   "sha256": "0k1lwh29fmid0a1zvaswj96k9phqp98xv908b4wdsc60vcww8qkg"
   },
   "stable": {
    "version": [
@@ -92583,14 +93190,14 @@
   "url": "https://repo.or.cz/org-contacts.git",
   "unstable": {
    "version": [
-    20260114,
-    754
+    20260221,
+    852
    ],
    "deps": [
     "org"
    ],
-   "commit": "690ae7e735e16eee6969ef4d79cdff021a621db1",
-   "sha256": "1vjalaqlib5k2alflajckdc41q59mfb4q6c7jbprqr3yzl4gff02"
+   "commit": "a9175a2918d2e6d5400368d9504a617e4eb2b49c",
+   "sha256": "1djnyswjbsb1k3ciyd2f9xfjfkhbkkfw3dzfmzzr8dx5v71gm47b"
   }
  },
  {
@@ -93173,39 +93780,38 @@
   "repo": "kidd/org-gcal.el",
   "unstable": {
    "version": [
-    20250624,
-    1628
+    20260225,
+    409
    ],
    "deps": [
     "aio",
     "alert",
-    "elnode",
     "oauth2-auto",
     "org",
     "persist",
     "request",
     "request-deferred"
    ],
-   "commit": "c7ad854ee44e88a55db74269d53819c931d55b8e",
-   "sha256": "1ja06l4yqp92cjcncyp7mq7lx3rcf7hixk0m4xqppahk6bkhq0s8"
+   "commit": "0f46c08f60355729526e970e370defe624e84956",
+   "sha256": "0cdscldk9fi9vvk8qc4qqhi61qm8n1y35d44jw52dxl4i6wfiggi"
   },
   "stable": {
    "version": [
     0,
     4,
-    2
+    3
    ],
    "deps": [
     "aio",
     "alert",
-    "elnode",
+    "oauth2-auto",
     "org",
     "persist",
     "request",
     "request-deferred"
    ],
-   "commit": "3cc48a989ac859a97d25964c28874317a6e1672a",
-   "sha256": "11whjprc6h7knapjg29wz85mw338mvmyjwcmdai65m25pplxr25i"
+   "commit": "9627478a7d26468957d965ebb858e5ff9e260568",
+   "sha256": "17bnk8l0b2kix595418wn0d7yg23jcicnn8xpvqap72jy3wfg303"
   }
  },
  {
@@ -93305,8 +93911,8 @@
   "repo": "Trevoke/org-gtd.el",
   "unstable": {
    "version": [
-    20260117,
-    1854
+    20260222,
+    2
    ],
    "deps": [
     "compat",
@@ -93316,14 +93922,14 @@
     "org-edna",
     "transient"
    ],
-   "commit": "21ba4b1c03a0b9e6feec1b3f1f85ccb682adf867",
-   "sha256": "1bbcil0h4ha7s9b4xnrmpdcza94yrq3pq6fpgc2xs5bj8dbip7bq"
+   "commit": "79ee241426a4266814743f0bcfe934fcb496b1fa",
+   "sha256": "1586v4jmpxdgpny0fz167vy01mnpav41qdkbgjla3fdvzqmbp853"
   },
   "stable": {
    "version": [
     4,
-    3,
-    1
+    6,
+    0
    ],
    "deps": [
     "compat",
@@ -93333,8 +93939,8 @@
     "org-edna",
     "transient"
    ],
-   "commit": "21ba4b1c03a0b9e6feec1b3f1f85ccb682adf867",
-   "sha256": "1bbcil0h4ha7s9b4xnrmpdcza94yrq3pq6fpgc2xs5bj8dbip7bq"
+   "commit": "79ee241426a4266814743f0bcfe934fcb496b1fa",
+   "sha256": "1586v4jmpxdgpny0fz167vy01mnpav41qdkbgjla3fdvzqmbp853"
   }
  },
  {
@@ -93714,16 +94320,16 @@
   "repo": "ahungry/org-jira",
   "unstable": {
    "version": [
-    20251120,
-    307
+    20260205,
+    2052
    ],
    "deps": [
     "cl-lib",
     "dash",
     "request"
    ],
-   "commit": "f5ccb0719478a6f7dd2c045b1b191420d04242d7",
-   "sha256": "0sxphr736pcvw7jj6nw67blh4vq6lr64200jf5qn75c20pqqycyl"
+   "commit": "738002ddbeb0b4311089706f0a979ceea53bf095",
+   "sha256": "0p46cwmc7d31bb9ra7f3wa2ij02332fkn4dmpjxqqf1swl2rr41s"
   },
   "stable": {
    "version": [
@@ -93921,15 +94527,15 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20260106,
-    1116
+    20260218,
+    1347
    ],
    "deps": [
     "nerd-icons",
     "qrencode"
    ],
-   "commit": "62955313268e27744ac2117ed5be9d2c362ded05",
-   "sha256": "0r43rlvc37l96h8bhkw8x1sswjqzk13svq9k85wrh1y3l57p8haf"
+   "commit": "68183f5f8ca66ac0c5636132a4ed72807daa6f95",
+   "sha256": "0c1ij0j9147rxsjj3zv4lgfvy2v2b7sr5mp3p90s413nvikln72p"
   },
   "stable": {
    "version": [
@@ -94014,11 +94620,11 @@
   "repo": "Anoncheg1/emacs-org-links",
   "unstable": {
    "version": [
-    20260116,
-    1316
+    20260220,
+    2318
    ],
-   "commit": "b1bb0da38ce14d31148abe9e733212747b0b5dc4",
-   "sha256": "06r3yjc48qa6dcarghg62pnzwkv3af8yy38ghihp4bxw5qni8gpa"
+   "commit": "8f9b49d66244c0ef423389a9a0440c9888ebc5fa",
+   "sha256": "1b9spgz5b1lc4bcnzm9dj5g6b8cvffdpdgq6wdqm2f63nfsa7db2"
   },
   "stable": {
    "version": [
@@ -94142,28 +94748,29 @@
   "repo": "meedstrom/org-mem",
   "unstable": {
    "version": [
-    20251108,
-    841
+    20260224,
+    1229
    ],
    "deps": [
     "el-job",
-    "llama"
+    "llama",
+    "truename-cache"
    ],
-   "commit": "0a33650ccb79c9bd49d7598fbb8f09beb2153350",
-   "sha256": "0jrisa0w6khiv2mndhyrr0yjsg191yix4gpj2g57nvp80l3xbnbl"
+   "commit": "ebecc2378422c6bec2fe82d3ba5194de303263a6",
+   "sha256": "1z8p5mnsm9prkgj4n8rq5rj61aaz1h9rl6dyqhhrq6yq0kf6h6qn"
   },
   "stable": {
    "version": [
     0,
-    25,
-    0
+    31,
+    2
    ],
    "deps": [
     "el-job",
     "llama"
    ],
-   "commit": "531a6b571ba0dcfa77a1997fb2b216a020ca6563",
-   "sha256": "0ga21yxyy2yr9bplgdqfhf8sc67ynjvzacl8l2j1i1rjj9a3h3g4"
+   "commit": "51a834dd6bbf69d8f4e2b479e16e9d9fbfcd3e05",
+   "sha256": "07ny0v6qp6p2lncfnkm6k6s3f4bv9yrf23m99kk8bw6pzihq8awx"
   }
  },
  {
@@ -94269,15 +94876,15 @@
   "repo": "minad/org-modern",
   "unstable": {
    "version": [
-    20260117,
-    1652
+    20260125,
+    1438
    ],
    "deps": [
     "compat",
     "org"
    ],
-   "commit": "9bbc44cc7e085dea24e96f0cc0332ed7fcf349ca",
-   "sha256": "01p5k85hj677x2vk7j7a88gchp51ybiaj6iqmdhxivmcw3lb6ibi"
+   "commit": "b4b5b1c864f1fdf240d1bbd7093529f5a75e8a06",
+   "sha256": "1ky4hwivfvna30kpj01mqzp30hmdh7znmv5jm9mpgjzibv12ilpg"
   },
   "stable": {
    "version": [
@@ -94331,11 +94938,11 @@
   "repo": "bpanthi977/org-mpv-notes",
   "unstable": {
    "version": [
-    20241222,
-    1958
+    20260224,
+    1801
    ],
-   "commit": "1d8db9ff803122e2a9bfc1b41d806f3b70acfc57",
-   "sha256": "0fii5v7c47jshrv8d064sa7nssixm8hy2fwfjvqaqwpbhvkl3w23"
+   "commit": "bb0e6b2dd5a9dd51d8f3dfa95302f245934391db",
+   "sha256": "15njhy4z25wycx9k55r7knqw282s7xv7qj6fyfm756y6zl8kgxkq"
   }
  },
  {
@@ -94370,14 +94977,14 @@
   "repo": "jeremy-compostella/org-msg",
   "unstable": {
    "version": [
-    20251029,
-    2127
+    20260211,
+    901
    ],
    "deps": [
     "htmlize"
    ],
-   "commit": "327768e2c38020f6ea44730e71f2a62f3f0ce3bd",
-   "sha256": "0gvm7865d4c2sv484y03icx1vhdygyrp99divjk7drcrhdqqnvly"
+   "commit": "aa608b399586fb771ad37045a837f8286a0b6124",
+   "sha256": "0n02g88jybzsx0lqqpzag7hkrlvy3gh6irphgm5wsx42w312k1jl"
   }
  },
  {
@@ -94505,64 +95112,30 @@
   "repo": "meedstrom/org-node",
   "unstable": {
    "version": [
-    20260119,
-    1746
+    20260223,
+    2314
    ],
    "deps": [
     "llama",
     "magit-section",
     "org-mem"
    ],
-   "commit": "7eba767815447105d9369d70fb30b9ce5c8e1ad3",
-   "sha256": "1127bc8x5zi6cl5ak8qay01aniscn94i908b52bzf3sz57cyknyj"
+   "commit": "4b1e1899bfd20b8d2bde294b7d3008367d435be0",
+   "sha256": "0q1h4ph2viblr35abkf45f9036n4acdh9wwmzdw9299ahdmy9qrf"
   },
   "stable": {
    "version": [
     3,
-    12,
-    1
+    16,
+    0
    ],
    "deps": [
     "llama",
     "magit-section",
     "org-mem"
    ],
-   "commit": "1bbcd8d644e4044befa4609b87b34737f24a410b",
-   "sha256": "1g6lasaz3vjknfr2y05dz7k28rb3bia8ni112031xs38db9jamq5"
-  }
- },
- {
-  "ename": "org-node-fakeroam",
-  "commit": "d2a49c680f461aa0fd7c25f98bfe7bfd9e49d64b",
-  "sha256": "0901141f3lydssnamdghzwjhbscwv66n53r9gww727gkayq420zx",
-  "fetcher": "github",
-  "repo": "meedstrom/org-node-fakeroam",
-  "unstable": {
-   "version": [
-    20250519,
-    2339
-   ],
-   "deps": [
-    "org-mem",
-    "org-node",
-    "org-roam"
-   ],
-   "commit": "449a5e841f8fe5dd389a390da79e21b696d3c7ac",
-   "sha256": "1pibsnpd9nw32ghdqvx63mkjhqsbzvkdfnp46p42jc49ic8yfl0y"
-  },
-  "stable": {
-   "version": [
-    3,
-    0,
-    2
-   ],
-   "deps": [
-    "org-mem",
-    "org-node",
-    "org-roam"
-   ],
-   "commit": "449a5e841f8fe5dd389a390da79e21b696d3c7ac",
-   "sha256": "1pibsnpd9nw32ghdqvx63mkjhqsbzvkdfnp46p42jc49ic8yfl0y"
+   "commit": "d2dd24fc7264a5f621a4ed55fc4c6450714202df",
+   "sha256": "0nc492plrd0l6qs2a9594gygvyzx7jr96p8ppzy6wy0sl1ys9s45"
   }
  },
  {
@@ -95191,10 +95764,10 @@
  },
  {
   "ename": "org-randomnote",
-  "commit": "d92cb392b23701948176ba12516df5ae6608e950",
-  "sha256": "06i42ig7icap1i1mqzv5cqwhnmsrzpjmjbjjn49nv26ljr3mjw0b",
+  "commit": "c57898ef0e67c97e64e859fe647581aa41865d5f",
+  "sha256": "1li98j1gigivmdw25dvr0mr93b0bhagrpwj1r7gkbkbpp2c3q2sz",
   "fetcher": "github",
-  "repo": "mwfogleman/org-randomnote",
+  "repo": "tasshin/org-randomnote",
   "unstable": {
    "version": [
     20200110,
@@ -95463,20 +96036,20 @@
   "repo": "TomoeMami/org-repeat-by-cron.el",
   "unstable": {
    "version": [
-    20260118,
-    526
+    20260225,
+    212
    ],
-   "commit": "414d872ed71642fdd0dee6c2163665db7fc4dab0",
-   "sha256": "0z9d3606x5j3dgkakzbdrl3474ppsdyqkiq5pgrh5m2qwx1vzj0v"
+   "commit": "cc5aabc3c8667836d0bf05d351e0a21bee677f4e",
+   "sha256": "1b1jrkg19kfinjqh2jnl6n7qa48hyp3fvsnjr60v1g41rlfcshmz"
   },
   "stable": {
    "version": [
     1,
-    0,
-    4
+    1,
+    1
    ],
-   "commit": "414d872ed71642fdd0dee6c2163665db7fc4dab0",
-   "sha256": "0z9d3606x5j3dgkakzbdrl3474ppsdyqkiq5pgrh5m2qwx1vzj0v"
+   "commit": "cc5aabc3c8667836d0bf05d351e0a21bee677f4e",
+   "sha256": "1b1jrkg19kfinjqh2jnl6n7qa48hyp3fvsnjr60v1g41rlfcshmz"
   }
  },
  {
@@ -95582,18 +96155,17 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20260103,
-    1921
+    20260224,
+    1637
    ],
    "deps": [
     "compat",
-    "dash",
     "emacsql",
     "magit-section",
     "org"
    ],
-   "commit": "b95d04cbd223e369b9578b0dc47bbdd376d40dc3",
-   "sha256": "1l7z8sc6mxx09r19z88j1qb4iz9gagsy39v2v852q4ayg50ad6gh"
+   "commit": "20934cfb5a2e7ae037ec10bbc81ca97478738178",
+   "sha256": "1wfz4xp6l2jz3a3ji5ss0nq62lixkd2gqd6m9jag4kdic8hyd101"
   },
   "stable": {
    "version": [
@@ -95641,6 +96213,37 @@
    ],
    "commit": "070a7a732cf38f51245116ddd41aad8ac697c3b0",
    "sha256": "166n1q30xamms4lfqq9vp0yknq33gwlk54qaravxxwz01fdpgb25"
+  }
+ },
+ {
+  "ename": "org-roam-latte",
+  "commit": "39601d3fb5ba706135be313cf41380fd8ec119f6",
+  "sha256": "1fabm5cg9l8sfgi95k7nbi537d4xc3njxz39lzc2lkaasj95z2vl",
+  "fetcher": "github",
+  "repo": "yad-tahir/org-roam-latte",
+  "unstable": {
+   "version": [
+    20260213,
+    555
+   ],
+   "deps": [
+    "inflections",
+    "org-roam"
+   ],
+   "commit": "28df5361d8b90b1ee739a11c6c1accdcb58cb08d",
+   "sha256": "18g8whpi4327ccm3zxxx0fb0kdbvcrv445fdxm9fbhz701qz0dzr"
+  },
+  "stable": {
+   "version": [
+    1,
+    1
+   ],
+   "deps": [
+    "inflections",
+    "org-roam"
+   ],
+   "commit": "28df5361d8b90b1ee739a11c6c1accdcb58cb08d",
+   "sha256": "18g8whpi4327ccm3zxxx0fb0kdbvcrv445fdxm9fbhz701qz0dzr"
   }
  },
  {
@@ -96024,8 +96627,8 @@
   "repo": "tanrax/org-social.el",
   "unstable": {
    "version": [
-    20260116,
-    749
+    20260223,
+    924
    ],
    "deps": [
     "emojify",
@@ -96033,13 +96636,13 @@
     "request",
     "seq"
    ],
-   "commit": "83015d1402c28cd1395b18a104dfbc4f1357a83c",
-   "sha256": "0s6bqyi7qy3i97hsn6hr3k1dwk1ws7l92w1ixldhrhfjx26ynqfj"
+   "commit": "367ab5cf6ae12715bb9cade7a8eb45cf8d7f8723",
+   "sha256": "1aw0zfg898ggyn139n0x2fgaygayl14gv48mq59zw6b8ffkrff52"
   },
   "stable": {
    "version": [
     2,
-    10
+    11
    ],
    "deps": [
     "emojify",
@@ -96047,8 +96650,8 @@
     "request",
     "seq"
    ],
-   "commit": "d4cfe777975519ae2908416eb58c4f1b4cb33b43",
-   "sha256": "1h7bqqa3v0ah4ai2m6chz6932l5gq6rx7nc8mjxiiydkq1rjhgxi"
+   "commit": "367ab5cf6ae12715bb9cade7a8eb45cf8d7f8723",
+   "sha256": "1aw0zfg898ggyn139n0x2fgaygayl14gv48mq59zw6b8ffkrff52"
   }
  },
  {
@@ -96470,14 +97073,14 @@
   "url": "https://repo.or.cz/org-tag-beautify.git",
   "unstable": {
    "version": [
-    20260103,
-    934
+    20260123,
+    235
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "de02883b9ad339539482d30450074ca572709d90",
-   "sha256": "1wmrvqflmgwszrm5kmnj71bdbsn28fddmrqwzmczqz80h9nnfi4p"
+   "commit": "3b0e03b5a7929b2c0b107d90355e0a0f03490aef",
+   "sha256": "1y2lilr1yjfcrbb6vhc2h8vknh0pwrfrwajim1h8c0xcc6ilzl9g"
   }
  },
  {
@@ -96556,6 +97159,30 @@
    ],
    "commit": "31aa5502d1d4f8b032807949908c016b00556684",
    "sha256": "11rfn0byy0k0321w7fjgpa785ik1nrk1j6d0y4j0j4a8gys5hjr5"
+  }
+ },
+ {
+  "ename": "org-tempus",
+  "commit": "15bf0d7ef4e45bd6ddd2b744ffc8d32a25ed8cb5",
+  "sha256": "1wwrc1rpfq86dzn304d7qxbig0ihj4wqlkr3gvswlz8bd7s8731a",
+  "fetcher": "github",
+  "repo": "rul/org-tempus",
+  "unstable": {
+   "version": [
+    20260222,
+    1840
+   ],
+   "commit": "f3912ccd9032bea28ff0ee4b3d49a90e17097e26",
+   "sha256": "158gq02r7vcpbl93s2f1zdwbz4ccyn39i3m6w7bz2c6q3w3ymja6"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    1
+   ],
+   "commit": "e07a05d66c084cf4796c2683f4320d9360af8b83",
+   "sha256": "1rsybp4827z7z3d66rzjp7kjyb84c12igzxqz26kfzhcd9dlqpav"
   }
  },
  {
@@ -97158,16 +97785,16 @@
   "repo": "p-snow/org-web-track",
   "unstable": {
    "version": [
-    20250610,
-    1142
+    20260215,
+    734
    ],
    "deps": [
     "enlive",
     "gnuplot",
     "request"
    ],
-   "commit": "c32eebcd1794f618b723cbaadae125cc98781121",
-   "sha256": "1nwmb3hxszyp8klzbqbvqvrgwi3ism6whk4z6yy00ay6jp5dqsi9"
+   "commit": "2c4215499c0851e85b480bc19e96a236fb9af8f1",
+   "sha256": "1al99lixw56yg5wvg6x3rvclkvfncgs6rz6ry6iniam62pdhp80s"
   },
   "stable": {
    "version": [
@@ -97182,6 +97809,70 @@
    ],
    "commit": "2cf9367ef6f8800fa058a8ca30cbb6f2e75fe4de",
    "sha256": "0ski1bvmxvjr2kf819hjr0lgx1q5y48g4g21mm0wmjcqjngfsh1r"
+  }
+ },
+ {
+  "ename": "org-wild-notifier",
+  "commit": "26147067d47c8666e6885e1dcf92a93d19a6b405",
+  "sha256": "0sz4f4v7f4jwz0rriwmd9d8x70n68fgaa6c51z84ifa2k8lz7g27",
+  "fetcher": "github",
+  "repo": "emacsorphanage/org-wild-notifier",
+  "unstable": {
+   "version": [
+    20260127,
+    533
+   ],
+   "deps": [
+    "alert",
+    "async",
+    "dash"
+   ],
+   "commit": "9211d14128a1097f78081dd7f8ba849671604575",
+   "sha256": "0ihqq3i5qzwp7l0kpj83j4rxrgw7awl9acnc5mch3j1xa3mq29fl"
+  },
+  "stable": {
+   "version": [
+    0,
+    7,
+    0
+   ],
+   "deps": [
+    "alert",
+    "async",
+    "dash"
+   ],
+   "commit": "832dd0d606f773499ffdad9845b1cf1f6735399d",
+   "sha256": "001yzk25l9yamkzi8x16vv4lfwy228qcrh05hyp9rdki68f8pbzs"
+  }
+ },
+ {
+  "ename": "org-window-habit",
+  "commit": "352e81dd12cc2b1d812ee7b50baab2b4a0d36b22",
+  "sha256": "184a9a5ib3wc59jsvdp45rmcrg2sg3qxb0w13p7ciwmbsgv1cnnn",
+  "fetcher": "github",
+  "repo": "colonelpanic8/org-window-habit",
+  "unstable": {
+   "version": [
+    20260204,
+    1025
+   ],
+   "deps": [
+    "dash"
+   ],
+   "commit": "4d23ef0994770b7d233e11dca9bbf1b1a5479c45",
+   "sha256": "19rfrkwxmj7iy9yh4l64kxg37242pw8nl9218lldxra9rxp02g3z"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    3
+   ],
+   "deps": [
+    "dash"
+   ],
+   "commit": "4d23ef0994770b7d233e11dca9bbf1b1a5479c45",
+   "sha256": "19rfrkwxmj7iy9yh4l64kxg37242pw8nl9218lldxra9rxp02g3z"
   }
  },
  {
@@ -97544,8 +98235,8 @@
   "repo": "magit/orgit",
   "unstable": {
    "version": [
-    20260101,
-    1851
+    20260201,
+    1458
    ],
    "deps": [
     "compat",
@@ -97553,8 +98244,8 @@
     "magit",
     "org"
    ],
-   "commit": "24c8fe48c477d561c2ce1720223f8c5aec664f4e",
-   "sha256": "0p1k171nmzscnzfrlc3paq94gbx46f52fx7djkr88xv7cgd5qgw4"
+   "commit": "39cb93b283c1b4ac05025eb17a43ccc623e44686",
+   "sha256": "1sa710pqd4mzhw9mf8jbrkcj8qyx9sv67ky01ixynim412zgizps"
   },
   "stable": {
    "version": [
@@ -97709,30 +98400,30 @@
   "repo": "isamert/orgmdb.el",
   "unstable": {
    "version": [
-    20251105,
-    2227
+    20260120,
+    1738
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "416b2d6e9a9db179d69798d0f034307dc9cc762d",
-   "sha256": "0ypga3ywmaiv74r14bxn668zvv77mv6dhw6f3hrmlmvm20k7q0f0"
+   "commit": "4f24d187e2bf484ef4f68c191324659dca62c2f6",
+   "sha256": "1199smcxxnixq5716y29g97fhykmiva5ygz433ywm7yh09gl7bxa"
   },
   "stable": {
    "version": [
     1,
-    0,
-    2
+    1,
+    0
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "416b2d6e9a9db179d69798d0f034307dc9cc762d",
-   "sha256": "0ypga3ywmaiv74r14bxn668zvv77mv6dhw6f3hrmlmvm20k7q0f0"
+   "commit": "4f24d187e2bf484ef4f68c191324659dca62c2f6",
+   "sha256": "1199smcxxnixq5716y29g97fhykmiva5ygz433ywm7yh09gl7bxa"
   }
  },
  {
@@ -97825,11 +98516,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20260109,
-    837
+    20260220,
+    1007
    ],
-   "commit": "ec32afaf3942ff30d9284fbcc594511ca9269393",
-   "sha256": "0mb1hhp5mk0lmc6nd14nv2s09s1zb2dvqgzin73xr247vsgh8ykf"
+   "commit": "32d78921e9068d607eda97143dd0eb9208a3c4e4",
+   "sha256": "0ibjm9j818aqhdvn18625wqgvkl9ivh2s6rc5plv94hhy2y9p257"
   }
  },
  {
@@ -97840,11 +98531,11 @@
   "repo": "tbanel/orgtblasciiplot",
   "unstable": {
    "version": [
-    20260111,
-    1140
+    20260126,
+    1121
    ],
-   "commit": "56d27e6ab021d8aad59372480d4eaedb19850c2d",
-   "sha256": "0b9l10avwkhl146nrmda0xhiy6m20y1jllv2p91kcv16ng7xradl"
+   "commit": "e9583daf44a9b1c88e767aa792527e6f21acb0a4",
+   "sha256": "0b9b9fk1h4wifl2x2s6s9jdvmkw18r0c4jgw643jlf9zwkb4l696"
   }
  },
  {
@@ -97870,11 +98561,11 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20260109,
-    917
+    20260217,
+    1139
    ],
-   "commit": "66d02c1d197a9506f8df7a7e35f760bdbbcddb3b",
-   "sha256": "1q8aclyk3hhwa3cw8lxrlskpifv2rvi790nj5v804w12cnzwk8p4"
+   "commit": "bd9edf54bdd55d1d33b8c6fb51a7f23a78c09355",
+   "sha256": "1clvbp9pb0qfwy3hibsx2a83r3zmhiw7m47cdylnwv61wz640rj9"
   }
  },
  {
@@ -98033,25 +98724,25 @@
   "repo": "minad/osm",
   "unstable": {
    "version": [
-    20260109,
-    1817
+    20260125,
+    1200
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7880b450138b3d260480e3e527fb3178cc8e2bc9",
-   "sha256": "0f2c1zhps2ln6xhsqwc67axp6d2hnnqckdr8xlppgzxbd4q7p4yn"
+   "commit": "19c9c958dd530a1ba606fc1074a28523af40ec28",
+   "sha256": "1lwjnxafhy5f83ydlccd47r2ramgwdlgzlj15h82yxsl4l0sq380"
   },
   "stable": {
    "version": [
     2,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7880b450138b3d260480e3e527fb3178cc8e2bc9",
-   "sha256": "0f2c1zhps2ln6xhsqwc67axp6d2hnnqckdr8xlppgzxbd4q7p4yn"
+   "commit": "19c9c958dd530a1ba606fc1074a28523af40ec28",
+   "sha256": "1lwjnxafhy5f83ydlccd47r2ramgwdlgzlj15h82yxsl4l0sq380"
   }
  },
  {
@@ -98306,26 +98997,26 @@
   "repo": "abougouffa/one-tab-per-project",
   "unstable": {
    "version": [
-    20250909,
-    2023
+    20260211,
+    2247
    ],
    "deps": [
     "compat"
    ],
-   "commit": "fb8e72b924013443ba810ad5347d6ca39f005158",
-   "sha256": "08jpxyabjvicvra757ykmskvdkq332bjwcr8gmqax8bvx0x6qyax"
+   "commit": "2c5bfb6ef06d27a9589394339dadb856580a5a84",
+   "sha256": "1qql95w8mdsb6scvi7xg0xc3c33pw385a1fvm1vilwbr1s7y32yd"
   },
   "stable": {
    "version": [
     3,
-    3,
-    6
+    4,
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "fb8e72b924013443ba810ad5347d6ca39f005158",
-   "sha256": "08jpxyabjvicvra757ykmskvdkq332bjwcr8gmqax8bvx0x6qyax"
+   "commit": "2c5bfb6ef06d27a9589394339dadb856580a5a84",
+   "sha256": "1qql95w8mdsb6scvi7xg0xc3c33pw385a1fvm1vilwbr1s7y32yd"
   }
  },
  {
@@ -98380,20 +99071,20 @@
   "repo": "jamescherti/outline-indent.el",
   "unstable": {
    "version": [
-    20260114,
-    1604
+    20260219,
+    1358
    ],
-   "commit": "9f5b72d22be8cccc1873f7b65ca9e0acad0b1e10",
-   "sha256": "05y0knsww8wha59i1yhxvmmgb19j50rppfkb2dw0n36bvbxhvr46"
+   "commit": "91d6d1c7a15f1c1a9575870ef2f564ad3f053589",
+   "sha256": "0ciijpza9jfwwr9li46babbm9d69zm34y0dks2ka55yw7j4n9n5v"
   },
   "stable": {
    "version": [
     1,
     1,
-    5
+    7
    ],
-   "commit": "46cb8657bed035042796fc48ccfcb922eb443d81",
-   "sha256": "0vw41bnysacb7hwfacb8m8qyz01skwcpnyzrm1mriwl5j51ni1aj"
+   "commit": "75e1b5d41e7b18ce1c04ec33a20af2fbed5baa96",
+   "sha256": "1pwnvpwq8x6rcjbxv79l2qiw4zf8i75n0yddbhpmivz5qcc6jsjs"
   }
  },
  {
@@ -98605,8 +99296,8 @@
   "repo": "vale981/overleaf.el",
   "unstable": {
    "version": [
-    20250728,
-    2103
+    20260122,
+    1439
    ],
    "deps": [
     "plz",
@@ -98614,8 +99305,8 @@
     "webdriver",
     "websocket"
    ],
-   "commit": "515e45df1bec11e1c0cd2dc4810c48f8ad0685cb",
-   "sha256": "08mzrcjm74xfxpj3bjlfr3w1079xpkbp1wgyvgrdiz9zh5i2b352"
+   "commit": "933a0185e9d13d9ae7fc5271f0b4a4113aab6eca",
+   "sha256": "0ci7pz6m6730hl95vnjcgk7lk89550r7mfpasrbpj6x1sawgjl4w"
   },
   "stable": {
    "version": [
@@ -99355,6 +100046,24 @@
   }
  },
  {
+  "ename": "ox-reveal-layouts",
+  "commit": "4cd3c0d8357dc6ae50b9a324eeb5a8bb56fcc110",
+  "sha256": "0q5pvx7ikcfbm3bwbgaixkpyifmjqwp2ac0b7qs2w77zmn1q0xjl",
+  "fetcher": "github",
+  "repo": "GerardoCendejas/ox-reveal-layouts",
+  "unstable": {
+   "version": [
+    20260123,
+    101
+   ],
+   "deps": [
+    "transient"
+   ],
+   "commit": "2daf9d61ae235a5bea5d0722529c37d55e4ecce9",
+   "sha256": "1xckaw30y6br0jlg4y9k7l5jk5ffsm718s33ck94d17a493cfmnz"
+  }
+ },
+ {
   "ename": "ox-review",
   "commit": "67bf75e1dee7c7d83e66234afb18104b844b1719",
   "sha256": "062ifdcgk4iwhz5k8srdd38z34gib5i36rcfhj90bn07d7jsrh2y",
@@ -99952,14 +100661,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20260115,
-    1042
+    20260216,
+    2011
    ],
    "deps": [
     "compat"
    ],
-   "commit": "79cff850383c875119da351567ea4713875f269f",
-   "sha256": "1yqxj6dd7zckmy2hp1lyr3prcqg2qh8w5f7rd2jb53p5xwmnr8qy"
+   "commit": "9da4218d5b260e0d5e9dad1c0b4fcea3bbb13cde",
+   "sha256": "0fmpy9292cch8pwsr4n05cxn2cslii0m9fcnlyrs3kk19ydkycdw"
   },
   "stable": {
    "version": [
@@ -100893,16 +101602,16 @@
   "repo": "NicolasPetton/pass",
   "unstable": {
    "version": [
-    20260109,
-    1144
+    20260214,
+    2130
    ],
    "deps": [
     "f",
     "password-store",
     "password-store-otp"
    ],
-   "commit": "de4adfaeba5eb4d1facaf75f582f1ba36373299a",
-   "sha256": "1by7rr1rjw8slxvkkkcg7g8qkwaz1bm0ylzj81p2rxi8xw3f2jq5"
+   "commit": "143456809fd2dbece9f241f4361085e1de0b0e75",
+   "sha256": "0pzay8s1aqg8x07jm87ylxf54d4vsy32f0jj9cn20b6gjc94x1fi"
   },
   "stable": {
    "version": [
@@ -101274,6 +101983,30 @@
    ],
    "commit": "34538affb3f341b3c56a875bb094ddb2b859a8ef",
    "sha256": "0qzsalbxksb44f0x7fndl2qyp1yf575qs56skfzmpnpa82dck88g"
+  }
+ },
+ {
+  "ename": "pathaction",
+  "commit": "217a081852ced7f1b88fb1b00e3fccabc193288a",
+  "sha256": "13pwya825rvlh9p26jqcs740vv7f3755fih53c08r8nm5xizk1qh",
+  "fetcher": "github",
+  "repo": "jamescherti/pathaction.el",
+  "unstable": {
+   "version": [
+    20260215,
+    2013
+   ],
+   "commit": "8a7c00b050e5f847f126c58889c5114336f5b744",
+   "sha256": "0kid65lzg9z45j8bpdgz171g3bp4dplfa73aiwn742hvz6dx71b5"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "97d22e6ba7f7b90ab30411c43ce61696cb1ce7bd",
+   "sha256": "06n0avdm8xqfz2gr4yhqikrr707lxz418sij3hlv50vxvb5qb7vp"
   }
  },
  {
@@ -101962,25 +102695,26 @@
  },
  {
   "ename": "persist-state",
-  "commit": "b968e7d25a52891796fd6717cc0ae4df664542b5",
-  "sha256": "0fxfzcyk9fc9p2zn12sfpjhbzm210ygb2r40vhlk4w4b1m6vjmf4",
+  "commit": "1833f93726a7129f4aa8a26ff4045c128ccdf991",
+  "sha256": "1x7wplh8j0nbb8jxnsja1hyb206wmnkjgpzsi6vbfj91764z4ivl",
   "fetcher": "codeberg",
-  "repo": "bram85/emacs-persist-state",
+  "repo": "meedstrom/emacs-persist-state",
   "unstable": {
    "version": [
-    20240904,
-    2057
+    20260217,
+    1752
    ],
-   "commit": "51b2092ac206a0d8a0f682fbc32fe089716c37cb",
-   "sha256": "16js69arkcccnns2bijc257lyr359f1f2ly3sx7rb6zc4dzwzwc0"
+   "commit": "bb8d39612197558a497152339ba927506f18bcb5",
+   "sha256": "0yhj0yxznvix7jx905nklx01blyz6dn6llg3mbs2n4imdsixl74a"
   },
   "stable": {
    "version": [
     0,
-    4
+    5,
+    0
    ],
-   "commit": "99e22bd6dd7b768c617596da952a5b8e53d16ecb",
-   "sha256": "1lg1myxb5pqf9m19kza2iwbcdcdghkrcb7fbgk7jghn2ag0naasf"
+   "commit": "bb8d39612197558a497152339ba927506f18bcb5",
+   "sha256": "0yhj0yxznvix7jx905nklx01blyz6dn6llg3mbs2n4imdsixl74a"
   }
  },
  {
@@ -101991,20 +102725,20 @@
   "repo": "jamescherti/persist-text-scale.el",
   "unstable": {
    "version": [
-    20260114,
-    1606
+    20260215,
+    2013
    ],
-   "commit": "4d7d58b75f6d998a69da1dd7d444642dfec38cf3",
-   "sha256": "1vnfq8vjhxjh5mkblv73dycbj4z690wmj1mzfyivjz20nfcrfavy"
+   "commit": "1d2983986a32da95c878ce05929f43ecc370c82c",
+   "sha256": "00d5yk0h3vzc2fc7n4g6rc7nw0hac9bzgi66c6q13rlhdjxz76zd"
   },
   "stable": {
    "version": [
     1,
     0,
-    3
+    4
    ],
-   "commit": "235e37b1ca38816b3bb882f7a40bb109e8739ea8",
-   "sha256": "1k2p7z95j331kw77q68151400723c6w4afjgrbgdjfj52przsxrk"
+   "commit": "8098af6ba9ff251d19f9e41b39c84f7b9b758f26",
+   "sha256": "006j8sdzp671wj07bs5lfr21lcfb81c2gn0kn13jphmki14s7i02"
   }
  },
  {
@@ -102054,15 +102788,16 @@
   "repo": "rolandwalker/persistent-soft",
   "unstable": {
    "version": [
-    20250805,
-    1017
+    20260202,
+    1154
    ],
    "deps": [
+    "cl-lib",
     "list-utils",
     "pcache"
    ],
-   "commit": "24e41d1952bef5953ef0af2288de146265c7ee10",
-   "sha256": "0wp4hd4j7dbiqf08yywi3s0y9rmpk2hycmlzqk0c0iq0r3kwl83d"
+   "commit": "c94b34332529df573bad8a97f70f5a35d5da7333",
+   "sha256": "057wk7ai3l1anhxxlgvqgsl3r2rjyivwi8mi5swsidc9qgzwczvf"
   },
   "stable": {
    "version": [
@@ -102108,6 +102843,25 @@
    ],
    "commit": "1adbb6a9f9a4db580a9b7ed8b4091738e01345e6",
    "sha256": "0f9ljpmq8b97n6wa8bwn4f2v7imvfxc2pjqk6xjkmwbfpihrns10"
+  }
+ },
+ {
+  "ename": "persp-gumshoe",
+  "commit": "cae5094c143c1eb882edb423f6f2b6f5b5217259",
+  "sha256": "0miynpx5z4xjyz4lrzyd51pkwxp2q2dp1sddh4aj6j6m6zs6c5bj",
+  "fetcher": "github",
+  "repo": "Overdr0ne/gumshoe",
+  "unstable": {
+   "version": [
+    20260217,
+    448
+   ],
+   "deps": [
+    "gumshoe",
+    "perspective"
+   ],
+   "commit": "4c228d89b35861f6461afcbd5cc596bd30582412",
+   "sha256": "07sfjy8plnnrqm9whkwbnly8m9sda1bnz5jj44fknb963rs5cqxa"
   }
  },
  {
@@ -102196,25 +102950,25 @@
   "repo": "nex3/perspective-el",
   "unstable": {
    "version": [
-    20251104,
-    1408
+    20260211,
+    633
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "7f47c9a7be7b7d03f6d8430c84eec80ae5896699",
-   "sha256": "1zsm848vrp97qfrfwjx7axijg8ji95a8nicxp1zia947g8fbpm33"
+   "commit": "64ef5eaaab9e7564e8b9788ce6d0e2359daf5dca",
+   "sha256": "1v22m3l7p89wsdy0ydv0w91v0h9wjl1v33gim756dz8zcx8m1p8y"
   },
   "stable": {
    "version": [
     2,
-    20
+    21
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "bdd14b96faa54807a4f822d4ddea1680f1bfd6c7",
-   "sha256": "108n8xgyxf0mxv6l0mbqb9s0v20bdnj4xcd2mi0zbl46r48cq6gp"
+   "commit": "64ef5eaaab9e7564e8b9788ce6d0e2359daf5dca",
+   "sha256": "1v22m3l7p89wsdy0ydv0w91v0h9wjl1v33gim756dz8zcx8m1p8y"
   }
  },
  {
@@ -102385,25 +103139,25 @@
   "repo": "emarsden/pg-el",
   "unstable": {
    "version": [
-    20251226,
-    1404
+    20260208,
+    1419
    ],
    "deps": [
     "peg"
    ],
-   "commit": "d0062a20788b48dba693368faee62b5e42ef5961",
-   "sha256": "04m0200lwkdycp55i0mraxhm4y6si6d5q9d0bwp6kqwxrcpsks7a"
+   "commit": "52888cb6120407654f248877b2a78a75f7df0d99",
+   "sha256": "19hh45mlb4j6a3ys3wvivj0bm5xy5vjwscnvn68b656b5jk5himh"
   },
   "stable": {
    "version": [
     0,
-    62
+    63
    ],
    "deps": [
     "peg"
    ],
-   "commit": "e63d6c7552dab58a056283b2292c7af6322f9703",
-   "sha256": "0fjzrn5b4s00km71ya98vwwfyvd4rvcywxdxqzy5xfrv8crm92w6"
+   "commit": "52888cb6120407654f248877b2a78a75f7df0d99",
+   "sha256": "19hh45mlb4j6a3ys3wvivj0bm5xy5vjwscnvn68b656b5jk5himh"
   }
  },
  {
@@ -102875,16 +103629,16 @@
   "repo": "emacs-php/phpstan.el",
   "unstable": {
    "version": [
-    20250930,
-    1139
+    20260218,
+    453
    ],
    "deps": [
     "compat",
     "php-mode",
     "php-runtime"
    ],
-   "commit": "07ef7531f2ec73b90a965ac865cca8c96086f9de",
-   "sha256": "1myzqbd00892a604kg88bxglk0w6valdvmaybsixapr5wgg2sbri"
+   "commit": "77fba8fe9d63661e940b392a0e4b573e7edafb7b",
+   "sha256": "0q08wx0k7n86v4jdspkjdjn1kmjy4cf1qrkj71qi0ga943vwz11l"
   },
   "stable": {
    "version": [
@@ -102977,26 +103731,28 @@
   "repo": "dnouri/pi-coding-agent",
   "unstable": {
    "version": [
-    20260117,
-    2159
+    20260224,
+    1042
    ],
    "deps": [
-    "markdown-mode"
+    "markdown-mode",
+    "transient"
    ],
-   "commit": "b734fe0b2007126bf2c33bf0ef7cb1c45d8bd365",
-   "sha256": "1vrd9b22q9w6z82m4ixzmwfbnibckzdbwmzmqmxi8g2l4czgp68h"
+   "commit": "46677cad30c3daf15e75ecf53a6206ff726ceb14",
+   "sha256": "0fq8g9sqsf5kmyzw4w1jnmmpxa81b62jbpkzzkc1296ai75nl173"
   },
   "stable": {
    "version": [
     1,
-    1,
-    0
+    3,
+    5
    ],
    "deps": [
-    "markdown-mode"
+    "markdown-mode",
+    "transient"
    ],
-   "commit": "1bcb63da9014121159fd43bd20d691a38e951bc0",
-   "sha256": "1w62wh3di14g6xcip8znb4p4ffnsm9irim3jlf26gkmv1pgd01ag"
+   "commit": "e6d43f2d936a1fd860ce9439e19b1e07e668c37d",
+   "sha256": "1v0yj95x7yl98qssdsabfqjr338k3xkilhhx7zwgjjqlq0npkp6w"
   }
  },
  {
@@ -103315,11 +104071,11 @@
   "repo": "Anoncheg1/pinyin-isearch",
   "unstable": {
    "version": [
-    20240328,
-    2110
+    20260222,
+    413
    ],
-   "commit": "bc69e38e25e623a321c5c37959fb175334cf9e1a",
-   "sha256": "0vmsl4b8hv9hdass8w4j7gyrhp9acrnyyc30hqfflsb61p69h770"
+   "commit": "a48376f1c48b827e3c373905621a669b98fa354c",
+   "sha256": "1813blixrjhnvs0hxnbkj177m3nrv1l3wdm51wqvfmxdjg6an067"
   },
   "stable": {
    "version": [
@@ -104100,17 +104856,17 @@
  },
  {
   "ename": "po-mode",
-  "commit": "38e855cde9264bff67016d23e7e5e00f113c55bf",
-  "sha256": "1w06i709bb04pziygdn7y47gcci7gybg0p7ncdsm07d0w7q14v2z",
-  "fetcher": "github",
-  "repo": "emacsmirror/po-mode",
+  "commit": "6667dff070897fa9de80f42649c1391ec1b181dc",
+  "sha256": "1vcjijk4m1iy4rmxka8shyx4bk0fmnlpww3kjgcj1b41ld01hwxg",
+  "fetcher": "git",
+  "url": "https://git.savannah.gnu.org/git/gettext/po-mode.git",
   "unstable": {
    "version": [
-    20260102,
-    409
+    20260217,
+    956
    ],
-   "commit": "5500e864a5aab5254efd7da11b57faefec08134e",
-   "sha256": "0af84q303f11xbbmkz8qy24yg4rby43d40lxkg8zlh9r200yp03v"
+   "commit": "27538dd0938d5a941833d503afc9dba13dcf16fe",
+   "sha256": "0963khl6vazhb1i760dg1h69n10xwsh9yn0bd6wx9w0zv8yb5lhc"
   },
   "stable": {
    "version": [
@@ -104842,15 +105598,15 @@
   "repo": "kn66/pomo-cat.el",
   "unstable": {
    "version": [
-    20251127,
-    1631
+    20260224,
+    2202
    ],
    "deps": [
     "popon",
     "posframe"
    ],
-   "commit": "441b5f8476e99e740eba72cf52c4edf1bbe51673",
-   "sha256": "0syi1chf570lsjpjh5fi5cbyh018kw5c9347zvgxlmq6ixsvq5zv"
+   "commit": "f9eab9a897598c6da713b1730739dd2e41e70fda",
+   "sha256": "0l9ad8lmxhr8ni1ivf4fwmsawwkri6rn8ms7iibs5z342jqy4bn7"
   }
  },
  {
@@ -105305,20 +106061,20 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20251125,
-    846
+    20260225,
+    112
    ],
-   "commit": "d93828bf6c36383c365bd564ad3bab5a4403804c",
-   "sha256": "16hl3whqxw25p3m8fsr2z2bcwrq3dkfcn7x27d9sicj3v64l30pm"
+   "commit": "41cc4def6190f100ba50dca51457c38f4f90dfb1",
+   "sha256": "1hk7ma2hs0l0d9ax7skg75g1syv3lpfj37y8kq5yh1i9bfl3p546"
   },
   "stable": {
    "version": [
     1,
     5,
-    0
+    1
    ],
-   "commit": "d93828bf6c36383c365bd564ad3bab5a4403804c",
-   "sha256": "16hl3whqxw25p3m8fsr2z2bcwrq3dkfcn7x27d9sicj3v64l30pm"
+   "commit": "4fc893c3c9ea3f6b5099ac1b369abb3c6da40b1e",
+   "sha256": "01x9kyfghx48gxh7mxfvkvvi0m64zv7w9pl4fnryzm9d5ql5lbw4"
   }
  },
  {
@@ -105726,14 +106482,14 @@
   "repo": "zonuexe/emacs-presentation-mode",
   "unstable": {
    "version": [
-    20250327,
-    202
+    20260131,
+    2112
    ],
    "deps": [
     "compat"
    ],
-   "commit": "42f13613b0d01ef78c36fc352ae8976cffc50e71",
-   "sha256": "12v8pcc5ayn26mhm2xbp5pb8269yc0mh0y5j34r54ajpsb9cwl1h"
+   "commit": "5393ea474d76a9d529d27fb1d6185c015e34368c",
+   "sha256": "1h5ygnc6zphhlzg7h6slk40584hb5qsjp5lilnp3iyq2gdzax9f4"
   },
   "stable": {
    "version": [
@@ -106200,14 +106956,14 @@
   "repo": "haji-ali/procress",
   "unstable": {
    "version": [
-    20250914,
-    1846
+    20260129,
+    1256
    ],
    "deps": [
     "auctex"
    ],
-   "commit": "137655ec1193bd1ea1a1ee3362349491c873710a",
-   "sha256": "0i4kgx51vw6kx8v70gdi84kagcm8xz4mbgwx9wz8cxir6yfbkwd9"
+   "commit": "de0c3b40a7f5d66d71529784e0a35069a064e27d",
+   "sha256": "1gq669fgkyki8a930p1nmacdi10akw2hpffiyrsyfi9mzwafrqa9"
   }
  },
  {
@@ -106509,6 +107265,24 @@
   }
  },
  {
+  "ename": "project-rails",
+  "commit": "1c851eb29971bd6935eaf2e57e2cfbafa78987a8",
+  "sha256": "1778z20n7qawqkbk6kk8gk7ds3856csnazqq731sj8da0c9v2d3b",
+  "fetcher": "github",
+  "repo": "harrybournis/project.el-rails",
+  "unstable": {
+   "version": [
+    20260201,
+    1909
+   ],
+   "deps": [
+    "inflections"
+   ],
+   "commit": "653e31a0b7b08445fa3efc41d741d642a46f9903",
+   "sha256": "0lk65na3l5ww1f45bv6d4zrjsbvf15lbly4val03cal9f15nds7k"
+  }
+ },
+ {
   "ename": "project-rootfile",
   "commit": "0fdd6cb9b09cfa3941c0d4dc8271d4c86863bd31",
   "sha256": "0yz3dg7r8pr9i79svd67vh2axskraxq2cjkavzjl9i8nidkyfjxn",
@@ -106612,11 +107386,14 @@
   "repo": "bbatsov/projectile",
   "unstable": {
    "version": [
-    20260109,
-    1335
+    20260216,
+    652
    ],
-   "commit": "f19262ae3f2764f10a4d087497058cdb9a0fd3df",
-   "sha256": "1gxsnsirf2nfmsg5j9iibya4r9drdmhni63fpf9k0mcmzkj4sfjv"
+   "deps": [
+    "compat"
+   ],
+   "commit": "f12fdae30a36e3614fa6944969bf37dec9998301",
+   "sha256": "17k271gbq64a9dbi1akp4frrccx7jqcq22xb34fddl28dhrpk49y"
   },
   "stable": {
    "version": [
@@ -106991,21 +107768,35 @@
  },
  {
   "ename": "projmake-mode",
-  "commit": "f98962bf6b55a432a45f98b0a302710546d1be07",
-  "sha256": "1bwydyjj2x7vlc1fh14505bl2pplksx46rsmqwx46zyfkrvgabp1",
+  "commit": "4d2bc3a7ab1fca4f6e4dae05a75fccdbe9723864",
+  "sha256": "1xdz8cxigkpdfcfxsc92v5gszmanpxv4c50jswi1m3jhb0gki1r5",
   "fetcher": "github",
-  "repo": "ericbmerritt/projmake-mode",
+  "repo": "emacsattic/projmake-mode",
   "unstable": {
    "version": [
-    20241228,
-    1643
+    20250211,
+    1534
    ],
    "deps": [
     "dash",
     "indicators"
    ],
-   "commit": "93e2a23f929d69ac3d735a05d6bdcd93fca32471",
-   "sha256": "0z5nbbwis749gdsfz7fqzahhr4dx3jxavnnww06pvbyj7g5k3zwk"
+   "commit": "99f10611c24e0884f1f24744adcccb3d972326f6",
+   "sha256": "1pbpggg6kp0j6314nbxjfc8dk7cbx3lmd0lfdy8mr21rwzlk4c2a"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    11,
+    1
+   ],
+   "deps": [
+    "dash",
+    "indicators"
+   ],
+   "commit": "99f10611c24e0884f1f24744adcccb3d972326f6",
+   "sha256": "1pbpggg6kp0j6314nbxjfc8dk7cbx3lmd0lfdy8mr21rwzlk4c2a"
   }
  },
  {
@@ -107129,11 +107920,11 @@
   "repo": "ProofGeneral/PG",
   "unstable": {
    "version": [
-    20260113,
-    1228
+    20260124,
+    1351
    ],
-   "commit": "e164eca4e94fe9db750e1a350bb462be30c4469a",
-   "sha256": "0xf98l2bszm2y0kn55m93r0gzpgi8wh9mw2rsfczxvq68jhlywld"
+   "commit": "75c13f91b6eb40b8855dfe8ac55f8f7dac876caa",
+   "sha256": "0zsvvq54q50q9zcmgxiqgks7hkzm9v740mrygvlxyb8yhrv7j4h9"
   },
   "stable": {
    "version": [
@@ -107242,10 +108033,10 @@
   "stable": {
    "version": [
     33,
-    4
+    5
    ],
-   "commit": "edaa823d8b36a8656d7b2b9241b7d0bfe50af878",
-   "sha256": "1lgrfnxdzp5jjfal2apkqwq37wf6g7jn2cvgv5iypsvf9f4nfrzy"
+   "commit": "b6f9284da830b69be787732ffdaa35049d20a088",
+   "sha256": "0wgp1indksx8fp18gg65kmvjb3nk1qz2v7wgr8cykal0jhqk0zvf"
   }
  },
  {
@@ -107833,11 +108624,11 @@
   "repo": "smoeding/puppet-ts-mode",
   "unstable": {
    "version": [
-    20251212,
-    1319
+    20260223,
+    1132
    ],
-   "commit": "7ef01e46e66b7b02c702bbd0523d63a8d567a474",
-   "sha256": "06dcgv6rd0hyvqzi4y9yh7f1mxb6xha04m00alc4h3fq5626gcb2"
+   "commit": "f287c44f357604ec7fbf2f3ab0196dcd47056593",
+   "sha256": "0lwx9j5p8ayg4px4jlfr57hv5cla1lmbxcqgagjpd73z3f8daahy"
   }
  },
  {
@@ -108159,14 +108950,14 @@
   "repo": "rocky/emacs-pyasm-mode",
   "unstable": {
    "version": [
-    20260117,
-    2029
+    20260122,
+    136
    ],
    "deps": [
     "compat"
    ],
-   "commit": "3d3dc5a820a488a1fb9618fda5d7307a5eae75ec",
-   "sha256": "03ywy2wi76dhna0sxzs9nrppfcxkqvvzh32k74a6ydbcvkk46al3"
+   "commit": "b9434097b5454a2b28440d72ec4eadbdff44f651",
+   "sha256": "0hza1c1p478yg5qw18mqd4npi5rjry5yb3ix7fxbggryfwzjg7bq"
   }
  },
  {
@@ -108896,11 +109687,11 @@
   "repo": "python-mode-devs/python-mode",
   "unstable": {
    "version": [
-    20251215,
-    1157
+    20260131,
+    1655
    ],
-   "commit": "5719f9a18c4813303df6c8102ac25fce8e4536d0",
-   "sha256": "1dzl5fiaz9cbis92avflfynq6lnb8c5iwg0w727jkz3jxxp7zgrr"
+   "commit": "2a6fdb1c823bf8125f6354727db63c8894092821",
+   "sha256": "07bpqfg11xrcsmbqmchgm77gi8ljgnn3wfajd4wbfh3w65yfcfdi"
   },
   "stable": {
    "version": [
@@ -109139,11 +109930,11 @@
   "repo": "psaris/q-mode",
   "unstable": {
    "version": [
-    20260110,
-    1639
+    20260216,
+    1450
    ],
-   "commit": "ce1c5e827c29f7799b699aa0a476f4f06a1cf7ff",
-   "sha256": "064xqqr2fdk037dnasibmayx9jsi3g6m36xbdmdp8niil5250xv8"
+   "commit": "766e7b58b666de13cd0dced7828c762be92f08cc",
+   "sha256": "1ijmw1dkpsq1i26wifz7yw7bykw0v3byb59wvnmqqi58z5j4lnyf"
   }
  },
  {
@@ -109492,11 +110283,11 @@
   "repo": "jamescherti/quick-sdcv.el",
   "unstable": {
    "version": [
-    20260114,
-    1535
+    20260221,
+    311
    ],
-   "commit": "10be5e6d499da524000d1b6891080d01d5b9a949",
-   "sha256": "1fyshazwr9pkfwf72imbbl2nnvif6f0qgpq6s2ivwc0vj1087wh4"
+   "commit": "d12901f87dd191fd6061abcb32cac31503da62be",
+   "sha256": "1bdp822rwz9xq9c5garfmn5afap32l9yr7lv7jgndib8qz3hgxf8"
   },
   "stable": {
    "version": [
@@ -110062,11 +110853,11 @@
   "repo": "punassuming/ranger.el",
   "unstable": {
    "version": [
-    20260117,
-    2303
+    20260201,
+    717
    ],
-   "commit": "8a7e0f246049789953b65e2776bfdf2a80d25bca",
-   "sha256": "0yqcy83hf9bmrf405inn1csw3w0pjr3w8jsnxhhba2wkl5k14va1"
+   "commit": "61e7c840c52007dc17e64215fe8dbcb71139fa39",
+   "sha256": "1nyh2c6z9pp2gmcybpy5b2i1rg4d7v9v2ck8m7siagrjwfzdxqfk"
   },
   "stable": {
    "version": [
@@ -110198,20 +110989,20 @@
   "repo": "ybiquitous/rbs-mode",
   "unstable": {
    "version": [
-    20240806,
-    56
+    20260203,
+    1023
    ],
-   "commit": "d382032cb276d452fdd512c1f1f1b9f95153b356",
-   "sha256": "1ibn8246q0yqdnf3qdww9rvzac9gla7gzjj0n5j5x08brgj5ll2h"
+   "commit": "c88a53a1981c301a65fa21de225708085d087b7e",
+   "sha256": "12ax8c7az9wlq7qhhf40vwrhng16wx9hjq7pr3fngmksma6cckk8"
   },
   "stable": {
    "version": [
     0,
     3,
-    2
+    3
    ],
-   "commit": "d382032cb276d452fdd512c1f1f1b9f95153b356",
-   "sha256": "1ibn8246q0yqdnf3qdww9rvzac9gla7gzjj0n5j5x08brgj5ll2h"
+   "commit": "c88a53a1981c301a65fa21de225708085d087b7e",
+   "sha256": "12ax8c7az9wlq7qhhf40vwrhng16wx9hjq7pr3fngmksma6cckk8"
   }
  },
  {
@@ -110494,11 +111285,11 @@
   "repo": "xenodium/ready-player",
   "unstable": {
    "version": [
-    20251205,
-    1320
+    20260224,
+    915
    ],
-   "commit": "f1a422c855748d0af0c61964f8a92ad81c445470",
-   "sha256": "19l72avwy7q8vc2im0q9i5f0hhhqf397xyf1dnz2lmd6rvy90kay"
+   "commit": "e7737e59f9bc70872935a46da67eef919b9141c4",
+   "sha256": "14jlwx8y6fvyhrv9w4w4rmri8xm9xzh27c5bgzg1lgbycyly2zqm"
   },
   "stable": {
    "version": [
@@ -110557,16 +111348,16 @@
   "repo": "realgud/realgud",
   "unstable": {
    "version": [
-    20260111,
-    1242
+    20260128,
+    841
    ],
    "deps": [
     "load-relative",
     "loc-changes",
     "test-simple"
    ],
-   "commit": "5fb027b628ebe9b54bcba8b0749dfa768275a77f",
-   "sha256": "13sxikl82bz0an0s2nl62w4x5pnhk4mj8bl30y14qy86gpvp4p8j"
+   "commit": "fe1d6eab69375c704c6861125fa1f4d0d758a5e8",
+   "sha256": "1h86qyfc9d4ch7h1znxbz49kwppgvwwgkhcgh4m24nidwh8hs03z"
   },
   "stable": {
    "version": [
@@ -110828,20 +111619,20 @@
   "repo": "xendk/reaper",
   "unstable": {
    "version": [
-    20260116,
-    2011
+    20260206,
+    2340
    ],
-   "commit": "747d53b4a7db77648931ae1396151ae447404b08",
-   "sha256": "04qjplbm5wj0iy1b473yz3angkb7x78gs0yg951222a004fzg9a9"
+   "commit": "71c0fcb54a13a446851d4fb351fd9576fefe4172",
+   "sha256": "1iczx7bxhnyvsbm5za79cckfnn2zirvfnb7769mi8c5p3f6ly01n"
   },
   "stable": {
    "version": [
     1,
-    5,
+    6,
     0
    ],
-   "commit": "7515ef42e0bfb0fd45d2e283e654271fe20cf447",
-   "sha256": "0lgsyabksiqlsh0m7x0ngryxkjpwl2lx42apjnpcbhl0ddwz9qhm"
+   "commit": "71c0fcb54a13a446851d4fb351fd9576fefe4172",
+   "sha256": "1iczx7bxhnyvsbm5za79cckfnn2zirvfnb7769mi8c5p3f6ly01n"
   }
  },
  {
@@ -111949,20 +112740,20 @@
   "repo": "BHFock/repo-grep",
   "unstable": {
    "version": [
-    20250826,
-    1109
+    20260219,
+    1754
    ],
-   "commit": "98dd4b492d93b8d13f9bc7b80efe91577c13e779",
-   "sha256": "1fhj9hyxawn3pdy0jhnc4fw1dfrxzm13q36bkz51kcnw2lkl1njk"
+   "commit": "786259b805bd0617f1e718c1da79a5ef2da5a2ec",
+   "sha256": "1fm9ngjz2pv0218qfxgnnf82m1j9vfkhg98dkrg2jlqlwm4bbxb7"
   },
   "stable": {
    "version": [
     1,
     5,
-    2
+    3
    ],
-   "commit": "98dd4b492d93b8d13f9bc7b80efe91577c13e779",
-   "sha256": "1fhj9hyxawn3pdy0jhnc4fw1dfrxzm13q36bkz51kcnw2lkl1njk"
+   "commit": "786259b805bd0617f1e718c1da79a5ef2da5a2ec",
+   "sha256": "1fm9ngjz2pv0218qfxgnnf82m1j9vfkhg98dkrg2jlqlwm4bbxb7"
   }
  },
  {
@@ -112556,11 +113347,11 @@
   "repo": "galdor/rfc-mode",
   "unstable": {
    "version": [
-    20231013,
-    1353
+    20260127,
+    1807
    ],
-   "commit": "ab09db78d9d1baa4da4f926930833598e1e978ce",
-   "sha256": "0sym5pji4ba4jy79zfs7gb2n9kqa60ma4z622s0mz647g56z09f4"
+   "commit": "2d3dcd649e291eeb93091560b504f96162371c32",
+   "sha256": "0hrh5b0ph39nbqxgvj69i3mcmiq2gfsxgfzydj539x3vcz8s4140"
   },
   "stable": {
    "version": [
@@ -112867,21 +113658,6 @@
   }
  },
  {
-  "ename": "rimero-theme",
-  "commit": "c6d07b0c021001195e6e0951c890566a5a784ce1",
-  "sha256": "0jbknrp9hc8s956cy2gqffxnx0fgnhmjqp2i4vyp0ywh45wrls5r",
-  "fetcher": "github",
-  "repo": "yveszoundi/emacs-rimero-theme",
-  "unstable": {
-   "version": [
-    20180901,
-    1348
-   ],
-   "commit": "a2e706c2b34f749019979a133f08a2d94a1104b3",
-   "sha256": "1kcvvaizggzi7s3dlh611bkirdf6y89kzddc273drdks705s01wh"
-  }
- },
- {
   "ename": "rinari",
   "commit": "4b243a909faa71e14ee7ca4f307df8e8136e5d7c",
   "sha256": "0qknicg3vzl7zbkwsdvp10hrvlng6mbi8hgslx4ir522dflrf9p0",
@@ -113170,11 +113946,11 @@
   "repo": "tad-lispy/roc-ts-mode",
   "unstable": {
    "version": [
-    20250311,
-    1928
+    20260206,
+    908
    ],
-   "commit": "f96ba038e53efbc4113bf675a22d2599be8c21ad",
-   "sha256": "0f5l0aiyasjz12k0zikh73lv8cv6v04h44kf9vylb6kcyy2m0nj6"
+   "commit": "00aa6d23192a85c4f8e2905c1aa526fefec51f20",
+   "sha256": "0id77k08ckr9780wbwhl5adbd7fin6lwgxi1m71fd1d9lxx9ai5x"
   }
  },
  {
@@ -113432,11 +114208,11 @@
   "repo": "vs-123/royal-hemlock-theme",
   "unstable": {
    "version": [
-    20260110,
-    903
+    20260123,
+    1254
    ],
-   "commit": "50c01627b7132feb6549e9498a41e12a8d53add7",
-   "sha256": "0fasipvx9b3q64cxmqkw347ii5bggih9mmc0s74zy7z7rzk276i7"
+   "commit": "8a4d85a7029866540db5261b33b20223374f26ac",
+   "sha256": "03n3mr97d5l84lck19a3hfzlwscp4v2bbfg6axsdjpzxpy9jpymx"
   }
  },
  {
@@ -113537,11 +114313,11 @@
   "repo": "Andersbakken/rtags",
   "unstable": {
    "version": [
-    20251228,
-    2249
+    20260207,
+    2156
    ],
-   "commit": "829a6298d6bfba8ed541570fcbe3daf5ce3135d0",
-   "sha256": "1qzd08sc3kg0cmfssdbdn595iwwalxhb5b43dsamzgfc3xhd7qap"
+   "commit": "a0b315437da7f17d6c04e33234833e3baa474562",
+   "sha256": "0sb63ysagmndqnymdg4yz8vyzm4kh6r41s73yzzfplza2nd92rhj"
   },
   "stable": {
    "version": [
@@ -114189,11 +114965,11 @@
   "repo": "rust-lang/rust-mode",
   "unstable": {
    "version": [
-    20260118,
-    536
+    20260207,
+    424
    ],
-   "commit": "4adb3a729653315ed3efcf3e89f20d940dfe0e2d",
-   "sha256": "028s0nh2y1jgmni3ypr8vy1531wh5pjrhd2f78a86xim9nkamdx5"
+   "commit": "f68ddca5c22b94a2de7c9ce20d629cd78d60b269",
+   "sha256": "17fnshvkxdnmca5544l3hlyqk6gv4ibzp1jqcpz3227jd2kac5fx"
   },
   "stable": {
    "version": [
@@ -114236,8 +115012,8 @@
   "repo": "emacs-rustic/rustic",
   "unstable": {
    "version": [
-    20250630,
-    1332
+    20260216,
+    440
    ],
    "deps": [
     "dash",
@@ -114250,8 +115026,8 @@
     "spinner",
     "xterm-color"
    ],
-   "commit": "bfff139f260c386f60d581edef6df1a0d109a131",
-   "sha256": "0z59fw0rvb6sk62sd393kgk0j65xlkn4xrxs6nhd06vdzx6kjrgv"
+   "commit": "eea94386bf0c7b55adc264faefdfb134ae2807b9",
+   "sha256": "1kl6wrdqj9i81q27m7v8il07sbzrxfcark7pmn4rmcdxs25g69ba"
   },
   "stable": {
    "version": [
@@ -114445,6 +115221,21 @@
    ],
    "commit": "e8bc089e8dfd76f688160e2ac77aee985afeade7",
    "sha256": "166plwg9ggivr3im0yfxw8k6m9ral37jzznnb06kb6g0zycb4aps"
+  }
+ },
+ {
+  "ename": "sail",
+  "commit": "37217c24120a8d7bd50bf68e67041e3928d17785",
+  "sha256": "039sragbw2y95m3kys2d491r94vkgkydqdg3ajs8cv55m726wp5b",
+  "fetcher": "github",
+  "repo": "brannala/esail",
+  "unstable": {
+   "version": [
+    20260209,
+    411
+   ],
+   "commit": "1cc38e174139dfb4732cfb5eb597829a982e1e99",
+   "sha256": "1y3l5z1gxvzq91n0vbgac334z7fs5av4cv4c815wgnc2bbbr9a1z"
   }
  },
  {
@@ -114854,11 +115645,11 @@
   "repo": "yoshinari-nomura/scad-ts-mode",
   "unstable": {
    "version": [
-    20260112,
-    423
+    20260202,
+    1350
    ],
-   "commit": "99e5e0f387de595f81aaf2d41572a8a851921e67",
-   "sha256": "125pay538hbxji9q5b7hmgvyfqzv7ygscdirjin5dk3lzkjx542x"
+   "commit": "afaf52a34050aa1f7da12b85b25f20beffb08e2f",
+   "sha256": "0f023iw8bkyxpy78q2wqpgrn9q8hf5nqwh8y264m3nlyp2nvn8rl"
   }
  },
  {
@@ -115407,20 +116198,19 @@
   "repo": "precompute/sculpture-themes",
   "unstable": {
    "version": [
-    20260112,
-    2109
+    20260215,
+    1259
    ],
-   "commit": "ce17fba2d12775e9596386b237158b8ca531a186",
-   "sha256": "0cw2727p0j23h4smqrilhnpsz8rif64m3mc56dynfk3lf40f0j5d"
+   "commit": "e5ac2c7b72ee58eb66510937270716d25484ecd6",
+   "sha256": "0137zqir9p1lfazs6n8qz0nw4vajawh7w1104psabrqm2izwpjz2"
   },
   "stable": {
    "version": [
     1,
-    7,
-    3
+    10
    ],
-   "commit": "ce17fba2d12775e9596386b237158b8ca531a186",
-   "sha256": "0cw2727p0j23h4smqrilhnpsz8rif64m3mc56dynfk3lf40f0j5d"
+   "commit": "e5ac2c7b72ee58eb66510937270716d25484ecd6",
+   "sha256": "0137zqir9p1lfazs6n8qz0nw4vajawh7w1104psabrqm2izwpjz2"
   }
  },
  {
@@ -115778,19 +116568,19 @@
   "repo": "Anoncheg/selected-window-contrast",
   "unstable": {
    "version": [
-    20260118,
-    1901
+    20260219,
+    1157
    ],
-   "commit": "0f23c16e99516d30bdb374a645f2a27c8b91eabb",
-   "sha256": "16b47s5bddpi9xafvdlc1vpjj7dx7b7l6vcz9hgjzk3l4rhq8s4p"
+   "commit": "600319fe8a15da2c330dcbb497474b3e760ae890",
+   "sha256": "08pqx1qfqh2nrbpy3298mmyysxlc6xgm7ydicj9b36dbzifvfxiq"
   },
   "stable": {
    "version": [
     0,
-    1
+    3
    ],
-   "commit": "c64c770f9663c6d2651ade64766f15d439b542cc",
-   "sha256": "19w6aa6ia4x1m0amj2al7g2as824vkvfxk00pqjkash1a5lwm33c"
+   "commit": "b5a15be393b6af4f74432d0b04a051af35f59272",
+   "sha256": "1y9ccqs9nwcrcylv97n0wbrdp2m7r37nzp22yx52q3vsc8l4c5jd"
   }
  },
  {
@@ -116000,15 +116790,15 @@
   "repo": "abailly/sensei",
   "unstable": {
    "version": [
-    20250831,
-    1341
+    20260125,
+    933
    ],
    "deps": [
     "projectile",
     "request"
    ],
-   "commit": "3129584a6b4b57cbf0e4769dcb8efcc21d8bc821",
-   "sha256": "108vsqv49xf8310fprghzm5v3dkh78p83yrr47z6kag3g85jg1ih"
+   "commit": "4257ca13aaabfeee7be245e1efd00a5b189e7c9a",
+   "sha256": "05jl3mdlzrdcp0ncxm8yjckqxlj9700cgiq05mv9123wlfspx9ll"
   },
   "stable": {
    "version": [
@@ -116131,11 +116921,11 @@
   "repo": "brannala/sequed",
   "unstable": {
    "version": [
-    20251219,
-    1858
+    20260219,
+    2234
    ],
-   "commit": "d8b76c47db7de52118ab9217dac7d3308d4df9cc",
-   "sha256": "0hgh93qyb5wg4xjx6kdj75171hf1mz0la2b684x0f87vvzzz8ij5"
+   "commit": "0156c71a163b7d55b2a8b198eab0be3de9dc229d",
+   "sha256": "1gcn6p0i05nrmrvvaq8jdkdsa2j18j0jrpbqc655agavk9lrnkzw"
   }
  },
  {
@@ -116724,20 +117514,20 @@
   "repo": "xenodium/shell-maker",
   "unstable": {
    "version": [
-    20260116,
-    1019
+    20260213,
+    1201
    ],
-   "commit": "6eafe72de916cb3e75deb4f7220085ac3e775a11",
-   "sha256": "1knswylikwipg8aqb7dip2jm1l8q3sxj8q0af31ipn92v6wh9bks"
+   "commit": "a7ff78f8cd29fba9a694b8d7bbee448c7a51472d",
+   "sha256": "1gy09saiqvcpgbcwkj0bmwp9paix5rw9fd7fhbypx93p80mqdcrn"
   },
   "stable": {
    "version": [
     0,
-    84,
-    8
+    85,
+    2
    ],
-   "commit": "6eafe72de916cb3e75deb4f7220085ac3e775a11",
-   "sha256": "1knswylikwipg8aqb7dip2jm1l8q3sxj8q0af31ipn92v6wh9bks"
+   "commit": "a7ff78f8cd29fba9a694b8d7bbee448c7a51472d",
+   "sha256": "1gy09saiqvcpgbcwkj0bmwp9paix5rw9fd7fhbypx93p80mqdcrn"
   }
  },
  {
@@ -117788,6 +118578,21 @@
   }
  },
  {
+  "ename": "signel",
+  "commit": "64c76292eb459bc98fa51b96c2d6ea82bb46d96c",
+  "sha256": "0hyrc8h102kppwyr16hfah1warsnnqshsq5l9xpj9yckix6c293b",
+  "fetcher": "github",
+  "repo": "keenban/signel",
+  "unstable": {
+   "version": [
+    20260130,
+    1719
+   ],
+   "commit": "5b309ddd8668344310ae7e9f93b6b756da28d9b4",
+   "sha256": "1sx30h0daws15q4vd9xmzx8ca2bbsava6p433dvq8mfmk5f34rki"
+  }
+ },
+ {
   "ename": "silkworm-theme",
   "commit": "9451d247693c3e991f79315868c73808c0a664d4",
   "sha256": "1zbrjqmhf80qs3i910sixirrv42rxkqdrg2z03gnz1g885gpcn13",
@@ -118493,8 +119298,8 @@
   "repo": "emacs-slack/emacs-slack",
   "unstable": {
    "version": [
-    20260115,
-    1525
+    20260211,
+    2317
    ],
    "deps": [
     "alert",
@@ -118506,8 +119311,8 @@
     "ts",
     "websocket"
    ],
-   "commit": "a35c605a2fe98e95d82a80f0f320fd4913418f52",
-   "sha256": "0sjrql913wykmc0bsbfn5ni1s35z8r4kaccaqlam54ypgwalv6wb"
+   "commit": "cbeb64371416e235a0292ba04c0e8815f761f7c5",
+   "sha256": "0dxi36pa2ffria6yf109fwi8gw7z59b2hflrwlj8871f8ydlgvwx"
   }
  },
  {
@@ -118565,14 +119370,14 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20260119,
-    505
+    20260224,
+    1834
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "71707c2bb7d60dc813cdfb2efdce0b948ed2d3ab",
-   "sha256": "15i4k192vmbfcrkdjfvhb8ncds12fzl4cf6inl0l4153sx10g623"
+   "commit": "3a8c17e55d485b31eb22b1bd7c92c2f9cfadf92f",
+   "sha256": "1mka4jzlgv4brwn2la1i2xrafn51l01kl95xvg2rrbmb021xm7qd"
   },
   "stable": {
    "version": [
@@ -119424,14 +120229,14 @@
   "repo": "Fuco1/smartparens",
   "unstable": {
    "version": [
-    20250612,
-    1050
+    20260129,
+    1214
    ],
    "deps": [
     "dash"
    ],
-   "commit": "b629b4e893ba21ba5a381f6c0054bb72f8e96df2",
-   "sha256": "1nfd10kxd1l8bmxhaghhxphl424yg5qn6xcqaligwc3b406b566w"
+   "commit": "82d2cf084a19b0c2c3812e0550721f8a61996056",
+   "sha256": "1b6jsr19nxrsg1isr494qi7p6x5fidcfnznang8h9sqj67iqybi3"
   },
   "stable": {
    "version": [
@@ -119874,16 +120679,16 @@
   "repo": "danielfm/smudge",
   "unstable": {
    "version": [
-    20251224,
-    1549
+    20260203,
+    20
    ],
    "deps": [
     "oauth2",
     "request",
     "simple-httpd"
    ],
-   "commit": "dcca1b9ac15886060788df83c7da63faa5ae027f",
-   "sha256": "0nkr0fy6c7jbjjcfywsw4klil305wjyirnafhgjvq5jrx95zs0m7"
+   "commit": "c90db830e84e34ac5724f57eda2f1112a589df5c",
+   "sha256": "0lql8aapikfyfar8a0p7x2lk49njmd25r3r2ywdwvljz3pr245v4"
   }
  },
  {
@@ -121118,6 +121923,36 @@
   }
  },
  {
+  "ename": "spatial-window",
+  "commit": "8818fe8d023d945a84a5922ac2a8f69fd893c766",
+  "sha256": "19p0lpzaw3gqpn9jfrbmzvjrqrs6qpdwsqbzlah2q08518sz2kqv",
+  "fetcher": "github",
+  "repo": "lewang/spatial-window",
+  "unstable": {
+   "version": [
+    20260221,
+    1439
+   ],
+   "deps": [
+    "posframe"
+   ],
+   "commit": "2a6a4cec766a3ebcd41ab637c3eb9946e80b22b2",
+   "sha256": "1g1yfl99cmmnzgwd1avpwrpvm1s8g4qybdzf68fkqp3hckxb724a"
+  },
+  "stable": {
+   "version": [
+    0,
+    9,
+    3
+   ],
+   "deps": [
+    "posframe"
+   ],
+   "commit": "5388bb6c1989578222b4d5b576482b538977bea4",
+   "sha256": "19nfqxhm3kh8x89z2pwwq7z2izi6wjlmgxqgk7l3m2mww1vphari"
+  }
+ },
+ {
   "ename": "spdx",
   "commit": "fb570e4a9a89319443c0df08980e7427aad7f1a0",
   "sha256": "1yg5rks9j4rbx14fh6d8gyggmw62gc9jfnid10175czd4nzj8vab",
@@ -121125,11 +121960,11 @@
   "repo": "condy0919/spdx.el",
   "unstable": {
    "version": [
-    20260117,
-    104
+    20260221,
+    116
    ],
-   "commit": "40c4691ed406ac2a905c94ec69c720f79a607389",
-   "sha256": "1358013fmpgg4hd8pm5xpfccf4rr1xlgvl43y4r3v5yndq93dfbx"
+   "commit": "f2b74e37c4293e7d29ce287225a723aed46aa07d",
+   "sha256": "0pv7yr0j7y31wcd6409xw6dcnwlrm0001304cn8r57mshah3hrzh"
   }
  },
  {
@@ -121190,14 +122025,14 @@
   "repo": "dakra/speed-type",
   "unstable": {
    "version": [
-    20260112,
-    1339
+    20260220,
+    2305
    ],
    "deps": [
     "compat"
    ],
-   "commit": "3b23b577f2bf76d44e6e5bcc72cba660ae4a4bda",
-   "sha256": "09x2jb54kmypqbzyw61ms7d434b3yqi2si4p0pj8fg13x5xs4qxy"
+   "commit": "e27ebe21cf498ffd1718a18a77baa385c0bcca12",
+   "sha256": "1wfdvg3bbp4ajl12id1fa6vpccx5vdckxczrsk0091xb60f9lcqr"
   },
   "stable": {
    "version": [
@@ -122776,11 +123611,11 @@
   "repo": "jamescherti/stripspace.el",
   "unstable": {
    "version": [
-    20260114,
-    1604
+    20260215,
+    2013
    ],
-   "commit": "e2671ccdd30a950ed84105e872ec564d74bef3ba",
-   "sha256": "16j24j11jnrvqrqmh2yq4km769aa2v20kpnbd457wpnm90ab5vb0"
+   "commit": "c6360e4643c8ead16fa68488d2116d77208c12f6",
+   "sha256": "165w02mmlv685n1x9ppafsr0x7a5sapdrhylhgpl8rirfvgpc7y2"
   },
   "stable": {
    "version": [
@@ -122896,9 +123731,9 @@
  },
  {
   "ename": "subatomic-theme",
-  "commit": "a3c6e6adb1a63534275f9d3d3d0fe0f5e85c549b",
-  "sha256": "0qh311h8vc3c7f2dv6gqq3kw1pxv6a7h4xbyqlas5ybkk2vzq12r",
-  "fetcher": "github",
+  "commit": "c3b5efd2795cb96626a0336f8f54250207e72baa",
+  "sha256": "02a2r6qhgl8vh93qvny6h2m0v4r6hnk0kzhpj1bk6jvilsz3wlf3",
+  "fetcher": "codeberg",
   "repo": "cryon/subatomic-theme",
   "unstable": {
    "version": [
@@ -123001,14 +123836,14 @@
   "repo": "amk/subsonic.el",
   "unstable": {
    "version": [
-    20220826,
-    748
+    20260126,
+    1705
    ],
    "deps": [
     "transient"
    ],
-   "commit": "011e58d434ed707a06a2cfa20509629ebb339c04",
-   "sha256": "0xb3l7ds2qf9p1k1f7dlww3g31drmjpvgdviz55bb65r2zlgnix2"
+   "commit": "d4f7502783fa06ba624ddc2314082340cea4ec9e",
+   "sha256": "09xl0blp1aymggyldhy4zcbf09wgxqa7y02a4d7579x14x230wam"
   },
   "stable": {
    "version": [
@@ -123170,8 +124005,8 @@
   "repo": "kiyoka/Sumibi",
   "unstable": {
    "version": [
-    20260104,
-    1157
+    20260214,
+    1216
    ],
    "deps": [
     "deferred",
@@ -123179,13 +124014,13 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "581a6d61ecc6d627676f946f9703b0fc74685551",
-   "sha256": "1pkglyi25mdgh3i2b9xdqzmx1v0pl3hj28hljfsw1q1y5j5ldi8q"
+   "commit": "dbbb06f6c0d5f921e3d5f8c34a2bcb4ec8caff4d",
+   "sha256": "1czh3r3nmail88wcgx334pprzcjf6v5iz1926gvn1a9pssh7xmam"
   },
   "stable": {
    "version": [
     5,
-    1,
+    2,
     0
    ],
    "deps": [
@@ -123194,8 +124029,8 @@
     "popup",
     "unicode-escape"
    ],
-   "commit": "581a6d61ecc6d627676f946f9703b0fc74685551",
-   "sha256": "1pkglyi25mdgh3i2b9xdqzmx1v0pl3hj28hljfsw1q1y5j5ldi8q"
+   "commit": "dbbb06f6c0d5f921e3d5f8c34a2bcb4ec8caff4d",
+   "sha256": "1czh3r3nmail88wcgx334pprzcjf6v5iz1926gvn1a9pssh7xmam"
   }
  },
  {
@@ -123769,14 +124604,14 @@
   "repo": "abo-abo/swiper",
   "unstable": {
    "version": [
-    20250329,
-    1401
+    20260101,
+    2125
    ],
    "deps": [
     "ivy"
    ],
-   "commit": "e33b028ed4b1258a211c87fd5fe801bed25de429",
-   "sha256": "1yv40k0swdywk0zwxs2s95s4y1pa9k2m3s25fx7gv9pnmf7yw8p1"
+   "commit": "d489b4f0d48fd215119261d92de103c5b5580895",
+   "sha256": "1jady7337ws51y2r78n4mgnijsq8415ga3s5c47f4lpd3d74j2bj"
   },
   "stable": {
    "version": [
@@ -123870,11 +124705,11 @@
   "repo": "dimitri/switch-window",
   "unstable": {
    "version": [
-    20250401,
-    839
+    20260225,
+    115
    ],
-   "commit": "8f771b571a1e60fac2d2a9845c0a5a52d5b440df",
-   "sha256": "0q3zhrylla6knyqjrckdwnwfwhk3pp9mr4zjks9rxccldmr8b1b4"
+   "commit": "a72cf11d21c1f24924a9faeaa9f5d213d8623141",
+   "sha256": "05wi8bxkx0im5plm00rzl1r70ibzvwmq7lcg8lpg0xlrv9d8vkn2"
   },
   "stable": {
    "version": [
@@ -124140,18 +124975,18 @@
   "repo": "zk-phi/symon",
   "unstable": {
    "version": [
-    20170224,
-    833
+    20260218,
+    1909
    ],
-   "commit": "76461679dfe13a5dccd3c8735fb6f58b26b46733",
-   "sha256": "06s7q0zhqmvnhdkqikhfzl1rgm6xzqaxp461ndf8gp44rp1alkl4"
+   "commit": "d663045c290f80b77136d6a49f2be0226f01b565",
+   "sha256": "0n4dqxmpa0vk9za991rcm9za90l5b8cqzqjgzj4nr1yj2lip7f72"
   },
   "stable": {
    "version": [
-    20160630
+    20260223
    ],
-   "commit": "7beeedd70dc37f5904c781fb697c8df056196ee9",
-   "sha256": "1q7di9s8k710nx98wnqnbkkhdimrn0jf6z4xkm4c78l6s5idjwlz"
+   "commit": "d663045c290f80b77136d6a49f2be0226f01b565",
+   "sha256": "0n4dqxmpa0vk9za991rcm9za90l5b8cqzqjgzj4nr1yj2lip7f72"
   }
  },
  {
@@ -124419,6 +125254,30 @@
    ],
    "commit": "014d78269daa99937fb4fa8f5d34e2b3eb368a5f",
    "sha256": "03id3zjiq15nyw0by4fari837c8362fscl7y329gn9ikf7z6hxd9"
+  }
+ },
+ {
+  "ename": "system-idle",
+  "commit": "d3c041dafd99718beccfe4153b34b7ac8a6848ea",
+  "sha256": "1ikqqzlv23rfd9v91ncafag2gmzdywn1x67csawx4ygdm6fyf8gr",
+  "fetcher": "github",
+  "repo": "meedstrom/system-idle",
+  "unstable": {
+   "version": [
+    20260215,
+    1611
+   ],
+   "commit": "74ae4437f2b151aaada98fd5fa99177b21394b7c",
+   "sha256": "06jaaq9lg4sz6w4xpf1g6a4ym6gfba1gfs5hfv9gy8m6c86l1hdh"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    0
+   ],
+   "commit": "598445de14924258f6a3a63cbc8b4cef10dee9d1",
+   "sha256": "05knhqnz3j3hd92xgkak1mlskckw5h4v0mv2gvk04vyi95hz60gy"
   }
  },
  {
@@ -124735,20 +125594,20 @@
   "repo": "Bastillan/tabbymacs",
   "unstable": {
    "version": [
-    20260119,
-    2318
+    20260126,
+    1157
    ],
-   "commit": "ad4b60ce83dea3ec548af4adbdb4beffe2722b5d",
-   "sha256": "0xhvhgp94rqmpklixwpddl9gy2xsnwmlx4cs1hsyjwvkalsrhb67"
+   "commit": "32b8c40774515c940a02c78874cf928b356478de",
+   "sha256": "0hr69fqg5nvka3wdc748rwxvcr58pvqij058wx9dldirbvsn7apl"
   },
   "stable": {
    "version": [
     1,
     0,
-    1
+    2
    ],
-   "commit": "b88bac22c923bebbbc7e52f10a25669a7680698c",
-   "sha256": "0yr9wmmqhv1svlf6yhwx8fnzxyxdzr3kil72sys9l8bablnajzg6"
+   "commit": "32b8c40774515c940a02c78874cf928b356478de",
+   "sha256": "0hr69fqg5nvka3wdc748rwxvcr58pvqij058wx9dldirbvsn7apl"
   }
  },
  {
@@ -124844,14 +125703,14 @@
   "repo": "mclear-tools/tabspaces",
   "unstable": {
    "version": [
-    20251108,
-    1927
+    20260222,
+    1958
    ],
    "deps": [
     "project"
    ],
-   "commit": "8873c46da96cbabe31056cd5c5e85731f4abf07e",
-   "sha256": "0q080bnyzf0ps74wsbrhkibzsm1r58czq5q9v83571jc66kllwjh"
+   "commit": "06fe5ad149bc5852698cd0adda6dd6e320b4cf8f",
+   "sha256": "180gzqjmmin35b7lj93pgrakh0b5wq10q232y5zfhibsmsnxayhi"
   }
  },
  {
@@ -125265,15 +126124,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20260102,
-    1148
+    20260224,
+    1606
    ],
    "deps": [
     "transient",
     "visual-fill-column"
    ],
-   "commit": "e34fb226ec56b17f77a6eb99c22e98d82529d2de",
-   "sha256": "17cbf9pqnfqrzd92s7gb9yvm6c5hlis1i9x0vzlfk1a9lgvy0yc1"
+   "commit": "feb32c92a2197251e65c8c2d5efb438a2e052ebd",
+   "sha256": "19rrycgq4031cd4wljzfy2drir5b21wzj6df0ljr28qjy5gpnkwm"
   },
   "stable": {
    "version": [
@@ -125404,25 +126263,25 @@
   "repo": "minad/tempel",
   "unstable": {
    "version": [
-    20260119,
-    1334
+    20260220,
+    1157
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6ffc61939d461df590f6913176c22bfecdda82e1",
-   "sha256": "0xcgiqq9fm7p050bc1vlr8ihhyl3nnp17f9xp63bs459038dr595"
+   "commit": "7120539bf047d3748636a7299fd7bca62ab2c74a",
+   "sha256": "17lisxzqnxm22132pdb04fk9dvl983x63x19wy0gcgybsbghzap3"
   },
   "stable": {
    "version": [
     1,
-    9
+    11
    ],
    "deps": [
     "compat"
    ],
-   "commit": "506a8d570c145f4df63a18921e34bac6bef3ebe0",
-   "sha256": "1d4flcfnszvl2nyxqav3ha42lx5mhj93f8r4l0gc4n3ir8x5y9f5"
+   "commit": "8d9a1646fb4014a5d34f3f19b7c894310f06a1e8",
+   "sha256": "08d1qd5k63y24sm082bkvyj48svggbryczz42kwjv6nyw9m3kwid"
   }
  },
  {
@@ -125483,6 +126342,21 @@
    ],
    "commit": "92fb170d572f044aaedaa2535990eba556347dfe",
    "sha256": "1ai27rlll766vp1njwzhvayad4k386j9x1hx550j1a8in9kk3wbh"
+  }
+ },
+ {
+  "ename": "template-literals-ts-mode",
+  "commit": "9ab0a00e26d1b8acbaf140a2f7e27abc2f5192fb",
+  "sha256": "1xgdmmraxwzdlsvj8klwf14crq8kvl9bc91f5rh900fdv226g65n",
+  "fetcher": "github",
+  "repo": "ispringle/template-literals-ts-mode",
+  "unstable": {
+   "version": [
+    20260218,
+    1632
+   ],
+   "commit": "cb5d55b4d962efff42d067463bee8cfc0a61a318",
+   "sha256": "19lr14rv6z306cdvivbb1xbkzz4rqwgy62198c5l4458d658avw2"
   }
  },
  {
@@ -125575,6 +126449,21 @@
    ],
    "commit": "bdcfda49b1819e82d61fe90947e50bb948cf7933",
    "sha256": "11nsh6dkd3i489lrqpd9xhr4c0ai51364rlrd6slm54720by9jql"
+  }
+ },
+ {
+  "ename": "tengo-mode",
+  "commit": "9ae2528b4322ed892d54e61a2c7c086a028aeab1",
+  "sha256": "1c1c4lmilr7d1688df0ykn1j2gjg5n2sa942pr957fr2q0vay75n",
+  "fetcher": "github",
+  "repo": "CsBigDataHub/tengo-mode",
+  "unstable": {
+   "version": [
+    20260125,
+    1430
+   ],
+   "commit": "faafdf361abd19024d02e3890684ab61e6637dc8",
+   "sha256": "0n7rig7mk240z4lb8cvx5b0b2acqm444hy3q7s97zsmcqiwjfy1v"
   }
  },
  {
@@ -125705,14 +126594,14 @@
   "repo": "colonelpanic8/term-manager",
   "unstable": {
    "version": [
-    20240811,
-    2337
+    20260220,
+    840
    ],
    "deps": [
     "dash"
    ],
-   "commit": "fbf64768902cded6d75261515bd4aafe7cf56111",
-   "sha256": "05awn9fmm29jrrf8jflr0xy2c983lhx2r8xw7dkaimf4655pcy41"
+   "commit": "1581a90ff9b359449e056da55259b9f42e749f0c",
+   "sha256": "1x88d0ji2b5vq9z1qybbrfqgmjvq3skyp6884zywfb0rlnhl2jc8"
   },
   "stable": {
    "version": [
@@ -126157,15 +127046,16 @@
   "repo": "johannes-mueller/test-cockpit.el",
   "unstable": {
    "version": [
-    20250615,
-    1258
+    20260224,
+    1810
    ],
    "deps": [
     "projectile",
-    "toml"
+    "toml",
+    "transient"
    ],
-   "commit": "6a8527a495fb4611d569c85d06eb06154f8cfe5e",
-   "sha256": "1hhqx05crc5pfd2q66f6c3d03gb1x6w1lc7w5hyd94v078hjr2zh"
+   "commit": "09b8978bba47c8fcefcde435a93ec63255405f8c",
+   "sha256": "1zvyh6pp6l3slj1qm4zs6vvzjvrfa5f70vk5gx8599cad2c2s12q"
   },
   "stable": {
    "version": [
@@ -126471,6 +127361,15 @@
    ],
    "commit": "a9143dbd6a073a6538f011d4095432152de127b7",
    "sha256": "146pj02pj9pgqnqqnfi63v6pgcgzzasay9fx3an85q2wippxn38g"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "a9143dbd6a073a6538f011d4095432152de127b7",
+   "sha256": "146pj02pj9pgqnqqnfi63v6pgcgzzasay9fx3an85q2wippxn38g"
   }
  },
  {
@@ -126675,21 +127574,21 @@
   "repo": "facebook/fbthrift",
   "unstable": {
    "version": [
-    20260119,
-    23
+    20260223,
+    1300
    ],
-   "commit": "6703ee890ae89ff265f4a43373b91e72322af64b",
-   "sha256": "1zc9nywkn5glys8vhg6vd6n674r2v8y2k5hhxw31ci58qx4a67cg"
+   "commit": "22294ff47c55a132e57facf4fd294d5a6759c678",
+   "sha256": "1asv4wqzxy0i7hw8r3gmr4k0w37dz3jx5fbix27ixfyc55m73yll"
   },
   "stable": {
    "version": [
     2026,
-    1,
-    19,
+    2,
+    23,
     0
    ],
-   "commit": "6703ee890ae89ff265f4a43373b91e72322af64b",
-   "sha256": "1zc9nywkn5glys8vhg6vd6n674r2v8y2k5hhxw31ci58qx4a67cg"
+   "commit": "22294ff47c55a132e57facf4fd294d5a6759c678",
+   "sha256": "1asv4wqzxy0i7hw8r3gmr4k0w37dz3jx5fbix27ixfyc55m73yll"
   }
  },
  {
@@ -126801,8 +127700,8 @@
   "repo": "ananthakumaran/tide",
   "unstable": {
    "version": [
-    20241019,
-    2101
+    20260219,
+    336
    ],
    "deps": [
     "cl-lib",
@@ -126810,8 +127709,8 @@
     "flycheck",
     "s"
    ],
-   "commit": "6a35fe355f1442da34b976bf2decf008d6e4f991",
-   "sha256": "0sr7r7bbsj724s7k8g3a4sy462057n0v6l2wx512naxnzhkk56xq"
+   "commit": "9498c4c7fc97d8042fdff532f47f1dc79ebd163a",
+   "sha256": "16i4ay15864mbqvhc6m7allv4zgylfpb1m0zmz8sdj8sdkz4z4ip"
   },
   "stable": {
    "version": [
@@ -126962,11 +127861,11 @@
   "repo": "xenodium/time-zones",
   "unstable": {
    "version": [
-    20251231,
-    1951
+    20260211,
+    2330
    ],
-   "commit": "fd94705f04b1e5bc4a9b08ef9092fea839fe92d7",
-   "sha256": "1bc3i7ljl03dikl5ldsm2gvh3s1w49vrcn4r9r12a05x10f4k4jn"
+   "commit": "9f1326ad9e62daa242a5174b193a27b28e209b36",
+   "sha256": "0wcbbxa6wsb08d76g4fyf4yblpx8rx8q96l2rhchk2jmrxl10rvz"
   },
   "stable": {
    "version": [
@@ -127166,19 +128065,19 @@
   "repo": "aimebertrand/timu-line",
   "unstable": {
    "version": [
-    20250228,
-    2053
+    20260131,
+    1904
    ],
-   "commit": "b57cc4716ca9ced3ebd8df3e689f6b1a21816f7d",
-   "sha256": "17hvf57f1iy085crpqzzvcx00r9g1h4asblvb43vxl292bngbiql"
+   "commit": "745f38f27e9bf73323d25d9624d462ba977131c3",
+   "sha256": "0cs91pwjb8lp4dr8b4mwcj9awsh9rk9f5y17p21b8zw0lc250yx6"
   },
   "stable": {
    "version": [
     1,
-    5
+    6
    ],
-   "commit": "b2ad1e2353b2b425537ddf5eb5ebedde5cd826b2",
-   "sha256": "07kh8raxz6kbak091g2m4hrhnmr49jvxk6qskji19spvfmpzrhy9"
+   "commit": "9ba731bd947b5851509c487be8f19887aab84234",
+   "sha256": "1cfxrzikbvqnjjyc73sasyimj2q0wlir3xna01g8l4xrzix8saw4"
   }
  },
  {
@@ -127212,11 +128111,11 @@
   "repo": "aimebertrand/timu-rouge-theme",
   "unstable": {
    "version": [
-    20250411,
-    36
+    20260122,
+    1354
    ],
-   "commit": "a9f396ee77c18c1df79b52389e203850446fce56",
-   "sha256": "13xjmklzsa8ls81r6j2r2lf0dpx40jsklz2ljdsh8igv85vz9kp8"
+   "commit": "a46e960a8f5aa078ec055bc1b819be52182fda0f",
+   "sha256": "0ibhwfzcgkhsgzlc7bzkkzl04f4n6kv51plw3i5qmr14d1gl98hs"
   },
   "stable": {
    "version": [
@@ -127263,6 +128162,14 @@
    ],
    "commit": "5f3b778eb7446ca2b366daacb9f1e71f1d89e097",
    "sha256": "03r0n1sx5dc4gnd9af674m1rfq9rzn53w5ndv8dxvzlax28w24gc"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "commit": "1198f4b97ee843641351375eaf57d3782ae64fea",
+   "sha256": "06yadc9kxi92mxagprqg66s46z1mg5yp9krk6lmlv9ps8dcsvz6x"
   }
  },
  {
@@ -127291,19 +128198,19 @@
   "repo": "lesharris/tintin-mode",
   "unstable": {
    "version": [
-    20251001,
-    2003
+    20260220,
+    2337
    ],
-   "commit": "7820fd9f15bfd0a492b03973621abd81c370babf",
-   "sha256": "0piyi4fj2xlml6rpqi8f5cslk7q7iqlh7fydpvj3jl6bjzrxl0nn"
+   "commit": "b94c10c5ba7fef01c53c4d4d66532e7abe82086c",
+   "sha256": "0qjxkzr5jvqcxrahifvfhr4pwlcqq8cxk8nwkysyf5fkzraz4wdz"
   },
   "stable": {
    "version": [
     0,
-    3
+    4
    ],
-   "commit": "7820fd9f15bfd0a492b03973621abd81c370babf",
-   "sha256": "0piyi4fj2xlml6rpqi8f5cslk7q7iqlh7fydpvj3jl6bjzrxl0nn"
+   "commit": "b94c10c5ba7fef01c53c4d4d66532e7abe82086c",
+   "sha256": "0qjxkzr5jvqcxrahifvfhr4pwlcqq8cxk8nwkysyf5fkzraz4wdz"
   }
  },
  {
@@ -127686,11 +128593,11 @@
   "repo": "topikettunen/tok-theme",
   "unstable": {
    "version": [
-    20251010,
-    2231
+    20260216,
+    949
    ],
-   "commit": "2fcfa85cbfbe46198e7f126fd4ecd32c0cecee70",
-   "sha256": "1n4gwnpghpivsvgfd4c34wmrasqlksh4qzkhqr3gp6h3n2dp7xdx"
+   "commit": "f2af92c73108a55c383f3687b96b21e7f89e0782",
+   "sha256": "14giqd950j0cvciiw5rfq1yisagf22ar6y3ii820wgmns1dw3nhc"
   }
  },
  {
@@ -127827,11 +128734,11 @@
   "repo": "jamescherti/tomorrow-night-deepblue-theme.el",
   "unstable": {
    "version": [
-    20260114,
-    1535
+    20260215,
+    2013
    ],
-   "commit": "28170a5c5d9cec2af1531f12b284037fe7fd043c",
-   "sha256": "06k5ncmv6l8mz17ryrmwg32kc3zjm41d1rxkhgjw6gci1r0f0wrb"
+   "commit": "5e688cde3fe91a929a3f36d9311eddc9e0dec0b0",
+   "sha256": "1gbd7qcv78fhm99yi45rl9rl642iz9slv3jhflbh84zj8yamzpdn"
   },
   "stable": {
    "version": [
@@ -127941,15 +128848,28 @@
   "repo": "sarg/torrent-mode.el",
   "unstable": {
    "version": [
-    20250813,
-    1529
+    20260130,
+    2140
    ],
    "deps": [
     "bencoding",
     "tablist"
    ],
-   "commit": "5dbb59c60c0c2db24d3d138eb003c66c3578b7b4",
-   "sha256": "0r6hi18mjlip002lqfbch7fnkkzn5g1h2p3y9c6qmw79kd32qlf8"
+   "commit": "a35a7c193b638207de0a266e8ded6e4e8a54505e",
+   "sha256": "1ajmdz6vk68diyp93q0jbmwjwrwmdyszya7yppsn2qdpiksgz1z5"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    2
+   ],
+   "deps": [
+    "bencoding",
+    "tablist"
+   ],
+   "commit": "a35a7c193b638207de0a266e8ded6e4e8a54505e",
+   "sha256": "1ajmdz6vk68diyp93q0jbmwjwrwmdyszya7yppsn2qdpiksgz1z5"
   }
  },
  {
@@ -128136,25 +129056,25 @@
   "repo": "martianh/tp.el",
   "unstable": {
    "version": [
-    20250206,
-    812
+    20260219,
+    1435
    ],
    "deps": [
     "transient"
    ],
-   "commit": "cce2dfe0ec2b5c070cb13a7bdf95695eeb6e3caf",
-   "sha256": "1hv0j4dzwamhm2gp5123j415mq13347v5lsbxlrksha5nw9h7kds"
+   "commit": "cef3fc2daefbbfc29ad02b7e1f39542b57c72fe8",
+   "sha256": "1zhvridy6p7dy9hpf088k166a1c918hqf6k3jmnm7raw8vflc7qq"
   },
   "stable": {
    "version": [
     0,
-    7
+    8
    ],
    "deps": [
     "transient"
    ],
-   "commit": "cce2dfe0ec2b5c070cb13a7bdf95695eeb6e3caf",
-   "sha256": "1hv0j4dzwamhm2gp5123j415mq13347v5lsbxlrksha5nw9h7kds"
+   "commit": "cef3fc2daefbbfc29ad02b7e1f39542b57c72fe8",
+   "sha256": "1zhvridy6p7dy9hpf088k166a1c918hqf6k3jmnm7raw8vflc7qq"
   }
  },
  {
@@ -128426,16 +129346,16 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20260118,
-    1322
+    20260223,
+    946
    ],
    "deps": [
     "compat",
     "cond-let",
     "seq"
    ],
-   "commit": "5d4a7e718c56cb1b3f99a4cd04d204d627f124b0",
-   "sha256": "1b2xkivmpjf9crv6n2rfcmd63ri58xs0hxk19placlldr9z9i9ih"
+   "commit": "aa033dc685415a44545552a272212e69db64d8a8",
+   "sha256": "0nka7yrdfjfbpi4gbg7pd982diq5nbb0gf14yx5g1h5nxq01hibz"
   },
   "stable": {
    "version": [
@@ -128904,26 +129824,26 @@
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20260119,
-    1658
+    20260222,
+    2023
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "94c368b26870ef05e2953db91dd2b88d467c13b8",
-   "sha256": "009gq18yb2xyf32xspc00i2dzyswaadm37hbibsrvkb76aq9fj30"
+   "commit": "57f9644e8485c8037e5bb506347029ce5b340695",
+   "sha256": "0msi526f5rbl0pgilf1ymynir9zxpipb27l46698imwhnp5acz6g"
   },
   "stable": {
    "version": [
     0,
     13,
-    17
+    27
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "94c368b26870ef05e2953db91dd2b88d467c13b8",
-   "sha256": "009gq18yb2xyf32xspc00i2dzyswaadm37hbibsrvkb76aq9fj30"
+   "commit": "57f9644e8485c8037e5bb506347029ce5b340695",
+   "sha256": "0msi526f5rbl0pgilf1ymynir9zxpipb27l46698imwhnp5acz6g"
   }
  },
  {
@@ -129351,20 +130271,20 @@
   "repo": "renzmann/treesit-auto",
   "unstable": {
    "version": [
-    20240511,
-    1425
+    20260210,
+    2010
    ],
-   "commit": "016bd286a1ba4628f833a626f8b9d497882ecdf3",
-   "sha256": "03bvam7cpxqp4idhd235n76qdqhsbgw7m2lphy8qqwslbmcq23m4"
+   "commit": "31466e4ccfd4f896ce3145c95c4c1f8b59d4bfdf",
+   "sha256": "12fipf9kxxkwam0l9c1z0abik0gxjaqaxxf08m8svanfd0pvky8y"
   },
   "stable": {
    "version": [
     1,
     0,
-    5
+    9
    ],
-   "commit": "09d1c8c4b5bd981c6d613c95cf0ad859ad1fbc53",
-   "sha256": "1a2d49chymhfbd9w0msksyyqgsywn17mkzqglaw0k794sb1gzx2q"
+   "commit": "e10d10adcf1a71d2c1813b44be00774237dad750",
+   "sha256": "1qw6y3089h1n3zjr4bja6dg3gaxrmwfljxk22k31afj9bccibiqb"
   }
  },
  {
@@ -129543,6 +130463,36 @@
    ],
    "commit": "7500ae0a05a3e26888949208afcd0185cc1b1404",
    "sha256": "0x1knf2jqkd1sdswv1w902jnlppih2yw6z028268nizl0c9q92yn"
+  }
+ },
+ {
+  "ename": "truename-cache",
+  "commit": "a28cc37a1b85e4fb42506886f7804e86cee4c502",
+  "sha256": "1xx0rzal1fcacr73q7dajp9rhiqla0qzkyla3xbh91qhirdplxpi",
+  "fetcher": "github",
+  "repo": "meedstrom/truename-cache",
+  "unstable": {
+   "version": [
+    20260224,
+    1123
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "6536896f9b16218c0b85fc624b160e2b7f169f0d",
+   "sha256": "1cdrjy72wxpch63jsxkd37zhfzkk0pmdgyh5cjlkv58a0rfzg9bj"
+  },
+  "stable": {
+   "version": [
+    0,
+    3,
+    0
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "6536896f9b16218c0b85fc624b160e2b7f169f0d",
+   "sha256": "1cdrjy72wxpch63jsxkd37zhfzkk0pmdgyh5cjlkv58a0rfzg9bj"
   }
  },
  {
@@ -129740,17 +130690,26 @@
  },
  {
   "ename": "ttl-mode",
-  "commit": "8a7d0c7287d157f45ebcb7a6ba2a776b3ee2bc2d",
-  "sha256": "1v34axc96n5aqsm9w2j94z8h9mqfa41300lx8aqccwj8a5qwk90k",
+  "commit": "8c91d71ce5c0a4355e15553ecc658d8f046bc8e4",
+  "sha256": "1a6fyd0qy7x60gn2x6nis9crs1n7d8hhml2gk5b1d9d9rx4z60gb",
   "fetcher": "github",
-  "repo": "nxg/ttl-mode",
+  "repo": "emacsattic/ttl-mode",
   "unstable": {
    "version": [
-    20170920,
-    1329
+    20260210,
+    1513
    ],
-   "commit": "b4084667f92afbfe5916d1307916acbd68c52e5e",
-   "sha256": "18ak4gmlp68r1kk8sg6lpzq9yjp03g2q0iyww615y3hvv0c8zdpc"
+   "commit": "66a9a27c828b6cc08cdd0184cfcf05beb5c2ac60",
+   "sha256": "0gfx8ns59vigpv53z4ps9v3wsfy33ivn73lh5dycib3g3ffrsfsb"
+  },
+  "stable": {
+   "version": [
+    0,
+    2,
+    1
+   ],
+   "commit": "66a9a27c828b6cc08cdd0184cfcf05beb5c2ac60",
+   "sha256": "0gfx8ns59vigpv53z4ps9v3wsfy33ivn73lh5dycib3g3ffrsfsb"
   }
  },
  {
@@ -129761,11 +130720,11 @@
   "repo": "DiogoDoreto/emacs-tts",
   "unstable": {
    "version": [
-    20251019,
-    1853
+    20260213,
+    2049
    ],
-   "commit": "e270fec575c35a24a52b762b67ef12651ebbf435",
-   "sha256": "0rslfrzr66acvik0zpjrliipj5x2ixy7y84vv3yll6has1lxmnax"
+   "commit": "315cec02dd3c90516165a84231820f151ac7fcdd",
+   "sha256": "1yy0sdp7vv94cij0i220scy5aafi7b9qmv59r2k739sr82c3pd75"
   }
  },
  {
@@ -130089,15 +131048,15 @@
   "repo": "tmalsburg/txl.el",
   "unstable": {
    "version": [
-    20260104,
-    1659
+    20260202,
+    1114
    ],
    "deps": [
     "guess-language",
     "request"
    ],
-   "commit": "e368746afba6d8ec170f479d06a10c4e2a9e2eee",
-   "sha256": "0za90idb0plcm9zhxb4k4a6m5crrjv61b1b64kzyl0vjlyxxhlfw"
+   "commit": "87fcd5f65cd572dd992abcbbff1b1f5990d8de7e",
+   "sha256": "0dzw5i5dnm8bjyhbnqam1cy1ass4hj5p7lv2y5qq049hir3y9bzl"
   }
  },
  {
@@ -130276,15 +131235,15 @@
   "repo": "havarddj/typst-preview.el",
   "unstable": {
    "version": [
-    20251110,
-    824
+    20260215,
+    2252
    ],
    "deps": [
     "compat",
     "websocket"
    ],
-   "commit": "c685857f2d61133fc268509b39796b2718728f29",
-   "sha256": "1c0d87q9jpghwxvxj4a6dch0j9gihxngnncg28931lcss2ibm3gv"
+   "commit": "7e89cf105e4fef5e79977a4a790d5b3b18d305f6",
+   "sha256": "0lsbr9i8kmzjbl9k86g8jnsbgz2vrlys7cii4fjrkg0dg9ijvk2w"
   },
   "stable": {
    "version": [
@@ -130308,11 +131267,11 @@
   "repo": "md-arif-shaikh/tzc",
   "unstable": {
    "version": [
-    20240403,
-    332
+    20260212,
+    715
    ],
-   "commit": "8f425cd6f020b5082445be9547e9308be73c6adf",
-   "sha256": "0wbgw4hvjqdflwjkyk9iscjh7243m9blbh9rzwinggkilgw44j2i"
+   "commit": "05f97298e7b20aefb41c16abe3eeae162dd1e2f9",
+   "sha256": "1xjqyspyjhvf1cq0jsaglggz2l6mwf8yd8vh13gi8vzfch2yv1vy"
   },
   "stable": {
    "version": [
@@ -130560,6 +131519,30 @@
   }
  },
  {
+  "ename": "ultisnips-mode",
+  "commit": "a650d936916c474bba38498511ad0f458ec1aa35",
+  "sha256": "0xzx89acfzd7hl9p7vrfilh41v9zndclrbnialwg8l8rmzk4sb0m",
+  "fetcher": "github",
+  "repo": "jamescherti/ultisnips-mode.el",
+  "unstable": {
+   "version": [
+    20260215,
+    2013
+   ],
+   "commit": "a33c16dca1f8669db7132500cedab959a271a62b",
+   "sha256": "1z4vd29x5qz7gc50v614py9kp2iym1nd6i92i1him2g53ddhhzh1"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    1
+   ],
+   "commit": "035cacccebe1629eca5ce24fd6f597a4e5453d23",
+   "sha256": "085cw9yx2ybvn1sxl8y1jjvyzaqbkz2liv35jgzn41l8c6y16qyl"
+  }
+ },
+ {
   "ename": "ultra-scroll",
   "commit": "21b5917792cf971a29e5902bd57e22590c62f9d8",
   "sha256": "05n59nxdh50169zgi4sf2a96gry96r0p5kf6mp0kqfsh3iakk193",
@@ -130741,11 +131724,11 @@
   "repo": "ideasman42/emacs-undo-fu-session",
   "unstable": {
    "version": [
-    20260108,
-    1313
+    20260209,
+    754
    ],
-   "commit": "34ae31308d2f290f87a330c76a627b7fe8ebb720",
-   "sha256": "174q13v7vrq5rfbpb8b1shv2qnsnhwpc59za2r2laph6hi0f0r4l"
+   "commit": "db5e165439c95bf36f3e48d0c87d3879cabb18f0",
+   "sha256": "05n9hmghn832zz4j8m1r9fia01j9wj88m50h9dfhxzd4drcyd2hv"
   }
  },
  {
@@ -130937,8 +131920,8 @@
   "repo": "rolandwalker/unicode-fonts",
   "unstable": {
    "version": [
-    20230926,
-    1502
+    20260202,
+    1156
    ],
    "deps": [
     "font-utils",
@@ -130947,8 +131930,8 @@
     "persistent-soft",
     "ucs-utils"
    ],
-   "commit": "6245b97d8ddaeaf1de4dbe2cd85ca0f3b20ef81b",
-   "sha256": "1ckcvy10sz4qvjy1bqrpvaijw92q2da4b6bxbgxaxvrw5d0ih81f"
+   "commit": "d4a0648a2206d9a896433817110957b3b9e1c17a",
+   "sha256": "14xplcx1miq1qbpkxb5rijqk5qpn464kd2v4j85sqxdyf4a047ls"
   },
   "stable": {
    "version": [
@@ -131138,14 +132121,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20260109,
-    823
+    20260222,
+    905
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "2aeee8f787ccbbb3da32100bceeb5d6c660aef7a",
-   "sha256": "0djaqcjcgi49zp0jlgfih8km55kp2i7166a8bp2nlz7lk813nvaj"
+   "commit": "36107e509f9da67738e38e41531f046cedf67159",
+   "sha256": "1wzv3gwfzfbaca82ykbxbg7cpffsby2szjwsk65qcif5cacfw397"
   }
  },
  {
@@ -131201,20 +132184,20 @@
   "repo": "fmguerreiro/unison-ts-mode",
   "unstable": {
    "version": [
-    20260113,
-    846
+    20260126,
+    915
    ],
-   "commit": "7f0ed7c03d98fefc88c420bc49c423c66db186d7",
-   "sha256": "13sy6kj29hlaqfdkk2hv86yi1i3wv6ibywf5sm9ndqnw8a8r50pv"
+   "commit": "83fe7aadecc5438be19ccb50b089c1ba95803839",
+   "sha256": "04abri83yz3yr3ffvj780sjljbhlz468a579i2i8rh01pgdz4dqx"
   },
   "stable": {
    "version": [
     0,
-    1,
-    3
+    2,
+    0
    ],
-   "commit": "f8d291e8be9b2a3259d59e2d469660465a3d5deb",
-   "sha256": "184j5c3c2akqbwxk0j1aql5xyrwr14ml5ilnas65ybi80q9hnplm"
+   "commit": "e31a211899e5c249a521b8b1e09f48bcc40383af",
+   "sha256": "00z4l8d1p80lb0n2h2sp1bbhyc6rym1y0wvcrcqwiq5k023kacyc"
   }
  },
  {
@@ -132707,11 +133690,11 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20251222,
-    2151
+    20260223,
+    2349
    ],
-   "commit": "f45e31b2bcdea2a859bb28cbb1819469978457c9",
-   "sha256": "1izr1km3ysh0cdlli1r36b3y5m5kl1wmhi95qsidc701mlb0749n"
+   "commit": "0625fb314341a479dd472ae5e7f10375c1988131",
+   "sha256": "0njf304naa33l6cvgjh2zmblz46g27nszpf16hmyhfz3i92gzc6y"
   },
   "stable": {
    "version": [
@@ -132939,14 +133922,14 @@
   "repo": "minad/vertico",
   "unstable": {
    "version": [
-    20260118,
-    743
+    20260210,
+    1021
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c12c8f842fd184db44fb2b835b0f954bbc90c7a6",
-   "sha256": "0klr2v6xhs7vkh5rsjpl58mgvnz25g12zq5jrplbcq4s2v6119xj"
+   "commit": "93f15873d7d6244d72202c5dd7724a030a2d5b9a",
+   "sha256": "00xhxk81vikdyn2q3jhxrac39rkxiimwqs1zx9ca0r7v6z5jpj8v"
   },
   "stable": {
    "version": [
@@ -133202,20 +134185,20 @@
   "repo": "jamescherti/vim-tab-bar.el",
   "unstable": {
    "version": [
-    20260114,
-    1604
+    20260219,
+    1823
    ],
-   "commit": "64917611b8223fdfe080882738b64f5a2c90ff98",
-   "sha256": "1vwznly9c6l81fyhmfgdciqrzql69lirdn3adjfswq7hxa98284f"
+   "commit": "7c876e3f3faf1a45ac2ef7793548fd630510fd97",
+   "sha256": "1qcd57j2cjiqxww3krd6a7idaaz0mmzlw3fs8zval7ph6756khln"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    4
    ],
-   "commit": "41f57f059bd89c8209a405afa2914482c9e9b306",
-   "sha256": "1lbx0v0xdwgnz8k8xyx2961xmygfdjri0fxhm5dyjz9wilcdas68"
+   "commit": "22d2d8a92b8d8cd0532c8382dcfe7df405f1563a",
+   "sha256": "00bajfkqcpn15d5vdr52nd56qny68r59xc7yshw7wxs9awfpxrzz"
   }
  },
  {
@@ -133698,11 +134681,11 @@
   "repo": "emacs-vs/vs-dark-theme",
   "unstable": {
    "version": [
-    20260101,
-    1429
+    20260217,
+    1623
    ],
-   "commit": "ce1442aa8ee8cdc37f29011fb0f88401918bb889",
-   "sha256": "11m59imwcv0bx80ci1ir5k2dh3qkivm6ri4xv0ci7zby4rjixi2w"
+   "commit": "ebc176a83808772746c55c91420a95b28b84c869",
+   "sha256": "04js1vkjf6pil0q6a2y5balciz5nqc8qwcj78kydbv4f2bd21ykf"
   },
   "stable": {
    "version": [
@@ -133721,11 +134704,11 @@
   "repo": "emacs-vs/vs-light-theme",
   "unstable": {
    "version": [
-    20260101,
-    1430
+    20260217,
+    1623
    ],
-   "commit": "3403f6843a87adc38b46993db41610c2db1606f7",
-   "sha256": "1v363zsi4k9bkdhdi9qpk7q4p5wmhvd78f4x52jbsy6v3jn5vzd9"
+   "commit": "105c9f2530b4834e1a0ea35964dbbe2c52bbbe5f",
+   "sha256": "0x649h4ars0bqh3qlb9chdriq6w6rqrjjddfzd54025wksq1wwhy"
   },
   "stable": {
    "version": [
@@ -133759,20 +134742,20 @@
   "repo": "ianyepan/vscode-dark-plus-emacs-theme",
   "unstable": {
    "version": [
-    20230725,
-    1703
+    20260219,
+    434
    ],
-   "commit": "65420ca73b543e1e7955905bea1a8d7e5fe6c5ff",
-   "sha256": "06wdyaiycxnmb6xgqv325413wl6017pr2z705hw78ddidjqlpi71"
+   "commit": "37f16729ee196dbfc533b02adea3d2129bdd8585",
+   "sha256": "1aphhpisg20cclclnygf8wrkrw9rxh2b653jnr86ikjki6j8sw98"
   },
   "stable": {
    "version": [
     2,
-    0,
+    1,
     0
    ],
-   "commit": "41772165b3b1195a7e86747ea5b316b16be4c7ef",
-   "sha256": "1vcaqvhdgr91pr7kqskbscs8awm8jp6dkh79h6w36i9ipmc4l4hl"
+   "commit": "37f16729ee196dbfc533b02adea3d2129bdd8585",
+   "sha256": "1aphhpisg20cclclnygf8wrkrw9rxh2b653jnr86ikjki6j8sw98"
   }
  },
  {
@@ -133803,6 +134786,21 @@
    ],
    "commit": "47c35e3062a20418340c8150c8d5ad41c1e7d6b4",
    "sha256": "0jmlgvm9jw247r4yqw4vyaq5slys5r54h33a183wafb30gvfsbi1"
+  }
+ },
+ {
+  "ename": "vtab",
+  "commit": "f561b8304fdb12bbb7b8ef5a690b432595a42e80",
+  "sha256": "16hnc1s2jbw5zvi2gcwl1gsj3d2li7ib3km645p5qxkw9jb487q1",
+  "fetcher": "github",
+  "repo": "mugen-void/vtab",
+  "unstable": {
+   "version": [
+    20260209,
+    1524
+   ],
+   "commit": "ae2ef3915e19c6ebd36f7e87dc37219263744f23",
+   "sha256": "12sy6i1b0f63py9aby4gi5m28ybzf64s1hrpkdsqlzipmciyzh7k"
   }
  },
  {
@@ -133956,11 +134954,11 @@
   "repo": "d12frosted/vui.el",
   "unstable": {
    "version": [
-    20260119,
-    714
+    20260130,
+    2113
    ],
-   "commit": "c5547a204dac1c8149127e9142a293f0d23761a6",
-   "sha256": "15ggd6gd9k3hald1c8fb7jcvkb1d83y2k3nja1ky936rypg713ii"
+   "commit": "7d904ddff91325d756ad7ffd4dfb0db855f3a120",
+   "sha256": "03p61v8ra4fy83amhgmzidhlh66vwpgcclw8h2wlwzsxg4sf3lr5"
   },
   "stable": {
    "version": [
@@ -134018,8 +135016,8 @@
   "repo": "d12frosted/vulpea",
   "unstable": {
    "version": [
-    20260106,
-    747
+    20260210,
+    1556
    ],
    "deps": [
     "dash",
@@ -134027,13 +135025,13 @@
     "org",
     "s"
    ],
-   "commit": "8a7ffece1b683e7c7439e05419e942d93d536348",
-   "sha256": "1hbpmwl28538fykvz97rjg2zf3s1bk3sf46g1139gn1vf5f8px20"
+   "commit": "60bfe3959a3a68f4957f83e33bf793d73a34f21b",
+   "sha256": "1m32gk0fr5y9si3bm2gn8hvivyxkw5sqn25qjv4i83n8xm5gkdrg"
   },
   "stable": {
    "version": [
     2,
-    0,
+    1,
     0
    ],
    "deps": [
@@ -134042,8 +135040,8 @@
     "org",
     "s"
    ],
-   "commit": "89ed53b762acf0c2d1985ff1501db7eac6ef412f",
-   "sha256": "166brn15x3l59mbvl6lb5136fdyfr4zbmb4k9v5ii35ikcw29b3f"
+   "commit": "5392b43459374c612d54db94bf278b98d0e73a49",
+   "sha256": "0grn4xplh0492i6k3zsp4szdfngy19iv0djrjnv7wiv99p9jbvc8"
   }
  },
  {
@@ -134054,30 +135052,30 @@
   "repo": "d12frosted/vulpea-journal",
   "unstable": {
    "version": [
-    20260118,
-    1223
+    20260205,
+    1628
    ],
    "deps": [
     "dash",
     "vulpea",
     "vulpea-ui"
    ],
-   "commit": "2d3b5b473669ab2b24b085ed632eb30770cd1cb8",
-   "sha256": "06l39x7sbl2agcgbwjgiksigczhc91gxkfa5pd2dg7y9j1k7wh6i"
+   "commit": "002344eedfce1690586c3a7d9de85f06e89d5bf2",
+   "sha256": "0yhqavbcsz0da7imjriz29hpwf6fj2nski4bk4xmrnlb4yj1iwdl"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
    "deps": [
     "dash",
     "vulpea",
     "vulpea-ui"
    ],
-   "commit": "1c674c4769d501269e3aae60dc31745fa8adfa2d",
-   "sha256": "0acg4gwg4hxnfc6cvh9sssi9pjvg7w16dyypffygkwwdyx85gqsf"
+   "commit": "7525fde77555d25cbe3b78fbe5cf35113b65e7cd",
+   "sha256": "0x47rvpmrpg6m2lyh7550mynkpjqqihgj7v04wbn2s85vr9gnv94"
   }
  },
  {
@@ -134088,28 +135086,28 @@
   "repo": "d12frosted/vulpea-ui",
   "unstable": {
    "version": [
-    20260118,
-    1232
+    20260201,
+    944
    ],
    "deps": [
     "vui",
     "vulpea"
    ],
-   "commit": "2b07223f4e40cf309ad7215295afabc6ac9ecad7",
-   "sha256": "0yl0181smpqdc4q4lcyh168gvs0xdcyygypmkiy9lip97jpdjkjm"
+   "commit": "2d06f4ba4f21394ee2861c8c99348563a7c68bdd",
+   "sha256": "1l5slm4ql8qm50nixsis0x67ljc0pc9zz4n31n5fiq2wqc7biq1n"
   },
   "stable": {
    "version": [
     1,
-    0,
+    1,
     0
    ],
    "deps": [
     "vui",
     "vulpea"
    ],
-   "commit": "39c842e47bd523b5cc37a13838277b3154fed920",
-   "sha256": "12r506748rs84ihb0cn27rjmqh6nklzkqd49xiljixfidw9vkg5d"
+   "commit": "fdd6749cb4a252a369e09dd1c76d01f063b44d8b",
+   "sha256": "1jc8c1s8slsbs1yvyw0h14wcmzmyxrc15jpmmcvr0jibp7k45brr"
   }
  },
  {
@@ -134504,6 +135502,21 @@
    ],
    "commit": "9414fc386945870913e5183817593596315eddd8",
    "sha256": "18cs87m7h7djpb8pfignjcfhjgx2sh0p1fad0nhbyrykh94ym73i"
+  }
+ },
+ {
+  "ename": "warm-mode",
+  "commit": "cbe1437976efbb674bc220080835c09e51c2e9e0",
+  "sha256": "1zvhkjzwfxgiglfr5xf2bm307ksn1xbfixcn1qd9sl87b7494i6y",
+  "fetcher": "github",
+  "repo": "smallwat3r/emacs-warm-mode",
+  "unstable": {
+   "version": [
+    20260209,
+    1810
+   ],
+   "commit": "27362826e970ed0e902bee3512d97dc02f196a7b",
+   "sha256": "0ivlsrmlmpcjf1nz7r8hf6ph2f0k9i4pvbg0wmk5wmsy37gbnr6h"
   }
  },
  {
@@ -134934,7 +135947,7 @@
  },
  {
   "ename": "webkit-color-picker",
-  "commit": "fdf3db5d263ec83c948273ea1390ccb16f788548",
+  "commit": "213520031412e385def90fd8cef402da87af1242",
   "sha256": "1k0akmamci7r8rp95n4wpj2006g9089zcljxcp35ac8449xxz47v",
   "fetcher": "github",
   "repo": "ozanmakes/emacs-webkit-color-picker",
@@ -135092,25 +136105,25 @@
   "repo": "ahyatt/emacs-websocket",
   "unstable": {
    "version": [
-    20230809,
-    305
+    20260201,
+    1517
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "40c208eaab99999d7c1e4bea883648da24c03be3",
-   "sha256": "0bq0y63rriwsw6v8mn72773iqic2q52vx1j7mfa8br27sm6y1pd4"
+   "commit": "03d1cca4bd910a8df73e4ec637836c6ac25213a2",
+   "sha256": "1q54cv9vrhgwxkw11fn79rmvixy4vyfr2f9rbhfswbv04a96lkgp"
   },
   "stable": {
    "version": [
     1,
-    15
+    16
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "40c208eaab99999d7c1e4bea883648da24c03be3",
-   "sha256": "0bq0y63rriwsw6v8mn72773iqic2q52vx1j7mfa8br27sm6y1pd4"
+   "commit": "03d1cca4bd910a8df73e4ec637836c6ac25213a2",
+   "sha256": "1q54cv9vrhgwxkw11fn79rmvixy4vyfr2f9rbhfswbv04a96lkgp"
   }
  },
  {
@@ -136176,6 +137189,21 @@
   }
  },
  {
+  "ename": "winpulse",
+  "commit": "9c81585651357829d1beb35014c733a578222523",
+  "sha256": "08hvk9lbcfi0mdvhxs7pj8gc3chqwzhlbi3agnbsbk2f67ccbd32",
+  "fetcher": "github",
+  "repo": "xenodium/winpulse",
+  "unstable": {
+   "version": [
+    20260216,
+    2106
+   ],
+   "commit": "c58352bea2223fd6f0cc11deb4d33bca2ff0213c",
+   "sha256": "0fpnh45mm608i41mv7abkkm4m29bzwhgls9r2gcdvcbsaddcfk61"
+  }
+ },
+ {
   "ename": "winring",
   "commit": "2476a28c33502f908b7161c5a9c63c86b8d7b57d",
   "sha256": "1mgr5z4h7mf677xx8md3pqd31k17qs62z9iamfih206fcwgh24k4",
@@ -137019,14 +138047,14 @@
   "repo": "cjennings/emacs-wttrin",
   "unstable": {
    "version": [
-    20251113,
-    2014
+    20260221,
+    1311
    ],
    "deps": [
     "xterm-color"
    ],
-   "commit": "bf989bb594680eb2e3b69f55752353aa33cb47bb",
-   "sha256": "0vphfq7whv53k631pn91hq6m28dmzn6hblgzwkcda6sval4x6qs8"
+   "commit": "b74b98f177d92d50ddbede900ba41212e07c5f63",
+   "sha256": "1whxfyq0gdgln7sj9dsg4911qg5r1p1kgnbig0vgxnff9r8v3hf4"
   },
   "stable": {
    "version": [
@@ -137886,11 +138914,11 @@
   "repo": "seahorse/yabaki-theme",
   "unstable": {
    "version": [
-    20231004,
-    2023
+    20260201,
+    1303
    ],
-   "commit": "209f2be321509dac00631fff1b0f7ea01ba382de",
-   "sha256": "1qlfnnlc1av630vc89csg29ps54l4ld4aw8f55kqkpfm84l4ki5s"
+   "commit": "eae3e0015da43f38a17b5a378f61c0f21fb83f79",
+   "sha256": "0qpf2yiv2vf7bbi5r42s3xgahgjpmv6w9ax3gb4sps27hchv9xr9"
   },
   "stable": {
    "version": [
@@ -138562,26 +139590,26 @@
   "url": "https://git.thanosapollo.org/yeetube",
   "unstable": {
    "version": [
-    20251219,
-    2333
+    20260130,
+    411
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b1093c75ab1729efbfd5bb92864ad8eab734eec6",
-   "sha256": "1srmf38zfc8qni40dlmlkdk12kvdgvk2qx507qzfvq3rlwawpzps"
+   "commit": "2eddda6d93050b25a00c739b8ad72b58ce8602cc",
+   "sha256": "0jydjijmmj1nkr4462w5j5b3hhy7ms43zpxs325mjna6f9cmylgd"
   },
   "stable": {
    "version": [
     2,
     1,
-    10
+    11
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e179f00b065188b5c50af7e307fc262a6efea7ff",
-   "sha256": "0krd2x0vyysqsgb7r3ca2qc7cl1s929gm52j5rihnqw0yfjpwgpv"
+   "commit": "2eddda6d93050b25a00c739b8ad72b58ce8602cc",
+   "sha256": "0jydjijmmj1nkr4462w5j5b3hhy7ms43zpxs325mjna6f9cmylgd"
   }
  },
  {
@@ -139425,11 +140453,11 @@
   "repo": "meow_king/zig-ts-mode",
   "unstable": {
    "version": [
-    20251221,
-    1517
+    20260123,
+    242
    ],
-   "commit": "e0fcb1b115ad334513caa6975f15eb54bca239db",
-   "sha256": "0qsp4l2v35h2akyl4ylmq1k61anf6mir13rikjv14343q3cj3k15"
+   "commit": "64611c6d512e4c15e8d1e3fd0fde6bd47c6c8f50",
+   "sha256": "19hayp03i2l2biyl572rbpr4108hfm149fyzy2rydxzjiwd595d9"
   }
  },
  {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- emacs-overlay commit: 76189153b33c00b044bdeed20df24fd126d6c395
- build failures
  - [ ] emacs-lichess-20260203.1027: [MELPA PR](https://github.com/melpa/melpa/pull/9872)
  - [ ] emacs-gptel-forge-prs-20251216.923: reported to [upstream](https://github.com/magit/forge/issues/828)
  - [X] emacs-futur-1.0: fixed by bumping to 1.1
  - [ ] emacs-ekg-20260222.2157: reported to [upstream](https://github.com/ahyatt/ekg/issues/263)
  - [ ] emacs-edit-metadata-20260210.2022: reported via email

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
