### PR TITLE
cosmic-ext-applet-pomodoro: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3431,6 +3431,12 @@
     githubId = 1010174;
     name = "Ben Gamari";
   };
+  bgub = {
+    email = "nebrelbug@gmail.com";
+    github = "bgub";
+    githubId = 25597854;
+    name = "Ben Gubler";
+  };
   bhall = {
     email = "brendan.j.hall@bath.edu";
     github = "brendan-hall";

--- a/pkgs/by-name/co/cosmic-ext-applet-pomodoro/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-applet-pomodoro/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  libcosmicAppHook,
+  just,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cosmic-ext-applet-pomodoro";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "bgub";
+    repo = "cosmic-ext-applet-pomodoro";
+    tag = finalAttrs.version;
+    hash = "sha256-Ep0osOVon8DvhvQSHjAzYGrFBtEaqrVATOAnG4ujnYc=";
+  };
+
+  cargoHash = "sha256-ocELklj50LkRhXMF4igT6jIxOWPdY3Cr74CceB+0v24=";
+
+  nativeBuildInputs = [
+    libcosmicAppHook
+    just
+  ];
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  justFlags = [
+    "--set"
+    "prefix"
+    (placeholder "out")
+    "--set"
+    "bin-src"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-ext-applet-pomodoro"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A pomodoro timer applet for the COSMIC desktop";
+    homepage = "https://github.com/bgub/cosmic-ext-applet-pomodoro";
+    changelog = "https://github.com/bgub/cosmic-ext-applet-pomodoro/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mpl20;
+    mainProgram = "cosmic-ext-applet-pomodoro";
+    maintainers = with lib.maintainers; [ bgub ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Summary

- Add `cosmic-ext-applet-pomodoro`, a pomodoro timer applet for the COSMIC desktop
- Add maintainer entry for `bgub`

## Description

A panel applet for the [COSMIC desktop environment](https://github.com/pop-os/cosmic-epoch) that provides a configurable pomodoro timer with work/break intervals, session tracking, and auto-start options.

- **Homepage**: https://github.com/bgub/cosmic-ext-applet-pomodoro
- **License**: MPL-2.0
- **Build verified**: builds successfully with `nix-build`

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable
- [x] Ensured that commit messages are in the [correct format](https://nixos.org/manual/nixpkgs/unstable/#sec-commit-style)
- [x] Added myself to `maintainers/maintainer-list.nix`
- [x] New package

🤖 Generated with [Claude Code](https://claude.com/claude-code)