### PR TITLE
obsidian-headless: init at 0.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19831,6 +19831,12 @@
     githubId = 9677399;
     name = "Ofek Lev";
   };
+  of-the-stars = {
+    name = "Stellae";
+    github = "of-the-stars";
+    githubId = 47869156;
+    email = "stellae.incaelis@gmail.com";
+  };
   offsetcyan = {
     github = "offsetcyan";
     githubId = 49906709;

--- a/pkgs/by-name/ob/obsidian-headless/package.nix
+++ b/pkgs/by-name/ob/obsidian-headless/package.nix
@@ -1,0 +1,41 @@
+{
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  lib,
+  nodejs,
+  pnpm,
+  pnpmConfigHook,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "obsidian-headless";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "obsidianmd";
+    repo = "obsidian-headless";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-b69b55e9261d05fb7c4c0ec82f6dc2b6af81b359";
+  };
+
+  nativeBuildInputs = [
+    nodejs # in case scripts are run outside of a pnpm call
+    pnpmConfigHook
+    pnpm # At least required by pnpmConfigHook, if not other (custom) phases
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 3;
+    hash = "sha256-b69b55e9261d05fb7c4c0ec82f6dc2b6af81b359";
+  };
+
+  meta = {
+    description = "Headless client for Obsidian Sync. Sync your vaults from the command line without the desktop app. ";
+    homepage = "https://obsidian.md/sync";
+    license = lib.licenses.unfree;
+    mainProgram = "ob";
+    maintainers = with lib.maintainers; [ of-the-stars ];
+  };
+})


### PR DESCRIPTION
Packages [obsidian-headless](https://github.com/obsidianmd/obsidian-headless), a package to use Obsidian's [Sync](https://obsidian.md/sync) feature without opening the application.

https://help.obsidian.md/sync/headless
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
