### PR TITLE
tableaunoir: init at 0.1-unstable-2026-03-11

### DIFF
--- a/nixos/modules/services/web-apps/tableaunoir.nix
+++ b/nixos/modules/services/web-apps/tableaunoir.nix
@@ -1,0 +1,95 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.tableaunoir;
+  package = pkgs.tableaunoir.override {
+    inherit (cfg) settings;
+    buildElectronApp = false;
+    buildWebsocketServer = cfg.wsServer.enable;
+    socketAddr =
+      if !(builtins.isNull cfg.wsServer.port) then
+        { inherit (cfg.wsServer) port; }
+      else
+        "/run/tableaunoir/ws.sock";
+  };
+in
+{
+  options.services.tableaunoir = {
+    enable = lib.mkEnableOption "Serve tableaunoir application";
+    wsServer = {
+      enable = lib.mkEnableOption "Server the websocket server";
+      port = lib.mkOption {
+        type = lib.types.nullOr lib.types.port;
+        default = null;
+        description = "Port for the websocket server, uses unix socket if null";
+      };
+      nginxVhost = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        description = ''
+          If set to non-null, will configure this nginx virtualhost for
+          proxying the websocket traffic to the tableaunoir ws server
+        '';
+        default = null;
+      };
+    };
+    settings = lib.mkOption {
+      type = lib.types.attrs;
+      description = "Settings to add to the config.json file before building the app";
+      default = { };
+    };
+    frontendNginxVhost = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      description = ''
+        If set to non-null, will configure this nginx virtualhost for
+        serving the frontend of tableaunoir
+      '';
+      default = null;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.tableaunoir-ws = lib.mkIf cfg.wsServer.enable {
+      description = "Tableaunoir websocket server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+      serviceConfig = {
+        DynamicUser = true;
+        RuntimeDirectory = "tableaunoir";
+      };
+      script = ''
+        ${package}/ws-server/tableaunoir-ws
+      '';
+    };
+
+    services.nginx.virtualHosts = lib.mkMerge [
+      (lib.mkIf (!builtins.isNull cfg.frontendNginxVhost) {
+        ${cfg.frontendNginxVhost} = {
+          root = toString package;
+          locations."/" = {
+            tryFiles = "$uri $uri/ =404";
+          };
+          locations."/ws-server" = {
+            return = "404";
+          };
+        };
+      })
+      (lib.mkIf (!builtins.isNull cfg.wsServer.nginxVhost) {
+        ${cfg.wsServer.nginxVhost} = {
+          locations."/" = {
+            proxyPass =
+              if builtins.isNull cfg.wsServer.port then
+                "http://unix:/run/tableaunoir/ws.sock:/"
+              else
+                "http://127.0.0.1:${toString cfg.wsServer.port}";
+            proxyWebsockets = true;
+          };
+        };
+      })
+    ];
+  };
+}

--- a/pkgs/by-name/ta/tableaunoir/package-lock.json
+++ b/pkgs/by-name/ta/tableaunoir/package-lock.json
@@ -1,0 +1,52 @@
+{
+  "name": "server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "small-uuid": "^1.0.1",
+        "ws": "^7.3.1"
+      }
+    },
+    "node_modules/node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha512-TkCET/3rr9mUuRp+CpO7qfgT++aAxfDRaalQhwPFzI9BY/2rCDn6OfpZOVggi1AXfTPpfkTrg5f5WQx5G1uLxA==",
+      "deprecated": "Use uuid module instead",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/small-uuid": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/small-uuid/-/small-uuid-1.0.1.tgz",
+      "integrity": "sha512-D1uHj309ltKiPmHDthjVuPesAeklk2rCHzor9HmAL+6iONYOCu5L0rkNs+MPpW7268O2fWFBw57bhG8tDGbnDg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-uuid": "^1.4.7"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/pkgs/by-name/ta/tableaunoir/package.nix
+++ b/pkgs/by-name/ta/tableaunoir/package.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  writeShellScript,
+
+  buildWebsocketServer ? false,
+  nodejs,
+  node ? nodejs,
+
+  buildElectronApp ? true,
+  makeWrapper,
+  electron_40,
+  electron ? electron_40,
+
+  # When using the package directly, must override these settings for frontend
+  settings ? {
+    # Required for sharing the board to others
+    # If not set, service will work as long as we don't use the share feature
+    server = {
+      websocket = "";
+      frontend = "";
+    };
+  },
+  socketAddr ? {
+    port = 8080;
+  },
+}:
+let
+  src = fetchFromGitHub {
+    owner = "tableaunoir";
+    repo = "tableaunoir";
+    rev = "a319dbe8e14d1042025a3cf974872e6c1ea77a97";
+    sha256 = "sha256-DC8pcm7loHwp8JXd8UjKaN69FAvR82J6uRb3iybA7do=";
+  };
+  version = "0.1-unstable-2026-03-11";
+
+  tableaunoir-ws-start = writeShellScript "tableaunoir-ws-start.sh" ''
+    cd $(dirname $0)
+    ${lib.getExe node} ./main.js
+  '';
+
+  wsbackend = buildNpmPackage {
+    pname = "tableaunoir-ws";
+    inherit version;
+    src = "${src}/server";
+    npmDepsHash = "sha256-TyCyrvJ/GbSPSlY2nvINe2w91u2D15Yej7aN9G4Er7c=";
+    dontBuild = true;
+    NODE_ENV = "production";
+    postPatch = ''
+      sed -i 's+{ port: 8080 }+${builtins.toJSON socketAddr}+g' main.js
+      cp ${./package-lock.json} ./package-lock.json
+    '';
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/
+      cp -r node_modules package*.json main.js $out/
+      cp ${tableaunoir-ws-start} $out/tableaunoir-ws
+      runHook postInstall
+    '';
+  };
+
+  installWebsocketServer = lib.strings.optionalString buildWebsocketServer ''
+    ln -s ${wsbackend} $out/ws-server
+  '';
+
+  installElectron = lib.strings.optionalString buildElectronApp ''
+    cp mainElectron.js $out/frontend/
+    sed -i "s+dist/index.html+$out/frontend/index.html+g" $out/frontend/mainElectron.js
+    makeWrapper '${electron}/bin/electron' "$out/bin/tableaunoir" \
+      --add-flags "$out/frontend/mainElectron.js"
+  '';
+in
+buildNpmPackage {
+  pname = "tableaunoir";
+  inherit version src;
+  __structuredAttrs = true;
+  npmDepsHash = "sha256-47rQ20kcRxYM1aUIzhfB+FCbQyMWHPfjNyRJzmrEyio=";
+  postPatch = ''
+    cat << 'EOF' > ./src/config.json
+    ${builtins.toJSON settings}
+    EOF
+  '';
+
+  nativeBuildInputs = lib.optional buildElectronApp makeWrapper;
+  ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  preBuild = ''
+    # Requires to fetch dev dependencies as well, in order to build in production later
+    export NODE_ENV="production"
+  '';
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r dist/ $out/frontend
+    ${installWebsocketServer}
+    ${installElectron}
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/tableaunoir/tableaunoir";
+    description = "A lightweight online blackboard for teaching";
+    longDescription = ''
+      An online blackboard with fridge magnets for teaching, and making animations and presentations.
+      All of that in a lightweight user interface, and without coding.
+    '';
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.litchipi ];
+  };
+}


### PR DESCRIPTION
Tableaunoir is a very simple (KISS) board for teaching purposes.

Packages as a web frontend or electron app, with an optional websocket server for the board sharing features.

The package have settings in its options as these are embedded to the built javascript files, so they must be set at build time

Adds some practical options for the nginx configuration

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
