### PR TITLE
ory-hydra: init at 25.4.0

### DIFF
--- a/pkgs/by-name/or/ory-hydra/package.nix
+++ b/pkgs/by-name/or/ory-hydra/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "hydra";
+  version = "25.4.0";
+
+  src = fetchFromGitHub {
+    owner = "ory";
+    repo = "hydra";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vcbJiwWoq7WA7K5WpD68za1VecNwdzqfyXuPfUpa1QU=";
+  };
+
+  vendorHash = "sha256-ADS1kBqSJXDwmCS4CCfiMvmlzzL39E0G4J2UEKXy2Qs=";
+
+  # `json1` not needed (see: https://github.com/ory/hydra/commit/93edc9ad894771c67f46ae2c57ee7e50382d73cd)
+  # `sqlite_omit_load_extension` consistency with upstream (see: https://github.com/ory/hydra/blob/master/.docker/Dockerfile-local-build#L20C58-L20C84). Will disable sqlite runtime extension loading (see: https://sqlite.org/loadext.html)
+  tags = [
+    "hsm"
+    "sqlite"
+    "sqlite_omit_load_extension"
+  ];
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-X github.com/ory/hydra/v2/driver/config.Version=v${finalAttrs.version}"
+    "-X github.com/ory/hydra/v2/driver/config.Commit=${finalAttrs.src.rev}"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "version" ];
+
+  meta = {
+    description = "OpenID Certified™ OAuth 2.0 Server and OpenID Connect Provider";
+    homepage = "https://www.ory.com/hydra";
+    changelog = "https://github.com/ory/hydra/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      debtquity
+    ];
+    mainProgram = "hydra";
+  };
+})


### PR DESCRIPTION
Several components of the Ory identity and access management system already exist in nixpkgs (oathkeeper, kratos, keto). This is yet another attempt to get it into nixpkgs as I do plan to write a nixos module that leverages all of these components (predecessors: #393364 #145747, both stale).

* upstream repository: https://github.com/ory/hydra
* changelog: https://github.com/ory/hydra/releases/tag/v25.4.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
