### PR TITLE
vmnet-helper: init at v0.12.0

### DIFF
--- a/pkgs/by-name/vm/vmnet-helper/package.nix
+++ b/pkgs/by-name/vm/vmnet-helper/package.nix
@@ -1,0 +1,51 @@
+{
+  darwin,
+  fetchFromGitHub,
+  git,
+  lib,
+  meson,
+  ninja,
+  nix-update-script,
+  python3,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vmnet-helper";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "nirs";
+    repo = finalAttrs.pname;
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wn9vZQA2BbjIwPjkiykr1nhzNnKoSjbbd2NNcbHMaxw=";
+  };
+
+  nativeBuildInputs = [
+    darwin.sigtool
+    git
+    meson
+    ninja
+    (python3.withPackages (
+      ps: with ps; [
+        pyyaml
+        scapy
+      ]
+    ))
+  ];
+
+  postFixup = ''
+    codesign -f --entitlements $src/entitlements.plist -s - $out/bin/vmnet-helper
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "High-performance network proxy connecting VMs to macOS vmnet";
+    mainProgram = "vmnet-helper";
+    homepage = "https://github.com/nirs/vmnet-helper";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.quinneden ];
+    platforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/vm/vmnet-helper/package.nix
+++ b/pkgs/by-name/vm/vmnet-helper/package.nix
@@ -1,0 +1,54 @@
+{
+  darwin,
+  fetchFromGitHub,
+  gitMinimal,
+  lib,
+  meson,
+  ninja,
+  nix-update-script,
+  python3,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vmnet-helper";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "nirs";
+    repo = "vmnet-helper";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pqkikynl5QzcPwKP3KdloZ6W5F8EfZW6arpL5jQOR9w=";
+  };
+
+  nativeBuildInputs = [
+    darwin.sigtool
+    gitMinimal
+    meson
+    ninja
+    (python3.withPackages (
+      ps: with ps; [
+        pyyaml
+        scapy
+      ]
+    ))
+  ];
+
+  postFixup = ''
+    codesign -f --entitlements $src/building/entitlements.plist -s - $out/bin/vmnet-helper
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "High-performance network proxy connecting VMs to macOS vmnet";
+    mainProgram = "vmnet-helper";
+    homepage = "https://github.com/nirs/vmnet-helper";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.quinneden ];
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Init vmnet-helper at v0.12.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (via rosetta)
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
