### PR TITLE
flac2mp3: init at 1.0.1

### DIFF
--- a/pkgs/by-name/fl/flac2mp3/package.nix
+++ b/pkgs/by-name/fl/flac2mp3/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  makeWrapper,
+  perl,
+  perlPackages,
+  flac,
+  lame,
+}:
+
+let
+  runtimeDeps = [
+    flac
+    lame
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "flac2mp3";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "robinbowes";
+    repo = "flac2mp3";
+    tag = finalAttrs.version;
+    hash = "sha256-mzZAlCMQYcKEkeJ0464zE1+F5KwA9IjvAbx6aZVCaxI=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/sktt/flac2mp3/commit/c81cb6f300445f2383562991b35d8622197635d7.patch";
+      hash = "sha256-vLXo+PfRQ97cNQnMoBrxA7K35C1EdedXXSL8wmWpPOs=";
+    })
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ perl ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp -r lib/* $out/lib/
+    install -Dm755 flac2mp3.pl $out/bin/flac2mp3
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/flac2mp3 \
+      --prefix PERL5LIB : "$out/lib" \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.passthru.runtimeDeps}
+  '';
+
+  passthru = {
+    inherit runtimeDeps;
+  };
+
+  meta = {
+    mainProgram = "flac2mp3";
+    description = "Tool to convert audio files from flac to mp3 format including the copying of tags";
+    homepage = "https://github.com/robinbowes/flac2mp3";
+    changelog = "https://github.com/robinbowes/flac2mp3/releases/tag/${finalAttrs.version}";
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ lilahummel ];
+  };
+})


### PR DESCRIPTION

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
