### PR TITLE
fakedir: init at 0-unstable-2025-12-02

### DIFF
--- a/pkgs/by-name/fa/fakedir/package.nix
+++ b/pkgs/by-name/fa/fakedir/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fakedir";
+  version = "0-unstable-2025-12-02";
+
+  src = fetchFromGitHub {
+    owner = "nixie-dev";
+    repo = "fakedir";
+    rev = "82bfac1f58a76f56fc4ef928982f507e01c552a5";
+    hash = "sha256-wPseLfbRffX0Pr4TxJh59cmuY1OEfSDTvM2KrORafKs=";
+  };
+
+  CFLAGS = "-Ofast -DSTRIP_DEBUG";
+
+  installPhase = ''
+    install -Dm755 libfakedir.dylib $out/lib/libfakedir.dylib
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version=branch"
+      "--version-regex=(0-unstable-.*)"
+    ];
+  };
+
+  meta = {
+    description = "Substitutes a directory elsewhere on macOS by replacing system calls";
+    homepage = "https://github.com/nixie-dev/fakedir";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ eveeifyeve ];
+    mainProgram = "fakedir";
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Adds [fakedir](https://github.com/nixie-dev/fakedir) to nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
