### PR TITLE
chronicler: init at 0.47.0

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -1250,6 +1250,13 @@ lib.mapAttrs mkLicense (
       free = false;
     };
 
+    polyFormShield = {
+      fullName = "PolyForm Shield License 1.0.0";
+      url = "https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt";
+      free = false;
+      redistributable = true;
+    };
+
     psfl = {
       spdxId = "Python-2.0";
       fullName = "Python Software Foundation License version 2";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7874,6 +7874,12 @@
     github = "encode42";
     githubId = 34699884;
   };
+  enderfare = {
+    name = "ender.fare";
+    email = "ender.fare.md@gmail.com";
+    github = "enderfare";
+    githubId = 135335132;
+  };
   enderger = {
     email = "endergeryt@gmail.com";
     github = "enderger";

--- a/pkgs/by-name/ch/chronicler/package.nix
+++ b/pkgs/by-name/ch/chronicler/package.nix
@@ -1,0 +1,69 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+  gtk3,
+  webkitgtk_4_1, # matches the .deb dependency libwebkit2gtk-4.1-0
+  wrapGAppsHook3, # ensures GTK environment variables are set
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "chronicler";
+  version = "0.47.0";
+
+  src = fetchurl {
+    url = "https://github.com/mak-kirkland/chronicler/releases/download/v${finalAttrs.version}-alpha/Chronicler_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-+HEdiyoPaFrvHS9rndTUMTSHN2QRS1/bVFMNfcTD/4I=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gtk3
+    webkitgtk_4_1
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    dpkg -x $src $out
+
+    # Move files from usr/ to the root of $out
+    cp -r $out/usr/* $out/
+    rm -rf $out/usr
+
+    # Some .deb packages also install to /opt; handle that if present
+    if [ -d $out/opt ]; then
+      cp -r $out/opt/* $out/
+      rm -rf $out/opt
+    fi
+
+    # Ensure binaries are executable
+    find $out/bin $out/lib -type f -exec chmod +x {} \; 2>/dev/null || true
+
+    runHook postInstall
+  '';
+
+  # autoPatchelfHook and wrapGAppsHook automatically fix binaries and set up GTK.
+
+  meta = {
+    description = "Worldbuilding application to manage complex fictional worlds";
+    longDescription = ''
+      Chronicler is an application for worldbuilding, allowing you to create
+      and manage complex fictional worlds.
+    '';
+    homepage = "https://chronicler.pro/";
+    license = lib.licenses.polyFormShield;
+    maintainers = with lib.maintainers; [ enderfare ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
###### Description of changes

This PR adds [Chronicler](https://github.com/mak-kirkland/chronicler), a worldbuilding application.

- Built from the official precompiled `.deb` package (version 0.47.0).
- Uses `autoPatchelfHook` and `wrapGAppsHook` to handle runtime dependencies and GTK integration.
- Tested locally with `nix-build -A chronicler` and verified that the application launches.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/manual/nixos/stable/options#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-sandbox) on non-NixOS)
- Built on platform(s)
   - [x] x86_64-linux
   - [ ] aarch64-linux
   - [ ] x86_64-darwin
   - [ ] aarch64-darwin
- [ ] For non-Linux: Is sandboxed correctly?
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` (note: this may not be necessary as it's a new package)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)