### PR TITLE
haven: fix TOML parse error in .env.example

### DIFF
--- a/nixos/modules/services/web-apps/haven.nix
+++ b/nixos/modules/services/web-apps/haven.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  # Load default values from package. See https://github.com/bitvora/haven/blob/master/.env.example
+  # Load default values from package. See https://github.com/barrydeen/haven/blob/master/.env.example
   defaultSettings = fromTOML (builtins.readFile "${cfg.package}/share/haven/.env.example");
 
   import_relays_file = "${pkgs.writeText "import_relays.json" (builtins.toJSON cfg.importRelays)}";
@@ -48,9 +48,9 @@ in
 
     settings = lib.mkOption {
       default = defaultSettings;
-      defaultText = "See <https://github.com/bitvora/haven/blob/master/.env.example>";
+      defaultText = "See <https://github.com/barrydeen/haven/blob/master/.env.example>";
       apply = lib.recursiveUpdate defaultSettings;
-      description = "See <https://github.com/bitvora/haven> for documentation.";
+      description = "See <https://github.com/barrydeen/haven> for documentation.";
       example = lib.literalExpression ''
         {
           RELAY_URL = "relay.example.com";
@@ -63,7 +63,7 @@ in
       type = lib.types.nullOr lib.types.path;
       default = null;
       description = ''
-        Path to a file containing sensitive environment variables. See <https://github.com/bitvora/haven> for documentation.
+        Path to a file containing sensitive environment variables. See <https://github.com/barrydeen/haven> for documentation.
         The file should contain environment-variable assignments like:
         S3_SECRET_KEY=mysecretkey
         S3_ACCESS_KEY_ID=myaccesskey

--- a/pkgs/by-name/ha/haven/package.nix
+++ b/pkgs/by-name/ha/haven/package.nix
@@ -6,13 +6,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "haven";
-  version = "1.2.0";
+  version = "1.2.0-unstable-2026-02-27";
 
   src = fetchFromGitHub {
-    owner = "bitvora";
+    owner = "barrydeen";
     repo = "haven";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-1rGOZVzlzijyxqjAnp2uvxy9KPr3uuRD8+48x38lQwg=";
+    rev = "1f81770d3a79f8ebb2f037b37635ab66e02d13d8";
+    hash = "sha256-4N7erObBg613aDFHRmjNE25eyQBPsenSz3JkQbdcki0=";
   };
 
   vendorHash = "sha256-VXx6uoOUKk/BkjDS3Ykf/0Xc2mUPm8dgyRArIb2I8X4=";
@@ -25,8 +25,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "High Availability Vault for Events on Nostr";
-    homepage = "https://github.com/bitvora/haven";
-    changelog = "https://github.com/bitvora/haven/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/barrydeen/haven";
+    changelog = "https://github.com/barrydeen/haven/releases";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ felixzieger ];
     mainProgram = "haven";


### PR DESCRIPTION
## Summary

The upstream `.env.example` shipped with v1.2.0 contains `WOT_REFRESH_INTERVAL=24h` which is not valid TOML (unquoted string). This causes `builtins.fromTOML` to fail in the NixOS module, breaking builds for anyone enabling `services.haven`.

This PR pins to upstream commit [1f81770](https://github.com/barrydeen/haven/commit/1f81770d3a79f8ebb2f037b37635ab66e02d13d8) which quotes the value as `"24h"`. Also updates the GitHub owner from `bitvora` to `barrydeen` following the upstream repository transfer.

Resolves #494493

## Things done

- [x] Built on platform(s)
  - [x] x86_64-darwin
- [ ] Tested, as applicable:
  - [ ] NixOS test(s) (look at [nixos/tests/](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [ ] and target platforms (determine via `meta.platforms`)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [x] `nix-build -A haven` succeeds
- For package updates:
  - [x] Checked that the update matches the [package update guidelines](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#how-to-update-a-package)
  - [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).