### PR TITLE
rocmPackages.composable_kernel: fix gfx906 only failure

### DIFF
--- a/pkgs/development/rocm-modules/composable_kernel/base.nix
+++ b/pkgs/development/rocm-modules/composable_kernel/base.nix
@@ -5,7 +5,6 @@
   rocmUpdateScript,
   cmake,
   rocm-cmake,
-  llvm,
   clr,
   rocminfo,
   python3,
@@ -124,7 +123,12 @@ stdenv.mkDerivation (finalAttrs: {
     "-DGOOGLETEST_DIR=${gtest.src}" # Custom linker names
   ];
 
-  # No flags to build selectively it seems...
+  patches = [
+    # Hacky fix for failure for some targets when all targets are selected out
+    # for a non-optional at link time kernel
+    ./fix-empty-offload-targets.diff
+  ];
+
   postPatch =
     # Reduce configure time by preventing thousands of clang-tidy targets being added
     # We will never call them

--- a/pkgs/development/rocm-modules/composable_kernel/fix-empty-offload-targets.diff
+++ b/pkgs/development/rocm-modules/composable_kernel/fix-empty-offload-targets.diff
@@ -1,0 +1,23 @@
+diff --git a/library/src/tensor_operation_instance/gpu/CMakeLists.txt b/library/src/tensor_operation_instance/gpu/CMakeLists.txt
+index 172f6681b8..d3ddbb2f15 100644
+--- a/library/src/tensor_operation_instance/gpu/CMakeLists.txt
++++ b/library/src/tensor_operation_instance/gpu/CMakeLists.txt
+@@ -154,9 +154,15 @@ function(add_instance_library INSTANCE_NAME)
+                 list(FILTER INST_TARGETS INCLUDE REGEX "gfx12")
+             endif()
+             set(offload_targets)
+-            foreach(target IN LISTS INST_TARGETS)
+-                string(APPEND offload_targets "--offload-arch=${target} ")
+-            endforeach()
++            if(NOT INST_TARGETS)
++                # No valid GPU targets for this source, compile for 90a as fallback
++                # so the add_device…instances and hip_fatbin… symbols still exist
++                set(offload_targets "--offload-arch=gfx90a")
++            else()
++                foreach(target IN LISTS INST_TARGETS)
++                    string(APPEND offload_targets "--offload-arch=${target} ")
++                endforeach()
++            endif()
+             set_source_files_properties(${source} PROPERTIES COMPILE_FLAGS ${offload_targets})
+             list(APPEND INST_OBJ ${source})
+         endforeach()


### PR DESCRIPTION
Fixes #490002

CC @wulfsta

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
