### PR TITLE
libreoffice: remove `noto-sans` font workaround

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -186,15 +186,6 @@ let
     optionalString
     ;
 
-  notoSubset =
-    suffixes:
-    runCommand "noto-fonts-subset" { } ''
-      mkdir -p "$out/share/fonts/noto/"
-      ${concatMapStrings (x: ''
-        cp "${noto-fonts}/share/fonts/noto/NotoSans${x}["*.[ot]tf "$out/share/fonts/noto/"
-      '') suffixes}
-    '';
-
   fontsConf = makeFontsConf {
     fontDirectories = [
       amiri
@@ -207,9 +198,8 @@ let
       liberation_ttf_v2
       libertine
       linux-libertine-g
-      # Font priority issues in some tests in Still
       noto-fonts-lgc-plus
-      (if variant == "fresh" then noto-fonts else (notoSubset [ "Arabic" ]))
+      noto-fonts
       noto-fonts-cjk-sans
     ];
   };


### PR DESCRIPTION
~~`noto-sans` filenames changed in https://github.com/NixOS/nixpkgs/pull/290000, overriding the `variants` argument is the preferred, less brittle, way.~~

Workaround no longer needed, `libreoffice-still` builds normally now.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
