### PR TITLE
Revert "[Backport release-25.11] kernel updates for 2026-02-26"

### DIFF
--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -30,13 +30,13 @@
         "lts": true
     },
     "6.18": {
-        "version": "6.18.14",
-        "hash": "sha256:1f3wv9vdg43cy1lnqd60zqgki6px67mdhfkfnpk1npqq5akk86cd",
-        "lts": true
+        "version": "6.18.13",
+        "hash": "sha256:0zv8qml075jpk2i58cxp61hm3yb74mpkbkjg15n87riqzmakqb7d",
+        "lts": false
     },
     "6.19": {
-        "version": "6.19.4",
-        "hash": "sha256:1b68i7z91fbs1zayzzzf71g9ilfk0wi2fr8nralha60xq723p6r7",
+        "version": "6.19.3",
+        "hash": "sha256:1glf369wfr66lmv9wmijin6idlfgijfsh0gx2qly7gpwmml4jiqf",
         "lts": false
     }
 }


### PR DESCRIPTION
Reverts NixOS/nixpkgs#494526

https://lore.kernel.org/all/bb9ab61c-3bed-4c3d-baf0-0bce4e142292@moonlit-rail.com/