### PR TITLE
anki: add missing qt6.qtwebchannel dependency

### DIFF
--- a/pkgs/by-name/an/anki/package.nix
+++ b/pkgs/by-name/an/anki/package.nix
@@ -153,6 +153,7 @@ python3Packages.buildPythonApplication rec {
   buildInputs = [
     qt6.qtbase
     qt6.qtsvg
+    qt6.qtwebchannel
     qt6.qtwebengine
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux qt6.qtwayland;


### PR DESCRIPTION
## Summary

- Add `qt6.qtwebchannel` to `buildInputs` for anki

## Problem

anki 25.09.2 fails at runtime with `ImportError: libQt6WebChannel.so.6: cannot open shared object file`. The `PyQt6.QtWebChannel` module (imported in `aqt/qt/qt6.py`) requires `libQt6WebChannel.so.6` which is provided by `qt6.qtwebchannel`.

The package tests also fail during collection with the same error.

Fixes #495318

## Test plan

- [x] `nix-build -A anki` succeeds
- [x] `anki` launches without ImportError