### PR TITLE
fluvio: init at 0.18.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2025,6 +2025,12 @@
     name = "Austin Lund";
     keys = [ { fingerprint = "7083 E268 4BFD 845F 2B84  9E74 B695 8918 ED23 32CE"; } ];
   };
+  aporro = {
+    email = "git@aporro.dev";
+    github = "aporro1";
+    githubId = 124402746;
+    name = "Apollon Tsikas";
+  };
   appleboblin = {
     email = "github@appleboblin.com";
     github = "appleboblin";

--- a/pkgs/by-name/fl/fluvio/package.nix
+++ b/pkgs/by-name/fl/fluvio/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  perl,
+  kubernetes-helm,
+  gitMinimal,
+  installShellFiles,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fluvio-cli";
+  version = "0.18.1";
+
+  src = fetchFromGitHub {
+    owner = "fluvio-community";
+    repo = "fluvio";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7kGMOAzBGrMOMj4Fyvy9xVwTGEkee5W7JAldbyTV298=";
+  };
+
+  cargoHash = "sha256-OAw/nftF63WyE3E+zaVCYYXh37p6HB0ib7WModfXKBA=";
+
+  nativeBuildInputs = [
+    # Necessary because of a hard dependency to the openssl-src rust crate
+    perl
+    kubernetes-helm
+    installShellFiles
+    # Needed by build.rs scripts
+    gitMinimal
+  ];
+
+  cargoBuildFlags = [
+    "-p"
+    "fluvio-cli"
+    "-p"
+    "fluvio-run"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "fluvio-cli"
+    "-p"
+    "fluvio-run"
+  ];
+
+  # Patch to make cargoAuditable work
+  postPatch = ''
+    substituteInPlace crates/fluvio-cli-common/Cargo.toml \
+      --replace-fail '"dep:fluvio-sc-schema"' '"fluvio-sc-schema"'
+  '';
+
+  # asset generation
+  preBuild = ''
+    make -C k8-util/helm package
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd fluvio \
+      --bash <($out/bin/fluvio completions bash) \
+      --fish <($out/bin/fluvio completions fish) \
+      --zsh <($out/bin/fluvio completions zsh)
+  '';
+
+  meta = {
+    description = "Event stream processing for developers";
+    homepage = "https://fluvio.io/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ aporro ];
+    mainProgram = "fluvio";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
added the fluvio package, fluvio is a kafka alternative written in rust with the added feature of allowing you to create wasm modules to manipulate data in stream https://github.com/fluvio-community/fluvio

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
