### PR TITLE
repath-studio: add nixos test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1398,6 +1398,7 @@ in
   refind = runTest ./refind.nix;
   remark42 = runTest ./remark42.nix;
   renovate = runTest ./renovate.nix;
+  repath-studio = runTest ./repath-studio.nix;
   replace-dependencies = handleTest ./replace-dependencies { };
   reposilite = runTest ./reposilite.nix;
   restartByActivationScript = runTest ./restart-by-activation-script.nix;

--- a/nixos/tests/repath-studio.nix
+++ b/nixos/tests/repath-studio.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  name = "Repath Studio";
+
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        imports = [
+          # enable graphical session + users (alice, bob)
+          ./common/x11.nix
+          ./common/user-account.nix
+        ];
+
+        services.xserver.enable = true;
+        test-support.displayManager.auto.user = "alice";
+
+        environment.systemPackages = with pkgs; [
+          xdotool
+          repath-studio
+        ];
+
+        # electron application, give more memory
+        virtualisation.memorySize = 4096;
+      };
+  };
+
+  enableOCR = true;
+
+  # Debug interactively with:
+  # - nix run .#nixosTests.repath-studio.driverInteractive -L
+  # - start_all()/run_tests()
+  # ssh -o User=root vsock%3 (can also do vsock/3, but % works with scp etc.)
+  interactive.sshBackdoor.enable = true;
+
+  testScript = /* python */ ''
+    start_all()
+
+    machine.wait_for_x()
+    machine.succeed("env DISPLAY=:0 sudo -u alice repath-studio &> /tmp/repath.log &")
+    machine.wait_for_text(r"(Welcome|Repath|Studio)") # initial telemetry prompt
+
+    machine.screenshot("Repath-Studio-GUI-Welcome")
+    machine.send_key("kp_enter") # OK
+
+    # sleep is required it needs time to dismiss the dialog
+    machine.sleep(2)
+    machine.send_key("ctrl-shift-s")
+    machine.sleep(2)
+    machine.send_chars("/tmp/saved.rps\n")
+    machine.sleep(2)
+    print(machine.succeed("cat /tmp/saved.rps"))
+    assert "${pkgs.repath-studio.version}" in machine.succeed("cat /tmp/saved.rps")
+
+    machine.screenshot("Repath-Studio-GUI")
+  '';
+
+  meta.maintainers = lib.teams.ngi.members;
+}


### PR DESCRIPTION
migrated from ngi-nix/ngipkgs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
