### PR TITLE
asyncapi: init at 6.0.0

### DIFF
--- a/pkgs/by-name/as/asyncapi/package.nix
+++ b/pkgs/by-name/as/asyncapi/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "asyncapi";
+  version = "6.0.0";
+
+  src = fetchFromGitHub {
+    owner = "asyncapi";
+    repo = "cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AvEzwUMXZZRexlcYbD4iW2GYmndN0usFxYJclXst57g=";
+  };
+
+  npmDepsHash = "sha256-f+1KRqPIufMoSv6pa7CAd8fvG8uigNjr6QE6leVCtUI=";
+
+  env.PUPPETEER_SKIP_DOWNLOAD = "true";
+
+  postPatch = ''
+    # The build script fetches AsyncAPI examples from the internet.
+    # Replace with a no-op since the CLI works without bundled examples.
+    mkdir -p assets/examples
+    echo '[]' > assets/examples/examples.json
+    substituteInPlace package.json \
+      --replace-fail "node scripts/fetch-asyncapi-example.js && " ""
+
+    # The logger tries to create a logs directory relative to __dirname,
+    # which ends up inside the read-only Nix store. Use a writable path instead.
+    substituteInPlace src/utils/logger.ts \
+      --replace-fail "path.join(__dirname, config.has('log.dir') ? config.get('log.dir') : 'logs')" \
+        "path.join(process.env.XDG_STATE_HOME || path.join(require('os').homedir(), '.local', 'state'), 'asyncapi', 'logs')" \
+      --replace-fail "fs.mkdirSync(logDir)" \
+        "fs.mkdirSync(logDir, { recursive: true })"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "CLI to work with your AsyncAPI files. You can validate them and in the future use a generator and even bootstrap a new file";
+    homepage = "https://www.asyncapi.com/tools/cli";
+    changelog = "https://github.com/asyncapi/cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ pmyjavec ];
+    mainProgram = "asyncapi";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
