### PR TITLE
nixos/journald: convert to RFC42-style settings

### DIFF
--- a/nixos/doc/manual/administration/systemd-state.section.md
+++ b/nixos/doc/manual/administration/systemd-state.section.md
@@ -47,6 +47,6 @@ form to `/var/log/journal/{machine-id}`; if (locally) persisting the entire log
 is desired, it is recommended to make all of `/var/log/journal` persistent.
 
 If not, one can set `Storage=volatile` in {manpage}`journald.conf(5)`
-([`services.journald.storage = "volatile";`](#opt-services.journald.storage)),
+(`services.journald.settings.Journal.Storage = "volatile";`),
 which disables journal persistence and causes it to be written to
 `/run/log/journal`.

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -217,6 +217,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `systemd.sleep.extraConfig` was replaced by [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md)-compliant `systemd.sleep.settings.Sleep`, which is used to generate the `sleep.conf` configuration file. See {manpage}`sleep.conf.d(5)` for available options.
 
+- `services.journald` was converted to [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md)-compliant `services.journald.settings.Journal`. The old individual options (`console`, `rateLimitInterval`, `rateLimitBurst`, `storage`, `audit`, `forwardToSyslog`) have been renamed to their upstream equivalents inside `settings.Journal`, and `services.journald.extraConfig` has been removed. Aliases mean current configs will continue to function, but users should move to the new options.
+
 - Support for Bluetooth audio based on `bluez-alsa` has been added to the `hardware.alsa` module. It can be enabled with the new [enableBluetooth](#opt-hardware.alsa.enableBluetooth) option.
 
 - `services.openssh` now supports generating host SSH keys by setting `services.openssh.generateHostKeys = true` while leaving `services.openssh.enable` disabled.  This is particularly useful for systems that have no need of an SSH daemon but want SSH host keys for other purposes such as using agenix or sops-nix.

--- a/nixos/modules/system/boot/systemd/journald.nix
+++ b/nixos/modules/system/boot/systemd/journald.nix
@@ -14,111 +14,66 @@ in
       [ "services" "journald" "enableHttpGateway" ]
       [ "services" "journald" "gateway" "enable" ]
     )
+
+    (lib.mkRemovedOptionModule [
+      "services"
+      "journald"
+      "extraConfig"
+    ] "Use services.journald.settings.Journal instead.")
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "console" ]
+      [ "services" "journald" "settings" "Journal" "TTYPath" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "rateLimitInterval" ]
+      [ "services" "journald" "settings" "Journal" "RateLimitIntervalSec" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "rateLimitBurst" ]
+      [ "services" "journald" "settings" "Journal" "RateLimitBurst" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "storage" ]
+      [ "services" "journald" "settings" "Journal" "Storage" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "audit" ]
+      [ "services" "journald" "settings" "Journal" "Audit" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "journald" "forwardToSyslog" ]
+      [ "services" "journald" "settings" "Journal" "ForwardToSyslog" ]
+    )
   ];
 
   options = {
-    services.journald.console = lib.mkOption {
-      default = "";
-      type = lib.types.str;
-      description = "If non-empty, write log messages to the specified TTY device.";
-    };
-
-    services.journald.rateLimitInterval = lib.mkOption {
-      default = "30s";
-      type = lib.types.str;
+    services.journald.settings.Journal = lib.mkOption {
+      default = { };
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf utils.systemdUtils.unitOptions.unitOption;
+      };
+      example = {
+        Storage = "volatile";
+        ForwardToSyslog = true;
+      };
       description = ''
-        Configures the rate limiting interval that is applied to all
-        messages generated on the system. This rate limiting is applied
-        per-service, so that two services which log do not interfere with
-        each other's limit. The value may be specified in the following
-        units: s, min, h, ms, us. To turn off any kind of rate limiting,
-        set either value to 0.
-
-        See {option}`services.journald.rateLimitBurst` for important
-        considerations when setting this value.
-      '';
-    };
-
-    services.journald.storage = lib.mkOption {
-      default = "persistent";
-      type = lib.types.enum [
-        "persistent"
-        "volatile"
-        "auto"
-        "none"
-      ];
-      description = ''
-        Controls where to store journal data. See
-        {manpage}`journald.conf(5)` for further information.
-      '';
-    };
-
-    services.journald.rateLimitBurst = lib.mkOption {
-      default = 10000;
-      type = lib.types.int;
-      description = ''
-        Configures the rate limiting burst limit (number of messages per
-        interval) that is applied to all messages generated on the system.
-        This rate limiting is applied per-service, so that two services
-        which log do not interfere with each other's limit.
-
-        Note that the effective rate limit is multiplied by a factor derived
-        from the available free disk space for the journal as described on
-        {manpage}`journald.conf(5)`.
-
-        Note that the total amount of logs stored is limited by journald settings
-        such as `SystemMaxUse`, which defaults to 10% the file system size
-        (capped at max 4GB), and `SystemKeepFree`, which defaults to 15% of the
-        file system size.
-
-        It is thus recommended to compute what period of time that you will be
-        able to store logs for when an application logs at full burst rate.
-        With default settings for log lines that are 100 Bytes long, this can
-        amount to just a few hours.
-      '';
-    };
-
-    services.journald.audit = lib.mkOption {
-      default = "keep";
-      type = lib.types.oneOf [
-        lib.types.bool
-        (lib.types.enum [ "keep" ])
-      ];
-      description = ''
-        If enabled systemd-journald will turn on auditing on start-up.
-        If disabled it will turn it off. If unset it will neither enable nor disable it, leaving the previous state unchanged.
-
-        NixOS defaults to leaving this unset as enabling audit without auditd running leads to spamming /dev/kmesg with random messages
-        and if you enable auditd then auditd is responsible for turning auditing on.
-
-        If you want to have audit logs in journald and do not mind audit logs also ending up in /dev/kmesg you can set this option to true.
-
-        If you want to for some ununderstandable reason disable auditing if auditd enabled it then you can set this option to false.
-        It is of NixOS' opinion that setting this to false is definitely the wrong thing to do - but it's an option.
-      '';
-    };
-
-    services.journald.extraConfig = lib.mkOption {
-      default = "";
-      type = lib.types.lines;
-      example = "Storage=volatile";
-      description = ''
-        Extra config options for systemd-journald. See {manpage}`journald.conf(5)`
+        Settings for systemd-journald. See {manpage}`journald.conf(5)`
         for available options.
-      '';
-    };
-
-    services.journald.forwardToSyslog = lib.mkOption {
-      default = config.services.rsyslogd.enable || config.services.syslog-ng.enable;
-      defaultText = lib.literalExpression "services.rsyslogd.enable || services.syslog-ng.enable";
-      type = lib.types.bool;
-      description = ''
-        Whether to forward log messages to syslog.
       '';
     };
   };
 
   config = {
+    services.journald.settings.Journal = {
+      Storage = lib.mkDefault "persistent";
+      RateLimitIntervalSec = lib.mkDefault "30s";
+      RateLimitBurst = lib.mkDefault 10000;
+      Audit = lib.mkDefault "keep";
+      ForwardToSyslog = lib.mkDefault (
+        config.services.rsyslogd.enable || config.services.syslog-ng.enable
+      );
+    };
+
     systemd.additionalUpstreamSystemUnits = [
       "systemd-journald.socket"
       "systemd-journald@.socket"
@@ -139,21 +94,7 @@ in
     ];
 
     environment.etc = {
-      "systemd/journald.conf".text = ''
-        [Journal]
-        Storage=${cfg.storage}
-        RateLimitInterval=${cfg.rateLimitInterval}
-        RateLimitBurst=${toString cfg.rateLimitBurst}
-        ${lib.optionalString (cfg.console != "") ''
-          ForwardToConsole=yes
-          TTYPath=${cfg.console}
-        ''}
-        ${lib.optionalString (cfg.forwardToSyslog) ''
-          ForwardToSyslog=yes
-        ''}
-        Audit=${utils.systemdUtils.lib.toOption cfg.audit}
-        ${cfg.extraConfig}
-      '';
+      "systemd/journald.conf".text = utils.systemdUtils.lib.settingsToSections cfg.settings;
     };
 
     users.groups.systemd-journal.gid = config.ids.gids.systemd-journal;

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -217,11 +217,11 @@ in
     environment.systemPackages = [ pkgs.xwininfo ];
 
     # Log everything to the serial console.
-    services.journald.extraConfig = ''
-      ForwardToConsole=yes
-      TTYPath=/dev/${qemu-common.qemuSerialDevice}
-      MaxLevelConsole=debug
-    '';
+    services.journald.settings.Journal = {
+      ForwardToConsole = true;
+      TTYPath = "/dev/${qemu-common.qemuSerialDevice}";
+      MaxLevelConsole = "debug";
+    };
 
     systemd.settings.Manager = managerSettings;
     systemd.user.extraConfig = ''

--- a/nixos/tests/rsyslogd.nix
+++ b/nixos/tests/rsyslogd.nix
@@ -16,7 +16,7 @@ with pkgs.lib;
       { config, pkgs, ... }:
       {
         services.rsyslogd.enable = true;
-        services.journald.forwardToSyslog = false;
+        services.journald.settings.Journal.ForwardToSyslog = false;
       };
 
     # ensure rsyslogd isn't receiving messages from journald if explicitly disabled

--- a/nixos/tests/systemd-journal.nix
+++ b/nixos/tests/systemd-journal.nix
@@ -14,7 +14,7 @@
     security.audit.enable = true;
   };
   nodes.journaldAudit = {
-    services.journald.audit = true;
+    services.journald.settings.Journal.Audit = true;
     security.audit.enable = true;
   };
   nodes.containerCheck = {

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -35,7 +35,7 @@
         KExecWatchdogSec = "5min";
       };
       systemd.user.extraConfig = "DefaultEnvironment=\"XXX_USER=bar\"";
-      services.journald.extraConfig = "Storage=volatile";
+      services.journald.settings.Journal.Storage = "volatile";
       test-support.displayManager.auto.user = "alice";
 
       systemd.shutdown.test = pkgs.writeScript "test.shutdown" ''


### PR DESCRIPTION
Replaces `services.journald`'s individual options and `extraConfig` with a freeform `services.journald.settings.Journal` submodule, per [RFC42](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md).

Users can now set any `journald.conf(5)` option directly instead of relying on `extraConfig`.

| Old | New |
|---|---|
| `extraConfig` | removed -- use `settings.Journal` |
| `storage` | `settings.Journal.Storage` |
| `rateLimitInterval` | `settings.Journal.RateLimitIntervalSec` |
| `rateLimitBurst` | `settings.Journal.RateLimitBurst` |
| `audit` | `settings.Journal.Audit` |
| `forwardToSyslog` | `settings.Journal.ForwardToSyslog` |
| `console` | `settings.Journal.TTYPath` |

All old paths except `extraConfig` have `mkRenamedOptionModule` aliases. The old `console` option implicitly set `ForwardToConsole=yes`. That's gone, set both explicitly now. Nobody in the tree used it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
