### PR TITLE
[Backport release-25.11] repath-studio: init at 0.4.12

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1346,6 +1346,7 @@ in
   redmine = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./redmine.nix { };
   refind = runTest ./refind.nix;
   renovate = runTest ./renovate.nix;
+  repath-studio = runTest ./repath-studio.nix;
   replace-dependencies = handleTest ./replace-dependencies { };
   reposilite = runTest ./reposilite.nix;
   restartByActivationScript = runTest ./restart-by-activation-script.nix;

--- a/nixos/tests/repath-studio.nix
+++ b/nixos/tests/repath-studio.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  name = "Repath Studio";
+
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        imports = [
+          # enable graphical session + users (alice, bob)
+          ./common/x11.nix
+          ./common/user-account.nix
+        ];
+
+        services.xserver.enable = true;
+        test-support.displayManager.auto.user = "alice";
+
+        environment.systemPackages = with pkgs; [
+          xdotool
+          repath-studio
+        ];
+
+        # electron application, give more memory
+        virtualisation.memorySize = 4096;
+      };
+  };
+
+  enableOCR = true;
+
+  # Debug interactively with:
+  # - nix run .#nixosTests.repath-studio.driverInteractive -L
+  # - start_all()/run_tests()
+  # ssh -o User=root vsock%3 (can also do vsock/3, but % works with scp etc.)
+  interactive.sshBackdoor.enable = true;
+
+  testScript = /* python */ ''
+    start_all()
+
+    machine.wait_for_x()
+    machine.succeed("env DISPLAY=:0 sudo -u alice repath-studio &> /tmp/repath.log &")
+    machine.wait_for_text(r"(Welcome|Repath|Studio)") # initial telemetry prompt
+
+    machine.screenshot("Repath-Studio-GUI-Welcome")
+    machine.send_key("kp_enter") # OK
+
+    # sleep is required it needs time to dismiss the dialog
+    machine.sleep(2)
+    machine.send_key("ctrl-shift-s")
+    machine.sleep(2)
+    machine.send_chars("/tmp/saved.rps\n")
+    machine.sleep(2)
+    print(machine.succeed("cat /tmp/saved.rps"))
+    assert "${pkgs.repath-studio.version}" in machine.succeed("cat /tmp/saved.rps")
+
+    machine.screenshot("Repath-Studio-GUI")
+  '';
+
+  meta.maintainers = lib.teams.ngi.members;
+}

--- a/pkgs/by-name/re/repath-studio/hardcode-git-paths.patch
+++ b/pkgs/by-name/re/repath-studio/hardcode-git-paths.patch
@@ -1,0 +1,14 @@
+diff --git a/deps.edn b/deps.edn
+index 195de4e..6ebe31b 100644
+--- a/deps.edn
++++ b/deps.edn
+@@ -1,8 +1,7 @@
+ {:paths ["src"]
+  :deps {binaryage/devtools {:mvn/version "1.0.7"}
+         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
+-        clj-kdtree/clj-kdtree {:git/url "https://github.com/abscondment/clj-kdtree.git"
+-                               :sha "5ec321c5e8006db00fa8b45a8ed9eb0b8f3dd56d"
++        clj-kdtree/clj-kdtree {:local/root "@clj-kdtree_src@"
+                                :deps/manifest :deps}
+         com.taoensso/tempura {:mvn/version "1.5.4"}
+         day8.re-frame/test {:mvn/version "0.1.7"}

--- a/pkgs/by-name/re/repath-studio/package.nix
+++ b/pkgs/by-name/re/repath-studio/package.nix
@@ -1,0 +1,205 @@
+{
+  lib,
+  stdenv,
+
+  buildNpmPackage,
+  fetchFromGitHub,
+  pkg-config,
+  electron,
+  chromium,
+  clojure,
+  vips,
+
+  writeShellScriptBin,
+  copyDesktopItems,
+  makeDesktopItem,
+  makeWrapper,
+  replaceVars,
+
+  vulkan-loader,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "repath-studio";
+  version = "0.4.12";
+
+  src = fetchFromGitHub {
+    owner = "repath-studio";
+    repo = "repath-studio";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sdM3owUYI0P12+R4YyYtF/20Zl0EpJY6t4Z1q/K5EqM=";
+  };
+
+  patches = [
+    (replaceVars ./hardcode-git-paths.patch {
+      clj-kdtree_src = fetchFromGitHub {
+        owner = "abscondment";
+        repo = "clj-kdtree";
+        rev = "5ec321c5e8006db00fa8b45a8ed9eb0b8f3dd56d";
+        hash = "sha256-ZOv+9TxBsOnSSbfM7kJLP3cQH9FpgA15aETszg7YSes=";
+      };
+    })
+    # outputHash of manvenDeps changes each time `clojure` is updated
+    # https://github.com/ngi-nix/ngipkgs/pull/1727#discussion_r2470180998
+    ./pin-clojure.patch
+  ];
+
+  makeCacheWritable = true;
+
+  npmDepsHash = "sha256-Zihy5VYlkeQtmZUS25kgu3aYGPfQdUxjNSK33WHOEeQ=";
+
+  nativeBuildInputs = [
+    finalAttrs.passthru.clojureWithCache
+    makeWrapper
+    copyDesktopItems
+    pkg-config # sharp
+  ];
+
+  # For 'sharp' dependency, otherwise it will try to build it
+  buildInputs = [ vips ];
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = true;
+    PUPPETEER_SKIP_DOWNLOAD = true;
+  };
+
+  postPatch = ''
+    substituteInPlace shadow-cljs.edn \
+      --replace-fail ":shadow-git-inject/version" '"v${finalAttrs.version}"'
+  '';
+
+  passthru = {
+    # this was taken and adapted from "logseq" package's nixpkgs derivation
+    mavenRepo = stdenv.mkDerivation {
+      name = "repath-studio-${finalAttrs.version}-maven-deps";
+      inherit (finalAttrs) src patches;
+
+      nativeBuildInputs = [ clojure ];
+
+      buildPhase = ''
+        runHook preBuild
+
+        export HOME="$(mktemp -d)"
+        mkdir -p "$out"
+
+        # -P       -> resolve all normal deps
+        # -M:alias -> resolve extra-deps of the listed aliases
+        clj -Sdeps "{:mvn/local-repo \"$out\"}" -P -M:dev:cljs
+
+        runHook postBuild
+      '';
+
+      # copied from buildMavenPackage
+      # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+      installPhase = ''
+        runHook preInstall
+
+        find $out -type f \( \
+          -name \*.lastUpdated \
+          -o -name resolver-status.properties \
+          -o -name _remote.repositories \) \
+          -delete
+
+        runHook postInstall
+      '';
+
+      dontFixup = true;
+
+      outputHash = "sha256-ytS7JiQUC7U0vxuQddxQfDnm0Pt4stkRBfiIlbOpeTk=";
+      outputHashMode = "recursive";
+      outputHashAlgo = "sha256";
+    };
+
+    clojureWithCache = writeShellScriptBin "clojure" ''
+      exec ${lib.getExe' clojure "clojure"} -Sdeps '{:mvn/local-repo "${finalAttrs.passthru.mavenRepo}"}' "$@"
+    '';
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    # electronDist needs to be modifiable
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+  ''
+  # Electron builder complains about symlink in electron-dist
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    rm electron-dist/libvulkan.so.1
+    cp ${lib.getLib vulkan-loader}/lib/libvulkan.so.1 electron-dist
+  ''
+  + ''
+    npm run build
+    npm exec electron-builder -- --dir \
+      -c.electronDist=electron-dist \
+      -c.electronVersion=${electron.version}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        # bash
+        ''
+          mkdir -p $out/Applications
+          cp -r "dist/mac"*"/Repath Studio.app" "$out/Applications"
+          makeWrapper "$out/Applications/Repath Studio.app/Contents/MacOS/Repath Studio" "$out/bin/repath-studio"
+        ''
+      else
+        # bash
+        ''
+          mkdir -p $out/share/{repath-studio,icons/hicolor/scalable/apps}
+          cp -r dist/*-unpacked/resources/app.asar $out/share/repath-studio
+          cp resources/public/img/icon.svg $out/share/icons/hicolor/scalable/apps/repath-studio.svg
+
+          makeWrapper '${lib.getExe electron}' "$out/bin/repath-studio" \
+            --add-flags "$out/share/repath-studio/app.asar" \
+            --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+            --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+            --inherit-argv0
+        ''
+    }
+
+    runHook postInstall
+  '';
+
+  # chromium package not available for darwin
+  doCheck = stdenv.hostPlatform.isLinux;
+  checkPhase = ''
+    runHook preCheck
+    export ELECTRON_OVERRIDE_DIST_PATH=electron-dist/
+    export PUPPETEER_EXECUTABLE_PATH=${chromium}/bin/chromium
+    export CHROME_BIN=${chromium}/bin/chromium
+    npm run test
+    unset ELECTRON_OVERRIDE_DIST_PATH
+    runHook postCheck
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Repath Studio";
+      desktopName = "Repath Studio";
+      exec = "repath-studio %U";
+      type = "Application";
+      terminal = false;
+      icon = "repath-studio";
+      comment = "Vector graphics editor, that combines procedural tooling with traditional design workflows";
+      categories = [ "Graphics" ];
+    })
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    changelog = "https://github.com/repath-studio/repath-studio/blob/v${finalAttrs.src.rev}/CHANGELOG.md";
+    description = "Cross-platform vector graphics editor, that combines procedural tooling with traditional design workflows";
+    homepage = "https://repath.studio";
+    downloadPage = "https://github.com/repath-studio/repath-studio";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "repath-studio";
+    maintainers = with lib.maintainers; [ phanirithvij ];
+    teams = with lib.teams; [ ngi ];
+    platforms = electron.meta.platforms;
+  };
+})

--- a/pkgs/by-name/re/repath-studio/pin-clojure.patch
+++ b/pkgs/by-name/re/repath-studio/pin-clojure.patch
@@ -1,0 +1,12 @@
+diff --git a/deps.edn b/deps.edn
+index 195de4e..02098e5 100644
+--- a/deps.edn
++++ b/deps.edn
+@@ -1,5 +1,6 @@
+ {:paths ["src"]
+- :deps {binaryage/devtools {:mvn/version "1.0.7"}
++ :deps {org.clojure/clojure {:mvn/version "1.12.4"}
++        binaryage/devtools {:mvn/version "1.0.7"}
+         camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
+         clj-kdtree/clj-kdtree {:git/url "https://github.com/abscondment/clj-kdtree.git"
+                                :sha "5ec321c5e8006db00fa8b45a8ed9eb0b8f3dd56d"

--- a/pkgs/by-name/re/repath-studio/update.sh
+++ b/pkgs/by-name/re/repath-studio/update.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix-update gitMinimal diffutils gnused
+
+set -x
+set -eou pipefail
+
+# check for updates
+token_args=""
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  token_args="-H \"Authorization: Bearer $GITHUB_TOKEN\""
+fi
+
+latest_tag=$(curl ${token_args} -sL "https://api.github.com/repos/repath-studio/repath-studio/releases/latest" | jq -r '.tag_name')
+version="${latest_tag#v}"
+
+set +ue
+if [[ "${UPDATE_NIX_OLD_VERSION:-}" == "$version" ]]; then
+  echo "Already up-to-date, version: $version"
+  exit 0
+fi
+set -ue
+
+NIXPKGS_PATH="$(git rev-parse --show-toplevel)"
+PACKAGE_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+PACKAGE_FILE="$PACKAGE_DIR/package.nix"
+PATCH_GIT_FILE="$PACKAGE_DIR/hardcode-git-paths.patch"
+PATCH_CLJ_FILE="$PACKAGE_DIR/pin-clojure.patch"
+
+pushd $NIXPKGS_PATH
+nix-update --version="$version" repath-studio
+popd
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+pushd "$TMPDIR"
+
+src="$(nix-build --no-link "$NIXPKGS_PATH" -A repath-studio.src)"
+cp "$src/deps.edn" deps.edn
+
+# pin clojure from the upstream's pinned version
+workflow_file="$src/.github/workflows/desktop-app.yml"
+clj_version="$(
+  grep -A 10 "uses:.*setup-clojure" "$workflow_file" |
+    grep "cli:" |
+    head -n1 |
+    sed -E 's/.*cli:\s+([0-9]+\.[0-9]+\.[0-9]+).*/\1/'
+)"
+
+if [[ -z "$clj_version" ]]; then
+  echo "Error: Could not parse clojure version from $workflow_file" >&2
+  exit 1
+fi
+
+mkdir -p a b
+cp deps.edn a/deps.edn
+cp deps.edn b/deps.edn
+
+# insert clojure dep at start of :deps map
+sed -i "0,/:deps {/s|:deps {|:deps {org.clojure/clojure {:mvn/version \"$clj_version\"}\n        |" b/deps.edn
+git diff --no-index --no-prefix a/deps.edn b/deps.edn >"$PATCH_CLJ_FILE" || true
+
+rm -rf a b
+
+# patches a dependency to be prefetched by nix
+# clojure otherwise tries to fetch it at buildtime
+
+# extract sha from clean deps.edn
+clj_sha=$(grep -A 2 "clj-kdtree/clj-kdtree" deps.edn | grep -oP ':sha "\K[^"]+')
+
+if [[ -z "$clj_sha" ]]; then
+  echo "Error: Could not extract clj-kdtree SHA from deps.edn" >&2
+  exit 1
+fi
+
+clj_hash=$(nix-prefetch-url --unpack "https://github.com/abscondment/clj-kdtree/archive/$clj_sha.tar.gz" --type sha256)
+clj_hash=$(nix hash convert --hash-algo sha256 --from nix32 "$clj_hash")
+
+sed -i "/owner = \"abscondment\"/,/hash =/ s/rev = \".*\"/rev = \"$clj_sha\"/" "$PACKAGE_FILE"
+sed -i "/owner = \"abscondment\"/,/hash =/ s|hash = \".*\"|hash = \"$clj_hash\"|" "$PACKAGE_FILE"
+
+mkdir -p a b
+cp deps.edn a/deps.edn
+cp deps.edn b/deps.edn
+
+sed -i '/clj-kdtree\/clj-kdtree/,/:sha/c\        clj-kdtree/clj-kdtree {:local/root "@clj-kdtree_src@"' b/deps.edn
+git diff --no-index --no-prefix a/deps.edn b/deps.edn >"$PATCH_GIT_FILE" || true
+
+rm -rf a b
+popd
+
+# maven deps
+
+dummy_hash="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+sed -i "s|outputHash = \".*\";|outputHash = \"$dummy_hash\";|" "$PACKAGE_FILE"
+
+# expect failure to get new hash
+set +e
+new_mvn_hash="$(
+  nix-build --no-link -A repath-studio.passthru.mavenRepo "$NIXPKGS_PATH" 2>&1 >/dev/null |
+    grep "got:" | cut -d':' -f2 | sed 's| ||g'
+)"
+set -e
+
+if [[ -z "$new_mvn_hash" ]]; then
+  echo "Failed to get new maven hash." >&2
+  exit 1
+fi
+
+sed -i "s|\"$dummy_hash\"|\"$new_mvn_hash\"|g" "$PACKAGE_FILE"
+
+echo "Update to $version complete."


### PR DESCRIPTION
Manual backport to release-25.11. for https://github.com/NixOS/nixpkgs/pull/483031 and https://github.com/NixOS/nixpkgs/pull/494608

- Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2026-01-11T08%3A14%3A15Z#changes-acceptable-for-releases).
- Even as a non-committer, if you find that it is not acceptable, leave a comment.
