### PR TITLE
oathkeeper: 0.40.9 -> 25.4.0

### DIFF
--- a/pkgs/by-name/oa/oathkeeper/package.nix
+++ b/pkgs/by-name/oa/oathkeeper/package.nix
@@ -5,8 +5,8 @@
 }:
 let
   pname = "oathkeeper";
-  version = "0.40.9";
-  commit = "c75695837f170334b526359f28967aa33d61bce6";
+  version = "25.4.0";
+  commit = "2020997ed914fbc8c4b048effbe28841c34ac23d";
 in
 buildGoModule {
   inherit pname version commit;
@@ -15,10 +15,10 @@ buildGoModule {
     owner = "ory";
     repo = "oathkeeper";
     rev = "v${version}";
-    hash = "sha256-R7xKhKF7mhS/vmSpOj+QDL0OBBWnh42X2Kr3TDQxVIo=";
+    hash = "sha256-J+76oQbm/CulzfJOhXVzlXWNtpl7PaEJPM96p1ko3Cg=";
   };
 
-  vendorHash = "sha256-qETVUpxckZGa41Ll+SZTGcDlImsCvbvGQBcIwuIzSY8=";
+  vendorHash = "sha256-YNpWjDOcjELCpNcxmd8eatMvPUTHos52yvDg4jsHAQk=";
 
   tags = [
     "sqlite"


### PR DESCRIPTION
* diff: https://github.com/ory/oathkeeper/compare/v0.40.9...v25.4.0
* changelog: https://github.com/ory/oathkeeper/releases/tag/v25.4.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
