### PR TITLE
python3Packages.pymilvus: 2.6.6 -> 2.6.9

### DIFF
--- a/pkgs/development/python-modules/pymilvus/default.nix
+++ b/pkgs/development/python-modules/pymilvus/default.nix
@@ -9,28 +9,39 @@
   setuptools-scm,
 
   # dependencies
+  cachetools,
   grpcio,
   # milvus-lite, (unpackaged)
+  orjson,
   pandas,
   protobuf,
   python-dotenv,
-  ujson,
+
+  # optional-dependencies
+  azure-storage-blob,
+  minio,
+  pyarrow,
+  requests,
+  urllib3,
 
   # tests
   grpcio-testing,
+  pytest-asyncio,
+  pytest-benchmark,
   pytestCheckHook,
+  scipy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pymilvus";
-  version = "2.6.6";
+  version = "2.6.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "milvus-io";
     repo = "pymilvus";
-    tag = "v${version}";
-    hash = "sha256-UVpsciVM6MUyTH6VxndQHUvd+lkZQKSyckiBHhzVRS0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2PDN642i+GZG4Uxs4aA5x/jC6vm2cx4RITVqKi3KvtY=";
   };
 
   build-system = [
@@ -48,41 +59,58 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
+    cachetools
     grpcio
     # milvus-lite
+    orjson
     pandas
     protobuf
     python-dotenv
     setuptools
-    ujson
   ];
+
+  optional-dependencies = {
+    bulk_writer = [
+      azure-storage-blob
+      minio
+      pyarrow
+      requests
+      urllib3
+    ];
+  };
 
   nativeCheckInputs = [
     grpcio-testing
+    pytest-asyncio
+    pytest-benchmark
     pytestCheckHook
-    # scikit-learn
-  ];
+    scipy
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.bulk_writer;
 
   pythonImportsCheck = [ "pymilvus" ];
 
   disabledTests = [
-    # Tries to read .git
+    # tries to read .git
     "test_get_commit"
-
-    # milvus-lite is not packaged
-    "test_milvus_lite"
+    # requires network access
+    "test_deadline_exceeded_shows_connecting_state"
+    # mock issue in sandbox
+    "test_milvus_client_creates_unbound_alias"
   ];
 
   disabledTestPaths = [
-    # pymilvus.exceptions.MilvusException: <MilvusException: (code=2, message=Fail connecting to server on localhost:19530, illegal connection params or server unavailable)>
-    "examples/test_bitmap_index.py"
+    # requires running milvus server
+    "examples/"
+    # tries to write to nix store
+    "tests/test_bulk_writer_stage.py"
   ];
 
   meta = {
     description = "Python SDK for Milvus";
     homepage = "https://github.com/milvus-io/pymilvus";
-    changelog = "https://github.com/milvus-io/pymilvus/releases/tag/${src.tag}";
+    changelog = "https://github.com/milvus-io/pymilvus/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ happysalada ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Bump to latest version 2.6.9
* Added optional dependencies for bulk-writer
* Switched from `rec` to `finalAttrs` convention
* Fixes build, unblocking build of open-webui

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
