### PR TITLE
vice: 3.9 -> 3.10, adopt

### DIFF
--- a/pkgs/by-name/vi/vice/package.nix
+++ b/pkgs/by-name/vi/vice/package.nix
@@ -18,52 +18,55 @@
   SDL,
   SDL_image,
   dos2unix,
-  runtimeShell,
   xa,
   file,
   wrapGAppsHook3,
   xdg-utils,
   libevdev,
   pulseaudio,
+  desktop-file-utils,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vice";
-  version = "3.9";
+  version = "3.10";
 
   src = fetchurl {
     url = "mirror://sourceforge/vice-emu/vice-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-QCArY0VeJrh+zGPrWlIyLG+j9XyrEqzwwifPn02uw3A=";
+    sha256 = "sha256-jlusGMvLnxkjgK0++IH4eQ9bdcQdez2mXYMZhdhk1tE=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     bison
+    desktop-file-utils
     dos2unix
     file
     flex
+    perl
     pkg-config
     wrapGAppsHook3
+    xa
+    xdg-utils
   ];
 
   buildInputs = [
     alsa-lib
     curl
     giflib
-    gtk3
     glew
+    gtk3
+    libevdev
     libGL
     libGLU
     libpng
-    perl
+    pulseaudio
     readline
     SDL
     SDL_image
-    xa
-    xdg-utils
-    libevdev
-    pulseaudio
   ];
-  dontDisableStatic = true;
+
   configureFlags = [
     "--enable-sdl2ui"
     "--enable-gtk3ui"
@@ -74,19 +77,32 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.LIBS = "-lGL";
 
-  preBuild = ''
-    sed -i -e 's|#!/usr/bin/env bash|${runtimeShell}/bin/bash|' src/arch/gtk3/novte/box_drawing_generate.sh
+  preConfigure = ''
+    patchShebangs .
+  '';
+
+  enableParallelBuilding = true;
+
+  preInstall = ''
+    # env var for `desktop-file-install`
+    export DESKTOP_FILE_INSTALL_DIR=$out/share/applications
+    mkdir -p $DESKTOP_FILE_INSTALL_DIR
   '';
 
   postInstall = ''
-    mkdir -p $out/share/applications
-    cp src/arch/gtk3/data/unix/vice-org-*.desktop $out/share/applications
+    for binary in vsid x128 x64 x64dtv xcbm2 xpet xplus4 xscpu64 xvic; do
+      for size in 16 24 32 48 64 256; do
+        install -D data/common/vice-''${binary}_''${size}.png $out/share/icons/hicolor/''${size}x''${size}/apps/vice-''${binary}.png
+      done
+      install -D data/common/vice-''${binary}_1024.svg $out/share/icons/hicolor/scalable/apps/vice-''${binary}.svg
+    done
   '';
 
   meta = {
     description = "Emulators for a variety of 8-bit Commodore computers";
     homepage = "https://vice-emu.sourceforge.io/";
     license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.nekowinston ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
Bumps the version, enables `strictDeps`, ships the application icons, and uses `patchShebangs` instead of `sed`-replacing it manually.

I don't think `dontDisableStatic` is needed anymore? Maybe I just haven't run into any breakage yet, it builds, and `x64sc` seems to work fine.

Cross-compiling seems to work now, I checked on `x86_64`'s `pkgsCross.aarch64-multiplatform.vice`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
