### PR TITLE
nixos-rebuild-ng: preserve local environment in nix.copy_closure via append_local_env

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -718,11 +718,11 @@ def _run_action_with_systemd(
 
     try:
         _run_action(
-            action,
-            path_to_config,
-            install_bootloader,
-            target_host,
-            sudo,
+            action=action,
+            path_to_config=path_to_config,
+            install_bootloader=install_bootloader,
+            target_host=target_host,
+            sudo=sudo,
             prefix=[*SYSTEMD_RUN_CMD_PREFIX, f"--unit={unique_unit_name}"],
         )
     except KeyboardInterrupt:
@@ -761,11 +761,11 @@ def switch_to_configuration(
 
     if _has_systemd(target_host):
         _run_action_with_systemd(
-            action,
-            path_to_config,
-            install_bootloader,
-            target_host,
-            sudo,
+            action=action,
+            path_to_config=path_to_config,
+            install_bootloader=install_bootloader,
+            target_host=target_host,
+            sudo=sudo,
         )
     else:
         logger.debug(
@@ -773,11 +773,11 @@ def switch_to_configuration(
             "not working in target host"
         )
         _run_action(
-            action,
-            path_to_config,
-            install_bootloader,
-            target_host,
-            sudo,
+            action=action,
+            path_to_config=path_to_config,
+            install_bootloader=install_bootloader,
+            target_host=target_host,
+            sudo=sudo,
         )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -193,13 +193,7 @@ def copy_closure(
     Also supports copying a closure from a remote to another remote."""
 
     sshopts = os.getenv("NIX_SSHOPTS", "")
-    # This command is always run locally and needs to keep its own environent
-    # while merging NIX_SSHOPTS and SSH_DEFAULT_OPTS together.
-    # E.g.: to preserve SSH_AUTH_SOCK
-    env = {
-        **os.environ,
-        "NIX_SSHOPTS": " ".join(filter(lambda x: x, [sshopts, *SSH_DEFAULT_OPTS])),
-    }
+    env = {"NIX_SSHOPTS": " ".join(filter(lambda x: x, [sshopts, *SSH_DEFAULT_OPTS]))}
 
     def nix_copy_closure(host: Remote, to: bool) -> None:
         run_wrapper(
@@ -210,7 +204,7 @@ def copy_closure(
                 host.host,
                 closure,
             ],
-            env=env,
+            append_local_env=env,
         )
 
     def nix_copy(to_host: Remote, from_host: Remote) -> None:
@@ -226,7 +220,7 @@ def copy_closure(
                 f"ssh://{to_host.host}",
                 closure,
             ],
-            env=env,
+            append_local_env=env,
         )
 
     match (to_host, from_host):

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -235,6 +235,7 @@ def run_wrapper(
     *,
     check: bool = True,
     env: Mapping[str, EnvValue] | None = None,
+    append_local_env: Mapping[str, str] | None = None,
     remote: Remote | None = None,
     sudo: bool = False,
     **kwargs: Unpack[RunKwargs],
@@ -245,11 +246,16 @@ def run_wrapper(
     )
 
     logger.debug(
-        "calling run with args=%r, kwargs=%r, env=%r",
+        "calling run with args=%r, kwargs=%r, env=%r, append_local_env=%r",
         _sanitize_env_run_args(list(final_args)),
         kwargs,
         env,
+        append_local_env,
     )
+
+    if append_local_env:
+        popen_env = dict(os.environ) if popen_env is None else dict(popen_env)
+        popen_env.update(append_local_env)
 
     try:
         r = subprocess.run(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/pyproject.toml
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/pyproject.toml
@@ -13,6 +13,7 @@ nixos-rebuild = "nixos_rebuild:main"
 nixos_rebuild = ["*.nix.template"]
 
 [tool.mypy]
+files = ["nixos_rebuild", "tests"]
 # `--strict` config, but explicit options to avoid breaking build when mypy is
 # updated
 warn_unused_configs = true

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import textwrap
 import uuid
@@ -79,11 +78,6 @@ def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> 
     )
 
 
-@patch.dict(
-    os.environ,
-    {"NIX_SSHOPTS": "--ssh opts", "SSH_ASKPASS": "/run/user/1000/ssh-agent"},
-    clear=True,
-)
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 @patch("uuid.uuid4", autospec=True)
 def test_build_remote(
@@ -140,8 +134,7 @@ def test_build_remote(
                     "user@host",
                     Path("/path/to/file"),
                 ],
-                env={
-                    "SSH_ASKPASS": "/run/user/1000/ssh-agent",
+                append_local_env={
                     "NIX_SSHOPTS": " ".join(["--ssh opts", *p.SSH_DEFAULT_OPTS]),
                 },
             ),
@@ -172,11 +165,6 @@ def test_build_remote(
     )
 
 
-@patch.dict(
-    os.environ,
-    {"NIX_SSHOPTS": "--ssh opts", "SSH_ASKPASS": "/run/user/1000/ssh-agent"},
-    clear=True,
-)
 @patch(
     get_qualified_name(n.run_wrapper, n),
     autospec=True,
@@ -190,6 +178,7 @@ def test_build_remote_flake(
     monkeypatch.chdir(tmpdir)
     flake = m.Flake.parse("/flake.nix#hostname")
     build_host = m.Remote("user@host", [], None)
+    monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
 
     assert n.build_remote_flake(
         "config.system.build.toplevel",
@@ -221,8 +210,7 @@ def test_build_remote_flake(
                     "user@host",
                     Path("/path/to/file"),
                 ],
-                env={
-                    "SSH_ASKPASS": "/run/user/1000/ssh-agent",
+                append_local_env={
                     "NIX_SSHOPTS": " ".join(["--ssh opts", *p.SSH_DEFAULT_OPTS]),
                 },
             ),
@@ -243,7 +231,6 @@ def test_build_remote_flake(
     )
 
 
-@patch.dict(os.environ, {}, clear=True)
 def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
     closure = Path("/path/to/closure")
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
@@ -256,7 +243,7 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
         n.copy_closure(closure, target_host)
         mock_run.assert_called_with(
             ["nix-copy-closure", "--to", "user@target.host", closure],
-            env={"NIX_SSHOPTS": " ".join(p.SSH_DEFAULT_OPTS)},
+            append_local_env={"NIX_SSHOPTS": " ".join(p.SSH_DEFAULT_OPTS)},
         )
 
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh build-opt")
@@ -264,7 +251,9 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
         n.copy_closure(closure, None, build_host, {"copy_flag": True})
         mock_run.assert_called_with(
             ["nix-copy-closure", "--copy-flag", "--from", "user@build.host", closure],
-            env={"NIX_SSHOPTS": " ".join(["--ssh build-opt", *p.SSH_DEFAULT_OPTS])},
+            append_local_env={
+                "NIX_SSHOPTS": " ".join(["--ssh build-opt", *p.SSH_DEFAULT_OPTS])
+            },
         )
 
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh build-target-opt")
@@ -284,7 +273,7 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
                 "ssh://user@target.host",
                 closure,
             ],
-            env=env,
+            append_local_env=env,
         )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -29,7 +29,7 @@ def test_remote_shell_script() -> None:
 
 @patch.dict(p.os.environ, {"PATH": "/path/to/bin"}, clear=True)
 @patch("subprocess.run", autospec=True)
-def test_run(mock_run: Any) -> None:
+def test_run_wrapper(mock_run: Any) -> None:
     p.run_wrapper(["test", "--with", "flags"], check=True)
     mock_run.assert_called_with(
         ["test", "--with", "flags"],
@@ -61,6 +61,51 @@ def test_run(mock_run: Any) -> None:
         text=True,
         errors="surrogateescape",
         env=None,
+        input=None,
+    )
+
+    p.run_wrapper(
+        ["test", "--with", "flags"],
+        check=False,
+        sudo=False,
+        append_local_env={"FOO": "bar"},
+    )
+    mock_run.assert_called_with(
+        [
+            "test",
+            "--with",
+            "flags",
+        ],
+        check=False,
+        text=True,
+        errors="surrogateescape",
+        env={
+            "FOO": "bar",
+            "PATH": "/path/to/bin",
+        },
+        input=None,
+    )
+
+    p.run_wrapper(
+        ["test", "--with", "flags"],
+        check=False,
+        sudo=False,
+        env={"PATH": "/"},
+        append_local_env={"FOO": "bar"},
+    )
+    mock_run.assert_called_with(
+        [
+            "test",
+            "--with",
+            "flags",
+        ],
+        check=False,
+        text=True,
+        errors="surrogateescape",
+        env={
+            "FOO": "bar",
+            "PATH": "/",
+        },
         input=None,
     )
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a refactor of PR https://github.com/NixOS/nixpkgs/pull/495610, that was created mostly to fix the underlying issue quickly. This one introduces the `append_local_env` parameter for `process.run_wrapper`, and this is used in `nix.copy_closure` in place of the previous injection of `os.environ` manually.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
