### PR TITLE
nixos/roundcube: add `database.type` to support SQLite

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -218,6 +218,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `services.slurm` now supports slurmrestd usage through the `services.slurm.rest` NixOS options.
 
+- `services.roundcube` now supports SQLite in addition to PostgreSQL. See `services.roundcube.database.type`.
+
 - The `services.calibre-web` systemd service has been hardened with additional sandboxing restrictions.
 
 - `services.kanidm` options for server, client and unix were moved under dedicated namespaces.

--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -7,12 +7,14 @@
 let
   cfg = config.services.roundcube;
   fpm = config.services.phpfpm.pools.roundcube;
+
   localDB = lib.hasPrefix "/" cfg.database.host;
+  localPgsql = localDB && cfg.database.type == "pgsql";
 
   user = cfg.database.username;
   phpWithPspell = pkgs.php83.withExtensions ({ enabled, all }: [ all.pspell ] ++ enabled);
 
-  env = {
+  commonEnv = {
     ASPELL_CONF = "dict-dir ${pkgs.aspellWithDicts (_: cfg.dicts)}/lib/aspell";
   };
 in
@@ -49,6 +51,19 @@ in
     };
 
     database = {
+      # TODO: support more DB types. The module started off as highly pgsql specific, and more work needs to be done
+      #       to ensure other DB types work properly.
+      type = lib.mkOption {
+        type = lib.types.enum [
+          "pgsql"
+          "sqlite"
+        ];
+        default = "pgsql";
+        description = ''
+          The type of database to use.
+        '';
+      };
+
       username = lib.mkOption {
         type = lib.types.str;
         default = "roundcube";
@@ -63,9 +78,9 @@ in
         type = lib.types.str;
         default = "localhost";
         description = ''
-          Host of the database server.
+          Host of the database server, or database file path when using SQLite.
 
-          If the value starts with a `/`, it is interpreted as a UNIX domain socket.
+          If using PostgreSQL and the value starts with a `/`, it is interpreted as a UNIX domain socket.
 
           See https://github.com/roundcube/roundcubemail/wiki/Configuration#database-connection
         '';
@@ -91,6 +106,17 @@ in
         type = lib.types.str;
         default = "roundcube";
         description = "Name of the postgresql database";
+      };
+
+      mode = lib.mkOption {
+        type = lib.types.nonEmptyStr;
+        default = "0640";
+        example = "0660";
+        description = ''
+          Mode of the database file.
+
+          Ignored if not using an SQLite database.
+        '';
       };
     };
 
@@ -149,13 +175,14 @@ in
 
   config = lib.mkIf cfg.enable {
     services.roundcube.database = lib.mkIf cfg.configurePgsql {
+      type = "pgsql";
       host = "/run/postgresql";
     };
 
     environment.etc."roundcube/config.inc.php".text = ''
       <?php
 
-      ${lib.optionalString (!cfg.configurePgsql) ''
+      ${lib.optionalString (cfg.database.type != "sqlite" && !cfg.configurePgsql) ''
         $password = file('${cfg.database.passwordFile}')[0];
         $password = preg_split('~\\\\.(*SKIP)(*FAIL)|\:~s', $password);
         $password = rtrim(end($password));
@@ -165,10 +192,15 @@ in
 
       $config = array();
 
-      $config['db_dsnw'] = '${let
-          host = if localDB then "unix(${cfg.database.host})" else cfg.database.host;
-          pass = lib.optionalString (!cfg.configurePgsql) ":' . $password . '";
-        in
+      $config['db_dsnw'] = '${
+        # https://pear.php.net/manual/en/package.database.mdb2.intro-dsn.php
+        if cfg.database.type == "sqlite" then
+          "sqlite:///${cfg.database.host}?mode=${cfg.database.mode}"
+        else
+          let
+            host = if localDB then "unix(${cfg.database.host})" else cfg.database.host;
+            pass = lib.optionalString (!cfg.configurePgsql) ":' . $password . '";
+          in
           "pgsql://${cfg.database.username}${pass}@${host}/${cfg.database.dbname}"
       }';
 
@@ -251,6 +283,18 @@ in
           equal!
         '';
       }
+      {
+        assertion = cfg.database.type != "pgsql" -> !cfg.configurePgsql;
+        message = ''
+          When using `${cfg.database.type}` as database, you must also set disable `services.roundcube.configurePgsql`.
+        '';
+      }
+      {
+        assertion = cfg.database.type == "sqlite" -> cfg.database.host != "localhost";
+        message = ''
+          When using SQLite as database, you must also set `services.roundcube.database.host` to the DB file path.
+        '';
+      }
     ];
 
     services.postgresql = lib.mkIf cfg.configurePgsql {
@@ -272,7 +316,7 @@ in
     users.groups.${user} = lib.mkIf cfg.configurePgsql { };
 
     services.phpfpm.pools.roundcube = {
-      user = if localDB then user else "nginx";
+      user = if cfg.configurePgsql then user else "nginx";
       phpOptions = ''
         error_log = '/dev/stderr'
         log_errors = on
@@ -292,9 +336,12 @@ in
         "catch_workers_output" = true;
       };
       phpPackage = phpWithPspell;
-      phpEnv = env;
+      phpEnv = commonEnv;
     };
-    systemd.services.phpfpm-roundcube.after = [ "roundcube-setup.service" ];
+    systemd.services.phpfpm-roundcube = {
+      requires = [ "roundcube-setup.service" ];
+      after = [ "roundcube-setup.service" ];
+    };
 
     # Restart on config changes.
     systemd.services.phpfpm-roundcube.restartTriggers = [
@@ -302,7 +349,7 @@ in
     ];
 
     systemd.services.roundcube-setup = lib.mkMerge [
-      (lib.mkIf localDB {
+      (lib.mkIf localPgsql {
         requires = [ "postgresql.target" ];
         after = [ "postgresql.target" ];
       })
@@ -311,49 +358,72 @@ in
         after = [ "network-online.target" ];
         wantedBy = [ "multi-user.target" ];
 
-        environment = env;
+        environment = commonEnv // {
+          PGPASSFILE = lib.mkIf (
+            cfg.database.type == "pgsql" && !cfg.configurePgsql
+          ) cfg.database.passwordFile;
+        };
 
-        path = [
-          (if localDB then config.services.postgresql.package else pkgs.postgresql)
-        ];
         script =
           let
-            psql = "${lib.optionalString (!localDB) "PGPASSFILE=${cfg.database.passwordFile} "}${
-              lib.escapeShellArgs (
-                [
-                  "psql"
-                  "-h"
-                  cfg.database.host # interprets a / prefix as UNIX sock path
-                ]
-                ++ lib.optionals (!localDB) [
-                  "-U"
-                  cfg.database.username
-                ]
-                ++ [
-                  cfg.database.dbname
-                ]
-              )
-            }";
+            dbCmd =
+              {
+                pgsql = lib.escapeShellArgs (
+                  [
+                    "${if localDB then config.services.postgresql.package else pkgs.postgresql}/bin/psql"
+                    "-h"
+                    cfg.database.host # interprets a / prefix as UNIX sock path
+                  ]
+                  ++ lib.optionals (!localDB) [
+                    "-U"
+                    cfg.database.username
+                  ]
+                  ++ [
+                    cfg.database.dbname
+                  ]
+                );
+
+                sqlite = lib.escapeShellArgs [
+                  "${pkgs.sqlite}/bin/sqlite3"
+                  cfg.database.host
+                ];
+              }
+              .${cfg.database.type};
+
+            initSqlFilePrefix =
+              {
+                pgsql = "postgres";
+              }
+              .${cfg.database.type} or cfg.database.type;
+
+            truncSql =
+              {
+                pgsql = "TRUNCATE TABLE";
+                sqlite = "DELETE FROM";
+              }
+              .${cfg.database.type};
           in
           ''
-            version="$(${psql} -t <<< "select value from system where name = 'roundcube-version';" || true)"
+            version="$(${dbCmd} <<< "SELECT value FROM system WHERE name = 'roundcube-version';" || true)"
             if ! (grep -E '[a-zA-Z0-9]' <<< "$version"); then
-              ${psql} -f ${cfg.package}/SQL/postgres.initial.sql
+              ${dbCmd} < ${cfg.package}/SQL/${initSqlFilePrefix}.initial.sql
             fi
 
             if [ ! -f /var/lib/roundcube/des_key ]; then
               base64 /dev/urandom | head -c 24 > /var/lib/roundcube/des_key;
+
               # we need to log out everyone in case change the des_key
               # from the default when upgrading from nixos 19.09
-              ${psql} <<< 'TRUNCATE TABLE session;'
+              ${dbCmd} <<< '${truncSql} session;'
             fi
 
             ${phpWithPspell}/bin/php ${cfg.package}/bin/update.sh
           '';
+
         serviceConfig = {
           Type = "oneshot";
           StateDirectory = "roundcube";
-          User = if localDB then user else "nginx";
+          User = config.services.phpfpm.pools.roundcube.user;
           # so that the des_key is not world readable
           StateDirectoryMode = "0700";
         };

--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -16,6 +16,14 @@ let
   };
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [ "services" "roundcube" "database" "postgresql" "password" ] ''
+      Use `services.roundcube.database.passwordFile` instead.
+
+      As with all `password` options, it was insecure: the value was stored as world readable in the Nix store.
+    '')
+  ];
+
   options.services.roundcube = {
     enable = lib.mkOption {
       type = lib.types.bool;
@@ -57,11 +65,6 @@ in
           postgresql user and database yourself, with appropriate
           permissions.
         '';
-      };
-      password = lib.mkOption {
-        type = lib.types.str;
-        description = "Password for the postgresql connection. Do not use: the password will be stored world readable in the store; use `passwordFile` instead.";
-        default = "";
       };
       passwordFile = lib.mkOption {
         type = lib.types.path;
@@ -132,14 +135,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    # backward compatibility: if password is set but not passwordFile, make one.
-    services.roundcube.database.passwordFile = lib.mkIf (!localDB && cfg.database.password != "") (
-      lib.mkDefault "${pkgs.writeText "roundcube-password" cfg.database.password}"
-    );
-    warnings =
-      lib.optional (!localDB && cfg.database.password != "")
-        "services.roundcube.database.password is deprecated and insecure; use services.roundcube.database.passwordFile instead";
-
     environment.etc."roundcube/config.inc.php".text = ''
       <?php
 

--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -7,7 +7,8 @@
 let
   cfg = config.services.roundcube;
   fpm = config.services.phpfpm.pools.roundcube;
-  localDB = cfg.database.host == "localhost";
+  localDB = lib.hasPrefix "/" cfg.database.host;
+
   user = cfg.database.username;
   phpWithPspell = pkgs.php83.withExtensions ({ enabled, all }: [ all.pspell ] ++ enabled);
 
@@ -53,19 +54,23 @@ in
         default = "roundcube";
         description = ''
           Username for the postgresql connection.
-          If `database.host` is set to `localhost`, a unix user and group of the same name will be created as well.
+
+          If `configurePgsql` is true, a unix user and group of the same name will be created as well.
         '';
       };
+
       host = lib.mkOption {
         type = lib.types.str;
         default = "localhost";
         description = ''
-          Host of the postgresql server. If this is not set to
-          `localhost`, you have to create the
-          postgresql user and database yourself, with appropriate
-          permissions.
+          Host of the database server.
+
+          If the value starts with a `/`, it is interpreted as a UNIX domain socket.
+
+          See https://github.com/roundcube/roundcubemail/wiki/Configuration#database-connection
         '';
       };
+
       passwordFile = lib.mkOption {
         type = lib.types.path;
         example = lib.literalExpression ''
@@ -77,9 +82,11 @@ in
           Password file for the postgresql connection.
           Must be formatted according to PostgreSQL .pgpass standard (see <https://www.postgresql.org/docs/current/libpq-pgpass.html>)
           but only one line, no comments and readable by user `nginx`.
-          Ignored if `database.host` is set to `localhost`, as peer authentication will be used.
+
+          Ignored if `configurePgsql` is true as peer authentication will be used.
         '';
       };
+
       dbname = lib.mkOption {
         type = lib.types.str;
         default = "roundcube";
@@ -127,6 +134,12 @@ in
       description = "Configure nginx as a reverse proxy for roundcube.";
     };
 
+    configurePgsql = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Configure the PostgreSQL service and use it to store Roundcube's data.";
+    };
+
     extraConfig = lib.mkOption {
       type = lib.types.lines;
       default = "";
@@ -135,10 +148,14 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    services.roundcube.database = lib.mkIf cfg.configurePgsql {
+      host = "/run/postgresql";
+    };
+
     environment.etc."roundcube/config.inc.php".text = ''
       <?php
 
-      ${lib.optionalString (!localDB) ''
+      ${lib.optionalString (!cfg.configurePgsql) ''
         $password = file('${cfg.database.passwordFile}')[0];
         $password = preg_split('~\\\\.(*SKIP)(*FAIL)|\:~s', $password);
         $password = rtrim(end($password));
@@ -147,16 +164,29 @@ in
       ''}
 
       $config = array();
-      $config['db_dsnw'] = 'pgsql://${cfg.database.username}${
-        lib.optionalString (!localDB) ":' . $password . '"
-      }@${if localDB then "unix(/run/postgresql)" else cfg.database.host}/${cfg.database.dbname}';
+
+      $config['db_dsnw'] = '${let
+          host = if localDB then "unix(${cfg.database.host})" else cfg.database.host;
+          pass = lib.optionalString (!cfg.configurePgsql) ":' . $password . '";
+        in
+          "pgsql://${cfg.database.username}${pass}@${host}/${cfg.database.dbname}"
+      }';
+
       $config['log_driver'] = 'syslog';
+
       $config['max_message_size'] =  '${cfg.maxAttachmentSize}';
+
       $config['plugins'] = [${lib.concatMapStringsSep "," (p: "'${p}'") cfg.plugins}];
+
       $config['des_key'] = file_get_contents('/var/lib/roundcube/des_key');
-      $config['mime_types'] = '${pkgs.nginx}/conf/mime.types';
+
+      ${lib.optionalString (cfg.configureNginx or config.services.nginx.enable) ''
+        $config['mime_types'] = '${config.services.nginx.package}/conf/mime.types';
+      ''}
+
       # Roundcube uses PHP-FPM which has `PrivateTmp = true;`
       $config['temp_dir'] = '/tmp';
+
       $config['enable_spellcheck'] = ${if cfg.dicts == [ ] then "false" else "true"};
       # by default, spellchecking uses a third-party cloud services
       $config['spellcheck_engine'] = 'pspell';
@@ -215,7 +245,7 @@ in
 
     assertions = [
       {
-        assertion = localDB -> cfg.database.username == cfg.database.dbname;
+        assertion = cfg.configurePgsql -> cfg.database.username == cfg.database.dbname;
         message = ''
           When setting up a DB and its owner user, the owner and the DB name must be
           equal!
@@ -223,7 +253,7 @@ in
       }
     ];
 
-    services.postgresql = lib.mkIf localDB {
+    services.postgresql = lib.mkIf cfg.configurePgsql {
       enable = true;
       ensureDatabases = [ cfg.database.dbname ];
       ensureUsers = [
@@ -234,12 +264,12 @@ in
       ];
     };
 
-    users.users.${user} = lib.mkIf localDB {
+    users.users.${user} = lib.mkIf cfg.configurePgsql {
       group = user;
       isSystemUser = true;
       createHome = false;
     };
-    users.groups.${user} = lib.mkIf localDB { };
+    users.groups.${user} = lib.mkIf cfg.configurePgsql { };
 
     services.phpfpm.pools.roundcube = {
       user = if localDB then user else "nginx";
@@ -288,9 +318,22 @@ in
         ];
         script =
           let
-            psql = "${lib.optionalString (!localDB) "PGPASSFILE=${cfg.database.passwordFile}"} psql ${
-              lib.optionalString (!localDB) "-h ${cfg.database.host} -U ${cfg.database.username} "
-            } ${cfg.database.dbname}";
+            psql = "${lib.optionalString (!localDB) "PGPASSFILE=${cfg.database.passwordFile} "}${
+              lib.escapeShellArgs (
+                [
+                  "psql"
+                  "-h"
+                  cfg.database.host # interprets a / prefix as UNIX sock path
+                ]
+                ++ lib.optionals (!localDB) [
+                  "-U"
+                  cfg.database.username
+                ]
+                ++ [
+                  cfg.database.dbname
+                ]
+              )
+            }";
           in
           ''
             version="$(${psql} -t <<< "select value from system where name = 'roundcube-version';" || true)"

--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ ... }:
 {
   name = "roundcube";
   meta = {
@@ -7,7 +7,7 @@
 
   nodes = {
     roundcube =
-      { config, pkgs, ... }:
+      { pkgs, ... }:
       {
         services.roundcube = {
           enable = true;
@@ -21,18 +21,36 @@
             de
           ];
         };
+
         services.nginx.virtualHosts.roundcube = {
           forceSSL = false;
           enableACME = false;
         };
+
+        specialisation.sqlite.configuration =
+          { ... }:
+          {
+            services.roundcube.configurePgsql = false;
+            services.roundcube.database = {
+              type = "sqlite";
+              host = "/var/lib/roundcube/db.sqlite";
+            };
+          };
       };
   };
 
-  testScript = ''
-    roundcube.start
-    roundcube.wait_for_unit("postgresql.target")
-    roundcube.wait_for_unit("phpfpm-roundcube.service")
-    roundcube.wait_for_unit("nginx.service")
-    roundcube.succeed("curl -sSfL http://roundcube/ | grep 'Keep me logged in'")
-  '';
+  testScript =
+    { nodes, ... }:
+    # python
+    ''
+      roundcube.start
+      roundcube.wait_for_unit("postgresql.target")
+      roundcube.wait_for_unit("phpfpm-roundcube.service")
+      roundcube.wait_for_unit("nginx.service")
+      roundcube.succeed("curl -sSfL http://roundcube/ | grep 'Keep me logged in'")
+
+      with subtest("SQLite database"):
+        roundcube.succeed('${nodes.roundcube.system.build.toplevel}/specialisation/sqlite/bin/switch-to-configuration test')
+        roundcube.succeed("curl -sSfL http://roundcube/ | grep 'Keep me logged in'")
+    '';
 }

--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -12,7 +12,7 @@
         services.roundcube = {
           enable = true;
           hostName = "roundcube";
-          database.password = "not production";
+          database.passwordFile = pkgs.writeText "roundcube-test-password.txt" "not production";
           package = pkgs.roundcube.withPlugins (plugins: [ plugins.persistent_login ]);
           plugins = [ "persistent_login" ];
           dicts = with pkgs.aspellDicts; [


### PR DESCRIPTION
A bit of cleanup and support for SQLite which is easier to admin.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
