### PR TITLE
matrix-authentication-service: fix cross compile

### DIFF
--- a/pkgs/by-name/ma/matrix-authentication-service/package.nix
+++ b/pkgs/by-name/ma/matrix-authentication-service/package.nix
@@ -72,10 +72,26 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail ./share/policy.wasm "$out/share/$pname/policy.wasm"
   '';
 
-  preBuild = ''
-    make -C policies
-    (cd "$npmRoot" && npm run build)
-  '';
+  preBuild =
+    let
+      rustTarget = stdenv.hostPlatform.rust.rustcTarget;
+      rustTargetUnderscore = builtins.replaceStrings [ "-" ] [ "_" ] rustTarget;
+    in
+    ''
+      make -C policies
+      (cd "$npmRoot" && npm run build)
+
+      # Fix aws-lc-sys cross-compilation:
+      # The cc crate looks for "aarch64-linux-gnu-gcc")
+      # when CC is unset and TARGET != HOST, but Nix's cross-compiler is
+      # named "aarch64-unknown-linux-gnu-gcc" (with vendor).
+      # We set the target-specific CC_<target> variable so the cc crate
+      # and aws-lc-sys find the correct cross-compiler, then unset the
+      # generic CC so aws-lc-sys doesn't misassign it.
+      export CC_${rustTargetUnderscore}=$CC
+      export CXX_${rustTargetUnderscore}=$CXX
+      unset CC CXX
+    '';
 
   # Adapted from https://github.com/element-hq/matrix-authentication-service/blob/v0.20.0/.github/workflows/build.yaml#L75-L84
   postInstall = ''


### PR DESCRIPTION
## Things done

Fix matrix-authentication-service cross-compile.
The upstream lib aws-lc-sys has many issues related to cross-compilation open.
And in nixpkgs we also have https://github.com/NixOS/nixpkgs/blob/402ddbac802c8dd0ee7c29ec89c8d31a5eb4d38b/pkgs/build-support/rust/default-crate-overrides.nix#L59
Maybe we should apply this. I don't know and understand in the doc if this is made to be applied in nixpkgs packages.

Cross compilation log : 
<details>

<summary>Build Log</summary>

```bash
$ nix build .#pkgsCross.aarch64-multiplatform.matrix-authentication-service -L
```

```log
matrix-authentication-service-aarch64-unknown-linux-gnu> Running phase: unpackPhase
matrix-authentication-service-aarch64-unknown-linux-gnu> unpacking source archive /nix/store/5yis0frmnj8db975mylk1apwakmbsndf-source
matrix-authentication-service-aarch64-unknown-linux-gnu> source root is source
matrix-authentication-service-aarch64-unknown-linux-gnu> Executing cargoSetupPostUnpackHook
matrix-authentication-service-aarch64-unknown-linux-gnu> Finished cargoSetupPostUnpackHook
matrix-authentication-service-aarch64-unknown-linux-gnu> Running phase: patchPhase
matrix-authentication-service-aarch64-unknown-linux-gnu> Executing npmConfigHook
matrix-authentication-service-aarch64-unknown-linux-gnu> /build/source/frontend /build/source
matrix-authentication-service-aarch64-unknown-linux-gnu> Configuring npm
matrix-authentication-service-aarch64-unknown-linux-gnu> Validating consistency between /build/source/frontend/package-lock.json and /nix/store/651ij42jmg5k25gqas5bk3i6mlalwwqx-matrix-authentication-service-1.12.0-npm-deps/package-lock.json
matrix-authentication-service-aarch64-unknown-linux-gnu> Setting npm_config_cache to /nix/store/651ij42jmg5k25gqas5bk3i6mlalwwqx-matrix-authentication-service-1.12.0-npm-deps
matrix-authentication-service-aarch64-unknown-linux-gnu> Installing dependencies
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn Unknown env config "nodedir". This will stop working in the next major version of npm.
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn Unknown env config "platform". This will stop working in the next major version of npm.
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn Unknown env config "arch". This will stop working in the next major version of npm.
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn deprecated @babel/plugin-proposal-class-properties@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn deprecated @babel/plugin-proposal-object-rest-spread@7.20.7: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead
matrix-authentication-service-aarch64-unknown-linux-gnu> 
matrix-authentication-service-aarch64-unknown-linux-gnu> added 823 packages, and audited 824 packages in 6s
matrix-authentication-service-aarch64-unknown-linux-gnu> 
matrix-authentication-service-aarch64-unknown-linux-gnu> 175 packages are looking for funding
matrix-authentication-service-aarch64-unknown-linux-gnu>   run `npm fund` for details
matrix-authentication-service-aarch64-unknown-linux-gnu> 
matrix-authentication-service-aarch64-unknown-linux-gnu> found 0 vulnerabilities
matrix-authentication-service-aarch64-unknown-linux-gnu> patching script interpreter paths in node_modules
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/@ardatan/relay-compiler/bin/relay-compiler: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/@babel/parser/bin/babel-parser.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/@biomejs/biome/bin/biome: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/@graphql-codegen/typescript-msw/node_modules/@ardatan/relay-compiler/bin/relay-compiler: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/@graphql-codegen/cli/cjs/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/@graphql-codegen/cli/esm/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/acorn/bin/acorn: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/i18next-cli/dist/cjs/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/i18next-cli/dist/esm/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/tailwindcss/node_modules/jiti/bin/jiti.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/tailwindcss/lib/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/vitest/vitest.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/autoprefixer/bin/autoprefixer: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/baseline-browser-mapping/dist/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/browserslist/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/browserslist-to-esbuild/cli/index.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/cssesc/bin/cssesc: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/esbuild/bin/esbuild: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/esprima/bin/esparse.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/esprima/bin/esvalidate.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/formatly/bin/index.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/i18next-resources-for-ts/bin/i18next-resources-for-ts.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/is-docker/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/is-inside-container/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/jiti/lib/jiti-cli.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/js-yaml/bin/js-yaml.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/jsesc/bin/jsesc: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/json5/lib/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/loose-envify/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/lz-string/bin/bin.js: interpreter directive changed from "#! /usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/msw/cli/index.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/nanoid/bin/nanoid.cjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/open/xdg-open: interpreter directive changed from "#!/bin/sh" to "/nix/store/2hjsch59amjs3nbgh7ahcfzm2bfwl8zi-bash-5.3p9/bin/sh"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/prettier/bin/prettier.cjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/resolve/bin/resolve: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/rollup/dist/bin/rollup: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/rimraf/dist/esm/bin.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/shell-quote/print.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/52y580gf32nxvll9gfxgv3g3q2dqphh9-python3-aarch64-unknown-linux-gnu-3.13.12-env/bin/python3"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/tldts/bin/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/typescript/bin/tsc: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/typescript/bin/tsserver: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/tsx/dist/cli.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/ua-parser-js/script/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/update-browserslist-db/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/vite/bin/vite.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/which/bin/node-which: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/why-is-node-running/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/yaml/bin.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/knip/bin/knip.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/make-dir/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/recast/example/add-braces: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/recast/example/generic-identity: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/recast/example/identity: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/recast/example/to-while: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/storybook/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/storybook/dist/bin/dispatcher.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/sucrase/bin/sucrase: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> node_modules/sucrase/bin/sucrase-node: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/sy0c7j0npsq33d9zhnnzvjnzc52f4y0p-nodejs-24.13.0/bin/node"
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn Unknown env config "nodedir". This will stop working in the next major version of npm.
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn Unknown env config "platform". This will stop working in the next major version of npm.
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn Unknown env config "arch". This will stop working in the next major version of npm.
matrix-authentication-service-aarch64-unknown-linux-gnu> rebuilt dependencies successfully
matrix-authentication-service-aarch64-unknown-linux-gnu> patching script interpreter paths in node_modules
matrix-authentication-service-aarch64-unknown-linux-gnu> ~/source
matrix-authentication-service-aarch64-unknown-linux-gnu> Finished npmConfigHook
matrix-authentication-service-aarch64-unknown-linux-gnu> Executing cargoSetupPostPatchHook
matrix-authentication-service-aarch64-unknown-linux-gnu> Validating consistency between /build/source/Cargo.lock and /build/matrix-authentication-service-1.12.0-vendor/Cargo.lock
matrix-authentication-service-aarch64-unknown-linux-gnu> Finished cargoSetupPostPatchHook
matrix-authentication-service-aarch64-unknown-linux-gnu> Running phase: updateAutotoolsGnuConfigScriptsPhase
matrix-authentication-service-aarch64-unknown-linux-gnu> Running phase: updateAutotoolsGnuConfigScriptsPhase
matrix-authentication-service-aarch64-unknown-linux-gnu> Running phase: configurePhase
matrix-authentication-service-aarch64-unknown-linux-gnu> Running phase: buildPhase
matrix-authentication-service-aarch64-unknown-linux-gnu> Executing cargoBuildHook
matrix-authentication-service-aarch64-unknown-linux-gnu> make: Entering directory '/build/source/policies'
matrix-authentication-service-aarch64-unknown-linux-gnu> opa build -t wasm \
matrix-authentication-service-aarch64-unknown-linux-gnu>        -e "client_registration/violation" \
matrix-authentication-service-aarch64-unknown-linux-gnu>        -e "register/violation" \
matrix-authentication-service-aarch64-unknown-linux-gnu>        -e "authorization_grant/violation" \
matrix-authentication-service-aarch64-unknown-linux-gnu>        -e "compat_login/violation" \
matrix-authentication-service-aarch64-unknown-linux-gnu>        -e "email/violation" \
matrix-authentication-service-aarch64-unknown-linux-gnu>        common/common.rego client_registration/client_registration.rego register/register.rego authorization_grant/authorization_grant.rego compat_login/compat_login.rego email/email.rego
matrix-authentication-service-aarch64-unknown-linux-gnu> tar xzf bundle.tar.gz /policy.wasm
matrix-authentication-service-aarch64-unknown-linux-gnu> tar: Removing leading `/' from member names
matrix-authentication-service-aarch64-unknown-linux-gnu> rm -f bundle.tar.gz
matrix-authentication-service-aarch64-unknown-linux-gnu> touch policy.wasm
matrix-authentication-service-aarch64-unknown-linux-gnu> make: Leaving directory '/build/source/policies'
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn Unknown env config "nodedir". This will stop working in the next major version of npm.
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn Unknown env config "platform". This will stop working in the next major version of npm.
matrix-authentication-service-aarch64-unknown-linux-gnu> npm warn Unknown env config "arch". This will stop working in the next major version of npm.
matrix-authentication-service-aarch64-unknown-linux-gnu> 
matrix-authentication-service-aarch64-unknown-linux-gnu> > mas-frontend@0.0.0 build
matrix-authentication-service-aarch64-unknown-linux-gnu> > rimraf ./dist/ && vite build
matrix-authentication-service-aarch64-unknown-linux-gnu> 
matrix-authentication-service-aarch64-unknown-linux-gnu> vite v7.3.1 building client environment for production...
matrix-authentication-service-aarch64-unknown-linux-gnu> 
matrix-authentication-service-aarch64-unknown-linux-gnu>   
matrix-authentication-service-aarch64-unknown-linux-gnu>   [
matrix-authentication-service-aarch64-unknown-linux-gnu>   3
matrix-authentication-service-aarch64-unknown-linux-gnu>   2
matrix-authentication-service-aarch64-unknown-linux-gnu>   m
matrix-authentication-service-aarch64-unknown-linux-gnu>   ✔
matrix-authentication-service-aarch64-unknown-linux-gnu>   
matrix-authentication-service-aarch64-unknown-linux-gnu>   [
matrix-authentication-service-aarch64-unknown-linux-gnu>   3
matrix-authentication-service-aarch64-unknown-linux-gnu>   9m
matrix-authentication-service-aarch64-unknown-linux-gnu> 
matrix-authentication-service-aarch64-unknown-linux-gnu>   P
matrix-authentication-service-aarch64-unknown-linux-gnu>   a
matrix-authentication-service-aarch64-unknown-linux-gnu>   r
matrix-authentication-service-aarch64-unknown-linux-gnu>   s
matrix-authentication-service-aarch64-unknown-linux-gnu>   e
matrix-authentication-service-aarch64-unknown-linux-gnu> 
matrix-authentication-service-aarch64-unknown-linux-gnu>   C
matrix-authentication-service-aarch64-unknown-linux-gnu>   o
matrix-authentication-service-aarch64-unknown-linux-gnu>   n
matrix-authentication-service-aarch64-unknown-linux-gnu>   f
matrix-authentication-service-aarch64-unknown-linux-gnu>   i
matrix-authentication-service-aarch64-unknown-linux-gnu>   g
matrix-authentication-service-aarch64-unknown-linux-gnu>   u
matrix-authentication-service-aarch64-unknown-linux-gnu>   r
matrix-authentication-service-aarch64-unknown-linux-gnu>   a
matrix-authentication-service-aarch64-unknown-linux-gnu>   t
matrix-authentication-service-aarch64-unknown-linux-gnu>   i
matrix-authentication-service-aarch64-unknown-linux-gnu>   o
matrix-authentication-service-aarch64-unknown-linux-gnu>   n
matrix-authentication-service-aarch64-unknown-linux-gnu> 
matrix-authentication-service-aarch64-unknown-linux-gnu>   
matrix-authentication-service-aarch64-unknown-linux-gnu>   [
matrix-authentication-service-aarch64-unknown-linux-gnu>   3
matrix-authentication-service-aarch64-unknown-linux-gnu>   2
matrix-authentication-service-aarch64-unknown-linux-gnu>   m
matrix-authentication-service-aarch64-unknown-linux-gnu>   ✔
matrix-authentication-service-aarch64-unknown-linux-gnu>   
matrix-authentication-service-aarch64-unknown-linux-gnu>   [
matrix-authentication-service-aarch64-unknown-linux-gnu>   3
matrix-authentication-service-aarch64-unknown-linux-gnu>   9m
matrix-authentication-service-aarch64-unknown-linux-gnu> 
matrix-authentication-service-aarch64-unknown-linux-gnu>   G
matrix-authentication-service-aarch64-unknown-linux-gnu>   e
matrix-authentication-service-aarch64-unknown-linux-gnu>   n
matrix-authentication-service-aarch64-unknown-linux-gnu>   e
matrix-authentication-service-aarch64-unknown-linux-gnu>   r
matrix-authentication-service-aarch64-unknown-linux-gnu>   a
matrix-authentication-service-aarch64-unknown-linux-gnu>   t
matrix-authentication-service-aarch64-unknown-linux-gnu>   e
matrix-authentication-service-aarch64-unknown-linux-gnu> 
matrix-authentication-service-aarch64-unknown-linux-gnu>   o
matrix-authentication-service-aarch64-unknown-linux-gnu>   u
matrix-authentication-service-aarch64-unknown-linux-gnu>   t
matrix-authentication-service-aarch64-unknown-linux-gnu>   p
matrix-authentication-service-aarch64-unknown-linux-gnu>   u
matrix-authentication-service-aarch64-unknown-linux-gnu>   t
matrix-authentication-service-aarch64-unknown-linux-gnu>   s
matrix-authentication-service-aarch64-unknown-linux-gnu> [plugin vite:resolve] Module "path" has been externalized for browser compatibility, imported by "/build/source/frontend/node_modules/swagger-ui-dist/absolute-path.js". See https://vite.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
matrix-authentication-service-aarch64-unknown-linux-gnu> ✓ 1165 modules transformed.
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/chrome_64x64-TTj2uZYF.png                             4.22 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-vietnamese-400-normal-DMkecbls.woff2            4.97 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-vietnamese-600-normal-Cc8MFFhd.woff2            5.10 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-vietnamese-700-normal-DlLaEgI2.woff2            5.10 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-vietnamese-500-normal-DOriooB6.woff2            5.11 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-ext-400-normal-DGGRlc-M.woff2             5.26 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-ext-500-normal-C4iEst2y.woff2             5.43 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-ext-600-normal-DRtmH8MT.woff2             5.43 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-ext-700-normal-qfdV9bQt.woff2             5.44 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/firefox_64x64-sbBPu9C9.png                            5.90 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inconsolata-vietnamese-400-normal-ByiM2lek.woff       6.09 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inconsolata-vietnamese-700-normal-DLCFFAUf.woff       6.30 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-vietnamese-400-normal-Bbgyi5SW.woff             6.50 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-vietnamese-500-normal-mJboJaSs.woff             6.60 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-vietnamese-700-normal-BZaoP0fm.woff             6.63 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-vietnamese-600-normal-BuLX-rYi.woff             6.64 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-ext-400-normal-KugGGMne.woff              7.06 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/safari_64x64-DJVjfeAY.png                             7.12 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-ext-500-normal-2j5mBUwD.woff              7.19 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-ext-600-normal-B8X0CLgF.woff              7.21 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-ext-700-normal-BoQ6DsYi.woff              7.22 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-400-normal-obahsSVq.woff2              7.71 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-400-normal-B4URO6DV.woff2                 7.78 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-500-normal-BasfLYem.woff2              7.90 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-700-normal-CjBOestx.woff2              7.90 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-500-normal-BIZE56-Y.woff2                 7.92 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-700-normal-C3JjAnD8.woff2                 7.92 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-600-normal-plRanbMR.woff2                 7.94 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-600-normal-CWCymEST.woff2              7.97 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inconsolata-vietnamese-400-normal-DfC_iMic.woff2      8.32 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inconsolata-vietnamese-700-normal-DuasYmn8.woff2      8.48 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-400-normal-HOLc17fK.woff               9.78 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-700-normal-DrXBdSj3.woff               9.91 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-400-normal-q2sYcFCs.woff                  9.92 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-600-normal-4D_pXhcN.woff               9.94 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-500-normal-CxZf_p3X.woff               9.94 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-500-normal-Xzm54t5V.woff                  9.98 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-700-normal-BUv2fZ6O.woff                  9.98 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-greek-600-normal-BZpKdvQh.woff                 10.03 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-ext-400-normal-BQZuk6qB.woff2         10.23 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-ext-500-normal-B0yAr1jD.woff2         10.43 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-ext-600-normal-Dfes3d0z.woff2         10.48 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-ext-700-normal-BjwYoWNd.woff2         10.50 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-ext-400-normal-DQukG94-.woff          13.34 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-ext-700-normal-LO58E6JB.woff          13.41 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-ext-500-normal-BmqWE9Dz.woff          13.45 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-cyrillic-ext-600-normal-Bcila6Z-.woff          13.46 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/en-Bwg6UIzF.json                                     14.71 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inconsolata-latin-400-normal-HYADljCo.woff           16.28 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/zh-Hans-Bf42-WuH.json                                16.55 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inconsolata-latin-700-normal-DzgUY3Rl.woff           16.62 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inconsolata-latin-ext-400-normal-yvPjCxxx.woff       17.20 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inconsolata-latin-ext-700-normal-Dlt-daqV.woff       17.56 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inconsolata-latin-400-normal-DTZQ6lD6.woff2          17.66 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/nl-Gzx3oS_b.json                                     17.89 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inconsolata-latin-700-normal-ByjKuJjN.woff2          17.96 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/nb-NO-fHeAvt7R.json                                  18.06 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inconsolata-latin-ext-400-normal-BaHVOdFB.woff2      18.23 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/da-C7iC4T2b.json                                     18.27 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inconsolata-latin-ext-700-normal-D0Kpgs_9.woff2      18.45 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/sv-CZZ1grTo.json                                     18.54 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/cs-DkP00NG1.json                                     18.71 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/fi-KKhdd5LL.json                                     18.73 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/pt-DqxHb1vZ.json                                     19.24 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/et-CEPVlzV9.json                                     19.27 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/pl-B2YioSBp.json                                     19.30 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/de-Cayx3jd2.json                                     19.33 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/hu-DcQ7N5iv.json                                     19.75 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/fr-Cmf_tbKY.json                                     20.08 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-400-normal-C38fXH4l.woff2                23.66 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-500-normal-Cerq10X2.woff2                24.27 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-700-normal-Yt3aPRUw.woff2                24.36 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-600-normal-LgqL8muc.woff2                24.45 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/uk-DYCPqOGO.json                                     26.95 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/ru-DBNI24b3.json                                     27.43 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-400-normal-CyCys3Eg.woff                 30.70 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-600-normal-CiBQ2DWP.woff                 31.26 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-500-normal-BL9OpVg8.woff                 31.28 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-700-normal-BLAVimhd.woff                 31.32 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-ext-400-normal-C1nco2VV.woff2            35.00 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-ext-500-normal-CV4jyFjo.woff2            36.02 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-ext-700-normal-Ca8adRJv.woff2            36.24 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-ext-600-normal-D2bJ5OIk.woff2            36.26 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-ext-400-normal-77YHD8bZ.woff             47.56 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-ext-500-normal-BxGbmqWO.woff             48.49 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-ext-700-normal-TidjK2hL.woff             48.63 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/inter-latin-ext-600-normal-CIVaiw4L.woff             48.67 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/manifest.json                                       103.71 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/ButtonLink-C4AMHHR_.css                               0.05 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/LastActive-C9wo4AOG.css                               0.06 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/clients-Dttfz2sD.css                                  0.08 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/Separator-C2iSg9zz.css                                0.13 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/computer-5n3hJ_65.css                                 0.16 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/_account.sessions-CQQxPQtC.css                        0.27 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/sessions-CEZ3Mbxr.css                                 0.97 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/_account-D5pwwkVm.css                                 1.08 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/Filter-lwtJLR9L.css                                   1.33 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/_account-Bo4jHeuD.css                                 1.96 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/EndBrowserSessionButton-CLcxyUoQ.css                  4.03 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/main-D1rRDDVj.css                                     7.70 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/templates-Dv-ESGWw.css                               23.41 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/swagger--HcZd4fm.css                                175.42 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/shared-CJF1S-UQ.css                                 204.54 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/Link-DkgB_R27.js                                      0.12 kB │ map:     0.61 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/Submit-Cjkn-RUa.js                                    0.23 kB │ map:     0.90 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/reset-cross-signing-9SMU0zSf.js                       0.25 kB │ map:     1.77 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/Separator-DL85C9X_.js                                 0.37 kB │ map:     1.47 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/ButtonLink-tfZ_HDsM.js                                0.37 kB │ map:     1.83 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/Heading-DeDTYNPL.js                                   0.48 kB │ map:     2.11 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/arrow-left-eXefVA9g.js                                0.49 kB │ map:     1.18 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/reset-cross-signing.success-CJcqs5f7.js               0.53 kB │ map:     1.94 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/sessions._id-DIwSiHij.js                              0.55 kB │ map:     3.48 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/devices._-B4Fu-VOv.js                                 0.55 kB │ map:     3.17 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/password.change.success-CoEyXoQR.js                   0.58 kB │ map:     1.81 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/reset-cross-signing-BYD7j1tb.js                       0.59 kB │ map:     2.15 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/edit-Cs343Yj_.js                                      0.59 kB │ map:     1.30 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/check-CVg5vFjh.js                                     0.60 kB │ map:     1.27 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/emails._id.in-use-B09VUJld.js                         0.63 kB │ map:     2.73 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/_commonjsHelpers-DaWZu8wl.js                          0.69 kB │ map:     0.11 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/computer-q65CqD4j.js                                  0.85 kB │ map:     2.66 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/VisualListItem-BEP7JwpE.js                            0.89 kB │ map:     3.23 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/_account.plan.index-DkTpsMe6.js                       0.96 kB │ map:     5.42 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/templates-4a1m02fU.js                                 0.99 kB │ map:     4.90 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/Avatar-d_T59wGl.js                                    1.08 kB │ map:     4.90 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/reset-cross-signing.cancelled-Cvh9Zw6w.js             1.39 kB │ map:     3.16 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/clients._id-Bb161b8O.js                               2.11 kB │ map:     7.85 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/reset-cross-signing.index-BjR3jfOU.js                 2.17 kB │ map:     7.35 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/Filter-CW-YL-7b.js                                    2.53 kB │ map:     9.33 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/_account.sessions.browsers-CAWd5Wd5.js                2.66 kB │ map:     7.73 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/password.change.index-CYwKk0SY.js                     2.91 kB │ map:     9.67 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/EndOAuth2SessionButton-DlUATcMU.js                    2.95 kB │ map:    11.08 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/password.recovery.index-BKuZT7qD.js                   4.38 kB │ map:    15.26 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/_account-CSI_P2ZC.js                                  4.68 kB │ map:    15.80 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/emails._id.verify-BvYpc8IY.js                         4.79 kB │ map:    16.86 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/EndBrowserSessionButton-XOOEloOM.js                   5.79 kB │ map:    19.45 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/SessionInfo-Do-6Cn75.js                               5.99 kB │ map:    15.45 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/_account.sessions.index-CQNgOmqU.js                   6.72 kB │ map:    21.94 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/LastActive-Bmam5PJx.js                                6.73 kB │ map:    69.53 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/password_changes-BhRgq21A.js                          8.91 kB │ map:    36.38 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/Trans-Bj-L7Y_G.js                                     9.19 kB │ map:    36.19 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/sessions._id-2U4gYK-u.js                             10.62 kB │ map:    36.47 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/_account.index-CibOmVhA.js                           17.13 kB │ map:    65.99 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/main-BUoaME1T.js                                    562.41 kB │ map: 2,936.72 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/index-CAYJKexB.js                                 1,017.25 kB │ map:   175.09 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> dist/swagger-DBpfnGqp.js                               1,622.89 kB │ map: 3,873.74 kB
matrix-authentication-service-aarch64-unknown-linux-gnu> 
matrix-authentication-service-aarch64-unknown-linux-gnu> (!) Some chunks are larger than 500 kB after minification. Consider:
matrix-authentication-service-aarch64-unknown-linux-gnu> - Using dynamic import() to code-split the application
matrix-authentication-service-aarch64-unknown-linux-gnu> - Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
matrix-authentication-service-aarch64-unknown-linux-gnu> - Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
matrix-authentication-service-aarch64-unknown-linux-gnu> ✓ built in 9.04s
matrix-authentication-service-aarch64-unknown-linux-gnu> cargoBuildHook flags: -j 5 --target aarch64-unknown-linux-gnu --offline --profile release --no-default-features --features=dist
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling proc-macro2 v1.0.101
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling unicode-ident v1.0.19
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling quote v1.0.44
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling serde v1.0.228
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling libc v0.2.180
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling serde_core v1.0.228
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cfg-if v1.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling version_check v0.9.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling autocfg v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling zeroize v1.8.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling memchr v2.7.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling typenum v1.18.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling once_cell v1.21.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling syn v2.0.106
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling allocator-api2 v0.2.21
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling itoa v1.0.15
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling getrandom v0.2.16
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling foldhash v0.1.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling equivalent v1.0.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling hashbrown v0.15.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rand_core v0.6.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling thiserror v2.0.17
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling log v0.4.28
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling generic-array v0.14.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling subtle v2.6.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pin-project-lite v0.2.16
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_locid_transform_data v1.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling lock_api v0.4.13
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling zerocopy v0.8.27
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling parking_lot_core v0.9.11
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling percent-encoding v2.3.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling futures-core v0.3.31
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling indexmap v2.11.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling jobserver v0.1.34
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling shlex v1.3.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling find-msvc-tools v0.1.8
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling stable_deref_trait v1.2.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cc v1.2.54
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_properties_data v1.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tracing-core v0.1.36
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling crypto-common v0.1.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_normalizer_data v1.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling crossbeam-utils v0.8.21
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling scopeguard v1.2.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling libm v0.2.15
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling litemap v0.7.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling futures-sink v0.3.31
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ryu v1.0.20
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling socket2 v0.6.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling synstructure v0.13.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling signal-hook-registry v1.4.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mio v1.0.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling serde_json v1.0.145
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling futures-channel v0.3.31
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling futures-task v0.3.31
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling futures-io v0.3.31
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling const-oid v0.9.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling slab v0.4.11
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pin-utils v0.1.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ppv-lite86 v0.2.21
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling block-buffer v0.10.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling digest v0.10.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling serde_derive v1.0.228
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling zerofrom-derive v0.1.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling yoke-derive v0.7.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling displaydoc v0.2.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling zerovec-derive v0.10.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling thiserror-impl v2.0.17
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_provider_macros v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tracing-attributes v0.1.31
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling zerofrom v0.1.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tokio-macros v2.6.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling yoke v0.7.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling zerovec v0.10.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling futures-macro v0.3.31
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tracing v0.1.44
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tinystr v0.7.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling futures-util v0.3.31
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_collections v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling smallvec v1.15.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling either v1.15.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling bytes v1.11.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling writeable v0.5.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling parking_lot v0.12.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_locid v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tokio v1.48.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cmake v0.1.54
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_provider v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling form_urlencoded v1.2.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling utf8_iter v1.0.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling dunce v1.0.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling write16 v1.0.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling utf16_iter v1.0.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_locid_transform v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling fs_extra v1.3.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling aws-lc-sys v0.31.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_properties v1.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cpufeatures v0.2.17
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling num-traits v0.2.19
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling base64 v0.22.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling aws-lc-rs v1.14.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling block-padding v0.3.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling inout v0.1.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rustversion v1.0.22
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cipher v0.4.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling hmac v0.12.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling strsim v0.11.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling fnv v1.0.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling bitflags v2.10.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ident_case v1.0.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling darling_core v0.20.11
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sha2 v0.10.9
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_normalizer v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling getrandom v0.3.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling http v1.3.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling idna_adapter v1.2.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling idna v1.1.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling url v2.5.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling crossbeam-epoch v0.9.18
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling darling_macro v0.20.11
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rustls-pki-types v1.13.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling darling v0.20.11
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rayon-core v1.13.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling base64ct v1.8.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling crossbeam-deque v0.8.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling aho-corasick v1.1.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling num-conv v0.2.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling spin v0.9.8
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling anyhow v1.0.100
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling regex-syntax v0.8.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling time-core v0.1.8
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mime v0.3.17
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling hex v0.4.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling httpdate v1.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling regex-automata v0.4.13
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling iana-time-zone v0.1.64
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling chrono v0.4.42
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rayon v1.11.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling aes v0.8.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rustls v0.23.35
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling untrusted v0.9.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling lazy_static v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling password-hash v0.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rand_core v0.9.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rand_chacha v0.9.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pem-rfc7468 v0.7.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling http-body v1.0.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tower-service v0.3.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling powerfmt v0.2.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling heck v0.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling deranged v0.5.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling der v0.7.10
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rand v0.9.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pbkdf2 v0.12.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling time-macros v0.2.27
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling hkdf v0.12.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling salsa20 v0.10.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling uuid v1.18.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rand_chacha v0.3.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rand v0.8.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling time v0.3.47
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling scrypt v0.11.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling spki v0.7.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cbc v0.1.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling httparse v1.10.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tower-layer v0.3.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pkcs5 v0.7.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tokio-util v0.7.16
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tokio-stream v0.1.17
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling async-trait v0.1.89
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sync_wrapper v1.0.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pkcs8 v0.10.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling http-body-util v0.1.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opentelemetry v0.31.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling try-lock v0.2.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling atomic-waker v1.1.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling h2 v0.4.12
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling want v0.3.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling num-integer v0.1.46
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling futures-executor v0.3.31
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ff v0.13.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling base16ct v0.2.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sec1 v0.7.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling group v0.13.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling crypto-bigint v0.5.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ipnet v2.11.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tower v0.5.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling elliptic-curve v0.13.8
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling signature v2.2.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-srcgen v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ref-cast v1.0.24
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-assembler-x64-meta v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling regex v1.12.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rfc6979 v0.4.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling serde_urlencoded v0.7.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling serde_spanned v0.6.9
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling toml_datetime v0.6.11
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ref-cast-impl v1.0.24
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling serde_derive_internals v0.29.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling hyper v1.8.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling gimli v0.32.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling winnow v0.7.13
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling hyper-util v0.1.18
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling toml_edit v0.22.27
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling schemars_derive v0.9.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ecdsa v0.16.9
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opentelemetry_sdk v0.31.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pulley-macros v40.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ahash v0.8.12
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling thread_local v1.1.9
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling dyn-clone v1.0.20
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rustix v1.1.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling crc32fast v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling num-bigint-dig v0.8.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling schemars v0.9.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling primeorder v0.13.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling num-iter v0.1.45
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-bitset v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling object v0.37.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling openssl-probe v0.1.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling linux-raw-sys v0.11.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-isle v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pulley-interpreter v40.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rustls-native-certs v0.8.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling proc-macro-crate v3.3.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pkcs1 v0.7.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling matchers v0.2.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sharded-slab v0.1.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling serde_with_macros v3.14.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling psm v0.1.26
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tracing-log v0.2.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-codegen-shared v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling target-lexicon v0.13.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling nu-ansi-term v0.50.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tracing-subscriber v0.3.22
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-codegen-meta v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling serde_with v3.14.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rsa v0.9.10
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling hashbrown v0.14.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-entity v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling p256 v0.13.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling p384 v0.13.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-iana v1.12.0 (/build/source/crates/iana)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling k256 v0.13.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-assembler-x64 v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling serde_html_form v0.2.8
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling stacker v0.1.21
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling unicase v2.8.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling thiserror v1.0.69
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rustc-hash v2.1.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling js_int v0.2.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling crc-catalog v2.4.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling web-time v1.1.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling crc v3.3.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ruma-identifiers-validation v0.11.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mime_guess v2.0.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-jose v1.12.0 (/build/source/crates/jose)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-codegen v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling toml v0.8.23
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wasmtime-internal-versioned-export-macros v40.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wasmtime-internal-math v40.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling universal-hash v0.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling bumpalo v3.19.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling hostname v0.4.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling fastrand v2.3.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opaque-debug v0.3.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling arbitrary v1.4.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ruma-common v0.16.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling regalloc2 v0.13.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-control v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ruma-macros v0.16.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-bforest v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sha1 v0.10.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling thiserror-impl v1.0.69
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wildmatch v2.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wasmparser v0.243.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ucd-trie v0.1.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling as_variant v1.3.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pest v2.8.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling chumsky v0.9.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tracing-opentelemetry v0.32.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ulid v1.1.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling email-encoding v0.4.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling language-tags v0.3.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling md-5 v0.10.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling nom v8.0.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling encoding_rs v0.8.35
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling quoted_printable v0.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling email_address v0.2.9
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling semver v1.0.27
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tinyvec_macros v0.1.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wasm-encoder v0.243.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling http-range-header v0.4.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling woothee v0.13.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling iri-string v0.7.8
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tower-http v0.6.8
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tinyvec v1.10.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling oauth2-types v1.12.0 (/build/source/crates/oauth2-types)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rustls-webpki v0.103.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling concurrent-queue v2.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling webpki-roots v1.0.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling axum-core v0.5.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cobs v0.3.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pin-project-internal v1.1.10
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling aead v0.5.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling serde_path_to_error v0.1.20
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_decimal_data v1.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_plurals_data v1.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_calendar_data v1.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling camino v1.2.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling matchit v0.8.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling unsafe-libyaml v0.2.11
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wasmtime-internal-unwinder v40.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling termcolor v1.4.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opentelemetry-semantic-conventions v0.31.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling parking v2.2.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling leb128fmt v0.1.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling event-listener v5.4.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tokio-rustls v0.26.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling hyper-rustls v0.27.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wasmprinter v0.243.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling serde_yaml v0.9.34+deprecated
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling axum v0.8.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rustc_version v0.4.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pin-project v1.1.10
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling postcard v1.1.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling webpki-roots v0.26.11
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling futures-intrusive v0.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling unicode-normalization v0.1.24
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling crossbeam-queue v0.3.12
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wasmtime-internal-fiber v40.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling debugid v0.8.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling hashlink v0.10.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling derive_builder_core v0.20.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling fixed_decimal v0.5.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ipnetwork v0.20.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling core_maths v0.1.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_timezone_data v1.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling unicode-properties v0.1.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling siphasher v1.0.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling unicode-bidi v0.3.18
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rust_decimal v1.38.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sqlx-core v0.8.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling phf_shared v0.12.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling stringprep v0.1.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling derive_builder_macro v0.20.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling calendrical_calculations v0.1.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sentry-types v0.46.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rustls-platform-verifier v0.6.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wasmtime-environ v40.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling lettre v0.11.19
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling reqwest v0.12.28
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-data-model v1.12.0 (/build/source/crates/data-model)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-native v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cranelift-frontend v0.127.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling atoi v2.0.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wasmtime v40.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling itertools v0.14.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling zerotrie v0.1.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling arrayvec v0.7.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_experimental_data v0.1.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling v_htmlescape v0.15.8
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling chrono-tz v0.10.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_datetime_data v1.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling whoami v1.6.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling byteorder v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling home v0.5.11
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling dotenvy v0.15.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sqlx-postgres v0.8.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wasmtime-internal-cranelift v40.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sentry-core v0.46.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_calendar v1.5.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_plurals v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_decimal v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling phf v0.12.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pest_meta v2.8.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling memfd v0.6.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wasmtime-internal-jit-icache-coherence v40.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling num-bigint v0.4.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling headers-core v0.3.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling jsonptr v0.7.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling proc-macro2-diagnostics v0.10.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling wasmtime-internal-slab v40.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling urlencoding v2.1.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling duration-str v0.15.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling num-rational v0.4.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling json-patch v4.0.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling headers v0.4.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pest_generator v2.8.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_timezone v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sqlx-macros-core v0.8.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opentelemetry-http v0.31.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling poly1305 v0.8.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling polyval v0.6.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling chronoutil v0.2.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling arc-swap v1.8.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling chacha20 v0.9.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling quanta v0.12.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_pattern v0.2.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sprintf v0.4.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling unicode-width v0.1.14
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling adler2 v2.0.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling memo-map v0.3.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling self_cell v1.2.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling parse-size v1.1.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling yansi v1.0.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opa-wasm v0.1.9
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling minijinja v2.15.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_datetime v1.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling miniz_oxide v0.8.9
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pad v0.1.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_experimental v0.1.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling chacha20poly1305 v0.10.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ghash v0.5.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sqlx-macros v0.8.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pest_derive v2.8.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling addr2line v0.25.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling vergen-lib v0.1.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling ctr v0.9.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling icu_provider_adapters v1.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling uncased v0.9.10
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cookie v0.18.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling same-file v1.0.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling unicode-width v0.2.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling heck v0.4.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling rustc-demangle v0.1.26
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling portable-atomic v1.11.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling backtrace v0.3.76
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sea-query-derive v0.4.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sqlx v0.8.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling console v0.15.11
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling walkdir v2.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling aes-gcm v0.10.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-keystore v1.12.0 (/build/source/crates/keystore)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling minijinja-contrib v2.12.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-policy v1.12.0 (/build/source/crates/policy)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pear_codegen v0.2.9
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-storage v1.12.0 (/build/source/crates/storage)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-spa v1.12.0 (/build/source/crates/spa)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling derive_builder v0.20.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-router v1.12.0 (/build/source/crates/router)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sentry-contexts v0.46.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling vergen v9.0.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling inherent v1.0.13
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling figment v0.10.19
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling futures-timer v3.0.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling inlinable_string v0.1.15
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cfg_aliases v0.2.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sentry v0.46.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling pear v0.2.9
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling prost-derive v0.14.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sea-query v0.32.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-i18n v1.12.0 (/build/source/crates/i18n)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-templates v1.12.0 (/build/source/crates/templates)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sentry-backtrace v0.46.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-http v1.12.0 (/build/source/crates/http)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tempfile v3.22.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling async-graphql-value v7.0.17
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling dashmap v6.1.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling strum_macros v0.26.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling vergen-gitcl v1.0.8
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling spinning_top v0.3.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling uname v0.1.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling multer v3.1.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling static_assertions v1.1.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling bit-vec v0.6.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-storage-pg v1.12.0 (/build/source/crates/storage-pg)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling num_threads v0.1.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling nonzero_ext v0.3.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling utf8parse v0.2.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling bit-set v0.5.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling anstyle-parse v0.2.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling governor v0.10.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling Inflector v0.11.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling async-graphql-parser v7.0.17
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling strum v0.26.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sentry-panic v0.46.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sea-query-binder v0.7.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling axum-extra v0.10.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling prost v0.14.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-context v1.12.0 (/build/source/crates/context)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sentry-tower v0.46.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tonic v0.14.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-matrix v1.12.0 (/build/source/crates/matrix)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling futures v0.3.31
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling async-stream-impl v0.3.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling smartstring v1.0.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling anstyle-query v1.1.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling anstyle v1.0.11
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling procfs v0.18.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling colorchoice v1.0.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling is_terminal_polyfill v1.70.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling winnow v0.6.26
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling indoc v2.0.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling anstream v0.6.20
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling async-stream v0.3.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-config v1.12.0 (/build/source/crates/config)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tonic-prost v0.14.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tracing-futures v0.2.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling cron v0.15.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling async-graphql-derive v7.0.17
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling fancy-regex v0.13.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-email v1.12.0 (/build/source/crates/email)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling blowfish v0.9.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling thiserror-ext-derive v0.3.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling procfs-core v0.18.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling aide-macros v0.15.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling castaway v0.2.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling itertools v0.13.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling blake2 v0.10.6
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling static_assertions_next v1.1.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling clap_lex v0.7.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opentelemetry-resource-detectors v0.10.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling psl-types v2.0.11
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling zxcvbn v3.1.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling psl v2.1.162
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling clap_builder v4.5.50
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling async-graphql v7.0.17
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling argon2 v0.5.3
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling thiserror-ext v0.3.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling compact_str v0.9.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling aide v0.15.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling bcrypt v0.18.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-cli v1.12.0 (/build/source/crates/cli)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-axum-utils v1.12.0 (/build/source/crates/axum-utils)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opentelemetry-proto v0.31.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-tasks v1.12.0 (/build/source/crates/tasks)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-oidc-client v1.12.0 (/build/source/crates/oidc-client)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling fuzzy-matcher v0.3.7
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling clap_derive v4.5.49
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling crossbeam-channel v0.5.15
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling axum-macros v0.5.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling shell-words v1.1.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling dialoguer v0.11.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling clap v4.5.50
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling tracing-appender v0.2.4
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-handlers v1.12.0 (/build/source/crates/handlers)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opentelemetry-prometheus-text-exporter v0.2.1
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opentelemetry-otlp v0.31.0
matrix-authentication-service-aarch64-unknown-linux-gnu> warning: mas-cli@1.12.0: no suitable 'git' command found!
matrix-authentication-service-aarch64-unknown-linux-gnu> warning: mas-cli@1.12.0: VERGEN_GIT_DESCRIBE overidden
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling syn2mas v1.12.0 (/build/source/crates/syn2mas)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opentelemetry-instrumentation-process v0.1.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-matrix-synapse v1.12.0 (/build/source/crates/matrix-synapse)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-listener v1.12.0 (/build/source/crates/listener)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling mas-tower v1.12.0 (/build/source/crates/tower)
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sentry-tracing v0.46.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opentelemetry-stdout v0.31.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opentelemetry-instrumentation-tokio v0.1.2
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling opentelemetry-jaeger-propagator v0.31.0
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling sd-notify v0.4.5
matrix-authentication-service-aarch64-unknown-linux-gnu>    Compiling listenfd v1.0.2
matrix-authentication-service-aarch64-unknown-linux-gnu>     Finished `release` profile [optimized] target(s) in 20m 07s
matrix-authentication-service-aarch64-unknown-linux-gnu> Executing cargoInstallPostBuildHook
matrix-authentication-service-aarch64-unknown-linux-gnu> Finished cargoInstallPostBuildHook
matrix-authentication-service-aarch64-unknown-linux-gnu> Finished cargoBuildHook
matrix-authentication-service-aarch64-unknown-linux-gnu> buildPhase completed in 20 minutes 18 seconds
matrix-authentication-service-aarch64-unknown-linux-gnu> Running phase: installPhase
matrix-authentication-service-aarch64-unknown-linux-gnu> Executing cargoInstallHook
matrix-authentication-service-aarch64-unknown-linux-gnu> Finished cargoInstallHook
matrix-authentication-service-aarch64-unknown-linux-gnu> Running phase: fixupPhase
matrix-authentication-service-aarch64-unknown-linux-gnu> shrinking RPATHs of ELF executables and libraries in /nix/store/ar60warfv764irb3zspgs26n7cafnyj1-matrix-authentication-service-aarch64-unknown-linux-gnu-1.12.0
matrix-authentication-service-aarch64-unknown-linux-gnu> shrinking /nix/store/ar60warfv764irb3zspgs26n7cafnyj1-matrix-authentication-service-aarch64-unknown-linux-gnu-1.12.0/bin/mas-cli
matrix-authentication-service-aarch64-unknown-linux-gnu> checking for references to /build/ in /nix/store/ar60warfv764irb3zspgs26n7cafnyj1-matrix-authentication-service-aarch64-unknown-linux-gnu-1.12.0...
matrix-authentication-service-aarch64-unknown-linux-gnu> patching script interpreter paths in /nix/store/ar60warfv764irb3zspgs26n7cafnyj1-matrix-authentication-service-aarch64-unknown-linux-gnu-1.12.0
matrix-authentication-service-aarch64-unknown-linux-gnu> stripping (with command aarch64-unknown-linux-gnu-strip and flags -S -p) in  /nix/store/ar60warfv764irb3zspgs26n7cafnyj1-matrix-authentication-service-aarch64-unknown-linux-gnu-1.12.0/bin
```

</details>

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
