### PR TITLE
tvheadend: re-add package and NixOS module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1433,6 +1433,7 @@
   ./services/networking/tox-node.nix
   ./services/networking/toxvpn.nix
   ./services/networking/trickster.nix
+  ./services/networking/tvheadend.nix
   ./services/networking/twingate.nix
   ./services/networking/ucarp.nix
   ./services/networking/udp-over-tcp.nix

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -343,9 +343,6 @@ in
     (mkRemovedOptionModule [ "services" "sourcehut" ] ''
       The sourcehut packages and the corresponding module have been removed due to being broken and unmaintained.
     '')
-    (mkRemovedOptionModule [ "services" "tvheadend" ]
-      "The tvheadend package and the corresponding module have been removed as nobody was willing to maintain them and they were stuck on an unmaintained version that required FFmpeg 4; please see https://github.com/NixOS/nixpkgs/pull/332259 if you are interested in maintaining a newer version."
-    )
     (mkRemovedOptionModule [ "services" "unifi-video" ]
       "The unifi-video package and the corresponding module have been removed as the software has been unsupported since 2021 and requires a MongoDB version that has reached end of life."
     )

--- a/nixos/modules/services/networking/tvheadend.nix
+++ b/nixos/modules/services/networking/tvheadend.nix
@@ -156,4 +156,6 @@ in
       };
     };
   };
+
+  meta.maintainers = with lib.maintainers; [ juaningan ];
 }

--- a/nixos/modules/services/networking/tvheadend.nix
+++ b/nixos/modules/services/networking/tvheadend.nix
@@ -26,6 +26,16 @@ in
       description = "Group under which Tvheadend runs.";
     };
 
+    extraGroups = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "video" ];
+      example = [
+        "video"
+        "dvb"
+      ];
+      description = "Additional groups for the systemd service.";
+    };
+
     dataDir = lib.mkOption {
       type = lib.types.path;
       default = "/var/lib/tvheadend";
@@ -92,6 +102,7 @@ in
         description = "Tvheadend service user";
         isSystemUser = true;
         group = cfg.group;
+        inherit (cfg) extraGroups;
         home = cfg.dataDir;
         createHome = true;
       };
@@ -119,7 +130,7 @@ in
         Type = "simple";
         User = cfg.user;
         Group = cfg.group;
-        SupplementaryGroups = [ "video" ];
+        SupplementaryGroups = lib.mkIf (cfg.user != "tvheadend") cfg.extraGroups;
         WorkingDirectory = cfg.dataDir;
         Restart = "on-failure";
         RestartSec = 5;

--- a/nixos/modules/services/networking/tvheadend.nix
+++ b/nixos/modules/services/networking/tvheadend.nix
@@ -87,14 +87,18 @@ in
       cfg.htspPort
     ];
 
-    users.groups.tvheadend = lib.mkIf (cfg.group == "tvheadend") { };
+    users.users = lib.mkIf (cfg.user == "tvheadend") {
+      tvheadend = {
+        description = "Tvheadend service user";
+        isSystemUser = true;
+        group = cfg.group;
+        home = cfg.dataDir;
+        createHome = true;
+      };
+    };
 
-    users.users.tvheadend = lib.mkIf (cfg.user == "tvheadend") {
-      description = "Tvheadend service user";
-      isSystemUser = true;
-      group = cfg.group;
-      home = cfg.dataDir;
-      createHome = true;
+    users.groups = lib.mkIf (cfg.group == "tvheadend") {
+      tvheadend = { };
     };
 
     systemd.tmpfiles.settings.tvheadend = {
@@ -117,7 +121,6 @@ in
         Group = cfg.group;
         SupplementaryGroups = [ "video" ];
         WorkingDirectory = cfg.dataDir;
-        Environment = [ "HOME=${toString cfg.dataDir}" ];
         Restart = "on-failure";
         RestartSec = 5;
 

--- a/nixos/modules/services/networking/tvheadend.nix
+++ b/nixos/modules/services/networking/tvheadend.nix
@@ -1,0 +1,145 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.tvheadend;
+in
+{
+  options.services.tvheadend = {
+    enable = lib.mkEnableOption "Tvheadend TV streaming server";
+
+    package = lib.mkPackageOption pkgs "tvheadend" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "tvheadend";
+      description = "User account under which Tvheadend runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "tvheadend";
+      description = "Group under which Tvheadend runs.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/tvheadend";
+      description = "Directory where Tvheadend stores its configuration and data.";
+    };
+
+    httpPort = lib.mkOption {
+      type = lib.types.port;
+      default = 9981;
+      description = "Port to bind HTTP to.";
+    };
+
+    htspPort = lib.mkOption {
+      type = lib.types.port;
+      default = 9982;
+      description = "Port to bind HTSP to.";
+    };
+
+    ipv6 = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Listen on IPv6.";
+    };
+
+    bindAddr = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "127.0.0.1";
+      description = "Bind address for HTTP and HTSP.";
+    };
+
+    openFirewall = lib.mkEnableOption "opening Tvheadend TCP ports in the firewall";
+
+    firstRun = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to pass `--firstrun` on startup.
+
+        This will create an initial admin account with no username and no
+        password if no access control exists yet.
+      '';
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Additional command line arguments passed to tvheadend.";
+      example = [
+        "--debug"
+        "dvr"
+      ];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [
+      cfg.httpPort
+      cfg.htspPort
+    ];
+
+    users.groups.tvheadend = lib.mkIf (cfg.group == "tvheadend") { };
+
+    users.users.tvheadend = lib.mkIf (cfg.user == "tvheadend") {
+      description = "Tvheadend service user";
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.dataDir;
+      createHome = true;
+    };
+
+    systemd.tmpfiles.settings.tvheadend = {
+      "${cfg.dataDir}"."d" = {
+        mode = "0750";
+        inherit (cfg) user group;
+      };
+    };
+
+    systemd.services.tvheadend = {
+      description = "Tvheadend TV streaming server";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        SupplementaryGroups = [ "video" ];
+        WorkingDirectory = cfg.dataDir;
+        Environment = [ "HOME=${toString cfg.dataDir}" ];
+        Restart = "on-failure";
+        RestartSec = 5;
+
+        ExecStart = lib.escapeShellArgs (
+          [
+            (lib.getExe cfg.package)
+            "--config"
+            (toString cfg.dataDir)
+            "--http_port"
+            (toString cfg.httpPort)
+            "--htsp_port"
+            (toString cfg.htspPort)
+          ]
+          ++ lib.optionals (cfg.bindAddr != null) [
+            "--bindaddr"
+            cfg.bindAddr
+          ]
+          ++ lib.optionals cfg.ipv6 [ "--ipv6" ]
+          ++ lib.optionals cfg.firstRun [ "--firstrun" ]
+          ++ cfg.extraArgs
+        );
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1697,6 +1697,7 @@ in
   turn-rs = runTest ./turn-rs.nix;
   tusd = runTest ./tusd/default.nix;
   tuxguitar = runTest ./tuxguitar.nix;
+  tvheadend = runTest ./tvheadend.nix;
   twingate = runTest ./twingate.nix;
   txredisapi = runTest ./txredisapi.nix;
   typesense = runTest ./typesense.nix;

--- a/nixos/tests/tvheadend.nix
+++ b/nixos/tests/tvheadend.nix
@@ -3,7 +3,7 @@
 {
   name = "tvheadend";
 
-  meta.maintainers = with lib.maintainers; [ ];
+  meta.maintainers = with lib.maintainers; [ juaningan ];
 
   nodes.machine =
     { ... }:

--- a/nixos/tests/tvheadend.nix
+++ b/nixos/tests/tvheadend.nix
@@ -1,0 +1,37 @@
+{ lib, pkgs, ... }:
+
+{
+  name = "tvheadend";
+
+  meta.maintainers = with lib.maintainers; [ ];
+
+  nodes.machine =
+    { ... }:
+    {
+      services.tvheadend = {
+        enable = true;
+        extraGroups = [ "tuners" ];
+      };
+
+      users.groups.tuners = { };
+
+      environment.systemPackages = [ pkgs.curl ];
+    };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("tvheadend.service")
+    machine.wait_for_open_port(9981)
+    machine.wait_for_open_port(9982)
+
+    # The Web UI should answer even before any setup is completed.
+    machine.succeed("curl -sS -D- http://localhost:9981/ -o /dev/null | grep -qi 'HTS/tvheadend\\|Tvheadend'")
+
+    pid = machine.succeed("systemctl show -p MainPID --value tvheadend.service").strip()
+    assert pid.isdigit() and int(pid) > 0
+
+    tuners_gid = machine.succeed("getent group tuners | cut -d: -f3").strip()
+    machine.succeed(f"grep -qE '^Groups:.*(\\s|^){tuners_gid}(\\s|$)' /proc/{pid}/status")
+  '';
+}

--- a/pkgs/by-name/tv/tvheadend/package.nix
+++ b/pkgs/by-name/tv/tvheadend/package.nix
@@ -121,6 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "TV streaming server and digital video recorder";
     homepage = "https://tvheadend.org";
     license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ juaningan ];
     platforms = lib.platforms.linux;
     mainProgram = "tvheadend";
   };

--- a/pkgs/by-name/tv/tvheadend/package.nix
+++ b/pkgs/by-name/tv/tvheadend/package.nix
@@ -32,6 +32,10 @@
   x265,
 }:
 
+let
+  pythonEnv = python3.withPackages (ps: [ ps.requests ]);
+in
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "tvheadend";
   version = "4.3-unstable-2026-02-25";
@@ -52,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     gettext
     makeWrapper
     pkg-config
-    python3
+    pythonEnv
     which
   ];
 
@@ -112,6 +116,12 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postInstall = ''
+    # Fix scripts shipped by upstream to not rely on a host-provided python3.
+    for f in $out/bin/tvhmeta $out/bin/tv_meta_tmdb.py $out/bin/tv_meta_tvdb.py; do
+      substituteInPlace "$f" \
+        --replace-fail '#! /usr/bin/env python3' '#!${pythonEnv}/bin/python3'
+    done
+
     # `tar -j` needs bzip2 in PATH for config backups.
     wrapProgram $out/bin/tvheadend \
       --prefix PATH : ${lib.makeBinPath [ bzip2 ]}

--- a/pkgs/by-name/tv/tvheadend/package.nix
+++ b/pkgs/by-name/tv/tvheadend/package.nix
@@ -1,0 +1,127 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # build-time
+  gettext,
+  makeWrapper,
+  pkg-config,
+  python3,
+  which,
+
+  # runtime/link-time
+  avahi,
+  bzip2,
+  dbus,
+  dtv-scan-tables,
+  ffmpeg,
+  gnutar,
+  gzip,
+  libdvbcsa,
+  libiconv,
+  openssl,
+  pcre2,
+  uriparser,
+  zlib,
+
+  # optional codec-profile integrations (autodetected)
+  libopus,
+  libvpx,
+  x264,
+  x265,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tvheadend";
+  version = "4.3-unstable-2026-02-25";
+
+  src = fetchFromGitHub {
+    owner = "tvheadend";
+    repo = "tvheadend";
+    rev = "7c4011de1087da5d43bf1c7537163f871fd161e4";
+    hash = "sha256-/gS7xgprropq2OLp2qMv4M8gqeApuvOOArKWFqhnWNU=";
+  };
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  nativeBuildInputs = [
+    gettext
+    makeWrapper
+    pkg-config
+    python3
+    which
+  ];
+
+  buildInputs = [
+    avahi
+    bzip2
+    dbus
+    ffmpeg
+    gzip
+    libdvbcsa
+    libiconv
+    libopus
+    libvpx
+    openssl
+    pcre2
+    uriparser
+    x264
+    x265
+    zlib
+  ];
+
+  enableParallelBuilding = true;
+
+  configureFlags = [
+    "--nowerror"
+
+    # avoid network during build
+    "--disable-dvbscan"
+
+    # use system libraries; avoid embedded builds
+    "--disable-ffmpeg_static"
+    "--disable-hdhomerun_client"
+    "--disable-hdhomerun_static"
+    "--disable-libx264_static"
+    "--disable-libx265_static"
+    "--disable-libvpx_static"
+    "--disable-libtheora_static"
+    "--disable-libvorbis_static"
+    "--disable-libfdkaac_static"
+    "--disable-libmfx_static"
+  ];
+
+  preConfigure = ''
+    # Ensure config backups work on NixOS (no FHS tar paths).
+    substituteInPlace src/config.c \
+      --replace-fail '"/usr/local/bin/tar"' '"${gnutar}/bin/tar"' \
+      --replace-fail '"/usr/bin/tar"' '"${gnutar}/bin/tar"' \
+      --replace-fail '"/bin/tar"' '"${gnutar}/bin/tar"'
+
+    # Point predefined mux lists at the packaged scan tables.
+    substituteInPlace src/input/mpegts/scanfile.c \
+      --replace-fail /usr/share/dvb ${dtv-scan-tables}/share/dvbv5
+
+    # The version detection script `support/version` reads this file if it
+    # exists, so set it explicitly for tarball builds.
+    echo ${finalAttrs.version} > rpm/version
+  '';
+
+  postInstall = ''
+    # `tar -j` needs bzip2 in PATH for config backups.
+    wrapProgram $out/bin/tvheadend \
+      --prefix PATH : ${lib.makeBinPath [ bzip2 ]}
+  '';
+
+  meta = {
+    description = "TV streaming server and digital video recorder";
+    homepage = "https://tvheadend.org";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    mainProgram = "tvheadend";
+  };
+})


### PR DESCRIPTION
Reintroduce tvheadend (and its NixOS module) after removal in #336395.

The previous packaging was stuck on an old tvheadend version that required EOL FFmpeg 4 (see the removal note in `nixos/modules/rename.nix`); this PR modernizes the package so it builds against current nixpkgs `ffmpeg` (8.x).

### Rationale / notable decisions
- Track upstream master snapshot `7c4011de1087da5d43bf1c7537163f871fd161e4` (`4.3-unstable-2026-02-25`) since there is no recent tagged release.
- Use nixpkgs `ffmpeg` (no FFmpeg 4 pin) and avoid bundled/static third-party builds to keep the derivation pure.
- Avoid network during build (`--disable-dvbscan`) and rely on packaged scan tables (`dtv-scan-tables`), patching the default `/usr/share/dvb` path.
- Patch config backup helper to use `${gnutar}/bin/tar` instead of FHS paths, and wrap `bzip2` for `tar -j`.
- Fix helper scripts (`tvhmeta`, `tv_meta_*.py`) to use a Nix-provided python (incl. `requests`) instead of relying on `/usr/bin/env python3`.
- NixOS service runs in foreground (no `-f`) and does not enable `--firstrun` by default (it creates a blank admin); exposed as `services.tvheadend.firstRun`.
- Use a regular system user (dynamic persistent ids via NixOS) rather than `DynamicUser`: tvheadend commonly needs stable ownership for data outside systemd state dirs (recordings, mounts) and device access. `services.tvheadend.extraGroups` covers tuner/video access.

### What’s included
- Package: `pkgs/by-name/tv/tvheadend/package.nix`
- Module: `nixos/modules/services/networking/tvheadend.nix`
- Test: `nixos/tests/tvheadend.nix`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`nix build .#nixosTests.tvheadend`)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

### Disclosure
This PR was authored with assistance from an AI coding tool (OpenCode) using model `openai/gpt-5.2`. All changes were reviewed and built/tested locally.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test