### PR TITLE
jj-spr: init at 0-unstable-2026-01-21

### DIFF
--- a/pkgs/by-name/jj/jj-spr/package.nix
+++ b/pkgs/by-name/jj/jj-spr/package.nix
@@ -1,0 +1,51 @@
+{
+  fetchFromGitHub,
+  jujutsu,
+  lib,
+  libgit2,
+  nix-update-script,
+  pkg-config,
+  rustPlatform,
+  zlib,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "jj-spr";
+  version = "0-unstable-2026-01-21";
+
+  src = fetchFromGitHub {
+    owner = "LucioFranco";
+    repo = "jj-spr";
+    rev = "982602e92542b53639679b3ce9cd71e43237a18d";
+    hash = "sha256-H2aNW6brQ3gIX83gEc8PwgzuscZISFhvQeqr0wVJ17A=";
+  };
+
+  cargoHash = "sha256-3pBP8ZgKiKnE6fK4a9IVR67br33ktsmB5ofwTyy95wA=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libgit2
+    zlib
+  ];
+
+  nativeCheckInputs = [ jujutsu ];
+  doCheck = false; # FIXME: https://github.com/LucioFranco/jj-spr/issues/102
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Power tool for Jujutsu + GitHub workflows";
+    longDescription = ''
+      Super Pull Requests (SPR) is the power tool for Jujutsu + GitHub
+      workflows.  It enables amend-friendly single PRs and effortless
+      stacked PRs, bridging the gap between Jujutsu’s change-based
+      workflow and GitHub’s pull request model.
+    '';
+    homepage = "https://luciofran.co/jj-spr";
+    changelog = "https://github.com/LucioFranco/jj-spr/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "jj-spr";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
