### PR TITLE
[25.11] netexec: apply patch for CVE-2026-27884

### DIFF
--- a/pkgs/by-name/ne/netexec/package.nix
+++ b/pkgs/by-name/ne/netexec/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   python312,
   writableTmpDirAsHomeHook,
 }:
@@ -43,6 +44,14 @@ python.pkgs.buildPythonApplication rec {
   pythonRemoveDeps = [
     # Fail to detect dev version requirement
     "neo4j"
+  ];
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2026-27884.patch";
+      url = "https://github.com/Pennyw0rth/NetExec/commit/7d027f2774d0520b322d60f9c99b9ab3edb4035e.patch";
+      hash = "sha256-2iVQypHbjPSH4Tg+TTLHuGFdN1MGVXIvt1Lfgc1QqJw=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
Fixes #494755

Not-cherry-picked-because: unstable is using a different version and a different set of dependencies.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
