### PR TITLE
magika-cli: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/by-name/ma/magika-cli/package.nix
+++ b/pkgs/by-name/ma/magika-cli/package.nix
@@ -16,16 +16,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "magika-cli";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "magika";
     tag = "cli/v${finalAttrs.version}";
-    hash = "sha256-g/fnSdh2jpOHOLTuR4DUPB1kbC0eKADHLKcfB1q08XI=";
+    hash = "sha256-1WJRkqFQqlSFzr4wkEbRwj1WoxDKTG/1OCtC+914ryY=";
   };
 
-  cargoHash = "sha256-uqnTyedry9nWyO2518r0D3hk6oWb4wQE/Ku0cOkSjBA=";
+  cargoHash = "sha256-rA+GYCWuinwRVWf3VuFbPgmAwl3vDsaxLjCtsKMtpiU=";
 
   cargoRoot = "rust/cli";
   buildAndTestSubdir = finalAttrs.cargoRoot;
@@ -41,13 +41,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env = {
     OPENSSL_NO_VENDOR = "true";
+    ORT_STRATEGY = "system";
+    ORT_LIB_LOCATION = "${lib.getLib onnxruntime}/lib";
+
+    # Required to prevent "ort-sys could not link to the ONNX Runtime build":
+    # https://github.com/pykeio/ort/issues/517#issuecomment-3761926178
+    ORT_PREFER_DYNAMIC_LINK = "true";
   };
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgramArg = "--version";
 
   passthru = {
     tests = {


### PR DESCRIPTION
Diff: https://github.com/google/magika/compare/cli/v1.0.1...cli/v1.0.2

- Remove `versionCheckProgramArg` to align style with 116036d574992ee61d97d16c4b065dca3f871974

- Set envs for [ort-sys@2.0.0-rc.11](https://github.com/pykeio/ort/releases/tag/v2.0.0-rc.11) update

- This version drops `x86_64-darwin` support. I think no updates to the `meta` section are needed: https://github.com/google/magika/commit/6236689eee514912453b34b8a61a03dc6f25315c

```console
>nix-build --attr pkgs.magika-cli.passthru.tests
...
Running phase: installCheckPhase
Executing versionCheckPhase
Successfully managed to find version 1.0.2 in the output of the command /nix/store/y2fyxij1jnwma7hchw4lmid7rikksxzr-magika-cli-1.0.2/bin/magika --version
magika 1.0.2 standard_v3_3
Finished versionCheckPhase
no Makefile or custom installCheckPhase, doing nothing
building '/nix/store/i6byab5hyc7xhif5i1wwbj1rrv6h5g6c-actual.drv'...
building '/nix/store/8zy64gbiq1xny6800ccz4qp6509yd9cf-equal-contents-magika-detects-the-correct-language-from-content-even-when-the-file-extension-is-wrong.drv'...
Checking:
magika detects the correct language from content even when the file extension is wrong
expected /nix/store/4rpa0g7l3pfj85bhfhx8k9cqb1bqxqz8-expected and actual /nix/store/44vmgkyk7ih6jrr1w3959jy2vwvdsfls-actual match.
OK
/nix/store/dqz3cdd9vsgxp76gbnxsjg7w6b5wrgxv-equal-contents-magika-detects-the-correct-language-from-content-even-when-the-file-extension-is-wrong
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
