### PR TITLE
lib/cli: add toCommandLineString and toCommandLineStringGNU functions

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -167,6 +167,25 @@
     options: attrs: lib.escapeShellArgs (lib.cli.toCommandLineGNU options attrs);
 
   /**
+    Converts the given attributes into a single unescaped and space-separated
+    command-line string.
+
+    This is useful for providing raw shell expressions.
+
+    # Examples
+
+    ::: {.example}
+    ## `lib.cli.toCommandLineStringGNU` usage example
+
+    ```nix
+    lib.cli.toCommandLineStringGNU { } { seed = ''"$(( RANDOM % 256 ))"''; }
+    => "--seed=\"$(( RANDOM % 256 ))\""
+    ```
+    :::
+  */
+  toCommandLineStringGNU = options: attrs: toString (lib.cli.toCommandLineGNU options attrs);
+
+  /**
     Converts an attribute set into a list of GNU-style command-line arguments.
 
     `toCommandLineGNU` returns a list of string arguments.
@@ -250,6 +269,14 @@
   */
   toCommandLineShell =
     optionFormat: attrs: lib.escapeShellArgs (lib.cli.toCommandLine optionFormat attrs);
+
+  /**
+    Converts the given attributes into a single unescaped and space-separated
+    command-line string.
+
+    This is useful for providing raw shell expressions.
+  */
+  toCommandLineString = optionFormat: attrs: toString (lib.cli.toCommandLine optionFormat attrs);
 
   /**
     Converts an attribute set into a list of command-line arguments.
@@ -417,8 +444,10 @@
     # See also
 
     - `lib.cli.toCommandLineShell`
+    - `lib.cli.toCommandLineString`
     - `lib.cli.toCommandLineGNU`
     - `lib.cli.toCommandLineShellGNU`
+    - `lib.cli.toCommandLineStringGNU`
   */
   toCommandLine =
     optionFormat: attrs:


### PR DESCRIPTION
```
lib/cli: add toCommandLineString and toCommandLineStringGNU functions

Add the toCommandLineString and toCommandLineStringGNU functions
complementary to toCommandLineShell and toCommandLineShellGNU,
leveraging the underlying toCommandLine construction without escaping
values:

    lib.cli.toCommandLineStringGNU { } {
      seed = ''"$(( RANDOM % 256 ))"'';
    }

Link: 73e8a483e6ba ("lib/cli: add toCommandLine")
```

This implements the https://github.com/NixOS/nixpkgs/pull/404233#discussion_r2442469490 suggestion.

CC: @gabyx, @h7x4, @hsjobeki, @lukaswrz

## Changelog

### v1: https://github.com/NixOS/nixpkgs/commit/b2113b498e84a3b3a14557843689daef8c19d7df

- Drop `[PATCH 2/2] lib/cli: add toCommandLineStandard{,Shell,String}`, following https://github.com/NixOS/nixpkgs/pull/494876#discussion_r2865934599.
- Add `toCommandLineStringGNU` function.
- Update function documentations.

### v0: https://github.com/NixOS/nixpkgs/commit/e033d6aa6856c7a75bb6866dd7f98f4cc9528f14

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
