### PR TITLE
corretto: use same build flags as openjdk & update corretto11

### DIFF
--- a/pkgs/development/compilers/corretto/11.nix
+++ b/pkgs/development/compilers/corretto/11.nix
@@ -20,12 +20,6 @@ let
       ;
     jdk = jdk11;
     gradle = gradle_8;
-    extraConfig = [
-      # jdk11 is built with --disable-warnings-as-errors (see openjdk/11.nix)
-      # because of several compile errors. We need to include this parameter for
-      # Corretto, too.
-      "--disable-warnings-as-errors"
-    ];
     version = "11.0.29.7.1";
     src = fetchFromGitHub {
       owner = "corretto";

--- a/pkgs/development/compilers/corretto/11.nix
+++ b/pkgs/development/compilers/corretto/11.nix
@@ -20,12 +20,12 @@ let
       ;
     jdk = jdk11;
     gradle = gradle_8;
-    version = "11.0.29.7.1";
+    version = "11.0.30.7.1";
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-11";
       rev = version;
-      hash = "sha256-/VlV8tAo1deOZ5Trc4VlLNtpjWx352qUGZmfVbj7HuU=";
+      hash = "sha256-SUdJlTYE+RRAZa8DhFW0EYW1kHmuNDG+hk+/3MXtx1w=";
     };
   };
 in

--- a/pkgs/development/compilers/corretto/mk-corretto.nix
+++ b/pkgs/development/compilers/corretto/mk-corretto.nix
@@ -44,6 +44,7 @@ jdk.overrideAttrs (
     postPatch =
       let
         extra_config = builtins.concatStringsSep " " extraConfig;
+        jdk_configure_flags = "'" + builtins.concatStringsSep "', '" oldAttrs.configureFlags + "'";
       in
       (oldAttrs.postPatch or "")
       + ''
@@ -70,6 +71,12 @@ jdk.overrideAttrs (
           substituteInPlace $file --replace-warn "workingDir '/usr/bin'" "workingDir '.'"
         done
 
+        # Prepend corresponding OpenJDK flags to Corretto's own configure flags.
+        # This will provide us with the version-specific fixes (see
+        # openjdk/generic.nix) while giving Corretto's flags precedence.
+        # Note that the OpenJdK flags contain "--with-boot-jdk=..."!
+        substituteInPlace build.gradle --replace-fail "correttoCommonFlags = [" "correttoCommonFlags = [${jdk_configure_flags} ,"
+        # Finally, *append* nix-corretto-version specific flags.
         gradleFlagsArray+=(-Pcorretto.extra_config="${extra_config}")
       '';
 

--- a/pkgs/development/compilers/corretto/mk-corretto.nix
+++ b/pkgs/development/compilers/corretto/mk-corretto.nix
@@ -145,6 +145,7 @@ jdk.overrideAttrs (
       license = lib.licenses.gpl2Only;
       description = "Amazon's distribution of OpenJDK";
       maintainers = with lib.maintainers; [ rollf ];
+      platforms = lib.platforms.linux;
       teams = [ ];
     };
   }


### PR DESCRIPTION
This PR makes the Corretto builds use the same configure flags as the corresponding OpenJDK build.
This has two main consequences: We can get openjdk-version-specific flag-based fixes in the nix package build for free and we now use Adoptium as boot jdk (previously, it was OpenJDK).

The latter avoids build problems as described [here](https://github.com/NixOS/nixpkgs/pull/487228#issuecomment-3853611645).

This PR also updates corretto11 from 11.0.29.7.1 to 11.0.30.7.1 which then fixes https://github.com/NixOS/nixpkgs/issues/484613.

I have re-ordered the commits (first use openjdk flags, then update corretto11) eventhough the corretto11 update originally caused my investigation that led to use usage of the openjdk flags.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
