### PR TITLE
neovim: rework provider code generation

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -216,7 +216,7 @@
 
 - `mold` is now wrapped by default.
 
-- `neovim` now disables by default the `python3` and `ruby` providers, unused by most users and reducing closure size from 365MiB to 240MiB.
+- `neovim` now disables by default the `python3` and `ruby` providers, unused by most users and reducing closure size from 365MiB to 240MiB. Host provider executables are not exposed anymore along with the neovim wrapper. You can still refer to those using the neovim provider variables (e.g., `python3_host_prog`).
 
 ### Deprecations {#sec-nixpkgs-release-26.05-lib-deprecations}
 

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -15,6 +15,7 @@
   perl,
   lndir,
   vimUtils,
+  runCommand,
 }:
 
 neovim-unwrapped:
@@ -154,14 +155,33 @@ let
           (lib.makeBinPath finalAttrs.runtimeDeps)
         ];
 
-        providerLuaRc = neovimUtils.generateProviderRc {
-          inherit (finalAttrs)
-            withPython3
-            withNodeJs
-            withPerl
-            withRuby
-            ;
-        };
+        providerLuaRc =
+          let
+            hostPython3 =
+              runCommand "nvim-host-${python3Env.name}"
+                {
+                  nativeBuildInputs = [
+                    makeWrapper
+                  ];
+                }
+                ''
+                  makeWrapper ${python3Env.interpreter} $out/bin/nvim-python3 --unset PYTHONPATH --unset PYTHONSAFEPATH
+                '';
+
+            genProviderCommand =
+              prog: withProg: exec:
+              if withProg then
+                "vim.g.${prog}_host_prog='${exec}'"
+              else
+                # speeds up neovim by bypassing provider discovery
+                "vim.g.loaded_${prog}_provider=0";
+          in
+          lib.concatStringsSep ";" [
+            (genProviderCommand "node" finalAttrs.withNodeJs "${neovim-node-client}/bin/neovim-node-host")
+            (genProviderCommand "perl" finalAttrs.withPerl "${perlEnv}/bin/perl")
+            (genProviderCommand "ruby" finalAttrs.withRuby "${finalAttrs.rubyEnv}/bin/neovim-ruby-host")
+            (genProviderCommand "python3" finalAttrs.withPython3 "${hostPython3}/bin/nvim-python3")
+          ];
 
         # If `configure` != {}, we can't generate the rplugin.vim file with e.g
         # NVIM_SYSTEM_RPLUGIN_MANIFEST *and* NVIM_RPLUGIN_MANIFEST env vars set in
@@ -235,18 +255,6 @@ let
             rm $out/share/applications/nvim.desktop
             substitute ${neovim-unwrapped}/share/applications/nvim.desktop $out/share/applications/nvim.desktop \
               --replace-warn 'Name=Neovim' 'Name=Neovim wrapper'
-          ''
-          + lib.optionalString finalAttrs.withPython3 ''
-            makeWrapper ${python3Env.interpreter} $out/bin/nvim-python3 --unset PYTHONPATH --unset PYTHONSAFEPATH
-          ''
-          + lib.optionalString (finalAttrs.withRuby) ''
-            ln -s ${finalAttrs.rubyEnv}/bin/neovim-ruby-host $out/bin/nvim-ruby
-          ''
-          + lib.optionalString finalAttrs.withNodeJs ''
-            ln -s ${neovim-node-client}/bin/neovim-node-host $out/bin/nvim-node
-          ''
-          + lib.optionalString finalAttrs.withPerl ''
-            ln -s ${perlEnv}/bin/perl $out/bin/nvim-perl
           ''
           + lib.optionalString finalAttrs.vimAlias ''
             ln -s $out/bin/nvim $out/bin/vim


### PR DESCRIPTION
Part of the work to limit the need for wrapping neovim and all its associated problems.
I dont know why those providers "neovim-node-host" etc were added to the wrapper `bin/` directory. It's probably easier when testing the providers but neovim plugins should refer to "vim.g.${prog}_host_prog" anyway. 

Fixes https://github.com/NixOS/nixpkgs/issues/190812

We shall deprecate `generateProviderRc` at a later date.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
