### PR TITLE
matugen: 3.1.0 -> 4.0.0

### DIFF
--- a/pkgs/by-name/ma/matugen/package.nix
+++ b/pkgs/by-name/ma/matugen/package.nix
@@ -6,22 +6,22 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matugen";
-  version = "3.1.0";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "InioX";
     repo = "matugen";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TD9XyqFdLIOLRZM7ozQ8gz4PyEQbLGLxB4MbzjLccg4=";
+    hash = "sha256-2jcqAU8QutF8AE15LYwd8cy7KjayGxUGHxvWnqAiS5M=";
   };
 
-  cargoHash = "sha256-OdJxr01wHqPHgEGIVrLcUv5h1JaYrY1zW9NrYO114OM=";
+  cargoHash = "sha256-RlzY0eaYrEVkO7ozzgfLHxKB2jy4nSYda9Z0jrqiUVA=";
 
   meta = {
     description = "Material you color generation tool";
     homepage = "https://github.com/InioX/matugen";
     changelog = "https://github.com/InioX/matugen/blob/${finalAttrs.src.rev}/CHANGELOG.md";
-    license = lib.licenses.gpl2Only;
+    license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ lampros ];
     mainProgram = "matugen";
   };


### PR DESCRIPTION
Updates matugen to 4.0.0 and updates the license to match upstream as requested in [review comment](https://github.com/NixOS/nixpkgs/pull/490092#discussion_r2806072989)

meta.description for matugen is: Material you color generation tool

meta.homepage for matugen is: https://github.com/InioX/matugen

meta.changelog for matugen is: https://github.com/InioX/matugen/blob/refs/tags/v4.0.0/CHANGELOG.md

meta.license changed to: lib.licenses.gpl2Plus

Closes #490092

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
