### PR TITLE
openrct2: 0.4.31 -> 0.4.32, add assets fetch functionality

### DIFF
--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchurl,
   unzip,
+  nix-update-script,
 
   SDL2,
   cmake,
@@ -30,46 +31,36 @@
   pkg-config,
   speexdsp,
   zlib,
+
   withDiscordRpc ? false,
 }:
 
 let
-  openrct2-version = "0.4.31";
-
-  # Those versions MUST match the pinned versions within the CMakeLists.txt
-  # file. The REPLAYS repository from the CMakeLists.txt is not necessary.
-  objects-version = "1.7.6";
-  openmsx-version = "1.6.1";
-  opensfx-version = "1.0.6";
-  title-sequences-version = "0.4.26";
-
-  objects = fetchurl {
-    url = "https://github.com/OpenRCT2/objects/releases/download/v${objects-version}/objects.zip";
-    hash = "sha256-asoutEH76MAi/4TVn7Ue1+pXd1ZkCXDcmJ6raF/0VpY=";
-  };
-  openmsx = fetchurl {
-    url = "https://github.com/OpenRCT2/OpenMusic/releases/download/v${openmsx-version}/openmusic.zip";
-    hash = "sha256-mUs1DTsYDuHLlhn+J/frrjoaUjKEDEvUeonzP6id4aE=";
-  };
-  opensfx = fetchurl {
-    url = "https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v${opensfx-version}/opensound.zip";
-    hash = "sha256-BrkPPhnCFnUt9EHVUbJqnj4bp3Vb3SECUEtzv5k2CL4=";
-  };
-  title-sequences = fetchurl {
-    url = "https://github.com/OpenRCT2/title-sequences/releases/download/v${title-sequences-version}/title-sequences.zip";
-    hash = "sha256-2ruXh7FXY0L8pN2fZLP4z6BKfmzpwruWEPR7dikFyFg=";
-  };
-in
-stdenv.mkDerivation (finalAttrs: {
   pname = "openrct2";
-  version = openrct2-version;
+  version = "0.4.32";
 
   src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "OpenRCT2";
-    tag = "v${openrct2-version}";
-    hash = "sha256-jXcB2lwf/2O+TMSakp32it6T8Fg0e5QFcbMU89WoMjU=";
+    tag = "v${version}";
+    hash = "sha256-V5DF7kaxzT2OvTgP8oUPr3y2BCFRo/RkIRqxvTdMsJY=";
   };
+
+  assetsMeta = builtins.fromJSON (builtins.readFile "${src}/assets.json");
+  fetchAsset =
+    asset:
+    fetchurl {
+      url = assetsMeta.${asset}.url;
+      sha256 = assetsMeta.${asset}.sha256;
+    };
+
+  objects = fetchAsset "objects";
+  openmusic = fetchAsset "openmusic";
+  opensfx = fetchAsset "opensfx";
+  title-sequences = fetchAsset "title-sequences";
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname version src;
 
   nativeBuildInputs = [
     cmake
@@ -114,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
   postUnpack = ''
     mkdir -p $sourceRoot/data/{object,sequence}
     unzip -o ${objects} -d $sourceRoot/data/object
-    unzip -o ${openmsx} -d $sourceRoot/data
+    unzip -o ${openmusic} -d $sourceRoot/data
     unzip -o ${opensfx} -d $sourceRoot/data
     unzip -o ${title-sequences} -d $sourceRoot/data/sequence
   '';
@@ -125,20 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "/usr/share/doc/openrct2" "$out/share/doc/openrct2"
   '';
 
-  preConfigure =
-    # Verify that the correct version of each third party repository is used.
-    (
-      let
-        versionCheck = cmakeKey: version: ''
-          grep -q '^set(${cmakeKey}_VERSION "${version}")$' CMakeLists.txt \
-            || (echo "${cmakeKey} differs from expected version!"; exit 1)
-        '';
-      in
-      (versionCheck "OBJECTS" objects-version)
-      + (versionCheck "OPENMSX" openmsx-version)
-      + (versionCheck "OPENSFX" opensfx-version)
-      + (versionCheck "TITLE_SEQUENCE" title-sequences-version)
-    );
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Open source re-implementation of RollerCoaster Tycoon 2 (original game required)";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Bumps to latest version
- Removes now unnecessary asset checks. See: https://github.com/OpenRCT2/OpenRCT2/pull/25968

Changelog: https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.4.32
Diff: https://github.com/OpenRCT2/OpenRCT2/compare/v0.4.31...v0.4.32

I'm not particularly in love with how I've implemented it here, but it does work. It allows for us to easily use nix-update now, so no need for manual updates anymore! Any suggestions on how to do this better would be greatly appreciated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
