### PR TITLE
firefoxpwa: wrap using wrapFirefox

### DIFF
--- a/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
@@ -1,5 +1,4 @@
 {
-  extraLibs ? [ ],
   firefoxRuntime ? firefox-unwrapped,
 
   lib,
@@ -8,27 +7,15 @@
   makeWrapper,
   rustPlatform,
 
-  cups,
-  ffmpeg,
   firefox-unwrapped,
-  libcanberra-gtk3,
-  libglvnd,
-  libnotify,
-  libpulseaudio,
-  libva,
-  libgbm,
   nixosTests,
   openssl,
-  pciutils,
-  pipewire,
   pkg-config,
   stdenv,
-  udev,
-  libxscrnsaver,
 }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "firefoxpwa";
+  pname = "firefoxpwa-unwrapped";
   version = "2.18.0";
 
   src = fetchFromGitHub {
@@ -62,27 +49,6 @@ rustPlatform.buildRustPackage rec {
   };
   completions = "target/${stdenv.targetPlatform.config}/release/completions";
 
-  gtk_modules = map (x: x + x.gtkModule) [ libcanberra-gtk3 ];
-  libs =
-    let
-      libs = [
-        cups
-        ffmpeg
-        libglvnd
-        libnotify
-        libpulseaudio
-        libva
-        libgbm
-        pciutils
-        pipewire
-        udev
-        libxscrnsaver
-      ]
-      ++ gtk_modules
-      ++ extraLibs;
-    in
-    lib.makeLibraryPath libs + ":" + lib.makeSearchPathOutput "lib" "lib64" libs;
-
   postInstall = ''
     # Runtime
     mkdir -p $out/share/firefoxpwa
@@ -113,17 +79,18 @@ rustPlatform.buildRustPackage rec {
     install -Dm644 packages/appstream/si.filips.FirefoxPWA.svg $out/share/icons/hicolor/scalable/apps/si.filips.FirefoxPWA.svg
 
     wrapProgram $out/bin/firefoxpwa \
-      --prefix FFPWA_SYSDATA : "$out/share/firefoxpwa" \
-      --prefix LD_LIBRARY_PATH : "$libs" \
-      --suffix-each GTK_PATH : "$gtk_modules"
+      --prefix FFPWA_SYSDATA : "$out/share/firefoxpwa"
 
     wrapProgram $out/bin/firefoxpwa-connector \
-      --prefix FFPWA_SYSDATA : "$out/share/firefoxpwa" \
-      --prefix LD_LIBRARY_PATH : "$libs" \
-      --suffix-each GTK_PATH : "$gtk_modules"
+      --prefix FFPWA_SYSDATA : "$out/share/firefoxpwa"
   '';
 
-  passthru.tests.firefoxpwa = nixosTests.firefoxpwa;
+  passthru = {
+    tests.firefoxpwa = nixosTests.firefoxpwa;
+    binaryName = "firefoxpwa";
+    applicationName = "firefoxpwa";
+    inherit (firefoxRuntime) gtk3;
+  };
 
   meta = {
     description = "Tool to install, manage and use Progressive Web Apps (PWAs) in Mozilla Firefox (native component)";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9664,6 +9664,8 @@ with pkgs;
     pname = "firefox-bin";
   };
 
+  firefoxpwa = wrapFirefox firefoxpwa-unwrapped { };
+
   librewolf = wrapFirefox librewolf-unwrapped {
     inherit (librewolf-unwrapped) extraPrefsFiles extraPoliciesFiles;
     libName = "librewolf";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixes #494628  for me

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
