### PR TITLE
python3Packages.telethon: drop patches

### DIFF
--- a/pkgs/development/python-modules/telethon/default.nix
+++ b/pkgs/development/python-modules/telethon/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   openssl,
   rsa,
   pyaes,
@@ -23,22 +22,6 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-NMHJkSTGR3/tck0k97EfVN9f85PAWst+EZ6G7Tgrt5s=";
   };
-
-  patches = [
-    # https://github.com/LonamiWebs/Telethon/pull/4670
-    (fetchpatch {
-      url = "https://github.com/LonamiWebs/Telethon/commit/8e2a46568ef9193f5887aea1abf919ac4ca6d31e.patch";
-      name = "fix_async_test.patch";
-      hash = "sha256-oVpLnO4OxNam/mq945OskVEHkbS5TDSUXk/0xPHVv3I=";
-    })
-  ]
-  ++ lib.optionals (lib.versionOlder version "1.40.1") [
-    (fetchpatch {
-      url = "https://github.com/LonamiWebs/Telethon/commit/ae9c798e2c3648ff40dee1b3f371f5d66851642e.patch";
-      name = "fix_test_messages_test.patch";
-      hash = "sha256-8SJm8EE6w7zRQxt1NuTX6KP1MTYPiYO/maJ5tOA2I9w=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace telethon/crypto/libssl.py --replace-fail \


### PR DESCRIPTION
1.42.0 already includes this change.

```
> Running phase: patchPhase
> applying patch /nix/store/rk85kikh9rikv50r0w1ma47afszs7ka1-fix_async_test.patch
> patching file tests/telethon/test_helpers.py
> Reversed (or previously applied) patch detected!  Assume -R? [n]
> Apply anyway? [n]
> Skipping patch.
> 3 out of 3 hunks ignored -- saving rejects to file tests/telethon/test_helpers.py.rej
For full logs, run:
nix log /nix/store/jgii0vqywyidvnmjddr1s6xxdp0dkgia-python3.13-telethon-1.42.0.drv
```

also, why are we doing `lib.versionOlder` instead of just removing those patches?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
