### PR TITLE
piper-tts: promote pathvalidate to non-optional dependency

### DIFF
--- a/pkgs/by-name/pi/piper-tts/package.nix
+++ b/pkgs/by-name/pi/piper-tts/package.nix
@@ -75,12 +75,15 @@ python3Packages.buildPythonApplication rec {
     cythonize --inplace src/piper/train/vits/monotonic_align/core.pyx
   '';
 
-  dependencies = [
-    python3Packages.onnxruntime
-  ]
-  ++ lib.optionals withTrain optional-dependencies.train
-  ++ lib.optionals withHTTP optional-dependencies.http
-  ++ lib.optionals withAlignment optional-dependencies.alignment;
+  dependencies =
+    with python3Packages;
+    [
+      onnxruntime
+      pathvalidate
+    ]
+    ++ lib.optionals withTrain optional-dependencies.train
+    ++ lib.optionals withHTTP optional-dependencies.http
+    ++ lib.optionals withAlignment optional-dependencies.alignment;
 
   optional-dependencies = {
     train =
@@ -89,7 +92,6 @@ python3Packages.buildPythonApplication rec {
         jsonargparse
         librosa
         lightning
-        pathvalidate
         pysilero-vad
         tensorboard
         tensorboardx


### PR DESCRIPTION
pathvalidate is needed even when disabling training.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
