### PR TITLE
oathkeeper: fix ldflags for build info

### DIFF
--- a/pkgs/by-name/oa/oathkeeper/package.nix
+++ b/pkgs/by-name/oa/oathkeeper/package.nix
@@ -32,8 +32,8 @@ buildGoModule {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/ory/oathkeeper/internal/driver/config.Version=${version}"
-    "-X github.com/ory/oathkeeper/internal/driver/config.Commit=${commit}"
+    "-X github.com/ory/oathkeeper/x.Version=${version}"
+    "-X github.com/ory/oathkeeper/x.Commit=${commit}"
   ];
 
   meta = {

--- a/pkgs/by-name/oa/oathkeeper/package.nix
+++ b/pkgs/by-name/oa/oathkeeper/package.nix
@@ -40,7 +40,10 @@ buildGoModule {
     description = "Open-source identity and access proxy that authorizes HTTP requests based on sets of rules";
     homepage = "https://www.ory.sh/oathkeeper/";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ camcalaquian ];
+    maintainers = with lib.maintainers; [
+      camcalaquian
+      debtquity
+    ];
     mainProgram = "oathkeeper";
   };
 }


### PR DESCRIPTION
* version and commit changed to `oathkeeper/x/version.go` since at least ~0.31.0
* add self as maintainer for oathkeeper

Resolves NixOS/nixpkgs#495394

---

before:
```
❯ nix-shell -p oathkeeper
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring
this path will be fetched (9.74 MiB download, 40.12 MiB unpacked):
  /nix/store/n68q2acj3s3q9cj1jmp2fwrg9irzx03w-oathkeeper-0.40.9
copying path '/nix/store/n68q2acj3s3q9cj1jmp2fwrg9irzx03w-oathkeeper-0.40.9' from 'https://cache.nixos.org'...

[nix-shell:~/Developer] oathkeeper version
Version:    master
Git Hash:   undefined
Build Time: undefined
```
after:

```
[nix-shell:~/.cache/nixpkgs-review/pr-495402]$ results/oathkeeper-aarch64-darwin/bin/oathkeeper version
Version:    0.40.9
Git Hash:   c75695837f170334b526359f28967aa33d61bce6
Build Time: undefined
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
