### PR TITLE
music-assistant: 2.7.8 -> 2.7.9

### DIFF
--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -47,14 +47,14 @@ assert
 
 python.pkgs.buildPythonApplication rec {
   pname = "music-assistant";
-  version = "2.7.8";
+  version = "2.7.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "server";
     tag = version;
-    hash = "sha256-o17H8cmMC8szh/hfgdq0JWCPh45TkrhuXOikr+DcBw8=";
+    hash = "sha256-c6WTalpjaZcUvppyYaTP03ErX5b+k7fUbphj58FVBS8=";
   };
 
   patches = [

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -1,7 +1,7 @@
 # Do not edit manually, run ./update-providers.py
 
 {
-  version = "2.7.8";
+  version = "2.7.9";
   providers = {
     airplay =
       ps: with ps; [

--- a/pkgs/development/python-modules/aiosendspin/default.nix
+++ b/pkgs/development/python-modules/aiosendspin/default.nix
@@ -55,6 +55,9 @@ buildPythonPackage rec {
     "aiosendspin"
   ];
 
+  # needs manual compat testing with music-assistant (sendspin provider)
+  passthru.skipBulkUpdate = true; # nixpkgs-update: no auto update
+
   meta = {
     changelog = "https://github.com/Sendspin/aiosendspin/releases/tag/${src.tag}";
     description = "Async Python library implementing the Sendspin Protocol";

--- a/pkgs/development/python-modules/aiosendspin/default.nix
+++ b/pkgs/development/python-modules/aiosendspin/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "aiosendspin";
-  version = "3.0.1";
+  version = "2.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Sendspin";
     repo = "aiosendspin";
     tag = version;
-    hash = "sha256-Z0hQyJayA/8OR6nkKxd1HfjskX+WBBkBl7l8rleV+fo=";
+    hash = "sha256-9VhNtfXH2r/cGkscz51PIK2/66pPOGv0S0IpO0wFvO4=";
   };
 
   # https://github.com/Sendspin/aiosendspin/blob/1.2.0/pyproject.toml#L7


### PR DESCRIPTION
https://github.com/music-assistant/server/releases/tag/2.7.9

diff: https://github.com/music-assistant/server/compare/2.7.8...2.7.9


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
