### PR TITLE
red-trul: init at 2.3.13

### DIFF
--- a/pkgs/by-name/re/red-trul/package.nix
+++ b/pkgs/by-name/re/red-trul/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  flac2mp3,
+  ffmpeg,
+  sox,
+}:
+
+let
+  runtimeDeps = [
+    ffmpeg
+    flac2mp3
+    sox
+  ];
+in
+buildNpmPackage (finalAttrs: {
+  pname = "red-trul";
+  version = "2.3.13";
+
+  src = fetchFromGitHub {
+    owner = "lfence";
+    repo = "red-trul";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-t8P59diMwYKaGuPuNajWDmRU0fBNT6yRwMBLIRfUhTk";
+  };
+
+  npmDepsHash = "sha256-BYgNgV0hTkfDByi/86X7ZLcAYKveVDiSKnvUfdjyfHc=";
+  dontNpmBuild = true;
+
+  postPatch = ''
+    substituteInPlace config.js \
+      --replace-fail '`''${__dirname}/flac2mp3/flac2mp3.pl`' '"flac2mp3"'
+    substituteInPlace trul.js \
+      --replace-fail "  await fs.access(FLAC2MP3)" ""
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/red-trul \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.passthru.runtimeDeps}
+  '';
+
+  passthru = {
+    inherit runtimeDeps;
+  };
+
+  meta = {
+    mainProgram = "red-trul";
+    description = "Lightweight utility to transcode FLAC releases";
+    homepage = "https://github.com/lfence/red-trul";
+    changelog = "https://github.com/lfence/red-trul/releases/tag/${finalAttrs.version}";
+    license = with lib.licenses; [ isc ];
+    maintainers = with lib.maintainers; [ lilahummel ];
+  };
+})


### PR DESCRIPTION
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
