### PR TITLE
util-linux: Ensure that liblastlog is linked with libpam

### DIFF
--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -35,6 +35,9 @@
   nixosTests,
 }:
 
+# lastlog requires PAM, or else it's broken.
+assert withLastlog -> pamSupport;
+
 let
   isMinimal = cryptsetupSupport == false && !nlsSupport && !ncursesSupport && !systemdSupport;
 in
@@ -52,6 +55,11 @@ stdenv.mkDerivation (finalAttrs: {
     # which isn't valid on NixOS (and a compatibility link on most other modern
     # distros anyway).
     ./rtcwake-search-PATH-for-shutdown.patch
+
+    # pam_lastlog2: link with libpam
+    # see https://github.com/NixOS/nixpkgs/issues/493934
+    ./pam_lastlog2-add-lpam-to-Makemodule.am.patch
+
     # bits: only build when cpu_set_t is available
     # Otherwise, the build fails on macOS
     (fetchurl {
@@ -202,7 +210,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     moveToOutput "bin/lastlog2" "$lastlog"
     ln -svf "$lastlog/bin/"* $bin/bin/
-
   ''
   + lib.optionalString (withLastlog && systemdSupport) ''
     moveToOutput "lib/systemd/system/lastlog2-import.service" "$lastlog"

--- a/pkgs/by-name/ut/util-linux/pam_lastlog2-add-lpam-to-Makemodule.am.patch
+++ b/pkgs/by-name/ut/util-linux/pam_lastlog2-add-lpam-to-Makemodule.am.patch
@@ -1,0 +1,52 @@
+From c8e620c6bcd044786c59f822810fc973090dbfa2 Mon Sep 17 00:00:00 2001
+From: Morgan Jones <me@numin.it>
+Date: Mon, 2 Mar 2026 11:03:39 -0800
+Subject: [PATCH] pam_lastlog2: add -lpam to Makemodule.am
+
+If we don't add this, we don't actually link with PAM; compare the
+before and after of `lib/security/pam_lastlog2.so`.
+
+```
+Dynamic section at offset 0x2ce8 contains 31 entries:
+  Tag        Type                         Name/Value
+ 0x0000000000000001 (NEEDED)             Shared library: [liblastlog2.so.2]
+ 0x0000000000000001 (NEEDED)             Shared library: [libsqlite3.so]
+ 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
+ 0x000000000000000e (SONAME)             Library soname: [pam_lastlog2.so]
+```
+
+```
+Dynamic section at offset 0x2cd8 contains 32 entries:
+  Tag        Type                         Name/Value
+ 0x0000000000000001 (NEEDED)             Shared library: [libpam.so.0]
+ 0x0000000000000001 (NEEDED)             Shared library: [liblastlog2.so.2]
+ 0x0000000000000001 (NEEDED)             Shared library: [libsqlite3.so]
+ 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
+ 0x000000000000000e (SONAME)             Library soname: [pam_lastlog2.so]
+```
+
+This causes issues like https://github.com/NixOS/nixpkgs/issues/493934
+where the library has trouble linking with PAM symbols because it is not
+linked.
+
+Signed-off-by: Morgan Jones <me@numin.it>
+---
+ pam_lastlog2/src/Makemodule.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pam_lastlog2/src/Makemodule.am b/pam_lastlog2/src/Makemodule.am
+index 40d597c58..629930853 100644
+--- a/pam_lastlog2/src/Makemodule.am
++++ b/pam_lastlog2/src/Makemodule.am
+@@ -13,7 +13,7 @@ pam_lastlog2_la_CFLAGS = \
+ 
+ pam_lastlog2_la_LIBADD = liblastlog2.la
+ 
+-pam_lastlog2_la_LDFLAGS = $(SOLIB_LDFLAGS) -module -avoid-version -shared
++pam_lastlog2_la_LDFLAGS = $(SOLIB_LDFLAGS) -lpam -module -avoid-version -shared
+ if HAVE_VSCRIPT
+ pam_lastlog2_la_LDFLAGS += $(VSCRIPT_LDFLAGS),$(top_srcdir)/pam_lastlog2/src/pam_lastlog2.sym
+ endif
+-- 
+2.50.1
+


### PR DESCRIPTION
If we don't add this, we don't actually link with PAM; compare the
before and after of `lib/security/pam_lastlog2.so`.

```
Dynamic section at offset 0x2ce8 contains 31 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [liblastlog2.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libsqlite3.so]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000000e (SONAME)             Library soname: [pam_lastlog2.so]
```

```
Dynamic section at offset 0x2cd8 contains 32 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libpam.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [liblastlog2.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libsqlite3.so]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000000e (SONAME)             Library soname: [pam_lastlog2.so]
```

This causes issues like https://github.com/NixOS/nixpkgs/issues/493934
where the library has trouble linking with PAM symbols because it is not
linked.

Signed-off-by: Morgan Jones <me@numin.it>

----

Patch: https://lore.kernel.org/util-linux/CAEUYr6ZH=9akE64zf5FM3u+Sr44oSJctk2gemiadisghEFESbg@mail.gmail.com

Pulling it in with fetchurl seemed to not work this time (and we can't use fetchpatch due to the bootstrap chain), so include it directly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
