### PR TITLE
Add Flux Keyboard software Polymath to nixpkgs

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5935,6 +5935,12 @@
     github = "dariof4";
     githubId = 9992814;
   };
+  darkjaguar91 = {
+    name = "Brandon Talbot";
+    email = "bjtal91@gmail.com";
+    github = "DarkJaguar91";
+    githubId = 3388903;
+  };
   darkalex = {
     email = "alex.j.tusa@gmail.com";
     github = "Dark-Alex-17";

--- a/pkgs/by-name/pl/polymath/package.nix
+++ b/pkgs/by-name/pl/polymath/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+
+  atk,
+  coreutils,
+  glib,
+  gnugrep,
+  libayatana-appindicator,
+  libusb1,
+  mpv,
+  ...
+}:
+let
+  arch =
+    if stdenv.hostPlatform.system == "x86_64-linux" then
+      "amd64"
+    else
+      throw "Unsupported system ${stdenv.hostPlatform.system} ";
+in
+stdenv.mkDerivation rec {
+  pname = "polymath";
+  version = "1.4.0.7";
+
+  src = fetchurl {
+    url = "https://fluxkeyboard.com/updates/polymath/linux/deb/polymath_${version}_amd64.deb";
+    sha256 = "1182c14ddf6bd2cdc1c66e06cbcc1b08d4b4772b972c8d63b7aada4b3acfff4d";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+  buildInputs = [
+    atk
+    glib
+    libayatana-appindicator
+    libusb1
+    mpv
+  ];
+
+  dontBuild = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    mkdir deb
+    dpkg-deb -x $src ./deb
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    mv deb/usr/* $out/
+    rmdir deb/usr
+    mv deb/* $out/
+
+    # patch launch binary
+    makeWrapper $out/opt/polymath/polymath $out/bin/polymath \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            gnugrep
+          ]
+        }
+
+    # Fix Paths in Desktop file
+    sed -i -e "s|Exec=.*|Exec=$out/bin/polymath|g" $out/share/applications/polymath.desktop
+    sed -i -e "s|Icon=.*|Icon=$out/share/pixmaps/polymath.png|g" $out/share/applications/polymath.desktop
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Flux Keyboard Software: Polymath";
+    homepage = "https://fluxkeyboard.com/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      darkjaguar91
+    ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Adding the Polymath package to nixpkgs using the Flux teams DEB file.

This software is used to control and interact with the Flux Keyboard, which is a keyboard that has a screen behind it, as well as uses hall effect keys with "maglev" technology.
This software is needed, not only to adjust the keyboard keys and background images, but will also allow for macro controls in applications.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
