### PR TITLE
pyedbglib, pymcuprog: use tag, support finalAttrs

### DIFF
--- a/pkgs/development/python-modules/pyedbglib/default.nix
+++ b/pkgs/development/python-modules/pyedbglib/default.nix
@@ -16,7 +16,7 @@
   mock,
 }:
 
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "pyedbglib";
   version = "2.24.2.18";
   pyproject = true;
@@ -24,9 +24,7 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "microchip-pic-avr-tools";
     repo = "pyedbglib";
-    # the repo currently does not tag releases, so using the
-    # commit ID for now
-    rev = "9bbeceba942772ef31b9c059b761460a782313e";
+    tag = finalAttrs.version;
     hash = "sha256-iZB/+JEBy5n1zfajmJmEqRVQ2hPzJD/U85SvmyFiGhc=";
   };
 
@@ -54,4 +52,4 @@ buildPythonPackage {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ prophetofxenu ];
   };
-}
+})

--- a/pkgs/development/python-modules/pymcuprog/default.nix
+++ b/pkgs/development/python-modules/pymcuprog/default.nix
@@ -21,7 +21,7 @@
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "pymcuprog";
   version = "3.19.4.61";
   pyproject = true;
@@ -29,9 +29,7 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "microchip-pic-avr-tools";
     repo = "pymcuprog";
-    # the repo currently does not tag releases, so using the
-    # commit ID for now
-    rev = "e2fa9a7f0b9cc413367c51b9ccf19d93cdca6c8";
+    tag = finalAttrs.version;
     hash = "sha256-RmFGQ6LbuwwM/WHr01nYGZYoWG7Qbasz/TL4r8l1NUk";
   };
 
@@ -66,4 +64,4 @@ buildPythonPackage {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ prophetofxenu ];
   };
-}
+})


### PR DESCRIPTION
These packages were previously added in #488386, but the repos they fetched from did not tag releases, so they had to reference the commit hash. Now, the maintainers have thankfully added tags, which this PR makes use of. It also adds `overrideAttrs` functionality which was verified locally.

Issues opened to ask for tags:
https://github.com/microchip-pic-avr-tools/pymcuprog/issues/62
https://github.com/microchip-pic-avr-tools/pyedbglib/issues/12

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
