### PR TITLE
nixos/pam: add u2f.control option

### DIFF
--- a/nixos/modules/programs/i3lock.nix
+++ b/nixos/modules/programs/i3lock.nix
@@ -32,7 +32,7 @@ in
         description = ''
           Whether to enable U2F support in the i3lock program.
           U2F enables authentication using a hardware device, such as a security key.
-          When U2F support is enabled, the i3lock program will set the setuid bit on the i3lock binary and enable the pam u2fAuth service,
+          When U2F support is enabled, the i3lock program will set the setuid bit on the i3lock binary and enable the pam u2f service,
         '';
       };
     };
@@ -51,7 +51,7 @@ in
       source = "${cfg.package.out}/bin/i3lock";
     };
 
-    security.pam.services.i3lock.u2fAuth = cfg.u2fSupport;
+    security.pam.services.i3lock.u2f.enable = cfg.u2fSupport;
 
   };
 

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -135,6 +135,7 @@ let
 
       imports = [
         (lib.mkRenamedOptionModule [ "enableKwallet" ] [ "kwallet" "enable" ])
+        (lib.mkRenamedOptionModule [ "u2fAuth" ] [ "u2f" "enable" ])
       ];
 
       options = {
@@ -202,17 +203,19 @@ let
           '';
         };
 
-        u2fAuth = lib.mkOption {
-          default = config.security.pam.u2f.enable;
-          defaultText = lib.literalExpression "config.security.pam.u2f.enable";
-          type = lib.types.bool;
-          description = ''
-            If set, users listed in
-            {file}`$XDG_CONFIG_HOME/Yubico/u2f_keys` (or
-            {file}`$HOME/.config/Yubico/u2f_keys` if XDG variable is
-            not set) are able to log in with the associated U2F key. Path can be
-            changed using {option}`security.pam.u2f.authFile` option.
-          '';
+        u2f = {
+          enable = lib.mkOption {
+            default = config.security.pam.u2f.enable;
+            defaultText = lib.literalExpression "config.security.pam.u2f.enable";
+            type = lib.types.bool;
+            description = ''
+              If set, users listed in
+              {file}`$XDG_CONFIG_HOME/Yubico/u2f_keys` (or
+              {file}`$HOME/.config/Yubico/u2f_keys` if XDG variable is
+              not set) are able to log in with the associated U2F key. Path can be
+              changed using {option}`security.pam.u2f.authFile` option.
+            '';
+          };
         };
 
         usshAuth = lib.mkOption {
@@ -1045,7 +1048,7 @@ let
                   in
                   {
                     name = "u2f";
-                    enable = cfg.u2fAuth;
+                    enable = cfg.u2f.enable;
                     control = u2f.control;
                     modulePath = "${pkgs.pam_u2f}/lib/security/pam_u2f.so";
                     inherit (u2f) settings;

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -216,6 +216,26 @@ let
               changed using {option}`security.pam.u2f.authFile` option.
             '';
           };
+
+          control = lib.mkOption {
+            default = config.security.pam.u2f.control;
+            defaultText = lib.literalExpression "config.security.pam.u2f.control";
+            type = lib.types.enum [
+              "required"
+              "requisite"
+              "sufficient"
+              "optional"
+            ];
+            description = ''
+              This option sets pam "control".
+              If you want to have multi factor authentication, use "required".
+              If you want to use U2F device instead of regular password, use "sufficient".
+
+              Read
+              {manpage}`pam.conf(5)`
+              for better understanding of this option.
+            '';
+          };
         };
 
         usshAuth = lib.mkOption {
@@ -1049,7 +1069,7 @@ let
                   {
                     name = "u2f";
                     enable = cfg.u2f.enable;
-                    control = u2f.control;
+                    control = cfg.u2f.control;
                     modulePath = "${pkgs.pam_u2f}/lib/security/pam_u2f.so";
                     inherit (u2f) settings;
                   }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds an option to configure a service-specific `control` for the `u2f` rule. Adding to address [a use case in the wild](https://discourse.nixos.org/t/login-to-sddm-with-yubikey-doesnt-unlock-kde-wallet/74344).

I would like to build a general solution for global service configuration defaults, but I ran into some snags with the module system. This will help users now until a general solution exists.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
    - `nixosTests.pam-u2f`
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
