### PR TITLE
dbeaver-bin: 25.3.4 -> 25.3.5

### DIFF
--- a/pkgs/by-name/db/dbeaver-bin/package.nix
+++ b/pkgs/by-name/db/dbeaver-bin/package.nix
@@ -19,23 +19,23 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "dbeaver-bin";
-  version = "25.3.4";
+  version = "25.3.5";
 
   src =
     let
       inherit (stdenvNoCC.hostPlatform) system;
       selectSystem = attrs: attrs.${system} or (throw "Unsupported system: ${system}");
       suffix = selectSystem {
-        x86_64-linux = "linux.gtk.x86_64.tar.gz";
-        aarch64-linux = "linux.gtk.aarch64.tar.gz";
+        x86_64-linux = "linux-x86_64.tar.gz";
+        aarch64-linux = "linux-aarch64.tar.gz";
         x86_64-darwin = "macos-x86_64.dmg";
         aarch64-darwin = "macos-aarch64.dmg";
       };
       hash = selectSystem {
-        x86_64-linux = "sha256-iqbpvXSn0jsHNdsn6/C1RV28Xc54o2XnvtG8WujpJFE=";
-        aarch64-linux = "sha256-fku9iDSyM5COrCAy9sIBZUCo7E8/2nIQmlhKAtBbmcw=";
-        x86_64-darwin = "sha256-DJpME9xxFSlRIgJuLtemIdnaskim7S1wPWLlrF0doxo=";
-        aarch64-darwin = "sha256-q/IZHXSAV7TR3EjKoxoB06zLnhEvb6A5TywgEK9uL8o=";
+        x86_64-linux = "sha256-pUjLM2tPIVuGiYpv0UgfUnINPRxzdbBvAPfeX4Vsrn8=";
+        aarch64-linux = "sha256-26RZrqpciHOgn6CGJhrxvyghxaIDojv1GkC7Df9KwyA=";
+        x86_64-darwin = "sha256-GWro2heKUny7psNym2bA8m8Hvk96GiDVhYDG9wgoJig=";
+        aarch64-darwin = "sha256-K2gjVHKYSLwAl0JuaZy5ZDLEXpsmHHLPfZUkuuTUoo4=";
       };
     in
     fetchurl {

--- a/pkgs/by-name/db/dbeaver-bin/update.sh
+++ b/pkgs/by-name/db/dbeaver-bin/update.sh
@@ -16,8 +16,8 @@ if [[ "$latestVersion" == "$currentVersion" ]]; then
 fi
 
 for i in \
-    "x86_64-linux linux.gtk.x86_64.tar.gz" \
-    "aarch64-linux linux.gtk.aarch64.tar.gz" \
+    "x86_64-linux linux-x86_64.tar.gz" \
+    "aarch64-linux linux-aarch64.tar.gz" \
     "x86_64-darwin macos-x86_64.dmg" \
     "aarch64-darwin macos-aarch64.dmg"
 do


### PR DESCRIPTION
Release: https://github.com/dbeaver/dbeaver/releases


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
