### PR TITLE
ntfy-sh-client: init at 1.0.3

### DIFF
--- a/pkgs/by-name/nt/ntfy-sh-client/package.nix
+++ b/pkgs/by-name/nt/ntfy-sh-client/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  curl,
+}:
+
+stdenv.mkDerivation {
+  pname = "ntfy-sh-client";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "virusdave";
+    repo = "ntfy-sh-client";
+    rev = "v1.0.2";
+    hash = "sha256-gwtXDTzhjVRqCBiqM0k7+awppQbSn7NN/mH3ldNFb1s=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ curl ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ntfy-sh-client.sh $out/bin/ntfy-sh-client
+    chmod +x $out/bin/ntfy-sh-client
+
+    wrapProgram $out/bin/ntfy-sh-client \
+      --prefix PATH : ${lib.makeBinPath [ curl ]}
+  '';
+
+  meta = {
+    description = "A convenience flake CLI wrapper around curl for using ntfy.sh alerting";
+    homepage = "https://github.com/virusdave/ntfy-sh-client";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ virusdave ];
+    platforms = lib.platforms.all;
+    mainProgram = "ntfy-sh-client";
+  };
+}


### PR DESCRIPTION
This is a simple CLI client wrapper around `curl` to interact with `ntfy.sh`, which is already present in `nixpkgs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
