### PR TITLE
speakeasy-cli: 1.636.3 -> 1.761.9

### DIFF
--- a/pkgs/by-name/sp/speakeasy-cli/package.nix
+++ b/pkgs/by-name/sp/speakeasy-cli/package.nix
@@ -11,7 +11,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "speakeasy-cli";
-  version = "1.636.3";
+  version = "1.761.9";
 
   sourceRoot = ".";
   src =
@@ -33,19 +33,19 @@ stdenv.mkDerivation (finalAttrs: {
     sources = {
       "x86_64-darwin" = fetchurl {
         url = "https://github.com/speakeasy-api/speakeasy/releases/download/v${finalAttrs.version}/speakeasy_darwin_amd64.zip";
-        hash = "sha256-Q1m4g5XBNAaxJZyYz6cD/7asTUGZMa493XVVJ9s0byE=";
+        hash = "sha256-rTnaKHCJt4bQepg6e110AZavsU4AGD/3WPR0/M14gBo=";
       };
       "x86_64-linux" = fetchurl {
         url = "https://github.com/speakeasy-api/speakeasy/releases/download/v${finalAttrs.version}/speakeasy_linux_amd64.zip";
-        hash = "sha256-H1c+b4/fBWudc3tAHTNdWwa9aoe8HpffRaLRU7OOWs4=";
+        hash = "sha256-fmoLK8hAgIS0vSBQkIiJagBtfEwvf6FElhvW5xjnje4=";
       };
       "aarch64-darwin" = fetchurl {
         url = "https://github.com/speakeasy-api/speakeasy/releases/download/v${finalAttrs.version}/speakeasy_darwin_arm64.zip";
-        hash = "sha256-xO9S9gjiMel2ZB8Dq2nN5O+zIB/4qf5Z2xeXS0wiprc=";
+        hash = "sha256-f9/Pse4B8DB86ZHHPdS21yUzVtecFFS+RhOPLf/8MLg=";
       };
       "aarch64-linux" = fetchurl {
         url = "https://github.com/speakeasy-api/speakeasy/releases/download/v${finalAttrs.version}/speakeasy_linux_arm64.zip";
-        hash = "sha256-zH/HyA6MrrCh9j53hoqfVSiRqIoL6IOCV/nsAwRlgjg=";
+        hash = "sha256-Su0ZiKwEFugniMNJshb5C156BnuHxhcArLI8FzixIEI=";
       };
     };
     updateScript = writeShellScript "update-speakeasy" ''

--- a/pkgs/by-name/sp/speakeasy-cli/package.nix
+++ b/pkgs/by-name/sp/speakeasy-cli/package.nix
@@ -57,14 +57,14 @@ stdenv.mkDerivation (finalAttrs: {
           common-updater-scripts
         ]
       }"
-
-      NEW_VERSION=$(curl --silent https://api.github.com/repos/speakeasy-api/speakeasy/releases/latest | jq '.tag_name' | ltrimstr("v") --raw-output)
-      if [[ ${finalAttrs.version} = "$NEW_VERSION"]]; then
+      NEW_VERSION=$(curl --silent https://api.github.com/repos/speakeasy-api/speakeasy/releases/latest | jq --raw-output '.tag_name | ltrimstr("v")')
+      if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
         echo "The new version is the same as old"
         exit 0
       fi
-      for platfrom in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+      for platform in ${lib.escapeShellArgs (builtins.attrNames finalAttrs.passthru.sources)}; do
         update-source-version "speakeasy-cli" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+      done
     '';
   };
 


### PR DESCRIPTION
Fixes the update script issue: https://nixpkgs-update-logs.nix-community.org/speakeasy-cli/2026-02-22.log which was caused by improper review of https://github.com/NixOS/nixpkgs/pull/451628

Updates speakeasy 1.761.9 from 1.636.3. 
Changelog: https://github.com/speakeasy-api/speakeasy/compare/v1.636.3...v1.761.9

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
