### PR TITLE
sox_ng: init at 14.7.1.2

### DIFF
--- a/pkgs/by-name/so/sox_ng/package.nix
+++ b/pkgs/by-name/so/sox_ng/package.nix
@@ -1,0 +1,114 @@
+{
+  config,
+  lib,
+  stdenv,
+  fetchFromCodeberg,
+  autoreconfHook,
+  autoconf-archive,
+  pkg-config,
+  enableReplace ? true,
+  enableAMR ? true,
+  opencore-amr,
+  enableAlsa ? true,
+  alsa-lib,
+  enableFLAC ? true,
+  flac,
+  enableFFTW ? true,
+  fftw,
+  enableLadspa ? true,
+  ladspa-sdk,
+  enableLame ? config.sox.enableLame or false,
+  lame,
+  enableLibao ? true,
+  libao,
+  enableLibid3tag ? true,
+  libid3tag,
+  enableLibmad ? true,
+  libmad,
+  enableLibogg ? true,
+  libogg,
+  libvorbis,
+  enableLibpulseaudio ?
+    stdenv.hostPlatform.isLinux && lib.meta.availableOn stdenv.hostPlatform libpulseaudio,
+  libpulseaudio,
+  enableLibsndfile ? true,
+  libsndfile,
+  enableOpusfile ? true,
+  opusfile,
+  enablePNG ? true,
+  libpng,
+  enableSpeex ? true,
+  speex,
+  speexdsp,
+  enableTwolame ? config.sox.enableTwolame or false,
+  twolame,
+  enableWavpack ? true,
+  wavpack,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sox";
+  version = "14.7.1.2";
+
+  src = fetchFromCodeberg {
+    owner = "sox_ng";
+    repo = "sox_ng";
+    tag = "sox_ng-${finalAttrs.version}";
+    hash = "sha256-yIebX0a/fbpr/NMgiK+gjDPNValf3gITpxDSJAc6eAw=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  outputs = [
+    "out"
+    "dev"
+    "lib"
+    "man"
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    autoconf-archive
+    pkg-config
+  ];
+
+  buildInputs =
+    lib.optional (enableAlsa && stdenv.hostPlatform.isLinux) alsa-lib
+    ++ lib.optional enableAMR opencore-amr
+    ++ lib.optional enableFLAC flac
+    ++ lib.optional enableFFTW fftw
+    ++ lib.optional enableLadspa ladspa-sdk
+    ++ lib.optional enableLame lame
+    ++ lib.optional enableLibao libao
+    ++ lib.optional enableLibid3tag libid3tag
+    ++ lib.optional enableLibmad libmad
+    ++ lib.optional enableLibpulseaudio libpulseaudio
+    ++ lib.optional enableLibsndfile libsndfile
+    ++ lib.optional enableOpusfile opusfile
+    ++ lib.optional enablePNG libpng
+    ++ lib.optional enableTwolame twolame
+    ++ lib.optional enableWavpack wavpack
+    ++ lib.optionals enableLibogg [
+      libogg
+      libvorbis
+    ]
+    ++ lib.optionals enableSpeex [
+      speex
+      speexdsp
+    ];
+
+  configureFlags = [
+    (lib.enableFeature enableReplace "replace")
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Another Swiss Army Knife of sound processing utilities";
+    homepage = "https://codeberg.org/sox_ng/sox_ng";
+    maintainers = with lib.maintainers; [ fpletz ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Things done

SoX is unmaintained, as part of #494308 I've been advised to use SoX_ng instead, but it isn't yet packaged.

I don't want to maintain this package, but took a stab at packaging it, mostly a copy-paste of the existing `sox` package definition. Leaving this open for anybody to take ownership.

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
