### PR TITLE
nixos/binfmt: Avoid adding to extra-sandbox-paths with fixBinary

### DIFF
--- a/nixos/tests/systemd-binfmt.nix
+++ b/nixos/tests/systemd-binfmt.nix
@@ -103,7 +103,12 @@ in
   chroot = makeTest {
     name = "systemd-binfmt-chroot";
     nodes.machine =
-      { pkgs, lib, ... }:
+      {
+        pkgs,
+        lib,
+        config,
+        ...
+      }:
       {
         boot.binfmt.emulatedSystems = [
           "aarch64-linux"
@@ -120,6 +125,13 @@ in
             chroot /tmp/chroot /busybox uname -m | grep aarch64
             echo 42 | chroot /tmp/chroot /yaml2json | grep 42
           '')
+        ];
+
+        assertions = [
+          {
+            assertion = config.nix.settings.extra-sandbox-paths == [ ];
+            message = "Using binfmt_misc with static emulators, nix.settings.extra-sandbox-paths should be empty";
+          }
         ];
       };
     testScript = ''


### PR DESCRIPTION
Static emulators should not require setting `nix.settings.extra-sandbox-paths`.

I hope this way of organizing the defaults makes sense.

Honestly I think non-static emulators should be thrown away altogether but I just want to make the static case happier for now.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux (The NixOS test, after some modification wrt systems used)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
