### PR TITLE
lunarvim: mark as broken

### DIFF
--- a/pkgs/by-name/lu/lunarvim/package.nix
+++ b/pkgs/by-name/lu/lunarvim/package.nix
@@ -145,5 +145,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = lib.platforms.unix;
     mainProgram = "lvim";
+    broken = true; # Incompatible with Neovim >= 0.10; upstream is unmaintained
   };
 })


### PR DESCRIPTION
lunarvim doesn't work with neovim 0.11.x, which is what nixpkgs ships now. The errors come from vim-illuminate and nvim-treesitter calling APIs that were removed or changed after neovim 0.9.5 (`vim.tbl_add_reverse_lookup`, treesitter node `:parent()`).

The LunarVim project hasn't been meaningfully updated in over a year and there's an open issue upstream (LunarVim/LunarVim#4646) about neovim compatibility with no signs of a fix. @lebensterben (one of the maintainers for this package) suggested marking it broken.

This marks the package as `broken` so users get a clear error instead of a confusing runtime crash.

Resolves NixOS/nixpkgs#394302

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
