### PR TITLE
nixos/ergochat: Use Type=notify-reload

### DIFF
--- a/nixos/modules/services/networking/ergochat.nix
+++ b/nixos/modules/services/networking/ergochat.nix
@@ -145,14 +145,10 @@ in
     systemd.services.ergochat = {
       description = "Ergo IRC daemon";
       wantedBy = [ "multi-user.target" ];
-      # reload is not applying the changed config. further investigation is needed
-      # at some point this should be enabled, since we don't want to restart for
-      # every config change
-      # reloadIfChanged = true;
-      restartTriggers = [ cfg.configFile ];
+      reloadTriggers = [ cfg.configFile ];
       serviceConfig = {
+        Type = "notify-reload";
         ExecStart = "${pkgs.ergochat}/bin/ergo run --conf /etc/ergo.yaml";
-        ExecReload = "${pkgs.util-linux}/bin/kill -HUP $MAINPID";
         DynamicUser = true;
         StateDirectory = "ergo";
         LimitNOFILE = toString cfg.openFilesLimit;

--- a/nixos/tests/ergochat.nix
+++ b/nixos/tests/ergochat.nix
@@ -5,6 +5,7 @@ let
   ];
   server = "ergochat";
   ircPort = 6667;
+  altIrcPort = 16667;
   channel = "nixos-cat";
   iiDir = "/tmp/irc";
 in
@@ -21,6 +22,10 @@ in
           The default MOTD doesn't contain the word "nixos" in it.
           This one does.
         '';
+      };
+
+      specialisation.new.configuration = {
+        services.ergochat.settings.server.listeners.":${toString altIrcPort}" = null;
       };
     };
   }
@@ -101,5 +106,10 @@ in
       # entry is executed by every client before advancing
       # to the next one.
     ''
-    + lib.concatStrings (reduce (lib.zipListsWith (cs: c: cs + c)) (map clientScript clients));
+    + lib.concatStrings (reduce (lib.zipListsWith (cs: c: cs + c)) (map clientScript clients))
+    # Test server config reloading
+    + ''
+      ${server}.succeed("/run/current-system/specialisation/new/bin/switch-to-configuration test")
+      ${server}.wait_for_open_port(${toString altIrcPort})
+    '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
