### PR TITLE
dwarfs: 0.12.4 -> 0.14.0

### DIFF
--- a/pkgs/by-name/dw/dwarfs/package.nix
+++ b/pkgs/by-name/dw/dwarfs/package.nix
@@ -12,7 +12,6 @@
   flac,
   glog,
   gtest,
-  howard-hinnant-date,
   jemalloc,
   libarchive,
   libevent,
@@ -57,7 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     bison
     cmake
-    howard-hinnant-date # uses only the header-only parts
     pkg-config
     range-v3 # header-only library
     ronn
@@ -118,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Fast high compression read-only file system";
     homepage = "https://github.com/mhx/dwarfs";
     changelog = "https://github.com/mhx/dwarfs/blob/v${finalAttrs.version}/CHANGES.md";
-    license = lib.licenses.gpl3Only;
+    license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.luftmensch-luftmensch ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/dw/dwarfs/package.nix
+++ b/pkgs/by-name/dw/dwarfs/package.nix
@@ -104,6 +104,15 @@ stdenv.mkDerivation (finalAttrs: {
         "dwarfs/tools_test.end_to_end/*"
         "dwarfs/tools_test.mutating_and_error_ops/*"
         "dwarfs/tools_test.categorize/*"
+        # Requires a working FUSE device and fusermount3, unavailable in sandbox.
+        "dwarfs/tools_test.timestamps_fuse*"
+        "dwarfs/tools_test.dwarfs_automount*"
+        "dwarfs/tools_test.dwarfs_fsname_and_subtype*"
+        "dwarfs/sparse_files_test.random_large_files*"
+        "dwarfs/sparse_files_test.random_small_files_fuse*"
+        "dwarfs/sparse_files_test.huge_holes_fuse*"
+        # Requires xattr support unavailable in sandbox.
+        "dwarfs/xattr_test.portable_xattr"
       ];
     in
     "-${lib.concatStringsSep ":" disabledTests}";

--- a/pkgs/by-name/dw/dwarfs/package.nix
+++ b/pkgs/by-name/dw/dwarfs/package.nix
@@ -34,14 +34,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dwarfs";
-  version = "0.12.4";
+  version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "mhx";
     repo = "dwarfs";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-EYNnmv0QKdWddIRFRsuwsazHep3nrJ8lInlR4S67rME=";
+    hash = "sha256-4Ec1AqumTSPZpPEi528OaO3bOU1Soc8ZHuuKXIDvCUA=";
   };
 
   cmakeFlags = [

--- a/pkgs/by-name/dw/dwarfs/package.nix
+++ b/pkgs/by-name/dw/dwarfs/package.nix
@@ -49,6 +49,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Needs to be set so `dwarfs` does not try to download `gtest`; it is not
     # a submodule, see: https://github.com/mhx/dwarfs/issues/188#issuecomment-1907657083
     "-DPREFER_SYSTEM_GTEST=ON"
+    # Upstream composes DESTDIR + CMAKE_INSTALL_PREFIX + CMAKE_INSTALL_SBINDIR
+    # in a create_link() install script. Keep SBINDIR relative to avoid
+    # nested nix/store path creation in the output.
+    "-DCMAKE_INSTALL_SBINDIR=sbin"
     "-DWITH_LEGACY_FUSE=ON"
     "-DWITH_TESTS=ON"
   ];
@@ -105,14 +109,14 @@ stdenv.mkDerivation (finalAttrs: {
         "dwarfs/tools_test.mutating_and_error_ops/*"
         "dwarfs/tools_test.categorize/*"
         # Requires a working FUSE device and fusermount3, unavailable in sandbox.
-        "dwarfs/tools_test.timestamps_fuse*"
-        "dwarfs/tools_test.dwarfs_automount*"
-        "dwarfs/tools_test.dwarfs_fsname_and_subtype*"
-        "dwarfs/sparse_files_test.random_large_files*"
-        "dwarfs/sparse_files_test.random_small_files_fuse*"
-        "dwarfs/sparse_files_test.huge_holes_fuse*"
+        "tools_test.timestamps_fuse*"
+        "tools_test.dwarfs_automount*"
+        "tools_test.dwarfs_fsname_and_subtype*"
+        "sparse_files_test.random_large_files*"
+        "sparse_files_test.random_small_files_fuse*"
+        "sparse_files_test.huge_holes_fuse*"
         # Requires xattr support unavailable in sandbox.
-        "dwarfs/xattr_test.portable_xattr"
+        "xattr_test.portable_xattr"
       ];
     in
     "-${lib.concatStringsSep ":" disabledTests}";
@@ -120,6 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/dwarfs";
+  dontMoveSbin = true;
 
   meta = {
     description = "Fast high compression read-only file system";


### PR DESCRIPTION
update DwarFS from 0.12.4 to 0.14.0.

- Resolves build failure tracked in https://github.com/NixOS/nixpkgs/issues/494561 (`boost_system` lookup failure with Boost 1.89 on `dwarfs` 0.12.4).

- Root-cause context from upstream:
  - https://github.com/mhx/dwarfs/issues/288
  - https://github.com/facebook/folly/issues/2489
- Upstream release notes indicate the relevant fix in v0.14.0:
  - https://github.com/mhx/dwarfs/releases/tag/v0.14.0

## Summary
- bump `dwarfs` from `0.12.4` to `0.14.0`
- update source hash for submodules
- remove `howard-hinnant-date` from inputs (upstream v0.14.0 removed hard dependency)
- align license metadata to `gpl3Plus` (upstream sources use `GPL-3.0-or-later` in v0.14.0)
- update sandbox test filtering for new FUSE/xattr-sensitive tests in 0.14.0
- set `-DCMAKE_INSTALL_SBINDIR=sbin` and `dontMoveSbin = true` to keep `mount.dwarfs` symlink valid in nix fixup/noBrokenSymlinks

## Changelog review
- reviewed v0.13.0: https://github.com/mhx/dwarfs/releases/tag/v0.13.0
- reviewed v0.14.0: https://github.com/mhx/dwarfs/releases/tag/v0.14.0

## Validation
- `nix-build -A dwarfs` (pass)
- `./result/bin/{dwarfs,mkdwarfs,dwarfsextract,dwarfsck} --help` (pass)
- `nixpkgs-review rev HEAD` (pass, built: `dwarfs`, `gearlever`)
