### PR TITLE
python3Packages.python-socks: 2.8.0 -> 2.8.1

### DIFF
--- a/pkgs/development/python-modules/python-socks/default.nix
+++ b/pkgs/development/python-modules/python-socks/default.nix
@@ -10,6 +10,7 @@
   pytest-trio,
   pytestCheckHook,
   setuptools,
+  tiny-proxy,
   trio,
   trustme,
   yarl,
@@ -17,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "python-socks";
-  version = "2.8.0";
+  version = "2.8.1";
   pyproject = true;
 
   __darwinAllowLocalNetworking = true;
@@ -26,7 +27,7 @@ buildPythonPackage rec {
     owner = "romis2012";
     repo = "python-socks";
     tag = "v${version}";
-    hash = "sha256-b19DfvoJo/9NCjgZ+07WdZGnXNS7/f+FgGdU8s1k2io=";
+    hash = "sha256-Eu4xeBZbZvAGfFArMiUlUQQa4yywKWj+azv+OHiKJfU=";
   };
 
   build-system = [ setuptools ];
@@ -43,14 +44,13 @@ buildPythonPackage rec {
     anyio = [ anyio ];
   };
 
-  doCheck = false; # requires tiny_proxy module
-
   nativeCheckInputs = [
     anyio
     flask
     pytest-asyncio
     pytest-trio
     pytestCheckHook
+    tiny-proxy
     trustme
     yarl
   ];

--- a/pkgs/development/python-modules/python-socks/default.nix
+++ b/pkgs/development/python-modules/python-socks/default.nix
@@ -16,7 +16,7 @@
   yarl,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "python-socks";
   version = "2.8.1";
   pyproject = true;
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "romis2012";
     repo = "python-socks";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Eu4xeBZbZvAGfFArMiUlUQQa4yywKWj+azv+OHiKJfU=";
   };
 
@@ -58,10 +58,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "python_socks" ];
 
   meta = {
-    changelog = "https://github.com/romis2012/python-socks/releases/tag/${src.tag}";
+    changelog = "https://github.com/romis2012/python-socks/releases/tag/${finalAttrs.src.tag}";
     description = "Core proxy client (SOCKS4, SOCKS5, HTTP) functionality for Python";
     homepage = "https://github.com/romis2012/python-socks";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
Also enables tests, as `python3Packages.tiny-proxy` is in nixpkgs
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
