### PR TITLE
selfci: use fetchFromRadicle

### DIFF
--- a/pkgs/by-name/se/selfci/package.nix
+++ b/pkgs/by-name/se/selfci/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchgit,
+  fetchFromRadicle,
   nix-update-script,
   rustPlatform,
   git,
@@ -11,8 +11,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "selfci";
   version = "0-unstable-2026-01-17";
 
-  src = fetchgit {
-    url = "https://radicle.dpc.pw/z2tDzYbAXxTQEKTGFVwiJPajkbeDU.git";
+  src = fetchFromRadicle {
+    seed = "radicle.dpc.pw";
+    repo = "z2tDzYbAXxTQEKTGFVwiJPajkbeDU";
     rev = "83e693dada851ce0da32713869d3da02c52ed257";
     hash = "sha256-f0BfHvIQnhhiPie3a+9MeEGzZ+/KcgrbKBneu8Jo+xs=";
   };


### PR DESCRIPTION
- small refactor to use fetchFromRadicle

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
