### PR TITLE
sing-box: 1.12.23 -> 1.13.0

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -62,6 +62,8 @@
   This update introduces several breaking changes: the Python plugin interface is now v5.0, the `PATH` plugin has been renamed to `Commandline`, and the QStylesheets-based widgets box model frontend has been removed.
   For more information read the [changelog for 34.0.0](https://albertlauncher.github.io/2026/01/19/albert-v34.0.0-released/).
 
+- `sing-box` has been updated to 1.13.0, which has removed some deprecated options.  See [upstream documentation](https://sing-box.sagernet.org/configuration/) for details and migration options.
+
 - `cargo-codspeed` has been updated from `3.0.5` to `4.2.0`. Version `4.0.0` includes breaking changes. For more information read the [changelog for 4.0.0](https://github.com/CodSpeedHQ/codspeed-rust/releases/tag/v4.0.0).
 
 - `corepack_latest` has been removed, as Corepack is no longer distributed with Node.js.

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -72,6 +72,8 @@
 
 - `services.crabfit` was removed because its upstream packages are unmaintained and insecure.
 
+- `sing-box` has been updated to 1.13.0, which has removed some deprecated options.  See [upstream documentation](https://sing-box.sagernet.org/configuration/) for details and migration options.
+
 - `services.tandoor-recipes` now uses a sub-directory for media files by default starting with `26.05`. Existing setups should move media files out of the data directory and adjust `services.tandoor-recipes.extraConfig.MEDIA_ROOT` accordingly. See [Migrating media files for pre 26.05 installations](#module-services-tandoor-recipes-migrating-media).
 
 - `rustic` was upgraded to `0.11.x`, which contains breaking [changes to command-line parameters and configuration file](https://rustic.cli.rs/docs/breaking_changes.html#0110).

--- a/nixos/modules/services/networking/sing-box.nix
+++ b/nixos/modules/services/networking/sing-box.nix
@@ -41,27 +41,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    assertions =
-      let
-        rules = cfg.settings.route.rules or [ ];
-      in
-      [
-        {
-          assertion = !lib.any (r: r ? source_geoip || r ? geoip) rules;
-          message = ''
-            Deprecated option `services.sing-box.settings.route.rules.*.{source_geoip,geoip}` is set.
-            See https://sing-box.sagernet.org/migration/#migrate-geoip-to-rule-sets for migration instructions.
-          '';
-        }
-        {
-          assertion = !lib.any (r: r ? geosite) rules;
-          message = ''
-            Deprecated option `services.sing-box.settings.route.rules.*.geosite` is set.
-            See https://sing-box.sagernet.org/migration/#migrate-geosite-to-rule-sets for migration instructions.
-          '';
-        }
-      ];
-
     # for polkit rules
     environment.systemPackages = [ cfg.package ];
     services.dbus.packages = [ cfg.package ];

--- a/pkgs/by-name/si/sing-box/package.nix
+++ b/pkgs/by-name/si/sing-box/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "sing-box";
-  version = "1.12.23";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = "SagerNet";
     repo = "sing-box";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GzZgsRvbSpppTFY7Jm+56nCi5auDzV34i0K7fKOMafk=";
+    hash = "sha256-lhkz/mXydZz5iJllqSp4skA4+jxs8oUmon/oFs98Zfc=";
   };
 
-  vendorHash = "sha256-CSAXPvXMUwD08fsp66vr1pA4Wxy0rY2cEJU1Pl0mdUA=";
+  vendorHash = "sha256-vVLaG0PV1OXA+YL67BnrHJiSkNVzJbZ8TeMKbO2rMu0=";
 
   tags = [
     "with_quic"


### PR DESCRIPTION
Release notes: https://github.com/SagerNet/sing-box/releases/tag/v1.13.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests]. (against #495428)
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
