### PR TITLE
conan: 2.22.2 -> 2.26.1

### DIFF
--- a/pkgs/by-name/co/conan/package.nix
+++ b/pkgs/by-name/co/conan/package.nix
@@ -12,18 +12,19 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "conan";
-  version = "2.22.2";
+  version = "2.26.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "conan-io";
     repo = "conan";
     tag = finalAttrs.version;
-    hash = "sha256-4OKrAfhHgtAS606P88JFYCjgYYlSAH8RReqFs6N2V5s=";
+    hash = "sha256-PBrVt8SM3AFdi/w18c4ZExzNnfTANtAdTUHIquk1At0=";
   };
 
   pythonRelaxDeps = [
     "distro"
+    "patch-ng"
     "urllib3"
   ];
 
@@ -82,6 +83,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "test_shared_windows_find_libraries"
     # 'cmake' tool version 'Any' is not available
     "test_build"
+    "test_conan_new"
     "test_conan_new_compiles"
     # 'cmake' tool version '3.27' is not available
     "test_metabuild"
@@ -104,6 +106,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # Requires cmake, meson, autotools, apt-get, etc.
     "test/functional/command/runner_test.py"
     "test/functional/command/test_install_deploy.py"
+    "test/functional/command/test_new.py"
     "test/functional/layout/test_editable_cmake.py"
     "test/functional/layout/test_editable_cmake_components.py"
     "test/functional/layout/test_in_subfolder.py"
@@ -113,12 +116,16 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "test/functional/toolchains/"
     "test/functional/tools/scm/test_git.py"
     "test/functional/tools/system/package_manager_test.py"
+    "test/functional/sbom/test_cyclonedx.py"
+    "test/functional/workspace/test_workspace.py"
     "test/functional/tools_versions_test.py"
     "test/functional/util/test_cmd_args_to_string.py"
-    "test/performance/test_large_graph.py"
+
+    # Requires network access to PyPI
+    "test/functional/tools/system/python_manager_test.py"
+
+    # Test failure
     "test/unittests/tools/env/test_env_files.py"
-    # pipenv will attempt to access the network.
-    "test/functional/tools/system/pip_manager_test.py"
   ];
 
   meta = {


### PR DESCRIPTION
https://github.com/conan-io/conan/releases/tag/2.26.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
