### PR TITLE
ocamlPackages.cudd: init at 0.1.3

### DIFF
--- a/pkgs/development/ocaml-modules/cudd/default.nix
+++ b/pkgs/development/ocaml-modules/cudd/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitLab,
+  fetchurl,
+}:
+
+let
+  cuddTarball = fetchurl {
+    url = "https://github.com/ivmai/cudd/archive/refs/tags/cudd-3.0.0.tar.gz";
+    hash = "sha256-X+FFBBxZRonm589M1iPV8rfDYmFwi+jJpyrtcs9nrM4=";
+  };
+in
+
+buildDunePackage (finalAttrs: {
+  pname = "cudd";
+  version = "0.1.3";
+
+  src = fetchFromGitLab {
+    domain = "git.frama-c.com";
+    owner = "pub/codex";
+    repo = "cudd.ml";
+    tag = finalAttrs.version;
+    hash = "sha256-RLImpj+5fPjZTds+r1q5rGn001QQo2GzOvJQWJlBR64=";
+  };
+
+  postUnpack = ''
+    cp ${cuddTarball} $sourceRoot/cudd/cudd.tar.gz
+  '';
+
+  meta = {
+    description = "Minimal cudd bindings";
+    homepage = "https://git.frama-c.com/pub/codex/cudd.ml";
+    license = lib.licenses.lgpl2Only;
+    maintainers = with lib.maintainers; [ redianthus ];
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -356,6 +356,8 @@ let
 
         ctypes-foreign = callPackage ../development/ocaml-modules/ctypes/foreign.nix { };
 
+        cudd = callPackage ../development/ocaml-modules/cudd { };
+
         cudf = callPackage ../development/ocaml-modules/cudf { };
 
         curl = callPackage ../development/ocaml-modules/curl { inherit (pkgs) curl; };


### PR DESCRIPTION
cc @vbgl, I went the "easy" way and simply fetched the cudd tarball and make sure it is where the OCaml bindings expect it to be. I guess it may be possible to use the nix package for `cudd` directly but then we would have to maintain patches to the bindings dune files and I'm not sure it's worth the troubles. Let me know what you think.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
