### PR TITLE
openshadinglanguage: move override to package.nix

### DIFF
--- a/pkgs/by-name/op/openshadinglanguage/package.nix
+++ b/pkgs/by-name/op/openshadinglanguage/package.nix
@@ -1,14 +1,12 @@
 {
   bison,
   boost,
-  clang,
   cmake,
   fetchFromGitHub,
   flex,
   lib,
-  libclang,
   libxml2,
-  llvm,
+  llvmPackages_19,
   openexr,
   openimageio,
   partio,
@@ -22,6 +20,7 @@
 
 let
   boost_static = boost.override { enableStatic = true; };
+  inherit (llvmPackages_19) clang libclang llvm;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openshadinglanguage";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3160,12 +3160,6 @@ with pkgs;
 
   update-systemd-resolved = callPackage ../tools/networking/openvpn/update-systemd-resolved.nix { };
 
-  openshadinglanguage = callPackage ../by-name/op/openshadinglanguage/package.nix {
-    libclang = llvmPackages_19.libclang;
-    clang = clang_19;
-    llvm = llvm_19;
-  };
-
   opentelemetry-collector = opentelemetry-collector-releases.otelcol;
   opentelemetry-collector-builder = callPackage ../tools/misc/opentelemetry-collector/builder.nix { };
   opentelemetry-collector-contrib = opentelemetry-collector-releases.otelcol-contrib;


### PR DESCRIPTION
This is a step towards #483820, which will help enable checking for additional by-name directories (e.g. Python) in nixpkgs-vet.

For more information, please see https://redirect.github.com/NixOS/nixpkgs/pull/483859#issuecomment-3799768711.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
