### PR TITLE
hare,harec: 0.24.2 → 0.26.0, adopt

### DIFF
--- a/pkgs/by-name/bo/bonsai/package.nix
+++ b/pkgs/by-name/bo/bonsai/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bonsai";
-  version = "1.2.1";
+  version = "1.5.1";
 
   src = fetchFromSourcehut {
     owner = "~stacyharper";
     repo = "bonsai";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-WAne0628lELQanUv2lg8Y9QEikZVAT7Xtkndhs8Ozjw=";
+    hash = "sha256-cAlTppDNXXZaL5bG+h4jANfFg2OBd0WqEmDBmY5IvZ8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ha/hare/001-tzdata.patch
+++ b/pkgs/by-name/ha/hare/001-tzdata.patch
@@ -1,45 +1,60 @@
-diff --git a/time/chrono/+freebsd.ha b/time/chrono/+freebsd.ha
-index af49080e..3dde7963 100644
---- a/time/chrono/+freebsd.ha
-+++ b/time/chrono/+freebsd.ha
-@@ -2,8 +2,8 @@
- // (c) Hare authors <https://harelang.org>
-
- def LOCALTIME_PATH: str = "/etc/localtime";
--def TZDB_PATH: str = "/usr/share/zoneinfo/";
-+def TZDB_PATH: str = "@tzdata@/share/zoneinfo/";
-
+diff --git c/time/chrono/+freebsd.ha i/time/chrono/+freebsd.ha
+index 967ae0a8..1779f6d9 100644
+--- c/time/chrono/+freebsd.ha
++++ i/time/chrono/+freebsd.ha
+@@ -3,4 +3,4 @@
+ 
  // The filepath of the system's "leap-seconds.list" file, which contains UTC/TAI
  // leap second data.
 -export def UTC_LEAPSECS_PATH: str = "/var/db/ntpd.leap-seconds.list";
 +export def UTC_LEAPSECS_PATH: str = "@tzdata@/share/zoneinfo/leap-seconds.list";
-diff --git a/time/chrono/+linux.ha b/time/chrono/+linux.ha
-index 2756fd6f..1ea22385 100644
---- a/time/chrono/+linux.ha
-+++ b/time/chrono/+linux.ha
-@@ -2,8 +2,8 @@
- // (c) Hare authors <https://harelang.org>
-
- def LOCALTIME_PATH: str = "/etc/localtime";
--def TZDB_PATH: str = "/usr/share/zoneinfo/";
-+def TZDB_PATH: str = "@tzdata@/share/zoneinfo/";
-
+diff --git c/time/chrono/+linux.ha i/time/chrono/+linux.ha
+index 3394a7b4..1779f6d9 100644
+--- c/time/chrono/+linux.ha
++++ i/time/chrono/+linux.ha
+@@ -3,4 +3,4 @@
+ 
  // The filepath of the system's "leap-seconds.list" file, which contains UTC/TAI
  // leap second data.
 -export def UTC_LEAPSECS_PATH: str = "/usr/share/zoneinfo/leap-seconds.list";
 +export def UTC_LEAPSECS_PATH: str = "@tzdata@/share/zoneinfo/leap-seconds.list";
-diff --git a/time/chrono/+openbsd.ha b/time/chrono/+openbsd.ha
-index 2756fd6f..1ea22385 100644
---- a/time/chrono/+openbsd.ha
-+++ b/time/chrono/+openbsd.ha
-@@ -2,8 +2,8 @@
- // (c) Hare authors <https://harelang.org>
-
- def LOCALTIME_PATH: str = "/etc/localtime";
--def TZDB_PATH: str = "/usr/share/zoneinfo/";
-+def TZDB_PATH: str = "@tzdata@/share/zoneinfo/";
-
+diff --git c/time/chrono/+openbsd.ha i/time/chrono/+openbsd.ha
+index 3394a7b4..1779f6d9 100644
+--- c/time/chrono/+openbsd.ha
++++ i/time/chrono/+openbsd.ha
+@@ -3,4 +3,4 @@
+ 
  // The filepath of the system's "leap-seconds.list" file, which contains UTC/TAI
  // leap second data.
 -export def UTC_LEAPSECS_PATH: str = "/usr/share/zoneinfo/leap-seconds.list";
 +export def UTC_LEAPSECS_PATH: str = "@tzdata@/share/zoneinfo/leap-seconds.list";
+diff --git c/time/date/+freebsd.ha i/time/date/+freebsd.ha
+index 3b08c385..b036002a 100644
+--- c/time/date/+freebsd.ha
++++ i/time/date/+freebsd.ha
+@@ -7,4 +7,4 @@ export def LOCALTIME_PATH: str = "/etc/localtime";
+ 
+ // The filepath of the system's TZDB (Timezone Database) directory, a filetree
+ // of TZif (Time Zone Information Format) files and other related files.
+-export def TZDB_PATH: str = "/usr/share/zoneinfo";
++export def TZDB_PATH: str = "@tzdata@/share/zoneinfo";
+diff --git c/time/date/+linux.ha i/time/date/+linux.ha
+index 3b08c385..b036002a 100644
+--- c/time/date/+linux.ha
++++ i/time/date/+linux.ha
+@@ -7,4 +7,4 @@ export def LOCALTIME_PATH: str = "/etc/localtime";
+ 
+ // The filepath of the system's TZDB (Timezone Database) directory, a filetree
+ // of TZif (Time Zone Information Format) files and other related files.
+-export def TZDB_PATH: str = "/usr/share/zoneinfo";
++export def TZDB_PATH: str = "@tzdata@/share/zoneinfo";
+diff --git c/time/date/+openbsd.ha i/time/date/+openbsd.ha
+index 3b08c385..b036002a 100644
+--- c/time/date/+openbsd.ha
++++ i/time/date/+openbsd.ha
+@@ -7,4 +7,4 @@ export def LOCALTIME_PATH: str = "/etc/localtime";
+ 
+ // The filepath of the system's TZDB (Timezone Database) directory, a filetree
+ // of TZif (Time Zone Information Format) files and other related files.
+-export def TZDB_PATH: str = "/usr/share/zoneinfo";
++export def TZDB_PATH: str = "@tzdata@/share/zoneinfo";

--- a/pkgs/by-name/ha/hare/002-dont-build-haredoc.patch
+++ b/pkgs/by-name/ha/hare/002-dont-build-haredoc.patch
@@ -1,39 +1,42 @@
-diff --git a/Makefile b/Makefile
-index 2482be1f..9d58bc81 100644
---- a/Makefile
-+++ b/Makefile
+diff --git i/Makefile w/Makefile
+index d1f50f5e..d60e93f6 100644
+--- i/Makefile
++++ w/Makefile
 @@ -5,7 +5,7 @@ all:
  include config.mk
  include makefiles/$(PLATFORM).$(ARCH).mk
  
--all: $(BINOUT)/hare $(BINOUT)/haredoc docs
-+all: $(BINOUT)/hare docs
+-all: $(BINOUT)/hare-configured $(BINOUT)/haredoc docs
++all: $(BINOUT)/hare-configured docs
  
  HARE_DEFINES = \
  	-D PLATFORM:str='"$(PLATFORM)"' \
-@@ -79,11 +79,10 @@ docs: \
- 	docs/haredoc.1 \
+@@ -82,14 +82,12 @@ docs: \
+ 	docs/hare-cache.1 \
+ 	docs/hare-deps.1 \
+ 	docs/hare-tool.1 \
+-	docs/haredoc.1 \
  	docs/hare-run.1 \
  	docs/hare-test.1 \
 -	docs/haredoc.5 \
  	docs/hare-module.5
  
--MAN1 = hare hare-build hare-cache hare-deps haredoc hare-run hare-test
+-MAN1 = hare hare-build hare-cache hare-deps haredoc hare-run hare-test hare-tool
 -MAN5 = haredoc hare-module
-+MAN1 = hare hare-build hare-cache hare-deps hare-run hare-test
++MAN1 = hare hare-build hare-cache hare-deps hare-run hare-test hare-tool
 +MAN5 = hare-module
  
  bootstrap:
  	@BINOUT=$(BINOUT) ./scripts/genbootstrap
-@@ -104,7 +103,6 @@ install-cmd:
+@@ -110,7 +108,6 @@ install-cmd: all $(BINOUT)/hare-configured
  		'$(DESTDIR)$(BINDIR)' '$(DESTDIR)$(MANDIR)/man1' \
  		'$(DESTDIR)$(BINDIR)' '$(DESTDIR)$(MANDIR)/man5'
- 	install -m755 '$(BINOUT)/hare' '$(DESTDIR)$(BINDIR)/hare'
+ 	install -m755 '$(BINOUT)/hare-configured' '$(DESTDIR)$(BINDIR)/hare'
 -	install -m755 '$(BINOUT)/haredoc' '$(DESTDIR)$(BINDIR)/haredoc'
  	for i in $(MAN1); do install -m644 docs/$$i.1 '$(DESTDIR)$(MANDIR)'/man1/$$i.1; done
  	for i in $(MAN5); do install -m644 docs/$$i.5 '$(DESTDIR)$(MANDIR)'/man5/$$i.5; done
  
-@@ -115,7 +113,6 @@ install-mods:
+@@ -121,7 +118,6 @@ install-mods:
  
  uninstall:
  	rm -- '$(DESTDIR)$(BINDIR)/hare'

--- a/pkgs/by-name/ha/hare/003-hardcode-qbe-and-harec.patch
+++ b/pkgs/by-name/ha/hare/003-hardcode-qbe-and-harec.patch
@@ -1,17 +1,8 @@
-diff --git a/cmd/hare/build.ha b/cmd/hare/build.ha
-index ce19af9e..8631b325 100644
---- a/cmd/hare/build.ha
-+++ b/cmd/hare/build.ha
-@@ -36,7 +36,7 @@ fn build(name: str, cmd: *getopt::command) (void | error) = {
- 		case let ncpu: size =>
- 			yield ncpu;
- 		},
--		version = build::get_version(os::tryenv("HAREC", "harec"))?,
-+		version = build::get_version(os::tryenv("HAREC", "@harec_bin@"))?,
- 		arch = arch,
- 		platform = build::get_platform(os::sysname())?,
- 		...
-@@ -143,8 +143,8 @@ fn build(name: str, cmd: *getopt::command) (void | error) = {
+diff --git i/cmd/hare/build.ha w/cmd/hare/build.ha
+index 44b6484f..ebecfd8b 100644
+--- i/cmd/hare/build.ha
++++ w/cmd/hare/build.ha
+@@ -144,8 +144,8 @@ fn build(name: str, cmd: *getopt::command) (void | error) = {
  	set_arch_tags(&ctx.ctx.tags, arch);
  
  	ctx.cmds = ["",

--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -75,7 +75,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare";
-  version = "0.24.2";
+  version = "0.26.0";
 
   outputs = [
     "out"
@@ -85,8 +85,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "hare";
-    rev = finalAttrs.version;
-    hash = "sha256-61lckI0F+Ez5LR/8g6ftS0W7Q/+EU/1flTDFleBg6pc=";
+    tag = finalAttrs.version;
+    hash = "sha256-3NrhnbAR0VIyr7JkAsY8NIkW8AelPSphzIYu8QMgXsU=";
   };
 
   patches = [
@@ -170,7 +170,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://harelang.org/";
     description = "Systems programming language designed to be simple, stable, and robust";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ sikmir ];
     mainProgram = "hare";
     inherit (harec.meta) platforms badPlatforms;
   };

--- a/pkgs/by-name/ha/harec/package.nix
+++ b/pkgs/by-name/ha/harec/package.nix
@@ -19,13 +19,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "harec";
-  version = "0.24.2";
+  version = "0.26.0";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "harec";
-    rev = finalAttrs.version;
-    hash = "sha256-YCUBdPYr/44stW9k54QoUEhNkti6ULJkVBphx7xhmKo=";
+    tag = finalAttrs.version;
+    hash = "sha256-azj37C+Uw8wqy0lf3g/kB353iufY6P7Rf20aLCRp9a8=";
   };
 
   nativeBuildInputs = [ qbe ];
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://harelang.org/";
     description = "Bootstrapping Hare compiler written in C for POSIX systems";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ sikmir ];
     mainProgram = "harec";
     # The upstream developers do not like proprietary operating systems; see
     # https://harelang.org/platforms/

--- a/pkgs/by-name/ha/haredo/package.nix
+++ b/pkgs/by-name/ha/haredo/package.nix
@@ -11,7 +11,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "haredo";
-  version = "1.0.5";
+  version = "1.0.6";
 
   outputs = [
     "out"
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "~autumnull";
     repo = "haredo";
     rev = finalAttrs.version;
-    hash = "sha256-gpui5FVRw3NKyx0AB/4kqdolrl5vkDudPOgjHc/IE4U=";
+    hash = "sha256-wjowPlSIotP8RSV0whiVWne+irtDdoPD+iSC2F9GVfs=";
   };
 
   patches = [
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   checkPhase = ''
     runHook preCheck
 
-    ./bin/haredo ''${enableParallelChecking:+-j$NIX_BUILD_CORES} test
+    ./bin/haredo ''${enableParallelChecking:+-j$NIX_BUILD_CORES} test/all
 
     runHook postCheck
   '';

--- a/pkgs/by-name/hi/himitsu/package.nix
+++ b/pkgs/by-name/hi/himitsu/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "himitsu";
-  version = "0.8";
+  version = "0.10";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "himitsu";
     rev = finalAttrs.version;
-    hash = "sha256-+GQgRPJut+3zvzSyTGujTbbwJNNgHtFxAoEEwU0lbfU=";
+    hash = "sha256-mG70yAZ0iq4KH6a99jM4MM5FSlx4BE7cvfdk+N1mo5w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/tr/treecat/package.nix
+++ b/pkgs/by-name/tr/treecat/package.nix
@@ -1,6 +1,5 @@
 {
   fetchFromSourcehut,
-  fetchpatch,
   hareHook,
   haredo,
   lib,
@@ -9,7 +8,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "treecat";
-  version = "1.0.2-unstable-2023-11-28";
+  version = "1.0.3";
 
   outputs = [
     "out"
@@ -19,17 +18,9 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromSourcehut {
     owner = "~autumnull";
     repo = "treecat";
-    rev = "d277aed99eb48eef891b76916a61029989c41d2d";
-    hash = "sha256-4A01MAGkBSSzkyRw4omNbLoX8z+pHfoUO7/6QvEUu70=";
+    tag = finalAttrs.version;
+    hash = "sha256-UCGx1v+AP9BeAktrniTXctkPp5mprf77fkapdhPWrqg=";
   };
-
-  patches = [
-    # Update for Hare 0.24.2.
-    (fetchpatch {
-      url = "https://git.sr.ht/~autumnull/treecat/commit/53ad8126261051dd3b3493c34ae49f23db2c2d16.patch";
-      hash = "sha256-cF/lMZjg1hB93rBXcjecT5Rrzb2Y73u6DSW1WcP5Vek=";
-    })
-  ];
 
   nativeBuildInputs = [
     hareHook

--- a/pkgs/development/hare-third-party/hare-compress/default.nix
+++ b/pkgs/development/hare-third-party/hare-compress/default.nix
@@ -2,19 +2,18 @@
   lib,
   stdenv,
   hareHook,
-  harec,
   fetchFromSourcehut,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare-compress";
-  version = "0-unstable-2023-11-01";
+  version = "0.25.2.0";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "hare-compress";
-    rev = "562706946871d1c994f60361883269916cbaa08e";
-    hash = "sha256-sz8xPBZaUFye3HH4lkRnH52ye451e6seZXN/qvg87jE=";
+    tag = finalAttrs.version;
+    hash = "sha256-s5K6xnzQeQ/lncpfZpxHx1FBdrjgnuhOih/YGJXCjkc=";
   };
 
   nativeBuildInputs = [ hareHook ];
@@ -28,6 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Compression algorithms for Hare";
     license = with lib.licenses; [ mpl20 ];
     maintainers = with lib.maintainers; [ starzation ];
-    inherit (harec.meta) platforms badPlatforms;
+    inherit (hareHook.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/development/hare-third-party/hare-ev/default.nix
+++ b/pkgs/development/hare-third-party/hare-ev/default.nix
@@ -3,18 +3,18 @@
   hareHook,
   lib,
   stdenv,
-  unstableGitUpdater,
+  gitUpdater,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "hare-ev";
-  version = "0-unstable-2024-12-29";
+  version = "0.26.0.0";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "hare-ev";
-    rev = "48bf3855a48467579321ba56c3406e574b046638";
-    hash = "sha256-fWdmZj8j3CSVsWX7Yxf42iGwSZc0ae5/hTNtdeo9dkw=";
+    tag = finalAttrs.version;
+    hash = "sha256-Chetww+F46ZJ+cgVuoFXRVYOT9g13iBK5EembWXQhuc=";
   };
 
   nativeCheckInputs = [ hareHook ];
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
 
   doCheck = true;
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     description = "Event loop for Hare programs";
@@ -32,4 +32,4 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ colinsane ];
     inherit (hareHook.meta) platforms badPlatforms;
   };
-}
+})

--- a/pkgs/development/hare-third-party/hare-http/default.nix
+++ b/pkgs/development/hare-third-party/hare-http/default.nix
@@ -1,0 +1,34 @@
+{
+  fetchFromSourcehut,
+  hareHook,
+  hareThirdParty,
+  lib,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hare-http";
+  version = "0.26.0.0";
+
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = "hare-http";
+    tag = finalAttrs.version;
+    hash = "sha256-0NPLYuoAVvIiDH7d0KtJnmKX/C1ShdBZIo9w3EPsmkA=";
+  };
+
+  nativeBuildInputs = [ hareHook ];
+  propagatedBuildInputs = [ hareThirdParty.hare-ev ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://git.sr.ht/~sircmpwn/hare-http/";
+    description = "HTTP(s) support for Hare";
+    license = with lib.licenses; [ mpl20 ];
+    maintainers = with lib.maintainers; [ sikmir ];
+    inherit (hareHook.meta) platforms badPlatforms;
+  };
+})

--- a/pkgs/development/hare-third-party/hare-json/default.nix
+++ b/pkgs/development/hare-third-party/hare-json/default.nix
@@ -1,20 +1,19 @@
 {
   fetchFromSourcehut,
   hareHook,
-  harec,
   lib,
   stdenv,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare-json";
-  version = "0-unstable-2024-04-19";
+  version = "0.26.0.0";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "hare-json";
-    rev = "b6aeae96199607a1f3b4d437d5c99f821bd6a6b6";
-    hash = "sha256-mgUzHGXbaJdWm7qUn7mWdDUQBgbEjh42O+Lo0ok80Wo=";
+    tag = finalAttrs.version;
+    hash = "sha256-vAT10QGFwazM5PYLQpW0ebFGa2sScXWM87jzI+m4/eM=";
   };
 
   nativeBuildInputs = [ hareHook ];
@@ -28,6 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "This package provides JSON support for Hare";
     license = with lib.licenses; [ mpl20 ];
     maintainers = with lib.maintainers; [ starzation ];
-    inherit (harec.meta) platforms badPlatforms;
+    inherit (hareHook.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/development/hare-third-party/hare-png/default.nix
+++ b/pkgs/development/hare-third-party/hare-png/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare-png";
-  version = "0-unstable-2023-09-09";
+  version = "0-unstable-2024-03-13";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "hare-png";
-    rev = "9deb848ae691d784c5cc7949153cfa04c67f90b6";
-    hash = "sha256-Q7xylsLVd/sp57kv6WzC7QHGN1xOsm7YEsYCbY/zi1Q=";
+    rev = "5ae7bc7f6caa6f89dcfd8e3ebed717b50c35e085";
+    hash = "sha256-DVXTlM3f5G5Zsra7KJn8++mmrEhAOr7q0kA4Ep66VKw=";
   };
 
   nativeBuildInputs = [ hareHook ];
@@ -30,5 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; [ mpl20 ];
     maintainers = with lib.maintainers; [ starzation ];
     inherit (hareHook.meta) platforms badPlatforms;
+    broken = true; # hare 0.26.0
   };
 })

--- a/pkgs/development/hare-third-party/hare-ssh/default.nix
+++ b/pkgs/development/hare-third-party/hare-ssh/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare-ssh";
-  version = "0-unstable-2023-11-16";
+  version = "0.26.0";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "hare-ssh";
-    rev = "c6a39e37ba4a42721594e0a907fe016f8e2198a8";
-    hash = "sha256-I43TLPoImBsvkgV3hDy9dw0pXVt4ezINnxFtEV9P2/M=";
+    tag = finalAttrs.version;
+    hash = "sha256-msPY8m7/GDKsGDrhZ1IK65U+6fcI26FW9CONC4w87Pg=";
   };
 
   nativeBuildInputs = [ hareHook ];

--- a/pkgs/development/hare-third-party/hare-toml/default.nix
+++ b/pkgs/development/hare-third-party/hare-toml/default.nix
@@ -9,22 +9,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare-toml";
-  version = "0.1.2";
+  version = "0.2.1";
 
   src = fetchFromCodeberg {
     owner = "lunacb";
     repo = "hare-toml";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-MfflJElDMu15UBuewssqhCEsNtzmN/H421H4HV+JCWc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PAXK7BHPzmZaTm3PIbTTn0ZB/8l6HzOkJ2prARxD9UE=";
   };
-
-  patches = [
-    # Update strconv module functions for 0.24.2
-    (fetchpatch {
-      url = "https://codeberg.org/lunacb/hare-toml/commit/9849908ba1fd3457abd6c708272ecb896954d2bc.patch";
-      hash = "sha256-herJZXJ8uusTO2b7Ddby2chIvDRuAPDFOPEt+wotTA0=";
-    })
-  ];
 
   nativeBuildInputs = [
     scdoc

--- a/pkgs/development/hare-third-party/hare-xml/default.nix
+++ b/pkgs/development/hare-third-party/hare-xml/default.nix
@@ -1,0 +1,32 @@
+{
+  fetchFromSourcehut,
+  hareHook,
+  lib,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hare-xml";
+  version = "0.25.2.0";
+
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = "hare-xml";
+    tag = finalAttrs.version;
+    hash = "sha256-YAXUt/gLtGgT/4XXwaVaFEkeWMTBxwjUeeHHm8o3QcA=";
+  };
+
+  nativeBuildInputs = [ hareHook ];
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://git.sr.ht/~sircmpwn/hare-xml/";
+    description = "This package provides XML support for Hare";
+    license = with lib.licenses; [ mpl20 ];
+    maintainers = with lib.maintainers; [ sikmir ];
+    inherit (hareHook.meta) platforms badPlatforms;
+  };
+})

--- a/pkgs/top-level/hare-third-party.nix
+++ b/pkgs/top-level/hare-third-party.nix
@@ -8,6 +8,7 @@ lib.makeScope newScope (
   {
     hare-compress = callPackage ../development/hare-third-party/hare-compress { };
     hare-ev = callPackage ../development/hare-third-party/hare-ev { };
+    hare-http = callPackage ../development/hare-third-party/hare-http { };
     hare-json = callPackage ../development/hare-third-party/hare-json { };
     hare-ssh = callPackage ../development/hare-third-party/hare-ssh { };
     hare-toml = callPackage ../development/hare-third-party/hare-toml { };

--- a/pkgs/top-level/hare-third-party.nix
+++ b/pkgs/top-level/hare-third-party.nix
@@ -13,5 +13,6 @@ lib.makeScope newScope (
     hare-ssh = callPackage ../development/hare-third-party/hare-ssh { };
     hare-toml = callPackage ../development/hare-third-party/hare-toml { };
     hare-png = callPackage ../development/hare-third-party/hare-png { };
+    hare-xml = callPackage ../development/hare-third-party/hare-xml { };
   }
 )


### PR DESCRIPTION
https://harelang.org/blog/2026-02-13-hare-0.26.0-released/

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
