### PR TITLE
ewm: init at 0-unstable-2026-03-01

### DIFF
--- a/pkgs/by-name/ew/ewm/package.nix
+++ b/pkgs/by-name/ew/ewm/package.nix
@@ -1,0 +1,75 @@
+{
+  fetchFromGitea,
+  glib,
+  lib,
+  libgbm,
+  libinput,
+  libxkbcommon,
+  nix-update-script,
+  pkg-config,
+  rustPlatform,
+  seatd,
+  udev,
+  wayland,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ewm";
+  version = "0-unstable-2026-03-01";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "ezemtsov";
+    repo = "ewm";
+    rev = "43f6b5ec82b336aef1acf0f78a016ba909a62b4d";
+    hash = "sha256-QBT0N9ozw5RkJxp8H23p4hoJSP19IQoR+85WC8rTcyI=";
+  };
+
+  cargoHash = "sha256-w34yg6xjG1nBUK2UZBJ+lCqqluCRgDTnoUgbtNLtd4Y=";
+
+  sourceRoot = "source/compositor";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    glib
+    libgbm
+    libinput
+    libxkbcommon
+    seatd
+    udev
+    wayland
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Emacs Wayland Manager";
+    longDescription = ''
+      EWM is a Wayland compositor that runs inside Emacs.  Wayland
+      applications appear as Emacs buffers, letting you switch between
+      code and apps with `C-x b`, organize windows with your familiar
+      Emacs commands, and keep everything responsive even when Emacs
+      is busy evaluating.
+
+      The compositor runs as a separate thread within Emacs (via a
+      dynamic module), so applications never freeze waiting for Elisp
+      evaluation.
+
+      ```
+      ┌─ Emacs Process ────────────────────────────────────────────┐
+      │  Main Thread: Elisp execution                              │
+      │       ↑↓ shared memory, mutex-protected                    │
+      │  Compositor Thread: Smithay (Rust dynamic module)          │
+      │       ↑↓                                                   │
+      │  Render Thread: DRM/GPU                                    │
+      └────────────────────────────────────────────────────────────┘
+      ```
+    '';
+    homepage = "https://codeberg.org/ezemtsov/ewm";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "ewm";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
