### PR TITLE
devpi-web: init at 5.0.1

### DIFF
--- a/pkgs/development/python-modules/devpi-common/default.nix
+++ b/pkgs/development/python-modules/devpi-common/default.nix
@@ -6,7 +6,6 @@
   packaging-legacy,
   pytestCheckHook,
   requests,
-  setuptools-changelog-shortener,
   setuptools,
   tomli,
   nix-update-script,
@@ -26,9 +25,13 @@ buildPythonPackage (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/common";
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail ', "setuptools_changelog_shortener"' ""
+  '';
+
   build-system = [
     setuptools
-    setuptools-changelog-shortener
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/devpi-ldap/default.nix
+++ b/pkgs/development/python-modules/devpi-ldap/default.nix
@@ -8,10 +8,8 @@
   pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
-  pythonAtLeast,
   pyyaml,
   setuptools,
-  setuptools-changelog-shortener,
   webtest,
 }:
 
@@ -20,8 +18,8 @@ buildPythonPackage (finalAttrs: {
   version = "2.1.1-unstable-2026-01-22";
   pyproject = true;
 
-  # build-system broken for 3.14, package incompatible <3.13
-  disabled = pythonOlder "3.13" || pythonAtLeast "3.14";
+  # some transitive deps incompatible <3.12
+  disabled = pythonOlder "3.12";
 
   src = fetchFromGitHub {
     owner = "devpi";
@@ -30,9 +28,13 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-2LpreWmG6WMRrc5L7ylSej5Ce6VhfNDAW2eoJ76D49o=";
   };
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail ', "setuptools_changelog_shortener"' ""
+  '';
+
   build-system = [
     setuptools
-    setuptools-changelog-shortener
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/devpi-server/default.nix
+++ b/pkgs/development/python-modules/devpi-server/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  buildPythonApplication,
+  buildPythonPackage,
   gitUpdater,
   aiohttp,
   appdirs,
@@ -22,7 +22,6 @@
   pytestCheckHook,
   repoze-lru,
   setuptools,
-  setuptools-changelog-shortener,
   strictyaml,
   waitress,
   webtest,
@@ -31,7 +30,7 @@
   nixosTests,
 }:
 
-buildPythonApplication (finalAttrs: {
+buildPythonPackage (finalAttrs: {
   pname = "devpi-server";
   version = "6.19.1";
   pyproject = true;
@@ -45,9 +44,13 @@ buildPythonApplication (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/server";
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail ', "setuptools_changelog_shortener"' ""
+  '';
+
   build-system = [
     setuptools
-    setuptools-changelog-shortener
   ];
 
   dependencies = [
@@ -108,16 +111,16 @@ buildPythonApplication (finalAttrs: {
     "devpi_server"
   ];
 
+  # devpi uses a monorepo for server, common, client and web
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "server-";
+  };
+
   passthru.tests = {
     devpi-server = nixosTests.devpi-server;
     version = testers.testVersion {
       package = devpi-server;
     };
-  };
-
-  # devpi uses a monorepo for server, common, client and web
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "server-";
   };
 
   meta = {

--- a/pkgs/development/python-modules/devpi-web/default.nix
+++ b/pkgs/development/python-modules/devpi-web/default.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  attrs,
+  beautifulsoup4,
+  buildPythonPackage,
+  defusedxml,
+  devpi-common,
+  devpi-server,
+  docutils,
+  fetchFromGitHub,
+  nix-update-script,
+  pygments,
+  pyramid,
+  pyramid-chameleon,
+  pytest-cov-stub,
+  pytestCheckHook,
+  pythonAtLeast,
+  pythonOlder,
+  readme-renderer,
+  setuptools,
+  setuptools-changelog-shortener,
+  tomli,
+  webtest,
+  whoosh,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "devpi-web";
+  version = "5.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "devpi";
+    repo = "devpi";
+    tag = "web-${finalAttrs.version}";
+    hash = "sha256-p52uwkXeCPPsnD9BLfqEa8NK4bAfIdpYIzdNgmwucms=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/web";
+
+  build-system = [
+    setuptools
+    setuptools-changelog-shortener
+  ];
+
+  # build-system broken for 3.14, package incompatible <3.13
+  disabled = pythonOlder "3.13" || pythonAtLeast "3.14";
+
+  dependencies = [
+    attrs
+    beautifulsoup4
+    defusedxml
+    devpi-common
+    devpi-server
+    docutils
+    pygments
+    pyramid
+    pyramid-chameleon
+    readme-renderer
+    readme-renderer.optional-dependencies.md
+    tomli
+    whoosh
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    webtest
+  ];
+
+  pythonImportsCheck = [ "devpi_web" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/devpi/devpi";
+    description = "Web view for devpi-server";
+    changelog = "https://github.com/devpi/devpi/blob/${finalAttrs.src.tag}/common/CHANGELOG";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      confus
+    ];
+  };
+})

--- a/pkgs/development/python-modules/devpi-web/default.nix
+++ b/pkgs/development/python-modules/devpi-web/default.nix
@@ -8,17 +8,15 @@
   devpi-server,
   docutils,
   fetchFromGitHub,
-  nix-update-script,
+  gitUpdater,
   pygments,
   pyramid,
   pyramid-chameleon,
   pytest-cov-stub,
   pytestCheckHook,
-  pythonAtLeast,
   pythonOlder,
   readme-renderer,
   setuptools,
-  setuptools-changelog-shortener,
   tomli,
   webtest,
   whoosh,
@@ -38,13 +36,17 @@ buildPythonPackage (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/web";
 
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail ', "setuptools_changelog_shortener"' ""
+  '';
+
   build-system = [
     setuptools
-    setuptools-changelog-shortener
   ];
 
-  # build-system broken for 3.14, package incompatible <3.13
-  disabled = pythonOlder "3.13" || pythonAtLeast "3.14";
+  # some transitive deps incompatible <3.12
+  disabled = pythonOlder "3.12";
 
   dependencies = [
     attrs
@@ -70,7 +72,10 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "devpi_web" ];
 
-  passthru.updateScript = nix-update-script { };
+  # devpi uses a monorepo for server, common, client and web
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "web-";
+  };
 
   meta = {
     homepage = "https://github.com/devpi/devpi";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3815,7 +3815,7 @@ with pkgs;
     llvmPackages = crystal.llvmPackages;
   };
 
-  devpi-server = python3Packages.callPackage ../development/tools/devpi-server { };
+  devpi-server = python3Packages.toPythonApplication python3Packages.devpi-server;
 
   dprint-plugins = recurseIntoAttrs (callPackage ../by-name/dp/dprint/plugins { });
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3856,6 +3856,8 @@ self: super: with self; {
 
   devpi-ldap = callPackage ../development/python-modules/devpi-ldap { };
 
+  devpi-web = callPackage ../development/python-modules/devpi-web { };
+
   devtools = callPackage ../development/python-modules/devtools { };
 
   dfdiskcache = callPackage ../development/python-modules/dfdiskcache { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3856,6 +3856,8 @@ self: super: with self; {
 
   devpi-ldap = callPackage ../development/python-modules/devpi-ldap { };
 
+  devpi-server = callPackage ../development/python-modules/devpi-server { };
+
   devpi-web = callPackage ../development/python-modules/devpi-web { };
 
   devtools = callPackage ../development/python-modules/devtools { };


### PR DESCRIPTION
Add devpi-web==5.0.1 to nixpkgs - a web view for devpi server

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
