### PR TITLE
pebl: init at 2.3.0

### DIFF
--- a/pkgs/by-name/pe/pebl/package.nix
+++ b/pkgs/by-name/pe/pebl/package.nix
@@ -12,15 +12,17 @@
   libpng,
 }:
 
-clangStdenv.mkDerivation rec {
+clangStdenv.mkDerivation (finalAttrs: rec {
   pname = "pebl";
   version = "2.3.0";
+
   src = fetchFromGitHub {
     owner = "stmueller";
     repo = pname;
-    rev = version;
+    tag = version;
     hash = "sha256-5BJUY4HHcWSzkPEuZRY9eguLJT5OTVMMqzzcnB9XSts=";
   };
+
   buildInputs = [
     SDL2
     SDL2_ttf
@@ -31,23 +33,24 @@ clangStdenv.mkDerivation rec {
     curl
     libpng
   ];
+
   env.NIX_CFLAGS_COMPILE = ''
-    -I${SDL2.dev}/include/SDL2
+    -I${lib.getInclude SDL2}/include/SDL2
     -I${SDL2_ttf}/include/SDL2
     -I${SDL2_image}/include/SDL2
-    -I${SDL2_mixer.dev}/include/SDL2
-    -I${SDL2_net.dev}/include/SDL2
-    -I${SDL2_gfx.dev}/include/SDL2
-    -I${curl.dev}/include
+    -I${lib.getInclude SDL2_mixer}/include/SDL2
+    -I${lib.getInclude SDL2_net}/include/SDL2
+    -I${lib.getInclude SDL2_gfx}/include/SDL2
+    -I${lib.getInclude curl}/include
   '';
 
   installFlags = [ "PREFIX=${placeholder "out"}/" ];
 
   meta = {
     description = "Psychology Experiment Building Language";
-    license = lib.licenses.gpl2;
+    license = lib.licenses.gpl2Plus;
     mainProgram = "pebl2";
     maintainers = with lib.maintainers; [ sauricat ];
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/pe/pebl/package.nix
+++ b/pkgs/by-name/pe/pebl/package.nix
@@ -12,14 +12,14 @@
   libpng,
 }:
 
-clangStdenv.mkDerivation (finalAttrs: rec {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "pebl";
   version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "stmueller";
-    repo = pname;
-    tag = version;
+    repo = "pebl";
+    tag = finalAttrs.version;
     hash = "sha256-5BJUY4HHcWSzkPEuZRY9eguLJT5OTVMMqzzcnB9XSts=";
   };
 
@@ -47,7 +47,7 @@ clangStdenv.mkDerivation (finalAttrs: rec {
   installFlags = [ "PREFIX=${placeholder "out"}/" ];
 
   meta = {
-    description = "Psychology Experiment Building Language";
+    description = "Free cross-platform system for designing psychological experiments";
     license = lib.licenses.gpl2Plus;
     mainProgram = "pebl2";
     maintainers = with lib.maintainers; [ sauricat ];

--- a/pkgs/by-name/pe/pebl/package.nix
+++ b/pkgs/by-name/pe/pebl/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  clangStdenv,
+  fetchFromGitHub,
+  SDL2,
+  SDL2_ttf,
+  SDL2_image,
+  SDL2_mixer,
+  SDL2_net,
+  SDL2_gfx,
+  curl,
+  libpng,
+}:
+
+clangStdenv.mkDerivation rec {
+  pname = "pebl";
+  version = "2.3.0";
+  src = fetchFromGitHub {
+    owner = "stmueller";
+    repo = pname;
+    rev = version;
+    hash = "sha256-5BJUY4HHcWSzkPEuZRY9eguLJT5OTVMMqzzcnB9XSts=";
+  };
+  buildInputs = [
+    SDL2
+    SDL2_ttf
+    SDL2_image
+    SDL2_mixer
+    SDL2_net
+    SDL2_gfx
+    curl
+    libpng
+  ];
+  env.NIX_CFLAGS_COMPILE = ''
+    -I${SDL2.dev}/include/SDL2
+    -I${SDL2_ttf}/include/SDL2
+    -I${SDL2_image}/include/SDL2
+    -I${SDL2_mixer.dev}/include/SDL2
+    -I${SDL2_net.dev}/include/SDL2
+    -I${SDL2_gfx.dev}/include/SDL2
+    -I${curl.dev}/include
+  '';
+
+  installFlags = [ "PREFIX=${placeholder "out"}/" ];
+
+  meta = {
+    description = "Psychology Experiment Building Language";
+    license = lib.licenses.gpl2;
+    mainProgram = "pebl2";
+    maintainers = with lib.maintainers; [ sauricat ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
[PEBL](https://pebl.sourceforge.net/), or "Psychology Experiment Building Language" in its full form, is a free programming language and execution environment designed specifically for creating psychology experiments. It provides both AppImage and build-from-[source](https://github.com/stmueller/pebl), the latter of which I packaged in this submission, more suitable for our distro.

I don't know why the author chose to invent a DSL to write psychology tests, and it's pretty glitchy. However, concerning its niche, irreplaceable significance in conducting psychological tests, I still would like to submit it as a new package for NixOS, and act as its maintainer.

Run after build/shell:
```bash
pebl2 $(dirname $(which pebl2))/../pebl2/battery/affectgrid/affectgrid.pbl
```
This sample demonstrates its capability of launching specific `pbl` scripts. Only the basic function of this binary.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
