### PR TITLE
tests.writers: replace semver with katex in writeJS* tests

### DIFF
--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -3,7 +3,7 @@
   lib,
   guile-lib,
   akkuPackages,
-  nodePackages,
+  katex,
   perlPackages,
   python3Packages,
   runCommand,
@@ -148,13 +148,14 @@ recurseIntoAttrs {
     );
 
     js = expectSuccessBin (
-      writeJSBin "test-writers-js-bin" { libraries = [ nodePackages.semver ]; } ''
-        var semver = require('semver');
+      writeJSBin "test-writers-js-bin" { libraries = [ katex ]; } ''
+        var katex = require('katex');
 
-        if (semver.valid('1.2.3')) {
-          console.log('success')
+        var html = katex.renderToString("c = \\pm\\sqrt{a^2 + b^2}");
+        if (html instanceof katex.ParseError) {
+          console.log("fail")
         } else {
-          console.log('fail')
+          console.log("success")
         }
       ''
     );
@@ -319,13 +320,14 @@ recurseIntoAttrs {
     );
 
     js = expectSuccess (
-      writeJS "test-writers-js" { libraries = [ nodePackages.semver ]; } ''
-        var semver = require('semver');
+      writeJS "test-writers-js" { libraries = [ katex ]; } ''
+        var katex = require('katex');
 
-        if (semver.valid('1.2.3')) {
-          console.log('success')
+        var html = katex.renderToString("c = \\pm\\sqrt{a^2 + b^2}");
+        if (html instanceof katex.ParseError) {
+          console.log("fail")
         } else {
-          console.log('fail')
+          console.log("success")
         }
       ''
     );


### PR DESCRIPTION
Part of #489959

Note the new code is slightly more complex just to deal with weird katex API stuff, but it is the same functionally as the previous test. print `success` when nothing goes wrong, print `fail` on any error.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
