### PR TITLE
python3Packages.sphinxfeed-lsaffre: init at 0.3.5

### DIFF
--- a/pkgs/development/python-modules/sphinxfeed-lsaffre/default.nix
+++ b/pkgs/development/python-modules/sphinxfeed-lsaffre/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  feedgen,
+  python-dateutil,
+  sphinx,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "sphinxfeed-lsaffre";
+  version = "0.3.5";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "sphinxfeed_lsaffre";
+    inherit (finalAttrs) version;
+    hash = "sha256-uwyAugA4JEkrheJ40CmZThqf/DZbSTBImZHIJeO3SLA=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    feedgen
+    python-dateutil
+    sphinx
+  ];
+
+  meta = {
+    description = "Sphinx extension for generating RSS feeds";
+    homepage = "https://github.com/lsaffre/sphinxfeed";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ MysteryBlokHed ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18241,6 +18241,8 @@ self: super: with self; {
 
   sphinxext-rediraffe = callPackage ../development/python-modules/sphinxext-rediraffe { };
 
+  sphinxfeed-lsaffre = callPackage ../development/python-modules/sphinxfeed-lsaffre { };
+
   spiderpy = callPackage ../development/python-modules/spiderpy { };
 
   spidev = callPackage ../development/python-modules/spidev { };


### PR DESCRIPTION
Adds the Python package [sphinxfeed-lsaffre](https://pypi.org/project/sphinxfeed-lsaffre/). This package is depended on by [khal](https://github.com/pimutils/khal) as of v0.14.0, as a replacement for `sphinxcontrib-newsfeed` that works with modern versions of Sphinx.

See: <https://github.com/pimutils/khal/blob/master/CHANGELOG.rst#0140>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
