### PR TITLE
ory: 0.3.4 -> 1.2.0

### DIFF
--- a/pkgs/by-name/or/ory/package.nix
+++ b/pkgs/by-name/or/ory/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "ory";
-  version = "0.3.4";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "ory";
     repo = "cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-q7+Fpttgx62GbKxCCiEDlX//e/pNO24e7KhhBeGRDH0=";
+    hash = "sha256-WqVcVqdgzlI6OvgLA4OViBsU0DGaTnv5F+Ew58UzQlM=";
   };
 
   nativeBuildInputs = [
@@ -29,12 +29,12 @@ buildGoModule (finalAttrs: {
     "sqlite"
   ];
 
-  vendorHash = "sha256-B0y1JVjJmC5eitn7yIcDpl+9+xaBDJBMdvm+7N/ZxTk=";
-
+  vendorHash = "sha256-W7yi6CSioLnLmOsK7hdB3C96fV7METOe+wzKKMWpphw=";
   postInstall = ''
     mv $out/bin/cli $out/bin/ory
   ''
   + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    export version=v${finalAttrs.version}
     installShellCompletion --cmd ory \
       --bash <($out/bin/ory completion bash) \
       --fish <($out/bin/ory completion fish) \


### PR DESCRIPTION
* diff: https://github.com/ory/cli/compare/v0.3.4...v1.2.0
* changelog: https://github.com/ory/cli/releases/tag/v1.2.0
* newer version of ory cli reads `version` env var, and expects it in `vMAJOR.MINOR.PATCH` format. Rather than update `finalAttrs.version` I opted to temporarily export `version` to the expected format during postInstall phase. Appears to be a known bug in upstream (see: ory/cli#404)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
