### PR TITLE
noctalia-shell: 4.5.0 -> 4.6.7, noctalia-qs: init at 0.0.9

### DIFF
--- a/pkgs/by-name/no/noctalia-qs/0001-fix-unneccessary-reloads.patch
+++ b/pkgs/by-name/no/noctalia-qs/0001-fix-unneccessary-reloads.patch
@@ -1,0 +1,23 @@
+diff --git a/src/core/generation.cpp b/src/core/generation.cpp
+index c68af71..4967562 100644
+--- a/src/core/generation.cpp
++++ b/src/core/generation.cpp
+@@ -172,12 +172,18 @@ void EngineGeneration::setWatchingFiles(bool watching) {
+ 		if (this->watcher == nullptr) {
+ 			this->watcher = new QFileSystemWatcher();
+ 
++			// note: not using canonicalFilePath() here on purpose,
++			//       since the path could be a link to the nix store
++			//       and the link might change
++
+ 			for (auto& file: this->scanner.scannedFiles) {
++				if (file.startsWith("/nix/store/")) continue;
+ 				this->watcher->addPath(file);
+ 				this->watcher->addPath(QFileInfo(file).dir().absolutePath());
+ 			}
+ 
+ 			for (auto& file: this->extraWatchedFiles) {
++				if (file.startsWith("/nix/store/")) continue;
+ 				this->watcher->addPath(file);
+ 				this->watcher->addPath(QFileInfo(file).dir().absolutePath());
+ 			}

--- a/pkgs/by-name/no/noctalia-qs/package.nix
+++ b/pkgs/by-name/no/noctalia-qs/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+
+  pkg-config,
+  cmake,
+  ninja,
+  spirv-tools,
+  qt6,
+  breakpad,
+  jemalloc,
+  cli11,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  libxcb,
+  libdrm,
+  libgbm ? null,
+  vulkan-headers,
+  pipewire,
+  pam,
+  polkit,
+  glib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noctalia-qs";
+  version = "0.0.9";
+
+  src = fetchFromGitHub {
+    owner = "noctalia-dev";
+    repo = "noctalia-qs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oRqz+5AbNKfUWWwN5c83CsSOsUWVGITh0HZg+wX5Q/8=";
+  };
+
+  patches = [
+    ./0001-fix-unneccessary-reloads.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    spirv-tools
+    pkg-config
+    qt6.qtwayland
+    qt6.wrapQtAppsHook
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtwayland
+    qt6.qtsvg
+    cli11
+    wayland
+    wayland-protocols
+    libdrm
+    libgbm
+    vulkan-headers
+    breakpad
+    jemalloc
+    libxcb
+    pam
+    pipewire
+    polkit
+    glib
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "DISTRIBUTOR" "Nixpkgs")
+    (lib.cmakeBool "DISTRIBUTOR_DEBUGINFO_AVAILABLE" true)
+    (lib.cmakeFeature "INSTALL_QML_PREFIX" qt6.qtbase.qtQmlPrefix)
+    (lib.cmakeFeature "GIT_REVISION" "tag-v${finalAttrs.version}")
+  ];
+
+  cmakeBuildType = "RelWithDebInfo";
+  separateDebugInfo = true;
+  dontStrip = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/noctalia-dev/noctalia-qs";
+    description = "Flexbile QtQuick based desktop shell toolkit";
+    license = lib.licenses.lgpl3Only;
+    platforms = lib.platforms.linux;
+    mainProgram = "quickshell";
+    maintainers = with lib.maintainers; [ iynaix ];
+  };
+})

--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -6,7 +6,7 @@
 
   # build
   qt6,
-  quickshell,
+  noctalia-qs,
 
   # runtime deps
   bluez,
@@ -16,6 +16,7 @@
   ddcutil,
   wlsunset,
   wl-clipboard,
+  wlr-randr,
   imagemagick,
   wget,
   gpu-screen-recorder,
@@ -37,6 +38,7 @@
   ddcutilSupport ? true,
   wlsunsetSupport ? true,
   wl-clipboardSupport ? true,
+  wlr-randrSupport ? true,
   imagemagickSupport ? true,
   calendarSupport ? false,
   # gpu-screen-recorder support was moved to an optional plugin in v4.0.0
@@ -54,6 +56,7 @@ let
   ++ lib.optional ddcutilSupport ddcutil
   ++ lib.optional wlsunsetSupport wlsunset
   ++ lib.optional wl-clipboardSupport wl-clipboard
+  ++ lib.optional wlr-randrSupport wlr-randr
   ++ lib.optional imagemagickSupport imagemagick
   ++ lib.optional gpuScreenRecorderSupport gpu-screen-recorder;
 
@@ -68,13 +71,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noctalia-shell";
-  version = "4.5.0";
+  version = "4.6.7";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Y5P0RYO9NKxa4UZBoGmmxtz3mEwJrBOfvdLJRGjV2Os=";
+    hash = "sha256-6fuxf185uga/AaeFgN6VUygGE8bUEkzZSA1UQ1FFes4=";
   };
 
   nativeBuildInputs = [
@@ -90,7 +93,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/share/noctalia-shell $out/bin
-    ln -s ${quickshell}/bin/qs $out/bin/noctalia-shell
+    ln -s ${noctalia-qs}/bin/qs $out/bin/noctalia-shell
 
     cp -R \
       Assets Commons CREDITS.md Helpers Modules Services Shaders Scripts Widgets shell.qml \
@@ -119,6 +122,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "noctalia-shell";
     maintainers = with lib.maintainers; [ spacedentist ];
-    platforms = quickshell.meta.platforms;
+    platforms = noctalia-qs.meta.platforms;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
noctalia-shell now uses its own fork of quickshell, which is required for 4.6.0 or it errors on starting up: <https://github.com/noctalia-dev/noctalia-shell/issues/1995#issuecomment-3975979458>.

I've opted for adding noctalia-qs as a new package instead of overriding quickshell as I don't know how far it will deviate from quickshell in the future.

@spacedentist Would you mind being co-maintainer for the noctalia-qs package? 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
