### PR TITLE
octave: 10.3.0 -> 11.1.0

### DIFF
--- a/pkgs/development/interpreters/octave/build-env.nix
+++ b/pkgs/development/interpreters/octave/build-env.nix
@@ -69,10 +69,14 @@ buildEnv {
     touch $out/.octave_packages
     for path in ${lib.concatStringsSep " " packages}; do
         if [ -e $path/*.tar.gz ]; then
+           # Glob-match here so that we grab the paths of all tarballs produced
+           # by "octave build" in buildOctavePackage's buildPhase. We can then
+           # Use this list later.
+           pkg_tarballs=($path/*.tar.gz)
            $out/bin/octave-cli --eval "pkg local_list $out/.octave_packages; \
                                        pkg prefix $out/${octave.octPkgsPath} $out/${octave.octPkgsPath}; \
                                        pfx = pkg (\"prefix\"); \
-                                       pkg install -nodeps -local $path/*.tar.gz"
+                                       pkg install -nodeps -local $pkg_tarballs"
         fi
     done
 

--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -23,6 +23,7 @@
   # Both are needed for discrete Fourier transform
   fftw,
   fftwSinglePrec,
+  fast-float,
   zlib,
   curl,
   rapidjson,
@@ -99,12 +100,12 @@ let
   allPkgs = pkgs;
 in
 stdenv.mkDerivation (finalAttrs: {
-  version = "10.3.0";
+  version = "11.1.0";
   pname = "octave";
 
   src = fetchurl {
     url = "mirror://gnu/octave/octave-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-L8s43AYuRA8eBsBpu8qEDtRtzI+YPkc+FVj8w4OE7ms=";
+    sha256 = "sha256-wOfiyRvFcyVkMbLMmJKQub0ThR263VnQrHRxTxM0sOY=";
   };
 
   postPatch = ''
@@ -155,6 +156,9 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    fast-float
   ];
   nativeBuildInputs = [
     perl
@@ -176,6 +180,8 @@ stdenv.mkDerivation (finalAttrs: {
     lib.optionalAttrs stdenv.hostPlatform.isDarwin {
       # Fix linker error on Darwin (see https://trac.macports.org/ticket/61865)
       NIX_LDFLAGS = "-lobjc";
+      # https://savannah.gnu.org/bugs/index.php?68042
+      NIX_CFLAGS_COMPILE = "-Wno-format-security";
     }
     // lib.optionalAttrs use64BitIdx {
       # See https://savannah.gnu.org/bugs/?50339


### PR DESCRIPTION
octavePackages: Ensure Octave's "pkg install" sees a real file path.

Octave 11's "pkg install" command supports more usage methods than previous versions did, including local files, URLs, and unqualified package names. We/Nix pass a path that both is a local file and does not look like a URL.

Despite us giving local paths in the shell script, the file path we pass in is not glob-expanded by the shell running the `postBuild` script from `build-env.nix`.

This happens Because Bash expansion and globbing do not fire for multiple "rounds" inside of a string. So "$path/*.tar.gz" is given to Octave as `/nix/store/...-octave-...-pkg-.../*.tar.gz`, which is NOT a file we/Nix created.

We always need the octave-cli commands to be wrapped up into strings so that Bash does not try to do anything with them. By doing the expansion into a Bash variable before the string expansion, we get the right thing:
/nix/store/...-octave-...-pkg-.../pkg-version-arch.tar.gz

Supersedes #492771

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
