### PR TITLE
xclicker: move icon to spec-compliant location, modernize

### DIFF
--- a/pkgs/by-name/xc/xclicker/package.nix
+++ b/pkgs/by-name/xc/xclicker/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "robiot";
     repo = "xclicker";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-zVbOfqh21+/41N3FcAFajcZCrQ8iNqedZjgNQO0Zj04=";
   };
 
@@ -39,12 +39,12 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
     install -Dm755 ./src/xclicker $out/bin/xclicker
     install -Dm644 $src/assets/xclicker.desktop $out/share/applications/xclicker.desktop
-    install -Dm644 $src/assets/icon.png $out/share/pixmaps/xclicker.png
+    install -Dm644 $src/assets/icon.png $out/share/icons/hicolor/256x256/apps/xclicker.png
     runHook postInstall
   '';
 
   meta = {
-    changelog = "https://github.com/robiot/xclicker/releases/tag/${finalAttrs.src.rev}";
+    changelog = "https://github.com/robiot/xclicker/releases/tag/${finalAttrs.src.tag}";
     description = "Fast gui autoclicker for x11 linux desktops";
     homepage = "https://xclicker.xyz/";
     license = lib.licenses.gpl3Only;


### PR DESCRIPTION
Part of #428824 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
