### PR TITLE
uasm: set NIX_CFLAGS_COMPILE correctly

### DIFF
--- a/pkgs/by-name/ua/uasm/package.nix
+++ b/pkgs/by-name/ua/uasm/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
       "Makefile-Linux-GCC-64.mak";
 
   # Needed for compiling with GCC > 13
-  env.NIX_CFLAGS_COMPILE = lib.escapeShellArgs [
+  env.NIX_CFLAGS_COMPILE = toString [
     "-std=c99"
     "-Wno-incompatible-pointer-types"
     "-Wno-int-conversion"


### PR DESCRIPTION
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `c6a8df061ac36dc7485e8b9af8119f7373633d40`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>_7zip-zstd-rar</li>
    <li>_7zip-zstd-rar.doc</li>
    <li>_7zz-rar</li>
    <li>_7zz-rar.doc</li>
    <li>uasm</li>
    <li>uasm.doc</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test