### PR TITLE
gogcli: init at 0.11.0

### DIFF
--- a/pkgs/by-name/go/gogcli/package.nix
+++ b/pkgs/by-name/go/gogcli/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  testers,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "gogcli";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "steipete";
+    repo = "gogcli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hJU40ysjRx4p9SWGmbhhpToYCpk3DcMAWCnKqxHRmh0=";
+  };
+
+  vendorHash = "sha256-WGRlv3UsK3SVBQySD7uZ8+FiRl03p0rzjBm9Se1iITs=";
+
+  subPackages = [ "cmd/gog" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/steipete/gogcli/internal/cmd.version=v${finalAttrs.version}"
+    "-X github.com/steipete/gogcli/internal/cmd.commit=${finalAttrs.src.rev}"
+    "-X github.com/steipete/gogcli/internal/cmd.date=1970-01-01T00:00:00Z"
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "gog --version";
+    version = "v${finalAttrs.version}";
+  };
+
+  meta = {
+    description = "CLI tool for interacting with Google APIs (Gmail, Calendar, Drive, and more)";
+    homepage = "https://github.com/steipete/gogcli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ macalinao ];
+    mainProgram = "gog";
+  };
+})


### PR DESCRIPTION
## Description

Add [gogcli](https://github.com/steipete/gogcli), CLI tool for interacting with Google APIs (Gmail, Calendar, Drive, and more).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test