### PR TITLE
libzim: 9.3.0 -> 9.5.0

### DIFF
--- a/pkgs/by-name/ki/kiwix-tools/package.nix
+++ b/pkgs/by-name/ki/kiwix-tools/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kiwix-tools";
-  version = "3.7.0-unstable-2024-12-21";
+  version = "3.8.1";
 
   src = fetchFromGitHub {
     owner = "kiwix";
     repo = "kiwix-tools";
-    rev = "43b00419dd3f33eb644e1d83c2e802fc200b2de7";
-    hash = "sha256-Rctb6ZPTXjgSrLRB5VK4CEqYHuEPB7a+SQaNi47cxv0=";
+    tag = finalAttrs.version;
+    hash = "sha256-lq7pP9ftRe26EEVntdY9xs951mvrvUKMMep/Oup4jdE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libkiwix/package.nix
+++ b/pkgs/by-name/li/libkiwix/package.nix
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libkiwix";
-  version = "14.0.0";
+  version = "14.1.1";
 
   src = fetchFromGitHub {
     owner = "kiwix";
     repo = "libkiwix";
     rev = finalAttrs.version;
-    hash = "sha256-QP23ZS0FJsMVtnWOofywaAPIU0GJ2L+hLP/x0LXMKiU=";
+    hash = "sha256-yZWzzu0LLUxg0CbdeKARuaFsf3UxvJJbqPRDGXWDjLI=";
   };
 
   nativeBuildInputs = [
@@ -56,9 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs scripts
-    substituteInPlace meson.build \
-        --replace-fail "libicu_dep = dependency('icu-i18n', static:static_deps)" \
-                       "libicu_dep = [dependency('icu-i18n', static:static_deps), dependency('icu-uc', static:static_deps)]"
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/li/libzim/package.nix
+++ b/pkgs/by-name/li/libzim/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch,
+  nix-update-script,
   icu,
   meson,
   ninja,
@@ -15,23 +16,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libzim";
-  version = "9.3.0";
+  version = "9.5.0";
 
   src = fetchFromGitHub {
     owner = "openzim";
     repo = "libzim";
     tag = finalAttrs.version;
-    hash = "sha256-DZiFeZ2ry3JpXDs3mvf0q7diwhkjQ2730KQkDQPbgcY=";
+    hash = "sha256-YeskvTtwibKQxMY4c6yEHW+EmXUq4AXpd5XLxKfsmXg=";
   };
-
-  patches = [
-    # Upstream patch for ICU76 compatibility.
-    # https://github.com/openzim/libzim/pull/936
-    (fetchpatch {
-      url = "https://github.com/openzim/libzim/commit/4a42b3c6971c9534b104f48f6d13db8630a97d2f.patch";
-      hash = "sha256-FjaGZ2bI1ROLg3rvWIGLbVoImGr51MbWjbBj+lGj1rs=";
-    })
-  ];
 
   nativeBuildInputs = [
     ninja
@@ -59,6 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
     # "...some tests need up to 16GB of memory..."
     "-Dtest_data_dir=none"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Reference implementation of the ZIM specification";


### PR DESCRIPTION
Updates libzim from 9.3.0 to 9.5.0. This also obviates the need to apply the patch that was previously defined, since the changes are present in the latest version.

`passthru.updateScript` was also added (and was then used to update the package), but this can be removed if desired.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
