### PR TITLE
chronicler: init at 0.47.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7880,6 +7880,12 @@
     githubId = 36283171;
     name = "Daniel";
   };
+  enderfare = {
+    name = "ender.fare";
+    email = "ender.fare.md@gmail.com";
+    github = "enderfare";
+    githubId = 135335132;
+  };
   endgame = {
     email = "jack@jackkelly.name";
     github = "endgame";

--- a/pkgs/applications/editors/chronicler/default.nix
+++ b/pkgs/applications/editors/chronicler/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, lib
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, makeWrapper
+, gtk3
+, webkitgtk_4_1   # matches the .deb dependency libwebkit2gtk-4.1-0
+, wrapGAppsHook3   # ensures GTK environment variables are set
+}:
+
+stdenv.mkDerivation rec {
+  pname = "chronicler";
+  version = "0.47.0";
+
+  src = fetchurl {
+    url = "https://github.com/mak-kirkland/chronicler/releases/download/v${version}-alpha/Chronicler_${version}_amd64.deb";
+hash = "sha256:f8711d8b2a0f685aef1d2f6b9dd4d43134873764114b5fdb54530d7dc4c3ff82";
+  };
+
+  nativeBuildInputs = [ dpkg autoPatchelfHook makeWrapper wrapGAppsHook3 ];
+
+  buildInputs = [
+    gtk3
+    webkitgtk_4_1
+  ];
+
+  unpackPhase = "true";
+
+  installPhase = ''
+    runHook preInstall
+
+    dpkg -x $src $out
+
+    # Move files from usr/ to the root of $out
+    cp -r $out/usr/* $out/
+    rm -rf $out/usr
+
+    # Some .deb packages also install to /opt; handle that if present
+    if [ -d $out/opt ]; then
+      cp -r $out/opt/* $out/
+      rm -rf $out/opt
+    fi
+
+    # Ensure binaries are executable
+    find $out/bin $out/lib -type f -exec chmod +x {} \; 2>/dev/null || true
+
+    runHook postInstall
+  '';
+
+  # autoPatchelfHook and wrapGAppsHook automatically fix binaries and set up GTK.
+
+  meta = with lib; {
+    description = "A worldbuilding application";
+    longDescription = ''
+      Chronicler is an application for worldbuilding, allowing you to create
+      and manage complex fictional worlds.
+    '';
+    homepage = "https://chronicler.pro/";
+    license = licenses.free;        # free software, exact license unknown
+    maintainers = [ "beta | ender" ];   # as requested
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -322,7 +322,9 @@ with pkgs;
   chef-cli = callPackage ../tools/misc/chef-cli { };
 
   coolercontrol = recurseIntoAttrs (callPackage ../applications/system/coolercontrol { });
-
+  
+  chronicler = callPackage ../applications/editors/chronicler { };
+  
   cup-docker-noserver = cup-docker.override { withServer = false; };
 
   dhallDirectoryToNix = callPackage ../build-support/dhall/directory-to-nix.nix { };


### PR DESCRIPTION
###### Description of changes

This PR adds [Chronicler](https://github.com/mak-kirkland/chronicler), a worldbuilding application.

- Built from the official precompiled `.deb` package (version 0.47.0).
- Uses `autoPatchelfHook` and `wrapGAppsHook` to handle runtime dependencies and GTK integration.
- Tested locally with `nix-build -A chronicler` and verified that the application launches.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/manual/nixos/stable/options#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-sandbox) on non-NixOS)
- Built on platform(s)
   - [x] x86_64-linux
   - [ ] aarch64-linux
   - [ ] x86_64-darwin
   - [ ] aarch64-darwin
- [ ] For non-Linux: Is sandboxed correctly?
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` (note: this may not be necessary as it's a new package)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)