### PR TITLE
Fix spelling typos in docs and module comments

### DIFF
--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -56,7 +56,7 @@ let
       }
     ))
     # No need to match up packages without maintainers with their files.
-    # This also filters out attributes where `packge = null`, which is the
+    # This also filters out attributes where `package = null`, which is the
     # case for libintl, for example.
     (lib.filter (pkg: pkg.users != [ ] || pkg.teams != [ ]))
   ];

--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -195,7 +195,7 @@ async function handleMerge({
         `:heavy_check_mark: [Queued](${resp.enqueuePullRequest.mergeQueueEntry.mergeQueue.url}) for merge (#306934)`,
       ]
     } catch (e) {
-      log('Enqueing failed', e.response.errors[0].message)
+      log('Enqueuing failed', e.response.errors[0].message)
     }
 
     // If required status checks are not satisfied, yet, the above will fail. In this case

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -233,7 +233,7 @@ The pre-existing `services.ankisyncd` has been marked deprecated and will be dro
   - The FHS `defaultPath` value set by Apptainer/Singularity developers, making Apptainer/Singularity work out of the box in FHS systems.
   - `defaultPathInputs`, a list of packages to form the fall-back `PATH`.
 
-  This change is required to enable Sylabs SingularityCE (`singularity`) to run images, as it requires a `fusermount3` commant with the SUID bit set.
+  This change is required to enable Sylabs SingularityCE (`singularity`) to run images, as it requires a `fusermount3` command with the SUID bit set.
 
   `newuidmapPath` and `newgidmapPath` arguments are deprecated in favour of `systemBinPaths`. Their support will be removed in future releases.
 
@@ -708,7 +708,7 @@ Use `services.pipewire.extraConfig` or `services.pipewire.configPackages` for Pi
   The port can be specified in [`services.nextcloud.config.dbhost`](#opt-services.nextcloud.config.dbhost).
 
 - `services.kavita` now uses the free-form option `services.kavita.settings` for the application settings file.
-  The options `services.kavita.ipAdresses` and `services.kavita.port` now exist at `services.kavita.settings.IpAddresses`
+  The options `services.kavita.ipAddresses` and `services.kavita.port` now exist at `services.kavita.settings.IpAddresses`
   and `services.kavita.settings.IpAddresses`. The file at `services.kavita.tokenKeyFile` now needs to contain a secret with
   512+ bits instead of 128+ bits.
 

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -367,13 +367,13 @@
   - `boot.isNspawnContainer` being `true` implies [](#opt-boot.isContainer) being `true`.
 
 - `amdgpu` kernel driver overdrive mode can now be enabled by setting [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable) and customized through [hardware.amdgpu.overdrive.ppfeaturemask](#opt-hardware.amdgpu.overdrive.ppfeaturemask).
-  This allows for fine-grained control over the GPU's performance and maybe required by overclocking softwares like Corectrl and Lact. These new options replace old options such as {option}`programs.corectrl.gpuOverclock.enable` and {option}`programs.tuxclocker.enableAMD`.
+  This allows for fine-grained control over the GPU's performance and maybe required by overclocking software like Corectrl and Lact. These new options replace old options such as {option}`programs.corectrl.gpuOverclock.enable` and {option}`programs.tuxclocker.enableAMD`.
 
 - `bcachefs` file systems will now use the out-of-tree module for supported kernels. The in-tree module has been removed, and users will need to switch to kernels that support the out-of-tree module.
 
 - `boot.plymouth` now has a [`package`](#opt-boot.plymouth.package) option to specify the package used in the module.
 
-- Drivers and utlities for [Tenstorrent](https://tenstorrent.com) have been added. Available as [hardware.tenstorrent](#opt-hardware.tenstorrent.enable).
+- Drivers and utilities for [Tenstorrent](https://tenstorrent.com) have been added. Available as [hardware.tenstorrent](#opt-hardware.tenstorrent.enable).
 
 - Due to [deprecation of gnome-session X11 support](https://blogs.gnome.org/alatiera/2025/06/08/the-x11-session-removal/), `services.desktopManager.pantheon` now defaults to pantheon-wayland session. The X11 session has been removed, see [this issue](https://github.com/elementary/session-settings/issues/91) for details.
 
@@ -468,7 +468,7 @@
 
 - `services.postsrsd` now automatically integrates with the local Postfix instance, when enabled. This behavior can disabled using the [services.postsrsd.configurePostfix](#opt-services.postsrsd.configurePostfix) option.
 
-- `services.varnish.http_address` has been superseeded by `services.varnish.listen` which is now
+- `services.varnish.http_address` has been superseded by `services.varnish.listen` which is now
   structured config for all of varnish's `-a` variations.
 
 - `services.xserver.desktopManager.deepin` and associated packages have been removed due to being unmaintained. See issue [#422090](https://github.com/NixOS/nixpkgs/issues/422090) for more details.

--- a/nixos/modules/image/amend-repart-definitions.py
+++ b/nixos/modules/image/amend-repart-definitions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Amend systemd-repart definiton files.
+"""Amend systemd-repart definition files.
 
 In order to avoid Import-From-Derivation (IFD) when building images with
 systemd-repart, the definition files created by Nix need to be amended with the
@@ -67,7 +67,7 @@ def main() -> None:
     """Amend the provided repart definitions by adding CopyFiles= instructions.
 
     For each file specified in the `contents` field of a partition in the
-    partiton config file, a `CopyFiles=` instruction is added to the
+    partition config file, a `CopyFiles=` instruction is added to the
     corresponding definition file.
 
     The same is done for every store path of the `closure` field.

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -81,7 +81,7 @@ let
             SizeMaxBytes = "2G";
           };
           description = ''
-            Specify the repart options for a partiton as a structural setting.
+            Specify the repart options for a partition as a structural setting.
             See {manpage}`repart.d(5)`
             for all available options.
           '';
@@ -385,7 +385,7 @@ in
               defined for '${fileName}' is ${toString labelLength} characters long.
               The suggested maximum label length is ${toString suggestedMaxLabelLength}.
 
-              If you use sytemd-sysupdate style A/B updates, this might
+              If you use systemd-sysupdate style A/B updates, this might
               not leave enough space to increment the version number included in
               the label in a future release. For example, if your label is
               ${toString GPTMaxLabelLength} characters long (the maximum enforced by UEFI) and

--- a/nixos/modules/programs/command-not-found/command-not-found.pl
+++ b/nixos/modules/programs/command-not-found/command-not-found.pl
@@ -49,10 +49,10 @@ if ($len == 0) {
         if ($ENV{"NIX_AUTO_RUN_INTERACTIVE"} // "") {
             while (1) {
                 print STDERR "'$program' from package '$package' will be run, confirm? [yn]: ";
-                chomp(my $comfirm = <STDIN>);
-                if (lc $comfirm eq "n") {
+                chomp(my $confirm = <STDIN>);
+                if (lc $confirm eq "n") {
                     exit 0;
-                } elsif (lc $comfirm eq "y") {
+                } elsif (lc $confirm eq "y") {
                     last;
                 }
             }

--- a/nixos/modules/programs/dconf.nix
+++ b/nixos/modules/programs/dconf.nix
@@ -127,7 +127,7 @@ let
             {
               "com/raggesilver/BlackBox" = {
                 scrollback-lines = mkUint32 10000;
-                theme-dark = "Tommorow Night";
+                theme-dark = "Tomorrow Night";
               };
             }
           '';

--- a/nixos/modules/programs/firefox.nix
+++ b/nixos/modules/programs/firefox.nix
@@ -254,7 +254,7 @@ in
       description = ''
         AutoConfig files can be used to set and lock preferences that are not covered
         by the policies.json for Mac and Linux. This method can be used to automatically
-        change user preferences or prevent the end user from modifiying specific
+        change user preferences or prevent the end user from modifying specific
         preferences by locking them. More info can be found in <https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig>.
       '';
     };
@@ -265,10 +265,10 @@ in
       description = ''
         AutoConfig files can be used to set and lock preferences that are not covered
         by the policies.json for Mac and Linux. This method can be used to automatically
-        change user preferences or prevent the end user from modifiying specific
+        change user preferences or prevent the end user from modifying specific
         preferences by locking them. More info can be found in <https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig>.
 
-        Files are concated and autoConfig is appended.
+        Files are concatenated and autoConfig is appended.
       '';
     };
 

--- a/nixos/modules/programs/wayland/hyprland.nix
+++ b/nixos/modules/programs/wayland/hyprland.nix
@@ -56,7 +56,7 @@ in
       description = ''
         Launch Hyprland with the UWSM (Universal Wayland Session Manager) session manager.
         This has improved systemd support and is recommended for most users.
-        This automatically starts appropiate targets like `graphical-session.target`,
+        This automatically starts appropriate targets like `graphical-session.target`,
         and `wayland-session@Hyprland.target`.
 
         ::: {.note}

--- a/nixos/modules/services/web-apps/kavita.nix
+++ b/nixos/modules/services/web-apps/kavita.nix
@@ -15,12 +15,12 @@ in
 {
   imports = [
     (lib.mkChangedOptionModule
-      [ "services" "kavita" "ipAdresses" ]
+      [ "services" "kavita" "ipAddresses" ]
       [ "services" "kavita" "settings" "IpAddresses" ]
       (
         config:
         let
-          value = lib.getAttrFromPath [ "services" "kavita" "ipAdresses" ] config;
+          value = lib.getAttrFromPath [ "services" "kavita" "ipAddresses" ] config;
         in
         lib.concatStringsSep "," value
       )


### PR DESCRIPTION
## Description

Fix several spelling typos in documentation and module comments.

Fixes #495441

## Typos Fixed

| Typo | Correction | Location |
|------|------------|----------|
| Enqueing | Enqueuing | ci/github-script/merge.js |
| packge | package | ci/eval/compare/maintainers.nix |
| softwares | software | rl-2511.section.md |
| utlities | utilities | rl-2511.section.md |
| superseeded | superseded | rl-2511.section.md |
| Adresses | Addresses | rl-2405.section.md, kavita.nix |
| partiton | partition | repart.nix, amend-repart-definitions.py |
| sytemd | systemd | repart.nix |
| definiton | definition | amend-repart-definitions.py |
| Tommorow | Tomorrow | dconf.nix |
| appropiate | appropriate | hyprland.nix |
| modifiying | modifying | firefox.nix |
| comfirm | confirm | command-not-found.pl |

## Notes

- All fixes are in comments, documentation, or error messages only
- No API/variable name changes to avoid breaking changes

## Checklist

- [x] Changes are documentation/comment only
- [x] No breaking changes