### PR TITLE
vibe-audio-visualizer: init at 3.0.0

### DIFF
--- a/pkgs/by-name/vi/vibe-audio-visualizer/package.nix
+++ b/pkgs/by-name/vi/vibe-audio-visualizer/package.nix
@@ -1,0 +1,70 @@
+{
+  rustPlatform,
+  lib,
+  pkg-config,
+  fetchFromGitHub,
+  alsa-lib,
+  libGL,
+  libxkbcommon,
+  wayland,
+  libgbm,
+  vulkan-loader,
+  vulkan-validation-layers,
+  vulkan-tools,
+  makeWrapper,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "vibe-audio-visualizer";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "TornaxO7";
+    repo = "vibe";
+    tag = "vibe-v${finalAttrs.version}";
+    hash = "sha256-zyPcEixrn0C2xpXeonaTWGaG0h72Qm4m1GrPv8YVdWo=";
+  };
+
+  cargoHash = "sha256-6FV1tJAkk8nCeA6q/RMim4AvFsZI4BrgRbUrucaGYkE=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    wayland
+    libGL
+    libxkbcommon
+    vulkan-loader
+    vulkan-validation-layers
+    vulkan-tools
+    libgbm
+  ];
+
+  # tests require a gpu (which requires `hardware.graphics.enable = true`)
+  doCheck = false;
+
+  postInstall = ''
+    wrapProgram $out/bin/vibe \
+      --suffix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          # Without wayland in library path, this warning is raised:
+          # "No windowing system present. Using surfaceless platform"
+          wayland
+          # Without vulkan-loader present, wgpu won't find any adapter
+          vulkan-loader
+          libgbm
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Wayland desktop audio visualizer";
+    homepage = "https://github.com/TornaxO7/vibe";
+    license = lib.licenses.agpl3Plus;
+    mainProgram = "vibe";
+    maintainers = with lib.maintainers; [ tornax ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Link to project: https://github.com/TornaxO7/vibe

I decidede to name that package `vibe-audio-visualizer` because there seems to be other apps in the wild (like [this one](https://thewh1teagle.github.io/vibe/)) which have the same name.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
