### PR TITLE
neuralnote init

### DIFF
--- a/pkgs/by-name/ne/neuralnote/package.nix
+++ b/pkgs/by-name/ne/neuralnote/package.nix
@@ -1,0 +1,98 @@
+{
+  stdenv,
+  fetchzip,
+  lib,
+  autoPatchelfHook,
+  makeWrapper,
+  libatomic_ops,
+  alsa-lib,
+  freetype,
+  libjack2,
+  libGL,
+  curl,
+  xorg,
+  fontconfig,
+}:
+stdenv.mkDerivation rec {
+  pname = "neuralnote";
+  version = "1.1.0";
+
+  srcs = [
+    (fetchzip {
+      name = "app";
+      url = "https://github.com/DamRsn/NeuralNote/releases/download/v${version}/NeuralNote_Standalone_Linux.zip";
+      sha256 = "sha256-Yi7Fj6kqTRAdwACUPvQwc5mqUMtkejkzGQCSLeWV8uU=";
+    })
+    (fetchzip {
+      name = "vst";
+      url = "https://github.com/DamRsn/NeuralNote/releases/download/v${version}/NeuralNote_VST3_Linux.zip";
+      sha256 = "sha256-nP7C0t21sQo9aR/7RR03uo60APvZHoGq7yT13jnohEI=";
+    })
+  ];
+
+  sourceRoot = ".";
+
+  buildInputs = [
+    libatomic_ops
+    alsa-lib
+    freetype
+    fontconfig
+    libjack2
+    libGL
+    curl
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXext
+    xorg.libXinerama
+    xorg.libXrender
+    xorg.libXrandr
+    xorg.libXdmcp
+    xorg.libXtst
+    stdenv.cc.cc.lib
+  ];
+
+  nativeBuildInputs = [makeWrapper autoPatchelfHook];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/vst3/NeuralNote.vst3
+    cp -r vst/Contents $out/lib/vst3/NeuralNote.vst3
+    
+    mkdir -p $out/bin/
+    mv ./app/NeuralNote ./app/$pname
+    install -m 755 -D ./app/$pname $out/bin/$pname
+
+    runHook postInstall
+  '';
+
+  postFixup = let
+    libPath = lib.makeLibraryPath [
+      libatomic_ops
+      alsa-lib
+      freetype
+      fontconfig
+      libjack2
+      libGL
+      curl
+      xorg.libX11
+      xorg.libXcursor
+      xorg.libXext
+      xorg.libXinerama
+      xorg.libXrender
+      xorg.libXrandr
+      xorg.libXdmcp
+      xorg.libXtst
+    ];
+  in ''
+    wrapProgram $out/bin/$pname \
+      --set LD_LIBRARY_PATH ${libPath}
+  '';
+
+  meta = with lib; {
+    description = "neuralnote";
+    homepage = "https://github.com/DamRsn/NeuralNote";
+    mainProgram = pname;
+    platforms = platforms.x86_64;
+  };
+}


### PR DESCRIPTION
[NeuralNote](https://github.com/DamRsn/NeuralNote) is a state-of-the-art Audio to MIDI conversion that works both as a standalone application and as a VST3 plugin for DAWs.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
