### PR TITLE
rPackages.iscream: use pkgs.htslib without libdeflate override

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11828,6 +11828,12 @@
     github = "james-atkins";
     githubId = 9221409;
   };
+  jamespeapen = {
+    name = "James Eapen";
+    email = "james.eapen@vai.org";
+    github = "jamespeapen";
+    githubId = 39574560;
+  };
   jamesward = {
     email = "james@jamesward.com";
     name = "James Ward";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -686,6 +686,7 @@ with lib.maintainers;
     members = [
       b-rodrigues
       bcdarwin
+      jamespeapen
       jbedo
       kupac
     ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -3136,19 +3136,13 @@ let
       '';
     });
 
-    iscream =
-      let
-        # https://huishenlab.github.io/iscream/articles/htslib.html
-        htslib-deflate = pkgs.htslib.overrideAttrs (attrs: {
-          buildInputs = attrs.buildInputs ++ [ pkgs.libdeflate ];
-        });
-      in
-      old.iscream.overrideAttrs (attrs: {
-        # Rhtslib (in LinkingTo) is not needed if we provide a proper htslib
-        propagatedBuildInputs =
-          builtins.filter (el: el != pkgs.rPackages.Rhtslib) attrs.propagatedBuildInputs
-          ++ [ htslib-deflate ];
-      });
+    iscream = old.iscream.overrideAttrs (attrs: {
+      # https://huishenlab.github.io/iscream/articles/htslib.html
+      # Rhtslib (in LinkingTo) is not needed if we provide a proper htslib
+      propagatedBuildInputs =
+        builtins.filter (el: el != pkgs.rPackages.Rhtslib) attrs.propagatedBuildInputs
+        ++ [ pkgs.htslib ];
+    });
 
     torch = old.torch.overrideAttrs (attrs: {
       preConfigure = ''

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -385,6 +385,7 @@ let
     data_table = [ jbedo ];
     BiocManager = [ jbedo ];
     ggplot2 = [ jbedo ];
+    iscream = [ jamespeapen ];
     svaNUMT = [ jbedo ];
     svaRetro = [ jbedo ];
     StructuralVariantAnnotation = [ jbedo ];


### PR DESCRIPTION
Now that pkgs.htslib is built with libdeflate support (#492537).
I'm iscream's author and happy to become its maintainer here if that's helpful.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
