### PR TITLE
[Backport release-25.11] maintainers: drop Hodapp87

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10587,12 +10587,6 @@
     githubId = 1903556;
     keys = [ { fingerprint = "F1C5 760E 45B9 9A44 72E9  6BFB D65C 9AFB 4C22 4DA3"; } ];
   };
-  hodapp = {
-    email = "hodapp87@gmail.com";
-    github = "Hodapp87";
-    githubId = 896431;
-    name = "Chris Hodapp";
-  };
   hogcycle = {
     email = "nate@gysli.ng";
     github = "hogcycle";

--- a/pkgs/by-name/au/autotrace/package.nix
+++ b/pkgs/by-name/au/autotrace/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/autotrace/autotrace";
     description = "Utility for converting bitmap into vector graphics";
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ hodapp ];
+    maintainers = [ ];
     license = lib.licenses.gpl2;
     mainProgram = "autotrace";
   };

--- a/pkgs/by-name/em/embree/package.nix
+++ b/pkgs/by-name/em/embree/package.nix
@@ -61,9 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "High performance ray tracing kernels from Intel";
     homepage = "https://embree.github.io/";
-    maintainers = with lib.maintainers; [
-      hodapp
-    ];
+    maintainers = [ ];
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/gl/glslviewer/package.nix
+++ b/pkgs/by-name/gl/glslviewer/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     description = "Live GLSL coding renderer";
     homepage = "https://patriciogonzalezvivo.com/2015/glslViewer/";
     license = lib.licenses.bsd3;
-    maintainers = [ lib.maintainers.hodapp ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "glslViewer";
     # never built on aarch64-darwin since first introduction in nixpkgs

--- a/pkgs/by-name/li/libyafaray/package.nix
+++ b/pkgs/by-name/li/libyafaray/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
     description = "Free, open source raytracer";
     downloadPage = "https://github.com/YafaRay/libYafaRay";
     homepage = "http://www.yafaray.org";
-    maintainers = with lib.maintainers; [ hodapp ];
+    maintainers = [ ];
     license = lib.licenses.lgpl21;
     platforms = [
       "aarch64-linux"

--- a/pkgs/development/compilers/osl/default.nix
+++ b/pkgs/development/compilers/osl/default.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Advanced shading language for production GI renderers";
     homepage = "https://opensource.imageworks.com/osl.html";
-    maintainers = with lib.maintainers; [ hodapp ];
+    maintainers = [ ];
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/libraries/libfive/default.nix
+++ b/pkgs/development/libraries/libfive/default.nix
@@ -116,7 +116,6 @@ stdenv.mkDerivation {
     description = "Infrastructure for solid modeling with F-Reps in C, C++, and Guile";
     homepage = "https://libfive.com/";
     maintainers = with lib.maintainers; [
-      hodapp
       kovirobi
       wulfsta
     ];

--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -73,7 +73,7 @@ buildPythonPackage rec {
     mainProgram = "ezdxf";
     homepage = "https://github.com/mozman/ezdxf/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ hodapp ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Backports #495562.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
