### PR TITLE
libpointmatcher, rtabmap: fix boost 1.89 compatibility

### DIFF
--- a/pkgs/by-name/li/libpointmatcher/package.nix
+++ b/pkgs/by-name/li/libpointmatcher/package.nix
@@ -9,14 +9,14 @@
   yaml-cpp,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libpointmatcher";
   version = "1.4.4";
 
   src = fetchFromGitHub {
     owner = "norlab-ulaval";
     repo = "libpointmatcher";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-OkfWdim0JDKiBx5spYpkMyFrLQP3AMWBVDpzmFwqNFM=";
   };
 
@@ -30,16 +30,16 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     (lib.cmakeFeature "EIGEN_INCLUDE_DIR" "${eigen}/include/eigen3")
-    (lib.cmakeBool "BUILD_TESTS" doCheck)
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
   ];
 
   doCheck = true;
 
   meta = {
-    inherit (src.meta) homepage;
+    inherit (finalAttrs.src.meta) homepage;
     description = "\"Iterative Closest Point\" library for 2-D/3-D mapping in robotic";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ cryptix ];
   };
-}
+})

--- a/pkgs/by-name/li/libpointmatcher/package.nix
+++ b/pkgs/by-name/li/libpointmatcher/package.nix
@@ -20,6 +20,25 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-OkfWdim0JDKiBx5spYpkMyFrLQP3AMWBVDpzmFwqNFM=";
   };
 
+  # Fix boost 1.89 compatibility
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        "find_package(Boost REQUIRED COMPONENTS thread system program_options date_time)" \
+        "find_package(Boost REQUIRED COMPONENTS thread program_options date_time)" \
+      --replace-fail \
+        "find_package(Boost REQUIRED COMPONENTS thread system program_options date_time chrono)" \
+        "find_package(Boost REQUIRED COMPONENTS thread program_options date_time chrono)"
+
+    substituteInPlace libpointmatcherConfig.cmake.in \
+      --replace-fail \
+        "find_package(Boost COMPONENTS thread system program_options date_time REQUIRED)" \
+        "find_package(Boost COMPONENTS thread program_options date_time REQUIRED)" \
+      --replace-fail \
+        "find_package(Boost COMPONENTS thread system program_options date_time chrono REQUIRED)" \
+        "find_package(Boost COMPONENTS thread program_options date_time chrono REQUIRED)"
+  '';
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     eigen

--- a/pkgs/by-name/rt/rtabmap/package.nix
+++ b/pkgs/by-name/rt/rtabmap/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
 
   # nativeBuildInputs
   cmake,
@@ -50,6 +49,14 @@ stdenv.mkDerivation (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-u9wswlFkGpPgJaBwSddnpv49wBAmkKRwWFO5jQ9/twA=";
   };
+
+  # Fix boost 1.89 compatibility
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        "find_package(Boost COMPONENTS thread filesystem system program_options date_time chrono timer serialization REQUIRED)" \
+        "find_package(Boost COMPONENTS thread filesystem program_options date_time chrono timer serialization REQUIRED)"
+  '';
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## Things done

- **libpointmatcher: cleanup**
- **libpointmatcher: fix boost 1.89 compatibility**
- **rtabmap: fix boost 1.89 compatibility**

cc @cryptix

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
