### PR TITLE
deadcode: init at 0.42.0

### DIFF
--- a/pkgs/by-name/de/deadcode/package.nix
+++ b/pkgs/by-name/de/deadcode/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "deadcode";
+  version = "0.42.0";
+
+  src = fetchFromGitHub {
+    owner = "golang";
+    repo = "tools";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0RiinnIocPaj8Z5jtYGkbFiRf1BXyap4Z8e/sw2FBgg=";
+  };
+
+  vendorHash = "sha256-oYmM+5lNmlP2i78NsG3v4WRhAUbiwS+EFkiicI6MKXA=";
+
+  subPackages = [ "cmd/deadcode" ];
+
+  meta = {
+    description = "Find unreachable functions in Go programs";
+    homepage = "https://pkg.go.dev/golang.org/x/tools/cmd/deadcode";
+    license = lib.licenses.bsd3;
+    mainProgram = "deadcode";
+  };
+})

--- a/pkgs/by-name/de/deadcode/package.nix
+++ b/pkgs/by-name/de/deadcode/package.nix
@@ -23,6 +23,7 @@ buildGoModule (finalAttrs: {
     description = "Find unreachable functions in Go programs";
     homepage = "https://pkg.go.dev/golang.org/x/tools/cmd/deadcode";
     license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ cpcloud ];
     mainProgram = "deadcode";
   };
 })


### PR DESCRIPTION
[deadcode](https://pkg.go.dev/golang.org/x/tools/cmd/deadcode) reports unreachable functions in Go programs using Rapid Type Analysis (RTA).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test