### PR TITLE
objection: init at 1.12.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4453,6 +4453,12 @@
     githubId = 495429;
     name = "Claas Augner";
   };
+  caverav = {
+    email = "camilo@fvv.cl";
+    github = "caverav";
+    githubId = 66751764;
+    name = "Camilo Vera Vidales";
+  };
   cawilliamson = {
     email = "home@chrisaw.com";
     github = "cawilliamson";

--- a/pkgs/by-name/ob/objection/package.nix
+++ b/pkgs/by-name/ob/objection/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchPypi,
+  frida-tools,
+  litecli,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "objection";
+  version = "1.12.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-Qwkn7LPfW/k3G4yLcuX9I1/3bZQf7tdrWFaRZycjNLQ=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    wheel
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      click
+      delegator-py
+      flask
+      frida-python
+      packaging
+      prompt-toolkit
+      pygments
+      requests
+      semver
+      setuptools
+      tabulate
+    ]
+    ++ [
+      frida-tools
+      litecli
+    ];
+
+  pythonImportsCheck = [ "objection" ];
+
+  meta = {
+    description = "Instrumented mobile pentest framework";
+    homepage = "https://github.com/sensepost/objection";
+    changelog = "https://github.com/sensepost/objection/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "objection";
+    maintainers = with lib.maintainers; [ caverav ];
+    platforms = python3Packages.frida-python.meta.platforms;
+  };
+})


### PR DESCRIPTION
  ## Summary
  - Add new package `objection` (`pkgs/by-name/ob/objection/package.nix`).
  - Add maintainer entry `caverav` (`Camilo Vera Vidales`) in `maintainers/maintainer-list.nix`.
  - Package source: PyPI `objection` version `1.12.3`.
  - Upstream release notes: https://github.com/sensepost/objection/releases/tag/1.12.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
