### PR TITLE
lucky-commit: fix build on aarch64-darwin

### DIFF
--- a/pkgs/by-name/lu/lucky-commit/package.nix
+++ b/pkgs/by-name/lu/lucky-commit/package.nix
@@ -20,6 +20,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-zuWPkaYltxOOLaR6NTVkf1WbKzUQByml45jNL+e5UJ0=";
 
+  # LLVM Apple assembler rejects `:lo12:` combined with `@PAGEOFF`.
+  postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
+    substituteInPlace "$cargoDepsCopy"/sha1-asm-*/src/aarch64_apple.S \
+      --replace-fail "#:lo12:.K0@PAGEOFF" ".K0@PAGEOFF" \
+      --replace-fail "#:lo12:.K1@PAGEOFF" ".K1@PAGEOFF" \
+      --replace-fail "#:lo12:.K2@PAGEOFF" ".K2@PAGEOFF" \
+      --replace-fail "#:lo12:.K3@PAGEOFF" ".K3@PAGEOFF"
+  '';
+
   buildInputs = lib.optional (withOpenCL && (!stdenv.hostPlatform.isDarwin)) ocl-icd;
 
   buildNoDefaultFeatures = !withOpenCL;


### PR DESCRIPTION
Fix build failure https://hydra.nixos.org/build/322354159

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
