### PR TITLE
dcp: init at 0.22.8

### DIFF
--- a/pkgs/by-name/dc/dcp/package.nix
+++ b/pkgs/by-name/dc/dcp/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  bash,
+  protobuf,
+  protoc-gen-go,
+  protoc-gen-go-grpc,
+  kubernetes-controller-tools,
+  installShellFiles,
+  nix-update-script,
+  writableTmpDirAsHomeHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "dcp";
+  version = "0.22.8";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "dcp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fhRTJYtkvPaPw73VZYvm8/GMhUqvnlBoazQziWXrH2U=";
+  };
+
+  vendorHash = "sha256-MRsd0+ySmZ8FlX6RBfW1LSYc1RcTMYu0Ji+0uFEWH3M=";
+
+  # This is required so we:
+  # - Delete an inconsistent vendor directory from upstream
+  # - Avoid running a preBuild before the codegen step
+  overrideModAttrs = _: {
+    preBuild = null;
+    postUnpack = ''
+      rm -rf $sourceRoot/vendor
+    '';
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+    protoc-gen-go
+    protoc-gen-go-grpc
+    writableTmpDirAsHomeHook
+  ];
+
+  # Run code generation using the upstream Makefile.
+  # Override SHELL for Nix sandbox compatibility.
+  # Use full paths for PROTOC and CONTROLLER_GEN to avoid Makefile target conflicts.
+  preBuild = ''
+    make generate \
+      SHELL="${bash}/bin/bash -o pipefail" \
+      PROTOC="${protobuf}/bin/protoc" \
+      CONTROLLER_GEN="${kubernetes-controller-tools}/bin/controller-gen"
+  '';
+
+  subPackages = [
+    "cmd/dcp"
+    "cmd/dcptun"
+  ];
+
+  ldflags =
+    let
+      pkg = "github.com/microsoft/dcp/internal/version";
+    in
+    [
+      "-s"
+      "-w"
+      "-X ${pkg}.ProductVersion=${finalAttrs.version}"
+      "-X ${pkg}.CommitHash=v${finalAttrs.version}"
+    ];
+
+  # The dcptun binary should be named dcptun_c for compatibility
+  # https://github.com/microsoft/dcp/blob/3146b1dd5b2ea283947f846a55bf2e01c294e2ba/Makefile#L103
+  postInstall = ''
+    mv $out/bin/dcptun $out/bin/dcptun_c
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd dcp \
+      --bash <($out/bin/dcp completion bash) \
+      --fish <($out/bin/dcp completion fish) \
+      --zsh <($out/bin/dcp completion zsh)
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Developer Control Plane - API server and CLI for managing developer workloads";
+    homepage = "https://github.com/microsoft/dcp";
+    changelog = "https://github.com/microsoft/dcp/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mtrsk ];
+    mainProgram = "dcp";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Packages [dcp](https://github.com/microsoft/dcp), a project that is a dependency of larger projects (like [.NET aspire](https://github.com/dotnet/aspire)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
