### PR TITLE
maintainers: drop averelld

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2690,12 +2690,6 @@
     githubId = 2530548;
     name = "Aaron VerDow";
   };
-  averelld = {
-    email = "averell+nixos@rxd4.com";
-    github = "averelld";
-    githubId = 687218;
-    name = "averelld";
-  };
   avery = {
     email = "nixpkgs@avery.cafe";
     github = "coolavery";

--- a/pkgs/by-name/le/leela-zero/package.nix
+++ b/pkgs/by-name/le/leela-zero/package.nix
@@ -42,9 +42,8 @@ stdenv.mkDerivation {
     description = "Go engine modeled after AlphaGo Zero";
     homepage = "https://github.com/gcp/leela-zero";
     license = lib.licenses.gpl3Plus;
-    maintainers = [
-      lib.maintainers.averelld
-      lib.maintainers.omnipotententity
+    maintainers = with lib.maintainers; [
+      omnipotententity
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/pd/pdftk/package.nix
+++ b/pkgs/by-name/pd/pdftk/package.nix
@@ -66,7 +66,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       raskin
-      averelld
     ];
     platforms = lib.platforms.unix;
     mainProgram = "pdftk";

--- a/pkgs/by-name/x2/x2goserver/package.nix
+++ b/pkgs/by-name/x2/x2goserver/package.nix
@@ -163,6 +163,6 @@ stdenv.mkDerivation {
     homepage = "http://x2go.org/";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ averelld ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/handout/default.nix
+++ b/pkgs/development/python-modules/handout/default.nix
@@ -25,6 +25,6 @@ buildPythonPackage rec {
     description = "Turn Python scripts into handouts with Markdown and figures";
     homepage = "https://github.com/danijar/handout";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ averelld ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
- last commented on [April 2020](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aaverelld)
- hasn't created any issues or PRs since [December 2019](https://github.com/NixOS/nixpkgs/issues?q=author%3Aaverelld)
- hasn't answered to [29](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aaverelld%20-commenter%3Aaverelld%20-author%3Aaverelld%20-reviewed-by%3Aaverelld) pings

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status).
@averelld you have one week to respond to this.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
