### PR TITLE
classicube: 1.3.7 -> 1.3.8

### DIFF
--- a/pkgs/by-name/cl/classicube/fix-linking.patch
+++ b/pkgs/by-name/cl/classicube/fix-linking.patch
@@ -1,14 +1,14 @@
 diff --git a/Makefile b/Makefile
-index a10eb5214..70e2f720e 100644
+index 2dcc31725..8326df3c1 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -55,7 +55,7 @@ endif
+@@ -80,7 +80,7 @@ endif
  
  ifeq ($(PLAT),linux)
- 	CFLAGS  += -DCC_BUILD_ICON
--	LIBS    =  -lX11 -lXi -lpthread -lGL -ldl
-+	LIBS    =  -lX11 -lXi -lpthread -lGL -ldl -lcurl -lopenal
- 	BUILD_DIR = build-linux
- endif
+ 	# -lm may be needed for __builtin_sqrtf (in cases where it isn't replaced by a CPU instruction intrinsic)
+-	LIBS    =  -lX11 -lXi -lpthread -lGL -ldl -lm
++	LIBS    =  -lX11 -lXi -lpthread -lGL -ldl -lm -lcurl -lopenal
+ 	BUILD_DIR = build/linux
  
+ 	# Detect MCST LCC, where -O3 is about equivalent to -O1
 

--- a/pkgs/by-name/cl/classicube/package.nix
+++ b/pkgs/by-name/cl/classicube/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ClassiCube";
-  version = "1.3.7";
+  version = "1.3.8";
 
   src = fetchFromGitHub {
     owner = "UnknownShadow200";
     repo = "ClassiCube";
     rev = version;
-    sha256 = "sha256-ZITyfxkQB4Jpm2ZsQyM+ouPLqCVmGB7UZRXDSU/BX0k=";
+    sha256 = "sha256-AF4cr3ZXCixwiihS+2ayrzVH5eYShkjlfF0myb2PbHM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
As requested in #495421, this updates classicube.

For that `fix-linking.patch` had to be adjusted slightly. (surroundings and line number changed)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
