### PR TITLE
freedoom: init at 0.13.0

### DIFF
--- a/pkgs/by-name/fr/freedoom/package.nix
+++ b/pkgs/by-name/fr/freedoom/package.nix
@@ -1,0 +1,57 @@
+{
+  asciidoc,
+  asciidoctor,
+  deutex,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  python3,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "freedoom";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "freedoom";
+    repo = "freedoom";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uOLyh/epVxv3/N+6P1glBX1ZkGWzHWGaERYZRSL/3AU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    (python3.withPackages (ps: with ps; [ pillow ]))
+    asciidoc
+    asciidoctor
+    deutex
+  ];
+
+  preBuild = ''
+    patchShebangs .
+  '';
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Game based on the Doom engine";
+    longDescription = ''
+      Freedoom is a complete, free content first person shooter game,
+      based on the Doom engine.
+
+      Freedoom is not a program - rather, it consists of the levels,
+      artwork, sound effects and music that make up the game.  To play
+      Freedoom, [it must be paired with an
+      engine](https://github.com/freedoom/freedoom#How-to-play) that
+      can play it.
+    '';
+    homepage = "https://freedoom.github.io";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ yiyu ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
