### PR TITLE
kicad: fix paths inside compressed step files

### DIFF
--- a/pkgs/by-name/ki/kicad/libraries.nix
+++ b/pkgs/by-name/ki/kicad/libraries.nix
@@ -28,7 +28,7 @@ let
 
       postInstall =
         lib.optionalString (name == "packages3d") ''
-          find $out -type f -name '*.step' | parallel 'stepreduce {} {} ${lib.optionalString compressStep "&& zip -9 {.}.stpZ {} && rm {}"}'
+          find $out -type f -name '*.step' | parallel 'stepreduce {} {} ${lib.optionalString compressStep "&& zip -j -9 {.}.stpZ {} && rm {}"}'
         ''
         + lib.optionalString ((name == "footprints") && compressStep) ''
           grep -rl '\.step' $out | xargs sed -i 's/\.step/.stpZ/g'


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
fix the file paths inside the zip archives for each 3d model
I stumbled over this while trying to get step export via jobsets working.

### before
```
$ unzip -l /nix/store/bnywsijw6zl7855j7v7vnaz4vd5bzz6s-kicad-packages3d-123ddef066/share/kicad/3dmodels/Battery.3dshapes/BatteryClip_Keystone_54_D16-19mm.stpZ
Archive:  /nix/store/bnywsijw6zl7855j7v7vnaz4vd5bzz6s-kicad-packages3d-123ddef066/share/kicad/3dmodels/Battery.3dshapes/BatteryClip_Keystone_54_D16-19mm.stpZ
  Length      Date    Time    Name
---------  ---------- -----   ----
   140200  03-02-2026 00:32   nix/store/bnywsijw6zl7855j7v7vnaz4vd5bzz6s-kicad-packages3d-123ddef066/share/kicad/3dmodels/Battery.3dshapes/BatteryClip_Keystone_54_D16-19mm.step
---------                     -------
   140200                     1 file
```

### after
```
$ unzip -l /nix/store/bssw2qy58l7i00pzc9gsf8qq4v6mpfki-kicad-packages3d-123ddef066/share/kicad/3dmodels/Battery.3dshapes/BatteryClip_Keystone_54_D16-19mm.stpZ
Archive:  /nix/store/bssw2qy58l7i00pzc9gsf8qq4v6mpfki-kicad-packages3d-123ddef066/share/kicad/3dmodels/Battery.3dshapes/BatteryClip_Keystone_54_D16-19mm.stpZ
  Length      Date    Time    Name
---------  ---------- -----   ----
   140200  03-02-2026 01:24   BatteryClip_Keystone_54_D16-19mm.step
---------                     -------
   140200                     1 file
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

