### PR TITLE
ec2-spot-interrupter: init at 0.0.16

### DIFF
--- a/pkgs/by-name/ec/ec2-spot-interrupter/package.nix
+++ b/pkgs/by-name/ec/ec2-spot-interrupter/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "ec2-spot-interrupter";
+  version = "0.0.16";
+
+  src = fetchFromGitHub {
+    owner = "aws";
+    repo = "amazon-ec2-spot-interrupter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lsd0ahIpN8l3qpXofA7Rjlg0f0J+GJtFiPAvo/wy6Mw=";
+  };
+
+  vendorHash = "sha256-qrxYLnj8DEGNtIq6sC7xvNBLgguG/lj9YLqgLFumQtE=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.versionID=${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    rm $out/bin/readme-test
+    mv $out/bin/cmd $out/bin/ec2-spot-interrupter
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Trigger Amazon EC2 Spot Interruption Notifications and Rebalance Recommendations";
+    homepage = "https://github.com/aws/amazon-ec2-spot-interrupter";
+    changelog = "https://github.com/aws/amazon-ec2-spot-interrupter/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ wcarlsen ];
+    mainProgram = "ec2-spot-interrupter";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adding [ec2-spot-interrupter](https://github.com/aws/amazon-ec2-spot-interrupter) package.

I did test it with `nix-shell -p nixpkgs-review --run "nixpkgs-review rev ec2-spot-interrupter --package ec2-spot-interrupter"`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
