### PR TITLE
Contract for files containing secrets

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -2034,6 +2034,7 @@
   ./tasks/stratis.nix
   ./tasks/swraid.nix
   ./tasks/trackpoint.nix
+  ./testing/hardcoded-secret.nix
   ./testing/service-runner.nix
   ./virtualisation/amazon-options.nix
   ./virtualisation/appvm.nix

--- a/nixos/modules/services/web-apps/stash.nix
+++ b/nixos/modules/services/web-apps/stash.nix
@@ -366,6 +366,69 @@ let
             done
           '';
     };
+
+  secretOptionType =
+    let
+      contractSecretsType = types.submodule {
+        options = {
+          input = mkOption {
+            description = "Input of the contract for file secrets.";
+            default = { };
+            type = types.submodule {
+              options = {
+                mode = mkOption {
+                  description = ''
+                    Mode the secret file must have.
+                  '';
+                  type = types.str;
+                  default = "0400";
+                  readOnly = true;
+                };
+
+                owner = mkOption {
+                  description = ''
+                    Linux user that must own the secret file.
+                  '';
+                  type = types.str;
+                  default = cfg.user;
+                  readOnly = true;
+                };
+
+                group = mkOption {
+                  description = ''
+                    Linux group that must own the secret file.
+                  '';
+                  type = types.str;
+                  default = cfg.group;
+                  readOnly = true;
+                };
+              };
+            };
+          };
+
+          output = mkOption {
+            description = "Output of the contract for file secrets.";
+            type = types.submodule {
+              options = {
+                path = mkOption {
+                  type = types.str;
+                  description = ''
+                    Path to the file containing the secret generated out of band.
+
+                    This path will exist after deploying to a target host,
+                    it is not available through the nix store.
+                  '';
+                };
+              };
+            };
+          };
+        };
+      };
+    in
+    types.oneOf [
+      types.path
+      contractSecretsType
+    ];
 in
 {
   meta = {
@@ -418,7 +481,7 @@ in
       };
 
       passwordFile = mkOption {
-        type = types.nullOr types.path;
+        type = types.nullOr secretOptionType;
         default = null;
         example = "/path/to/password/file";
         description = ''
@@ -431,12 +494,12 @@ in
         '';
       };
 
-      jwtSecretKeyFile = mkOption {
-        type = types.path;
+      jwtSecretKey = mkOption {
+        type = secretOptionType;
         description = "Path to file containing a secret used to sign JWT tokens.";
       };
-      sessionStoreKeyFile = mkOption {
-        type = types.path;
+      sessionStoreKey = mkOption {
+        type = secretOptionType;
         description = "Path to file containing a secret for session store.";
       };
 
@@ -514,9 +577,15 @@ in
               install -d ${cfg.settings.generated}
               if [[ -z "${toString cfg.mutableSettings}" || ! -f ${cfg.dataDir}/config.yml ]]; then
                 env \
-                  password=$(< ${cfg.passwordFile}) \
-                  jwtSecretKeyFile=$(< ${cfg.jwtSecretKeyFile}) \
-                  sessionStoreKeyFile=$(< ${cfg.sessionStoreKeyFile}) \
+                  password=$(< ${
+                    if lib.isPath cfg.passwordFile then cfg.passwordFile else cfg.passwordFile.output.path
+                  }) \
+                  jwtSecretKeyFile=$(< ${
+                    if lib.isPath cfg.jwtSecretKey then cfg.jwtSecretKey else cfg.jwtSecretKey.output.path
+                  }) \
+                  sessionStoreKeyFile=$(< ${
+                    if lib.isPath cfg.sessionStoreKey then cfg.sessionStoreKey else cfg.sessionStoreKey.output.path
+                  }) \
                   ${lib.getExe pkgs.yq-go} '
                     .jwt_secret_key = strenv(jwtSecretKeyFile) |
                     .session_store_key = strenv(sessionStoreKeyFile) |

--- a/nixos/modules/testing/hardcoded-secret.nix
+++ b/nixos/modules/testing/hardcoded-secret.nix
@@ -1,0 +1,127 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.testing.hardcoded-secret;
+
+  inherit (lib) mapAttrs' mkOption nameValuePair;
+  inherit (lib.types)
+    attrsOf
+    str
+    submodule
+    ;
+  inherit (pkgs) writeText;
+in
+{
+  options.testing.hardcoded-secret = mkOption {
+    default = { };
+    description = ''
+      Hardcoded file secrets. These should only be used in tests.
+
+      They aim to replace the usage of pkgs.writeText in NixOS VM tests
+      as those make the file world readable
+      while this module set runtime permissions on the file.
+      This makes the tests more accurate, ensuring the permissions
+      set by the contract consumer are correct.
+    '';
+    example = lib.literalExpression ''
+      {
+        mySecret = {
+          input = {
+            user = "me";
+            mode = "0400";
+          };
+          content = "My Secret";
+        };
+      }
+    '';
+    type = attrsOf (
+      submodule (
+        { name, ... }:
+        {
+          options = {
+            input = mkOption {
+              description = "Input of the contract for file secrets.";
+              type = lib.types.submodule {
+                options = {
+                  mode = mkOption {
+                    description = ''
+                      Mode the secret file must have.
+                    '';
+                    type = str;
+                    default = "0400";
+                  };
+
+                  owner = mkOption {
+                    description = ''
+                      Linux user that must own the secret file.
+                    '';
+                    type = str;
+                    default = "root";
+                  };
+
+                  group = mkOption {
+                    description = ''
+                      Linux group that must own the secret file.
+                    '';
+                    type = str;
+                    default = "root";
+                  };
+                };
+              };
+            };
+
+            output = mkOption {
+              description = "Output of the contract for file secrets.";
+              default = { };
+              type = lib.types.submodule {
+                options = {
+                  path = mkOption {
+                    type = str;
+                    description = ''
+                      Path to the file containing the secret generated out of band.
+
+                      This path will exist after deploying to a target host,
+                      it is not available through the nix store.
+                    '';
+                    default = "/run/hardcodedsecrets/${name}";
+                  };
+                };
+              };
+            };
+
+            content = mkOption {
+              type = str;
+              description = ''
+                Content of the secret as a string.
+
+                This will be stored in the nix store and should only be used for testing or maybe in dev.
+              '';
+            };
+          };
+        }
+      )
+    );
+  };
+
+  config = {
+    system.activationScripts = mapAttrs' (
+      n: cfg':
+      let
+        source = writeText "hardcodedsecret_${n}_content" cfg'.content;
+
+        inherit (cfg') input output;
+      in
+      nameValuePair "hardcodedsecret_${n}" ''
+        mkdir -p "$(dirname "${output.path}")"
+        touch "${output.path}"
+        chmod ${input.mode} "${output.path}"
+        chown ${input.owner}:${input.group} "${output.path}"
+        cp ${source} "${output.path}"
+      ''
+    ) cfg;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -420,6 +420,9 @@ in
   containers-restart_networking = runTest ./containers-restart_networking.nix;
   containers-tmpfs = runTest ./containers-tmpfs.nix;
   containers-unified-hierarchy = runTest ./containers-unified-hierarchy.nix;
+  contracts = import ./contracts {
+    inherit runTest;
+  };
   convos = runTest ./convos.nix;
   coredns = runTest ./coredns.nix;
   corerad = runTest ./corerad.nix;

--- a/nixos/tests/contracts/default.nix
+++ b/nixos/tests/contracts/default.nix
@@ -1,0 +1,4 @@
+{ runTest }:
+{
+  filesecrets-hardcoded-secret = runTest ./filesecrets/hardcoded-secret.nix;
+}

--- a/nixos/tests/contracts/filesecrets/hardcoded-secret.nix
+++ b/nixos/tests/contracts/filesecrets/hardcoded-secret.nix
@@ -1,0 +1,29 @@
+args@{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  test = import ./test.nix args;
+in
+test {
+  name = "contracts-secrets-hardcoded-secret";
+  providerRoot = [
+    "testing"
+    "hardcoded-secret"
+    "mysecret"
+  ];
+  extraModules = [
+    ../../../modules/testing/hardcoded-secret.nix
+    (
+      { config, ... }:
+      {
+        testing.hardcoded-secret.mysecret.content = config.test.content;
+      }
+    )
+  ];
+}
+// {
+  meta.maintainers = [ lib.maintainers.ibizaman ];
+}

--- a/nixos/tests/contracts/filesecrets/test.nix
+++ b/nixos/tests/contracts/filesecrets/test.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) getAttrFromPath setAttrByPath;
+  inherit (lib) mkOption types;
+in
+{
+  name,
+  providerRoot,
+  extraModules ? [ ],
+}:
+{
+  name = "contracts_filesecrets_${name}";
+
+  nodes.machine =
+    { config, ... }:
+    {
+      imports = extraModules;
+
+      options.test = {
+        owner = mkOption {
+          type = types.str;
+          default = "root";
+        };
+
+        group = mkOption {
+          type = types.str;
+          default = "root";
+        };
+
+        mode = mkOption {
+          type = types.str;
+          default = "0400";
+        };
+
+        content = mkOption {
+          type = types.str;
+          default = "a super secret secret!";
+        };
+      };
+
+      config = lib.mkMerge [
+        (setAttrByPath providerRoot {
+          input = {
+            inherit (config.test) owner group mode;
+          };
+        })
+        (lib.mkIf (config.test.owner != "root") {
+          users.users.${config.test.owner}.isNormalUser = true;
+        })
+        (lib.mkIf (config.test.group != "root") {
+          users.groups.${config.test.group} = { };
+        })
+      ];
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      cfg = nodes.machine;
+      inherit (getAttrFromPath providerRoot nodes.machine) output;
+    in
+    ''
+      owner = machine.succeed("stat -c '%U' ${output.path}").strip()
+      print(f"Got owner {owner}")
+      if owner != "${cfg.test.owner}":
+          raise Exception(f"Owner should be '${cfg.test.owner}' but got '{owner}'")
+
+      group = machine.succeed("stat -c '%G' ${output.path}").strip()
+      print(f"Got group {group}")
+      if group != "${cfg.test.group}":
+          raise Exception(f"Group should be '${cfg.test.group}' but got '{group}'")
+
+      mode = str(int(machine.succeed("stat -c '%a' ${output.path}").strip()))
+      print(f"Got mode {mode}")
+      wantedMode = str(int("${cfg.test.mode}"))
+      if mode != wantedMode:
+          raise Exception(f"Mode should be '{wantedMode}' but got '{mode}'")
+
+      content = machine.succeed("cat ${output.path}").strip()
+      print(f"Got content {content}")
+      if content != "${cfg.test.content}":
+          raise Exception(f"Content should be '${cfg.test.content}' but got '{content}'")
+    '';
+}

--- a/nixos/tests/stash.nix
+++ b/nixos/tests/stash.nix
@@ -9,61 +9,75 @@ import ./make-test-python.nix (
     name = "stash";
     meta.maintainers = pkgs.stash.meta.maintainers;
 
-    nodes.machine = {
-      services.stash = {
-        inherit dataDir;
-        enable = true;
+    nodes.machine =
+      { config, ... }:
+      {
+        services.stash = {
+          inherit dataDir;
+          enable = true;
 
-        username = "test";
-        passwordFile = pkgs.writeText "stash-password" "MyPassword";
+          username = "test";
+          passwordFile.output = config.testing.hardcoded-secret."stash-password".output;
 
-        jwtSecretKeyFile = pkgs.writeText "jwt_secret_key" "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        sessionStoreKeyFile = pkgs.writeText "session_store_key" "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+          jwtSecretKey.output.path = config.testing.hardcoded-secret."jwt_secret_key".output.path;
+          sessionStoreKey.output.path = config.testing.hardcoded-secret."session_store_key".output.path;
 
-        plugins =
-          let
-            src = pkgs.fetchFromGitHub {
-              owner = "stashapp";
-              repo = "CommunityScripts";
-              rev = "9b6fac4934c2fac2ef0859ea68ebee5111fc5be5";
-              hash = "sha256-PO3J15vaA7SD4r/LyHlXjnpaeYAN9Q++O94bIWdz7OA=";
-            };
-          in
-          [
-            (pkgs.runCommand "stashNotes" { inherit src; } ''
-              mkdir -p $out/plugins
-              cp -r $src/plugins/stashNotes $out/plugins/stashNotes
-            '')
-            (pkgs.runCommand "Theme-Plex" { inherit src; } ''
-              mkdir -p $out/plugins
-              cp -r $src/themes/Theme-Plex $out/plugins/Theme-Plex
-            '')
-          ];
+          plugins =
+            let
+              src = pkgs.fetchFromGitHub {
+                owner = "stashapp";
+                repo = "CommunityScripts";
+                rev = "9b6fac4934c2fac2ef0859ea68ebee5111fc5be5";
+                hash = "sha256-PO3J15vaA7SD4r/LyHlXjnpaeYAN9Q++O94bIWdz7OA=";
+              };
+            in
+            [
+              (pkgs.runCommand "stashNotes" { inherit src; } ''
+                mkdir -p $out/plugins
+                cp -r $src/plugins/stashNotes $out/plugins/stashNotes
+              '')
+              (pkgs.runCommand "Theme-Plex" { inherit src; } ''
+                mkdir -p $out/plugins
+                cp -r $src/themes/Theme-Plex $out/plugins/Theme-Plex
+              '')
+            ];
 
-        mutableScrapers = true;
-        scrapers =
-          let
-            src = pkgs.fetchFromGitHub {
-              owner = "stashapp";
-              repo = "CommunityScrapers";
-              rev = "2ece82d17ddb0952c16842b0775274bcda598d81";
-              hash = "sha256-AEmnvM8Nikhue9LNF9dkbleYgabCvjKHtzFpMse4otM=";
-            };
-          in
-          [
-            (pkgs.runCommand "FTV" { inherit src; } ''
-              mkdir -p $out/scrapers/FTV
-              cp -r $src/scrapers/FTV.yml $out/scrapers/FTV
-            '')
-          ];
+          mutableScrapers = true;
+          scrapers =
+            let
+              src = pkgs.fetchFromGitHub {
+                owner = "stashapp";
+                repo = "CommunityScrapers";
+                rev = "2ece82d17ddb0952c16842b0775274bcda598d81";
+                hash = "sha256-AEmnvM8Nikhue9LNF9dkbleYgabCvjKHtzFpMse4otM=";
+              };
+            in
+            [
+              (pkgs.runCommand "FTV" { inherit src; } ''
+                mkdir -p $out/scrapers/FTV
+                cp -r $src/scrapers/FTV.yml $out/scrapers/FTV
+              '')
+            ];
 
-        settings = {
-          inherit host port;
+          settings = {
+            inherit host port;
 
-          stash = [ { path = "/srv"; } ];
+            stash = [ { path = "/srv"; } ];
+          };
+        };
+        testing.hardcoded-secret."stash-password" = {
+          input = config.services.stash.passwordFile.input;
+          content = "MyPassword";
+        };
+        testing.hardcoded-secret."jwt_secret_key" = {
+          input = config.services.stash.jwtSecretKey.input;
+          content = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        };
+        testing.hardcoded-secret."session_store_key" = {
+          input = config.services.stash.sessionStoreKey.input;
+          content = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
         };
       };
-    };
 
     testScript = ''
       machine.wait_for_unit("stash.service")


### PR DESCRIPTION
TL; DR:

What if modules could not only ask for a secret but also tell what unix owner, group and mode that file should have?

What if all modules used the same option to describe those properties?

---

Yet another PR for contracts, yes I know. But this one is different, hear me out!

Starting with presenting an underlying implementation was I realize a mistake.
The concept of contracts is still too abstract, for me too, to be able to choose the best implementation.
I noticed this because none of the comments in the previous PRs talked about the actual contracts.

So this PR focuses on one contract. The contract for secrets that are exchanged through files. With no fluff, no clever implementation. Just the plain old options which work because the consumer and provider sides agree on which options should exist. We can always reconvene later on when and if we find it important to have some sort of underlying implementation to contracts.

## Motivation

The contract for file secrets intends to improve the user experience when a user must provide a secret to a module and its underlying service(s) through a file path.

Currently, most modules declare one or several options of type `string` which expect to receive the path to a file.
This file is expected to exist at runtime, on the target host, before the service that requires them are started.
No constrain is set on how that file is generated nor when, as long as it exists when it is required.

An issue arise when the permissions of that file is incorrect.
In that case, the service that will try to read it will fail to do so and will not be able to start.
In other words, although the nix code correctly evaluates, a runtime error will happen which is bad user experience.

At best, some services do document what permissions they expect. But this is quite weak.

## Contract Definition

This contract encodes what permissions the file should have.

A module or service that requires such a file is called a consumer.
One that will generate the file is called a provider. Sops-nix and Agenix are two such providers.

- Consumer options:
  - `mode` (type `string`): the expected mode of the file.
  - `owner` (type `string`): the expected owner of the file.
  - `group` (type `string`): the expected group of the file.
- Provider options:
  - `path` (type `string`): the path at which the file will exist on the target host.

We could maybe remove the `mode` option if we made the `mode` be `0400` if `group == "root"` and `0440` otherwise. I'm not sure if this cover all cases.

The consumer and provider options are fully compatible with Sops-nix and Agenix and even share the same names.

## Vars?

If you're wondering if this is a competing implementation to the Vars initiative, fear not, it is not!

The contract is downstream of Vars. Vars is about how to generate a secret and how to pass it to services while the contract is how services should advertise they want a secret in a file.

## Hardcoded Secrets Provider

This PR introduces a new provider.
The intention is to replace current usage of `pkgs.writeText` in the tests with this contract provider.
Like `pkgs.writeText`, the `hardcodedsecrets` module does store the secret in the nix store.
But although `pkgs.writeText` creates a file accessible by all users,
the `hardcodedsecrets` module correctly set the mode, owner and group of the file as expected by the consumer.
This is useful to make sure the consumer sets the options correctly.

## Generic test

A generic test is added to make sure any provider claiming to implement this contract behaves as expected.
The test makes sure the file generated by a provider has the correct content, mode, owner and group.

The `hardcodedsecrets` provider uses this test.

## Consumer Module: Stash

The Stash module's options has been changed to implement the consumer contract but still be backwards compatible.

## Next Steps

I'd like reviews to address at least the options of the contract. Are they enough? Too much?

Also I’d love to hear thoughts on the genetic test.

I did myself successfully use this exact set of options in about 15 modules in my project and find them good as is and cover all use cases.

## What Comes Next

- Create more PRs to convert string/path options to use this contract.
- Create documentation advertising about this contract. Show how to use Sops-nix and Agenix with it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

EDIT: Update to make scope clearer - this contract is for files.