### PR TITLE
eumdac: init at 3.1.1

### DIFF
--- a/pkgs/development/python-modules/eumdac/default.nix
+++ b/pkgs/development/python-modules/eumdac/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildPythonPackage,
+  certifi,
+  fetchFromGitLab,
+  nix-update-script,
+  paho-mqtt,
+  pytestCheckHook,
+  pyyaml,
+  requests,
+  responses,
+  setuptools,
+  urllib3,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage rec {
+  pname = "eumdac";
+  version = "3.1.1";
+  pyproject = true;
+
+  # PyPI sdist omits tests/base.py and tests/data fixtures.
+  src = fetchFromGitLab {
+    domain = "gitlab.eumetsat.int";
+    group = "eumetlab";
+    owner = "data-services";
+    repo = pname;
+    tag = version;
+    hash = "sha256-756KYhlmQR/s7uRO5+m3XPIDbd8pEW3mE2szhYz/MxY=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    certifi
+    paho-mqtt
+    pyyaml
+    requests
+    urllib3
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    responses
+    writableTmpDirAsHomeHook
+  ];
+
+  preCheck = ''
+    export EUMDAC_CONFIG_DIR="$TMPDIR/.eumdac"
+    mkdir -p "$EUMDAC_CONFIG_DIR/orders/active"
+
+    # `from sh import eumdac` is an unused import that fails collection in nix.
+    substituteInPlace tests/test_subscription.py \
+      --replace-fail "from sh import eumdac" ""
+  '';
+
+  disabledTestPaths = [
+    # Requires live EUMETSAT endpoints.
+    "tests/test_other_functional.py"
+  ];
+
+  pythonImportsCheck = [ "eumdac" ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "EUMETSAT Data Access Client";
+    homepage = "https://gitlab.eumetsat.int/eumetlab/data-services/eumdac";
+    changelog = "https://user.eumetsat.int/resources/user-guides/eumetsat-data-access-client-eumdac-release-changelog";
+    license = lib.licenses.mit;
+    mainProgram = "eumdac";
+    maintainers = with lib.maintainers; [ Zaczero ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5110,6 +5110,8 @@ self: super: with self; {
 
   eufylife-ble-client = callPackage ../development/python-modules/eufylife-ble-client { };
 
+  eumdac = callPackage ../development/python-modules/eumdac { };
+
   euporie = callPackage ../development/python-modules/euporie { };
 
   eval-type-backport = callPackage ../development/python-modules/eval-type-backport { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
