### PR TITLE
seastar: init at 25.05.0

### DIFF
--- a/pkgs/by-name/se/seastar/package.nix
+++ b/pkgs/by-name/se/seastar/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  boost,
+  c-ares,
+  fmt_11,
+  lz4,
+  gnutls,
+  hwloc,
+  lksctp-tools,
+  yaml-cpp,
+  protobuf,
+  ragel,
+  valgrind,
+  openssl,
+  doxygen,
+  python3,
+  xfsprogs,
+  liburing,
+  useIoUring ? true,
+}:
+stdenv.mkDerivation rec {
+  pname = "seastar";
+  version = "25.05.0";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    ragel
+    valgrind
+    openssl
+    doxygen
+    python3
+  ];
+
+  buildInputs = [
+    boost
+    c-ares
+    fmt_11
+    lz4
+    gnutls
+    hwloc
+    lksctp-tools
+    yaml-cpp
+    protobuf
+    xfsprogs
+  ]
+  ++ lib.optional useIoUring liburing;
+
+  postPatch = ''
+    patchShebangs scripts
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail '$'"{CMAKE_INSTALL_PREFIX}/"'$'"{CMAKE_INSTALL_LIBDIR}" '$'"{CMAKE_INSTALL_FULL_LIBDIR}" \
+      --replace-fail "-I"'$'"{CMAKE_INSTALL_PREFIX}/"'$'"{CMAKE_INSTALL_INCLUDEDIR}" '$'"{CMAKE_INSTALL_FULL_INCLUDEDIR}"
+  '';
+
+  src = fetchFromGitHub {
+    owner = "scylladb";
+    repo = "seastar";
+    tag = "seastar-${version}";
+    hash = "sha256-d8n+razhGQZ9YV37Fp0RzKC0DHdwnohe87PgVSkymGA=";
+  };
+
+  cmakeFlags = lib.optional useIoUring (lib.cmakeBool "Seastar_IO_URING" true);
+
+  meta = with lib; {
+    description = "High performance server-side application framework";
+    homepage = "https://github.com/scylladb/seastar";
+    changelog = "https://github.com/scylladb/seastar/releases/tag/seastar-${src.tag}";
+    license = licenses.asl20;
+  };
+}


### PR DESCRIPTION
I have added the [seastar](https://github.com/scylladb/seastar/) package. A C++ framework for building high-performance applications using a thread-per-core architecture.



## Things done

I was going to use this for an application that I'm building, so I've tested that it works and that an application built with it technically starts, but I haven't tested a full application built with it. However, since everything builds fine, links fine and starts up fine, I'd assume it should work.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
