### PR TITLE
groups-relay: init at 0-unstable-2025-05-10

### DIFF
--- a/pkgs/by-name/gr/groups-relay/package.nix
+++ b/pkgs/by-name/gr/groups-relay/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule {
+  pname = "groups-relay";
+  version = "0-unstable-2025-05-10";
+
+  src = fetchFromGitHub {
+    owner = "max21dev";
+    repo = "groups-relay";
+    rev = "f7f81d4daf9b2d5fb12e04e9081cf2e307763508";
+    hash = "sha256-2my17kgpL+5dROB3iQN2SAe9jTPDRHPvW0QIwFun0vg=";
+  };
+
+  vendorHash = "sha256-oZgku/7KA/V3IiSH7LnJPSk2mBy3Y3RmypuGDo1d7VA=";
+
+  meta = {
+    description = "NIP-29 group chat relay for Nostr, built on khatru and relay29";
+    homepage = "https://github.com/max21dev/groups-relay";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pinpox ];
+    mainProgram = "groups-relay";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
