### PR TITLE
python3Packages.*: move LC_ALL into env for structuredAttrs

### DIFF
--- a/pkgs/development/python-modules/cython/0.nix
+++ b/pkgs/development/python-modules/cython/0.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
     ncurses
   ];
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   patches = [
     # backport Cython 3.0 trashcan support (https://github.com/cython/cython/pull/2842) to 0.X series.

--- a/pkgs/development/python-modules/djmail/default.nix
+++ b/pkgs/development/python-modules/djmail/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ glibcLocales ];
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   propagatedBuildInputs = [
     celery

--- a/pkgs/development/python-modules/fs/default.nix
+++ b/pkgs/development/python-modules/fs/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage rec {
     glibcLocales
   ];
 
-  LC_ALL = "en_US.utf-8";
+  env.LC_ALL = "en_US.utf-8";
 
   preCheck = ''
     HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/libarchive-c/default.nix
+++ b/pkgs/development/python-modules/libarchive-c/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     })
   ];
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   postPatch = ''
     substituteInPlace libarchive/ffi.py --replace-fail \

--- a/pkgs/development/python-modules/mail-parser/default.nix
+++ b/pkgs/development/python-modules/mail-parser/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     hash = "sha256-wwLUD/k26utugK/Yx9eXYEdSOvrk0Cy6RkXGDnzZ+fE=";
   };
 
-  LC_ALL = "en_US.utf-8";
+  env.LC_ALL = "en_US.utf-8";
 
   nativeBuildInputs = [ glibcLocales ];
 

--- a/pkgs/development/python-modules/musicbrainzngs/default.nix
+++ b/pkgs/development/python-modules/musicbrainzngs/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   buildInputs = [ pkgs.glibcLocales ];
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   preCheck = ''
     # Remove tests that rely on networking (breaks sandboxed builds)

--- a/pkgs/development/python-modules/pypdf3/default.nix
+++ b/pkgs/development/python-modules/pypdf3/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-yUbzJzQZ43JY415yJz9JkEqxVyPYenYcERXvmXmfjF8=";
   };
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
   buildInputs = [ glibcLocales ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/rpmfluff/default.nix
+++ b/pkgs/development/python-modules/rpmfluff/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     sha256 = "19vnlzma8b0aghdiixk0q3wc10y6306hsnic0qvswaaiki94fss1";
   };
 
-  LC_ALL = "en_US.utf-8";
+  env.LC_ALL = "en_US.utf-8";
   buildInputs = [ glibcLocales ];
 
   meta = {

--- a/pkgs/development/python-modules/scrapy/default.nix
+++ b/pkgs/development/python-modules/scrapy/default.nix
@@ -98,7 +98,7 @@ buildPythonPackage rec {
     uvloop
   ];
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   pytestFlags = [
     # DeprecationWarning: There is no current event loop

--- a/pkgs/development/python-modules/seekpath/default.nix
+++ b/pkgs/development/python-modules/seekpath/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     hash = "sha256-mrutQCSSiiLPt0KEohZeYcQ8aw2Jhy02bEvn6Of8w6U=";
   };
 
-  LC_ALL = "en_US.utf-8";
+  env.LC_ALL = "en_US.utf-8";
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/tqdm/default.nix
+++ b/pkgs/development/python-modules/tqdm/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   # Too sensitive for on Hydra.
   disabledTests = [ "perf" ];
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   pythonImportsCheck = [ "tqdm" ];
 

--- a/pkgs/development/python-modules/whichcraft/default.nix
+++ b/pkgs/development/python-modules/whichcraft/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "11yfkzyplizdgndy34vyd5qlmr1n5mxis3a3svxmx8fnccdvknxc";
   };
 
-  LC_ALL = "en_US.utf-8";
+  env.LC_ALL = "en_US.utf-8";
   buildInputs = [ glibcLocales ];
 
   nativeCheckInputs = [ pytest ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
