### PR TITLE
reredirect: 0.3 -> unstable-2026-02-15

### DIFF
--- a/pkgs/by-name/re/reredirect/package.nix
+++ b/pkgs/by-name/re/reredirect/package.nix
@@ -6,20 +6,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "reredirect";
-  version = "0.3";
+  version = "unstable-2026-02-15";
 
   src = fetchFromGitHub {
     owner = "jerome-pouiller";
     repo = "reredirect";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-RHRamDo7afnJ4DlOVAqM8lQAC60YESGSMKa8Io2vcX0=";
+    rev = "b85df395e18d09b54e1fb73dfe344f8f04224a83";
+    sha256 = "sha256-lLhF8taK6PqWo4u6pMZDN2PZavnWwsz4NbEUT7EtULo=";
   };
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   postFixup = ''
     substituteInPlace ${placeholder "out"}/bin/relink \
-      --replace "reredirect" "${placeholder "out"}/bin/reredirect"
+      --replace-fail "reredirect" "${placeholder "out"}/bin/reredirect"
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated reredirect from 0.3 to latest commit https://github.com/jerome-pouiller/reredirect/commit/b85df395e18d09b54e1fb73dfe344f8f04224a83. 

Old version 0.3 no longer builds, and 0.4 tagged version also fails to build which was fixed in https://github.com/jerome-pouiller/reredirect/commit/b85df395e18d09b54e1fb73dfe344f8f04224a83 hence the use of commit revision not tagged 0.4

Solves https://github.com/NixOS/nixpkgs/issues/491358

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
