### PR TITLE
lib/cli: add detachArg to toCommandLineGNU

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -208,26 +208,44 @@ rec {
 
     : A function that turns the option argument into a string.
 
+    `detachArg`
+
+    : A function that determines whether the option should be separated from its
+      argument.
+
     # Examples
 
     :::{.example}
-    ## `lib.cli.toCommandLineGNU` usage example
+    ## `lib.cli.toCommandLineGNU` basic usage example
 
     ```nix
-    lib.cli.toCommandLineGNU {} {
+    lib.cli.toCommandLineGNU { } {
       v = true;
-      verbose = [true true false null];
+      verbose = [
+        true
+        true
+        false
+        null
+      ];
       i = ".bak";
-      testsuite = ["unit" "integration"];
-      e = ["s/a/b/" "s/b/c/"];
+      testsuite = [
+        "unit"
+        "integration"
+      ];
+      e = [
+        "s/a/b/"
+        "s/b/c/"
+      ];
       n = false;
-      data = builtins.toJSON {id = 0;};
+      data = builtins.toJSON { id = 0; };
+      s = "";
     }
     => [
       "--data={\"id\":0}"
       "-es/a/b/"
       "-es/b/c/"
       "-i.bak"
+      "-s"
       "--testsuite=unit"
       "--testsuite=integration"
       "-v"
@@ -235,7 +253,107 @@ rec {
       "--verbose"
     ]
     ```
+    :::
 
+    :::{.example}
+    ## `lib.cli.toCommandLineGNU` usage with `detachArg`
+
+    ```nix
+    lib.cli.toCommandLineGNU
+      {
+        detachArg =
+          optionName:
+          builtins.elem optionName [
+            "n"
+            "s"
+          ];
+      }
+      {
+        v = true;
+        verbose = [
+          true
+          true
+          false
+          null
+        ];
+        i = ".bak";
+        testsuite = [
+          "unit"
+          "integration"
+        ];
+        e = [
+          "s/a/b/"
+          "s/b/c/"
+        ];
+        n = false;
+        data = builtins.toJSON { id = 0; };
+        s = "";
+      }
+    => [
+      "--data={\"id\":0}"
+      "-es/a/b/"
+      "-es/b/c/"
+      "-i.bak"
+      "-s"
+      ""
+      "--testsuite=unit"
+      "--testsuite=integration"
+      "-v"
+      "--verbose"
+      "--verbose"
+    ]
+    ```
+    :::
+
+    :::{.example}
+    ## `lib.cli.toCommandLineGNU` usage with `detachArg` for all options
+
+    ```nix
+    lib.cli.toCommandLineGNU
+      {
+        detachArg = _: true;
+      }
+      {
+        v = true;
+        verbose = [
+          true
+          true
+          false
+          null
+        ];
+        i = ".bak";
+        testsuite = [
+          "unit"
+          "integration"
+        ];
+        e = [
+          "s/a/b/"
+          "s/b/c/"
+        ];
+        n = false;
+        data = builtins.toJSON { id = 0; };
+        s = "";
+      }
+    => [
+      "--data"
+      "{\"id\":0}"
+      "-e"
+      "s/a/b/"
+      "-e"
+      "s/b/c/"
+      "-i"
+      ".bak"
+      "-s"
+      ""
+      "--testsuite"
+      "unit"
+      "--testsuite"
+      "integration"
+      "-v"
+      "--verbose"
+      "--verbose"
+    ]
+    ```
     :::
   */
   toCommandLineGNU =
@@ -243,11 +361,18 @@ rec {
       isLong ? optionName: stringLength optionName > 1,
       explicitBool ? false,
       formatArg ? mkValueString,
+      detachArg ? _: false,
     }:
     let
       optionFormat = optionName: {
         option = if isLong optionName then "--${optionName}" else "-${optionName}";
-        sep = if isLong optionName then "=" else "";
+        sep =
+          if detachArg optionName then
+            null
+          else if isLong optionName then
+            "="
+          else
+            "";
         inherit explicitBool formatArg;
       };
     in

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -3297,6 +3297,54 @@ runTests {
     ];
   };
 
+  testToCommandLineGNUWithDetachArg = {
+    expr =
+      cli.toCommandLineGNU
+        {
+          detachArg =
+            optionName:
+            builtins.elem optionName [
+              "n"
+              "s"
+            ];
+        }
+        {
+          v = true;
+          verbose = [
+            true
+            true
+            false
+            null
+          ];
+          i = ".bak";
+          testsuite = [
+            "unit"
+            "integration"
+          ];
+          e = [
+            "s/a/b/"
+            "s/b/c/"
+          ];
+          n = false;
+          data = builtins.toJSON { id = 0; };
+          s = "";
+        };
+
+    expected = [
+      "--data={\"id\":0}"
+      "-es/a/b/"
+      "-es/b/c/"
+      "-i.bak"
+      "-s"
+      ""
+      "--testsuite=unit"
+      "--testsuite=integration"
+      "-v"
+      "--verbose"
+      "--verbose"
+    ];
+  };
+
   testSanitizeDerivationNameLeadingDots = testSanitizeDerivationName {
     name = "..foo";
     expected = "foo";


### PR DESCRIPTION
`toCommandLineGNU` currently assumes that every option *optionally* takes an argument, meaning it uses the `--option=value` and `-ovalue` syntax rather than `--option value` and `-o value`. This approach avoids ambiguity for long options, but short options can't be generated in an entirely unambiguous manner. For example, if a program has a short option `-p` that *requires* an argument, passing an empty string to it through `toCommandLineGNU` will result in just `-p` being emitted, without an argument, which will obviously break (see https://github.com/nix-community/home-manager/issues/8544). Another case where the current behavior breaks is programs like `nix-collect-garbage`, which don't support the `--option=value` syntax (see #494884).

What I've opted for as a solution is to add the `detachArg` argument to `toCommandLineGNU`, which takes the option name and returns whether the option argument should be separated from the option.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
