### PR TITLE
perl-language-server: init at 2.6.2

### DIFF
--- a/pkgs/by-name/pe/perl-language-server/package.nix
+++ b/pkgs/by-name/pe/perl-language-server/package.nix
@@ -1,0 +1,63 @@
+{
+  fetchFromGitHub,
+  lib,
+  makeBinaryWrapper,
+  perl,
+  perlPackages,
+}:
+
+perlPackages.buildPerlPackage rec {
+  pname = "perl-language-server";
+  version = "2.6.2";
+
+  src = fetchFromGitHub {
+    owner = "richterger";
+    repo = "Perl-LanguageServer";
+    tag = "V${version}";
+    hash = "sha256-sd3q6QONg3uNiASi+iSZJI/mTAENRZZI3FPtegjkMrc=";
+  };
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+  buildInputs = with perlPackages; [
+    AnyEvent
+    AnyEventAIO
+    ClassRefresh
+    CompilerLexer
+    Coro
+    DataDump
+    IOAIO
+    JSON
+    Moose
+    PadWalker
+    ScalarListUtils
+  ];
+
+  doCheck = false; # Flaky due to Coro/AnyEvent/IO::AIO in sandbox
+
+  postInstall = ''
+    mainProgramPath="$out"/bin/${meta.mainProgram}
+    mkdir -p "$out"/bin
+    cat > "$mainProgramPath" <<'EOF'
+    #!${lib.getExe perl}
+    use strict;
+    use warnings;
+    use Perl::LanguageServer;
+    Perl::LanguageServer->run(@ARGV);
+    EOF
+
+    chmod +x "$mainProgramPath"
+    wrapProgram "$mainProgramPath" \
+      --prefix PERL5LIB : "${perlPackages.makeFullPerlPath buildInputs}" \
+      --prefix PERL5LIB : "$out/lib/perl5/site_perl/5.42.0"
+  '';
+
+  meta = {
+    description = "Language Server for Perl";
+    homepage = "https://github.com/richterger/Perl-LanguageServer";
+    changelog = "https://github.com/richterger/Perl-LanguageServer/blob/${src.tag}/Changes.pod";
+    license = lib.licenses.artistic2;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "perl-language-server";
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
