### PR TITLE
python3Packages.torchaudio: remove unused ffmpeg dependency

### DIFF
--- a/pkgs/development/python-modules/torchaudio/default.nix
+++ b/pkgs/development/python-modules/torchaudio/default.nix
@@ -10,7 +10,6 @@
   ninja,
 
   # buildInputs
-  ffmpeg_6-full,
   pybind11,
   sox,
   torch,
@@ -99,15 +98,6 @@ buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
 
   env = {
     TORCH_CUDA_ARCH_LIST = "${lib.concatStringsSep ";" torch.cudaCapabilities}";
-    # https://github.com/pytorch/audio/blob/v2.1.0/docs/source/build.linux.rst#optional-build-torchaudio-with-a-custom-built-ffmpeg
-    FFMPEG_ROOT = symlinkJoin {
-      name = "ffmpeg";
-      paths = [
-        ffmpeg_6-full.bin
-        ffmpeg_6-full.dev
-        ffmpeg_6-full.lib
-      ];
-    };
     BUILD_SOX = 0;
     BUILD_KALDI = 0;
     BUILD_RNNT = 0;
@@ -130,7 +120,6 @@ buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
   );
 
   buildInputs = [
-    ffmpeg_6-full
     pybind11
     sox
     torch.cxxdev


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

At some point between the 2.8.0 and 2.9.0 release of `torchaudio`, `ffmpeg` support was completely dropped:
https://github.com/pytorch/audio/pull/4081

This PR removes it from the closure.

Thanks to @bengsparks for noticing this.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
