### PR TITLE
dart-source: don't clobber `passthru` elements

### DIFF
--- a/pkgs/development/compilers/dart/source/default.nix
+++ b/pkgs/development/compilers/dart/source/default.nix
@@ -247,9 +247,11 @@ dart-bin.overrideAttrs (oldAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = writeShellScript "update-dart" ''
-    ${lib.getExe nix-update} --version=$(${lib.getExe curlMinimal} --fail --location --silent https://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION | ${lib.getExe jq} --raw-output .version)
-  '';
+  passthru = oldAttrs.passthru // {
+    updateScript = writeShellScript "update-dart" ''
+      ${lib.getExe nix-update} --version=$(${lib.getExe curlMinimal} --fail --location --silent https://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION | ${lib.getExe jq} --raw-output .version)
+    '';
+  };
 
   meta = oldAttrs.meta // {
     platforms = [


### PR DESCRIPTION
Without the change `passthru` override deleted `fetchGitHashesScript` entry and caused updater scripts to fail:

```
$ nix-instantiate -A butterfly.updateScript
error:
       … while evaluating the attribute 'command'
         at pkgs/common-updater/combinators.nix:190:7:
          189|     {
          190|       command = commandsToShellInvocation (map ({ command, ... }: command) scripts);
             |       ^
          191|       supportedFeatures =

       … while evaluating the attribute 'paths'
         at pkgs/common-updater/combinators.nix:91:7:
           90|       commands = commands ++ [ new.args ];
           91|       paths = paths ++ new.paths;
             |       ^
           92|       maxArgIndex = new.maxArgIndex;

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'fetchGitHashesScript' missing
       at pkgs/by-name/bu/butterfly/package.nix:64:11:
           63|         command = [
           64|           dart.fetchGitHashesScript
             |           ^
           65|           "--input"
```

Let's use attribute merge instead.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
