### PR TITLE
logcheck: modernize

### DIFF
--- a/pkgs/by-name/lo/logcheck/package.nix
+++ b/pkgs/by-name/lo/logcheck/package.nix
@@ -6,24 +6,23 @@
   perlPackages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "logcheck";
   version = "1.4.7";
-  _name = "logcheck_${version}";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/l/logcheck/${_name}.tar.xz";
-    sha256 = "sha256-zBYMvKwo85OI6LluRixOYtAFRTtpV/Hw6qjAk/+c898=";
+    url = "mirror://debian/pool/main/l/logcheck/logcheck_${finalAttrs.version}.tar.xz";
+    hash = "sha256-zBYMvKwo85OI6LluRixOYtAFRTtpV/Hw6qjAk/+c898=";
   };
 
   prePatch = ''
     # do not set sticky bit in nix store.
-    substituteInPlace Makefile --replace 2750 0750
+    substituteInPlace Makefile --replace-fail 2750 0750
   '';
 
   preConfigure = ''
-    substituteInPlace src/logtail --replace "/usr/bin/perl" "${perlPackages.perl}/bin/perl"
-    substituteInPlace src/logtail2 --replace "/usr/bin/perl" "${perlPackages.perl}/bin/perl"
+    substituteInPlace src/logtail --replace-fail "/usr/bin/perl" "${perlPackages.perl}/bin/perl"
+    substituteInPlace src/logtail2 --replace-fail "/usr/bin/perl" "${perlPackages.perl}/bin/perl"
 
     sed -i -e 's|! -f /usr/bin/lockfile|! -f ${lockfile-progs}/bin/lockfile|' \
            -e 's|^\([ \t]*\)lockfile-|\1${lockfile-progs}/bin/lockfile-|' \
@@ -50,4 +49,4 @@ stdenv.mkDerivation rec {
     homepage = "https://salsa.debian.org/debian/logcheck";
     license = lib.licenses.gpl2Plus;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
