### PR TITLE
logstalgia: fix build with boost 1.89

### DIFF
--- a/pkgs/by-name/lo/logstalgia/package.nix
+++ b/pkgs/by-name/lo/logstalgia/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   SDL2,
   ftgl,
+  autoreconfHook,
   pkg-config,
   libpng,
   libjpeg,
@@ -27,7 +28,18 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-wEnv9AXpJANSIu2ya8xse18AoIkmq9t7Rn4kSSQnkKk=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  postPatch = ''
+    # Fix build with boost 1.89
+    rm m4/ax_boost_system.m4
+    substituteInPlace configure.ac \
+      --replace-fail "AX_BOOST_SYSTEM" ""
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
   buildInputs = [
     glew
     SDL2


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/485826

Upstream has a commit fixing this; however, it includes unrelated changes and a version bump despite no official release being available. Using substituteInPlace is a cleaner, more targeted solution for now and will be removed cleanly once the next version is officially released.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
