### PR TITLE
nh-unwrapped: 4.2.0 -> 4.3.0

### DIFF
--- a/nixos/modules/programs/nh.nix
+++ b/nixos/modules/programs/nh.nix
@@ -12,6 +12,7 @@ in
     NotAShelf
     mdaniels5757
     viperML
+    faukah
   ];
 
   options.programs.nh = {

--- a/pkgs/by-name/nh/nh-unwrapped/package.nix
+++ b/pkgs/by-name/nh/nh-unwrapped/package.nix
@@ -4,53 +4,96 @@
   rustPlatform,
   installShellFiles,
   fetchFromGitHub,
-  fetchpatch,
   nix-update-script,
   buildPackages,
+  sudo,
+  versionCheckHook,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nh-unwrapped";
-  version = "4.2.0"; # Did you remove the patch below (and this comment)?
-
+  version = "4.3.0";
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6n5SVO8zsdVTD691lri7ZcO4zpqYFU8GIvjI6dbxkA8=";
+    hash = "sha256-A3bEBKJlWYqsw41g4RaTwSLUWq8Mw/zz4FpMj4Lua+c=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/nix-community/nh/commit/8bf323483166797a204579a43ed8810113eb128c.patch";
-      hash = "sha256-hg0LgDPjiPWR+1DRzqORv6QPlrds7ys4PTDXFw6PUoI=";
-    })
-  ];
-
   strictDeps = true;
+
+  cargoBuildFlags = [
+    "-p"
+    "nh"
+    "-p"
+    "xtask"
+  ];
 
   nativeBuildInputs = [
     installShellFiles
   ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
-    let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
-    in
-    ''
-      mkdir completions
+  # pkgs.sudo is not available on the Darwin platform, and thus breaks build
+  # if added to nativeCheckInputs. We must manually disable the tests that
+  # *require* it, because they will fail when sudo is missing.
+  nativeCheckInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [ sudo ];
+  checkFlags = [
+    # These do not work in Nix's sandbox
+    "--skip"
+    "test_get_build_image_variants_expression"
+    "--skip"
+    "test_get_build_image_variants_file"
+    "--skip"
+    "test_get_build_image_variants_flake"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Tests that require sudo in PATH (not available on Darwin)
+    "--skip"
+    "test_build_sudo_cmd_basic"
+    "--skip"
+    "test_build_sudo_cmd_with_preserve_vars"
+    "--skip"
+    "test_build_sudo_cmd_with_preserve_vars_disabled"
+    "--skip"
+    "test_build_sudo_cmd_with_set_vars"
+    "--skip"
+    "test_build_sudo_cmd_force_no_stdin"
+    "--skip"
+    "test_build_sudo_cmd_with_remove_vars"
+    "--skip"
+    "test_build_sudo_cmd_with_askpass"
+    "--skip"
+    "test_build_sudo_cmd_env_added_once"
+    "--skip"
+    "test_elevation_strategy_passwordless_resolves"
+    "--skip"
+    "test_build_sudo_cmd_with_nix_config_spaces"
+  ];
 
-      for shell in bash zsh fish; do
-        NH_NO_CHECKS=1 ${emulator} $out/bin/nh completions $shell > completions/nh.$shell
-      done
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
-      installShellCompletion completions/*
+  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+    # Run both shell completion and manpage generation tasks. Unlike the
+    # fine-grained variants, the 'dist' command doesn't allow specifying the
+    # path but that's fine, because we can simply install them from the implicit
+    # output directories.
+    $out/bin/xtask dist
 
-      cargo xtask man --out-dir gen
-      installManPage gen/nh.1
-    ''
-  );
+    # The dist task above should've created
+    #  1. Shell completions in comp/
+    #  2. The NH manpage (nh.1) in man/
+    # Let's install those.
+    # The important thing to note here is that installShellCompletion cannot
+    # actually load *all* shell completions we generate with 'xtask dist'.
+    # Elvish, for example isn't supported. So we have to be very explicit
+    # about what we're installing, or this will fail.
+    installShellCompletion --cmd ${finalAttrs.meta.mainProgram} ./comp/*.{bash,fish,zsh,nu}
+    installManPage ./man/nh.1
 
-  cargoHash = "sha256-cxZsePgraYevuYQSi3hTU2EsiDyn1epSIcvGi183fIU=";
+    # Avoid populating PATH with an 'xtask' cmd
+    rm $out/bin/xtask
+  '';
+
+  cargoHash = "sha256-BLv69rL5L84wNTMiKHbSumFU4jVQqAiI1pS5oNLY9yE=";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/nh/nh-unwrapped/package.nix
+++ b/pkgs/by-name/nh/nh-unwrapped/package.nix
@@ -110,6 +110,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mdaniels5757
       viperML
       midischwarz12
+      faukah
     ];
   };
 })


### PR DESCRIPTION
nh bump. 
diff: https://github.com/nix-community/nh/compare/v4.2.0...v4.3.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
