### PR TITLE
nixos/outline: Remove references to minio

### DIFF
--- a/nixos/modules/services/web-apps/outline.nix
+++ b/nixos/modules/services/web-apps/outline.nix
@@ -128,7 +128,7 @@ in
         To support uploading of images for avatars and document attachments an
         s3-compatible storage can be provided. AWS S3 is recommended for
         redundancy however if you want to keep all file storage local an
-        alternative such as [minio](https://github.com/minio/minio)
+        alternative such as [garage](https://garagehq.deuxfleurs.fr/)
         can be used.
         Local filesystem storage can also be used.
 
@@ -139,7 +139,7 @@ in
         {
           accessKey = "...";
           secretKeyFile = "/somewhere";
-          uploadBucketUrl = "https://minio.example.com";
+          uploadBucketUrl = "https://garage.example.com";
           uploadBucketName = "outline";
           region = "us-east-1";
         }


### PR DESCRIPTION
## Things done

minio is deprecated, thus replaced references to it with references to garage.

See #490996

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
