### PR TITLE
python3Packages.{character-encoding-utils,pcffont,pixel-font-builder,pixel-font-knife,unidata-data-blocks}: fix builds

### DIFF
--- a/pkgs/development/python-modules/character-encoding-utils/default.nix
+++ b/pkgs/development/python-modules/character-encoding-utils/default.nix
@@ -1,10 +1,10 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pytestCheckHook,
   nix-update-script,
-  hatchling,
+  uv-build,
 }:
 
 buildPythonPackage rec {
@@ -12,13 +12,14 @@ buildPythonPackage rec {
   version = "0.0.12";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "character_encoding_utils";
-    inherit version;
-    hash = "sha256-sOXdpO7c2EpbNbJK1WIYx/Xb5UGIMW8daw154V/NpU0=";
+  src = fetchFromGitHub {
+    owner = "TakWolf";
+    repo = "character-encoding-utils";
+    tag = version;
+    hash = "sha256-4WaVvr6/d/oePtmwpGJ/D6tv10V/ok9iN4BrqGk97f0=";
   };
 
-  build-system = [ hatchling ];
+  build-system = [ uv-build ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/pcffont/default.nix
+++ b/pkgs/development/python-modules/pcffont/default.nix
@@ -1,10 +1,10 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pytestCheckHook,
   nix-update-script,
-  hatchling,
+  uv-build,
   bdffont,
 }:
 
@@ -13,13 +13,14 @@ buildPythonPackage rec {
   version = "0.0.24";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "pcffont";
-    inherit version;
-    hash = "sha256-Sax3bUs6ogQ+LuUAy6k1zEfN4WT81zm1LzP2s/6Pecg=";
+  src = fetchFromGitHub {
+    owner = "TakWolf";
+    repo = "pcffont";
+    tag = version;
+    hash = "sha256-32u4FE5QLLqYmRVDuYYGC/laLCRH9phNGi1B9JC+cps=";
   };
 
-  build-system = [ hatchling ];
+  build-system = [ uv-build ];
 
   dependencies = [ bdffont ];
 

--- a/pkgs/development/python-modules/pixel-font-builder/default.nix
+++ b/pkgs/development/python-modules/pixel-font-builder/default.nix
@@ -1,10 +1,10 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pytestCheckHook,
   nix-update-script,
-  hatchling,
+  uv-build,
   fonttools,
   brotli,
   bdffont,
@@ -17,13 +17,14 @@ buildPythonPackage rec {
   version = "0.0.47";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "pixel_font_builder";
-    inherit version;
-    hash = "sha256-O3HtwoZUp89mUgVMMcAd4CCPFqQpsyqlmug+QgNpgNQ=";
+  src = fetchFromGitHub {
+    owner = "TakWolf";
+    repo = "pixel-font-builder";
+    tag = version;
+    hash = "sha256-a25JKZy5XaBfpeFwH7YnSTY28hQF8dLa/AGEOXHN94I=";
   };
 
-  build-system = [ hatchling ];
+  build-system = [ uv-build ];
 
   dependencies = [
     fonttools

--- a/pkgs/development/python-modules/pixel-font-knife/default.nix
+++ b/pkgs/development/python-modules/pixel-font-knife/default.nix
@@ -1,11 +1,11 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pythonOlder,
   pytestCheckHook,
   nix-update-script,
-  hatchling,
+  uv-build,
   pypng,
   unidata-blocks,
   pyyaml,
@@ -18,13 +18,14 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.12";
 
-  src = fetchPypi {
-    pname = "pixel_font_knife";
-    inherit version;
-    hash = "sha256-QTwrxXn5uAp44D/rgbZiCaFP+rDU4H4LGw75n2hQJGs=";
+  src = fetchFromGitHub {
+    owner = "TakWolf";
+    repo = "pixel-font-knife";
+    tag = version;
+    hash = "sha256-f4jaLEPXl8oo1olWBeymMn5a8Tyl07h1TW4pZ5OItZU=";
   };
 
-  build-system = [ hatchling ];
+  build-system = [ uv-build ];
 
   dependencies = [
     pypng

--- a/pkgs/development/python-modules/unidata-blocks/default.nix
+++ b/pkgs/development/python-modules/unidata-blocks/default.nix
@@ -1,10 +1,10 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   pytestCheckHook,
   nix-update-script,
-  hatchling,
+  uv-build,
   langcodes,
 }:
 
@@ -13,13 +13,14 @@ buildPythonPackage rec {
   version = "0.0.24";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "unidata_blocks";
-    inherit version;
-    hash = "sha256-yQJW4u0v9TrYNPOeEqhOnCcuyrgpj4Qy1ayLBeCgp2E=";
+  src = fetchFromGitHub {
+    owner = "TakWolf";
+    repo = "unidata-blocks";
+    tag = version;
+    hash = "sha256-WGo7Sn2lubsOWfLglBAEx/2PQ1YCrF/wI7/pDwoHMRk=";
   };
 
-  build-system = [ hatchling ];
+  build-system = [ uv-build ];
 
   dependencies = [
     langcodes


### PR DESCRIPTION
Requires switches to uv-build

Closes #495257

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
