### PR TITLE
nixos-rebuild-ng: default temp directory to /tmp if too long

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/package.nix
@@ -10,9 +10,6 @@
   runCommand,
   scdoc,
   withShellFiles ? true,
-  # Very long tmp dirs lead to "too long for Unix domain socket"
-  # SSH ControlPath errors. Especially macOS sets long TMPDIR paths.
-  withTmpdir ? if stdenv.hostPlatform.isDarwin then "/tmp" else null,
   # passthru.tests
   nixosTests,
 }:
@@ -67,10 +64,6 @@ python3Packages.buildPythonApplication rec {
   ];
 
   pytestFlags = [ "-vv" ];
-
-  makeWrapperArgs = lib.optionals (withTmpdir != null) [
-    "--set TMPDIR ${withTmpdir}"
-  ];
 
   passthru =
     let

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/tmpdir.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/tmpdir.py
@@ -1,6 +1,38 @@
+import logging
 from pathlib import Path
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, gettempdir
 from typing import Final
 
-TMPDIR: Final = TemporaryDirectory(prefix="nixos-rebuild.")
+logger: Final = logging.getLogger(__name__)
+
+
+# Very long tmp dirs lead to "too long for Unix domain socket"
+# SSH ControlPath errors. Especially macOS sets long TMPDIR paths.
+# This is also required for Linux, if the user tries to build
+# from inside a shell using `--target-host`, which will cause
+# ssh to fail with "ControlPath too long"
+#
+# The constant is based on a worst case example FQDN, e.g.:
+# `ec2-123-123-123-123.ap-southeast-2.compute.amazonaws.com` (56 bytes).
+# The `ControlPath` can maximum be 108 bytes. Given the prefix
+# that is used for the tempdir, ie. `nixos-rebuild.47i6dz8c` (22 bytes),
+# we have 30 bytes left to work with.
+# This should be fine for the usual temp folders:
+# /tmp/tmp.7hBqN2Fm5H (19)
+# /var/tmp/tmp.7hBqN2Fm5H (23)
+# /run/user/1000/tmp.7hBqN2Fm5H (29)
+def make_tmpdir() -> TemporaryDirectory[str]:
+    tmp = gettempdir()
+    if len(tmp) >= 30:
+        logger.debug(
+            "tempdir '%s' exceeds 30 bytes limit, defaulting to /tmp instead",
+            tmp,
+        )
+
+        return TemporaryDirectory(prefix="nixos-rebuild.", dir="/tmp")
+
+    return TemporaryDirectory(prefix="nixos-rebuild.")
+
+
+TMPDIR: Final = make_tmpdir()
 TMPDIR_PATH: Final = Path(TMPDIR.name)


### PR DESCRIPTION
If using nixos-rebuild-ng inside a shell on Linux, the temp directory will be very long, and cause `--target-host` commands to fail because SSH `ControlPath` gets too long.

This removes that, as if any path is longer than 60 bytes, it will default to use `/tmp` instead.

This also removes the argument to the package.nix, as it is no longer required.

Ensure parity with the old nixos-rebuild command:
https://github.com/NixOS/nixpkgs/blob/1267bb4920d0fc06ea916734c11b0bf004bbe17e/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh#L445-L450

The error in question looks like this:

```
ControlPath too long ('/tmp/nix-shell-1kqklgwvzyb463sasqq66q1dg1/build-top-5akhvh2zwhki2f96cbcyh1wlj3/nixos-rebuild.47i6dz8c/ssh-gerd.fricloud.dk' >= 108 bytes)
```

I've tested this patch on my own setup, and it fixed my issue.

Fixes #495484

(reopened because I targeted the wrong branch, and the other PR get mangled)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
