### PR TITLE
nixos/shadow: use su from sudo-rs when enabled

### DIFF
--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -22,6 +22,13 @@ in
       '';
     };
 
+    security.shadow.su.package = lib.mkPackageOption pkgs [ "shadow" "su" ] {
+      extraDescription = ''
+        This can be overridden by other modules (e.g. sudo-rs) to provide
+        an alternative `su` implementation.
+      '';
+    };
+
     security.loginDefs = {
       package = lib.mkPackageOption pkgs "shadow" { };
 
@@ -262,7 +269,7 @@ in
           };
         in
         {
-          su = mkSetuidRoot "${cfg.package.su}/bin/su";
+          su = mkSetuidRoot "${config.security.shadow.su.package}/bin/su";
           sg = mkSetuidRoot "${cfg.package.out}/bin/sg";
           newgrp = mkSetuidRoot "${cfg.package.out}/bin/newgrp";
           newuidmap = mkSetuidRoot "${cfg.package.out}/bin/newuidmap";

--- a/nixos/modules/security/sudo-rs.nix
+++ b/nixos/modules/security/sudo-rs.nix
@@ -215,6 +215,8 @@ in
     ];
     security.sudo.enable = lib.mkDefault false;
 
+    security.shadow.su.package = lib.mkDefault cfg.package;
+
     security.sudo-rs.extraRules =
       let
         defaultRule =

--- a/nixos/tests/shadow.nix
+++ b/nixos/tests/shadow.nix
@@ -171,5 +171,10 @@ in
         shadow.wait_for_file("/tmp/leo")
         assert "leo" in shadow.succeed("cat /tmp/leo")
         shadow.send_chars("logout\n")
+
+    with subtest("su wrapper should point to shadow by default"):
+        output = shadow.succeed("grep -aoP '/nix/store/[a-z0-9]{32}-[^\\x00]+' /run/wrappers/bin/su | head -1").strip()
+        assert "shadow" in output, \
+            f"su should come from shadow, but points to: {output}"
   '';
 }

--- a/nixos/tests/sudo-rs.nix
+++ b/nixos/tests/sudo-rs.nix
@@ -162,5 +162,10 @@ in
 
       with subtest("non-wheel users should be unable to run sudo thanks to execWheelOnly"):
           strict.fail('faketty -- su - noadmin -c "sudo --help"')
+
+      with subtest("su should come from sudo-rs"):
+          output = machine.succeed("grep -aoP '/nix/store/[a-z0-9]{32}-[^\\x00]+' /run/wrappers/bin/su | head -1").strip()
+          assert "sudo-rs" in output, \
+              f"su should come from sudo-rs, but points to: {output}"
     '';
 }


### PR DESCRIPTION
When `security.sudo-rs.enable` is `true`, the `su` setuid wrapper now uses the memory-safe `su` implementation from `sudo-rs` instead of the one from the `shadow` package.

Users who opt into `sudo-rs` likely want the full benefit of its memory-safe tooling, including `su`.

### Changes

- `nixos/modules/programs/shadow.nix`: Conditionally set the `su` wrapper source to `sudo-rs`'s `su` binary when `security.sudo-rs.enable` is `true`.

### Testing

Verified with `nix-instantiate --eval`:
- `sudo-rs.enable = true` → `su` source resolves to `.../sudo-rs-0.2.12/bin/su`
- `sudo-rs.enable = false` → `su` source resolves to `.../shadow-4.19.3-su/bin/su`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test