### PR TITLE
python3Packages.librosa: skip failing tests on python>=3.14

### DIFF
--- a/pkgs/development/python-modules/librosa/default.nix
+++ b/pkgs/development/python-modules/librosa/default.nix
@@ -36,7 +36,7 @@
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "librosa";
   version = "0.11.0";
   pyproject = true;
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "librosa";
     repo = "librosa";
-    tag = version;
+    tag = finalAttrs.version;
     fetchSubmodules = true; # for test data
     hash = "sha256-T58J/Gi3tHzelr4enbYJi1KmO46QxE5Zlhkc0+EgvRg=";
   };
@@ -89,7 +89,7 @@ buildPythonPackage rec {
     samplerate
     writableTmpDirAsHomeHook
   ]
-  ++ optional-dependencies.matplotlib;
+  ++ finalAttrs.passthru.optional-dependencies.matplotlib;
 
   disabledTests = [
     # requires network access
@@ -132,8 +132,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for audio and music analysis";
     homepage = "https://github.com/librosa/librosa";
-    changelog = "https://github.com/librosa/librosa/releases/tag/${version}";
+    changelog = "https://github.com/librosa/librosa/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [ carlthome ];
   };
-}
+})

--- a/pkgs/development/python-modules/librosa/default.nix
+++ b/pkgs/development/python-modules/librosa/default.nix
@@ -34,6 +34,7 @@
   resampy,
   samplerate,
   writableTmpDirAsHomeHook,
+  pythonAtLeast,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -127,6 +128,13 @@ buildPythonPackage (finalAttrs: {
     "test_istft_multi"
     "test_pitch_shift_multi"
     "test_time_stretch_multi"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # ValueError: cannot resize an array that references or is referenced
+    "test_resample_mono"
+    "test_resample_multichannel"
+    "test_resample_scale"
+    "test_resample_stereo"
   ];
 
   meta = {


### PR DESCRIPTION
## Things done

- **python3Packages.librosa: use finalAttrs**
- **python3Packages.librosa: skip failing tests on python>=3.14**

cc @carlthome

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
