### PR TITLE
ghidra-extensions.ghidramcp: init at 1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4453,6 +4453,12 @@
     githubId = 495429;
     name = "Claas Augner";
   };
+  caverav = {
+    email = "camilo@fvv.cl";
+    github = "caverav";
+    githubId = 66751764;
+    name = "Camilo Vera Vidales";
+  };
   cawilliamson = {
     email = "home@chrisaw.com";
     github = "cawilliamson";

--- a/pkgs/tools/security/ghidra/extensions.nix
+++ b/pkgs/tools/security/ghidra/extensions.nix
@@ -21,6 +21,8 @@ lib.makeScope newScope (self: {
 
   ghidra-golanganalyzerextension = self.callPackage ./extensions/ghidra-golanganalyzerextension { };
 
+  ghidramcp = self.callPackage ./extensions/ghidramcp { };
+
   ghidraninja-ghidra-scripts = self.callPackage ./extensions/ghidraninja-ghidra-scripts { };
 
   gnudisassembler = self.callPackage ./extensions/gnudisassembler { inherit ghidra; };

--- a/pkgs/tools/security/ghidra/extensions/ghidramcp/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/ghidramcp/default.nix
@@ -1,0 +1,53 @@
+{
+  fetchurl,
+  ghidra,
+  lib,
+  stdenvNoCC,
+  unzip,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ghidramcp";
+  version = "1.4";
+
+  src = fetchurl {
+    url = "https://github.com/LaurieWired/GhidraMCP/releases/download/${finalAttrs.version}/GhidraMCP-release-1-4.zip";
+    hash = "sha256-uBylJA/d5X6k6JkXDc2f3ubtKSRigMdCY6UJv8/H5zQ=";
+  };
+
+  nativeBuildInputs = [ unzip ];
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    releaseDir="$(mktemp -d)"
+    unzip -q "$src" -d "$releaseDir"
+
+    extensionZip="$(find "$releaseDir" -type f -name 'GhidraMCP-*.zip' | head -n1)"
+    if [ -z "$extensionZip" ]; then
+      echo "Failed to locate GhidraMCP extension zip in release archive" >&2
+      exit 1
+    fi
+
+    mkdir -p "$out/lib/ghidra/Ghidra/Extensions"
+    unzip -q "$extensionZip" -d "$out/lib/ghidra/Ghidra/Extensions"
+
+    # Prevent attempted creation of plugin lock files in the Nix store.
+    for i in "$out"/lib/ghidra/Ghidra/Extensions/*; do
+      touch "$i/.dbDirLock"
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Model Context Protocol extension for Ghidra";
+    homepage = "https://github.com/LaurieWired/GhidraMCP";
+    downloadPage = "https://github.com/LaurieWired/GhidraMCP/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/LaurieWired/GhidraMCP/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.caverav ];
+    platforms = ghidra.meta.platforms;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+  };
+})


### PR DESCRIPTION
## Summary
- Add `ghidra-extensions.ghidramcp` at upstream version `1.4`.
- Install the extension payload from the upstream release archive into Ghidra's extension directory.

Upstream release notes:
- https://github.com/LaurieWired/GhidraMCP/releases/tag/1.4

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests.
  - [ ] Package tests at `passthru.tests`.
  - [ ] Tests in `lib/tests` or `pkgs/test`.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.

## Testing
- `nix-shell --run treefmt`
- `nix-build -A ghidra-extensions.ghidramcp`
- `nix-build -E 'with import ./. {}; ghidra.withExtensions (p: [ p.ghidramcp ])'`

## Notes
- This package installs a Ghidra extension payload and does not expose standalone binaries in `result/bin`.
