### PR TITLE
nixos/autoUpgrade: explain what happens on missed rebootWindow

### DIFF
--- a/nixos/modules/tasks/auto-upgrade.nix
+++ b/nixos/modules/tasks/auto-upgrade.nix
@@ -140,9 +140,19 @@ in
       rebootWindow = lib.mkOption {
         description = ''
           Define a lower and upper time value (in HH:MM format) which
-          constitute a time window during which reboots are allowed after an upgrade.
+          constitute a time window during which reboots are allowed
+          immediately after the upgrade finishes.
+
           This option only has an effect when {option}`allowReboot` is enabled.
           The default value of `null` means that reboots are allowed at any time.
+
+          If the system should be rebooted but the time window is missed,
+          no reboot will be scheduled, and no switch will be performed.
+          The reboot will be reattempted after the next upgrade operation,
+          even when no further system upgrades are available,
+          as long as the time window is then met.
+          Therefore {option}`dates` (with and without {option}`randomizedDelaySec`)
+          should be enclosed by the time window.
         '';
         default = null;
         example = {


### PR DESCRIPTION
esp. because it is important to know that no actual scheduling is performed and therefore that no reboot may happen if the rebootWindow is never met

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
