### PR TITLE
fetchFromRadicle: simplify

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -920,14 +920,13 @@ respectively. Otherwise, the fetcher uses `fetchzip`.
 
 This is used with Radicle repositories. The arguments expected are similar to `fetchgit`.
 
-Requires a `seed` argument (e.g. `seed.radicle.xyz` or `rosa.radicle.xyz`) and a `repo` argument
-(the repository id *without* the `rad:` prefix). Also accepts an optional `node` argument which
-contains the id of the node from which to fetch the specified ref. If `node` is `null` (the
-default), a canonical ref is fetched instead.
+Requires a `repo` argument (the repository id *without* the `rad:` prefix) and accepts an optional `seed` argument
+(e.g. `seed.radicle.xyz`, `iris.radicle.xyz` or `rosa.radicle.xyz`; defaults to `seed.radicle.xyz`).
+Also accepts an optional `node` argument which contains the id of the node from which to fetch the
+specified ref. If `node` is `null` (the default), a canonical ref is fetched instead.
 
 ```nix
 fetchFromRadicle {
-  seed = "seed.radicle.xyz";
   repo = "z3gqcJUoA1n9HaHKufZs5FCSGazv5"; # heartwood
   tag = "releases/1.3.0";
   hash = "sha256-4o88BWKGGOjCIQy7anvzbA/kPOO+ZsLMzXJhE61odjw=";
@@ -942,7 +941,6 @@ contains the full revision id of the Radicle patch to fetch.
 
 ```nix
 fetchRadiclePatch {
-  seed = "rosa.radicle.xyz";
   repo = "z4V1sjrXqjvFdnCUbxPFqd5p4DtH5"; # radicle-explorer
   revision = "d97d872386c70607beda2fb3fc2e60449e0f4ce4"; # patch: d77e064
   hash = "sha256-ttnNqj0lhlSP6BGzEhhUOejKkkPruM9yMwA5p9Di4bk=";

--- a/pkgs/build-support/fetchradicle/default.nix
+++ b/pkgs/build-support/fetchradicle/default.nix
@@ -2,7 +2,7 @@
 
 lib.makeOverridable (
   {
-    seed,
+    seed ? "seed.radicle.xyz",
     repo,
     node ? null,
     rev ? null,

--- a/pkgs/build-support/fetchradicle/default.nix
+++ b/pkgs/build-support/fetchradicle/default.nix
@@ -3,6 +3,7 @@
 lib.makeOverridable (
   {
     seed ? "seed.radicle.xyz",
+    explorer ? "app.radicle.xyz",
     repo,
     node ? null,
     rev ? null,
@@ -17,6 +18,7 @@ lib.makeOverridable (
   let
     namespacePrefix = lib.optionalString (node != null) "refs/namespaces/${node}/";
     rev' = if tag != null then "refs/tags/${tag}" else rev;
+    homeUrl = "https://${explorer}/nodes/${seed}/rad:${repo}";
   in
 
   fetchgit (
@@ -26,6 +28,7 @@ lib.makeOverridable (
     }
     // removeAttrs args [
       "seed"
+      "explorer"
       "repo"
       "node"
       "rev"
@@ -35,10 +38,12 @@ lib.makeOverridable (
   // {
     inherit
       seed
+      explorer
       repo
       node
       rev
       tag
+      homeUrl
       ;
   }
 )

--- a/pkgs/by-name/ra/radicle-ci-broker/package.nix
+++ b/pkgs/by-name/ra/radicle-ci-broker/package.nix
@@ -17,7 +17,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.25.0";
 
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
     repo = "zwTxygwuz5LDGBq255RA2CbNGrz8";
     node = "z6MkgEMYod7Hxfy9qCvDv5hYHkZ4ciWmLFgfvm3Wn1b2w2FV";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/ra/radicle-ci-broker/package.nix
+++ b/pkgs/by-name/ra/radicle-ci-broker/package.nix
@@ -65,8 +65,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Radicle CI broker";
-    homepage = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:zwTxygwuz5LDGBq255RA2CbNGrz8";
-    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:zwTxygwuz5LDGBq255RA2CbNGrz8/tree/NEWS.md";
+    homepage = finalAttrs.src.homeUrl;
+    changelog = "${finalAttrs.src.homeUrl}/tree/NEWS.md";
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/by-name/ra/radicle-desktop/package.nix
+++ b/pkgs/by-name/ra/radicle-desktop/package.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.8.0";
 
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
     repo = "z4D5UCArafTzTQpDZNQRuqswh3ury";
     rev = "aeb405aaf53b56a426ab8d68c7f89b8953683224";
     hash = "sha256-Z/6GdXf3ag/89H8UMD2GNU4CXA8TWyX8dl8uh0CTem8=";

--- a/pkgs/by-name/ra/radicle-desktop/package.nix
+++ b/pkgs/by-name/ra/radicle-desktop/package.nix
@@ -120,8 +120,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Radicle desktop app";
-    homepage = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z4D5UCArafTzTQpDZNQRuqswh3ury";
-    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z4D5UCArafTzTQpDZNQRuqswh3ury/tree/CHANGELOG.md";
+    homepage = finalAttrs.src.homeUrl;
+    changelog = "${finalAttrs.src.homeUrl}/tree/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/ra/radicle-httpd/package.nix
+++ b/pkgs/by-name/ra/radicle-httpd/package.nix
@@ -21,7 +21,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # You must update the radicle-explorer source hash when changing this.
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
     repo = "z4V1sjrXqjvFdnCUbxPFqd5p4DtH5";
     tag = "releases/${finalAttrs.version}";
     sparseCheckout = [ "radicle-httpd" ];

--- a/pkgs/by-name/ra/radicle-httpd/package.nix
+++ b/pkgs/by-name/ra/radicle-httpd/package.nix
@@ -77,7 +77,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       repositories on a Radicle node via their web browser.
     '';
     homepage = "https://radicle.xyz";
-    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z4V1sjrXqjvFdnCUbxPFqd5p4DtH5/tree/radicle-httpd/CHANGELOG.md";
+    changelog = "${finalAttrs.src.homeUrl}/tree/radicle-httpd/CHANGELOG.md";
     # cargo.toml says MIT and asl20, LICENSE file says GPL3
     license = with lib.licenses; [
       gpl3Only

--- a/pkgs/by-name/ra/radicle-job/package.nix
+++ b/pkgs/by-name/ra/radicle-job/package.nix
@@ -12,7 +12,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.4.0";
 
   src = fetchFromRadicle {
-    seed = "iris.radicle.xyz";
     repo = "z2UcCU1LgMshWvXj6hXSDDrwB8q8M";
     tag = "releases/v${finalAttrs.version}";
     hash = "sha256-EGNs0IOJSp5SMJ3tdGCxIAN6hvVFwWWUmXoB914jw3k=";

--- a/pkgs/by-name/ra/radicle-job/package.nix
+++ b/pkgs/by-name/ra/radicle-job/package.nix
@@ -31,8 +31,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Create, update, and query Radicle Job Collaborative Objects";
-    homepage = "https://app.radicle.xyz/nodes/iris.radicle.xyz/rad:z2UcCU1LgMshWvXj6hXSDDrwB8q8M";
-    changelog = "https://app.radicle.xyz/nodes/iris.radicle.xyz/rad:z2UcCU1LgMshWvXj6hXSDDrwB8q8M/tree/CHANGELOG.md";
+    homepage = finalAttrs.src.homeUrl;
+    changelog = "${finalAttrs.src.homeUrl}/tree/CHANGELOG.md";
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/by-name/ra/radicle-native-ci/package.nix
+++ b/pkgs/by-name/ra/radicle-native-ci/package.nix
@@ -13,7 +13,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.12.0";
 
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
     repo = "z3qg5TKmN83afz2fj9z3fQjU8vaYE";
     node = "z6MkgEMYod7Hxfy9qCvDv5hYHkZ4ciWmLFgfvm3Wn1b2w2FV";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/ra/radicle-native-ci/package.nix
+++ b/pkgs/by-name/ra/radicle-native-ci/package.nix
@@ -39,8 +39,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Radicle CI adapter for native CI";
-    homepage = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE";
-    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE/tree/NEWS.md";
+    homepage = finalAttrs.src.homeUrl;
+    changelog = "${finalAttrs.src.homeUrl}/tree/NEWS.md";
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/by-name/ra/radicle-node/package.nix
+++ b/pkgs/by-name/ra/radicle-node/package.nix
@@ -27,7 +27,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "radicle-node";
 
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
     repo = "z3gqcJUoA1n9HaHKufZs5FCSGazv5";
     tag = "releases/${finalAttrs.version}";
     hash = srcHash;

--- a/pkgs/by-name/ra/radicle-tui/package.nix
+++ b/pkgs/by-name/ra/radicle-tui/package.nix
@@ -14,7 +14,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.6.0";
 
   src = fetchFromRadicle {
-    seed = "seed.radicle.xyz";
     repo = "z39mP9rQAaGmERfUMPULfPUi473tY";
     node = "z6MkswQE8gwZw924amKatxnNCXA55BMupMmRg7LvJuim2C1V";
     tag = finalAttrs.version;

--- a/pkgs/by-name/ra/radicle-tui/package.nix
+++ b/pkgs/by-name/ra/radicle-tui/package.nix
@@ -95,8 +95,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Radicle terminal user interface";
-    homepage = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z39mP9rQAaGmERfUMPULfPUi473tY";
-    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z39mP9rQAaGmERfUMPULfPUi473tY/tree/CHANGELOG.md";
+    homepage = finalAttrs.src.homeUrl;
+    changelog = "${finalAttrs.src.homeUrl}/tree/CHANGELOG.md";
     license = with lib.licenses; [
       asl20 # or
       mit

--- a/pkgs/by-name/se/selfci/package.nix
+++ b/pkgs/by-name/se/selfci/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchgit,
+  fetchFromRadicle,
   nix-update-script,
   rustPlatform,
   git,
@@ -11,8 +11,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "selfci";
   version = "0-unstable-2026-01-17";
 
-  src = fetchgit {
-    url = "https://radicle.dpc.pw/z2tDzYbAXxTQEKTGFVwiJPajkbeDU.git";
+  src = fetchFromRadicle {
+    seed = "radicle.dpc.pw";
+    repo = "z2tDzYbAXxTQEKTGFVwiJPajkbeDU";
     rev = "83e693dada851ce0da32713869d3da02c52ed257";
     hash = "sha256-f0BfHvIQnhhiPie3a+9MeEGzZ+/KcgrbKBneu8Jo+xs=";
   };
@@ -38,7 +39,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Minimalistic local-first Unix-philosophy-abiding CI";
-    homepage = "https://app.radicle.xyz/nodes/radicle.dpc.pw/rad%3Az2tDzYbAXxTQEKTGFVwiJPajkbeDU";
+    homepage = finalAttrs.src.homeUrl;
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
       dvn0


### PR DESCRIPTION
- harmless refactor to simplify `fetchFromRadicle` usage across nixpkgs
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
