### PR TITLE
firefly-desktop: move icon to spec-compliant location, cleanup

### DIFF
--- a/pkgs/by-name/fi/firefly-desktop/package.nix
+++ b/pkgs/by-name/fi/firefly-desktop/package.nix
@@ -20,12 +20,11 @@ appimageTools.wrapType2 {
   extraPkgs = pkgs: [ pkgs.libsecret ];
 
   extraInstallCommands = ''
-    mkdir -p $out/share/applications $out/share/pixmaps
-    cp ${appimageContents}/desktop.desktop $out/share/applications/firefly-desktop.desktop
+    install -D ${appimageContents}/desktop.desktop $out/share/applications/firefly-desktop.desktop
     substituteInPlace $out/share/applications/firefly-desktop.desktop \
       --replace 'Exec=AppRun' 'Exec=firefly-desktop' \
       --replace 'Icon=desktop' 'Icon=firefly-desktop'
-    cp ${appimageContents}/desktop.png $out/share/pixmaps/firefly-desktop.png
+    install -D ${appimageContents}/desktop.png $out/share/icons/firefly-desktop.png
   '';
 
   meta = {

--- a/pkgs/by-name/fi/firefly-desktop/package.nix
+++ b/pkgs/by-name/fi/firefly-desktop/package.nix
@@ -22,8 +22,8 @@ appimageTools.wrapType2 {
   extraInstallCommands = ''
     install -D ${appimageContents}/desktop.desktop $out/share/applications/firefly-desktop.desktop
     substituteInPlace $out/share/applications/firefly-desktop.desktop \
-      --replace 'Exec=AppRun' 'Exec=firefly-desktop' \
-      --replace 'Icon=desktop' 'Icon=firefly-desktop'
+      --replace-fail 'Exec=AppRun' 'Exec=firefly-desktop' \
+      --replace-fail 'Icon=desktop' 'Icon=firefly-desktop'
     install -D ${appimageContents}/desktop.png $out/share/icons/firefly-desktop.png
   '';
 


### PR DESCRIPTION
Part of #428824 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
