### PR TITLE
nixos/nix-gc: deprecate nix.gc.options string type with attribute set

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -208,26 +208,44 @@ rec {
 
     : A function that turns the option argument into a string.
 
+    `detachArg`
+
+    : A function that determines whether the option should be separated from its
+      argument.
+
     # Examples
 
     :::{.example}
-    ## `lib.cli.toCommandLineGNU` usage example
+    ## `lib.cli.toCommandLineGNU` basic usage example
 
     ```nix
-    lib.cli.toCommandLineGNU {} {
+    lib.cli.toCommandLineGNU { } {
       v = true;
-      verbose = [true true false null];
+      verbose = [
+        true
+        true
+        false
+        null
+      ];
       i = ".bak";
-      testsuite = ["unit" "integration"];
-      e = ["s/a/b/" "s/b/c/"];
+      testsuite = [
+        "unit"
+        "integration"
+      ];
+      e = [
+        "s/a/b/"
+        "s/b/c/"
+      ];
       n = false;
-      data = builtins.toJSON {id = 0;};
+      data = builtins.toJSON { id = 0; };
+      s = "";
     }
     => [
       "--data={\"id\":0}"
       "-es/a/b/"
       "-es/b/c/"
       "-i.bak"
+      "-s"
       "--testsuite=unit"
       "--testsuite=integration"
       "-v"
@@ -235,7 +253,107 @@ rec {
       "--verbose"
     ]
     ```
+    :::
 
+    :::{.example}
+    ## `lib.cli.toCommandLineGNU` usage with `detachArg`
+
+    ```nix
+    lib.cli.toCommandLineGNU
+      {
+        detachArg =
+          optionName:
+          builtins.elem optionName [
+            "n"
+            "s"
+          ];
+      }
+      {
+        v = true;
+        verbose = [
+          true
+          true
+          false
+          null
+        ];
+        i = ".bak";
+        testsuite = [
+          "unit"
+          "integration"
+        ];
+        e = [
+          "s/a/b/"
+          "s/b/c/"
+        ];
+        n = false;
+        data = builtins.toJSON { id = 0; };
+        s = "";
+      }
+    => [
+      "--data={\"id\":0}"
+      "-es/a/b/"
+      "-es/b/c/"
+      "-i.bak"
+      "-s"
+      ""
+      "--testsuite=unit"
+      "--testsuite=integration"
+      "-v"
+      "--verbose"
+      "--verbose"
+    ]
+    ```
+    :::
+
+    :::{.example}
+    ## `lib.cli.toCommandLineGNU` usage with `detachArg` for all options
+
+    ```nix
+    lib.cli.toCommandLineGNU
+      {
+        detachArg = _: true;
+      }
+      {
+        v = true;
+        verbose = [
+          true
+          true
+          false
+          null
+        ];
+        i = ".bak";
+        testsuite = [
+          "unit"
+          "integration"
+        ];
+        e = [
+          "s/a/b/"
+          "s/b/c/"
+        ];
+        n = false;
+        data = builtins.toJSON { id = 0; };
+        s = "";
+      }
+    => [
+      "--data"
+      "{\"id\":0}"
+      "-e"
+      "s/a/b/"
+      "-e"
+      "s/b/c/"
+      "-i"
+      ".bak"
+      "-s"
+      ""
+      "--testsuite"
+      "unit"
+      "--testsuite"
+      "integration"
+      "-v"
+      "--verbose"
+      "--verbose"
+    ]
+    ```
     :::
   */
   toCommandLineGNU =
@@ -243,11 +361,18 @@ rec {
       isLong ? optionName: stringLength optionName > 1,
       explicitBool ? false,
       formatArg ? mkValueString,
+      detachArg ? _: false,
     }:
     let
       optionFormat = optionName: {
         option = if isLong optionName then "--${optionName}" else "-${optionName}";
-        sep = if isLong optionName then "=" else "";
+        sep =
+          if detachArg optionName then
+            null
+          else if isLong optionName then
+            "="
+          else
+            "";
         inherit explicitBool formatArg;
       };
     in

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -3297,6 +3297,54 @@ runTests {
     ];
   };
 
+  testToCommandLineGNUWithDetachArg = {
+    expr =
+      cli.toCommandLineGNU
+        {
+          detachArg =
+            optionName:
+            builtins.elem optionName [
+              "n"
+              "s"
+            ];
+        }
+        {
+          v = true;
+          verbose = [
+            true
+            true
+            false
+            null
+          ];
+          i = ".bak";
+          testsuite = [
+            "unit"
+            "integration"
+          ];
+          e = [
+            "s/a/b/"
+            "s/b/c/"
+          ];
+          n = false;
+          data = builtins.toJSON { id = 0; };
+          s = "";
+        };
+
+    expected = [
+      "--data={\"id\":0}"
+      "-es/a/b/"
+      "-es/b/c/"
+      "-i.bak"
+      "-s"
+      ""
+      "--testsuite=unit"
+      "--testsuite=integration"
+      "-v"
+      "--verbose"
+      "--verbose"
+    ];
+  };
+
   testSanitizeDerivationNameLeadingDots = testSanitizeDerivationName {
     name = "..foo";
     expected = "foo";

--- a/nixos/modules/services/misc/nix-gc.nix
+++ b/nixos/modules/services/misc/nix-gc.nix
@@ -61,9 +61,16 @@ in
       };
 
       options = lib.mkOption {
-        default = "";
-        example = "--max-freed $((64 * 1024**3))";
-        type = lib.types.singleLineStr;
+        default = { };
+        example = {
+          max-freed = "$((64 * 1024**3))";
+        };
+        type = with lib.types; either (attrsOf str) str;
+        apply =
+          value:
+          lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2611 && builtins.isString value)
+            "migrate the `nix.gc.options` string to the `lib.cli.toCommandLineGNU { detachArg = _: true; }` attribute set"
+            value;
         description = ''
           Options given to [`nix-collect-garbage`](https://nixos.org/manual/nix/stable/command-ref/nix-collect-garbage) when the garbage collector is run automatically.
         '';
@@ -85,7 +92,16 @@ in
 
     systemd.services.nix-gc = lib.mkIf config.nix.enable {
       description = "Nix Garbage Collector";
-      script = "exec ${config.nix.package.out}/bin/nix-collect-garbage ${cfg.options}";
+      script = ''
+        exec \
+          ${config.nix.package.out}/bin/nix-collect-garbage \
+          ${
+            if builtins.isString cfg.options then
+              cfg.options
+            else
+              toString (lib.cli.toCommandLineGNU { detachArg = _: true; } cfg.options)
+          }
+      '';
       serviceConfig.Type = "oneshot";
       startAt = lib.optionals cfg.automatic cfg.dates;
       # do not start and delay when switching


### PR DESCRIPTION
```
    nixos/nix-gc: deprecate nix.gc.options string type with attribute set

    Deprecate the nix.gc.options string type with an attribute set of
    strings as a more general application of the NixOS RFC 42.

 nixos/modules/services/misc/nix-gc.nix | 24 ++++++++++++++++++++----
 1 file changed, 20 insertions(+), 4 deletions(-)
```

This PR upstreams my following quality of life improvement:

```diff
-nix.gc.options = toString (
-  lib.cli.toCommandLineGNU { detachArg = _: true; } { delete-older-than = "30d"; }
-);
+nix.gc.options.delete-older-than = "30d";
```

This PR is stacked on top of the pending PR https://github.com/NixOS/nixpkgs/pull/495240 to leverage its added `detachArg` argument to the `lib.cli.toCommandLineGNU` function.

This PR can be verified with:

```console
$ nix-instantiate --eval --strict -E '
    (import ./nixos/lib/eval-config.nix {
      modules = [({ ... }: { nix.gc.options = "--max-freed $((64 * 1024**3))"; })];
    }).config.systemd.services.nix-gc.script
  '
"exec \\\n  /nix/store/iirndnicd13h4zjr8xwwj8hq2cghpfjn-nix-2.34.8/bin/nix-collect-garbage \\\n  --max-freed $((64 * 1024**3))\n"
$ nix-instantiate --eval --strict -E '
    (import ./nixos/lib/eval-config.nix {
      modules = [({ ... }: { nix.gc.options.max-freed = "$((64 * 1024**3))"; })];
    }).config.systemd.services.nix-gc.script
  '
"exec \\\n  /nix/store/iirndnicd13h4zjr8xwwj8hq2cghpfjn-nix-2.34.8/bin/nix-collect-garbage \\\n  --max-freed $((64 * 1024**3))\n"
```

> [!IMPORTANT]
>
> This PR should be merged after https://github.com/NixOS/nixpkgs/pull/495240, and will remaing in draft mode until then. This PR is already ready for review.

CC: @SuperSandro2000, @Prince213, @isabelroses

## Changelog

### v1: https://github.com/NixOS/nixpkgs/commit/d8db6cc4c4189e159b37dfdaac6d45df54d37974

- Rebase on top of commit 97316317a7cf ("nixos-option: set pname and version (#541940)").
- Increase `lib.oldestSupportedReleaseIsAtLeast` from `2605` to `2611`.
- Replace the rejected `lib.cli.toCommandLineStandardString` convenience function from https://github.com/NixOS/nixpkgs/pull/494876 with the proposed `detachArg` argument for `lib.cli.toCommandLineGNU` from https://github.com/NixOS/nixpkgs/pull/495240.

### v0: https://github.com/NixOS/nixpkgs/commit/69f5dae1335049ae9419b8c4f5b6093815984de7

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
    - The previous verification was done on x86_64-linux.
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
