### PR TITLE
nbted: init at 1.5.2-unstable-2026-02-27

### DIFF
--- a/pkgs/by-name/nb/nbted/package.nix
+++ b/pkgs/by-name/nb/nbted/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nbted";
+  version = "1.5.2-unstable-2026-02-27";
+
+  src = fetchFromGitHub {
+    owner = "C4K3";
+    repo = "nbted";
+    rev = "ce89021a2d84e80331ef7fdc84fa9c53fa80a671";
+    hash = "sha256-TCllGon6x4gWlZYIxzcH0GXs/+M57VepyyGz8RyG1o8=";
+  };
+
+  cargoHash = "sha256-IMF5vc9p/+M/gMrUxOE3eojdATfera5dD62kcJEpzd8=";
+
+  env.VERGEN_GIT_SHA = finalAttrs.src.rev;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command-line NBT editor";
+    homepage = "https://github.com/C4K3/nbted";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ jaredmontoya ];
+    mainProgram = "nbted";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Creates a package for [nbted](https://github.com/C4K3/nbted) (a CLI editor for [NBT](https://minecraft.fandom.com/wiki/NBT_format) files)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
