### PR TITLE
python3Packages.sqlacodegen: init at 4.0.4

### DIFF
--- a/pkgs/development/python-modules/sqlacodegen/default.nix
+++ b/pkgs/development/python-modules/sqlacodegen/default.nix
@@ -1,0 +1,66 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  geoalchemy2,
+  inflect,
+  lib,
+  mysql-connector,
+  nix-update-script,
+  pgvector,
+  psycopg,
+  pytestCheckHook,
+  setuptools-scm,
+  sqlalchemy-citext,
+  sqlalchemy,
+  sqlmodel,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "sqlacodegen";
+  version = "4.0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "agronholm";
+    repo = "sqlacodegen";
+    tag = finalAttrs.version;
+    hash = "sha256-iiSYgGzSKDN6ivrAI0Ow5e1nCqtJMLtoM9pTkCKE65M=";
+  };
+
+  build-system = [ setuptools-scm ];
+
+  dependencies = [
+    inflect
+    sqlalchemy
+  ];
+
+  nativeBuildInputs = [
+    geoalchemy2
+    pgvector
+    sqlalchemy-citext
+    sqlmodel
+  ];
+
+  nativeCheckInputs = [
+    mysql-connector
+    psycopg
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "sqlacodegen" ];
+
+  preCheck = ''
+    export PATH="$out/bin:$PATH"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Reads the structure of an existing database and generates the appropriate SQLAlchemy model code";
+    homepage = "https://github.com/agronholm/sqlacodegen";
+    changelog = "https://github.com/agronholm/sqlacodegen/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gaelj ];
+    mainProgram = "sqlacodegen";
+  };
+})

--- a/pkgs/development/python-modules/sqlacodegen/default.nix
+++ b/pkgs/development/python-modules/sqlacodegen/default.nix
@@ -1,0 +1,68 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  geoalchemy2,
+  inflect,
+  lib,
+  mysql-connector-python,
+  nix-update-script,
+  pgvector,
+  psycopg,
+  pytestCheckHook,
+  setuptools-scm,
+  sqlalchemy-citext,
+  sqlalchemy,
+  sqlmodel,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "sqlacodegen";
+  version = "4.0.4";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "agronholm";
+    repo = "sqlacodegen";
+    tag = finalAttrs.version;
+    hash = "sha256-ZNlMqFmj2vVlhfo9EooQNYH8pRmsqCov9CGtm2xBzC4=";
+  };
+
+  build-system = [ setuptools-scm ];
+
+  dependencies = [
+    inflect
+    sqlalchemy
+  ];
+
+  nativeBuildInputs = [
+    geoalchemy2
+    pgvector
+    sqlalchemy-citext
+    sqlmodel
+  ];
+
+  nativeCheckInputs = [
+    mysql-connector-python
+    psycopg
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "sqlacodegen" ];
+
+  preCheck = ''
+    export PATH="$out/bin:$PATH"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Reads the structure of an existing database and generates the appropriate SQLAlchemy model code";
+    homepage = "https://github.com/agronholm/sqlacodegen";
+    changelog = "https://github.com/agronholm/sqlacodegen/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gaelj ];
+    mainProgram = "sqlacodegen";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18398,6 +18398,8 @@ self: super: with self; {
 
   sqids = callPackage ../development/python-modules/sqids { };
 
+  sqlacodegen = callPackage ../development/python-modules/sqlacodegen { };
+
   sqlalchemy = callPackage ../development/python-modules/sqlalchemy { };
 
   sqlalchemy-citext = callPackage ../development/python-modules/sqlalchemy-citext { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19680,6 +19680,8 @@ self: super: with self; {
 
   sqids = callPackage ../development/python-modules/sqids { };
 
+  sqlacodegen = callPackage ../development/python-modules/sqlacodegen { };
+
   sqlalchemy = callPackage ../development/python-modules/sqlalchemy { };
 
   sqlalchemy-adapter = callPackage ../development/python-modules/sqlalchemy-adapter { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Changelog: https://github.com/agronholm/sqlacodegen/releases

```bash

 ./result/bin/sqlacodegen
You must supply a url

usage: sqlacodegen [-h] [--options OPTIONS] [--version] [--schemas SCHEMAS]
                   [--generator {dataclasses,declarative,sqlmodels,tables}] [--tables TABLES] [--noviews]
                   [--engine-arg ENGINE_ARG] [--outfile OUTFILE]
                   [url]

Generates SQLAlchemy model code from an existing database.

positional arguments:
  url                   SQLAlchemy url to the database

options:
  -h, --help            show this help message and exit
  --options OPTIONS     options (comma-delimited) passed to the generator class
  --version             print the version number and exit
  --schemas SCHEMAS     load tables from the given schemas (comma-delimited)
  --generator {dataclasses,declarative,sqlmodels,tables}
                        generator class to use
  --tables TABLES       tables to process (comma-delimited, default: all)
  --noviews             ignore views (always true for sqlmodels generator)
  --engine-arg ENGINE_ARG
                        engine arguments in key=value format, e.g., --engine-arg=connect_args='{"user": "scott"}'
                        --engine-arg thick_mode=true or --engine-arg thick_mode='{"lib_dir": "/path"}' (values are
                        parsed with ast.literal_eval)
  --outfile OUTFILE     file to write output to (default: stdout)
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
