### PR TITLE
Update/python3 packages.radish bdd

### DIFF
--- a/pkgs/development/python-modules/radish-bdd/default.nix
+++ b/pkgs/development/python-modules/radish-bdd/default.nix
@@ -8,7 +8,6 @@
   humanize,
   lxml,
   parse-type,
-  pysingleton,
   pytest-mock,
   pytestCheckHook,
   pyyaml,
@@ -17,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "radish-bdd";
-  version = "0.18.3";
+  version = "0.18.4";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = "radish";
     tag = "v${version}";
-    hash = "sha256-UjJz9ysejz5DBewMwoVof1+JU8tbGbBa3z1quuN1TWg=";
+    hash = "sha256-pnZ/vqjMd1Q/wF1W6joYrIulZSXAzS2G3E5Ke5VSAQg=";
   };
 
   propagatedBuildInputs = [
@@ -33,7 +32,6 @@ buildPythonPackage rec {
     humanize
     lxml
     parse-type
-    pysingleton
     pyyaml
     tag-expressions
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Replaces https://github.com/NixOS/nixpkgs/pull/495082 and also removes pysingleton since it was removed by upstream:
https://github.com/radish-bdd/radish/commit/10fdc60131c72ad7a84dfab0e51c2262cd507794 otherwise this is mostly a maintenance release fixing docs, updating ci and adding tests.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
