### PR TITLE
rtk: init at 0.22.2

### DIFF
--- a/pkgs/by-name/rt/rtk/package.nix
+++ b/pkgs/by-name/rt/rtk/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  sqlite,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rtk";
+  version = "0.22.2";
+
+  src = fetchFromGitHub {
+    owner = "rtk-ai";
+    repo = "rtk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dNODYk5PNiKU6+9AgB9c5f06PCcjStwFPEpuIb+BT0g=";
+  };
+
+  cargoHash = "sha256-lgmgorgT/KDSyzEcE33qkPF4f/3LJbAzEH0s9thTohE=";
+
+  preBuild = ''
+    substituteInPlace Cargo.toml --replace-fail 'features = ["bundled"]' 'features = []'
+    cargo update --offline -p rusqlite
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    sqlite
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI proxy that reduces LLM token consumption by 60-90% on common dev commands";
+    homepage = "https://github.com/rtk-ai/rtk";
+    changelog = "https://github.com/rtk-ai/rtk/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ryoppippi ];
+    mainProgram = "rtk";
+  };
+})


### PR DESCRIPTION
Add [rtk](https://github.com/rtk-ai/rtk), a high-performance CLI proxy that reduces LLM token consumption by 60-90% on common developer commands by filtering and compressing command outputs before they reach the LLM context window.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test