### PR TITLE
python3Packages.materialyoucolor: 2.0.10 -> 3.0.2

### DIFF
--- a/pkgs/development/python-modules/materialyoucolor/default.nix
+++ b/pkgs/development/python-modules/materialyoucolor/default.nix
@@ -1,31 +1,27 @@
 {
   lib,
   buildPythonPackage,
-  fetchurl,
-  fetchPypi,
+  fetchFromGitHub,
+
   setuptools,
   pybind11,
-  requests,
-  rich,
+
   pillow,
+
+  psutil,
+  rich,
 }:
 
-let
-  test-image = fetchurl {
-    name = "test-image.jpg";
-    url = "https://unsplash.com/photos/u9tAl8WR3DI/download";
-    hash = "sha256-shGNdgOOydgGBtl/JCbTJ0AYgl+2xWvCgHBL+bEoTaE=";
-  };
-in
 buildPythonPackage (finalAttrs: {
   pname = "materialyoucolor";
-  version = "2.0.10";
+  version = "3.0.2";
   pyproject = true;
 
-  # PyPI sources contain additional vendored sources
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-MbTUB7mk/UtUswVZsNAxP21tofnRm3VUbtZdpSZx6nY=";
+  src = fetchFromGitHub {
+    owner = "T-Dynamos";
+    repo = "materialyoucolor-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CCpYrNp79gdnj5TYcQ7fEiLsFW/kbuZ+3/cHZF4Bv/s=";
   };
 
   build-system = [
@@ -33,15 +29,23 @@ buildPythonPackage (finalAttrs: {
     pybind11
   ];
 
-  nativeCheckInputs = [
-    requests
-    rich
+  dependencies = [
     pillow
+  ];
+
+  nativeCheckInputs = [
+    psutil
+    rich
   ];
 
   checkPhase = ''
     runHook preCheck
-    python tests/test_all.py ${test-image} 1
+
+    # test script taken from .github/workflows/cibuildwheel.yml
+    python -c "from PIL import Image; Image.new('RGB', (128, 128), (70, 120, 180)).save('test_image.jpg')"
+    python tests/test_all.py --image test_image.jpg --quality 1 --method pillow --tonal-spot
+    python tests/test_all.py --image test_image.jpg --quality 1 --method cpp --tonal-spot
+
     runHook postCheck
   '';
 


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/495425

3.0.* now properly vendors the `quantize` directory in the github repo, so we don't have to use the pypi sources anymore.

I updated the checkPhase to reflect the things done in the CI. So we no longer need an external test image.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
