### PR TITLE
python3Packages.sphinx-autodoc-typehints: 3.6.2 -> 3.9.2; python3Packages.hatchling: 1.28.0 -> 1.29.0; python3Packages.poetry-core: 2.3.0 -> 2.3.1

### DIFF
--- a/pkgs/development/python-modules/hatchling/default.nix
+++ b/pkgs/development/python-modules/hatchling/default.nix
@@ -19,12 +19,12 @@
 
 buildPythonPackage rec {
   pname = "hatchling";
-  version = "1.28.0";
+  version = "1.29.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-TVCwKuzmiSuM0LPObILLIYWU0+xYNtvedb9BohqwBMg=";
+    hash = "sha256-eTwxgW2VLO5AW4NIjOABxxnzJdnNpp8fxM11BSdkDqY=";
   };
 
   # listed in backend/pyproject.toml

--- a/pkgs/development/python-modules/poetry-core/default.nix
+++ b/pkgs/development/python-modules/poetry-core/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "poetry-core";
-  version = "2.3.0";
+  version = "2.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "python-poetry";
     repo = "poetry-core";
     tag = version;
-    hash = "sha256-oE0kv6ofe+qBFJq+OrgDIHsaysN+y5D9bIy8IB5n5y8=";
+    hash = "sha256-gGXAPdFnrS/T7xvw8rpzI/7nW0bXdUiZnPeEwDgtWuQ=";
   };
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/sphinx-autodoc-typehints/default.nix
+++ b/pkgs/development/python-modules/sphinx-autodoc-typehints/default.nix
@@ -1,35 +1,24 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   hatch-vcs,
   hatchling,
   sphinx,
   pytestCheckHook,
 }:
 
-let
+buildPythonPackage (finalAttrs: {
   pname = "sphinx-autodoc-typehints";
-  version = "3.6.2";
-in
-
-buildPythonPackage {
-  inherit pname version;
+  version = "3.9.2";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "sphinx_autodoc_typehints";
-    inherit version;
-    hash = "sha256-PTdwmiG3t2WtbiCgTs78sim56wAHyyT266qKRXbqfwY=";
+  src = fetchFromGitHub {
+    owner = "tox-dev";
+    repo = "sphinx-autodoc-typehints";
+    tag = finalAttrs.version;
+    hash = "sha256-RfeY9i7M+5SoZtJzdORm/ZyCZ+RLyERJFK7I9L1B7ws=";
   };
-
-  postPatch = ''
-    # https://github.com/tox-dev/sphinx-autodoc-typehints/issues/586
-    substituteInPlace src/sphinx_autodoc_typehints/__init__.py \
-      --replace-fail "sphinx.ext.autodoc.mock" "sphinx.ext.autodoc._dynamic._mock"
-  '';
-
-  pythonRelaxDeps = [ "sphinx" ];
 
   build-system = [
     hatch-vcs
@@ -46,10 +35,10 @@ buildPythonPackage {
   pythonImportsCheck = [ "sphinx_autodoc_typehints" ];
 
   meta = {
-    changelog = "https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/${version}";
+    changelog = "https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/${finalAttrs.version}";
     description = "Type hints (PEP 484) support for the Sphinx autodoc extension";
     homepage = "https://github.com/tox-dev/sphinx-autodoc-typehints";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hexa ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
