### PR TITLE
jpmml-statsmodels: init at 1.3.13

### DIFF
--- a/pkgs/by-name/jp/jpmml-statsmodels/package.nix
+++ b/pkgs/by-name/jp/jpmml-statsmodels/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  fetchFromGitHub,
+  maven,
+  jre_headless,
+  makeBinaryWrapper,
+  nix-update-script,
+}:
+
+maven.buildMavenPackage (finalAttrs: {
+  pname = "jpmml-statsmodels";
+  version = "1.3.13";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jpmml";
+    repo = "jpmml-statsmodels";
+    tag = finalAttrs.version;
+    hash = "sha256-QVJhJliHLST5MJV9OZVC+jTk8vV+bUu7i2IL6GSqK34=";
+  };
+
+  mvnHash = "sha256-Q0b45RdpdVfaLe+LdIKbvey/wGX/DYVGJWuL/L0d5Ag=";
+
+  # go-offline-maven-plugin only fetches pinned JARs/POMs, not the
+  # ever-changing maven-metadata.xml timestamps, so the FOD hash is stable
+  # even when Maven Central publishes new versions of unrelated packages.
+  buildOffline = true;
+
+  # go-offline-maven-plugin cannot handle "dynamic" test dependencies
+  # (those resolved at test runtime rather than declared in the POM).
+  # List them explicitly so they end up in the offline repo.
+  manualMvnArtifacts = [
+    "org.apache.maven.surefire:surefire-junit-platform:3.5.5"
+    "org.junit.jupiter:junit-jupiter-engine:5.14.3"
+    "org.junit.platform:junit-platform-launcher:1.14.3"
+  ];
+
+  mvnParameters = "-B package";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/java" "$out/bin"
+    install -Dm444 \
+      pmml-statsmodels-example/target/pmml-statsmodels-example-executable-${finalAttrs.version}.jar \
+      "$out/share/java/jpmml-statsmodels.jar"
+
+    makeBinaryWrapper ${lib.getExe jre_headless} "$out/bin/jpmml-statsmodels" \
+      --add-flags "-jar $out/share/java/jpmml-statsmodels.jar"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Java library and CLI for converting StatsModels models to PMML";
+    longDescription = ''
+      JPMML-StatsModels converts Python StatsModels fitted model results
+      (serialized as Pickle files) into the Predictive Model Markup Language
+      (PMML) format, enabling deployment of those models on the JVM via
+      JPMML-Evaluator.
+
+      Supported model families include OLS/WLS/QuantReg linear regression,
+      GLMs (Binomial, Gaussian, Poisson), Logit, MNLogit, Poisson count
+      models, OrderedModel, and ARIMA time-series models.
+    '';
+    homepage = "https://github.com/jpmml/jpmml-statsmodels";
+    changelog = "https://github.com/jpmml/jpmml-statsmodels/releases/tag/${finalAttrs.version}";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ b-rodrigues ];
+    mainProgram = "jpmml-statsmodels";
+    platforms = platforms.all;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+  };
+})


### PR DESCRIPTION
This PR introduces jpmml-statsmodels, a Java library and CLI tool for converting Python StatsModels fitted models into the Predictive Model Markup Language (PMML) format. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
