### PR TITLE
python3.pkgs.autodocsumm: mark as broken (conditionally)

### DIFF
--- a/pkgs/development/python-modules/autodocsumm/default.nix
+++ b/pkgs/development/python-modules/autodocsumm/default.nix
@@ -31,5 +31,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/Chilipp/autodocsumm";
     license = lib.licenses.asl20;
     maintainers = [ ];
+    # https://github.com/Chilipp/autodocsumm/issues/108
+    broken = lib.versionAtLeast sphinx.version "9.0";
   };
 }

--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -29,7 +29,6 @@
   buildPythonPackage,
   pythonAtLeast,
   fetchFromGitHub,
-  fetchpatch,
 
   # build-system
   poetry-core,

--- a/pkgs/development/python-modules/beets/default.nix
+++ b/pkgs/development/python-modules/beets/default.nix
@@ -52,11 +52,6 @@
 
   # native
   gobject-introspection,
-  sphinxHook,
-  sphinx-design,
-  sphinx-copybutton,
-  sphinx-toolbox,
-  pydata-sphinx-theme,
 
   # buildInputs
   gst_all_1,
@@ -161,11 +156,6 @@ buildPythonPackage (finalAttrs: {
 
   nativeBuildInputs = [
     gobject-introspection
-    sphinxHook
-    sphinx-design
-    sphinx-copybutton
-    sphinx-toolbox
-    pydata-sphinx-theme
   ]
   ++ extraNativeBuildInputs;
 
@@ -177,19 +167,7 @@ buildPythonPackage (finalAttrs: {
 
   outputs = [
     "out"
-    "doc"
-    "man"
   ];
-  sphinxBuilders = [
-    "html"
-    "man"
-  ];
-  # Causes an installManPage error. Not clear why this directory gets generated
-  # with the manpages. The same directory is observed correctly in
-  # $doc/share/doc/beets-${version}/html
-  preInstallSphinx = ''
-    rm -r .sphinx/man/man/_sphinx_design_static
-  '';
 
   postInstall = ''
     mkdir -p $out/share/zsh/site-functions

--- a/pkgs/development/python-modules/sphinx-toolbox/default.nix
+++ b/pkgs/development/python-modules/sphinx-toolbox/default.nix
@@ -19,13 +19,14 @@
   tabulate,
   python,
 }:
-buildPythonPackage rec {
+
+buildPythonPackage (finalAttrs: {
   pname = "sphinx-toolbox";
   version = "4.1.2";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "sphinx_toolbox";
     hash = "sha256-wwpPhsTCnpetsOuTN9NfUJPLlqRPScr/z31bxYqIt4E=";
   };
@@ -57,7 +58,7 @@ buildPythonPackage rec {
 
   # Not PEP420 compliant, some variables are imported from within the package.
   postFixup = ''
-    echo '__version__: str = "${version}"' > $out/${python.sitePackages}/sphinx_toolbox/__init__.py
+    echo '__version__: str = "${finalAttrs.version}"' > $out/${python.sitePackages}/sphinx_toolbox/__init__.py
   '';
 
   meta = {
@@ -66,4 +67,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/sphinx-toolbox/default.nix
+++ b/pkgs/development/python-modules/sphinx-toolbox/default.nix
@@ -11,6 +11,7 @@
   dict2css,
   filelock,
   html5lib,
+  roman,
   ruamel-yaml,
   sphinx-autodoc-typehints,
   sphinx-jinja2-compat,
@@ -48,6 +49,7 @@ buildPythonPackage (finalAttrs: {
     dict2css
     filelock
     html5lib
+    roman
     ruamel-yaml
     sphinx-autodoc-typehints
     sphinx-jinja2-compat


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test