### PR TITLE
bashdb: improve & build for darwin

### DIFF
--- a/pkgs/by-name/ba/bashdb/package.nix
+++ b/pkgs/by-name/ba/bashdb/package.nix
@@ -9,6 +9,8 @@
   perl,
 
   python3,
+  bash,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation {
@@ -35,6 +37,7 @@ stdenv.mkDerivation {
   buildInputs = [
     # used at runtime by term-highlight.py
     (python3.withPackages (ps: [ ps.pygments ]))
+    bash
   ];
 
   configureFlags = [
@@ -42,6 +45,8 @@ stdenv.mkDerivation {
     # for now point to self
     "--with-dbg-main=${placeholder "out"}/share/bashdb/bashdb-main.inc"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://bashdb.sourceforge.net/";
@@ -55,6 +60,6 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [
       jk
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/ba/bashdb/package.nix
+++ b/pkgs/by-name/ba/bashdb/package.nix
@@ -13,15 +13,15 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bashdb";
-  version = "5.2-1.1.2-unstable-2025-06-07";
+  version = "5.2-1.2.0";
 
   src = fetchFromGitHub {
     owner = "Trepan-Debuggers";
     repo = "bashdb";
-    rev = "7d0f9751e04fa54f48f0ab4be32ecb8030a4315d";
-    sha256 = "sha256-fwxmlFC66Lv+zD632s9a44I9IEQ/82caKnQ44pdVes4=";
+    tag = finalAttrs.version;
+    sha256 = "sha256-cbrBRP/NT3pUwT9KPpS3DxzrDhY2PGmLO/l+jKAbI68=";
   };
 
   patches = [
@@ -62,4 +62,4 @@ stdenv.mkDerivation {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Pull in the normal bash in buildInputs (instead of bashMinimal which
  was implicit). This avoids various runtime errors.
- Enable auto update with nix-update.
- Make available for unix (including darwin).
- Bump version to 5.2-1.2.0: https://github.com/Trepan-Debuggers/bashdb/blob/bash-5.2/NEWS.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
