### PR TITLE
nixos/rancher: add `extraContainerdSettings` option and fix list merging

### DIFF
--- a/nixos/modules/services/cluster/rancher/default.nix
+++ b/nixos/modules/services/cluster/rancher/default.nix
@@ -904,13 +904,11 @@ let
           })
           // (lib.optionalAttrs (cfg.extraContainerdSettings != null) {
             ${containerdConfigTemplateFile} = {
-              "L+".argument = "${
-                pkgs.runCommand "config.toml.tmpl" { } ''
-                  echo '{{ template "base" . }}' > $out
-                  echo >> $out
-                  cat ${containerdSettingsFormat.generate "extra-containerd-settings.toml" cfg.extraContainerdSettings} >> $out
-                ''
-              }";
+              "L+".argument = "${pkgs.runCommand "config.toml.tmpl" { } ''
+                echo '{{ template "base" . }}' > $out
+                echo >> $out
+                cat ${containerdSettingsFormat.generate "extra-containerd-settings.toml" cfg.extraContainerdSettings} >> $out
+              ''}";
             };
           })
           // (lib.mapAttrs' mkChartRule helmCharts);

--- a/nixos/modules/services/cluster/rancher/default.nix
+++ b/nixos/modules/services/cluster/rancher/default.nix
@@ -30,6 +30,7 @@ let
       staticContentChartDir = "/var/lib/rancher/${name}/server/static/charts";
 
       manifestFormat = if jsonManifests then pkgs.formats.json { } else pkgs.formats.yaml { };
+      containerdSettingsFormat = pkgs.formats.toml { };
       # Manifests need a valid suffix to be respected
       mkManifestTarget =
         name:
@@ -639,6 +640,27 @@ let
           '';
         };
 
+        extraContainerdSettings = lib.mkOption {
+          type = lib.types.nullOr containerdSettingsFormat.type;
+          default = null;
+          example = lib.literalExpression ''
+            {
+              plugins."io.containerd.grpc.v1.cri".containerd.runtimes."custom" = {
+                runtime_type = "io.containerd.runc.v2";
+              };
+              plugins."io.containerd.grpc.v1.cri".containerd.runtimes."custom".options = {
+                BinaryName = "/path/to/custom-container-runtime";
+              };
+            }
+          '';
+          description = ''
+            Extra structured settings for containerd, converted to TOML and placed at
+            `/var/lib/rancher/${name}/agent/etc/containerd/config.toml.tmpl`.
+            The base containerd config template is automatically included.
+            See the docs on [configuring containerd](https://docs.${name}.io/advanced#configuring-containerd).
+          '';
+        };
+
         images = lib.mkOption {
           type = with lib.types; listOf package;
           default = [ ];
@@ -829,6 +851,13 @@ let
             cfg.role == "agent" && !(cfg.agentTokenFile != null || cfg.agentToken != "")
           ) "${name}: agentToken and agentToken should not be set if role is 'agent'");
 
+        assertions = [
+          {
+            assertion = !(cfg.containerdConfigTemplate != null && cfg.extraContainerdSettings != null);
+            message = "services.${name}.containerdConfigTemplate and services.${name}.extraContainerdSettings are mutually exclusive.";
+          }
+        ];
+
         environment.systemPackages = [ config.services.${name}.package ];
 
         # Use systemd-tmpfiles to activate content
@@ -871,6 +900,17 @@ let
           // (lib.optionalAttrs (cfg.containerdConfigTemplate != null) {
             ${containerdConfigTemplateFile} = {
               "L+".argument = "${pkgs.writeText "config.toml.tmpl" cfg.containerdConfigTemplate}";
+            };
+          })
+          // (lib.optionalAttrs (cfg.extraContainerdSettings != null) {
+            ${containerdConfigTemplateFile} = {
+              "L+".argument = "${
+                pkgs.runCommand "config.toml.tmpl" { } ''
+                  echo '{{ template "base" . }}' > $out
+                  echo >> $out
+                  cat ${containerdSettingsFormat.generate "extra-containerd-settings.toml" cfg.extraContainerdSettings} >> $out
+                ''
+              }";
             };
           })
           // (lib.mapAttrs' mkChartRule helmCharts);

--- a/nixos/modules/services/cluster/rancher/k3s.nix
+++ b/nixos/modules/services/cluster/rancher/k3s.nix
@@ -116,11 +116,11 @@ in
 
   config = lib.mkIf cfg.enable (
     lib.recursiveUpdate baseModule.config {
-      warnings = baseModule.config.warnings ++ (
-        lib.optional (
-          cfg.disableAgent && cfg.images != [ ]
-        ) "k3s: Images are only imported on nodes with an enabled agent, they will be ignored by this node."
-      );
+      warnings =
+        baseModule.config.warnings
+        ++ (lib.optional (cfg.disableAgent && cfg.images != [ ])
+          "k3s: Images are only imported on nodes with an enabled agent, they will be ignored by this node."
+        );
 
       assertions = baseModule.config.assertions ++ [
         {

--- a/nixos/modules/services/cluster/rancher/k3s.nix
+++ b/nixos/modules/services/cluster/rancher/k3s.nix
@@ -116,13 +116,13 @@ in
 
   config = lib.mkIf cfg.enable (
     lib.recursiveUpdate baseModule.config {
-      warnings = (
+      warnings = baseModule.config.warnings ++ (
         lib.optional (
           cfg.disableAgent && cfg.images != [ ]
         ) "k3s: Images are only imported on nodes with an enabled agent, they will be ignored by this node."
       );
 
-      assertions = [
+      assertions = baseModule.config.assertions ++ [
         {
           assertion = cfg.role == "agent" -> !cfg.disableAgent;
           message = "k3s: disableAgent must be false if role is 'agent'";

--- a/nixos/modules/services/cluster/rancher/rke2.nix
+++ b/nixos/modules/services/cluster/rancher/rke2.nix
@@ -122,11 +122,13 @@ in
 
   config = lib.mkIf cfg.enable (
     lib.recursiveUpdate baseModule.config {
-      warnings = (
+      warnings = baseModule.config.warnings ++ (
         lib.optional (
           cfg.role == "agent" && cfg.cni != null
         ) "rke2: cni should not be set if role is 'agent'"
       );
+
+      assertions = baseModule.config.assertions;
 
       # Configure NetworkManager to ignore CNI network interfaces.
       # See: https://docs.rke2.io/known_issues#networkmanager

--- a/nixos/modules/services/cluster/rancher/rke2.nix
+++ b/nixos/modules/services/cluster/rancher/rke2.nix
@@ -122,11 +122,11 @@ in
 
   config = lib.mkIf cfg.enable (
     lib.recursiveUpdate baseModule.config {
-      warnings = baseModule.config.warnings ++ (
-        lib.optional (
+      warnings =
+        baseModule.config.warnings
+        ++ (lib.optional (
           cfg.role == "agent" && cfg.cni != null
-        ) "rke2: cni should not be set if role is 'agent'"
-      );
+        ) "rke2: cni should not be set if role is 'agent'");
 
       assertions = baseModule.config.assertions;
 


### PR DESCRIPTION
Add `extraContainerdSettings` option to k3s/rke2 modules that accepts Nix attribute sets and generates TOML containerd config with the base template (`{{ template "base" . }}`) automatically included. This is mutually exclusive with the existing `containerdConfigTemplate` string option.

Also fix `warnings` and `assertions` lists from the base rancher module being silently dropped by `lib.recursiveUpdate` in k3s.nix and rke2.nix.

Example usage:
```nix
services.k3s.extraContainerdSettings = {
  plugins."io.containerd.grpc.v1.cri".containerd.runtimes."custom" = {
    runtime_type = "io.containerd.runc.v2";
  };
};
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
    - `nixosTests.k3s.configuration.k3s_1_{32,33,34,35}` all pass (regression)
    - Custom integration test for `extraContainerdSettings` passes
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test