### PR TITLE
listenbrainz-mpd: add self as maintainer, add update script, 2.3.9 -> 2.5.1

### DIFF
--- a/pkgs/by-name/li/listenbrainz-mpd/package.nix
+++ b/pkgs/by-name/li/listenbrainz-mpd/package.nix
@@ -66,7 +66,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://codeberg.org/elomatreb/listenbrainz-mpd/src/tag/v${finalAttrs.version}/CHANGELOG.md";
     description = "ListenBrainz submission client for MPD";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ DeeUnderscore ];
+    maintainers = with lib.maintainers; [
+      DeeUnderscore
+      Kladki
+    ];
     mainProgram = "listenbrainz-mpd";
   };
 })

--- a/pkgs/by-name/li/listenbrainz-mpd/package.nix
+++ b/pkgs/by-name/li/listenbrainz-mpd/package.nix
@@ -9,6 +9,7 @@
   sqlite,
   installShellFiles,
   asciidoctor,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -60,6 +61,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     asciidoctor --backend=manpage listenbrainz-mpd.adoc -o listenbrainz-mpd.1
     installManPage listenbrainz-mpd.1
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://codeberg.org/elomatreb/listenbrainz-mpd";

--- a/pkgs/by-name/li/listenbrainz-mpd/package.nix
+++ b/pkgs/by-name/li/listenbrainz-mpd/package.nix
@@ -14,16 +14,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "listenbrainz-mpd";
-  version = "2.3.9";
+  version = "2.5.1";
 
   src = fetchFromCodeberg {
     owner = "elomatreb";
     repo = "listenbrainz-mpd";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-j9MlvE2upocwC5xxroms3am6tqJX30sSw7PFNw8Ofog=";
+    hash = "sha256-087+l3calge6hKu3h84C98mIpW6qFAZwRMe4lkQCU4o=";
   };
 
-  cargoHash = "sha256-1x3F2TqNlqwfPUvLwU8ac4aEeEwpIy5gEyxRBC0Q5YM=";
+  cargoHash = "sha256-SxXEathWAGqdgeJmIn5h9Zvv7Z3DGXa4htkODf/ANRQ=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Release notes:
- [2.4.0](https://codeberg.org/elomatreb/listenbrainz-mpd/releases/tag/v2.4.0)
- [2.5.0](https://codeberg.org/elomatreb/listenbrainz-mpd/releases/tag/v2.5.0)
- [2.5.1](https://codeberg.org/elomatreb/listenbrainz-mpd/releases/tag/v2.5.1)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
