### PR TITLE
filen-desktop: move icon to spec-compliant location, cleanup

### DIFF
--- a/pkgs/by-name/fi/filen-desktop/package.nix
+++ b/pkgs/by-name/fi/filen-desktop/package.nix
@@ -76,9 +76,8 @@ buildNpmPackage {
 
   # Set up icon assets in path required by desktopItem
   preInstall = ''
-    mkdir -p $out/share/pixmaps
-    cp $src/assets/icons/app/${iconPrefix}.${iconSuffix} $out/share/pixmaps/${packageName}.${iconSuffix}
-    cp $src/assets/icons/app/${iconPrefix}Notification.${iconSuffix} $out/share/pixmaps/${packageName}-notification.${iconSuffix}
+    install -D $src/assets/icons/app/${iconPrefix}.${iconSuffix} $out/share/icons/hicolor/128x128/apps/${packageName}.${iconSuffix}
+    install -D $src/assets/icons/app/${iconPrefix}Notification.${iconSuffix} $out/share/icons/hicolor/128x128/apps/${packageName}-notification.${iconSuffix}
   '';
 
   # Create binary wrapper and desktopItem

--- a/pkgs/by-name/fi/filen-desktop/package.nix
+++ b/pkgs/by-name/fi/filen-desktop/package.nix
@@ -1,11 +1,16 @@
 {
   lib,
-  pkgs,
   stdenv,
   buildNpmPackage,
   fetchFromGitHub,
   makeDesktopItem,
   desktopToDarwinBundle,
+  pkg-config,
+  electron,
+  makeWrapper,
+  pixman,
+  cairo,
+  pango,
 }:
 let
   packageName = "filen-desktop";
@@ -54,18 +59,18 @@ buildNpmPackage {
   };
 
   nativeBuildInputs = [
-    pkgs.pkg-config
-    pkgs.electron
-    pkgs.makeWrapper
+    pkg-config
+    electron
+    makeWrapper
   ]
   ++ lib.optionals stdenv.isDarwin [
     desktopToDarwinBundle
   ];
 
   buildInputs = [
-    pkgs.pixman
-    pkgs.cairo
-    pkgs.pango
+    pixman
+    cairo
+    pango
   ];
 
   # Override package-lock.json electron version to use what's given by nixpkgs
@@ -83,10 +88,10 @@ buildNpmPackage {
   # Create binary wrapper and desktopItem
   # desktopItem auto-creates the .app bundle for Darwin
   postInstall = ''
-    makeWrapper ${pkgs.electron}/bin/electron $out/bin/${packageName} \
+    makeWrapper ${electron}/bin/electron $out/bin/${packageName} \
       --set-default ELECTRON_IS_DEV 0 \
       --add-flags $out/lib/node_modules/@filen/desktop/dist/index.js \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ]}"
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
 
     mkdir -p $out/share/applications
     cp ${desktopItem}/share/applications/* $out/share/applications/


### PR DESCRIPTION
Part of #428824, also stop pulling in `pkgs` 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
