### PR TITLE
python3Packages.python-novaclient: 18.11.0 -> 18.12.0

### DIFF
--- a/pkgs/development/python-modules/dogpile-cache/default.nix
+++ b/pkgs/development/python-modules/dogpile-cache/default.nix
@@ -6,6 +6,7 @@
   pytestCheckHook,
   mako,
   decorator,
+  stdenv,
   stevedore,
   typing-extensions,
 }:
@@ -32,6 +33,19 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     mako
+  ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # AssertionError: <dogpile.cache.api.NoValue object> != 'some value 1'
+    "test_expire_override"
+    # flaky
+    "test_get_value_plus_created_long_create"
+    "test_get_value_plus_created_registry_safe_cache_quick"
+    "test_get_value_plus_created_registry_safe_cache_slow"
+    "test_get_value_plus_created_registry_unsafe_cache"
+    "test_quick"
+    "test_return_while_in_progress"
+    "test_slow"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/python-novaclient/fix-setup-cfg.patch
+++ b/pkgs/development/python-modules/python-novaclient/fix-setup-cfg.patch
@@ -1,0 +1,21 @@
+diff --git a/setup.cfg b/setup.cfg
+index d78f2950..50a0f7cd 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -25,9 +25,13 @@ classifier =
+     Programming Language :: Python :: 3 :: Only
+     Programming Language :: Python :: Implementation :: CPython
+ 
+-[files]
+-packages =
+-    novaclient
++[options]
++packages=find:
++
++[options.packages.find]
++exclude =
++    releasenotes
++    releasenotes.*
+ 
+ [entry_points]
+ console_scripts =


### PR DESCRIPTION
Update package to latest version, build from sources, use stestrCheckHook and versionCheckHook
Update non-working tests

Replace #494185


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
