### PR TITLE
gotosocial: build web assets from source

### DIFF
--- a/pkgs/by-name/go/gotosocial/package.nix
+++ b/pkgs/by-name/go/gotosocial/package.nix
@@ -1,28 +1,21 @@
 {
   lib,
-  fetchurl,
-  fetchFromCodeberg,
   buildGo124Module,
+  fetchFromCodeberg,
+  fetchYarnDeps,
+  nodejs,
+  yarn,
+  yarnConfigHook,
   nixosTests,
 }:
-let
-  owner = "superseriousbusiness";
-  repo = "gotosocial";
-
+buildGo124Module (finalAttrs: {
+  pname = "gotosocial";
   version = "0.21.0";
 
-  web-assets = fetchurl {
-    url = "https://codeberg.org/${owner}/${repo}/releases/download/v${version}/${repo}_${version}_web-assets.tar.gz";
-    hash = "sha256-eExVquNTXkvxg0SAR60kXi5mnROp+tHNO3os1K+rWzU=";
-  };
-in
-buildGo124Module rec {
-  inherit version;
-  pname = repo;
-
   src = fetchFromCodeberg {
-    inherit owner repo;
-    tag = "v${version}";
+    owner = "superseriousbusiness";
+    repo = "gotosocial";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ifSm3tV8P435v7WUS2BYXfVS3FHu9Axz3IQWGdTw3Bg=";
   };
 
@@ -31,17 +24,46 @@ buildGo124Module rec {
   ldflags = [
     "-s"
     "-w"
-    "-X main.Version=${version}"
+    "-X main.Version=${finalAttrs.version}"
   ];
 
   tags = [
     "kvformat"
   ];
 
+  nativeBuildInputs = [
+    nodejs
+    yarn
+    yarnConfigHook
+  ];
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/web/source/yarn.lock";
+    hash = "sha256-rfZxslIEoOTufENIvk8Eq5wzdD3rUpUP3wrMjmLH44k=";
+  };
+
+  # manually calling yarnConfigHook in sub-directory
+  dontYarnInstallDeps = true;
+
+  postConfigure = ''
+    pushd ./web/source
+    runHook yarnConfigHook
+    popd
+  '';
+
+  # preparing assets
+  # https://codeberg.org/superseriousbusiness/gotosocial/src/branch/main/.goreleaser.yml#L12
+  preBuild = ''
+    go run ./vendor/github.com/go-swagger/go-swagger/cmd/swagger generate spec --scan-models --exclude-deps -o web/assets/swagger.yaml
+    substituteInPlace web/assets/swagger.yaml --replace-fail "REPLACE_ME" "${finalAttrs.version}"
+    yarn --offline --cwd ./web/source ts-patch install
+    yarn --offline --cwd ./web/source build
+    ./scripts/bundle_licenses.sh
+  '';
+
   postInstall = ''
-    tar xf ${web-assets}
-    mkdir -p $out/share/gotosocial
-    mv web $out/share/gotosocial/
+    mkdir -p $out/share/gotosocial/web
+    mv web/{assets,template} $out/share/gotosocial/web
   '';
 
   # tests are working only on x86_64-linux
@@ -63,7 +85,7 @@ buildGo124Module rec {
 
   meta = {
     homepage = "https://gotosocial.org";
-    changelog = "https://codeberg.org/superseriousbusiness/gotosocial/releases/tag/v${version}";
+    changelog = "https://codeberg.org/superseriousbusiness/gotosocial/releases/tag/v${finalAttrs.version}";
     description = "Fast, fun, ActivityPub server, powered by Go";
     longDescription = ''
       ActivityPub social network server, written in Golang.
@@ -78,4 +100,4 @@ buildGo124Module rec {
     ];
     license = lib.licenses.agpl3Only;
   };
-}
+})


### PR DESCRIPTION
From https://github.com/NixOS/nixpkgs/pull/493993#issuecomment-3960980283
I diffed the directories with
```console
$ diff <(tree -a ~/Downloads/gotosocial_0.21.0_web-assets/) <(tree -a ./result/share/gotosocial/)
1,2c1
< /home/winston/Downloads/gotosocial_0.21.0_web-assets/
< ├── LICENSE
---
> ./result/share/gotosocial/
240c239
< 13 directories, 225 files
---
> 13 directories, 224 files
```
and everything but the extra LICENSE file is there. don't know if we should still ship that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
