### PR TITLE
oxwm: 0.9.0 -> 0.11.3 (Zig rewrite)

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1218,6 +1218,7 @@ in
   owi = runTest ./owi.nix;
   owncast = runTest ./owncast.nix;
   oxidized = handleTest ./oxidized.nix { };
+  oxwm = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./oxwm.nix;
   pacemaker = runTest ./pacemaker.nix;
   packagekit = runTest ./packagekit.nix;
   pairdrop = runTest ./web-apps/pairdrop.nix;

--- a/nixos/tests/oxwm.nix
+++ b/nixos/tests/oxwm.nix
@@ -1,0 +1,39 @@
+{ lib, ... }:
+{
+  name = "oxwm";
+
+  meta = {
+    maintainers = with lib.maintainers; [
+      sigmanificient
+      tonybanters
+    ];
+  };
+
+  nodes.machine =
+    { pkgs, lib, ... }:
+    {
+      imports = [
+        ./common/x11.nix
+        ./common/user-account.nix
+      ];
+      test-support.displayManager.auto.user = "alice";
+      services.displayManager.defaultSession = lib.mkForce "oxwm";
+      services.xserver.windowManager.oxwm.enable = true;
+
+      environment.systemPackages = [ pkgs.alacritty ];
+    };
+
+  testScript = ''
+    with subtest("ensure x starts"):
+        machine.wait_for_x()
+        machine.wait_for_file("/home/alice/.Xauthority")
+        machine.succeed("xauth merge ~alice/.Xauthority")
+
+    with subtest("ensure we can open a new terminal"):
+        machine.sleep(2)
+        machine.send_key("meta_l-ret")
+        machine.wait_for_window(r"alice.*?machine")
+        machine.sleep(2)
+        machine.screenshot("terminal")
+  '';
+}

--- a/pkgs/by-name/ox/oxwm/package.nix
+++ b/pkgs/by-name/ox/oxwm/package.nix
@@ -1,34 +1,38 @@
 {
   lib,
-  rustPlatform,
+  stdenv,
   fetchFromGitHub,
+  zig,
   pkg-config,
   libx11,
   libxft,
-  libxrender,
+  libxinerama,
+  lua5_4,
   freetype,
   fontconfig,
-  versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
-rustPlatform.buildRustPackage (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "oxwm";
-  version = "0.9.0";
+  version = "0.11.3";
 
   src = fetchFromGitHub {
     owner = "tonybanters";
     repo = "oxwm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zVYYRGe5ZIR1AJgKZi9s403NKM7hKAqhEbNWYSkgpT0=";
+    hash = "sha256-W6muqajSk9UR646ZmLkx/wWfiaWLo+d1lJMiLm82NC8=";
   };
 
-  cargoHash = "sha256-Rs8eGR8WY7qOPM0rfu6lTNDl6TVMR+rrIc6Ub+M7vfs=";
-
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    zig.hook
+    pkg-config
+  ];
 
   buildInputs = [
     libx11
     libxft
-    libxrender
+    libxinerama
+    lua5_4
     freetype
     fontconfig
   ];
@@ -36,8 +40,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # tests require a running X server
   doCheck = false;
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
 
   postInstall = ''
     install -Dm644 resources/oxwm.desktop -t $out/share/xsessions
@@ -48,7 +56,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.providedSessions = [ "oxwm" ];
 
   meta = {
-    description = "Dynamic window manager written in Rust, inspired by dwm";
+    description = "Dynamic window manager written in Zig, inspired by dwm";
     homepage = "https://github.com/tonybanters/oxwm";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ tonybanters ];


### PR DESCRIPTION
## Summary

Updates oxwm from 0.9.0 to 0.11.3. The project was rewritten from Rust to Zig.

Changes:
- Switched from `rustPlatform.buildRustPackage` to `stdenv.mkDerivation` with `zig.hook`
- Added new dependencies: `libXinerama`, `lua5_4`
- Removed: `libxrender`, `cargoHash`
- Added NixOS VM test

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
