### PR TITLE
insync: 3.9.6.60027 -> 3.9.8.60034

### DIFF
--- a/pkgs/by-name/in/insync/package.nix
+++ b/pkgs/by-name/in/insync/package.nix
@@ -13,15 +13,14 @@
   xkeyboard_config,
   libthai,
   libsForQt5,
-  xz,
 }:
 
 let
   pname = "insync";
   # Find a binary from https://www.insynchq.com/downloads/linux
-  version = "3.9.6.60027";
-  web-archive-id = "20250502161201"; # upload via https://web.archive.org/save/
-  debian-dist = "trixie_amd64";
+  version = "3.9.8.60034";
+  web-archive-id = "20260301163242"; # upload via https://web.archive.org/save/
+  debian-dist = "forky_amd64";
   insync-pkg = stdenvNoCC.mkDerivation {
     pname = "${pname}-pkg";
     inherit version;
@@ -31,7 +30,7 @@ let
         "https://cdn.insynchq.com/builds/linux/${version}/insync_${version}-${debian-dist}.deb"
         "https://web.archive.org/web/${web-archive-id}/${builtins.elemAt urls 0}"
       ];
-      hash = "sha256-q1s4hFQTXjS9VmA6XETpsvEEES79b84y8zCZwpy3gKo=";
+      hash = "sha256-EeTp49so038/bEJ9P1ubPiSj7dKhGHtHmkV0ExMCmj0=";
     };
 
     nativeBuildInputs = [
@@ -46,7 +45,6 @@ let
       lz4
       libgcrypt
       libthai
-      xz
     ]
     ++ (with libsForQt5; [ qt5.qtvirtualkeyboard ]);
 
@@ -86,9 +84,6 @@ buildFHSEnv {
   runScript = writeShellScript "insync-wrapper.sh" ''
     # xkb configuration needed: https://github.com/NixOS/nixpkgs/issues/236365
     export XKB_CONFIG_ROOT=${xkeyboard_config}/share/X11/xkb/
-
-    # When using Ubuntu deb package, this might be needed for showing system tray icon.
-    # export XDG_CURRENT_DESKTOP=Unity
 
     # For debugging:
     # export QT_DEBUG_PLUGINS=1


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
