### PR TITLE
quint: 0.30.0 -> 0.31.0

### DIFF
--- a/pkgs/by-name/qu/quint/package.nix
+++ b/pkgs/by-name/qu/quint/package.nix
@@ -14,12 +14,13 @@
   gnugrep,
   nix-update,
   common-updater-scripts,
+  libiconv,
 }:
 
 let
-  version = "0.30.0";
+  version = "0.31.0";
   apalacheVersion = "0.51.1";
-  evaluatorVersion = "0.4.0";
+  evaluatorVersion = "0.5.0";
 
   metaCommon = {
     description = "Formal specification language with TLA+ semantics";
@@ -33,7 +34,7 @@ let
     owner = "informalsystems";
     repo = "quint";
     tag = "v${version}";
-    hash = "sha256-4gZUGw5T4iVbg7IWkXXIpSib/dPVXhK6Srt1kNewPGA=";
+    hash = "sha256-d1iCkpUh5z+Gr2AbjpyfwiR4XZ6vYk96UHCeippC6iw=";
   };
 
   # Build the Quint CLI from source
@@ -43,7 +44,7 @@ let
 
     sourceRoot = "${src.name}/quint";
 
-    npmDepsHash = "sha256-qmekskqCePyI/k1AaBRVfc6q6SQNCA4K61E6GxfsAUI=";
+    npmDepsHash = "sha256-UZbATCXqyAulEX+oxLEsT5VPm7y4NiCgnAwyugbzc9g=";
 
     npmBuildScript = "compile";
 
@@ -75,7 +76,11 @@ let
     # Skip tests during build, as many rust tests rely on the Quint CLI
     doCheck = false;
 
-    cargoHash = "sha256-beWqUDaWWCbGL+V1LNtf35wZrIqWCCbFLYo5HCZF7FI=";
+    buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+      libiconv
+    ];
+
+    cargoHash = "sha256-aGVs/J+lAPHOsi01xShfZHBeUjd6eONpraNuMkaVfO8=";
 
     meta = metaCommon // {
       description = "Evaluator for the Quint formal specification language";
@@ -132,7 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
       })
       (writeShellScript "update" ''
         src=$(nix build --print-out-paths --no-link .#quint.src)
-        QUINT_EVALUATOR_VERSION=$(${lib.getExe gnugrep} -m1 "const QUINT_EVALUATOR_VERSION" $src/quint/src/quintRustWrapper.ts | sed -E "s/.*= 'v?([^']+)'.*/\1/")
+        QUINT_EVALUATOR_VERSION=$(${lib.getExe gnugrep} -m1 "const QUINT_EVALUATOR_VERSION" $src/quint/src/rust/binaryManager.ts | sed -E "s/.*= 'v?([^']+)'.*/\1/")
         ${lib.getExe nix-update} quint.quint-evaluator --version $QUINT_EVALUATOR_VERSION
         DEFAULT_APALACHE_VERSION_TAG=$(${lib.getExe gnugrep} "DEFAULT_APALACHE_VERSION_TAG" $src/quint/src/apalache.ts | sed -E "s/.*= '([^']+)'.*/\1/")
         ${lib.getExe' common-updater-scripts "update-source-version"} quint $DEFAULT_APALACHE_VERSION_TAG --version-key=apalacheVersion --source-key=apalacheDist --ignore-same-version --ignore-same-hash


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/informalsystems/quint/releases/tag/v0.31.0

I updated the `updateScript` since we changed the name of a file from the Quint codebase that is read by it.

I also added two dependencies that are necessary for MacOS, as I heard reports that this package was not working on MacOS. I'll get people to test this on Mac for me this time (update: they tested, it works).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
