### PR TITLE
python3Packages.icalendar-searcher: 1.0.4 -> 1.0.5

### DIFF
--- a/pkgs/development/python-modules/icalendar-searcher/default.nix
+++ b/pkgs/development/python-modules/icalendar-searcher/default.nix
@@ -1,10 +1,10 @@
 {
   buildPythonPackage,
   fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
   icalendar,
   lib,
-  poetry-core,
-  poetry-dynamic-versioning,
   pyicu,
   pytestCheckHook,
   recurring-ical-events,
@@ -12,19 +12,19 @@
 
 buildPythonPackage rec {
   pname = "icalendar-searcher";
-  version = "1.0.4";
+  version = "1.0.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "python-caldav";
     repo = "icalendar-searcher";
     tag = "v${version}";
-    hash = "sha256-CHW1++VHoTfNw5GkRfDDTERZGA/RJxc8iME8OPx1q/o=";
+    hash = "sha256-x11gdW6FuSCktMGtPxTg39C98J0/0C7F07jIHN0ewbY=";
   };
 
   build-system = [
-    poetry-core
-    poetry-dynamic-versioning
+    hatch-vcs
+    hatchling
   ];
 
   dependencies = [


### PR DESCRIPTION
Diff: https://github.com/python-caldav/icalendar-searcher/compare/v1.0.4...v1.0.5

Changelog: https://github.com/python-caldav/icalendar-searcher/blob/v1.0.5/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
