### PR TITLE
kube-diagrams: init at 0.8.0

### DIFF
--- a/pkgs/by-name/ku/kube-diagrams/package.nix
+++ b/pkgs/by-name/ku/kube-diagrams/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  python3,
+  stdenv,
+}:
+let
+  pythonEnv = python3.withPackages (ps: [
+    ps.pyyaml
+    ps.diagrams
+    ps.pygraphviz
+  ]);
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kube-diagrams";
+
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "philippemerle";
+    repo = "KubeDiagrams";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-C/hY3+fWWYvufox1T5smzhCZAHwIc6B2cqKNxZgh+0Y=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postPatch = ''
+    substituteInPlace bin/kube-diagrams \
+      --replace-fail '/usr/bin/env python3' '${pythonEnv}/bin/python'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/kube-diagrams $out/bin
+    cp -r bin/* $out/share/kube-diagrams/
+    chmod +x $out/share/kube-diagrams/*-diagrams
+
+    # kube-diagrams locates its yaml config and icons next to itself via
+    # os.path.dirname(__file__), which does not resolve symlinks
+    makeWrapper $out/share/kube-diagrams/kube-diagrams $out/bin/kube-diagrams
+    ln -s $out/share/kube-diagrams/helm-diagrams $out/bin/helm-diagrams
+    ln -s $out/share/kube-diagrams/kubectl-diagrams $out/bin/kubectl-diagrams
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/philippemerle/KubeDiagrams/releases/tag/v${finalAttrs.version}";
+    description = "Generate Kubernetes architecture diagrams from Kubernetes manifest files, kustomization files, Helm charts, helmfiles, and actual cluster state";
+    homepage = "https://kubediagrams.lille.inria.fr";
+    license = lib.licenses.asl20;
+    mainProgram = "kube-diagrams";
+    maintainers = with lib.maintainers; [ allsimon ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
