### PR TITLE
python3Packages.langgraph-store-mongodb: 0.1.1 -> 0.2.0

### DIFF
--- a/pkgs/development/python-modules/langgraph-store-mongodb/default.nix
+++ b/pkgs/development/python-modules/langgraph-store-mongodb/default.nix
@@ -12,7 +12,7 @@
   langchain-mongodb,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "langgraph-store-mongodb";
   version = "0.2.0";
   pyproject = true;
@@ -20,11 +20,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-mongodb";
-    tag = "libs/langgraph-store-mongodb/v${version}";
+    tag = "libs/langgraph-store-mongodb/v${finalAttrs.version}";
     hash = "sha256-IXISxo3mC0/FkjGdHTmin6z/fk71ecto+L+VZ6VFdeE=";
   };
 
-  sourceRoot = "${src.name}/libs/langgraph-store-mongodb";
+  sourceRoot = "${finalAttrs.src.name}/libs/langgraph-store-mongodb";
 
   build-system = [
     hatchling
@@ -55,8 +55,8 @@ buildPythonPackage rec {
   meta = {
     description = "Integrations between MongoDB, Atlas, LangChain, and LangGraph";
     homepage = "https://github.com/langchain-ai/langchain-mongodb/tree/main/libs/langgraph-store-mongodb";
-    changelog = "https://github.com/langchain-ai/langchain-mongodb/releases/tag/${src.tag}";
+    changelog = "https://github.com/langchain-ai/langchain-mongodb/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sarahec ];
   };
-}
+})

--- a/pkgs/development/python-modules/langgraph-store-mongodb/default.nix
+++ b/pkgs/development/python-modules/langgraph-store-mongodb/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
 
   # build-system
   hatchling,
@@ -13,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-store-mongodb";
-  version = "0.1.1";
+  version = "0.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-mongodb";
     tag = "libs/langgraph-store-mongodb/v${version}";
-    hash = "sha256-/dafQK6iy85rMt7FMVb3ssaIop9JjjrwajaHAfBUp7g=";
+    hash = "sha256-IXISxo3mC0/FkjGdHTmin6z/fk71ecto+L+VZ6VFdeE=";
   };
 
   sourceRoot = "${src.name}/libs/langgraph-store-mongodb";
@@ -39,6 +40,17 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonImportsCheck = [ "langgraph.store.mongodb" ];
+
+  # updater script selects wrong tag
+  passthru = {
+    skipBulkUpdate = true;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "-vr"
+        "libs/langgraph-store-mongodb/v(.*)"
+      ];
+    };
+  };
 
   meta = {
     description = "Integrations between MongoDB, Atlas, LangChain, and LangGraph";

--- a/pkgs/development/python-modules/langgraph-store-mongodb/default.nix
+++ b/pkgs/development/python-modules/langgraph-store-mongodb/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-store-mongodb";
-  version = "0.11.0";
+  version = "0.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-mongodb";
-    tag = "libs/langchain-mongodb/v${version}";
-    hash = "sha256-dO0dASjyNMxnbxZ/ry8lcJxedPdrv6coYiTjOcaT8/0=";
+    tag = "libs/langgraph-store-mongodb/v${version}";
+    hash = "sha256-/dafQK6iy85rMt7FMVb3ssaIop9JjjrwajaHAfBUp7g=";
   };
 
   sourceRoot = "${src.name}/libs/langgraph-store-mongodb";


### PR DESCRIPTION
1. Revert bulk update (incorrect tag)
2. `skipBulkUpdate = true`
3. Version bump to 0.2.0
4. Migrate to finalAttrs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
