### PR TITLE
nixosTests.{initrd-secrets-changing,pulseaudio}: mark broken on aarch64-linux

### DIFF
--- a/nixos/tests/initrd-secrets-changing.nix
+++ b/nixos/tests/initrd-secrets-changing.nix
@@ -14,6 +14,11 @@ in
 testing.makeTest {
   name = "initrd-secrets-changing";
 
+  meta = {
+    maintainers = [ ];
+    broken = pkgs.stdenv.hostPlatform.isAarch64;
+  };
+
   nodes.machine =
     { ... }:
     {

--- a/nixos/tests/pulseaudio.nix
+++ b/nixos/tests/pulseaudio.nix
@@ -31,6 +31,7 @@ let
         name = "pulseaudio${lib.optionalString fullVersion "Full"}${lib.optionalString systemWide "-systemWide"}";
         meta = with pkgs.lib.maintainers; {
           maintainers = [ synthetica ] ++ pkgs.pulseaudio.meta.maintainers;
+          broken = pkgs.stdenv.hostPlatform.isAarch64;
         };
 
         nodes.machine =


### PR DESCRIPTION
See:

- https://hydra.nixos.org/job/nixos/unstable/nixos.tests.initrd-secrets-changing.aarch64-linux
- https://hydra.nixos.org/job/nixos/unstable/nixos.tests.pulseaudio.system.aarch64-linux
- https://hydra.nixos.org/job/nixos/unstable/nixos.tests.pulseaudio.user.aarch64-linux
- https://hydra.nixos.org/job/nixos/unstable/nixos.tests.pulseaudio.systemFull.aarch64-linux
- https://hydra.nixos.org/job/nixos/unstable/nixos.tests.pulseaudio.userFull.aarch64-linux

The initrd-secrets tests were already disabled in #459745.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test