### PR TITLE
fish-fillets-ng: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/fi/fish-fillets-ng/package.nix
+++ b/pkgs/by-name/fi/fish-fillets-ng/package.nix
@@ -10,6 +10,7 @@
   SDL_mixer,
   SDL_image,
   SDL_ttf,
+  imagemagick,
 }:
 
 stdenv.mkDerivation rec {
@@ -28,7 +29,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     copyDesktopItems
+    imagemagick
   ];
+
   buildInputs = [
     SDL
     lua5_1
@@ -61,7 +64,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/share/games/fillets-ng
     tar -xf ${data} -C $out/share/games/fillets-ng --strip-components=1
-    install -Dm644 ${./icon.xpm} $out/share/pixmaps/fish-fillets-ng.xpm
+    mkdir -p $out/share/icons/hicolor/32x32/apps
+    magick ${./icon.xpm} $out/share/icons/hicolor/32x32/apps/fish-fillets-ng.png
   '';
 
   meta = {


### PR DESCRIPTION
Part of #428824 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
