### PR TITLE
vmware-workstation: 17.6.4 -> 25H2u1

### DIFF
--- a/pkgs/by-name/vm/vmware-workstation/package.nix
+++ b/pkgs/by-name/vm/vmware-workstation/package.nix
@@ -49,12 +49,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vmware-workstation";
-  version = "17.6.4";
-  build = "24832109";
+  version = "25H2u1";
+  build = "25219725";
 
   src = fetchurl {
-    url = "https://archive.org/download/vmware-workstation-full-${finalAttrs.version}-${finalAttrs.build}.x86_64/VMware-Workstation-Full-${finalAttrs.version}-${finalAttrs.build}.x86_64.bundle";
-    hash = "sha256-ZPv7rqzEiGVGgRQ2Kiu6rekRDMnoe8O9k4OWun8Zqb0=";
+    url = "https://archive.org/download/VMware-Workstation-Full-${finalAttrs.version}-${finalAttrs.build}.x86_64/VMware-Workstation-Full-${finalAttrs.version}-${finalAttrs.build}.x86_64.bundle";
+    hash = "sha256-chqpPE68qlGsbbde2Xx6TbEKqIEQRGiQ2x5Av6/HVmo=";
   };
 
   vmware-unpack-env = buildFHSEnv {
@@ -223,7 +223,6 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r $unpacked/lib/modules $out/lib/vmware/
     cp -r $unpacked/lib/include $out/lib/vmware/
 
-    cp -r $unpacked/extra/checkvm $out/bin/
     cp -r $unpacked/extra/modules.xml $out/lib/vmware/modules/
 
     ln -s $out/lib/vmware/bin/appLoader $out/lib/vmware/bin/vmware-vmblock-fuse
@@ -377,6 +376,11 @@ stdenv.mkDerivation (finalAttrs: {
       if [[ "$lib_name" == libX* || "$lib_name" == libxcb* ]]; then
         rm -rf "$lib"
       fi
+    done
+
+    # VMware upgraded their shipped libxml2 without recompiling these libraries against it?
+    for lib in $out/lib/vmware/lib/{libcroco-0.6.so.3/libcroco-0.6.so.3,librsvg-2.so.2/librsvg-2.so.2} $out/lib/vmware/libconf/lib/gtk-3.0/3.0.0/loaders/libpixbufloader-svg.so; do
+      patchelf $lib --replace-needed libxml2.so.2 libxml2.so.16
     done
 
     runHook postInstall

--- a/pkgs/os-specific/linux/vmware/default.nix
+++ b/pkgs/os-specific/linux/vmware/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation {
   pname = "vmware-modules";
-  version = "workstation-17.6.3-20250728-${kernel.version}";
+  version = "workstation-25h2-20251015-${kernel.version}";
 
   src = fetchFromGitHub {
     owner = "philipl";
     repo = "vmware-host-modules";
-    rev = "6797e552638a28d1fa1e9ebd7ab5d3c628671ba0";
-    hash = "sha256-KCLxAF6UtNIdKcDoANviln2RJuz1Ld8jq5QFW9ONghs=";
+    rev = "5c80f597017882f76e9c7ffd48a292a4b7c860fe";
+    hash = "sha256-EFOkzwul1QCaKUBwFqH8uIsIUcvtEmxYVaE/OdoHdZI=";
   };
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
## Things done

Update VMware Workstation to 25H2u1, the latest version available.

[ChangeLog](https://techdocs.broadcom.com/us/en/vmware-cis/desktop-hypervisors/workstation-pro/25H2/release-notes/vmware-workstation-pro-25h2u1-release-notes.html)

It appears as though VMware upgraded their shipped libxml2 without recompiling a few of their libraries against it.
Using patchelf to replace libxml2 in these libraries with the upgraded version works.
This was testing by starting the app to create and start a VM.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
