### PR TITLE
premake5: Apply patch to fix filtering with alias values

### DIFF
--- a/pkgs/development/tools/misc/premake/5.nix
+++ b/pkgs/development/tools/misc/premake/5.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
 
   # build inputs
   cacert,
@@ -29,7 +30,16 @@ stdenv.mkDerivation (finalAttrs: {
     readline
   ];
 
-  patches = [ ./no-curl-ca.patch ];
+  patches = [
+    # https://github.com/premake/premake-core/issues/2614
+    (fetchpatch {
+      name = "0001-premake5-Fix-filters-using-alias-value.patch";
+      url = "https://github.com/premake/premake-core/commit/d01097bb38da6855beeef7158b8b04ab1e63249b.patch";
+      hash = "sha256-ZGhNUoXZbbW9ioFnAgPwypYhepoChtWF1SOCxs1WLj8=";
+    })
+
+    ./no-curl-ca.patch
+  ];
   postPatch = ''
     substituteInPlace contrib/curl/premake5.lua \
       --replace-fail "ca = nil" "ca = '${cacert}/etc/ssl/certs/ca-bundle.crt'"


### PR DESCRIPTION
Fixes edopro on aarch64-linux (uses now-aliased ARM64 architecture label).

CCs:

- @sarahec, `premake5` maintainer
- @vcunat, merged #492252
- @SuperSandro2000, merged #492298 (where this was discovered & being discussed)

:confused:

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
