### PR TITLE
python3Packages.devpi-{server,ldap,common,client}: fixes

### DIFF
--- a/pkgs/by-name/de/devpi-client/package.nix
+++ b/pkgs/by-name/de/devpi-client/package.nix
@@ -43,6 +43,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ++ (with python3.pkgs; [
     mercurial
     mock
+    packaging-legacy
     pypitoken
     pytestCheckHook
     sphinx

--- a/pkgs/by-name/de/devpi-server/package.nix
+++ b/pkgs/by-name/de/devpi-server/package.nix
@@ -1,0 +1,4 @@
+{ python3Packages }:
+
+with python3Packages;
+toPythonApplication devpi-server

--- a/pkgs/development/python-modules/devpi-common/default.nix
+++ b/pkgs/development/python-modules/devpi-common/default.nix
@@ -2,14 +2,18 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   lazy,
+  requests,
+  tomli,
+
+  # tests
   packaging-legacy,
   pytestCheckHook,
-  requests,
-  setuptools-changelog-shortener,
-  setuptools,
-  tomli,
-  nix-update-script,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -24,25 +28,29 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-YFY2iLnORzFxnfGYU2kCpJL8CZi+lALIkL1bRpfd4NE=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"setuptools_changelog_shortener",' ""
+  '';
+
   sourceRoot = "${finalAttrs.src.name}/common";
 
   build-system = [
     setuptools
-    setuptools-changelog-shortener
   ];
 
   dependencies = [
     lazy
-    packaging-legacy
     requests
     tomli
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    packaging-legacy
+  ];
 
   pythonImportsCheck = [ "devpi_common" ];
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/devpi/devpi";

--- a/pkgs/development/python-modules/devpi-ldap/default.nix
+++ b/pkgs/development/python-modules/devpi-ldap/default.nix
@@ -1,17 +1,21 @@
 {
   lib,
   buildPythonPackage,
-  devpi-server,
   fetchFromGitHub,
-  ldap3,
-  mock,
-  pytest-cov-stub,
-  pytestCheckHook,
-  pythonOlder,
-  pythonAtLeast,
-  pyyaml,
+
+  # build-system
   setuptools,
-  setuptools-changelog-shortener,
+
+  # dependencies
+  devpi-server,
+  ldap3,
+  pyyaml,
+
+  # tests
+  packaging-legacy,
+  pytest-cov-stub,
+  pytest-mock,
+  pytestCheckHook,
   webtest,
 }:
 
@@ -20,9 +24,6 @@ buildPythonPackage (finalAttrs: {
   version = "2.1.1-unstable-2026-01-22";
   pyproject = true;
 
-  # build-system broken for 3.14, package incompatible <3.13
-  disabled = pythonOlder "3.13" || pythonAtLeast "3.14";
-
   src = fetchFromGitHub {
     owner = "devpi";
     repo = "devpi-ldap";
@@ -30,26 +31,32 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-2LpreWmG6WMRrc5L7ylSej5Ce6VhfNDAW2eoJ76D49o=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"setuptools_changelog_shortener",' ""
+  '';
+
   build-system = [
     setuptools
-    setuptools-changelog-shortener
   ];
 
   dependencies = [
     devpi-server
-    pyyaml
     ldap3
+    pyyaml
   ];
 
   nativeCheckInputs = [
-    devpi-server
-    mock
+    packaging-legacy
     pytest-cov-stub
+    pytest-mock
     pytestCheckHook
     webtest
   ];
 
   pythonImportsCheck = [ "devpi_ldap" ];
+
+  passthru.skipBulkUpdate = true; # avoid reversion to previous stable version
 
   meta = {
     description = "LDAP authentication for devpi-server";

--- a/pkgs/development/python-modules/devpi-server/default.nix
+++ b/pkgs/development/python-modules/devpi-server/default.nix
@@ -1,37 +1,45 @@
 {
   lib,
   fetchFromGitHub,
-  buildPythonApplication,
-  gitUpdater,
+  buildPythonPackage,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   aiohttp,
   appdirs,
-  beautifulsoup4,
   defusedxml,
   devpi-common,
   execnet,
+  httpx,
   itsdangerous,
-  nginx,
   packaging,
   passlib,
   platformdirs,
   pluggy,
   py,
-  httpx,
   pyramid,
-  pytest-asyncio,
-  pytestCheckHook,
   repoze-lru,
-  setuptools,
-  setuptools-changelog-shortener,
   strictyaml,
   waitress,
+
+  # tests
+  beautifulsoup4,
+  nginx,
+  packaging-legacy,
+  pytest-asyncio,
+  pytestCheckHook,
   webtest,
-  testers,
+
+  # passthru
   devpi-server,
+  gitUpdater,
   nixosTests,
+  testers,
 }:
 
-buildPythonApplication (finalAttrs: {
+buildPythonPackage (finalAttrs: {
   pname = "devpi-server";
   version = "6.19.1";
   pyproject = true;
@@ -43,11 +51,15 @@ buildPythonApplication (finalAttrs: {
     hash = "sha256-YFY2iLnORzFxnfGYU2kCpJL8CZi+lALIkL1bRpfd4NE=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"setuptools_changelog_shortener",' ""
+  '';
+
   sourceRoot = "${finalAttrs.src.name}/server";
 
   build-system = [
     setuptools
-    setuptools-changelog-shortener
   ];
 
   dependencies = [
@@ -56,25 +68,25 @@ buildPythonApplication (finalAttrs: {
     defusedxml
     devpi-common
     execnet
+    httpx
     itsdangerous
     packaging
     passlib
     platformdirs
     pluggy
+    py
     pyramid
     repoze-lru
     setuptools
     strictyaml
     waitress
-    py
-    httpx
   ]
   ++ passlib.optional-dependencies.argon2;
 
   nativeCheckInputs = [
     beautifulsoup4
     nginx
-    py
+    packaging-legacy
     pytest-asyncio
     pytestCheckHook
     webtest

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3822,8 +3822,6 @@ with pkgs;
     llvmPackages = crystal.llvmPackages;
   };
 
-  devpi-server = python3Packages.callPackage ../development/tools/devpi-server { };
-
   dprint-plugins = recurseIntoAttrs (callPackage ../by-name/dp/dprint/plugins { });
 
   reaction-plugins = reaction.passthru.plugins;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3856,6 +3856,8 @@ self: super: with self; {
 
   devpi-ldap = callPackage ../development/python-modules/devpi-ldap { };
 
+  devpi-server = callPackage ../development/python-modules/devpi-server { };
+
   devtools = callPackage ../development/python-modules/devtools { };
 
   dfdiskcache = callPackage ../development/python-modules/dfdiskcache { };


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/321712858

Fixes #494500 (strange bug where building on 3.13 worked, but no other version did)

1. Split `devpi-server` into a python library and an entry in `pkgs/by-name`. Rationale: `devpi-server` is a ~~floor wax and a dessert topping~~ [library with a standalone CLI](https://devpi.net/docs/devpi/devpi/stable/%2Bd/index.html), was built using `buildPythonApplication`, and was failing to be found as a runtime dependency. Packaging it as a library with a standalone CLI app solved the issue.
2. `python3Packages.devpi-ldap` was having missing dependency issues with build system file `setuptools_changelog_shortener`. Since we're not PyPi, we don't need to embed a generated changelog file. Patched out.
3. Stubbed out code coverage reports.
4. Since we're on pytest, `mock` -> `pytest-mock`
5. Since this is shipping from unstable, disabled the bulk python updater script (these scripts have a tendency to revert packages to the base stable version).
6. Added `packaging-legacy` so each part will complete passthru tests.

Python 3.14 tracker: #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
