### PR TITLE
python3Packages.lttng: move env vars into env for structuredAttrs

### DIFF
--- a/pkgs/development/python-modules/lttng/default.nix
+++ b/pkgs/development/python-modules/lttng/default.nix
@@ -10,6 +10,7 @@ toPythonModule (
     {
       nativeBuildInputs ? [ ],
       configureFlags ? [ ],
+      env ? { },
       ...
     }:
     {
@@ -28,12 +29,14 @@ toPythonModule (
         "--disable-man-pages"
       ];
 
-      # Nix treats nativeBuildInputs specially for cross-compilation, but in this
-      # case, cross-compilation is accounted for explicitly. Using the variables
-      # ensures that the platform setup isn't messed with further. It also allows
-      # regular Python to be added in the future if it is ever needed.
-      PYTHON = "${python.pythonOnBuildForHost}/bin/python";
-      PYTHON_CONFIG = "${python.pythonOnBuildForHost}/bin/python-config";
+      env = env // {
+        # Nix treats nativeBuildInputs specially for cross-compilation, but in this
+        # case, cross-compilation is accounted for explicitly. Using the variables
+        # ensures that the platform setup isn't messed with further. It also allows
+        # regular Python to be added in the future if it is ever needed.
+        PYTHON = "${python.pythonOnBuildForHost}/bin/python";
+        PYTHON_CONFIG = "${python.pythonOnBuildForHost}/bin/python-config";
+      };
     }
   )
 )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
