### PR TITLE
protobuf_34: init at 34.0

### DIFF
--- a/pkgs/development/libraries/protobuf/34.nix
+++ b/pkgs/development/libraries/protobuf/34.nix
@@ -1,0 +1,9 @@
+{ callPackage, ... }@args:
+
+callPackage ./generic.nix (
+  {
+    version = "34.0";
+    hash = "sha256-qtSP3I7RA7F6tKe+VfGd+oNXMT5HZ/Xl7u4vkefNxX4=";
+  }
+  // args
+)

--- a/pkgs/development/libraries/protobuf/fix-upb-linkarr-sentinel-init.patch
+++ b/pkgs/development/libraries/protobuf/fix-upb-linkarr-sentinel-init.patch
@@ -1,0 +1,35 @@
+diff --git a/upb/port/def.inc b/upb/port/def.inc
+index f66885ddf55cf..1305fd164b293 100644
+--- a/upb/port/def.inc
++++ b/upb/port/def.inc
+@@ -534,7 +534,7 @@ Error, UINTPTR_MAX is undefined
+ #define UPB_LINKARR_DECLARE(name, type) \
+   extern type __start_linkarr_##name;   \
+   extern type __stop_linkarr_##name;    \
+-  UPB_LINKARR_APPEND(name)              \
+-  UPB_LINKARR_SENTINEL type UPB_linkarr_internal_empty_##name[1]
++  UPB_LINKARR_APPEND(name)                                          \
++  UPB_LINKARR_SENTINEL type UPB_linkarr_internal_empty_##name[1] = {0}
+ #define UPB_LINKARR_START(name) (&__start_linkarr_##name)
+ #define UPB_LINKARR_STOP(name) (&__stop_linkarr_##name)
+ 
+@@ -554,7 +554,7 @@ Error, UINTPTR_MAX is undefined
+   extern type __stop_linkarr_##name __asm(  \
+       "section$end$__DATA$"                 \
+       "__la_" #name);                       \
+-  UPB_LINKARR_APPEND(name)                  \
+-  UPB_LINKARR_SENTINEL type UPB_linkarr_internal_empty_##name[1]
++  UPB_LINKARR_APPEND(name)                                              \
++  UPB_LINKARR_SENTINEL type UPB_linkarr_internal_empty_##name[1] = {0}
+ #define UPB_LINKARR_START(name) (&__start_linkarr_##name)
+ #define UPB_LINKARR_STOP(name) (&__stop_linkarr_##name)
+ 
+@@ -570,7 +570,7 @@ Error, UINTPTR_MAX is undefined
+ 
+ #define UPB_LINKARR_ATTR
+ 
+-#define UPB_LINKARR_SENTINEL UPB_RETAIN __attribute__((weak, used))
++#define UPB_LINKARR_SENTINEL __attribute__((weak, used))
+ 
+ #if defined(__ELF__) || defined(__wasm__)
+ 

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -64,12 +64,28 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://github.com/protocolbuffers/protobuf/commit/211f52431b9ec30d4d4a1c76aafd64bd78d93c43.patch";
         hash = "sha256-2/vc4anc+kH7otfLHfBtW8dRowPyObiXZn0+HtQktak=";
       })
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "34") [
+      # upb linker-array fix for newer toolchains (notably GCC 15):
+      # `UPB_linkarr_internal_empty_upb_AllExts` can conflict with extension
+      # entries in `linkarr_upb_AllExts` during test builds.
+      # Context: https://github.com/protocolbuffers/protobuf/issues/21021
+      ./fix-upb-linkarr-sentinel-init.patch
     ];
 
-  postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin && lib.versionOlder version "29") ''
-    substituteInPlace src/google/protobuf/testing/googletest.cc \
-      --replace-fail 'tmpnam(b)' '"'$TMPDIR'/foo"'
-  '';
+  postPatch =
+    lib.optionalString (stdenv.hostPlatform.isDarwin && lib.versionOlder version "29") ''
+      substituteInPlace src/google/protobuf/testing/googletest.cc \
+        --replace-fail 'tmpnam(b)' '"'$TMPDIR'/foo"'
+    ''
+    # Keep the sentinel macro non-retained for GCC 15+ to match generated
+    # extension objects in linker arrays and avoid section type conflicts.
+    + lib.optionalString (lib.versionAtLeast version "34") ''
+      substituteInPlace upb/port/def.inc \
+        --replace-fail \
+          '#define UPB_LINKARR_SENTINEL UPB_RETAIN __attribute__((weak, used))' \
+          '#define UPB_LINKARR_SENTINEL            __attribute__((weak, used))'
+    '';
 
   preHook = ''
     export build_protobuf=${

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -36,11 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
     inherit hash;
   };
 
-  postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin && lib.versionOlder version "29") ''
-    substituteInPlace src/google/protobuf/testing/googletest.cc \
-      --replace-fail 'tmpnam(b)' '"'$TMPDIR'/foo"'
-  '';
-
   patches =
     lib.optionals (lib.versionOlder version "22") [
       # fix protobuf-targets.cmake installation paths, and allow for CMAKE_INSTALL_LIBDIR to be absolute
@@ -70,6 +65,11 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-2/vc4anc+kH7otfLHfBtW8dRowPyObiXZn0+HtQktak=";
       })
     ];
+
+  postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin && lib.versionOlder version "29") ''
+    substituteInPlace src/google/protobuf/testing/googletest.cc \
+      --replace-fail 'tmpnam(b)' '"'$TMPDIR'/foo"'
+  '';
 
   preHook = ''
     export build_protobuf=${
@@ -102,14 +102,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeDir = if lib.versionOlder version "22" then "../cmake" else null;
   cmakeFlags = [
-    "-Dprotobuf_USE_EXTERNAL_GTEST=ON"
-    "-Dprotobuf_ABSL_PROVIDER=package"
+    (lib.cmakeBool "protobuf_USE_EXTERNAL_GTEST" true)
+    (lib.cmakeFeature "protobuf_ABSL_PROVIDER" "package")
+    (lib.cmakeBool "protobuf_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ]
   ++ lib.optionals enableShared [
-    "-Dprotobuf_BUILD_SHARED_LIBS=ON"
-  ]
-  ++ lib.optionals (!finalAttrs.finalPackage.doCheck) [
-    "-Dprotobuf_BUILD_TESTS=OFF"
+    (lib.cmakeBool "protobuf_BUILD_SHARED_LIBS" true)
   ];
 
   doCheck =
@@ -122,7 +120,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgram = [ "${placeholder "out"}/bin/protoc" ];
   doInstallCheck = true;
 
   env = lib.optionalAttrs (lib.versions.major version == "29") {

--- a/pkgs/development/python-modules/protobuf/7.nix
+++ b/pkgs/development/python-modules/protobuf/7.nix
@@ -1,0 +1,58 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  python,
+  setuptools,
+  protobuf,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "protobuf";
+  version = "7.34.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-OHGj32fHEKr3u40hTMmXNC5jzuvZQMjH/GXJs9aXWRo=";
+  };
+
+  build-system = [ setuptools ];
+
+  propagatedNativeBuildInputs = [
+    protobuf
+  ];
+
+  doCheck =
+    # https://protobuf.dev/support/cross-version-runtime-guarantee/#backwards
+    # The non-python protobuf provides the protoc binary which must not be newer.
+    assert lib.versionAtLeast finalAttrs.version ("7." + protobuf.version);
+    # the pypi source archive does not ship tests
+    false;
+
+  pythonImportsCheck = [
+    "google.protobuf"
+    "google.protobuf.compiler"
+    "google.protobuf.internal"
+    "google.protobuf.pyext"
+    "google.protobuf.testdata"
+    "google.protobuf.util"
+    "google._upb._message"
+  ];
+
+  # Tries to explicitly create a namespace package with pkg_resources,
+  # which breaks everything with our PYTHONPATH setup.
+  postInstall = ''
+    rm $out/${python.sitePackages}/google/__init__.py
+  '';
+
+  meta = {
+    description = "Protocol Buffers are Google's data interchange format";
+    homepage = "https://developers.google.com/protocol-buffers/";
+    changelog = "https://github.com/protocolbuffers/protobuf/releases/v${
+      builtins.substring 2 (-1) finalAttrs.version
+    }";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7296,6 +7296,7 @@ with pkgs;
 
   inherit
     ({
+      protobuf_34 = callPackage ../development/libraries/protobuf/34.nix { };
       protobuf_33 = callPackage ../development/libraries/protobuf/33.nix { };
       protobuf_32 = callPackage ../development/libraries/protobuf/32.nix { };
       protobuf_31 = callPackage ../development/libraries/protobuf/31.nix { };
@@ -7313,6 +7314,7 @@ with pkgs;
         abseil-cpp = abseil-cpp_202103;
       };
     })
+    protobuf_34
     protobuf_33
     protobuf_32
     protobuf_31

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7292,7 +7292,7 @@ with pkgs;
 
   # this version should align with the static protobuf version linked into python3.pkgs.tensorflow
   # $ nix-shell -I nixpkgs=$(git rev-parse --show-toplevel) -p python3.pkgs.tensorflow --run "python3 -c 'import google.protobuf; print(google.protobuf.__version__)'"
-  protobuf = protobuf_33;
+  protobuf = protobuf_34;
 
   inherit
     ({

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12813,6 +12813,11 @@ self: super: with self; {
     inherit (pkgs.__splicedPackages) protobuf;
   };
 
+  # Protobuf 7.x
+  protobuf7 = callPackage ../development/python-modules/protobuf/7.nix {
+    inherit (pkgs.__splicedPackages) protobuf;
+  };
+
   protoletariat = callPackage ../development/python-modules/protoletariat { };
 
   proton-client = callPackage ../development/python-modules/proton-client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12794,7 +12794,7 @@ self: super: with self; {
   proto-plus = callPackage ../development/python-modules/proto-plus { };
 
   # If a protobuf upgrade causes many Python packages to fail, please pin it here to the previous version.
-  protobuf = protobuf6;
+  protobuf = protobuf7;
 
   protobuf3-to-dict = callPackage ../development/python-modules/protobuf3-to-dict { };
 


### PR DESCRIPTION
## Things done

- **protobuf: cleanup**
- **protobuf_34: init at 34.0**
- **protobuf: 33.5 -> 34.0**

Diff: https://github.com/protocolbuffers/protobuf/compare/v33.5...v34.0
Changelog: https://github.com/protocolbuffers/protobuf/releases/tag/v34.0

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
