### PR TITLE
python3Packages.pytest-ansible: 26.1.0 -> 26.2.0

### DIFF
--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -8,8 +8,6 @@
   fetchFromGitHub,
   packaging,
   pytest,
-  pytest-plus,
-  pytest-sugar,
   pytest-xdist,
   pytestCheckHook,
   setuptools,
@@ -18,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "pytest-ansible";
-  version = "26.1.0";
+  version = "26.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ansible";
     repo = "pytest-ansible";
     tag = "v${version}";
-    hash = "sha256-uCuGDAEIiVAB9lfYf2X60nIA8IsmEJ9Dola0eFBNC+U=";
+    hash = "sha256-3pppBAgAfkwJNPRsI6CH4UDMqyZ45+mFNejlQwX5bCg=";
   };
 
   postPatch = ''
@@ -44,8 +42,6 @@ buildPythonPackage rec {
     ansible-core
     ansible-compat
     packaging
-    pytest-plus
-    pytest-sugar
     pytest-xdist
   ];
 


### PR DESCRIPTION
changelog for python3Packages.pytest-ansible is: https://github.com/ansible-community/pytest-ansible/releases/tag/v26.2.0

Supersedes #494911


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
