### PR TITLE
tdarr: 2.58.02 -> 2.66.01

### DIFF
--- a/pkgs/tools/misc/tdarr/common.nix
+++ b/pkgs/tools/misc/tdarr/common.nix
@@ -100,7 +100,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   inherit pname;
-  version = "2.58.02";
+  version = "2.66.01";
 
   src = fetchzip {
     url = "https://storage.tdarr.io/versions/${finalAttrs.version}/${platform}/${componentName}.zip";
@@ -160,9 +160,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     makeWrapper $out/share/${pname}/${componentName} $out/bin/${pname} ${commonWrapperArgs}
-  ''
-  # TODO: Check on each update to see if the Tdarr_Node_tray gets re-added to the aarch64-linux build. Reach out to upstream?
-  + lib.optionalString (stdenv.hostPlatform.system != "aarch64-linux") ''
     makeWrapper $out/share/${pname}/${componentTrayName} $out/bin/${pname}-tray ${commonWrapperArgs}
   ''
   + lib.optionalString installIcons ''
@@ -177,7 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + "";
 
-  desktopItems = lib.optionals (stdenv.isLinux && stdenv.hostPlatform.system != "aarch64-linux") [
+  desktopItems = lib.optionals stdenv.isLinux [
     (makeDesktopItem {
       desktopName = "Tdarr ${componentUpper} Tray";
       name = "Tdarr ${componentUpper} Tray";

--- a/pkgs/tools/misc/tdarr/node.nix
+++ b/pkgs/tools/misc/tdarr/node.nix
@@ -5,9 +5,9 @@ callPackage ./common.nix { } {
   component = "node";
 
   hashes = {
-    linux_x64 = "sha256-+vD5oaoYh/bOCuk/Bxc8Fsm9UnFICownSKvg9i726nk=";
-    linux_arm64 = "sha256-2uPtEno0dSdVBg5hCiUuvBCB5tuTOcpeU2BuXPiqdUU=";
-    darwin_x64 = "sha256-8O5J1qFpQxD6fzojxjWnbkS4XQoCZauxCtbl/drplfI=";
-    darwin_arm64 = "sha256-oA+nTkO4LDAX5/cGkjNOLnPu0Rss9el+4JF8PBEfsPQ=";
+    linux_x64 = "sha256-3dd8ouRfThm481rDJDnxxUuSkqNlFR+2aywPzyy7xrw=";
+    linux_arm64 = "sha256-LD/cQECal9dLZY/FQSFztOVzd7MaeHL1rdbMUJ2DPNY=";
+    darwin_x64 = "sha256-icgzoHqZ+P6gXJ8jQTau3O2D6uRvET4MtNoWJI/JnvM=";
+    darwin_arm64 = "sha256-Rw478IpDLLe+Ek3Jt5Duaq1sHL1D3pE0HkVqk+v1ECE=";
   };
 }

--- a/pkgs/tools/misc/tdarr/server.nix
+++ b/pkgs/tools/misc/tdarr/server.nix
@@ -5,10 +5,10 @@ callPackage ./common.nix { } {
   component = "server";
 
   hashes = {
-    linux_x64 = "sha256-+nxwSGAkA+BPf481N6KHW7s0iJzoGFPWp0XCbsVEwrI=";
-    linux_arm64 = "sha256-tA5VX27XmH3C4Bkll2mJlr1BYz5V7PPvzbJeaDht7uI=";
-    darwin_x64 = "sha256-jgHEezqtzUWTIvmxsmV1VgaXY9wHePkg6bQO16eSSGI=";
-    darwin_arm64 = "sha256-pcPpqFbqYsXf5Og9uC+eF/1kOQ1ZiletDzkk3qavPS0=";
+    linux_x64 = "sha256-YbEFgvOEAY5HGyTZw9vr4SC85zLQHUQKq++Qbsg1+5A=";
+    linux_arm64 = "sha256-PGguxjOGVUPV5CW3iAtoehnxqGkTe9UA6Vu+7bf6DlQ=";
+    darwin_x64 = "sha256-Gya1DmrLM5UCChwocEwdjYxSWECOl5Ew/e8LpmPQB7M=";
+    darwin_arm64 = "sha256-RJYQZ4L49WTwgMj+vZYFd5Kl3gX1DrkR+fF5E7L9fVs=";
   };
 
   includeInPath = [ ccextractor ];

--- a/pkgs/tools/misc/tdarr/update-hashes.sh
+++ b/pkgs/tools/misc/tdarr/update-hashes.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq unzip
 set -euo pipefail
 
 # Updates tdarr packages to the latest version
@@ -20,11 +21,12 @@ fi
 
 echo "Latest version: $LATEST_VERSION" >&2
 
-# Check current version in common.nix
-CURRENT_VERSION=$(grep -oP '(?<=version = ")[^"]+' "$COMMON_FILE" 2>/dev/null)
+# Use the current version injected by update.nix, falling back to grepping common.nix for standalone use
+CURRENT_VERSION="${UPDATE_NIX_OLD_VERSION:-$(grep -oP '(?<=version = ")[^"]+' "$COMMON_FILE")}"
 
 if [[ "$CURRENT_VERSION" == "$LATEST_VERSION" ]]; then
     echo "Tdarr packages are already on the latest version ($LATEST_VERSION)" >&2
+    echo "[]"
     exit 0
 fi
 
@@ -32,7 +34,14 @@ echo "Updating from $CURRENT_VERSION to $LATEST_VERSION..." >&2
 
 fetch_and_convert() {
     local url=$1
-    nix-prefetch-url --unpack "$url" 2>/dev/null | xargs nix hash convert --hash-algo sha256 --to sri
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    # Clean up temp directory on return
+    trap "rm -rf '$tmpdir'" RETURN
+
+    curl -sSL -o "$tmpdir/archive.zip" "$url" || { echo "Error: failed to download $url" >&2; return 1; }
+    unzip -q "$tmpdir/archive.zip" -d "$tmpdir/unpacked" || { echo "Error: failed to unzip $url" >&2; return 1; }
+    nix hash path "$tmpdir/unpacked"
 }
 
 # Fetch all hashes for both server and node


### PR DESCRIPTION
Updated the update script to actually work properly. It ran into issues with non-ASCII characters. And also updated to the latest version
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
