### PR TITLE
edbrowse: init at 3.8.15

### DIFF
--- a/pkgs/by-name/ed/edbrowse/package.nix
+++ b/pkgs/by-name/ed/edbrowse/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  perl,
+  curl,
+  openssl,
+  pcre2,
+  quickjs-ng,
+  readline,
+  unixODBC,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "edbrowse";
+  version = "3.8.15";
+
+  src = fetchFromGitHub {
+    owner = "edbrowse";
+    repo = "edbrowse";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KVNmcS9eWIS0GZgXcxMirjNtl0b1pwJWSzv/edsU7Tk=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  nativeBuildInputs = [
+    pkg-config
+    perl
+  ];
+
+  buildInputs = [
+    curl
+    openssl
+    pcre2
+    quickjs-ng
+    readline
+    unixODBC
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "QUICKJS_INCLUDE=${lib.getDev quickjs-ng}/include"
+    "QUICKJS_LIB=${lib.getLib quickjs-ng}/lib"
+    "QUICKJS_LIB_NAME=qjs"
+    "EBDEMIN=on"
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    install -Dm644 ../doc/man-edbrowse-debian.1 $out/share/man/man1/edbrowse.1
+    substituteInPlace $out/share/man/man1/edbrowse.1 \
+      --replace-fail "/usr/share/doc/edbrowse" "$out/share/doc/edbrowse"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://edbrowse.org/";
+    description = "Command line editor, browser, and mail client";
+    longDescription = ''
+      Edbrowse is a combination editor, browser, and mail client that is 100%
+      text based. The interface is similar to /bin/ed, though there are many
+      more features, such as editing multiple files simultaneously, and
+      rendering html. This program was originally written for blind users, but
+      many sighted users have taken advantage of the unique scripting
+      capabilities of this program, which can be found nowhere else. A batch
+      job, or cron job, can access web pages on the internet, submit forms, and
+      send email, with no human intervention whatsoever. edbrowse can also tap
+      into databases through ODBC.
+    '';
+    license = lib.licenses.gpl1Plus;
+    mainProgram = "edbrowse";
+    maintainers = with lib.maintainers; [ jhhuh ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Restores [edbrowse](https://edbrowse.org/), a command line editor, browser, and mail client, which was dropped in #408351.

The removal stated "Unmaintained browser in Nixpkgs for 3 years," but the upstream project has been actively developed throughout — the old nixpkgs package pointed to `CMB/edbrowse`, while development had silently moved to [edbrowse/edbrowse](https://github.com/edbrowse/edbrowse) under the original author Karl Dahlke. The previous maintainer CMB had been dealing with medical issues, and the transition was not widely noticed.

### Changes from the previously packaged v3.8.0

- **Source repo**: `CMB/edbrowse` → `edbrowse/edbrowse`
- **JS engine**: duktape + quickjs → quickjs-ng
- **Regex library**: pcre → pcre2
- **html-tidy**: no longer needed
- **Patches**: the old `0001-small-fixes.patch` (for hardcoded `gcc`/`g++` paths) is no longer needed — upstream fixed the makefile
- **ODBC**: always built (was optional via `withODBC`)
- **Update script**: added `passthru.updateScript` to prevent the package from going stale again

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- Nixpkgs Release Notes
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- NixOS Release Notes
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Module update) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).