### PR TITLE
radicle-tui: use canonical release tag

### DIFF
--- a/pkgs/by-name/ra/radicle-tui/package.nix
+++ b/pkgs/by-name/ra/radicle-tui/package.nix
@@ -17,7 +17,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromRadicle {
     seed = "seed.radicle.xyz";
     repo = "z39mP9rQAaGmERfUMPULfPUi473tY";
-    node = "z6MkgFq6z5fkF2hioLLSNu1zP2qEL1aHXHZzGH1FLFGAnBGz";
     tag = "releases/${finalAttrs.version}";
     hash = "sha256-2/pLlhilJyrZl9eLFWIh4YxlJwBbzjmb1Cg1xFSSl5k=";
     leaveDotGit = true;

--- a/pkgs/by-name/ra/radicle-tui/update.sh
+++ b/pkgs/by-name/ra/radicle-tui/update.sh
@@ -1,18 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p coreutils gnused gitMinimal nix-update
+#!nix-shell -i bash -p coreutils gnugrep common-updater-scripts nix-update
 
-set -euo pipefail
-
-dirname="$(dirname "${BASH_SOURCE[0]}")"
-
-url=$(nix-instantiate --eval --raw -A radicle-tui.src.url)
-old_node=$(nix-instantiate --eval --raw -A radicle-tui.src.node)
-
-ref=$(git ls-remote "$url" 'refs/namespaces/*/refs/tags/releases/*' \
-  | cut -f2 | grep -Ev '\^\{\}$' | sort -t/ -k6rV | head -1)
-[[ "$ref" =~ ^refs/namespaces/([^/]+)/refs/tags/releases/([^/]+)$ ]]
-new_node="${BASH_REMATCH[1]}"
-version="${BASH_REMATCH[2]}"
-
-sed -i "s/${old_node}/${new_node}/g" "${dirname}/package.nix"
+version=$(list-git-tags | grep -oP '^releases/\K\d+\.\d+\.\d+$' | sort -rV | head -1)
 nix-update --version="$version" radicle-tui


### PR DESCRIPTION
shouldn't cause any rebuilds

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
