### PR TITLE
fwupd: 2.0.19 -> 2.1.1

### DIFF
--- a/nixos/tests/installed-tests/fwupd.nix
+++ b/nixos/tests/installed-tests/fwupd.nix
@@ -7,9 +7,6 @@ makeInstalledTest {
   testRunnerFlags = [ "--timeout=1200" ];
 
   testConfig = {
-    # for easier debugging
-    systemd.globalEnvironment.FWUPD_VERBOSE = "1";
-
     services.fwupd = {
       enable = true;
       daemonSettings.TestDevices = true;

--- a/nixos/tests/installed-tests/fwupd.nix
+++ b/nixos/tests/installed-tests/fwupd.nix
@@ -3,7 +3,13 @@
 makeInstalledTest {
   tested = pkgs.fwupd;
 
+  # same as fwupd upstream CI
+  testRunnerFlags = [ "--timeout=1200" ];
+
   testConfig = {
+    # for easier debugging
+    systemd.globalEnvironment.FWUPD_VERBOSE = "1";
+
     services.fwupd = {
       enable = true;
       daemonSettings.TestDevices = true;

--- a/pkgs/by-name/fw/fwupd/0001-Install-fwupdplugin-to-out.patch
+++ b/pkgs/by-name/fw/fwupd/0001-Install-fwupdplugin-to-out.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] Install fwupdplugin to out
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index b711ab04b..7b065f278 100644
+index 1a56d3308..c7bf2c9aa 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -734,7 +734,7 @@ if build_standalone

--- a/pkgs/by-name/fw/fwupd/0002-Add-output-for-installed-tests.patch
+++ b/pkgs/by-name/fw/fwupd/0002-Add-output-for-installed-tests.patch
@@ -24,11 +24,11 @@ index e15cab2fa..bad033dbf 100644
  
  if umockdev_integration_tests.allowed()
 diff --git a/meson.build b/meson.build
-index 7b065f278..1a4b0ea1f 100644
+index c7bf2c9aa..bf77bf6d6 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -239,8 +239,8 @@ else
-   datadir = join_paths(prefix, get_option('datadir'))
+@@ -241,8 +241,8 @@ else
+   includedir = join_paths(prefix, get_option('includedir'))
    sysconfdir = join_paths(prefix, get_option('sysconfdir'))
    localstatedir = join_paths(prefix, get_option('localstatedir'))
 -  installed_test_bindir = join_paths(libexecdir, 'installed-tests', meson.project_name())
@@ -47,10 +47,10 @@ index 7b065f278..1a4b0ea1f 100644
  conf.set_quoted('FWUPD_LIBDIR', libdir)
  conf.set_quoted('FWUPD_LIBEXECDIR', libexecdir)
 diff --git a/meson_options.txt b/meson_options.txt
-index 18991b983..937578f19 100644
+index eb57391eb..420997355 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -197,6 +197,11 @@ option(
+@@ -198,6 +198,11 @@ option(
    value: 'fwupd-refresh',
    description: 'User account to use for fwupd-refresh.service (empty for DynamicUser)',
  )

--- a/pkgs/by-name/fw/fwupd/0003-Add-option-for-installation-sysconfdir.patch
+++ b/pkgs/by-name/fw/fwupd/0003-Add-option-for-installation-sysconfdir.patch
@@ -6,13 +6,13 @@ Subject: [PATCH] Add option for installation sysconfdir
 ---
  data/bios-settings.d/meson.build |  2 +-
  data/meson.build                 |  2 +-
- data/pki/meson.build             |  8 ++++----
+ data/pki/meson.build             |  4 ++--
  data/remotes.d/meson.build       |  8 ++++----
  docs/meson.build                 | 16 ++++++++--------
  meson.build                      |  6 ++++++
  meson_options.txt                |  6 ++++++
  plugins/uefi-capsule/meson.build |  4 ++--
- 8 files changed, 32 insertions(+), 20 deletions(-)
+ 8 files changed, 30 insertions(+), 18 deletions(-)
 
 diff --git a/data/bios-settings.d/meson.build b/data/bios-settings.d/meson.build
 index 2a2a07016..99df55afb 100644
@@ -27,7 +27,7 @@ index 2a2a07016..99df55afb 100644
    )
  endif
 diff --git a/data/meson.build b/data/meson.build
-index 5716669f0..78e754f40 100644
+index 70d08c55e..5a5d8bf46 100644
 --- a/data/meson.build
 +++ b/data/meson.build
 @@ -29,7 +29,7 @@ if build_standalone
@@ -40,25 +40,10 @@ index 5716669f0..78e754f40 100644
    )
    plugin_quirks += files('cfi.quirk', 'ds20.quirk', 'power.quirk', 'vendors.quirk')
 diff --git a/data/pki/meson.build b/data/pki/meson.build
-index 1072051c0..6ef9c9111 100644
+index b87068405..21f59753a 100644
 --- a/data/pki/meson.build
 +++ b/data/pki/meson.build
-@@ -12,12 +12,12 @@ if supported_gpg
-   install_data(
-     ['GPG-KEY-Linux-Foundation-Firmware', 'GPG-KEY-Linux-Vendor-Firmware-Service'],
-     install_tag: 'runtime',
--    install_dir: join_paths(sysconfdir, 'pki', 'fwupd'),
-+    install_dir: join_paths(sysconfdir_install, 'pki', 'fwupd'),
-   )
-   install_data(
-     ['GPG-KEY-Linux-Foundation-Metadata', 'GPG-KEY-Linux-Vendor-Firmware-Service'],
-     install_tag: 'runtime',
--    install_dir: join_paths(sysconfdir, 'pki', 'fwupd-metadata'),
-+    install_dir: join_paths(sysconfdir_install, 'pki', 'fwupd-metadata'),
-   )
- endif
- 
-@@ -25,11 +25,11 @@ if supported_pkcs7
+@@ -8,11 +8,11 @@ if supported_pkcs7
    install_data(
      ['LVFS-CA.pem', 'LVFS-CA-2025PQ.pem'],
      install_tag: 'runtime',
@@ -111,7 +96,7 @@ index b8d24c267..0dd4ad32a 100644
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
 diff --git a/docs/meson.build b/docs/meson.build
-index 787b4387c..b3144757f 100644
+index b4d48b086..8a1f8fc8c 100644
 --- a/docs/meson.build
 +++ b/docs/meson.build
 @@ -196,7 +196,7 @@ if build_docs
@@ -123,7 +108,7 @@ index 787b4387c..b3144757f 100644
    )
  
    subdir('hsi-tests.d')
-@@ -247,7 +247,7 @@ if build_docs
+@@ -257,7 +257,7 @@ if build_docs
      build_by_default: true,
      install: true,
      install_tag: 'doc',
@@ -132,7 +117,7 @@ index 787b4387c..b3144757f 100644
    )
    man_cmd = []
    foreach man : man_md
-@@ -260,36 +260,36 @@ if build_docs
+@@ -270,36 +270,36 @@ if build_docs
      command: [generate_index, '@INPUT@', '-o', '@OUTPUT@', man_cmd],
      install: true,
      install_tag: 'doc',
@@ -176,10 +161,10 @@ index 787b4387c..b3144757f 100644
    )
  endif
 diff --git a/meson.build b/meson.build
-index 1a4b0ea1f..16c7cad40 100644
+index bf77bf6d6..f1f51e841 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -246,6 +246,12 @@ endif
+@@ -248,6 +248,12 @@ endif
  mandir = join_paths(prefix, get_option('mandir'))
  localedir = join_paths(prefix, get_option('localedir'))
  
@@ -193,7 +178,7 @@ index 1a4b0ea1f..16c7cad40 100644
  gio = dependency(
    'gio-2.0',
 diff --git a/meson_options.txt b/meson_options.txt
-index 937578f19..08b26b3ad 100644
+index 420997355..67b3058d5 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -14,6 +14,12 @@ option(
@@ -210,7 +195,7 @@ index 937578f19..08b26b3ad 100644
    'build',
    type: 'combo',
 diff --git a/plugins/uefi-capsule/meson.build b/plugins/uefi-capsule/meson.build
-index 647ace53e..4ee0192df 100644
+index f104f36d7..30356ea53 100644
 --- a/plugins/uefi-capsule/meson.build
 +++ b/plugins/uefi-capsule/meson.build
 @@ -23,7 +23,7 @@ if host_machine.system() == 'linux'

--- a/pkgs/by-name/fw/fwupd/0004-Get-the-efi-app-from-fwupd-efi.patch
+++ b/pkgs/by-name/fw/fwupd/0004-Get-the-efi-app-from-fwupd-efi.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] Get the efi app from fwupd-efi
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index 16c7cad40..81804bf3b 100644
+index f1f51e841..aaefe55d9 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -657,7 +657,7 @@ endif
+@@ -646,7 +646,7 @@ endif
  
  # EFI
  if build_standalone

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -263,6 +263,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "sysconfdir_install" "${placeholder "out"}/etc")
     (lib.mesonOption "efi_os_dir" "nixos")
     (lib.mesonEnable "plugin_modem_manager" true)
+    # HSI is auto-disabled on non-x86 upstream; auto_features=enabled overrides
+    # that, breaking the fwupdtool installed test which expects rc=1 on non-x86.
+    (lib.mesonEnable "hsi" isx86)
     (lib.mesonBool "vendor_metadata" true)
     (lib.mesonBool "plugin_uefi_capsule_splash" false)
     # TODO: what should this be?

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -17,9 +17,6 @@
   pkg-config,
   pkgsBuildBuild,
 
-  # propagatedBuildInputs
-  json-glib,
-
   # nativeBuildInputs
   ensureNewerSourcesForZipFilesHook,
   gettext,
@@ -27,8 +24,6 @@
   gobject-introspection,
   meson,
   ninja,
-  protobuf,
-  protobufc,
   shared-mime-info,
   vala,
   wrapGAppsNoGuiHook,
@@ -42,7 +37,6 @@
   fwupd-efi,
   gnutls,
   gusb,
-  libarchive,
   libcbor,
   libdrm,
   libgudev,
@@ -135,7 +129,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fwupd";
-  version = "2.0.19";
+  version = "2.1.1";
 
   # libfwupd goes to lib
   # daemon, plug-ins and libfwupdplugin go to out
@@ -153,7 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "fwupd";
     repo = "fwupd";
     tag = finalAttrs.version;
-    hash = "sha256-DjO+7CEOef5KMbYEPtDr3GrnXTDUO/jwwZ4P17o4oDg=";
+    hash = "sha256-pb5BBA+3KTeZZ8WyNDaY9EKNTxp4MT/3G/MEgQ+Nysk=";
   };
 
   patches = [
@@ -174,6 +168,18 @@ stdenv.mkDerivation (finalAttrs: {
 
     # EFI capsule is located in fwupd-efi now.
     ./0004-Get-the-efi-app-from-fwupd-efi.patch
+
+    # FIXME: remove patches that fix CI on aarch64 after next release
+    (fetchpatch {
+      url = "https://github.com/fwupd/fwupd/commit/b3d721360faa4de7dd6960d8f9f8f13aa310715f.patch";
+      sha256 = "sha256-x37QCK7XBzUUjUj1m3jaNe1qvaqtszB9DGFyF8gC3Ig=";
+      name = "fix-mtdram-test-for-missing-kernel-module.patch";
+    })
+    (fetchpatch {
+      url = "https://github.com/fwupd/fwupd/commit/9ad8b76dc6c5af005a2c712ae3a6f352b51e9eea.patch";
+      sha256 = "sha256-h9zLTHeJbfDoamdfICKc0ohQ51yJC4I/CK0SQ4H6rRk=";
+      name = "fix-test_get_devices-on-non-x86-architectures.patch";
+    })
   ];
 
   postPatch = ''
@@ -197,10 +203,6 @@ stdenv.mkDerivation (finalAttrs: {
     (pkgsBuildBuild.callPackage ./build-time-python.nix { })
   ];
 
-  propagatedBuildInputs = [
-    json-glib
-  ];
-
   nativeBuildInputs = [
     ensureNewerSourcesForZipFilesHook # required for firmware zipping
     gettext
@@ -210,8 +212,6 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    protobuf # for protoc
-    protobufc # for protoc-gen-c
     shared-mime-info
     vala
     wrapGAppsNoGuiHook
@@ -230,7 +230,6 @@ stdenv.mkDerivation (finalAttrs: {
     fwupd-efi
     gnutls
     gusb
-    libarchive
     libcbor
     libdrm
     libgudev
@@ -243,7 +242,6 @@ stdenv.mkDerivation (finalAttrs: {
     modemmanager
     pango
     polkit
-    protobufc
     readline
     sqlite
     tpm2-tss
@@ -359,12 +357,8 @@ stdenv.mkDerivation (finalAttrs: {
       "fwupd/remotes.d/lvfs.conf"
       "fwupd/remotes.d/vendor.conf"
       "fwupd/remotes.d/vendor-directory.conf"
-      "pki/fwupd/GPG-KEY-Linux-Foundation-Firmware"
-      "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"
       "pki/fwupd/LVFS-CA-2025PQ.pem"
       "pki/fwupd/LVFS-CA.pem"
-      "pki/fwupd-metadata/GPG-KEY-Linux-Foundation-Metadata"
-      "pki/fwupd-metadata/GPG-KEY-Linux-Vendor-Firmware-Service"
       "pki/fwupd-metadata/LVFS-CA-2025PQ.pem"
       "pki/fwupd-metadata/LVFS-CA.pem"
       "grub.d/35_fwupd"


### PR DESCRIPTION
Also remove unused input.

Diff: https://github.com/fwupd/fwupd/compare/2.0.19...2.0.20

Changelog: https://github.com/fwupd/fwupd/releases/tag/2.0.20


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
