### PR TITLE
freerdp: 3.22.0 -> 3.23.0

### DIFF
--- a/pkgs/by-name/fr/freerdp/package.nix
+++ b/pkgs/by-name/fr/freerdp/package.nix
@@ -70,13 +70,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "freerdp";
-  version = "3.22.0";
+  version = "3.23.0";
 
   src = fetchFromGitHub {
     owner = "FreeRDP";
     repo = "FreeRDP";
     rev = finalAttrs.version;
-    hash = "sha256-cJFY0v2zvbaKVINOKVZGvLozwgD7kf2ffVU9EGYBMGQ=";
+    hash = "sha256-WGuRnNwcvxwIudSzPoJB4BmaTLHKU7bsZkgWmzJPLSQ=";
   };
 
   postPatch = ''


### PR DESCRIPTION
https://www.freerdp.com/2026/02/25/3_23_0-release

Fixes:
* CVE-2026-26271 / https://github.com/NixOS/nixpkgs/issues/494703
* CVE-2026-26965 / https://github.com/NixOS/nixpkgs/issues/494702
* CVE-2026-26955 / https://github.com/NixOS/nixpkgs/issues/494699
* CVE-2026-27951 / https://github.com/NixOS/nixpkgs/issues/494712
* CVE-2026-25952 / https://github.com/NixOS/nixpkgs/issues/494700
* CVE-2026-26986 / https://github.com/NixOS/nixpkgs/issues/494708
* CVE-2026-25997 / https://github.com/NixOS/nixpkgs/issues/494710
* CVE-2026-25953 / https://github.com/NixOS/nixpkgs/issues/494706
* CVE-2026-25955 / https://github.com/NixOS/nixpkgs/issues/494705
* CVE-2026-25959 / https://github.com/NixOS/nixpkgs/issues/494701
* CVE-2026-25942 / https://github.com/NixOS/nixpkgs/issues/494697
* CVE-2026-27015 / https://github.com/NixOS/nixpkgs/issues/494709
* CVE-2026-25954 / https://github.com/NixOS/nixpkgs/issues/494704
* CVE-2026-25941 / https://github.com/NixOS/nixpkgs/issues/494698
* CVE-2026-27950 / https://github.com/NixOS/nixpkgs/issues/494696


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 494802`
Commit: `5b217270d64f53be6a79eae2479d38751ee52d0f`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 28 packages built:</summary>
  <ul>
    <li>brutespray</li>
    <li>crowbar</li>
    <li>crowbar.dist</li>
    <li>freerdp</li>
    <li>gnome-connections</li>
    <li>gnome-control-center</li>
    <li>gnome-control-center.debug</li>
    <li>gnome-remote-desktop</li>
    <li>gtk-frdp</li>
    <li>guacamole-server</li>
    <li>kdePackages.krdc</li>
    <li>kdePackages.krdc.debug</li>
    <li>kdePackages.krdc.dev</li>
    <li>kdePackages.krdc.devtools</li>
    <li>kdePackages.krdp</li>
    <li>kdePackages.krdp.debug</li>
    <li>kdePackages.krdp.dev</li>
    <li>kdePackages.krdp.devtools</li>
    <li>medusa</li>
    <li>medusa.man</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>remmina</li>
    <li>weston</li>
    <li>winboat</li>
    <li>x11docker</li>
    <li>xwayland-run</li>
    <li>xwayland-run.man</li>
  </ul>
</details

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
