### PR TITLE
octavePackages.control: 3.6.1 -> 4.2.1

### DIFF
--- a/pkgs/development/octave-modules/control/default.nix
+++ b/pkgs/development/octave-modules/control/default.nix
@@ -6,17 +6,19 @@
   lapack,
   blas,
   autoreconfHook,
+  nix-update-script,
 }:
 
 buildOctavePackage rec {
   pname = "control";
-  version = "3.6.1";
+  version = "4.2.1";
 
   src = fetchFromGitHub {
     owner = "gnu-octave";
     repo = "pkg-control";
-    tag = "control-${version}";
-    sha256 = "sha256-7beEsdrne50NY4lGCotxGXwwWnMzUR2CKCc20OCjd0g=";
+    tag = "${pname}-${version}";
+    fetchSubmodules = true;
+    sha256 = "sha256-NOZi003brDQ5nVyP7w5n7hxhafbiBwMPErhhTQhn2bw=";
   };
 
   # Running autoreconfHook inside the src directory fixes a compile issue about
@@ -40,6 +42,13 @@ buildOctavePackage rec {
     lapack
     blas
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "control-(.*)"
+    ];
+  };
 
   meta = {
     homepage = "https://gnu-octave.github.io/packages/control/";


### PR DESCRIPTION



<!--

-->

## Things done
Added fetchSubmodules to let control fetch slicot-reference.
Added updateScript, so control gets updates more often.

The changelog is here [gnu-octave/pkg-control/blob/main/NEWS](https://github.com/gnu-octave/pkg-control/blob/main/NEWS).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
