### PR TITLE
hoptodesk: init at 1.45.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10731,6 +10731,12 @@
     githubId = 25618740;
     name = "Vincent Cui";
   };
+  hoptodesk = {
+    name = "HopToDesk";
+    email = "app@hoptodesk.com";
+    github = "hoptodesk";
+    githubId = 103363758;
+  };
   hornwall = {
     email = "hannes@hornwall.me";
     github = "Hornwall";

--- a/pkgs/by-name/ho/hoptodesk/package.nix
+++ b/pkgs/by-name/ho/hoptodesk/package.nix
@@ -1,0 +1,121 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  copyDesktopItems,
+  makeDesktopItem,
+  alsa-lib,
+  curl,
+  gst_all_1,
+  gtk3,
+  linux-pam,
+  libpulseaudio,
+  libva,
+  libvdpau,
+  libxcb,
+  libxfixes,
+  libxrandr,
+  systemd,
+  xdotool,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hoptodesk";
+  version = "1.45.9";
+
+  src = fetchurl {
+    url = "https://www.hoptodesk.com/download/hoptodesk-${finalAttrs.version}-x86_64.deb";
+    hash = "sha256-1v+TODpUsYQqMVSzGModmpNcisMWjLwrx93Kz/D/QXA=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    dpkg
+  ];
+
+  buildInputs = [
+    alsa-lib
+    curl
+    gst_all_1.gst-plugins-base
+    gtk3
+    linux-pam
+    libpulseaudio
+    libva
+    libvdpau
+    libxcb
+    libxfixes
+    (lib.getLib stdenv.cc.cc)
+    systemd
+    xdotool
+    libxrandr
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  preFixup = ''
+    # The .deb bundles libsciter-gtk.so alongside the binary
+    addAutoPatchelfSearchPath $out/lib
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib $out/share
+
+    # Install binary
+    install -Dm755 usr/bin/hoptodesk $out/bin/hoptodesk
+
+    # Install bundled library
+    install -Dm644 usr/lib/libsciter-gtk.so $out/lib/libsciter-gtk.so
+
+    # Install icons
+    install -Dm644 usr/share/icons/hicolor/128x128/128x128.png \
+      $out/share/icons/hicolor/128x128/apps/hoptodesk.png
+    install -Dm644 usr/share/icons/hicolor/32x32/32x32.png \
+      $out/share/icons/hicolor/32x32/apps/hoptodesk.png
+
+    # Install systemd service
+    install -Dm644 usr/share/hoptodesk/files/systemd/hoptodesk.service \
+      $out/lib/systemd/system/hoptodesk.service
+    substituteInPlace $out/lib/systemd/system/hoptodesk.service \
+      --replace-quiet "/usr/bin/hoptodesk" "$out/bin/hoptodesk"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "hoptodesk";
+      desktopName = "HopToDesk";
+      genericName = "Remote Desktop Software";
+      comment = "Remote Desktop Software";
+      exec = "hoptodesk %u";
+      icon = "hoptodesk";
+      terminal = false;
+      type = "Application";
+      startupNotify = true;
+      categories = [
+        "Network"
+        "RemoteAccess"
+        "GTK"
+      ];
+      keywords = [ "internet" ];
+    })
+  ];
+
+  meta = {
+    description = "Remote desktop application with peer-to-peer connection";
+    homepage = "https://www.hoptodesk.com";
+    license = lib.licenses.agpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [
+      hoptodesk
+    ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "hoptodesk";
+  };
+})


### PR DESCRIPTION
## Description

Add HopToDesk, a remote desktop application with peer-to-peer connections.

- **Homepage:** https://www.hoptodesk.com
- **License:** AGPL-3.0
- **Platform:** x86_64-linux
- **Source provenance:** Binary (pre-built .deb)

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Assured that relevant documentation is up to date
- [x] Added to `maintainers/maintainer-list.nix`
- [x] New package in `pkgs/by-name`

## Notes for reviewers

- Package is built from pre-compiled .deb using `autoPatchelfHook`
- Desktop file is generated via `makeDesktopItem` (upstream .desktop had hardcoded FHS paths)
- Systemd service file is installed with patched binary paths
