### PR TITLE
colorfuldarkglobal6-kde: Porting plasma theme

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15076,6 +15076,12 @@
     github = "Liamolucko";
     githubId = 43807659;
   };
+  liamthexpl0rer = {
+    name = "Liam";
+    matrix = "@liamthexpl0rer:matrix.org";
+    github = "liamthexpl0rer";
+    githubId = 119797945;
+  };
   liarokapisv = {
     email = "liarokapis.v@gmail.com";
     github = "liarokapisv";

--- a/pkgs/by-name/co/colorfuldarkglobal6-kde/package.nix
+++ b/pkgs/by-name/co/colorfuldarkglobal6-kde/package.nix
@@ -1,0 +1,44 @@
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+  lib,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "colorfuldarkglobal6-kde";
+  version = "0-unstable-2026-01-29";
+
+  src = fetchFromGitHub {
+    owner = "L4ki";
+    repo = "Colorful-Plasma-Themes";
+    rev = "67fe0058dc44c3b86898fee1c930d718fcc834dc";
+    hash = "sha256-bC4uAHnR4xZ50nEmG4Xyr0APvgL2r0BMD6b4a8UJbD0=";
+  };
+
+  installPhase = ''
+    mkdir -p "$out/share/plasma/desktoptheme/Colorful-Dark-Global-6"
+    mkdir -p "$out/share/aurorae/themes/Colorful-Dark-6"
+    mkdir -p "$out/share/color-schemes"
+    mkdir -p "$out/share/konsole"
+    mkdir -p "$out/share/icons/Colorful-Dark-6"
+
+    cp -rd "Colorful Global Themes/Colorful-Dark-Global-6"/* -t "$out/share/plasma/desktoptheme/Colorful-Dark-Global-6/"
+
+    cp -rd "Colorful Window Decorations/Colorful-Blur-Dark-Aurorae-6" -t "$out/share/aurorae/themes/"
+    cp -rd "Colorful Window Decorations/Colorful-Dark-Aurorae-6" -t "$out/share/aurorae/themes/"
+    cp -rd "Colorful Window Decorations/Colorful-Dark-Color-Aurorae-6" -t "$out/share/aurorae/themes/"
+
+    cp -rd "Colorful Konsole Color Schemes"/* -t "$out/share/konsole"
+
+    cp -rd "Colorful Color Schemes"/* -t "$out/share/color-schemes/"
+    cp -rd "Colorful Icons Themes/Colorful-Dark-Icons" -t "$out/share/icons/"
+  '';
+
+  meta = {
+    description = "Port of the Colorful-Dark-Global-6 theme for Plasma";
+    homepage = "https://github.com/L4ki/Colorful-Plasma-Themes/";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.liamthexpl0rer ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
