### PR TITLE
home-assistant-custom-components.oref_alert: 4.1.1 -> 5.2.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/oref_alert/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/oref_alert/package.nix
@@ -6,21 +6,31 @@
   shapely,
   paho-mqtt,
   pytestCheckHook,
+  pytest-cov-stub,
   pytest-homeassistant-custom-component,
   pytest-freezer,
+  pythonOlder,
 }:
 
 buildHomeAssistantComponent rec {
   owner = "amitfin";
   domain = "oref_alert";
-  version = "4.1.1";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "amitfin";
     repo = "oref_alert";
     tag = "v${version}";
-    hash = "sha256-nWp8cG0lFYUEO11lcZGkqx5QvOSfSVnqIqpHA8YAN30=";
+    hash = "sha256-Az2pZriKPXgLK1QarwycWUEn5VBufUQdYomYlpStOrY=";
   };
+
+  # This package uses the `if TYPE_CHECKING:` pattern in the test code to avoid
+  # expensive imports (see https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING for more info on this pattern).
+  # In Python 3.13, this makes tests fail with errors like "NameError: name 'AiohttpClientMocker' is not defined" error.
+  # However, Python 3.14 introduces lazy annotations (see https://peps.python.org/pep-0563/), which should fix this problem.
+  postPatch = lib.optionalString (pythonOlder "3.14") ''
+    find tests -name '*.py' -exec sh -c 'for f; do if ! grep -q "^from __future__ import annotations" "$f"; then sed -i "1i from __future__ import annotations" "$f"; fi; done' sh {} +
+  '';
 
   dependencies = [
     aiofiles
@@ -32,6 +42,7 @@ buildHomeAssistantComponent rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-cov-stub
     pytest-homeassistant-custom-component
     pytest-freezer
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This updates the `home-assistant-custom-components.oref_alert` from 4.1.1 to 5.2.0.

Changes: https://github.com/amitfin/oref_alert/compare/v4.1.1...v5.2.0

The main problem with this update were test failures due to the `if TYPE_CHECKING:` pattern used in the project. I added more info to the Nix expression (see the file change).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
