### PR TITLE
maintainers: remove pawelchcki

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20591,12 +20591,6 @@
     name = "Michael Bergmeister";
     githubId = 53442728;
   };
-  pawelchcki = {
-    email = "pawel.chcki@gmail.com";
-    github = "pawelchcki";
-    githubId = 812891;
-    name = "Paweł Chojnacki";
-  };
   pawelpacana = {
     email = "pawel.pacana@gmail.com";
     github = "mostlyobvious";

--- a/pkgs/by-name/cp/cpuinfo/package.nix
+++ b/pkgs/by-name/cp/cpuinfo/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/pytorch/cpuinfo";
     license = lib.licenses.bsd2;
     mainProgram = "cpu-info";
-    maintainers = with lib.maintainers; [ pawelchcki ];
+    maintainers = [ ];
     pkgConfigModules = [ "libcpuinfo" ];
     # https://github.com/pytorch/cpuinfo/blob/7364b490b5f78d58efe23ea76e74210fd6c3c76f/CMakeLists.txt#L98
     platforms = lib.platforms.x86 ++ lib.platforms.aarch ++ lib.platforms.riscv;


### PR DESCRIPTION
## Reasons

- Last commented in [August 2025](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Apawelchcki)
- Hasn't created any PRs / Issues since [July 2024](https://github.com/NixOS/nixpkgs/issues?q=author%3Apawelchcki)
- About 9 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Apawelchcki%20-commenter%3Apawelchcki%20-author%3Apawelchcki%20-reviewed-by%3Apawelchcki%20created%3A%3E%40today-1y) PRs / Issues

See [lossing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.