### PR TITLE
nixos/tmp: allow customizing tmpfs options

### DIFF
--- a/nixos/modules/system/boot/tmp.nix
+++ b/nixos/modules/system/boot/tmp.nix
@@ -61,6 +61,22 @@ in
         '';
       };
 
+      tmpfsOptions = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "nosuid"
+          "nodev"
+        ];
+        example = [
+          "nosuid"
+          "nodev"
+          "noexec"
+        ];
+        description = ''
+          Extra options to use when mounting {file}`/tmp` as a tmpfs.
+        '';
+      };
+
       # These options are also shared with virtualisation/qemu-vm.nix
       tmpfsFinalOptions = lib.mkOption {
         type = lib.types.listOf lib.types.str;
@@ -79,11 +95,10 @@ in
       "mode=1777"
       "strictatime"
       "rw"
-      "nosuid"
-      "nodev"
       "size=${toString cfg.tmpfsSize}"
       "huge=${cfg.tmpfsHugeMemoryPages}"
-    ];
+    ]
+    ++ cfg.tmpfsOptions;
 
     systemd.mounts = lib.mkIf cfg.useTmpfs [
       {

--- a/nixos/modules/system/boot/tmp.nix
+++ b/nixos/modules/system/boot/tmp.nix
@@ -60,25 +60,37 @@ in
           :::
         '';
       };
+
+      # These options are also shared with virtualisation/qemu-vm.nix
+      tmpfsFinalOptions = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        readOnly = true;
+        internal = true;
+        description = ''
+          Final list of options that will be used for the {file}`/tmp` tmpfs
+          mount.
+        '';
+      };
     };
   };
 
   config = {
-    # When changing remember to update /tmp mount in virtualisation/qemu-vm.nix
+    boot.tmp.tmpfsFinalOptions = [
+      "mode=1777"
+      "strictatime"
+      "rw"
+      "nosuid"
+      "nodev"
+      "size=${toString cfg.tmpfsSize}"
+      "huge=${cfg.tmpfsHugeMemoryPages}"
+    ];
+
     systemd.mounts = lib.mkIf cfg.useTmpfs [
       {
         what = "tmpfs";
         where = "/tmp";
         type = "tmpfs";
-        mountConfig.Options = lib.concatStringsSep "," [
-          "mode=1777"
-          "strictatime"
-          "rw"
-          "nosuid"
-          "nodev"
-          "size=${toString cfg.tmpfsSize}"
-          "huge=${cfg.tmpfsHugeMemoryPages}"
-        ];
+        mountConfig.Options = lib.concatStringsSep "," cfg.tmpfsFinalOptions;
       }
     ];
 

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -1432,14 +1432,8 @@ in
             device = "tmpfs";
             fsType = "tmpfs";
             neededForBoot = true;
-            # Sync with systemd's tmp.mount;
-            options = [
-              "mode=1777"
-              "strictatime"
-              "nosuid"
-              "nodev"
-              "size=${toString config.boot.tmp.tmpfsSize}"
-            ];
+            # Sync with systemd's tmp.mount
+            options = config.boot.tmp.tmpfsFinalOptions;
           };
           "/nix/store" = lib.mkIf (cfg.useNixStoreImage || cfg.mountHostNixStore) (
             if cfg.writableStore then


### PR DESCRIPTION
Adds an option to allow customizing the mount options when using a tmpfs for `/tmp`, for example, to add `noexec` to it.

Also moves the options to a "final options" internal option so they can be shared with the QEMU module instead of having to always keep them in sync.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
