### PR TITLE
nixos/xdg/mime: auto-set defaults for URL scheme handlers

### DIFF
--- a/nixos/modules/config/xdg/mime.nix
+++ b/nixos/modules/config/xdg/mime.nix
@@ -138,6 +138,32 @@ in
 
       if [ -w $out/share/applications ]; then
           ${pkgs.buildPackages.desktop-file-utils}/bin/update-desktop-database $out/share/applications
+
+          # Auto-set defaults for URL scheme handlers that have exactly one
+          # registered handler. Some desktop environments (notably GNOME) need
+          # an explicit default in mimeapps.list to resolve URL scheme handlers;
+          # having the handler declared only in mimeinfo.cache is not sufficient.
+          # Without this, browser-to-app authentication flows that rely on
+          # custom URL schemes (e.g. OAuth redirects via slack://) fail.
+          # See: https://github.com/NixOS/nixpkgs/issues/301893
+          #
+          # These defaults are installed at distribution-level priority
+          # ($XDG_DATA_DIRS/applications/mimeapps.list) and are overridden by
+          # entries in xdg.mime.defaultApplications (/etc/xdg/mimeapps.list)
+          # and user-level configuration (~/.config/mimeapps.list).
+          if [ -f $out/share/applications/mimeinfo.cache ]; then
+              scheme_handler_defaults=""
+              while IFS='=' read -r mime apps; do
+                  handler_count=$(printf '%s' "$apps" | tr ';' '\n' | grep -c . || true)
+                  if [ "$handler_count" -eq 1 ]; then
+                      handler=$(printf '%s' "$apps" | sed 's/;*$//')
+                      scheme_handler_defaults="''${scheme_handler_defaults}$mime=$handler"$'\n'
+                  fi
+              done < <(grep '^x-scheme-handler/' $out/share/applications/mimeinfo.cache || true)
+              if [ -n "$scheme_handler_defaults" ]; then
+                  printf '[Default Applications]\n%s' "$scheme_handler_defaults" > $out/share/applications/mimeapps.list
+              fi
+          fi
       fi
     '';
   };


### PR DESCRIPTION
## Summary

- After `update-desktop-database` generates `mimeinfo.cache`, parse it for `x-scheme-handler/*` entries that have exactly one registered handler and auto-set them as defaults in `$out/share/applications/mimeapps.list`
- These distribution-level defaults are overridden by `xdg.mime.defaultApplications` (`/etc/xdg/mimeapps.list`) and user-level config (`~/.config/mimeapps.list`), per the XDG MIME Applications spec lookup order

## Motivation

Some desktop environments (notably GNOME) require an explicit default in `mimeapps.list` to resolve URL scheme handlers. Having the handler declared only in `mimeinfo.cache` (via the `.desktop` file's `MimeType` field) is not sufficient. This causes browser-to-app authentication flows that rely on custom URL schemes (e.g. OAuth redirects via `slack://`, `discord://`) to fail silently - the browser opens the auth page, but clicking "Open App" does nothing.

Other Linux distributions get this for free because their package managers (dpkg, rpm, pacman) run post-install triggers that handle MIME database updates and default registration. On NixOS, `update-desktop-database` runs during system activation and generates `mimeinfo.cache`, but no defaults are set in `mimeapps.list` for URL scheme handlers unless the user explicitly configures `xdg.mime.defaultApplications`.

The fix only auto-sets defaults when there is a **single** registered handler for a scheme (e.g. only Slack handles `slack://`). Schemes with multiple handlers (e.g. `x-scheme-handler/http` with both Firefox and Chromium) are left for the user to configure.

Fixes: #301893

## Test plan

- [ ] Build a NixOS config with Slack (or another app declaring `x-scheme-handler/*` in its `.desktop` file) in `environment.systemPackages`
- [ ] After rebuild, verify `/run/current-system/sw/share/applications/mimeapps.list` exists and contains `x-scheme-handler/slack=slack.desktop` under `[Default Applications]`
- [ ] Verify `xdg-open slack://test` launches Slack
- [ ] Verify that `xdg.mime.defaultApplications` entries override the auto-generated defaults
- [ ] Verify that schemes with multiple handlers (e.g. `x-scheme-handler/http`) are NOT auto-set