### PR TITLE
nixos/tests/systemd-repart: do not assume structured journal logs in tests

### DIFF
--- a/nixos/tests/systemd-repart.nix
+++ b/nixos/tests/systemd-repart.nix
@@ -110,8 +110,7 @@ in
         machine.start()
         machine.wait_for_unit("multi-user.target")
 
-        systemd_repart_logs = machine.succeed("journalctl --boot --unit systemd-repart.service")
-        assert "Growing existing partition 1." in systemd_repart_logs
+        machine.succeed("journalctl --boot --grep 'Growing existing partition 1.' --identifier systemd-repart")
       '';
   };
 
@@ -173,8 +172,7 @@ in
         machine.start()
         machine.wait_for_unit("multi-user.target")
 
-        systemd_repart_logs = machine.succeed("journalctl --boot --unit systemd-repart.service")
-        assert "Encrypting future partition 2" in systemd_repart_logs
+        machine.succeed("journalctl --boot --grep 'Encrypting future partition 2' --identifier systemd-repart")
 
         assert "/dev/mapper/created-crypt" in machine.succeed("mount")
       '';
@@ -205,8 +203,7 @@ in
         machine.start()
         machine.wait_for_unit("multi-user.target")
 
-        systemd_repart_logs = machine.succeed("journalctl --unit systemd-repart.service")
-        assert "Growing existing partition 1." in systemd_repart_logs
+        machine.succeed("journalctl --grep 'Growing existing partition 1.' --identifier systemd-repart")
       '';
   };
 
@@ -273,8 +270,7 @@ in
         machine.start()
         machine.wait_for_unit("multi-user.target")
 
-        systemd_repart_logs = machine.succeed("journalctl --boot --unit systemd-repart.service")
-        assert "Adding new partition 2 to partition table." in systemd_repart_logs
+        machine.succeed("journalctl --boot --grep 'Adding new partition 2 to partition table.' --identifier systemd-repart")
       '';
   };
 


### PR DESCRIPTION
systemd-repart and systemd-journal start up in parallel. This means that quite often systemd-repart ends up logging to /dev/kmesg as opposed to the journal. 

This makes the tests very flakey (see e.g.
https://hydra.nixos.org/job/nixos/release-25.11/nixos.tests.systemd-repart.after-initrd.x86_64-linux)

Instead we switch to --syslog-identifier which is set for both  logs in /dev/kmesg and for journal logs


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
