### PR TITLE
kubernetes-helmPlugins.helm-schema: split into helm-schema-losisin and helm-schema-dadav

### DIFF
--- a/pkgs/applications/networking/cluster/helm/plugins/default.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/default.nix
@@ -18,6 +18,8 @@ in
 
   helm-secrets = callPackage ./helm-secrets.nix { };
 
+  helm-schema-dadav = callPackage ./helm-schema-dadav.nix { };
+
   inherit helm-schema-losisin;
 
   # Alias for backwards compatibility, points to the original package

--- a/pkgs/applications/networking/cluster/helm/plugins/default.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/default.nix
@@ -1,5 +1,8 @@
 { callPackage }:
 
+let
+  helm-schema-losisin = callPackage ./helm-schema-losisin.nix { };
+in
 {
   helm-cm-push = callPackage ./helm-cm-push.nix { };
 
@@ -15,7 +18,10 @@
 
   helm-secrets = callPackage ./helm-secrets.nix { };
 
-  helm-schema = callPackage ./helm-schema.nix { };
+  inherit helm-schema-losisin;
+
+  # Alias for backwards compatibility, points to the original package
+  helm-schema = helm-schema-losisin;
 
   helm-unittest = callPackage ./helm-unittest.nix { };
 }

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-schema-dadav.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-schema-dadav.nix
@@ -1,0 +1,50 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "helm-schema-dadav";
+  version = "0.21.2";
+
+  src = fetchFromGitHub {
+    owner = "dadav";
+    repo = "helm-schema";
+    tag = finalAttrs.version;
+    hash = "sha256-nN+i0HrgybS/fyhyEaAb/VH24noyV7dE4svrEhH8cs8=";
+  };
+
+  vendorHash = "sha256-JV9/za2NeRmWTLrP9Urr5Ak/Am85uFTq+hFgTurtPUU=";
+
+  subPackages = [ "cmd/helm-schema" ];
+
+  env.CGO_ENABLED = 0;
+
+  postPatch = ''
+    # Remove the install and upgrade hooks
+    sed -i '/^hooks:/,+2 d' plugin.yaml
+  '';
+
+  postInstall = ''
+    install -dm755 $out/${finalAttrs.pname}
+    mv $out/bin $out/${finalAttrs.pname}/
+    install -m644 -Dt $out/${finalAttrs.pname} plugin.yaml
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/${finalAttrs.pname}/bin/helm-schema";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "helm-schema";
+    description = "Helm plugin for generating JSON schemas from Helm charts values files";
+    homepage = "https://github.com/dadav/helm-schema";
+    changelog = "https://github.com/dadav/helm-schema/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-schema-losisin.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-schema-losisin.nix
@@ -7,7 +7,7 @@
 }:
 
 buildGoModule (finalAttrs: {
-  pname = "helm-schema";
+  pname = "helm-schema-losisin";
   version = "2.3.1";
 
   src = fetchFromGitHub {
@@ -34,10 +34,10 @@ buildGoModule (finalAttrs: {
   '';
 
   postInstall = ''
-    install -D plugin.complete -t $out/helm-schema/
-    install -m644 plugin.yaml -t $out/helm-schema/
+    install -D plugin.complete -t $out/${finalAttrs.pname}/
+    install -m644 plugin.yaml -t $out/${finalAttrs.pname}/
     mv $out/bin/{helm-values-schema-json,schema}
-    mv $out/bin $out/helm-schema
+    mv $out/bin $out/${finalAttrs.pname}
   '';
 
   # Unit tests try to open web server on port 0
@@ -45,7 +45,7 @@ buildGoModule (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgram = "${placeholder "out"}/helm-schema/bin/schema";
+  versionCheckProgram = "${placeholder "out"}/${finalAttrs.pname}/bin/schema";
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Two unrelated upstream projects share the name "helm-schema":

- [losisin/helm-values-schema-json](https://github.com/losisin/helm-values-schema-json) -- generates `values.schema.json` from values files
- [dadav/helm-schema](https://github.com/dadav/helm-schema) -- generates JSON schemas from Helm chart values files

This PR disambiguates them by suffixing each with the upstream author name,
as discussed in https://discourse.nixos.org/t/duplicate-package-name-for-a-helmplugin/71054

Changes:
- Rename `helm-schema` to `helm-schema-losisin` (the existing package by @applejag)
- Add `helm-schema-dadav` as a new package at version 0.21.2
- Keep `helm-schema` as a backwards-compatible alias to `helm-schema-losisin`

Supersedes #487946 and #467659.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test