### PR TITLE
nixos/borgbackup: add randomizedDelaySec option

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -194,6 +194,7 @@ let
       timerConfig = {
         Persistent = cfg.persistentTimer;
         OnCalendar = cfg.startAt;
+        RandomizedDelaySec = cfg.randomizedDelaySec;
       };
       # if remote-backup wait for network
       after = lib.optional (cfg.persistentTimer && !isLocalPath cfg.repo) "network-online.target";
@@ -499,6 +500,18 @@ in
                 {manpage}`systemd.timer(5)`
                 which triggers the backup immediately if the last trigger
                 was missed (e.g. if the system was powered down).
+              '';
+            };
+
+            randomizedDelaySec = lib.mkOption {
+              default = "0";
+              type = lib.types.str;
+              example = "45min";
+              description = ''
+                Add a randomized delay before each backup.
+                The delay will be chosen between zero and this value.
+                This value must be a time span in the format specified by
+                {manpage}`systemd.time(7)`
               '';
             };
 


### PR DESCRIPTION
```
    nixos/borgbackup: add randomizedDelaySec option

    Add a services.borgbackup.jobs.<name>.randomizedDelaySec option to
    mitigate the thundering herd problem when abstracting several
    repositories and distributing workloads by generating static
    services.borgbackup.jobs.<name>.startAt values is undesired.

 nixos/modules/services/backup/borgbackup.nix | 13 +++++++++++++
 1 file changed, 13 insertions(+)
```

This has been tested locally in my NixOS configuration.

The implementation is strongly inspired by existing `randomizedDelaySec` patterns:

```console
$ rg --after-context 10 'randomizedDelaySec ='
nixos/modules/virtualisation/docker.nix:      randomizedDelaySec = mkOption {
nixos/modules/virtualisation/docker.nix-        default = "0";
nixos/modules/virtualisation/docker.nix-        type = types.singleLineStr;
nixos/modules/virtualisation/docker.nix-        example = "45min";
nixos/modules/virtualisation/docker.nix-        description = ''
nixos/modules/virtualisation/docker.nix-          Add a randomized delay before each auto prune.
nixos/modules/virtualisation/docker.nix-          The delay will be chosen between zero and this value.
nixos/modules/virtualisation/docker.nix-          This value must be a time span in the format specified by
nixos/modules/virtualisation/docker.nix-          {manpage}`systemd.time(7)`
nixos/modules/virtualisation/docker.nix-        '';
nixos/modules/virtualisation/docker.nix-      };
--
nixos/modules/tasks/auto-upgrade.nix:      randomizedDelaySec = lib.mkOption {
nixos/modules/tasks/auto-upgrade.nix-        default = "0";
nixos/modules/tasks/auto-upgrade.nix-        type = lib.types.str;
nixos/modules/tasks/auto-upgrade.nix-        example = "45min";
nixos/modules/tasks/auto-upgrade.nix-        description = ''
nixos/modules/tasks/auto-upgrade.nix-          Add a randomized delay before each automatic upgrade.
nixos/modules/tasks/auto-upgrade.nix-          The delay will be chosen between zero and this value.
nixos/modules/tasks/auto-upgrade.nix-          This value must be a time span in the format specified by
nixos/modules/tasks/auto-upgrade.nix-          {manpage}`systemd.time(7)`
nixos/modules/tasks/auto-upgrade.nix-        '';
nixos/modules/tasks/auto-upgrade.nix-      };
--
nixos/modules/tasks/filesystems/zfs.nix:      randomizedDelaySec = lib.mkOption {
nixos/modules/tasks/filesystems/zfs.nix-        default = "6h";
nixos/modules/tasks/filesystems/zfs.nix-        type = lib.types.str;
nixos/modules/tasks/filesystems/zfs.nix-        example = "12h";
nixos/modules/tasks/filesystems/zfs.nix-        description = ''
nixos/modules/tasks/filesystems/zfs.nix-          Add a randomized delay before each ZFS trim.
nixos/modules/tasks/filesystems/zfs.nix-          The delay will be chosen between zero and this value.
nixos/modules/tasks/filesystems/zfs.nix-          This value must be a time span in the format specified by
nixos/modules/tasks/filesystems/zfs.nix-          {manpage}`systemd.time(7)`
nixos/modules/tasks/filesystems/zfs.nix-        '';
nixos/modules/tasks/filesystems/zfs.nix-      };
--
nixos/modules/tasks/filesystems/zfs.nix:      randomizedDelaySec = lib.mkOption {
nixos/modules/tasks/filesystems/zfs.nix-        default = "6h";
nixos/modules/tasks/filesystems/zfs.nix-        type = lib.types.str;
nixos/modules/tasks/filesystems/zfs.nix-        example = "12h";
nixos/modules/tasks/filesystems/zfs.nix-        description = ''
nixos/modules/tasks/filesystems/zfs.nix-          Add a randomized delay before each ZFS autoscrub.
nixos/modules/tasks/filesystems/zfs.nix-          The delay will be chosen between zero and this value.
nixos/modules/tasks/filesystems/zfs.nix-          This value must be a time span in the format specified by
nixos/modules/tasks/filesystems/zfs.nix-          {manpage}`systemd.time(7)`
nixos/modules/tasks/filesystems/zfs.nix-        '';
nixos/modules/tasks/filesystems/zfs.nix-      };
--
nixos/modules/services/misc/nix-optimise.nix:      randomizedDelaySec = lib.mkOption {
nixos/modules/services/misc/nix-optimise.nix-        default = "1800";
nixos/modules/services/misc/nix-optimise.nix-        type = lib.types.singleLineStr;
nixos/modules/services/misc/nix-optimise.nix-        example = "45min";
nixos/modules/services/misc/nix-optimise.nix-        description = ''
nixos/modules/services/misc/nix-optimise.nix-          Add a randomized delay before the optimizer will run.
nixos/modules/services/misc/nix-optimise.nix-          The delay will be chosen between zero and this value.
nixos/modules/services/misc/nix-optimise.nix-          This value must be a time span in the format specified by
nixos/modules/services/misc/nix-optimise.nix-          {manpage}`systemd.time(7)`
nixos/modules/services/misc/nix-optimise.nix-        '';
nixos/modules/services/misc/nix-optimise.nix-      };
--
nixos/modules/services/misc/nix-gc.nix:      randomizedDelaySec = lib.mkOption {
nixos/modules/services/misc/nix-gc.nix-        default = "0";
nixos/modules/services/misc/nix-gc.nix-        type = lib.types.singleLineStr;
nixos/modules/services/misc/nix-gc.nix-        example = "45min";
nixos/modules/services/misc/nix-gc.nix-        description = ''
nixos/modules/services/misc/nix-gc.nix-          Add a randomized delay before each garbage collection.
nixos/modules/services/misc/nix-gc.nix-          The delay will be chosen between zero and this value.
nixos/modules/services/misc/nix-gc.nix-          This value must be a time span in the format specified by
nixos/modules/services/misc/nix-gc.nix-          {manpage}`systemd.time(7)`
nixos/modules/services/misc/nix-gc.nix-        '';
nixos/modules/services/misc/nix-gc.nix-      };
```

CC: @Scrumplex, @dotlambda

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
