### PR TITLE
maintainers: drop Hodapp87

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10689,12 +10689,6 @@
     githubId = 1903556;
     keys = [ { fingerprint = "F1C5 760E 45B9 9A44 72E9  6BFB D65C 9AFB 4C22 4DA3"; } ];
   };
-  hodapp = {
-    email = "hodapp87@gmail.com";
-    github = "Hodapp87";
-    githubId = 896431;
-    name = "Chris Hodapp";
-  };
   hogcycle = {
     email = "nate@gysli.ng";
     github = "hogcycle";

--- a/pkgs/by-name/au/autotrace/package.nix
+++ b/pkgs/by-name/au/autotrace/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/autotrace/autotrace";
     description = "Utility for converting bitmap into vector graphics";
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ hodapp ];
+    maintainers = [ ];
     license = lib.licenses.gpl2;
     mainProgram = "autotrace";
   };

--- a/pkgs/by-name/em/embree/package.nix
+++ b/pkgs/by-name/em/embree/package.nix
@@ -61,9 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "High performance ray tracing kernels from Intel";
     homepage = "https://embree.github.io/";
-    maintainers = with lib.maintainers; [
-      hodapp
-    ];
+    maintainers = [ ];
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/gl/glslviewer/package.nix
+++ b/pkgs/by-name/gl/glslviewer/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Live GLSL coding renderer";
     homepage = "https://patriciogonzalezvivo.com/2015/glslViewer/";
     license = lib.licenses.bsd3;
-    maintainers = [ lib.maintainers.hodapp ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "glslViewer";
     # never built on aarch64-darwin since first introduction in nixpkgs

--- a/pkgs/by-name/li/libfive/package.nix
+++ b/pkgs/by-name/li/libfive/package.nix
@@ -115,7 +115,6 @@ stdenv.mkDerivation {
     description = "Infrastructure for solid modeling with F-Reps in C, C++, and Guile";
     homepage = "https://libfive.com/";
     maintainers = with lib.maintainers; [
-      hodapp
       kovirobi
       wulfsta
     ];

--- a/pkgs/by-name/li/libyafaray/package.nix
+++ b/pkgs/by-name/li/libyafaray/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
     description = "Free, open source raytracer";
     downloadPage = "https://github.com/YafaRay/libYafaRay";
     homepage = "http://www.yafaray.org";
-    maintainers = with lib.maintainers; [ hodapp ];
+    maintainers = [ ];
     license = lib.licenses.lgpl21;
     platforms = [
       "aarch64-linux"

--- a/pkgs/by-name/op/openshadinglanguage/package.nix
+++ b/pkgs/by-name/op/openshadinglanguage/package.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Advanced shading language for production GI renderers";
     homepage = "http://openshadinglanguage.org";
-    maintainers = with lib.maintainers; [ hodapp ];
+    maintainers = [ ];
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -100,7 +100,7 @@ buildPythonPackage rec {
     homepage = "https://ezdxf.mozman.at/";
     changelog = "https://github.com/mozman/ezdxf/blob/${src.rev}/notes/pages/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ hodapp ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Inactive since 2020.
Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/tree/a7808b41c3cfd040fbe03e12a68654db3c02d5bc/maintainers#losing-maintainer-status).

@Hodapp87 if you'd like to stay involved, please respond within a week. Even if you don't do so, you are welcome back at any time.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
