### PR TITLE
yaziPlugins: update on 2026-02-28

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/chmod/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/chmod/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "chmod.yazi";
-  version = "25.12.29-unstable-2025-12-29";
+  version = "26.1.22-unstable-2026-02-27";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "517619af126f25f3da096ff156ce46b561b54be3";
-    hash = "sha256-j7fsUmx2nK4Tyj5KCamcCmfs99K6duV+okf8NvzccsI=";
+    rev = "0897e20d41b79a5ec8e80e645b041bb950547a0b";
+    hash = "sha256-tHOHWFH9E7aGrmHb8bUD1sLGU0OIdTjQ2p4SbJVfh/s=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/drag/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/drag/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "drag.yazi";
-  version = "0-unstable-2025-08-29";
+  version = "0-unstable-2026-02-21";
 
   src = fetchFromGitHub {
     owner = "Joao-Queiroga";
     repo = "drag.yazi";
-    rev = "27606689cb82c56a19c052a7b7935cd9b1466bab";
-    hash = "sha256-ITkZjpwWXni4tQpDhUiVvtPrEkAo6RISgCH594NgpYE=";
+    rev = "3dff129c52b30d8c08015e6f4ef8f2c07b299d4b";
+    hash = "sha256-nmFlh+zW3aOU+YjbfrAWQ7A6FlGaTDnq2N2gOZ5yzzc=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/git/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/git/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "git.yazi";
-  version = "25.12.29-unstable-2026-01-26";
+  version = "26.1.22-unstable-2026-02-27";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "e07bf41442a7f6fdd003069f380e1ae469a86211";
-    hash = "sha256-aC8DUZpzNHEf9MW3tX3XcDYY/mWClAHkw+nZaxDQHp8=";
+    rev = "0897e20d41b79a5ec8e80e645b041bb950547a0b";
+    hash = "sha256-tHOHWFH9E7aGrmHb8bUD1sLGU0OIdTjQ2p4SbJVfh/s=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/gitui/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/gitui/default.nix
@@ -6,21 +6,14 @@
 
 mkYaziPlugin {
   pname = "gitui.yazi";
-  version = "0-unstable-2025-05-26";
+  version = "0-unstable-2026-02-24";
 
   src = fetchFromGitHub {
     owner = "gclarkjr5";
     repo = "gitui.yazi";
-    rev = "397e9cf9cff536a43e746d72e0e81fd5c3050d2d";
-    hash = "sha256-Bo16/5XuSxRhN6URwTBxuw0FTMHLF3nV1UDBQQJFHMM=";
+    rev = "b3362f54db9c0da51b1d4fb2fe8315a0dada7274";
+    hash = "sha256-lNj5dH6LDvl9TlA7/+bnDrRMlpOE0bCW3umrW3gBpP8=";
   };
-
-  installPhase = ''
-    runHook preInstall
-    cp -r . $out
-    mv $out/init.lua $out/main.lua
-    runHook postInstall
-  '';
 
   meta = {
     description = "Plugin for Yazi to manage git repos with gitui";

--- a/pkgs/by-name/ya/yazi/plugins/mactag/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mactag/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mactag.yazi";
-  version = "25.12.29-unstable-2025-12-29";
+  version = "26.1.22-unstable-2026-02-27";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "517619af126f25f3da096ff156ce46b561b54be3";
-    hash = "sha256-j7fsUmx2nK4Tyj5KCamcCmfs99K6duV+okf8NvzccsI=";
+    rev = "0897e20d41b79a5ec8e80e645b041bb950547a0b";
+    hash = "sha256-tHOHWFH9E7aGrmHb8bUD1sLGU0OIdTjQ2p4SbJVfh/s=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "25.5.31-unstable-2026-02-12";
+  version = "25.5.31-unstable-2026-02-22";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "8ab04b24595e0ba14a815d0596baa6c70986ccc4";
-    hash = "sha256-6mYZba/fF5G81FqAB4dJ7hLwIV7GFh+/yA0eyX+vB6Q=";
+    rev = "20ecff6dd154da4c6e28fc7f754e865fd5f9d1b3";
+    hash = "sha256-br8UDDPxVe4ZfoHIURD2zzjmyUImhKak0DYwCF9r2vw=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/rsync/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/rsync/default.nix
@@ -5,12 +5,12 @@
 }:
 mkYaziPlugin {
   pname = "rsync.yazi";
-  version = "0-unstable-2025-10-23";
+  version = "0-unstable-2026-02-28";
   src = fetchFromGitHub {
     owner = "GianniBYoung";
     repo = "rsync.yazi";
-    rev = "14d28283f49b39593a2763d7457e0dacb78f7597";
-    hash = "sha256-LT+4NKiCkiF72RG9g/tOjS6F+Wc4tY3vtnHNHPxbn1w=";
+    rev = "c094a5ce2dc2ebdb37f97a6f1f15af6c14c06402";
+    hash = "sha256-SqN3jDwHtsVDqawJyYHWdndi9IaCKPJH9+d7ffX9H7c=";
   };
 
   meta = {


### PR DESCRIPTION
- chmod: 25.12.29-unstable-2025-12-29 → 26.1.22-unstable-2026-02-27
  Compare: https://github.com/yazi-rs/plugins/compare/517619af126f25f3da096ff156ce46b561b54be3...0897e20d41b79a5ec8e80e645b041bb950547a0b
- drag: 0-unstable-2025-08-29 → 0-unstable-2026-02-21
  Compare: https://github.com/Joao-Queiroga/drag.yazi/compare/27606689cb82c56a19c052a7b7935cd9b1466bab...3dff129c52b30d8c08015e6f4ef8f2c07b299d4b
- git: 25.12.29-unstable-2026-01-26 → 26.1.22-unstable-2026-02-27
  Compare: https://github.com/yazi-rs/plugins/compare/e07bf41442a7f6fdd003069f380e1ae469a86211...0897e20d41b79a5ec8e80e645b041bb950547a0b
- gitui: 0-unstable-2025-05-26 → 0-unstable-2026-02-24
  Compare: https://github.com/gclarkjr5/gitui.yazi/compare/397e9cf9cff536a43e746d72e0e81fd5c3050d2d...b3362f54db9c0da51b1d4fb2fe8315a0dada7274
- mactag: 25.12.29-unstable-2025-12-29 → 26.1.22-unstable-2026-02-27
  Compare: https://github.com/yazi-rs/plugins/compare/517619af126f25f3da096ff156ce46b561b54be3...0897e20d41b79a5ec8e80e645b041bb950547a0b
- mediainfo: 25.5.31-unstable-2026-02-12 → 25.5.31-unstable-2026-02-22
  Compare: https://github.com/boydaihungst/mediainfo.yazi/compare/8ab04b24595e0ba14a815d0596baa6c70986ccc4...20ecff6dd154da4c6e28fc7f754e865fd5f9d1b3
- rsync: 0-unstable-2025-10-23 → 0-unstable-2026-02-28
  Compare: https://github.com/GianniBYoung/rsync.yazi/compare/14d28283f49b39593a2763d7457e0dacb78f7597...c094a5ce2dc2ebdb37f97a6f1f15af6c14c06402


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
