### PR TITLE
polymath: init at 1.4.0.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5941,6 +5941,12 @@
     githubId = 39523942;
     name = "Alex Clarke";
   };
+  darkjaguar91 = {
+    name = "Brandon Talbot";
+    email = "bjtal91@gmail.com";
+    github = "DarkJaguar91";
+    githubId = 3388903;
+  };
   darkonion0 = {
     name = "Alexandre Peruggia";
     email = "darkgenius1@protonmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17344,6 +17344,14 @@
     github = "michaelvanstraten";
     githubId = 50352631;
   };
+  michailik = {
+    name = "Michail Konstantinidis";
+    github = "MichailiK";
+    githubId = 39029839;
+    email = "git@michaili.dev";
+    matrix = "@michailik:matrix.org";
+    keys = [ { fingerprint = "BF68 0E5D 6D55 01B3 17EF  B7D6 8704 07F9 D274 E6BA"; } ];
+  };
   michalrus = {
     email = "m@michalrus.com";
     github = "michalrus";

--- a/pkgs/by-name/po/polymath/package.nix
+++ b/pkgs/by-name/po/polymath/package.nix
@@ -75,6 +75,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [
       darkjaguar91
+      michailik
     ];
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/by-name/po/polymath/package.nix
+++ b/pkgs/by-name/po/polymath/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+
+  atk,
+  coreutils,
+  glib,
+  gnugrep,
+  libayatana-appindicator,
+  libusb1,
+  mpv,
+}:
+stdenv.mkDerivation rec {
+  pname = "polymath";
+  version = "1.4.0.7";
+
+  src = fetchurl {
+    url = "https://fluxkeyboard.com/updates/polymath/linux/deb/polymath_${version}_amd64.deb";
+    hash = "sha256-EYLBTd9r0s3Bxm4Gy8wbCNS0dyuXLI1jt6raSzrP/00=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+  buildInputs = [
+    atk
+    glib
+    libayatana-appindicator
+    libusb1
+    mpv
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    mv usr/* $out/
+    rmdir usr
+    mv ./* $out/
+
+    # Move Pixmaps to icons folder
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    mv $out/share/pixmaps/polymath.png $out/share/icons/hicolor/512x512/apps/
+    rmdir $out/share/pixmaps
+
+    # patch launch binary
+    makeWrapper $out/opt/polymath/polymath $out/bin/polymath \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            gnugrep
+          ]
+        }
+
+    # Fix Paths in Desktop file
+    sed -i -e "s|Exec=.*|Exec=$out/bin/polymath|g" $out/share/applications/polymath.desktop
+    sed -i -e "s|Icon=.*|Icon=polymath|g" $out/share/applications/polymath.desktop
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Flux Keyboard Software: Polymath";
+    homepage = "https://fluxkeyboard.com/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      darkjaguar91
+    ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/po/polymath/package.nix
+++ b/pkgs/by-name/po/polymath/package.nix
@@ -11,6 +11,7 @@
   coreutils,
   glib,
   gnugrep,
+  xprop,
   libayatana-appindicator,
   libusb1,
   mpv,
@@ -58,6 +59,7 @@ stdenv.mkDerivation rec {
           lib.makeBinPath [
             coreutils
             gnugrep
+            xprop
           ]
         }
 


### PR DESCRIPTION
Adding the Polymath package to nixpkgs using the Flux teams DEB file.

This software is used to control and interact with the Flux Keyboard, which is a keyboard that has a screen behind it, as well as uses hall effect keys with "maglev" technology.
This software is needed, not only to adjust the keyboard keys and background images, but will also allow for macro controls in applications.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
