### PR TITLE
cpptrace: fix Darwin tests

### DIFF
--- a/pkgs/by-name/cp/cpptrace/package.nix
+++ b/pkgs/by-name/cp/cpptrace/package.nix
@@ -46,6 +46,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkInputs = [ gtest ];
 
+  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    dsymutil unittest
+  '';
+
   doCheck = true;
 
   passthru = {

--- a/pkgs/by-name/od/odamex/package.nix
+++ b/pkgs/by-name/od/odamex/package.nix
@@ -41,15 +41,6 @@
   withWayland ? stdenv.hostPlatform.isLinux,
 }:
 
-let
-  # TODO: remove when this is resolved, likely at the next cpptrace bump
-  cpptrace' = cpptrace.overrideAttrs {
-    # tests are failing on darwin
-    # https://hydra.nixos.org/build/310535948
-    doCheck = !stdenv.hostPlatform.isDarwin;
-  };
-in
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "odamex";
   version = "12.1.0";
@@ -77,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2
     SDL2_mixer
     SDL2_net
-    cpptrace'
+    cpptrace
     curl
     expat
     fltk


### PR DESCRIPTION
Run dsymutil on unittest in preCheck on Darwin so libdwarf can resolve line info during ctest.
Without the generated dSYM, the unittest run fails with DW_DLE_MACHO_CORRUPT_COMMAND(487) in checkPhase.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
