### PR TITLE
obs-studio-plugins.obs-backgroundremoval: 1.1.13 -> 1.3.7

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-backgroundremoval/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-backgroundremoval/default.nix
@@ -8,23 +8,25 @@
   onnxruntime,
   opencv,
   qt6,
+  pkg-config,
   curl,
 }:
 
 stdenv.mkDerivation rec {
   pname = "obs-backgroundremoval";
-  version = "1.1.13";
+  version = "1.3.7";
 
   src = fetchFromGitHub {
-    owner = "occ-ai";
+    owner = "royshil";
     repo = "obs-backgroundremoval";
     rev = version;
-    hash = "sha256-QoC9/HkwOXMoFNvcOxQkGCLLAJmsja801LKCNT9O9T0=";
+    hash = "sha256-bl0KixfBnBeyidZ4+RJhX4TDy33l9awo0wISMr7XUwk=";
   };
 
   nativeBuildInputs = [
     cmake
     ninja
+    pkg-config
   ];
   buildInputs = [
     obs-studio
@@ -37,11 +39,12 @@ stdenv.mkDerivation rec {
   dontWrapQtApps = true;
 
   cmakeFlags = [
-    "--preset linux-x86_64"
+    "--preset"
+    "ubuntu-ci-x86_64"
     "-DCMAKE_MODULE_PATH:PATH=${src}/cmake"
+    "-DVCPKG_TARGET_TRIPLET="
+    "-DUSE_PKGCONFIG=ON"
     "-DUSE_SYSTEM_ONNXRUNTIME=ON"
-    "-DUSE_SYSTEM_OPENCV=ON"
-    "-DDISABLE_ONNXRUNTIME_GPU=ON"
   ];
 
   buildPhase = ''


### PR DESCRIPTION
 ## obs-backgroundremoval: 1.1.13 -> 1.3.7

  Update `obs-backgroundremoval` to `1.3.7` and adapt the derivation to upstream build-system changes so it builds in nixpkgs with system dependencies.

  - source moved from `occ-ai/obs-backgroundremoval` to `royshil/obs-backgroundremoval`
  - updated source hash for `1.3.7`
  - added `pkg-config` to `nativeBuildInputs`
  - switched CMake preset from `linux-x86_64` to `ubuntu-x86_64`
  - added `-DUSE_PKGCONFIG=ON` and `-DVCPKG_TARGET_TRIPLET=` to prefer nixpkgs-provided deps and avoid vcpkg triplet issues
  - removed   "-DUSE_SYSTEM_OPENCV=ON" "-DDISABLE_ONNXRUNTIME_GPU=ON" as these where ignored during compilation anyways

  Upstream release notes/changelog:
  - https://github.com/royshil/obs-backgroundremoval/releases/tag/1.3.7
  - https://github.com/royshil/obs-backgroundremoval/compare/1.1.13...1.3.7

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (`obs-backgroundremoval` installs OBS plugin files under `lib/obs-plugins`, no `bin/` executables.)
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

  [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

  [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
  [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
  [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
  [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test