### PR TITLE
dms-greeter: fix auto login

### DIFF
--- a/nixos/modules/services/display-managers/dms-greeter.nix
+++ b/nixos/modules/services/display-managers/dms-greeter.nix
@@ -22,6 +22,7 @@ let
   cfg = config.services.displayManager.dms-greeter;
   cfgDms = config.programs.dms-shell;
   cfgAutoLogin = config.services.displayManager.autoLogin;
+  sessionData = config.services.displayManager.sessionData;
 
   cacheDir = "/var/lib/dms-greeter";
 
@@ -51,6 +52,38 @@ let
       )
     } ${optionalString cfg.logs.save "> ${cfg.logs.path} 2>&1"}
   '';
+
+  autoLoginCommand =
+    pkgs.runCommand "dms-greeter-autologin-command"
+      {
+        nativeBuildInputs = [
+          pkgs.gnugrep
+          pkgs.coreutils
+        ];
+      }
+      ''
+        set -euo pipefail
+
+        session="${sessionData.autologinSession}"
+        desktops="${sessionData.desktops}"
+
+        for sessionFile in \
+          "$desktops/share/wayland-sessions/$session.desktop" \
+          "$desktops/share/xsessions/$session.desktop"
+        do
+          if [ -f "$sessionFile" ]; then
+            command="$(grep -m1 '^Exec=' "$sessionFile" | cut -d= -f2- || true)"
+
+            if [ -n "$command" ]; then
+              printf '%s\n' "$command" > "$out"
+              exit 0
+            fi
+          fi
+        done
+
+        echo "dms-greeter autologin: could not resolve Exec for session '$session'" >&2
+        exit 1
+      '';
 
   jq = getExe pkgs.jq;
 
@@ -217,6 +250,13 @@ in
             programs.${cfg.compositor.name}.enable = true;
         '';
       }
+      {
+        assertion = cfgAutoLogin.enable -> sessionData.autologinSession != null;
+        message = ''
+          dms-greeter auto-login requires services.displayManager.defaultSession to be set,
+          or at least one session in services.displayManager.sessionPackages.
+        '';
+      }
     ];
 
     services.greetd = {
@@ -227,7 +267,8 @@ in
           command = getExe greeterScript;
         };
         initial_session = mkIf (cfgAutoLogin.enable && (cfgAutoLogin.user != null)) {
-          inherit (cfgAutoLogin) user command;
+          inherit (cfgAutoLogin) user;
+          command = ''${getExe pkgs.bash} -lc "${pkgs.systemd}/bin/systemd-cat $(<${autoLoginCommand})"'';
         };
       };
     };


### PR DESCRIPTION
Fixes #473688 

Fixes auto-login functionality in dms-greeter module. Before, the module was incorrectly trying to access `services.displayManager.autoLogin.command`, which does not exist. I updated it for getting the session from `config.services.displayManager.sessionData.autologinSession`, as used by other greeters modules in Nixpkgs. 

Note that greetd expects the command rather than the session .desktop name (which is what `autoLoginSession` is), so I made a small bash script to find the .desktop file and get the command from the line starting with `Exec=`. Let me know if there's a better way of finding/parsing the .desktop file instead. The script for finding the command name is ran on build time with `pkgs.runCommand`, so this avoids boot errors if the .desktop file can't be found/parsed by giving the error on build time instead.

Tested functionality in my system, with 
```nix
services.displayManager.autoLogin = {
  enable = true;
  user = "luckshiba";
};
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
