### PR TITLE
 home-assistant-custom-components.scheduler: fix license;  home-assistant-custom-lovelace-modules.scheduler-card: fix license 

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/scheduler/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/scheduler/package.nix
@@ -26,6 +26,6 @@ buildHomeAssistantComponent rec {
     homepage = "https://github.com/nielsfaber/scheduler-component";
     changelog = "https://github.com/nielsfaber/scheduler-component/releases/tag/v${version}";
     maintainers = with maintainers; [ SuperSandro2000 ];
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
   };
 }

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/scheduler-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/scheduler-card/package.nix
@@ -39,6 +39,6 @@ buildNpmPackage rec {
     homepage = "https://github.com/nielsfaber/scheduler-card";
     changelog = "https://github.com/nielsfaber/scheduler-card/releases/tag/v${version}";
     maintainers = with maintainers; [ SuperSandro2000 ];
-    license = licenses.isc;
+    license = licenses.gpl3Plus;
   };
 }


### PR DESCRIPTION
According to https://tools.spdx.org/app/check_license/ they are plus

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
