### PR TITLE
cloudflare-warp: reuse darwin src to fix updateScript

### DIFF
--- a/pkgs/by-name/cl/cloudflare-warp/package.nix
+++ b/pkgs/by-name/cl/cloudflare-warp/package.nix
@@ -27,7 +27,7 @@
 
 let
   version = "2025.10.186.0";
-  sources = {
+  sources = rec {
     x86_64-linux = fetchurl {
       url = "https://pkg.cloudflareclient.com/pool/noble/main/c/cloudflare-warp/cloudflare-warp_${version}_amd64.deb";
       hash = "sha256-l+csDSBXRAFb2075ciCAlE0bS5F48mAIK/Bv1r3Q8GE=";
@@ -36,14 +36,11 @@ let
       url = "https://pkg.cloudflareclient.com/pool/noble/main/c/cloudflare-warp/cloudflare-warp_${version}_arm64.deb";
       hash = "sha256-S6CfWYzcv+1Djj+TX+lrP5eG7oIpM0JrqtSw/UDD9ko=";
     };
-    x86_64-darwin = fetchurl {
-      url = "https://downloads.cloudflareclient.com/v1/download/macos/version/${version}";
-      hash = "sha256-nnoOXPSpOJRyNdCC0/YAoBK8SwB+++qVwgZplrjNi2U=";
-    };
     aarch64-darwin = fetchurl {
       url = "https://downloads.cloudflareclient.com/v1/download/macos/version/${version}";
       hash = "sha256-nnoOXPSpOJRyNdCC0/YAoBK8SwB+++qVwgZplrjNi2U=";
     };
+    x86_64-darwin = aarch64-darwin;
   };
 in
 stdenv.mkDerivation (finalAttrs: {


### PR DESCRIPTION
The current updater seems to have stopped updating to `2026.1.150.0`.

https://nixpkgs-update-logs.nix-community.org/cloudflare-warp/2026-01-24.log
https://nixpkgs-update-logs.nix-community.org/cloudflare-warp/2026-01-31.log
https://nixpkgs-update-logs.nix-community.org/cloudflare-warp/2026-02-07.log
https://nixpkgs-update-logs.nix-community.org/cloudflare-warp/2026-02-15.log
https://nixpkgs-update-logs.nix-community.org/cloudflare-warp/2026-02-22.log

```
Going to be running update for following packages:
 - cloudflare-warp-2025.10.186.0

Press Enter key to continue...
Running update for:
Enqueuing group of 1 packages
 - cloudflare-warp-2025.10.186.0: UPDATING ...
 - cloudflare-warp-2025.10.186.0: ERROR

--- SHOWING ERROR LOG FOR cloudflare-warp-2025.10.186.0 ----------------------

update-source-version: error: Couldn't locate old source hash 'sha256-nnoOXPSpOJRyNdCC0/YAoBK8SwB+++qVwgZplrjNi2U=' (or it appeared more than once) in '/var/cache/nixpkgs-update/worker/worktree/cloudflare-warp/pkgs/by-name/cl/cloudflare-warp/package.nix'!
```




<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. # No rebuilds
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @marcusramberg, @ap-1