### PR TITLE
python3Packages.pynormaliz: init at 2.24

### DIFF
--- a/pkgs/development/python-modules/pynormaliz/default.nix
+++ b/pkgs/development/python-modules/pynormaliz/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  flint,
+  fetchPypi,
+  gmpxx,
+  normaliz,
+  setuptools,
+  python,
+}:
+
+buildPythonPackage rec {
+  pname = "pynormaliz";
+  version = "2.24";
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-HpHN8kxXxEcsuPAXD+kEHoNm/H1ZjsIUthefYjn4iZw=";
+  };
+
+  buildInputs = [
+    flint
+    gmpxx
+    normaliz
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} tests/runtests.py
+    runHook postCheck
+  '';
+
+  pythonImportsCheck = [ "PyNormaliz" ];
+
+  meta = {
+    description = "Python interface to Normaliz";
+    homepage = "https://github.com/Normaliz/PyNormaliz";
+    changelog = "https://github.com/Normaliz/PyNormaliz/releases/tag/${version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ kilianar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14200,6 +14200,8 @@ self: super: with self; {
 
   pynordpool = callPackage ../development/python-modules/pynordpool { };
 
+  pynormaliz = callPackage ../development/python-modules/pynormaliz { };
+
   pynotifier = callPackage ../development/python-modules/pynotifier { };
 
   pynput = callPackage ../development/python-modules/pynput { };


### PR DESCRIPTION
This pull request adds [PyNormaliz](https://github.com/Normaliz/PyNormaliz), the Python bindings for already packaged Normaliz library, which performs computations related to affine monoids, lattice polytopes, and rational cones. This package is required to use Normaliz as a backend in SageMath.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
