### PR TITLE
[staging] perPackages updates 2026-02

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21093,10 +21093,10 @@ with self;
 
   MathBigIntLite = buildPerlPackage {
     pname = "Math-BigInt-Lite";
-    version = "0.29";
+    version = "0.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-Lite-0.29.tar.gz";
-      hash = "sha256-R4YN/KYxl4txxKqZkaGynk7LrzYbW7nrOVl1t//Nd/U=";
+      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-Lite-0.30.tar.gz";
+      hash = "sha256-K0R8adle6QltpiVqzAK4LTUAxjl01Xp6Inw7X816PrU=";
     };
     propagatedBuildInputs = [ MathBigInt ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27887,12 +27887,12 @@ with self;
 
   ParserMGC = buildPerlModule {
     pname = "Parser-MGC";
-    version = "0.21";
+    version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Parser-MGC-0.21.tar.gz";
-      hash = "sha256-DmGIpydqn5B1fGIEc98W08mGGRO6viWvIJz0RhWgKk8=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Parser-MGC-0.23.tar.gz";
+      hash = "sha256-tXXBrwc4fl/6/rOs+1ydJRC7CbD/eUQYAw1lz2U999k=";
     };
-    buildInputs = [ TestFatal ];
+    buildInputs = [ ModuleBuild ];
     propagatedBuildInputs = [ FeatureCompatTry ];
     meta = {
       description = "Build simple recursive-descent parsers";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21940,11 +21940,12 @@ with self;
 
   MIMETypes = buildPerlPackage {
     pname = "MIME-Types";
-    version = "2.24";
+    version = "2.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/MIME-Types-2.24.tar.gz";
-      hash = "sha256-Yp42HyKyIL5QwtpzVOI8BFF1dwmgPCWiLzFg7blMtl8=";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/MIME-Types-2.30.tar.gz";
+      hash = "sha256-8xsWZr30ILS2XDc84BKe40ndJLq0zRbH8Btpj+RQvm8=";
     };
+    buildInputs = [ TestPod ];
     meta = {
       description = "Definition of MIME types";
       homepage = "http://perl.overmeer.net/CPAN";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22479,10 +22479,10 @@ with self;
 
   ModuleExtractVERSION = buildPerlPackage {
     pname = "Module-Extract-VERSION";
-    version = "1.116";
+    version = "1.119";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Module-Extract-VERSION-1.116.tar.gz";
-      hash = "sha256-QZA6BoUXgoU0X12oVdkluUVO5xCpeV48TDJ7ri9Vdpg=";
+      url = "mirror://cpan/authors/id/B/BR/BRIANDFOY/Module-Extract-VERSION-1.119.tar.gz";
+      hash = "sha256-Fys0XjtlsZaXoKxRP+asHyDvj+XtPYjNQlwrT+vEXfU=";
     };
     meta = {
       homepage = "https://github.com/briandfoy/module-extract-version";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -38083,16 +38083,17 @@ with self;
 
   URI = buildPerlPackage {
     pname = "URI";
-    version = "5.21";
+    version = "5.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/URI-5.21.tar.gz";
-      hash = "sha256-liZYYM1hveFuhBXc+/EIBW3hYsqgrDf4HraVydLgq3c=";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/URI-5.34.tar.gz";
+      hash = "sha256-3mTHeaIS/xghiWxcortp50dn0mdM7kEed33up6ImBKg=";
     };
     buildInputs = [
       TestFatal
       TestNeeds
       TestWarnings
     ];
+    propagatedBuildInputs = [ MIMEBase32 ];
     meta = {
       description = "Uniform Resource Identifiers (absolute and relative)";
       homepage = "https://github.com/libwww-perl/URI";
@@ -40615,6 +40616,23 @@ with self;
     meta = {
       description = "Play trics with HASH keys";
       homepage = "http://perl.overmeer.net/CPAN/";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
+    };
+  };
+
+  MIMEBase32 = buildPerlPackage {
+    pname = "MIME-Base32";
+    version = "1.303";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/MIME-Base32-1.303.tar.gz";
+      hash = "sha256-qyH6mRMOM6Cv9s21lvZH5eVl0gfWNLou8Gvb71BCTpk=";
+    };
+    meta = {
+      description = "Base32 encoder and decoder";
+      homepage = "https://metacpan.org/release/MIME-Base32";
       license = with lib.licenses; [
         artistic1
         gpl1Plus

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21453,10 +21453,10 @@ with self;
 
   MathRound = buildPerlPackage {
     pname = "Math-Round";
-    version = "0.07";
+    version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GROMMEL/Math-Round-0.07.tar.gz";
-      hash = "sha256-c6cymoblSlwppEA4LlgDCVtY8zEp5hod8Ak7SCTekyc=";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Math-Round-0.08.tar.gz";
+      hash = "sha256-e00nda07hZpf1h9/P8XPukKxoQ3whtLtFaCucSyP1AI=";
     };
     meta = {
       description = "Perl extension for rounding numbers";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -35259,10 +35259,10 @@ with self;
 
   TestOutput = buildPerlPackage {
     pname = "Test-Output";
-    version = "1.034";
+    version = "1.036";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Test-Output-1.034.tar.gz";
-      hash = "sha256-zULigBwNK0gtGMn7SwbHVwVIGLy7KCTl378zrXo9aaA=";
+      url = "mirror://cpan/authors/id/B/BR/BRIANDFOY/Test-Output-1.036.tar.gz";
+      hash = "sha256-o6lcuMTTh/4Hmt1EkHV+aZJ+8EiLuxi01V5/xtJfGmM=";
     };
     propagatedBuildInputs = [ CaptureTiny ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39988,13 +39988,15 @@ with self;
 
   ZonemasterEngine = buildPerlPackage {
     pname = "Zonemaster-Engine";
-    version = "4.6.1";
+    version = "8.001000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZN/ZNMSTR/Zonemaster-Engine-v4.6.1.tar.gz";
-      hash = "sha256-4AXo3bZTOLnnPjjX5KNb/2O7MRqcAtlqpz5sPwNN9b0=";
+      url = "mirror://cpan/authors/id/Z/ZN/ZNMSTR/Zonemaster-Engine-v8.1.0.tar.gz";
+      hash = "sha256-cLTcBg5uNazlQHhOZQJI7Z4KbmYCIh8DxXdaSMIQ+44=";
     };
     buildInputs = [
+      LocalePO
       PodCoverage
+      SubOverride
       TestDifferences
       TestException
       TestFatal
@@ -40008,16 +40010,18 @@ with self;
       FileShareDir
       FileSlurp
       IOSocketINET6
+      ListCompare
       ListMoreUtils
+      LogAny
+      MailSPF
       ModuleFind
-      Moose
-      MooseXSingleton
-      NetIP
+      NetDNS
       NetIPXS
       Readonly
       TextCSV
+      YAMLLibYAML
       ZonemasterLDNS
-      libintl-perl
+      libintlperl
     ];
 
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -37513,10 +37513,10 @@ with self;
 
   TimeDate = buildPerlPackage {
     pname = "TimeDate";
-    version = "2.33";
+    version = "2.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AT/ATOOMIC/TimeDate-2.33.tar.gz";
-      hash = "sha256-wLacSwOd5vUBsNnxPsWMhrBAwffpsn7ySWUcFD1gXrI=";
+      url = "mirror://cpan/authors/id/A/AT/ATOOMIC/TimeDate-2.34.tar.gz";
+      hash = "sha256-RXHaj61Dk+cFG+AJi9OtAos8YMLXWt+IsfgbkSFU1tI=";
     };
     meta = {
       description = "Miscellaneous timezone manipulations routines";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20039,10 +20039,10 @@ with self;
 
   Logger = buildPerlPackage {
     pname = "Log-ger";
-    version = "0.040";
+    version = "0.042";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/Log-ger-0.040.tar.gz";
-      hash = "sha256-6JEdM4ePoWmeQ+jQpU7V1WEEA4Z/9cM5+TQQPRfsZLA=";
+      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/Log-ger-0.042.tar.gz";
+      hash = "sha256-eZa8pb5ZXj7Q2rbBz+NR7DeE7iRHvA8knhp5Wrg9Etk=";
     };
     meta = {
       description = "Lightweight, flexible logging framework";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28560,10 +28560,10 @@ with self;
 
   PerlTidy = buildPerlPackage {
     pname = "Perl-Tidy";
-    version = "20250711";
+    version = "20260204";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHANCOCK/Perl-Tidy-20250711.tar.gz";
-      hash = "sha256-NHqpC8773itZDa9I04fvH9m3pzqZawQCafEatvuLpEg=";
+      url = "mirror://cpan/authors/id/S/SH/SHANCOCK/Perl-Tidy-20260204.tar.gz";
+      hash = "sha256-VqH8Lx+BPkkCag8oS5IJprKCRiCZPnWYyFsBxET/D2Q=";
     };
     meta = {
       description = "Indent and reformat perl scripts";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -37317,10 +37317,10 @@ with self;
 
   TieCycle = buildPerlPackage {
     pname = "Tie-Cycle";
-    version = "1.227";
+    version = "1.233";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Tie-Cycle-1.227.tar.gz";
-      hash = "sha256-eDgzV5HnGjszuKGd4wUpSeGJCkgj3vY5eCPJkiL6Hdg=";
+      url = "mirror://cpan/authors/id/B/BR/BRIANDFOY/Tie-Cycle-1.233.tar.gz";
+      hash = "sha256-BD0L7wr7pATq/yNqQAoXJly7YJqiESdDIS4fnuKQOfE=";
     };
     meta = {
       description = "Cycle through a list of values via a scalar";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18972,10 +18972,10 @@ with self;
 
   libintl-perl = buildPerlPackage {
     pname = "libintl-perl";
-    version = "1.33";
+    version = "1.37";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GU/GUIDO/libintl-perl-1.33.tar.gz";
-      hash = "sha256-USbtqczQ7rENuC3e9jy8r329dx54zA+xEMw7WmuGeec=";
+      url = "mirror://cpan/authors/id/G/GU/GUIDO/libintl-perl-1.37.tar.gz";
+      hash = "sha256-pJsI1WgTeJ5fAyiaP5SUWer+nkChqfwGbELJAAmjIs8=";
     };
     meta = {
       description = "Portable l10n and i10n functions";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26246,10 +26246,10 @@ with self;
 
   NetMQTTSimple = buildPerlPackage {
     pname = "Net-MQTT-Simple";
-    version = "1.28";
+    version = "1.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JU/JUERD/Net-MQTT-Simple-1.28.tar.gz";
-      hash = "sha256-Sp6hB+a8IuJrUzZ4oKPMbEI7N4TsP8ROjjM5t8Vr7gM=";
+      url = "mirror://cpan/authors/id/J/JU/JUERD/Net-MQTT-Simple-1.33.tar.gz";
+      hash = "sha256-WFOcHCeU0lhyZS14omyf0mtie9rRuRNKFZhpwbKCKqc=";
     };
     propagatedBuildInputs = [
       IOSocketSSL

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -31666,10 +31666,10 @@ with self;
 
   SQLTranslator = buildPerlPackage {
     pname = "SQL-Translator";
-    version = "1.63";
+    version = "1.66";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VE/VEESH/SQL-Translator-1.63.tar.gz";
-      hash = "sha256-WIWwTJNJi+MqGX3JcjlHUdXeYJNBiTqWZW3oikJgMTM=";
+      url = "mirror://cpan/authors/id/V/VE/VEESH/SQL-Translator-1.66.tar.gz";
+      hash = "sha256-9/9+Np2Ck6OUyzeDtUt0Xn+vREIuioO/zDWTeKblYUU=";
     };
     buildInputs = [
       FileShareDirInstall
@@ -31686,9 +31686,8 @@ with self;
       Moo
       PackageVariant
       ParseRecDescent
+      SubQuote
       TryTiny
-      GraphViz
-      GD
     ];
 
     postPatch = ''

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -23062,10 +23062,10 @@ with self;
 
   MojoliciousPluginOpenAPI = buildPerlPackage {
     pname = "Mojolicious-Plugin-OpenAPI";
-    version = "5.09";
+    version = "5.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojolicious-Plugin-OpenAPI-5.09.tar.gz";
-      hash = "sha256-BIJdfOIe20G80Ujrz6Gu+Ek258QOhKOdvyeGcdSaMQY=";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojolicious-Plugin-OpenAPI-5.11.tar.gz";
+      hash = "sha256-wpypJDztdgN/6y/63dmulPlJYMVbPfSlH7Jr8Xnm0zI=";
     };
     propagatedBuildInputs = [
       JSONValidator

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -35559,15 +35559,20 @@ with self;
 
   TestRun = buildPerlModule {
     pname = "Test-Run";
-    version = "0.0305";
+    version = "0.0306";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-0.0305.tar.gz";
-      hash = "sha256-+Jpx3WD44qd26OYBd8ntXlkJbUAF1QvSmJuSeeCHwkg=";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-0.0306.tar.gz";
+      hash = "sha256-q2CgUpk3K2l8L1adkyCKz5tBKcxmAzYbyRNMgvkQkfw=";
     };
-    buildInputs = [ TestTrap ];
+    buildInputs = [
+      ModuleBuild
+      TestTrap
+    ];
     propagatedBuildInputs = [
       IPCSystemSimple
       ListMoreUtils
+      MROCompat
+      Moose
       MooseXStrictConstructor
       TextSprintfNamed
       UNIVERSALrequire

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27122,22 +27122,22 @@ with self;
 
   OpenGL = buildPerlPackage rec {
     pname = "OpenGL";
-    version = "0.70";
+    version = "0.7006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHM/OpenGL-0.70.tar.gz";
-      hash = "sha256-sg4q9EBLSQGrNbumrV46iqYL/3JBPJkojwEBjEz4dOA=";
+      url = "mirror://cpan/authors/id/E/ET/ETJ/OpenGL-0.7006.tar.gz";
+      hash = "sha256-aaFYchO39BTloqfCiZ8xuR/WgcBVos7iOsTbky1n1Vc=";
     };
 
     # FIXME: try with libGL + libGLU instead of libGLU libGL
     buildInputs = [
-      pkgs.libGLU
       pkgs.libGL
+      pkgs.libGLU
       pkgs.libGLU
       pkgs.libglut
       pkgs.libx11
+      pkgs.libxext
       pkgs.libxi
       pkgs.libxmu
-      pkgs.libxext
       pkgs.xdummy
     ];
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -37429,10 +37429,10 @@ with self;
 
   TieRefHash = buildPerlPackage {
     pname = "Tie-RefHash";
-    version = "1.40";
+    version = "1.41";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Tie-RefHash-1.40.tar.gz";
-      hash = "sha256-Ws8fUY0vtfYgyq16Gy/x9vdRb++PQLprdD7si5aSftc=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Tie-RefHash-1.41.tar.gz";
+      hash = "sha256-SBQ1BbF2ZliWrEJ2Fnwsq+lN21nFnYFhBETxvTaEMTg=";
     };
     meta = {
       description = "Use references as hash keys";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -37625,10 +37625,10 @@ with self;
 
   TimeParseDate = buildPerlPackage {
     pname = "Time-ParseDate";
-    version = "2015.103";
+    version = "2026.0219";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MU/MUIR/modules/Time-ParseDate-2015.103.tar.gz";
-      hash = "sha256-LBoGI1v4EYE8qsnqqdqnGvdYZnzfewgstZhjIg/K7tE=";
+      url = "mirror://cpan/authors/id/B/BP/BPS/Time-ParseDate-2026.0219.tar.gz";
+      hash = "sha256-+41PTwomtxJNBL/5cNEDq12mno7FDxQI3axFIhEfey4=";
     };
     doCheck = false;
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32285,10 +32285,10 @@ with self;
 
   ShellGuess = buildPerlPackage {
     pname = "Shell-Guess";
-    version = "0.09";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Shell-Guess-0.09.tar.gz";
-      hash = "sha256-QGn6JjfkQxGO2VbXECMdFmgj0jsqZOuHuKRocuhloSs=";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Shell-Guess-0.10.tar.gz";
+      hash = "sha256-s+hxutqP58yCvLQzVa5B0BSTI0mCEjjKq8gVdsxh9G8=";
     };
     meta = {
       description = "Make an educated guess about the shell in use";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -34909,11 +34909,12 @@ with self;
 
   TestMemoryGrowth = buildPerlModule {
     pname = "Test-MemoryGrowth";
-    version = "0.04";
+    version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-MemoryGrowth-0.04.tar.gz";
-      hash = "sha256-oGWFJ1Kr1J5BFbmPbbRsdSy71ePkjtAUXO45L3k9LtA=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-MemoryGrowth-0.05.tar.gz";
+      hash = "sha256-ZuwIhxsCiJScstAkSiu9/iTY9m1YOWBf7nTlRRHhnTc=";
     };
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "Assert that code does not cause growth in memory usage";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30359,10 +30359,10 @@ with self;
 
   RegexpCommon = buildPerlPackage {
     pname = "Regexp-Common";
-    version = "2017060201";
+    version = "2024080801";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AB/ABIGAIL/Regexp-Common-2017060201.tar.gz";
-      hash = "sha256-7geFOu4G8xDgQLa/GgGZoY2BiW0yGbmzXJYw0OtpCJs=";
+      url = "mirror://cpan/authors/id/A/AB/ABIGAIL/Regexp-Common-2024080801.tar.gz";
+      hash = "sha256-BnevrsjhMAzv4ka02AnnXN9V4swPd8SG0TBztpq0+90=";
     };
     meta = {
       description = "Provide commonly requested regular expressions";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -23874,14 +23874,15 @@ with self;
 
   MooXCmd = buildPerlPackage {
     pname = "MooX-Cmd";
-    version = "0.017";
+    version = "1.000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/MooX-Cmd-0.017.tar.gz";
-      hash = "sha256-lD/yjaqAiXMnx8X+xacQDPqsktrw+fl8OOOnfQCucPU=";
+      url = "mirror://cpan/authors/id/G/GE/GETTY/MooX-Cmd-1.000.tar.gz";
+      hash = "sha256-2MDmRDHPNEe7XNaXEnfvU+NBIr0yrEKucZvbFfimDxY=";
     };
     propagatedBuildInputs = [
       ListMoreUtils
       ModulePluggable
+      ModuleRuntime
       Moo
       PackageStash
       ParamsUtil

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27793,10 +27793,10 @@ with self;
 
   ParseLocalDistribution = buildPerlPackage {
     pname = "Parse-LocalDistribution";
-    version = "0.19";
+    version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Parse-LocalDistribution-0.19.tar.gz";
-      hash = "sha256-awvDLE6NnoHz8qzB0qdMKi+IepHBUisxzkyNSaQV6Z4=";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Parse-LocalDistribution-0.20.tar.gz";
+      hash = "sha256-Zk9DUeVe6Uc8mwEq+H0oMvZSl5y4mt55VObzjNEmqFk=";
     };
     propagatedBuildInputs = [ ParsePMFile ];
     buildInputs = [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21379,10 +21379,10 @@ with self;
 
   MathRandom = buildPerlPackage {
     pname = "Math-Random";
-    version = "0.72";
+    version = "0.75";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GROMMEL/Math-Random-0.72.tar.gz";
-      hash = "sha256-vgUiMogR2W3lBdnrrD0JY1kCb6jVw497uZmnjsW8JUw=";
+      url = "mirror://cpan/authors/id/D/DJ/DJERIUS/Math-Random-0.75.tar.gz";
+      hash = "sha256-cvnJTDL8xtzaFr0qXlD2ViOG0q/FKOXvs2mqLpWWAls=";
     };
     meta = {
       description = "Random Number Generators";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39656,14 +39656,14 @@ with self;
 
   XSParseKeyword = buildPerlModule {
     pname = "XS-Parse-Keyword";
-    version = "0.48";
+    version = "0.49";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/XS-Parse-Keyword-0.48.tar.gz";
-      hash = "sha256-hXoHC6Rlq1uJ1NjTbZI1jt1m5ee0qRWEYR2FElrJqcc=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/XS-Parse-Keyword-0.49.tar.gz";
+      hash = "sha256-dsXtFCq7ofHfIzWEloHIPYPMCEL+hUr3EIHSxBHvsLs=";
     };
     buildInputs = [
       ExtUtilsCChecker
-      Test2Suite
+      ModuleBuild
     ];
     propagatedBuildInputs = [ FileShareDir ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -33860,14 +33860,14 @@ with self;
 
   Test2PluginNoWarnings = buildPerlPackage {
     pname = "Test2-Plugin-NoWarnings";
-    version = "0.09";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Test2-Plugin-NoWarnings-0.09.tar.gz";
-      hash = "sha256-vj3YAAQu7zYr8X0gVs+ek03ukczOmOTxeLj7V3Ly+3Q=";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Test2-Plugin-NoWarnings-0.10.tar.gz";
+      hash = "sha256-yXyxEizG4+SgeQWdpx4S9ldgv7BnHRnSWn7HxfHyQPs=";
     };
     buildInputs = [
       IPCRun3
-      Test2Suite
+      ModulePluggable
     ];
     meta = {
       description = "Fail if tests warn";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30168,10 +30168,10 @@ with self;
 
   POSIXstrftimeCompiler = buildPerlModule {
     pname = "POSIX-strftime-Compiler";
-    version = "0.44";
+    version = "0.46";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/POSIX-strftime-Compiler-0.44.tar.gz";
-      hash = "sha256-39PJc5jc/lHII2uF49woA1Znt2Ux96oKZTXzqlQFs1o=";
+      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/POSIX-strftime-Compiler-0.46.tar.gz";
+      hash = "sha256-v4iHMkjviMxeaO0HRJNJa+aE7DNOESc9RlQwbdna5IU=";
     };
     # We cannot change timezones on the fly.
     prePatch = "rm t/04_tzset.t";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32387,12 +32387,12 @@ with self;
 
   StructDumb = buildPerlModule {
     pname = "Struct-Dumb";
-    version = "0.14";
+    version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Struct-Dumb-0.14.tar.gz";
-      hash = "sha256-E8FIU2sQ4oxuC04TLynkym5ptXSQWcRBV6J+hKVFlDY=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Struct-Dumb-0.16.tar.gz";
+      hash = "sha256-68kDJkB3elv5AKMN4OVUNWr5zZUQHlEqNP4VU1xoJQg=";
     };
-    buildInputs = [ Test2Suite ];
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "Make simple lightweight record-like structures";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26307,15 +26307,16 @@ with self;
 
   NetPatricia = buildPerlPackage {
     pname = "Net-Patricia";
-    version = "1.22";
+    version = "1.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRUBER/Net-Patricia-1.22.tar.gz";
-      hash = "sha256-cINakm4cWo0DJMcv/+6C7rfsbBQd7gT9RGggtk9xxVI=";
+      url = "mirror://cpan/authors/id/G/GR/GRUBER/Net-Patricia-1.24.tar.gz";
+      hash = "sha256-2U9SCATiVBsc0g5zNmcgqXPK9d0tJiODj8jWOYr9fts=";
     };
     propagatedBuildInputs = [
       NetCIDRLite
       Socket6
     ];
+    buildInputs = [ TestPod ];
     meta = {
       description = "Patricia Trie perl module for fast IP address lookups";
       license = with lib.licenses; [ gpl2Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -31482,10 +31482,10 @@ with self;
 
   SpreadsheetXLSX = buildPerlPackage {
     pname = "Spreadsheet-XLSX";
-    version = "0.17";
+    version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AS/ASB/Spreadsheet-XLSX-0.17.tar.gz";
-      hash = "sha256-M7d4knz/FjCQZbdOuMRpawNxZg0szf5FvkYFCSrO6XY=";
+      url = "mirror://cpan/authors/id/A/AS/ASB/Spreadsheet-XLSX-0.18.tar.gz";
+      hash = "sha256-/eaJ2iCd9tPqlgCf82IgdcLAm1nYg3472xSAWpVRVtc=";
     };
     buildInputs = [
       TestNoWarnings

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -36048,10 +36048,10 @@ with self;
 
   TestWarnings = buildPerlPackage {
     pname = "Test-Warnings";
-    version = "0.032";
+    version = "0.038";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Warnings-0.032.tar.gz";
-      hash = "sha256-Ryfa4kFunwfkHi3DqRQ7pq/8HsV2UhF8mdUAOOMT6dk=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Test-Warnings-0.038.tar.gz";
+      hash = "sha256-PaJ+ADo8PK/tPAm0K+Bc+b2/8L7lyFkKcxsChTiAonM=";
     };
     buildInputs = [
       CPANMetaCheck

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17416,14 +17416,14 @@ with self;
 
   Imager = buildPerlPackage {
     pname = "Imager";
-    version = "1.025";
+    version = "1.029";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TONYC/Imager-1.025.tar.gz";
-      hash = "sha256-TwJ1y7HgEdfz/sYE3GtgwaxvAt78KYs9A31ur3vqcFg=";
+      url = "mirror://cpan/authors/id/T/TO/TONYC/Imager-1.029.tar.gz";
+      hash = "sha256-/4mps2s44kVjxTjvN5LT//3Es4l4Ziw5Tlk+rRypKIc=";
     };
     buildInputs = [
-      pkgs.freetype
       pkgs.fontconfig
+      pkgs.freetype
       pkgs.libjpeg
       pkgs.libpng
     ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17355,10 +17355,10 @@ with self;
 
   HTTPTinyish = buildPerlPackage {
     pname = "HTTP-Tinyish";
-    version = "0.18";
+    version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/HTTP-Tinyish-0.18.tar.gz";
-      hash = "sha256-gDgLjTPGv6lrsBBPpqQcJ9zE6cg6SN8frTkJf1/c/eU=";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/HTTP-Tinyish-0.19.tar.gz";
+      hash = "sha256-6c6UqZE/knXTEt7U3bNPdrrwEba41gKf8ocdW9e65Gg=";
     };
     propagatedBuildInputs = [
       FileWhich

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -37860,10 +37860,10 @@ with self;
 
   TypeTiny = buildPerlPackage {
     pname = "Type-Tiny";
-    version = "2.004000";
+    version = "2.010001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Type-Tiny-2.004000.tar.gz";
-      hash = "sha256-aX5/d17fyF9M8HeS0E/RmwnCUoX5j1k46O/E90UHoSg=";
+      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Type-Tiny-2.010001.tar.gz";
+      hash = "sha256-zVg+SYMDnzUFLUkPDEQ5EkumZ9TwnE467EfeUgD5kho=";
     };
     propagatedBuildInputs = [ ExporterTiny ];
     buildInputs = [ TestMemoryCycle ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19398,12 +19398,12 @@ with self;
 
   LinuxFD = buildPerlModule {
     pname = "Linux-FD";
-    version = "0.014";
+    version = "0.017";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Linux-FD-0.014.tar.gz";
-      hash = "sha256-eDHcJkxG2bh/dkNhdNdmFBRSQ2Mwg+CQqrTZo1LwQ60=";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Linux-FD-0.017.tar.gz";
+      hash = "sha256-EtvBV/Dp9cjZDfEX+GDL0+2J1D/LD+mQRtqocwNdX5A=";
     };
-    buildInputs = [ TestException ];
+    buildInputs = [ ModuleBuild ];
     propagatedBuildInputs = [ SubExporter ];
     meta = {
       description = "Linux specific special filehandles";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -2263,10 +2263,10 @@ with self;
 
   autobox = buildPerlPackage {
     pname = "autobox";
-    version = "3.0.1";
+    version = "3.0.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHOCOLATE/autobox-v3.0.1.tar.gz";
-      hash = "sha256-wwO3/M+qH/TUxCmrPxXlyip3VU74yfw7jGK6hZ6HTJg=";
+      url = "mirror://cpan/authors/id/C/CH/CHOCOLATE/autobox-v3.0.2.tar.gz";
+      hash = "sha256-cHUVMbp412jW9Pd6MrHqLRlZ5243tvieXOaTDAbGC/Y=";
     };
     propagatedBuildInputs = [ ScopeGuard ];
     buildInputs = [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -31279,10 +31279,10 @@ with self;
 
   SoftwareLicense = buildPerlPackage {
     pname = "Software-License";
-    version = "0.104004";
+    version = "0.104007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Software-License-0.104004.tar.gz";
-      hash = "sha256-of2iTsh3UhmAlzgPuTAMFLV0gmJwzFgNr3UONYX8Jww=";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Software-License-0.104007.tar.gz";
+      hash = "sha256-gUYto82edFkB8p/wBsTIBMydsBfM9FFUs82VWFQLwZE=";
     };
     buildInputs = [ TryTiny ];
     propagatedBuildInputs = [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32151,10 +32151,10 @@ with self;
 
   StringInterpolateNamed = buildPerlPackage {
     pname = "String-Interpolate-Named";
-    version = "1.03";
+    version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JV/JV/String-Interpolate-Named-1.03.tar.gz";
-      hash = "sha256-on13VgcnX2jtkqQT85SsAJLn3hzZPWJHnUf7pwF6Jtw=";
+      url = "mirror://cpan/authors/id/J/JV/JV/String-Interpolate-Named-1.06.tar.gz";
+      hash = "sha256-ASzKV7r4M1sWPHNLeJ1ZZt3kfwvYpXlDP0hSymZv/+I=";
     };
     meta = {
       description = "Interpolated named arguments in string";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26846,14 +26846,18 @@ with self;
 
   NumberFraction = buildPerlModule {
     pname = "Number-Fraction";
-    version = "3.0.4";
+    version = "3.1.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAVECROSS/Number-Fraction-v3.0.4.tar.gz";
-      hash = "sha256-xkGcird4/XKbENfmp487ewf8CJV8H3nlZm3Ny01iwIU=";
+      url = "mirror://cpan/authors/id/D/DA/DAVECROSS/Number-Fraction-v3.1.0.tar.gz";
+      hash = "sha256-I3rAIVjJ4dL3X7MhGynkrF16ct3U7Aq+VErhlS909+I=";
     };
     propagatedBuildInputs = [
       Moo
-      MooXTypesMooseLike
+      TypeTiny
+    ];
+    buildInputs = [
+      ModuleBuild
+      TestWarn
     ];
     meta = {
       description = "Perl extension to model fractions";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22807,12 +22807,12 @@ with self;
     };
   };
 
-  ModuleRuntime = buildPerlModule {
+  ModuleRuntime = buildPerlPackage {
     pname = "Module-Runtime";
-    version = "0.016";
+    version = "0.018";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/Module-Runtime-0.016.tar.gz";
-      hash = "sha256-aDAuxkaDNUfUEL4o4JZ223UAb0qlihHzvbRP/pnw8CQ=";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Module-Runtime-0.018.tar.gz";
+      hash = "sha256-C/d+9o5TchkU/1VOraIJc1ljELTizxQB/JWGAYB95Xc=";
     };
     meta = {
       description = "Runtime module handling";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19363,11 +19363,12 @@ with self;
 
   LinuxDesktopFiles = buildPerlModule {
     pname = "Linux-DesktopFiles";
-    version = "0.25";
+    version = "0.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TR/TRIZEN/Linux-DesktopFiles-0.25.tar.gz";
-      hash = "sha256-YDd6dPupD6RlIA7hx0MNvd5p1FTYX57hAcA5gDoH5fU=";
+      url = "mirror://cpan/authors/id/T/TR/TRIZEN/Linux-DesktopFiles-0.26.tar.gz";
+      hash = "sha256-VZ2rWbsPxW+5kEiAcW5euYY8H71CNjKSOCxp2WiZqMg=";
     };
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "Fast parsing of the Linux desktop files";
       homepage = "https://github.com/trizen/Linux-DesktopFiles";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18255,10 +18255,10 @@ with self;
 
   IPCRun3 = buildPerlPackage {
     pname = "IPC-Run3";
-    version = "0.048";
+    version = "0.049";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/IPC-Run3-0.048.tar.gz";
-      hash = "sha256-PYHDzBtc/2nMqTYeLG443wNSJRrntB4v8/68hQ5GNWU=";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/IPC-Run3-0.049.tar.gz";
+      hash = "sha256-nQSK57muY4cbrpdroB4IHYhzktkE5dSLBOItNe0iARo=";
     };
     meta = {
       description = "Run a subprocess with input/output redirection";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21558,25 +21558,37 @@ with self;
 
   MaxMindDBWriter = buildPerlModule {
     pname = "MaxMind-DB-Writer";
-    version = "0.300003";
+    version = "0.300004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Writer-0.300003.tar.gz";
-      hash = "sha256-ulP1upZfekd/ZxZNl7R1oMESCIcv7fI4mIVQ2SvN6z4=";
+      url = "mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Writer-0.300004.tar.gz";
+      hash = "sha256-mVaTQrXUnerhaFLO3/DONhDiBwHBWKFrg8yZuJCmR+s=";
     };
     propagatedBuildInputs = [
-      DigestSHA1
+      DataDumperConcise
+      DataIEEE754
+      MathInt128
+      MathInt64
+      MaxMindDBCommon
       MaxMindDBReader
+      Moose
       MooseXParamsValidate
       MooseXStrictConstructor
       NetWorks
       SerealDecoder
       SerealEncoder
+      TestDeep
+      namespaceautoclean
     ];
     buildInputs = [
+      DataPrinter
       DevelRefcount
       JSON
+      ListAllUtils
+      MaxMindDBCommon
+      MaxMindDBReader
+      ModuleBuild
+      NetWorks
       TestBits
-      TestDeep
       TestFatal
       TestHexDifferences
       TestRequires

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16676,10 +16676,10 @@ with self;
 
   HTMLTagset = buildPerlPackage {
     pname = "HTML-Tagset";
-    version = "3.20";
+    version = "3.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/HTML-Tagset-3.20.tar.gz";
-      hash = "sha256-rbF9rJ42zQEfUkOIHJc5QX/RAvznYPjeTpvkxxMRCOI=";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/HTML-Tagset-3.24.tar.gz";
+      hash = "sha256-64nhRaYI7R+PFBpXRy7l9p5nWSpDLc0uix27RF8rIws=";
     };
     meta = {
       description = "Data tables useful in parsing HTML";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22963,10 +22963,10 @@ with self;
 
   Mojolicious = buildPerlPackage {
     pname = "Mojolicious";
-    version = "9.39";
+    version = "9.42";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-9.39.tar.gz";
-      hash = "sha256-EwpJDXfXYTn3NM4biU1Fm64DgF+x89/dWPxE/oKvPP0=";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-9.42.tar.gz";
+      hash = "sha256-Iyi1HaA3HkFqhTcrms0EQz9SE+mXy/rk7ITUxj7jbIo=";
     };
     meta = {
       description = "Real-time web framework";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32945,10 +32945,10 @@ with self;
 
   SysSigAction = buildPerlPackage {
     pname = "Sys-SigAction";
-    version = "0.23";
+    version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LB/LBAXTER/Sys-SigAction-0.23.tar.gz";
-      hash = "sha256-xO9sk0VTQDH8u+Ktw0f8cZTUevyUXnpE+sfpVjCV01M=";
+      url = "mirror://cpan/authors/id/L/LB/LBAXTER/Sys-SigAction-0.24.tar.gz";
+      hash = "sha256-4Eyaf990XT6c2eiy1aRtgmupWMXh4MSLPNEyuxU5YlU=";
     };
     doCheck = !stdenv.hostPlatform.isAarch64; # it hangs on Aarch64
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -23348,10 +23348,10 @@ with self;
 
   MojoPg = buildPerlPackage {
     pname = "Mojo-Pg";
-    version = "4.27";
+    version = "4.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Mojo-Pg-4.27.tar.gz";
-      hash = "sha256-oyLI3wDj5WVf300LernXmSiTIOKfZP6ZrHrxJEhO+dg=";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Mojo-Pg-4.28.tar.gz";
+      hash = "sha256-7YuqMc04jIL9N4rDdVAvGOUnbXgRtukfkDiY7CJ/3yE=";
     };
     propagatedBuildInputs = [
       DBDPg

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -35006,13 +35006,16 @@ with self;
 
   TestMockModule = buildPerlModule {
     pname = "Test-MockModule";
-    version = "0.177.0";
+    version = "0.180.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GF/GFRANKS/Test-MockModule-v0.177.0.tar.gz";
-      hash = "sha256-G9p6SdzqdgdtQKe2psPz4V5rGchLYXHfRFNNkROPEEU=";
+      url = "mirror://cpan/authors/id/G/GF/GFRANKS/Test-MockModule-v0.180.0.tar.gz";
+      hash = "sha256-OQ5gNh0sHEBEY6RtSWaBsFRY1Q2BHumSgpkrm2HtbPY=";
     };
     propagatedBuildInputs = [ SUPER ];
-    buildInputs = [ TestWarnings ];
+    buildInputs = [
+      ModuleBuild
+      TestWarnings
+    ];
     meta = {
       description = "Override subroutines in a module for unit testing";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -38709,33 +38709,33 @@ with self;
 
   Workflow = buildPerlPackage {
     pname = "Workflow";
-    version = "1.62";
+    version = "2.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JO/JONASBN/Workflow-1.62.tar.gz";
-      hash = "sha256-WNNokAm4j+Gp2DcWfTKaoe4xTzFZeeVik2OGVFs80pU=";
+      url = "mirror://cpan/authors/id/J/JO/JONASBN/Workflow-2.09.tar.gz";
+      hash = "sha256-WQoHrNrPb67Nt4SsWWwKtU4tAQhV10r2V7g7t03Wx4s=";
     };
     buildInputs = [
       DBDMock
       ListMoreUtils
       MockMonkeyPatch
-      PodCoverageTrustPod
       TestException
-      TestKwalitee
-      TestPod
-      TestPodCoverage
+      TestWithoutModule
     ];
     propagatedBuildInputs = [
       ClassAccessor
       ClassFactory
-      DateTime
       DBI
       DataUUID
+      DateTime
       DateTimeFormatStrptime
       ExceptionClass
       FileSlurp
-      LogLog4perl
+      LogAny
+      ModuleRuntime
       Readonly
+      SyntaxKeywordTry
       XMLSimple
+      YAML
     ];
     meta = {
       description = "Simple, flexible system to implement workflows";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39789,10 +39789,10 @@ with self;
 
   YAMLLibYAML = buildPerlPackage {
     pname = "YAML-LibYAML";
-    version = "0.89";
+    version = "0.904.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TINITA/YAML-LibYAML-0.89.tar.gz";
-      hash = "sha256-FVq4NnU0XFCt0DMRrPndkVlVcH+Qmiq9ixfXeShZsuw=";
+      url = "mirror://cpan/authors/id/T/TI/TINITA/YAML-LibYAML-v0.904.0.tar.gz";
+      hash = "sha256-tlawsRpCGcElZ56Mv3Q2o/Y26DP9Y88yLRcdy3w+rz4=";
     };
     meta = {
       description = "Perl YAML Serialization using XS and libyaml";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21922,10 +21922,10 @@ with self;
 
   MIMETools = buildPerlPackage {
     pname = "MIME-tools";
-    version = "5.509";
+    version = "5.517";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DS/DSKOLL/MIME-tools-5.509.tar.gz";
-      hash = "sha256-ZFefDJI9gdmiGUWG5Hw0dVGeJkbktcECqJIHWfrPaXM=";
+      url = "mirror://cpan/authors/id/D/DS/DSKOLL/MIME-tools-5.517.tar.gz";
+      hash = "sha256-4F+ORdCJUWSx/lOgqOcl3YHpIZGilAnhtIxV+COwNIM=";
     };
     propagatedBuildInputs = [ MailTools ];
     buildInputs = [ TestDeep ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16891,12 +16891,19 @@ with self;
 
   HTTPCookies = buildPerlPackage {
     pname = "HTTP-Cookies";
-    version = "6.10";
+    version = "6.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Cookies-6.10.tar.gz";
-      hash = "sha256-4282Yzxc5rXkuHb/z3R4fMXv4HNt1/SHvdc8FPC9cAc=";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Cookies-6.11.tar.gz";
+      hash = "sha256-jJpUGko59sDH49C3ALBd/bgwvUkKGxlCp97dG1DZqMg=";
     };
-    propagatedBuildInputs = [ HTTPMessage ];
+    propagatedBuildInputs = [
+      HTTPDate
+      HTTPMessage
+    ];
+    buildInputs = [
+      HTTPMessage
+      URI
+    ];
     meta = {
       description = "HTTP cookie jars";
       homepage = "https://github.com/libwww-perl/HTTP-Cookies";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20774,10 +20774,10 @@ with self;
 
   MailDKIM = buildPerlPackage {
     pname = "Mail-DKIM";
-    version = "1.20230911";
+    version = "1.20240923";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-DKIM-1.20230911.tar.gz";
-      hash = "sha256-kecxcoK3JM+9LJtuZjDvFDKISLb8UgPv1w3sL7hyaMo=";
+      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-DKIM-1.20240923.tar.gz";
+      hash = "sha256-Rd5G9dxNI7y2rWQBdZiB3UOWjqsg5z9vedlVdGfeIO4=";
     };
     propagatedBuildInputs = [
       CryptOpenSSLRSA
@@ -20788,8 +20788,10 @@ with self;
     ];
     doCheck = false; # tries to access the domain name system
     buildInputs = [
+      NetDNS
       NetDNSResolverMock
       TestRequiresInternet
+      YAML
       YAMLLibYAML
     ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19015,18 +19015,20 @@ with self;
 
   libwwwperl = buildPerlPackage {
     pname = "libwww-perl";
-    version = "6.72";
+    version = "6.81";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/libwww-perl-6.72.tar.gz";
-      hash = "sha256-6bg1T9XiC+IHr+I93VhPzVm/gpmNwHfez2hLodrloF0=";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/libwww-perl-6.81.tar.gz";
+      hash = "sha256-qzBVLxlOi1rjrAiFEy/R1OoExMf+ZVV2W5jwGvcMFzY=";
     };
     buildInputs = [
+      HTTPCookieJar
       HTTPDaemon
       TestFatal
       TestNeeds
       TestRequiresInternet
     ];
     propagatedBuildInputs = [
+      ApacheTest
       EncodeLocale
       FileListing
       HTMLParser

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27814,10 +27814,10 @@ with self;
 
   ParsePlainConfig = buildPerlPackage {
     pname = "Parse-PlainConfig";
-    version = "3.06";
+    version = "3.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CORLISS/Parse-PlainConfig/Parse-PlainConfig-3.06.tar.gz";
-      hash = "sha256-8ffT5OWawrbPbJjaDKpBxdTl2GVcIQdRSBlplS/+G4c=";
+      url = "mirror://cpan/authors/id/C/CO/CORLISS/Parse-PlainConfig/Parse-PlainConfig-3.07.tar.gz";
+      hash = "sha256-pbD5Y6uljevlEEFY7N05/Dtq6jOZxx3lEudns0lRmpg=";
     };
     propagatedBuildInputs = [
       ClassEHierarchy

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -34371,10 +34371,10 @@ with self;
 
   TestDifferences = buildPerlPackage {
     pname = "Test-Differences";
-    version = "0.70";
+    version = "0.72";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Test-Differences-0.70.tar.gz";
-      hash = "sha256-vuG1GGqpuif+0r8bBnRSDQvQzQUdkTOH+QhsH5SlaFQ=";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Test-Differences-0.72.tar.gz";
+      hash = "sha256-ZIhEudy32ub5taFck1nQ8J3iR6YktlxGIOv/JJVY+RM=";
     };
     propagatedBuildInputs = [
       CaptureTiny

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -34529,10 +34529,10 @@ with self;
 
   TestFatal = buildPerlPackage {
     pname = "Test-Fatal";
-    version = "0.017";
+    version = "0.018";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-Fatal-0.017.tar.gz";
-      hash = "sha256-N9//2vuEt2Lv6WsC+yqkHzcCbHPmuDWQ23YilpfzxKY=";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-Fatal-0.018.tar.gz";
+      hash = "sha256-uNLMz57kZycbxHj5z366SVRUUr6TAq41m8U4uL9ofNY=";
     };
     propagatedBuildInputs = [ TryTiny ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -24749,20 +24749,24 @@ with self;
 
   MooseXTypes = buildPerlModule {
     pname = "MooseX-Types";
-    version = "0.50";
+    version = "0.51";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-0.50.tar.gz";
-      hash = "sha256-nNh7NJLL8L6dLfkxeyrfn8MGY3cOaZBmVL6j9BsXywg=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-0.51.tar.gz";
+      hash = "sha256-pTdMewJzIgI5sZ3aiLgk3XO5U5jJE8XJ4wXtvbXgJw8=";
     };
     buildInputs = [
       ModuleBuildTiny
+      Moose
       TestFatal
-      TestRequires
+      TestNeeds
     ];
     propagatedBuildInputs = [
       CarpClan
+      ModuleRuntime
       Moose
+      SubExporter
       SubExporterForMethods
+      SubInstall
       namespaceautoclean
     ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28203,12 +28203,16 @@ with self;
 
   PerlCritic = buildPerlModule {
     pname = "Perl-Critic";
-    version = "1.150";
+    version = "1.156";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Perl-Critic-1.150.tar.gz";
-      hash = "sha256-5c2V3j5DvOcHdRdidLqkBfMm/IdA3wBUu4FpdcyNNJs=";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Perl-Critic-1.156.tar.gz";
+      hash = "sha256-Vyp8h1i6HAq22vC9QCl8Tw3PFRbwhFIt8sK/BNUl4jI=";
     };
-    buildInputs = [ TestDeep ];
+    buildInputs = [
+      BKeywords
+      ListSomeUtils
+      ModuleBuild
+    ];
     propagatedBuildInputs = [
       BKeywords
       ConfigTiny
@@ -28217,11 +28221,12 @@ with self;
       ListSomeUtils
       ModulePluggable
       PPI
+      PPIxIndexOffsets
       PPIxQuoteLike
       PPIxRegexp
-      PPIxUtilities
       PPIxUtils
       PerlTidy
+      PodParser
       PodSpell
       Readonly
       StringFormat

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16560,12 +16560,16 @@ with self;
 
   HTMLRewriteAttributes = buildPerlPackage {
     pname = "HTML-RewriteAttributes";
-    version = "0.05";
+    version = "0.06";
     src = fetchurl {
       url = "mirror://cpan/authors/id/B/BP/BPS/HTML-RewriteAttributes-0.06.tar.gz";
       hash = "sha256-vGQgAmEUL5pffgeG3FqySmMwvBm9Hj6btLbXwxYhtyI=";
     };
-    propagatedBuildInputs = [ HTMLParser ];
+    propagatedBuildInputs = [
+      HTMLParser
+      HTMLTagset
+      URI
+    ];
     meta = {
       description = "Concise attribute rewriting";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -37038,14 +37038,17 @@ with self;
     };
   };
 
-  TestVars = buildPerlModule {
+  TestVars = buildPerlPackage {
     pname = "Test-Vars";
-    version = "0.015";
+    version = "0.017";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GF/GFUJI/Test-Vars-0.015.tar.gz";
-      hash = "sha256-4Y3RWCcuTsmTnh37M8dDGrTnXGtAsoDDi16AT9pHGlQ=";
+      url = "mirror://cpan/authors/id/J/JK/JKEENAN/Test-Vars-0.017.tar.gz";
+      hash = "sha256-Vt2su2Y89UJnOqZVJe9QmAtT8gd3DnQ6HRhhS9gmgXg=";
     };
-    buildInputs = [ ModuleBuildTiny ];
+    buildInputs = [
+      Moose
+      TestOutput
+    ];
     preCheck = ''
       # Remove tests with hardcoded line numbers.
       rm t/03_warned.t

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3425,6 +3425,7 @@ with self;
     propagatedBuildInputs = [
       CatalystModelDBICSchema
       CatalystPluginAuthentication
+      ClassAccessorFast
     ];
     buildInputs = [ TestWarn ];
     meta = {
@@ -3750,6 +3751,10 @@ with self;
       TryTiny
       namespaceautoclean
     ];
+    preCheck = ''
+      rm t/store_nopassord.t
+      rm t/live_app.t
+    '';
     meta = {
       description = "Infrastructure plugin for the Catalyst authentication framework";
       license = with lib.licenses; [
@@ -5928,8 +5933,8 @@ with self;
     preConfigure = ''
       cat > config.in <<EOF
         BUILD_ZLIB   = False
-        INCLUDE      = ${pkgs.zlib.dev}/include
-        LIB          = ${pkgs.zlib.out}/lib
+        ZLIB_INCLUDE = ${pkgs.zlib.dev}/include
+        ZLIB_LIB     = ${pkgs.zlib.out}/lib
         OLD_ZLIB     = False
         GZIP_OS_CODE = AUTO_DETECT
         USE_ZLIB_NG  = False
@@ -6742,7 +6747,6 @@ with self;
       url = "mirror://cpan/authors/id/R/RU/RURBAN/Cpanel-JSON-XS-4.40.tar.gz";
       hash = "sha256-eFRz8HZzsZfhwplk6URe2WnuC0sq31HXvr7GiHzTUUw=";
     };
-    patches = [ ../development/perl-modules/Cpanel-JSON-XS-CVE-2025-40929.patch ];
     meta = {
       description = "CPanel fork of JSON::XS, fast and correct serializing";
       license = with lib.licenses; [
@@ -8845,9 +8849,6 @@ with self;
       url = "mirror://cpan/authors/id/G/GT/GTERMARS/Data-UUID-1.227.tar.gz";
       hash = "sha256-lb2nJ2Jl9XvEj/3t3sXvKM1vdl46GDdX+l8J8M5rmKw=";
     };
-    patches = [
-      ../development/perl-modules/Data-UUID-CVE-2013-4184.patch
-    ];
     meta = {
       description = "Globally/Universally Unique Identifiers (GUIDs/UUIDs)";
       license = with lib.licenses; [ bsd0 ];
@@ -13658,9 +13659,6 @@ with self;
       url = "mirror://cpan/authors/id/R/RC/RCLAMP/File-Find-Rule-0.35.tar.gz";
       hash = "sha256-K9VWKJptRK0u50gDJYuwsAUNJG8egcqrCyY8MDrPDII=";
     };
-    patches = [
-      ../development/perl-modules/FileFindRule-CVE-2011-10007.patch
-    ];
     propagatedBuildInputs = [
       NumberCompare
       TextGlob
@@ -18712,7 +18710,6 @@ with self;
       url = "mirror://cpan/authors/id/M/ML/MLEHMANN/JSON-XS-4.04.tar.gz";
       hash = "sha256-jv8enzBMViW1mre0IlhBX20+NoHB3atrclUYoBin9eA=";
     };
-    patches = [ ../development/perl-modules/JSON-XS-CVE-2025-40928.patch ];
     propagatedBuildInputs = [
       TypesSerialiser
       commonsense
@@ -19010,46 +19007,6 @@ with self;
       description = "Add paths relative to the current file to @INC";
       homepage = "https://github.com/Grinnz/lib-relative";
       license = with lib.licenses; [ artistic2 ];
-    };
-  };
-
-  libwwwperl = buildPerlPackage {
-    pname = "libwww-perl";
-    version = "6.81";
-    src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/libwww-perl-6.81.tar.gz";
-      hash = "sha256-qzBVLxlOi1rjrAiFEy/R1OoExMf+ZVV2W5jwGvcMFzY=";
-    };
-    buildInputs = [
-      HTTPCookieJar
-      HTTPDaemon
-      TestFatal
-      TestNeeds
-      TestRequiresInternet
-    ];
-    propagatedBuildInputs = [
-      ApacheTest
-      EncodeLocale
-      FileListing
-      HTMLParser
-      HTTPCookieJar
-      HTTPCookies
-      HTTPDate
-      HTTPMessage
-      HTTPNegotiate
-      LWPMediaTypes
-      NetHTTP
-      TryTiny
-      URI
-      WWWRobotRules
-    ];
-    meta = {
-      homepage = "https://github.com/libwww-perl/libwww-perl";
-      description = "World-Wide Web library for Perl";
-      license = with lib.licenses; [
-        artistic1
-        gpl1Plus
-      ];
     };
   };
 
@@ -22762,10 +22719,6 @@ with self;
       url = "mirror://cpan/authors/id/S/SI/SIMONW/Module-Pluggable-6.3.tar.gz";
       hash = "sha256-WFErucZUdG0JN3cLmLVZswhy2FrCQHNIXlgwiQ3RsqA=";
     };
-    patches = [
-      # !!! merge this patch into Perl itself (which contains Module::Pluggable as well)
-      ../development/perl-modules/module-pluggable.patch
-    ];
     buildInputs = [ AppFatPacker ];
     meta = {
       description = "Automatically give your module the ability to have plugins";
@@ -25520,6 +25473,7 @@ with self;
       DateTimeFormatHTTP
       DigestHMAC
       DigestMD5File
+      ExporterTiny
       FileFindRule
       LWPUserAgentDetermined
       MIMETypes
@@ -40152,6 +40106,7 @@ with self;
   LWPProtocolconnect = self.LWPProtocolConnect;
   LWPProtocolhttps = self.LWPProtocolHttps;
   LWPUserAgent = self.LWP;
+  libwwwperl = self.LWP;
   MIMEtools = self.MIMETools;
   NetLDAP = self.perlldap;
   NetSMTP = self.libnet;
@@ -40508,6 +40463,7 @@ with self;
       hash = "sha256-tF8dpLpVUMeDneJtJqc5hTZ2vJk380uuTpNvnNeYIVM=";
     };
     propagatedBuildInputs = [ PPI ];
+    doCheck = false; # Shebang patching breaks offset tests
     meta = {
       description = "Index offsets for tokens in PPI";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22930,10 +22930,10 @@ with self;
 
   MojoDOM58 = buildPerlPackage {
     pname = "Mojo-DOM58";
-    version = "3.001";
+    version = "3.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/Mojo-DOM58-3.001.tar.gz";
-      hash = "sha256-GLJtVB5TFEFa3d8xQ2nZQMi6BrESNMpQb9vmzyJPV5Y=";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/Mojo-DOM58-3.002.tar.gz";
+      hash = "sha256-GwZgNaM1UylsnpcNQZa3WYQqSvHXJ7GVpgtdsKwU4zg=";
     };
     meta = {
       description = "Minimalistic HTML/XML DOM parser with CSS selectors";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39773,10 +39773,10 @@ with self;
 
   YAMLTiny = buildPerlPackage {
     pname = "YAML-Tiny";
-    version = "1.74";
+    version = "1.76";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/YAML-Tiny-1.74.tar.gz";
-      hash = "sha256-ezjKn1084kIwpri9wfR/Wy2zSOf3+WZsJvWVVjbjPWw=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/YAML-Tiny-1.76.tar.gz";
+      hash = "sha256-qNWEOUzwab+PF8uj3VCZADsJf84xbDH7CU8bHBccCKM=";
     };
     meta = {
       description = "Read/Write YAML files with as little code as possible";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29211,10 +29211,10 @@ with self;
 
   ProcProcessTable = buildPerlPackage {
     pname = "Proc-ProcessTable";
-    version = "0.636";
+    version = "0.637";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JW/JWB/Proc-ProcessTable-0.636.tar.gz";
-      hash = "sha256-lEIk/7APwe81BpYzdwoK/ahiO1x1MtHkq0ip3zlIkP0=";
+      url = "mirror://cpan/authors/id/J/JW/JWB/Proc-ProcessTable-0.637.tar.gz";
+      hash = "sha256-1+aItfC9XTjluzBvFvkEqskxEt+O2gmP7+8cgQu6b4U=";
     };
     meta = {
       description = "Perl extension to access the unix process table";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32813,13 +32813,13 @@ with self;
 
   SyntaxKeywordJunction = buildPerlPackage {
     pname = "Syntax-Keyword-Junction";
-    version = "0.003008";
+    version = "0.003009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/Syntax-Keyword-Junction-0.003008.tar.gz";
-      hash = "sha256-i0l18hsZkqfmwt9dzJKyVMYZJVle3c368LFJhxeqle8=";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Syntax-Keyword-Junction-0.003009.tar.gz";
+      hash = "sha256-7NQswpJ9LtiegNdXHjS6RDdlFA5RIV1llYOo2knTGfA=";
     };
-    buildInputs = [ TestRequires ];
-    propagatedBuildInputs = [ syntax ];
+    buildInputs = [ TestNeeds ];
+    propagatedBuildInputs = [ SubExporterProgressive ];
     meta = {
       description = "Perl6 style Junction operators in Perl5";
       homepage = "https://github.com/frioux/Syntax-Keyword-Junction";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28047,10 +28047,10 @@ with self;
 
   PDFAPI2 = buildPerlPackage {
     pname = "PDF-API2";
-    version = "2.045";
+    version = "2.048";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SS/SSIMMS/PDF-API2-2.045.tar.gz";
-      hash = "sha256-tr204NDNZSYQP91YwXHgVgw2uEO3/jyk3cm7HkyDJAY=";
+      url = "mirror://cpan/authors/id/S/SS/SSIMMS/PDF-API2-2.048.tar.gz";
+      hash = "sha256-Np3hpKVlKJmjmkVZgyYkjZxy8CwWgSpQ6Gi3QB9jTYk=";
     };
     buildInputs = [
       TestException

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30568,11 +30568,12 @@ with self;
 
   RoleBasic = buildPerlModule {
     pname = "Role-Basic";
-    version = "0.13";
+    version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OV/OVID/Role-Basic-0.13.tar.gz";
-      hash = "sha256-OKCVnvnxk/925ywyWp6SEbxIaGib0OKwBXePU/i282o=";
+      url = "mirror://cpan/authors/id/O/OV/OVID/Role-Basic-0.16.tar.gz";
+      hash = "sha256-RxfXAMqnv97517TsL0ig3wbs51iv6qnos/BJYbnDaKY=";
     };
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "Just roles. Nothing else";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27871,10 +27871,10 @@ with self;
 
   ParseSyslog = buildPerlPackage {
     pname = "Parse-Syslog";
-    version = "1.10";
+    version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DS/DSCHWEI/Parse-Syslog-1.10.tar.gz";
-      hash = "sha256-ZZohRUQe822YNd7K+D2jCPzQP0kTjLPZCSjov8nxOdk=";
+      url = "mirror://cpan/authors/id/D/DS/DSCHWEI/Parse-Syslog-1.11.tar.gz";
+      hash = "sha256-I424Mw/twTuijuU5BQQcwSQVN1mxYrDvZ2PRgB3nnrw=";
     };
     meta = {
       description = "Parse Unix syslog files";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -34275,10 +34275,10 @@ with self;
 
   TestDeep = buildPerlPackage {
     pname = "Test-Deep";
-    version = "1.204";
+    version = "1.205";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-Deep-1.204.tar.gz";
-      hash = "sha256-tlkfbM3YU8fvyf88V1Y3BAMhHP/kYEfwgrHNFhGoTl8=";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Test-Deep-1.205.tar.gz";
+      hash = "sha256-QngemUOnohXmYsSXO5/q/cAZ/RZGm9uEmoU37liVYnM=";
     };
     meta = {
       description = "Extremely flexible deep comparison";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30101,10 +30101,10 @@ with self;
 
   PodWeaver = buildPerlPackage {
     pname = "Pod-Weaver";
-    version = "4.019";
+    version = "4.020";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Pod-Weaver-4.019.tar.gz";
-      hash = "sha256-aUatHwTq+aoR8kzFRJTh1Xli9Y4FkS82S3T5WT595/c=";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Pod-Weaver-4.020.tar.gz";
+      hash = "sha256-ZV/PJhIGwa28MDiYF5CxFsMVCEhRNcZICTuZs7PeCdI=";
     };
     buildInputs = [
       PPI
@@ -30112,11 +30112,21 @@ with self;
       TestDifferences
     ];
     propagatedBuildInputs = [
+      ConfigMVP
       ConfigMVPReaderINI
       DateTime
       ListMoreUtils
       LogDispatchouli
+      MixinLinewise
+      ModuleRuntime
+      Moose
+      ParamsUtil
       PodElemental
+      StringFlogger
+      StringFormatter
+      StringRewritePrefix
+      TextTemplate
+      namespaceautoclean
     ];
     meta = {
       description = "Weave together a Pod document from an outline";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21865,10 +21865,10 @@ with self;
 
   MIMEEncWords = buildPerlPackage {
     pname = "MIME-EncWords";
-    version = "1.014.3";
+    version = "1.015.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEZUMI/MIME-EncWords-1.014.3.tar.gz";
-      hash = "sha256-6a+1SGEdTn5sULfwa70rG7KAjjeoEN7vtTfGevVIUjg=";
+      url = "mirror://cpan/authors/id/N/NE/NEZUMI/MIME-EncWords-1.015.0.tar.gz";
+      hash = "sha256-I+8GWJeCEze90WSH5l4qN5g4M0giXHLNdiuzdBrQCbU=";
     };
     propagatedBuildInputs = [ MIMECharset ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25954,10 +25954,10 @@ with self;
 
   NetHTTP = buildPerlPackage {
     pname = "Net-HTTP";
-    version = "6.23";
+    version = "6.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/Net-HTTP-6.23.tar.gz";
-      hash = "sha256-DWXAndbIWJsq4RGBdNPBphcDtuz8FKNEKox0r2XgyU4=";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/Net-HTTP-6.24.tar.gz";
+      hash = "sha256-KQ7ZqXsFx5NbBI5tKjVgNYcfypitcsAcWWFyat+FyDw=";
     };
     propagatedBuildInputs = [ URI ];
     __darwinAllowLocalNetworking = true;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39956,23 +39956,28 @@ with self;
 
   ZonemasterCLI = buildPerlPackage {
     pname = "Zonemaster-CLI";
-    version = "6.000003";
+    version = "8.000001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZN/ZNMSTR/Zonemaster-CLI-v6.0.3.tar.gz";
-      hash = "sha256-oYDBYVygvPUZ9vrGX/y5A0MAQ6zgSsrf6AtUdFcZG4Q=";
+      url = "mirror://cpan/authors/id/Z/ZN/ZNMSTR/Zonemaster-CLI-v8.0.1.tar.gz";
+      hash = "sha256-QLUza9M72r/q1W+uhG5pn6YWz7dDJQ0rIq3NyDVUtjU=";
     };
     propagatedBuildInputs = [
       JSONXS
-      MooseXGetopt
-      TextReflow
+      NetIPXS
+      Readonly
+      TryTiny
       ZonemasterEngine
       ZonemasterLDNS
-      libintl-perl
+      libintlperl
     ];
 
     preConfigure = ''
       patchShebangs script/
     '';
+    buildInputs = [
+      JSONValidator
+      TestDifferences
+    ];
 
     meta = {
       description = "Run Zonemaster tests from the command line";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -35696,18 +35696,24 @@ with self;
 
   TestRunPluginTrimDisplayedFilenames = buildPerlModule {
     pname = "Test-Run-Plugin-TrimDisplayedFilenames";
-    version = "0.0126";
+    version = "0.0127";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-TrimDisplayedFilenames-0.0126.tar.gz";
-      hash = "sha256-ioZJw8anmIp3N65KcW1g4MazIXMBtAFT6tNquPTqkCg=";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-TrimDisplayedFilenames-0.0127.tar.gz";
+      hash = "sha256-1mGR4s+zqhaveSduktJbeGdeHPGm6H/5F9k/+K3q0Mg=";
     };
     buildInputs = [
-      TestRun
+      ModuleBuild
       TestRunCmdLine
       TestTrap
       YAMLLibYAML
     ];
-    propagatedBuildInputs = [ Moose ];
+    propagatedBuildInputs = [
+      ListSomeUtils
+      MROCompat
+      Moose
+      TestRun
+      TestRunCmdLine
+    ];
     meta = {
       description = "Trim the first components";
       homepage = "https://web-cpan.shlomifish.org/modules/Test-Run";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29151,15 +29151,16 @@ with self;
 
   PPIxUtils = buildPerlPackage {
     pname = "PPIx-Utils";
-    version = "0.003";
+    version = "0.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/PPIx-Utils-0.003.tar.gz";
-      hash = "sha256-KpvM/I6tA74BtnJI/o4VJSIED3mChvpO9EMrfy79uhE=";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/PPIx-Utils-0.004.tar.gz";
+      hash = "sha256-M2kY1WrJSC0kjSym557X8sxnQD+97N1zqcQUoDSts88=";
     };
     propagatedBuildInputs = [
       BKeywords
       PPI
     ];
+    buildInputs = [ PPI ];
     meta = {
       homepage = "https://github.com/Grinnz/PPIx-Utils";
       description = "Utility functions for PPI";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39805,15 +39805,12 @@ with self;
 
   YAMLPP = buildPerlPackage {
     pname = "YAML-PP";
-    version = "0.38.0";
+    version = "0.39.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TINITA/YAML-PP-v0.38.0.tar.gz";
-      hash = "sha256-qBlGXFL2o0EEmjlCdCwI4E8olLKmZILkOn9AfOELTqA=";
+      url = "mirror://cpan/authors/id/T/TI/TINITA/YAML-PP-v0.39.0.tar.gz";
+      hash = "sha256-MvU8ZXgSd9y+UIJ7TL8hfs7v8mR3njpsmMlCKesUn1g=";
     };
-    buildInputs = [
-      TestDeep
-      TestWarn
-    ];
+    buildInputs = [ TestWarn ];
     meta = {
       description = "YAML 1.2 Processor";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29603,10 +29603,10 @@ with self;
 
   PerlVersion = buildPerlPackage {
     pname = "Perl-Version";
-    version = "1.013";
+    version = "1.019";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Perl-Version-1.013.tar.gz";
-      hash = "sha256-GIdBTRyGidhkyEARQQHgQ+mdfdW5zKaTaaYOgh460Pc=";
+      url = "mirror://cpan/authors/id/B/BR/BRIANDFOY/Perl-Version-1.019.tar.gz";
+      hash = "sha256-pFpuPw2S/LMyFCSKUtRD4rj/1f/9rwm1TLfLnf9YgAQ=";
     };
     propagatedBuildInputs = [ FileSlurpTiny ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26280,20 +26280,21 @@ with self;
     };
   };
 
-  NetOAuth = buildPerlModule {
+  NetOAuth = buildPerlPackage {
     pname = "Net-OAuth";
-    version = "0.28";
+    version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KG/KGRENNAN/Net-OAuth-0.28.tar.gz";
-      hash = "sha256-e/wxnaCsV44Ali81o1DPUREKOjEwFtH9wwciAooikEw=";
+      url = "mirror://cpan/authors/id/R/RR/RRWO/Net-OAuth-0.31.tar.gz";
+      hash = "sha256-wncPAoJp/NtlFQ8rsxP4pva13vTuIbVhn1y/pAMbfFQ=";
     };
     buildInputs = [ TestWarn ];
     propagatedBuildInputs = [
       ClassAccessor
       ClassDataInheritable
-      DigestHMAC
-      DigestSHA1
-      LWP
+      CryptURandom
+      TestWarn
+      URI
+      libwwwperl
     ];
     meta = {
       description = "Implementation of the OAuth protocol";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21182,10 +21182,10 @@ with self;
 
   MathGMPz = buildPerlPackage {
     pname = "Math-GMPz";
-    version = "0.59";
+    version = "0.68";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SI/SISYPHUS/Math-GMPz-0.59.tar.gz";
-      hash = "sha256-mmrN45G0Ff5f7HwUyCTVUf/j+W81rycYRWuJ3jpkEaQ=";
+      url = "mirror://cpan/authors/id/S/SI/SISYPHUS/Math-GMPz-0.68.tar.gz";
+      hash = "sha256-Pt3OOJl4a0WCp2f69afLdyOnAZwdg1k7RSDkkm5S5l0=";
     };
     buildInputs = [
       TestWarn

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -35739,10 +35739,10 @@ with self;
 
   TestScript = buildPerlPackage {
     pname = "Test-Script";
-    version = "1.29";
+    version = "1.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Test-Script-1.29.tar.gz";
-      hash = "sha256-iS5+bB6nsWcQkJlCz1wL2rcO7i79SqnBbqlS4rkPiVA=";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/Test-Script-1.31.tar.gz";
+      hash = "sha256-RAU7GDpbAYgZnL3btawLG6nlBq+z1MVpjvJRTCjM00c=";
     };
     buildInputs = [ Test2Suite ];
     propagatedBuildInputs = [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20751,18 +20751,23 @@ with self;
 
   MailMessage = buildPerlPackage {
     pname = "Mail-Message";
-    version = "3.013";
+    version = "4.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/Mail-Message-3.013.tar.gz";
-      hash = "sha256-yK1YiNsBWkUOti7Cqj6mbcLdwRtwpdtsjKGn+fgg6B8=";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/Mail-Message-4.04.tar.gz";
+      hash = "sha256-mRXbF8Pg3rT/TJBl3C6vHTgzCWk3oNRuVz9vKnYVjFQ=";
     };
     propagatedBuildInputs = [
+      HashCase
       IOStringy
+      LogReport
       MIMETypes
       MailTools
+      StringPrint
+      TimeDate
       URI
       UserIdentity
     ];
+    buildInputs = [ TestPod ];
     meta = {
       description = "Processing MIME messages";
       homepage = "http://perl.overmeer.net/CPAN";
@@ -40468,6 +40473,24 @@ with self;
     propagatedBuildInputs = [ LogReport ];
     meta = {
       description = "Delayed realization of objects";
+      homepage = "http://perl.overmeer.net/CPAN/";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
+    };
+  };
+
+  HashCase = buildPerlPackage {
+    pname = "Hash-Case";
+    version = "1.07";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/Hash-Case-1.07.tar.gz";
+      hash = "sha256-9ZHbn5qDVcZ/upSuJ+BuYzm4AMp4xSUNdcdojAvDOWk=";
+    };
+    buildInputs = [ TestPod ];
+    meta = {
+      description = "Play trics with HASH keys";
       homepage = "http://perl.overmeer.net/CPAN/";
       license = with lib.licenses; [
         artistic1

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28489,10 +28489,10 @@ with self;
 
   PerlLanguageServer = buildPerlPackage {
     pname = "Perl-LanguageServer";
-    version = "2.6.1";
+    version = "2.6.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRICHTER/Perl-LanguageServer-2.6.1.tar.gz";
-      hash = "sha256-IDM0uwsEXMeHAu9DA0CdCB87aN3XRoNEdGOIJ8NMsZg=";
+      url = "mirror://cpan/authors/id/G/GR/GRICHTER/Perl-LanguageServer-2.6.2.tar.gz";
+      hash = "sha256-bQk3kK/nBOvdjH4SnI8GA1LvgULb2884cnZnCzWAvWo=";
     };
     propagatedBuildInputs = [
       AnyEvent
@@ -28501,6 +28501,7 @@ with self;
       CompilerLexer
       Coro
       DataDump
+      EncodeLocale
       HashSafeKeys
       IOAIO
       JSON

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28305,10 +28305,10 @@ with self;
 
   PerlCriticPolicyVariablesProhibitLoopOnHash = buildPerlPackage {
     pname = "Perl-Critic-Policy-Variables-ProhibitLoopOnHash";
-    version = "0.008";
+    version = "0.009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XS/XSAWYERX/Perl-Critic-Policy-Variables-ProhibitLoopOnHash-0.008.tar.gz";
-      hash = "sha256-EvXwvpbqG9x4KAWFd70cXGPKI8F/rJw3CUUrPf9bhOA=";
+      url = "mirror://cpan/authors/id/X/XS/XSAWYERX/Perl-Critic-Policy-Variables-ProhibitLoopOnHash-0.009.tar.gz";
+      hash = "sha256-zkozTeCSf8RdyzXt/IG+Y4FSilKBlbL4dzBKqD12HqU=";
     };
     propagatedBuildInputs = [ PerlCritic ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25232,13 +25232,14 @@ with self;
 
   MusicBrainz = buildPerlModule {
     pname = "WebService-MusicBrainz";
-    version = "1.0.6";
+    version = "1.0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BF/BFAIST/WebService-MusicBrainz-1.0.6.tar.gz";
-      hash = "sha256-XpH1ZZZ3w5CJv28lO0Eoe7zTVh9qJaB5Zc6DsmKIUuE=";
+      url = "mirror://cpan/authors/id/B/BF/BFAIST/WebService-MusicBrainz-1.0.10.tar.gz";
+      hash = "sha256-6vxX8Pw/Cz4to/WtWw/MFVSn+/h9cqBZVtl0VaKuvb8=";
     };
     propagatedBuildInputs = [ Mojolicious ];
     doCheck = false; # Test performs network access.
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "API to search the musicbrainz.org database";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20262,12 +20262,13 @@ with self;
 
   LongJump = buildPerlPackage {
     pname = "Long-Jump";
-    version = "0.000001";
+    version = "0.000003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Long-Jump-0.000001.tar.gz";
-      hash = "sha256-1dZFbYaZK1Wdj2b8kJYPkZKSzTgDwTQD+qxXV2LHevQ=";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Long-Jump-0.000003.tar.gz";
+      hash = "sha256-W0rvEiHdo92XCOe42nP/2LjbvPVxcmrGz6EVWgw4IGQ=";
     };
     buildInputs = [ Test2Suite ];
+    propagatedBuildInputs = [ Importer ];
     meta = {
       description = "Mechanism for returning to a specific point from a deeply nested stack";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -33842,13 +33842,13 @@ with self;
 
   Test2PluginUUID = buildPerlPackage {
     pname = "Test2-Plugin-UUID";
-    version = "0.002001";
+    version = "0.002010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test2-Plugin-UUID-0.002001.tar.gz";
-      hash = "sha256-TGyNSE1xU9h3ncFVqZKyAwlbXFqhz7Hui87c0GAYeMk=";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test2-Plugin-UUID-0.002010.tar.gz";
+      hash = "sha256-MaHsnRbVYhY1p7eYHZKupXtsWgeSMv7V52HC57RJZXk=";
     };
     buildInputs = [ Test2Suite ];
-    propagatedBuildInputs = [ DataUUID ];
+    propagatedBuildInputs = [ UUIDTiny ];
     meta = {
       description = "Use REAL UUIDs in Test2";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17031,12 +17031,16 @@ with self;
 
   HTTPDAV = buildPerlPackage {
     pname = "HTTP-DAV";
-    version = "0.49";
+    version = "0.50";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/COSIMO/HTTP-DAV-0.49.tar.gz";
-      hash = "sha256-MzOd+ewQbeN9hgnP0NPAg8z7sGwWxlG1s4UaVtF6lXw=";
+      url = "mirror://cpan/authors/id/C/CO/COSIMO/HTTP-DAV-0.50.tar.gz";
+      hash = "sha256-qvMVAnwmkEuGxijTIv4tZdWnd9Re+2lqmtCkPGC3mCg=";
     };
-    propagatedBuildInputs = [ XMLDOM ];
+    propagatedBuildInputs = [
+      URI
+      XMLDOM
+      libwwwperl
+    ];
     meta = {
       description = "WebDAV client library";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20375,22 +20375,27 @@ with self;
 
   LWPProtocolHttps = buildPerlPackage {
     pname = "LWP-Protocol-https";
-    version = "6.11";
+    version = "6.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/LWP-Protocol-https-6.11.tar.gz";
-      hash = "sha256-ATLdvwNmFWXKhQUPKlCU+5Jjy7w8yxpNnEGsm7CDuRc=";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/LWP-Protocol-https-6.15.tar.gz";
+      hash = "sha256-RO7C2hR7oFEQkIcbDKgvaXlDdrwx6MdtEECWG6V/Wbg=";
     };
     patches = [ ../development/perl-modules/lwp-protocol-https-cert-file.patch ];
     propagatedBuildInputs = [
       IOSocketSSL
-      LWP
+      NetHTTP
+      NetHTTPSNB
+      libwwwperl
     ];
     preCheck = ''
       export NO_NETWORK_TESTING=1
     '';
     buildInputs = [
-      TestRequiresInternet
+      IOSocketSSL
       TestNeeds
+      TestRequiresInternet
+      TryTiny
+      libwwwperl
     ];
     meta = {
       description = "Provide https support for LWP::UserAgent";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22531,10 +22531,10 @@ with self;
 
   ModuleInfo = buildPerlPackage {
     pname = "Module-Info";
-    version = "0.37";
+    version = "0.39";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Module-Info-0.37.tar.gz";
-      hash = "sha256-jqgCUpeQsZwfNzoeR9g4FmT5xMH3ao2LvG221zEcJEg=";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Module-Info-0.39.tar.gz";
+      hash = "sha256-fAH6VseKYDaa71X+Zo9GKisdd419EGlmmU9M+vQw7Qc=";
     };
     buildInputs = [
       TestPod

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28065,16 +28065,20 @@ with self;
 
   PDFBuilder = buildPerlPackage {
     pname = "PDF-Builder";
-    version = "3.025";
+    version = "3.028";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMPERRY/PDF-Builder-3.025.tar.gz";
-      hash = "sha256-qb6076DsKXWpFFzvBSEYsgmPRtnBUQ3WV4agPQ2j49U=";
+      url = "mirror://cpan/authors/id/P/PM/PMPERRY/PDF-Builder-3.028.tar.gz";
+      hash = "sha256-YsXRt0gbezwSxYkkQxaxPlyrF59mhb6AhAtdBIeXWow=";
     };
     nativeCheckInputs = [
       TestException
       TestMemoryCycle
     ];
     propagatedBuildInputs = [ FontTTF ];
+    buildInputs = [
+      TestException
+      TestMemoryCycle
+    ];
     meta = {
       description = "Facilitates the creation and modification of PDF files";
       homepage = "https://metacpan.org/pod/PDF::Builder";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25295,14 +25295,14 @@ with self;
 
   namespaceautoclean = buildPerlPackage {
     pname = "namespace-autoclean";
-    version = "0.29";
+    version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/namespace-autoclean-0.29.tar.gz";
-      hash = "sha256-RevY5kpUqG+I2OAa5VISlnyKqP7VfoFAhd73YIrGWAQ=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/namespace-autoclean-0.31.tar.gz";
+      hash = "sha256-07MsguHSyqnVi4yAdZZSQObKtmq5NQvW9r6kygfpONY=";
     };
     buildInputs = [ TestNeeds ];
     propagatedBuildInputs = [
-      SubIdentify
+      BHooksEndOfScope
       namespaceclean
     ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -36564,10 +36564,10 @@ with self;
 
   TestInter = buildPerlPackage {
     pname = "Test-Inter";
-    version = "1.10";
+    version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SB/SBECK/Test-Inter-1.10.tar.gz";
-      hash = "sha256-cewRXqwm+2aJGb1mQLQcNzInUuvUjBx222a3O679O10=";
+      url = "mirror://cpan/authors/id/S/SB/SBECK/Test-Inter-1.12.tar.gz";
+      hash = "sha256-8rGYfs759skiPo+6Lo5IhUMziWZQqr6oG9ww4Mlla2M=";
     };
     buildInputs = [
       FileFindRule

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -38048,10 +38048,10 @@ with self;
 
   UnicodeUTF8 = buildPerlPackage {
     pname = "Unicode-UTF8";
-    version = "0.62";
+    version = "0.66";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Unicode-UTF8-0.62.tar.gz";
-      hash = "sha256-+oci0LdGluMy/d1EKZRDbqk9O/x5gtS6vc7f3dZX0PY=";
+      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Unicode-UTF8-0.66.tar.gz";
+      hash = "sha256-hodCOPxP9cSTHtuI7R3NUBFcUZAlc/GAeyfZsTr1wPA=";
     };
     buildInputs = [ TestFatal ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25001,13 +25001,14 @@ with self;
 
   MooseXTypesURI = buildPerlModule {
     pname = "MooseX-Types-URI";
-    version = "0.09";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-URI-0.09.tar.gz";
-      hash = "sha256-Jxd1Ta25EIbhHSH+oGy6qaEuYBtB0VRDFQ7dfZUI7+g=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-URI-0.10.tar.gz";
+      hash = "sha256-Mwqx0TTu+FQq4raFLwEx61PX2QOgL5B0DMANyY7uCMw=";
     };
     buildInputs = [
       ModuleBuildTiny
+      Moose
       TestNeeds
       TestWithoutModule
     ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22754,10 +22754,10 @@ with self;
 
   ModulePluggable = buildPerlPackage {
     pname = "Module-Pluggable";
-    version = "5.2";
+    version = "6.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SI/SIMONW/Module-Pluggable-5.2.tar.gz";
-      hash = "sha256-s/KtReT9ELP7kNkS142LeVqylUgNtW3GToa5+nXFpt8=";
+      url = "mirror://cpan/authors/id/S/SI/SIMONW/Module-Pluggable-6.3.tar.gz";
+      hash = "sha256-WFErucZUdG0JN3cLmLVZswhy2FrCQHNIXlgwiQ3RsqA=";
     };
     patches = [
       # !!! merge this patch into Perl itself (which contains Module::Pluggable as well)

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -34209,12 +34209,13 @@ with self;
 
   TestCompile = buildPerlModule {
     pname = "Test-Compile";
-    version = "3.3.1";
+    version = "3.3.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EG/EGILES/Test-Compile-v3.3.1.tar.gz";
-      hash = "sha256-gIRQ89Ref0GapNZo4pgodonp6jY4hpO/8YDXhwzj5iE=";
+      url = "mirror://cpan/authors/id/E/EG/EGILES/Test-Compile-v3.3.3.tar.gz";
+      hash = "sha256-3zqzDstRrhShqpufwUMkyWnMJY7yrazDW8aBlBEtpoU=";
     };
     propagatedBuildInputs = [ UNIVERSALrequire ];
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "Assert that your Perl files compile OK";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39578,10 +39578,10 @@ with self;
 
   XMLTwig = buildPerlPackage {
     pname = "XML-Twig";
-    version = "3.52";
+    version = "3.54";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIROD/XML-Twig-3.52.tar.gz";
-      hash = "sha256-/vdYJsJPK4d9Cg0mRSEvxPuXVu1NJxFhSsFcSX6GgK0=";
+      url = "mirror://cpan/authors/id/M/MI/MIROD/XML-Twig-3.54.tar.gz";
+      hash = "sha256-C3RKlzegcPlcMhVK/VJr9evnaln+uLwfXbxs2qXg5Sk=";
     };
     postInstall = ''
       mkdir -p $out/bin

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27838,10 +27838,10 @@ with self;
 
   ParsePMFile = buildPerlPackage {
     pname = "Parse-PMFile";
-    version = "0.44";
+    version = "0.47";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Parse-PMFile-0.44.tar.gz";
-      hash = "sha256-4I8PVkVbOsEtzNjHEWUGErfTzRUPim+K5rQ7LaR9+ZQ=";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Parse-PMFile-0.47.tar.gz";
+      hash = "sha256-JoF889cuJFRSN13P+ekjoGHuCkC78GDToI6+YKM0qq4=";
     };
     buildInputs = [ ExtUtilsMakeMakerCPANfile ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39384,16 +39384,18 @@ with self;
 
   XMLRSS = buildPerlModule {
     pname = "XML-RSS";
-    version = "1.62";
+    version = "1.65";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/XML-RSS-1.62.tar.gz";
-      hash = "sha256-0ycGNELH/3FDmTqgwtFv3lEhSRyXFmHrbLcA0uBDi04=";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/XML-RSS-1.65.tar.gz";
+      hash = "sha256-uzsjH1CBRFkS7oZqkEbfrLCFz9MX40Lp2JZjyFymgPA=";
     };
     propagatedBuildInputs = [
       DateTimeFormatMail
       DateTimeFormatW3CDTF
+      HTMLParser
       XMLParser
     ];
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "Creates and updates RSS files";
       homepage = "https://metacpan.org/release/XML-RSS";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32832,12 +32832,15 @@ with self;
 
   SyntaxKeywordTry = buildPerlModule {
     pname = "Syntax-Keyword-Try";
-    version = "0.30";
+    version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Syntax-Keyword-Try-0.30.tar.gz";
-      hash = "sha256-8Gjwuccf/4/vbYqentaVHLelK5djIr2VUYHMXnsX5pI=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Syntax-Keyword-Try-0.31.tar.gz";
+      hash = "sha256-e8YkLXRjeJgqWZs03jXwfT3syeCdVkb4+juH9FlBSko=";
     };
-    buildInputs = [ Test2Suite ];
+    buildInputs = [
+      ModuleBuild
+      XSParseKeyword
+    ];
     propagatedBuildInputs = [ XSParseKeyword ];
     meta = {
       description = "Try/catch/finally syntax for perl";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28877,23 +28877,26 @@ with self;
 
   PlackMiddlewareSession = buildPerlModule {
     pname = "Plack-Middleware-Session";
-    version = "0.33";
+    version = "0.36";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-Session-0.33.tar.gz";
-      hash = "sha256-T/miydGK2ASbRd/ze5vdQSIeLC8eFrr7gb/tyIxRpO4=";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-Session-0.36.tar.gz";
+      hash = "sha256-kqWDFliBDSNzLm47rnpEofpafYpqbm3NdbkcapwktGY=";
     };
     propagatedBuildInputs = [
+      CookieBaker
+      CryptSysRandom
       DigestHMAC
       Plack
     ];
     buildInputs = [
+      ApacheTest
       HTTPCookies
-      LWP
       ModuleBuildTiny
       TestFatal
       TestRequires
       TestSharedFork
       TestTCP
+      libwwwperl
     ];
     meta = {
       description = "Middleware for session management";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30023,10 +30023,10 @@ with self;
 
   PodSimple = buildPerlPackage {
     pname = "Pod-Simple";
-    version = "3.45";
+    version = "3.47";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KH/KHW/Pod-Simple-3.45.tar.gz";
-      hash = "sha256-hIO7lc0+QwfWbe8JKjd5+EOvdySCv9wCTj4A0MTbDPo=";
+      url = "mirror://cpan/authors/id/K/KH/KHW/Pod-Simple-3.47.tar.gz";
+      hash = "sha256-qz44RTN7eO4UtQ/bxoGXxx9epm693ghw3uTmQsMFxRQ=";
     };
     meta = {
       description = "Framework for parsing Pod";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27466,10 +27466,10 @@ with self;
 
   ParallelForkManager = buildPerlPackage {
     pname = "Parallel-ForkManager";
-    version = "2.02";
+    version = "2.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YA/YANICK/Parallel-ForkManager-2.02.tar.gz";
-      hash = "sha256-wbKXCou2ZsPefKrEqPTbzAQ6uBm7wzdpLse/J62uRAQ=";
+      url = "mirror://cpan/authors/id/Y/YA/YANICK/Parallel-ForkManager-2.04.tar.gz";
+      hash = "sha256-YGiU/C6ffNE9nsCZqqwQOo8JQ9HYDCxIa64Ucwo5t/w=";
     };
     buildInputs = [ TestWarn ];
     propagatedBuildInputs = [ Moo ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -36741,18 +36741,16 @@ with self;
 
   TextMultiMarkdown = buildPerlPackage {
     pname = "Text-MultiMarkdown";
-    version = "1.001";
+    version = "1.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Text-MultiMarkdown-1.001.tar.gz";
-      hash = "sha256-UB1ErH2lSUSZzqhR6bL7UlOAgLDB6TYjDIwm1n4EhDM=";
+      url = "mirror://cpan/authors/id/B/BR/BRIANDFOY/Text-MultiMarkdown-1.005.tar.gz";
+      hash = "sha256-Chkembd+aPywyI0q/6p5dSuqYzqLZaeG36unn5MKhxk=";
     };
-    buildInputs = [
-      ListMoreUtils
-      TestException
-    ];
+    buildInputs = [ TestException ];
     propagatedBuildInputs = [
       HTMLParser
       TextMarkdown
+      TextUnidecode
     ];
     meta = {
       description = "Convert MultiMarkdown syntax to (X)HTML";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -36601,16 +36601,16 @@ with self;
 
   TextLayout = buildPerlPackage {
     pname = "Text-Layout";
-    version = "0.037";
+    version = "0.045";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JV/JV/Text-Layout-0.037.tar.gz";
-      hash = "sha256-WCeTQSR8SBh0BIdkAPBq19qm/nFilVgYXfNnPfCbnOo=";
+      url = "mirror://cpan/authors/id/J/JV/JV/Text-Layout-0.045.tar.gz";
+      hash = "sha256-dU/HiJ5LW7Q+4Hqqrq6f8vlW6TmQt731LTQo15V1y2s=";
     };
     buildInputs = [
-      IOString
       ObjectPad
       PDFAPI2
     ];
+    propagatedBuildInputs = [ ObjectPad ];
     meta = {
       description = "Pango style markup formatting";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25045,10 +25045,10 @@ with self;
 
   MockMonkeyPatch = buildPerlModule {
     pname = "Mock-MonkeyPatch";
-    version = "1.02";
+    version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mock-MonkeyPatch-1.02.tar.gz";
-      hash = "sha256-xbaUTKVP6DVXN2cwYO1OnvhyNyZXfXluHK5eVr8bAYE=";
+      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mock-MonkeyPatch-1.03.tar.gz";
+      hash = "sha256-rMWGUwy2LoFBZsrPt5K4l3tsPVbHexaearHDDUjh1YU=";
     };
     buildInputs = [ ModuleBuildTiny ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27015,17 +27015,18 @@ with self;
 
   ObjectPad = buildPerlModule {
     pname = "Object-Pad";
-    version = "0.821";
+    version = "0.823";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Object-Pad-0.821.tar.gz";
-      hash = "sha256-tdUF+PoWLg5r4q5YsPM0SUxPeRs6BA8va4kBTwSEUgw=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Object-Pad-0.823.tar.gz";
+      hash = "sha256-I84tZ+qSoe6SmX6hTCYaJNgt+jcYFamE9nionUqtzbI=";
     };
     buildInputs = [
-      Test2Suite
-      TestFatal
-      TestRefcount
+      ModuleBuild
+      XSParseKeyword
+      XSParseSublike
     ];
     propagatedBuildInputs = [
+      FileShareDir
       XSParseKeyword
       XSParseSublike
     ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -24781,17 +24781,20 @@ with self;
 
   MooseXTypesCommon = buildPerlModule {
     pname = "MooseX-Types-Common";
-    version = "0.001014";
+    version = "0.001015";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Common-0.001014.tar.gz";
-      hash = "sha256-75Nxi20vJA1QtcOssadLTCoZGGllFHAAGoK+HzXQ7w8=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Common-0.001015.tar.gz";
+      hash = "sha256-KzDiCzJRM7uv6QemK0yH93ymG7qhFwIqxWr5Tig1oxM=";
     };
     buildInputs = [
       ModuleBuildTiny
       TestDeep
       TestWarnings
     ];
-    propagatedBuildInputs = [ MooseXTypes ];
+    propagatedBuildInputs = [
+      Moose
+      MooseXTypes
+    ];
     meta = {
       description = "Library of commonly used type constraints";
       homepage = "https://github.com/moose/MooseX-Types-Common";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29798,10 +29798,10 @@ with self;
 
   PodParser = buildPerlPackage {
     pname = "Pod-Parser";
-    version = "1.66";
+    version = "1.67";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAREKR/Pod-Parser-1.66.tar.gz";
-      hash = "sha256-IpKKe//mG0UsBbu7j1IW1LnPn+KoSbd2wlUA0k0g33w=";
+      url = "mirror://cpan/authors/id/M/MA/MAREKR/Pod-Parser-1.67.tar.gz";
+      hash = "sha256-XezL9V11DOZViM0hHBoD+h7zqqFdGsK42FODpCwUJ+o=";
     };
     meta = {
       description = "Modules for parsing/translating POD format documents";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20605,10 +20605,10 @@ with self;
 
   MailAuthenticationResults = buildPerlPackage {
     pname = "Mail-AuthenticationResults";
-    version = "2.20230112";
+    version = "2.20260216";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-AuthenticationResults-2.20230112.tar.gz";
-      hash = "sha256-wtFEyuAiX4vJ0PX60cPxOdJ89TT85+rHB2T79m/SI0E=";
+      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-AuthenticationResults-2.20260216.tar.gz";
+      hash = "sha256-mlPBt8fxYOiY5stb6ZSNZBQdKBmt4teoc9DofR6D9mY=";
     };
     buildInputs = [ TestException ];
     propagatedBuildInputs = [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25099,12 +25099,13 @@ with self;
 
   Mouse = buildPerlModule {
     pname = "Mouse";
-    version = "2.5.11";
+    version = "2.6.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKAJI/Mouse-v2.5.11.tar.gz";
-      hash = "sha256-4qDQkwGQwhpES5YHk6ouNp7yih3QuPNIKXlfhqGRWVY=";
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/Mouse-v2.6.1.tar.gz";
+      hash = "sha256-qs+6G/xvn4nY7LJtq4aU8lav5E62dQaDGHWWmLtH4po=";
     };
     buildInputs = [
+      ModuleBuild
       ModuleBuildXSUtil
       TestException
       TestFatal

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27090,10 +27090,10 @@ with self;
 
   Opcodes = buildPerlPackage {
     pname = "Opcodes";
-    version = "0.14";
+    version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/Opcodes-0.14.tar.gz";
-      hash = "sha256-f3NlRH5NHFuHtDCRRI8EiOZ8nwNrJsAipUCc1z00OJM=";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/Opcodes-0.16.tar.gz";
+      hash = "sha256-nYv58QARWqjmJJesWU3/kbY66fKazzGV/ksf+Nm1MNA=";
     };
     meta = {
       description = "More Opcodes information from opnames.h and opcode.h";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27990,10 +27990,10 @@ with self;
 
   PathTiny = buildPerlPackage {
     pname = "Path-Tiny";
-    version = "0.144";
+    version = "0.150";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Path-Tiny-0.144.tar.gz";
-      hash = "sha256-9uoJTs6EXJUqAsJ4kzJXk1TejUEKcH+bcEW9JBIGSH0=";
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Path-Tiny-0.150.tar.gz";
+      hash = "sha256-/yBxPRoU0levnHggkAH0DcF35LnRSWEVy9hybVd5Rsc=";
     };
     preConfigure = ''
       substituteInPlace lib/Path/Tiny.pm --replace 'use File::Spec 3.40' \

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20693,11 +20693,11 @@ with self;
   };
 
   MailBox = buildPerlPackage {
-    version = "3.010";
+    version = "4.01";
     pname = "Mail-Box";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/Mail-Box-3.010.tar.gz";
-      hash = "sha256-rhlPolDFRcm5FT4/tRA8qyn3nPKs1On9dc7FMiAalWQ=";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/Mail-Box-4.01.tar.gz";
+      hash = "sha256-rWaAfdgwNxJ4x/wx89+QSMFs6dAUMNX7RBT+rgXx/g0=";
     };
 
     doCheck = false;
@@ -20705,9 +20705,15 @@ with self;
     propagatedBuildInputs = [
       DevelGlobalDestruction
       FileRemove
-      Later
+      IOStringy
+      LogReport
+      MailMessage
       MailTransport
+      ObjectRealizeLater
+      StringPrint
+      TimeDate
     ];
+    buildInputs = [ TestPod ];
     meta = {
       description = "Manage a mailbox, a folder with messages";
       license = with lib.licenses; [
@@ -40440,6 +40446,25 @@ with self;
     ];
     meta = {
       description = "printf extensions";
+      homepage = "http://perl.overmeer.net/CPAN/";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
+    };
+  };
+
+  ObjectRealizeLater = buildPerlPackage {
+    pname = "Object-Realize-Later";
+    version = "4.00";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/Object-Realize-Later-4.00.tar.gz";
+      hash = "sha256-xHU9WjXxR+7eCc29Xm1ifd472qq/6eVvLP9yty0Zl5s=";
+    };
+    buildInputs = [ TestPod ];
+    propagatedBuildInputs = [ LogReport ];
+    meta = {
+      description = "Delayed realization of objects";
       homepage = "http://perl.overmeer.net/CPAN/";
       license = with lib.licenses; [
         artistic1

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -24863,16 +24863,23 @@ with self;
 
   MooseXTypesLoadableClass = buildPerlModule {
     pname = "MooseX-Types-LoadableClass";
-    version = "0.015";
+    version = "0.016";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-LoadableClass-0.015.tar.gz";
-      hash = "sha256-4DfTd4JT3PkpRkNXFbraDmRJwKKAj6P/MqllBk1aO/Q=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-LoadableClass-0.016.tar.gz";
+      hash = "sha256-8QW2m8tEzZhW7f1idT/1jDVRn/qW4Xz8nvML25iZTMw=";
     };
     buildInputs = [
+      ClassLoad
       ModuleBuildTiny
+      Moose
       TestFatal
+      namespaceclean
     ];
-    propagatedBuildInputs = [ MooseXTypes ];
+    propagatedBuildInputs = [
+      ModuleRuntime
+      MooseXTypes
+      namespaceautoclean
+    ];
     meta = {
       description = "ClassName type constraint with coercion to load the class";
       homepage = "https://github.com/moose/MooseX-Types-LoadableClass";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27504,10 +27504,10 @@ with self;
 
   ParallelPipes = buildPerlModule {
     pname = "Parallel-Pipes";
-    version = "0.200";
+    version = "0.201";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SK/SKAJI/Parallel-Pipes-0.200.tar.gz";
-      hash = "sha256-iLmFDqzJ1hjz6RpRyqOGxKZOgswYc1AzUkTjSbgREQY=";
+      url = "mirror://cpan/authors/id/S/SK/SKAJI/Parallel-Pipes-0.201.tar.gz";
+      hash = "sha256-tzy91CArKeq5fgwI3NWdknNjNhDochz0SQeGVr1ZGnw=";
     };
     buildInputs = [ ModuleBuildTiny ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20624,16 +20624,20 @@ with self;
     };
   };
 
-  MailDMARC = buildPerlPackage {
+  MailDMARC = buildPerlModule {
     pname = "Mail-DMARC";
-    version = "1.20230215";
+    version = "1.20260301";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-DMARC-1.20230215.tar.gz";
-      hash = "sha256-V9z1R1nLkkSOVukUE0D2E0QnTFjZ3WWqkKqczw5+uQM=";
+      url = "mirror://cpan/authors/id/M/MS/MSIMERSON/Mail-DMARC-1.20260301.tar.gz";
+      hash = "sha256-/H95KSDpP4NIaNL3AL/VoSNFyiBwRTBSj0PDQ28HB1M=";
     };
     buildInputs = [
-      ExtUtilsMakeMaker
       FileShareDirInstall
+      ModuleBuild
+      NetDNSResolverMock
+      TestException
+      TestFileShareDir
+      TestOutput
     ];
     doCheck = false; # uses actual DNS at runtime
     checkInputs = [
@@ -20650,11 +20654,8 @@ with self;
       DBIxSimple
       EmailMIME
       EmailSender
-      Encode
+      EmailSimple
       FileShareDir
-      GetoptLong
-      IOCompress
-      IO
       IOSocketSSL
       NetDNS
       NetIDNEncode
@@ -20662,7 +20663,7 @@ with self;
       NetSSLeay
       RegexpCommon
       Socket6
-      SysSyslog
+      TestFileShareDir
       URI
       XMLLibXML
     ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26360,19 +26360,20 @@ with self;
 
   NetPrometheus = buildPerlModule {
     pname = "Net-Prometheus";
-    version = "0.12";
+    version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Prometheus-0.12.tar.gz";
-      hash = "sha256-rs73NJygSW/yNahKkQ+KBDZtB/WqQfrieixKxbip6SM=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Prometheus-0.16.tar.gz";
+      hash = "sha256-BLSq7LEwu6zX8Ic2SZ9sArPtHWTngdy5B6s6HXvzCtI=";
     };
     propagatedBuildInputs = [
       RefUtil
       StructDumb
       URI
+      meta
     ];
     buildInputs = [
       HTTPMessage
-      TestFatal
+      ModuleBuild
     ];
     meta = {
       description = "Export monitoring metrics for prometheus";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29173,10 +29173,10 @@ with self;
 
   PPR = buildPerlPackage {
     pname = "PPR";
-    version = "0.001008";
+    version = "0.001010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCONWAY/PPR-0.001008.tar.gz";
-      hash = "sha256-EQ5xwF8uLJDrAfCgaU5VqdvpHIV+SBJeF0LRflzbHkk=";
+      url = "mirror://cpan/authors/id/D/DC/DCONWAY/PPR-0.001010.tar.gz";
+      hash = "sha256-ozmCj+xL1gLY9TAdlLG6GBv7f47Rs0VdWrrqImNkpm8=";
     };
     meta = {
       description = "Pattern-based Perl Recognizer";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20933,10 +20933,10 @@ with self;
 
   MailTools = buildPerlPackage {
     pname = "MailTools";
-    version = "2.21";
+    version = "2.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/MailTools-2.21.tar.gz";
-      hash = "sha256-Stm9aCa28DonJzMkZrG30piQyNmaMrSzsKjZJu4aRMs=";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/MailTools-2.22.tar.gz";
+      hash = "sha256-O/aLshIpj6aZpSdJ3d/zVYOnTzapLKichDuFTynYfHc=";
     };
     propagatedBuildInputs = [ TimeDate ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -38106,12 +38106,16 @@ with self;
 
   URIdb = buildPerlModule {
     pname = "URI-db";
-    version = "0.21";
+    version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DW/DWHEELER/URI-db-0.21.tar.gz";
-      hash = "sha256-pkM9wVF6kH4YmRKkx2td/HYzLj/X/Is4oTfkAZx4CzQ=";
+      url = "mirror://cpan/authors/id/D/DW/DWHEELER/URI-db-0.23.tar.gz";
+      hash = "sha256-C1hG8fbqHaemgG1GqgbjkT0loQrlLoe6aM43OCZ8VX0=";
     };
-    propagatedBuildInputs = [ URINested ];
+    propagatedBuildInputs = [
+      URI
+      URINested
+    ];
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "Database URIs";
       homepage = "https://search.cpan.org/dist/URI-db";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18020,21 +18020,19 @@ with self;
 
   IOSocketSSL = buildPerlPackage {
     pname = "IO-Socket-SSL";
-    version = "2.083";
+    version = "2.098";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SU/SULLR/IO-Socket-SSL-2.083.tar.gz";
-      hash = "sha256-kE7yh2VECpfYqaDfWX+MPX88sKBT0bCCwQvtA7yAIGk=";
+      url = "mirror://cpan/authors/id/S/SU/SULLR/IO-Socket-SSL-2.098.tar.gz";
+      hash = "sha256-s4RzviAlaxoGRH3WdprRYr+taiWCNO0sfi4YGcFsTfc=";
     };
-    propagatedBuildInputs = [
-      MozillaCA
-      NetSSLeay
-    ];
+    propagatedBuildInputs = [ NetSSLeay ];
     # Fix path to default certificate store.
     postPatch = ''
       substituteInPlace lib/IO/Socket/SSL.pm \
         --replace "\$openssldir/cert.pem" "/etc/ssl/certs/ca-certificates.crt"
     '';
     doCheck = false; # tries to connect to facebook.com etc.
+    buildInputs = [ NetSSLeay ];
     meta = {
       description = "Nearly transparent SSL encapsulation for IO::Socket::INET";
       homepage = "https://github.com/noxxi/p5-io-socket-ssl";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22493,10 +22493,10 @@ with self;
 
   ModuleFind = buildPerlPackage {
     pname = "Module-Find";
-    version = "0.16";
+    version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CR/CRENZ/Module-Find-0.16.tar.gz";
-      hash = "sha256-S8qqN2kVAUco1PUzqYxbWdZlBRzTzbr8lg5aZv0TEJI=";
+      url = "mirror://cpan/authors/id/C/CR/CRENZ/Module-Find-0.17.tar.gz";
+      hash = "sha256-df8cjJjowFN2kmRc1i0qTEirCXsdSl6kKiUwUJjX/Tk=";
     };
     meta = {
       description = "Find and use installed modules in a (sub)category";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25821,10 +25821,10 @@ with self;
 
   NetDNS = buildPerlPackage {
     pname = "Net-DNS";
-    version = "1.48";
+    version = "1.54";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NL/NLNETLABS/Net-DNS-1.48.tar.gz";
-      hash = "sha256-5V8+caMcK4VgJL9QYbEWCwP4edgBNUFPONgiBHaUR1M=";
+      url = "mirror://cpan/authors/id/N/NL/NLNETLABS/Net-DNS-1.54.tar.gz";
+      hash = "sha256-er4OA+jurQS/5DLQ2Q7A3WG4unGvrTJKnHasxqb74qQ=";
     };
     propagatedBuildInputs = [ DigestHMAC ];
     makeMakerFlags = [ "--noonline-tests" ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -24807,18 +24807,23 @@ with self;
 
   MooseXTypesDateTime = buildPerlModule {
     pname = "MooseX-Types-DateTime";
-    version = "0.13";
+    version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-DateTime-0.13.tar.gz";
-      hash = "sha256-uJ+iZjb2oX6qOGi0UUNARytou9whYaHXmiKhv1sdOcY=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-DateTime-0.14.tar.gz";
+      hash = "sha256-Y9/UXFuQ+6lL6VglS4VFy6Tlp6XeBttiUpzZkNGFY+o=";
     };
     buildInputs = [
       ModuleBuildTiny
+      Moose
       TestFatal
     ];
     propagatedBuildInputs = [
       DateTime
+      DateTimeLocale
+      DateTimeTimeZone
+      Moose
       MooseXTypes
+      namespaceclean
     ];
     meta = {
       description = "DateTime related constraints and coercions for Moose";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -33687,10 +33687,10 @@ with self;
 
   TermTable = buildPerlPackage {
     pname = "Term-Table";
-    version = "0.017";
+    version = "0.028";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Term-Table-0.017.tar.gz";
-      hash = "sha256-8R20JorYBE9uGhrJU0ygzTrXecQAb/83+uUA25j6yRo=";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Term-Table-0.028.tar.gz";
+      hash = "sha256-8rpipS8y0YrqioynMpm+8OUkCTMs/lFKnEdTFvbVNRw=";
     };
     propagatedBuildInputs = [ Importer ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25148,10 +25148,10 @@ with self;
 
   MozillaCA = buildPerlPackage {
     pname = "Mozilla-CA";
-    version = "20230821";
+    version = "20250602";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LW/LWP/Mozilla-CA-20230821.tar.gz";
-      hash = "sha256-MuHQBFKZAEBFucTRbC2q5FOiFiCIc97qJED3EmCnzaE=";
+      url = "mirror://cpan/authors/id/L/LW/LWP/Mozilla-CA-20250602.tar.gz";
+      hash = "sha256-rerAdSRAstoJToA2urbIV+IhckV2WIaPWsNk8MezVIE=";
     };
 
     postPatch = ''

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30797,15 +30797,12 @@ with self;
 
   ScalarType = buildPerlPackage {
     pname = "Scalar-Type";
-    version = "0.3.2";
+    version = "1.0.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Scalar-Type-0.3.2.tar.gz";
-      hash = "sha256-WQyv6gz1RZmSoEiFYsDb1vnfdYtfAH8OQ6uhMLRe7oY=";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Scalar-Type-1.0.1.tar.gz";
+      hash = "sha256-l62UulpGAF2bPliay4sFGxOZ3/30Yav3/Hx9718BnsU=";
     };
-    propagatedBuildInputs = [
-      CaptureTiny
-      TestException
-    ];
+    propagatedBuildInputs = [ CaptureTiny ];
     meta = {
       description = "Figure out what type a scalar is";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19575,10 +19575,10 @@ with self;
 
   LocaleCodes = buildPerlPackage {
     pname = "Locale-Codes";
-    version = "3.76";
+    version = "3.86";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SB/SBECK/Locale-Codes-3.76.tar.gz";
-      hash = "sha256-Qo00GFUJ7fbaYoYoAJcohrsCwySTRU/L4Y+Zmk9DXzk=";
+      url = "mirror://cpan/authors/id/S/SB/SBECK/Locale-Codes-3.86.tar.gz";
+      hash = "sha256-l+HE0WYZYaxQ5k6zE9Y7j3DyGizgPBVQdpICJglweNI=";
     };
     buildInputs = [ TestInter ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29640,15 +29640,16 @@ with self;
 
   PodAbstract = buildPerlPackage {
     pname = "Pod-Abstract";
-    version = "0.20";
+    version = "0.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BL/BLILBURNE/Pod-Abstract-0.20.tar.gz";
-      hash = "sha256-lW73u4hMVUVuL7bn8in5qH3VCmHXAFAMc4248ronf4c=";
+      url = "mirror://cpan/authors/id/B/BL/BLILBURNE/Pod-Abstract-0.26.tar.gz";
+      hash = "sha256-Ebq0umkd1z1b5sb1CI1iTRKKgSM7db1pCvBBVAIU76Y=";
     };
     propagatedBuildInputs = [
       IOString
-      TaskWeaken
+      ModulePluggable
       PodParser
+      TaskWeaken
     ];
     meta = {
       description = "Abstract, tree-based interface to perl POD documents";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22152,11 +22152,11 @@ with self;
 
   ModernPerl = buildPerlPackage {
     pname = "Modern-Perl";
-    version = "1.20230106";
+    version = "1.20250607";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHROMATIC/Modern-Perl-1.20230106.tar.gz";
-      hash = "sha256-BFncq4DOgrY0Yf2B7pTgbpplFdmPP7wxmDjdHmAoUfc=";
+      url = "mirror://cpan/authors/id/C/CH/CHROMATIC/Modern-Perl-1.20250607.tar.gz";
+      hash = "sha256-OO1+t7ka7tFTiHSD5JqagHouiWKrInzG/bXqTcQd8Sg=";
     };
     meta = {
       description = "Enable all of the features of Modern Perl with one import";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25596,15 +25596,16 @@ with self;
 
   NetAsyncHTTPServer = buildPerlModule {
     pname = "Net-Async-HTTP-Server";
-    version = "0.14";
+    version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Async-HTTP-Server-0.14.tar.gz";
-      hash = "sha256-6nG3kcEtD6X3JubMA/Zuo20bRhNxj2xb84EzvRinsrY=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Async-HTTP-Server-0.15.tar.gz";
+      hash = "sha256-Q/HvE+6uETImZXg3KDfE5L37BVax9LRdf12X1M6f6Zo=";
     };
     buildInputs = [
-      Test2Suite
+      HTTPMessage
+      IOAsync
+      ModuleBuild
       TestMetricsAny
-      TestRefcount
     ];
     propagatedBuildInputs = [
       HTTPMessage

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28614,37 +28614,32 @@ with self;
 
   Plack = buildPerlPackage {
     pname = "Plack";
-    version = "1.0050";
+    version = "1.0051";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-1.0050.tar.gz";
-      hash = "sha256-0mUa3oLrv/er4KOhifyTLa3Ed5GGzolGjlbQGJ6qbtQ=";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-1.0051.tar.gz";
+      hash = "sha256-vr3pHEIpjtbsjmyCshQzobSao5QSwkfzkFuA+VWs93s=";
     };
     buildInputs = [
-      AuthenSimplePasswd
-      CGIEmulatePSGI
       FileShareDirInstall
-      HTTPRequestAsCGI
-      HTTPServerSimplePSGI
-      IOHandleUtil
-      LWP
-      LWPProtocolhttp10
-      LogDispatchArray
-      MIMETypes
-      TestMockTimeHiRes
       TestRequires
       TestSharedFork
-      TestTCP
     ];
     propagatedBuildInputs = [
       ApacheLogFormatCompiler
       CookieBaker
+      DevelStackTrace
       DevelStackTraceAsHTML
       FileShareDir
       FilesysNotifySimple
       HTTPEntityParser
       HTTPHeadersFast
       HTTPMessage
+      HashMultiValue
+      StreamBuffered
+      TestTCP
       TryTiny
+      URI
+      WWWFormUrlEncoded
     ];
     patches = [
       ../development/perl-modules/Plack-test-replace-DES-hash-with-bcrypt.patch

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21994,10 +21994,10 @@ with self;
 
   Minion = buildPerlPackage {
     pname = "Minion";
-    version = "10.31";
+    version = "11.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Minion-10.31.tar.gz";
-      hash = "sha256-MGj5kDPmnfCBRbWEqR7iJPTpfcYkLhAiIegiCj8oUDs=";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Minion-11.0.tar.gz";
+      hash = "sha256-+E71qy1suUsy796DMVU7klNDqQBwc1XRggXcKj2s86w=";
     };
     propagatedBuildInputs = [
       Mojolicious

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18657,15 +18657,19 @@ with self;
 
   JSONValidator = buildPerlPackage {
     pname = "JSON-Validator";
-    version = "5.14";
+    version = "5.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/JSON-Validator-5.14.tar.gz";
-      hash = "sha256-YISl1AdeQhqTj/su6XuFBPqjXoZtD3tbWBETr17ijhs=";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/JSON-Validator-5.15.tar.gz";
+      hash = "sha256-6rV2dr08fDGLyZEYdU5/lzJZeS8coTCZ4EGTjdUVvAU=";
     };
     buildInputs = [ TestDeep ];
     propagatedBuildInputs = [
+      DataValidateDomain
+      DataValidateIP
       Mojolicious
+      NetIDNEncode
       YAMLLibYAML
+      YAMLPP
     ];
     meta = {
       description = "Validate data against a JSON schema";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39222,16 +39222,16 @@ with self;
 
   XMLLibXSLT = buildPerlPackage {
     pname = "XML-LibXSLT";
-    version = "2.002001";
+    version = "2.003000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/XML-LibXSLT-2.002001.tar.gz";
-      hash = "sha256-34knxP8ZSfYlgNHB5vAPDNVrU9OpV+5LFxtZv/pjssA=";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/XML-LibXSLT-2.003000.tar.gz";
+      hash = "sha256-fKpa7nL1O+Wdi4Tuy2hkoHxhKhLqayfVxwaWDtzVRYc=";
     };
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = [
-      pkgs.zlib
       pkgs.libxml2
       pkgs.libxslt
+      pkgs.zlib
     ];
     propagatedBuildInputs = [ XMLLibXML ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22136,10 +22136,10 @@ with self;
 
   MockConfig = buildPerlPackage {
     pname = "Mock-Config";
-    version = "0.03";
+    version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/Mock-Config-0.03.tar.gz";
-      hash = "sha256-pbg0V1fKTyuTNfW+FOk+u7UChlIzp1W/U7xxVt7sABs=";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/Mock-Config-0.05.tar.gz";
+      hash = "sha256-IAFwlsZGT71ZrnVJ+8Zjv7DJAU16w6RXqBp+QIJo9iw=";
     };
     meta = {
       description = "Temporarily set Config or XSConfig values";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -23622,15 +23622,12 @@ with self;
 
   MooXStrictConstructor = buildPerlPackage {
     pname = "MooX-StrictConstructor";
-    version = "0.011";
+    version = "0.013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HARTZELL/MooX-StrictConstructor-0.011.tar.gz";
-      hash = "sha256-2jgvgi/8TiKgOqQZpCVydJmdNtiaThI27PT892vGU+I=";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/MooX-StrictConstructor-0.013.tar.gz";
+      hash = "sha256-uVakoP7z5Ig3pXO4nZnfs5n/+JASynfn2A19dvBLTps=";
     };
-    propagatedBuildInputs = [
-      Moo
-      strictures
-    ];
+    propagatedBuildInputs = [ Moo ];
     buildInputs = [ TestFatal ];
     meta = {
       description = "Make your Moo-based object constructors blow up on unknown attributes";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39274,10 +39274,10 @@ with self;
 
   XMLParser = buildPerlPackage {
     pname = "XML-Parser";
-    version = "2.46";
+    version = "2.47";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/XML-Parser-2.46.tar.gz";
-      hash = "sha256-0zEzJJHFHMz7TLlP/ET5zXM3jmGEmNSjffngQ2YcUV0=";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/XML-Parser-2.47.tar.gz";
+      hash = "sha256-rUquZD7HhPSJuVar6VJDKHGmItTitcYZ6IVazL/E0dg=";
     };
     patches = [ ../development/perl-modules/xml-parser-0001-HACK-Assumes-Expat-paths-are-good.patch ];
     postPatch =
@@ -39291,7 +39291,7 @@ with self;
       "EXPATLIBPATH=${pkgs.expat.out}/lib"
       "EXPATINCPATH=${pkgs.expat.dev}/include"
     ];
-    propagatedBuildInputs = [ LWP ];
+    propagatedBuildInputs = [ libwwwperl ];
     meta = {
       description = "Perl module for parsing XML documents";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -37582,10 +37582,10 @@ with self;
 
   TimeMoment = buildPerlPackage {
     pname = "Time-Moment";
-    version = "0.44";
+    version = "0.46";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Time-Moment-0.44.tar.gz";
-      hash = "sha256-ZKz6BC9jT8742t9V5/QrpOqriq631SEuuJgVox949v0=";
+      url = "mirror://cpan/authors/id/C/CH/CHANSEN/Time-Moment-0.46.tar.gz";
+      hash = "sha256-4exMC4usRRSQ9g3bIbbkhJ20n+u2geHLBHN+LScx5a0=";
     };
     buildInputs = [
       TestFatal

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29663,10 +29663,10 @@ with self;
 
   PodChecker = buildPerlPackage {
     pname = "Pod-Checker";
-    version = "1.75";
+    version = "1.77";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAREKR/Pod-Checker-1.75.tar.gz";
-      hash = "sha256-82O1dOxmCvbtvT5dTJ/8UVodRsvxx8ytmkbO0oh5wiE=";
+      url = "mirror://cpan/authors/id/M/MA/MAREKR/Pod-Checker-1.77.tar.gz";
+      hash = "sha256-Exp8BJvtdYyrKZAXksmZyjFdTogcYw0/k79qrmnp4kI=";
     };
     preCheck = ''
       # Remove tests with hardcoded line numbers.

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26114,10 +26114,10 @@ with self;
 
   NetIPXS = buildPerlPackage {
     pname = "Net-IP-XS";
-    version = "0.22";
+    version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOMHRR/Net-IP-XS-0.22.tar.gz";
-      hash = "sha256-JZe0aDizgur3S6XJnD9gpqC1poHsNqFBchJL9E9LGSA=";
+      url = "mirror://cpan/authors/id/T/TO/TOMHRR/Net-IP-XS-0.23.tar.gz";
+      hash = "sha256-c7E+E68xWC/whLgNUK+LOeGStGc6wvfWj+4Mpa9txX8=";
     };
     propagatedBuildInputs = [
       IOCapture

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28590,10 +28590,10 @@ with self;
 
   PkgConfig = buildPerlPackage rec {
     pname = "PkgConfig";
-    version = "0.25026";
+    version = "0.26026";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/PkgConfig-0.25026.tar.gz";
-      hash = "sha256-Tbpe08LWpoG5XF6/FLammVzmmRrkcZutfxqvOOmHwqA=";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/PkgConfig-0.26026.tar.gz";
+      hash = "sha256-U1LtFWpLXejFI3ce45n2+M5ei/z4Z08eHb1KjINkO4U=";
     };
     # support cross-compilation by simplifying the way we get version during build
     postPatch = ''

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32365,12 +32365,12 @@ with self;
     };
   };
 
-  StringUtil = buildPerlModule {
+  StringUtil = buildPerlPackage {
     pname = "String-Util";
-    version = "1.34";
+    version = "1.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BA/BAKERSCOT/String-Util-1.34.tar.gz";
-      hash = "sha256-MZzozWZTQeVlIfoVXZYqGTKOkNn3A2dlklzN4mclxGk=";
+      url = "mirror://cpan/authors/id/B/BA/BAKERSCOT/String-Util-1.35.tar.gz";
+      hash = "sha256-4IncSqcUxIAbNZ32VG8mW605LKI4AwnIkA5FtGaLt24=";
     };
     buildInputs = [ ModuleBuildTiny ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32483,13 +32483,14 @@ with self;
 
   SubHandlesVia = buildPerlPackage {
     pname = "Sub-HandlesVia";
-    version = "0.050002";
+    version = "0.053005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Sub-HandlesVia-0.050002.tar.gz";
-      hash = "sha256-PMWPrjBcCOEZziwz44SHBD5odSE4JkRBw1oxATTrUDg=";
+      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Sub-HandlesVia-0.053005.tar.gz";
+      hash = "sha256-3HBuCUo3ioGfdOsyZq142rwW2UHBxdCHAtHkz0XJhZ4=";
     };
     propagatedBuildInputs = [
       ClassMethodModifiers
+      ExporterTiny
       RoleHooks
       RoleTiny
       TypeTiny

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30039,22 +30039,17 @@ with self;
 
   PodSpell = buildPerlPackage {
     pname = "Pod-Spell";
-    version = "1.26";
+    version = "1.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Pod-Spell-1.26.tar.gz";
-      hash = "sha256-LwW/yc+wS5b8v6LIVE0eaukIWW02lsRuDiZVa3UK+78=";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Pod-Spell-1.27.tar.gz";
+      hash = "sha256-fvVskinz77xxoEYs5ESQwN1J+/OyH+hbsIse6sb3sGM=";
     };
     propagatedBuildInputs = [
       ClassTiny
       FileShareDir
       LinguaENInflect
-      PathTiny
-      PodParser
     ];
-    buildInputs = [
-      FileShareDirInstall
-      TestDeep
-    ];
+    buildInputs = [ FileShareDirInstall ];
     meta = {
       description = "Formatter for spellchecking Pod";
       homepage = "https://github.com/perl-pod/Pod-Spell";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18590,10 +18590,10 @@ with self;
 
   JSONMaybeXS = buildPerlPackage {
     pname = "JSON-MaybeXS";
-    version = "1.004005";
+    version = "1.004008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/JSON-MaybeXS-1.004005.tar.gz";
-      hash = "sha256-9ba8GfV55mtymfh0i4rD4XGTbcTn/LcqiiV6m9SCozE=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/JSON-MaybeXS-1.004008.tar.gz";
+      hash = "sha256-zTk3r6eIMfgKKtWrq2xRuegvykwx5YVuogjVmNtdyGc=";
     };
     buildInputs = [ TestNeeds ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -23464,29 +23464,31 @@ with self;
 
   Moose = buildPerlPackage {
     pname = "Moose";
-    version = "2.2206";
+    version = "2.4000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Moose-2.2206.tar.gz";
-      hash = "sha256-Z5csTivDn72jhRgXevDme7vrVIVi5OxLdZoaelg+UFs=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Moose-2.4000.tar.gz";
+      hash = "sha256-xL3L5NqutQ3PQOoX37FIPbIsuIMih6vYdipEq5j7Vh8=";
     };
     buildInputs = [
-      DistCheckConflicts
       CPANMetaCheck
-      TestCleanNamespaces
+      DistCheckConflicts
       TestFatal
       TestNeeds
-      TestRequires
     ];
     propagatedBuildInputs = [
+      ClassLoad
       ClassLoadXS
       DataOptList
       DevelGlobalDestruction
       DevelOverloadInfo
       DevelStackTrace
+      DistCheckConflicts
       EvalClosure
       MROCompat
+      ModuleRuntime
       ModuleRuntimeConflicts
       PackageDeprecationManager
+      PackageStash
       PackageStashXS
       ParamsUtil
       SubExporter

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26412,10 +26412,10 @@ with self;
 
   NetServer = buildPerlPackage {
     pname = "Net-Server";
-    version = "2.014";
+    version = "2.018";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RH/RHANDOM/Net-Server-2.014.tar.gz";
-      hash = "sha256-NAa5ylpmKgB17tR/t43hMWtgHJT2Kg7jSlVE25uqNyA=";
+      url = "mirror://cpan/authors/id/B/BB/BBB/Net-Server-2.018.tar.gz";
+      hash = "sha256-TWvRrbDeYA1rRLmoYpuUP+hnALBVGGeR6jl7fPOkVrM=";
     };
     doCheck = false; # seems to hang waiting for connections
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -33365,10 +33365,10 @@ with self;
 
   TemplateTiny = buildPerlPackage {
     pname = "Template-Tiny";
-    version = "1.14";
+    version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Template-Tiny-1.14.tar.gz";
-      hash = "sha256-gZz6tgREg8/ijOsof938MXaiAlsbbw6YCy3MJtImm0w=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Template-Tiny-1.16.tar.gz";
+      hash = "sha256-zqRzUiCvgccpQ96nBGWoP2G+tJmiorpn6lV2LhzYBg4=";
     };
     meta = {
       description = "Template Toolkit reimplemented in as little code as possible";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30765,10 +30765,10 @@ with self;
 
   ScalarListUtils = buildPerlPackage {
     pname = "Scalar-List-Utils";
-    version = "1.63";
+    version = "1.70";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.63.tar.gz";
-      hash = "sha256-yvvfIS9oJ9yaDdO1e27lDoYFhtcZgiijMmLVXFWesqk=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.70.tar.gz";
+      hash = "sha256-4MwD+f41Zc301hAmVPh7ujvKLY/5ido4MH6FfQrjyIY=";
     };
     meta = {
       description = "Common Scalar and List utility subroutines";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22677,10 +22677,10 @@ with self;
 
   ModuleInstallRepository = buildPerlPackage {
     pname = "Module-Install-Repository";
-    version = "0.06";
+    version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Module-Install-Repository-0.06.tar.gz";
-      hash = "sha256-AOJZDQkznMzL2qMo0SrY7HfoMaOMmtZjcF5Z7LsYcis=";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Module-Install-Repository-0.08.tar.gz";
+      hash = "sha256-hJIF0NLAZdkWxcx0OKEBrlDsVh4K3IRMDpCoI0SFlfk=";
     };
     buildInputs = [ PathClass ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17465,10 +17465,10 @@ with self;
 
   ImageInfo = buildPerlPackage {
     pname = "Image-Info";
-    version = "1.44";
+    version = "1.45";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SREZIC/Image-Info-1.44.tar.gz";
-      hash = "sha256-y3/GXdHv/gHrR8HHmlLdFlT0KOOpfbHvI7EmzgFjbw0=";
+      url = "mirror://cpan/authors/id/S/SR/SREZIC/Image-Info-1.45.tar.gz";
+      hash = "sha256-nWwdKMKbE3saUVLmKAg9hDdXczbYvqGRYF3aINVbNTk=";
     };
     propagatedBuildInputs = [ IOStringy ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26210,15 +26210,12 @@ with self;
 
   NetNetmask = buildPerlPackage {
     pname = "Net-Netmask";
-    version = "2.0002";
+    version = "2.0003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMASLAK/Net-Netmask-2.0002.tar.gz";
-      hash = "sha256-JKmy58a8wTAteXROukwCG/PeR/FJqvrM2U+bBC/dv5Q=";
+      url = "mirror://cpan/authors/id/J/JM/JMASLAK/Net-Netmask-2.0003.tar.gz";
+      hash = "sha256-dKICElnLbPe7ufTKomd9yoIP2TyPEyIzb0ikh5MVW9w=";
     };
-    buildInputs = [
-      Test2Suite
-      TestUseAllModules
-    ];
+    buildInputs = [ TestUseAllModules ];
     meta = {
       description = "Understand and manipulate IP netmasks";
       homepage = "https://search.cpan.org/~jmaslak/Net-Netmask";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22983,10 +22983,10 @@ with self;
 
   MojoliciousPluginAssetPack = buildPerlPackage {
     pname = "Mojolicious-Plugin-AssetPack";
-    version = "2.14";
+    version = "2.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-Plugin-AssetPack-2.14.tar.gz";
-      hash = "sha256-jwWMyIw1mb6/ZjeK7GS91uvNkMljGL3m1ov6551j6qM=";
+      url = "mirror://cpan/authors/id/S/SR/SRI/Mojolicious-Plugin-AssetPack-2.15.tar.gz";
+      hash = "sha256-YpepABobKs9qLjTqTYFOKyj/5AExtI/P42OR89hE5w0=";
     };
     propagatedBuildInputs = [
       FileWhich

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19946,15 +19946,17 @@ with self;
 
   LogContextual = buildPerlPackage {
     pname = "Log-Contextual";
-    version = "0.008001";
+    version = "0.009001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/Log-Contextual-0.008001.tar.gz";
-      hash = "sha256-uTy8+7h5bVHINuOwAkPNpWMICMFSwU7uXyDKCclFGZM=";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Log-Contextual-0.009001.tar.gz";
+      hash = "sha256-51aHKEv+A7Dka/ncUwbmXu1oBwjsg+SgD+KWCLj9zJE=";
     };
-    buildInputs = [ TestFatal ];
+    buildInputs = [
+      TestFatal
+      TestNeeds
+    ];
     propagatedBuildInputs = [
       DataDumperConcise
-      ExporterDeclare
       Moo
     ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20569,12 +20569,15 @@ with self;
 
   MacPropertyList = buildPerlPackage {
     pname = "Mac-PropertyList";
-    version = "1.504";
+    version = "1.606";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Mac-PropertyList-1.504.tar.gz";
-      hash = "sha256-aIl96Yw2j76c22iF1H3qADxG7Ho3MmNSPvZkVwc7eq4=";
+      url = "mirror://cpan/authors/id/B/BR/BRIANDFOY/Mac-PropertyList-1.606.tar.gz";
+      hash = "sha256-yA+fsbqHm3lETHMLi65yQkms+ahEvLTSCMcHBpnSCQk=";
     };
-    propagatedBuildInputs = [ XMLEntities ];
+    propagatedBuildInputs = [
+      HTMLParser
+      XMLEntities
+    ];
     meta = {
       description = "Work with Mac plists at a low level";
       homepage = "https://github.com/briandfoy/mac-propertylist";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -36434,11 +36434,12 @@ with self;
 
   TextFormat = buildPerlModule {
     pname = "Text-Format";
-    version = "0.62";
+    version = "0.63";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Format-0.62.tar.gz";
-      hash = "sha256-fUKQVzGeEjxZC6B2UzTwreSl656o23wOxNOQLeX5BAQ=";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Format-0.63.tar.gz";
+      hash = "sha256-/GRlT32NpwcXYOoBFuESttZhsKe8MYjf8bLVL7amY8s=";
     };
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "Various subroutines to format text";
       homepage = "https://github.com/shlomif/perl-Module-Format";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29894,10 +29894,10 @@ with self;
 
   podlators = buildPerlPackage {
     pname = "podlators";
-    version = "5.01";
+    version = "6.0.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RR/RRA/podlators-5.01.tar.gz";
-      hash = "sha256-zP0d+fGkfwlbzm1xj61a9A94ziSR8scjlibhW3AgvHE=";
+      url = "mirror://cpan/authors/id/R/RR/RRA/podlators-v6.0.2.tar.gz";
+      hash = "sha256-KZISXqt9KxxaKxWiateVX32Ynrpsgxq9yvIADoapEzc=";
     };
     preCheck = ''
       # remove failing spdx check

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18745,12 +18745,14 @@ with self;
   };
 
   Later = buildPerlPackage {
-    version = "0.21";
+    version = "4.00";
     pname = "Object-Realize-Later";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/Object-Realize-Later-0.21.tar.gz";
-      hash = "sha256-j3uWQMyONOqSvPbAEEmgPBReDrRuViJ14o3d06jW2Nk=";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/Object-Realize-Later-4.00.tar.gz";
+      hash = "sha256-xHU9WjXxR+7eCc29Xm1ifd472qq/6eVvLP9yty0Zl5s=";
     };
+    buildInputs = [ TestPod ];
+    propagatedBuildInputs = [ LogReport ];
     meta = {
       description = "Delayed creation of objects";
       license = with lib.licenses; [
@@ -40365,6 +40367,71 @@ with self;
     };
     meta = {
       description = "Perl extensions for keeping data partially sorted";
+    };
+  };
+
+  LogReport = buildPerlPackage {
+    pname = "Log-Report";
+    version = "1.44";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/Log-Report-1.44.tar.gz";
+      hash = "sha256-90fmV1/Gj1gRtlXuUWdFk/+ekPYBYULydkqM0/DvT8k=";
+    };
+    buildInputs = [ TestPod ];
+    propagatedBuildInputs = [
+      DevelGlobalDestruction
+      LogReportOptional
+      StringPrint
+    ];
+    meta = {
+      description = "report a problem, pluggable handlers and language support";
+      homepage = "http://perl.overmeer.net/CPAN/";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
+    };
+  };
+
+  LogReportOptional = buildPerlPackage {
+    pname = "Log-Report-Optional";
+    version = "1.08";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/Log-Report-Optional-1.08.tar.gz";
+      hash = "sha256-d7JI1M9/7Kp+hlkw5y3wudWzMzWNAMW9ReLHHV3xE60=";
+    };
+    buildInputs = [ TestPod ];
+    propagatedBuildInputs = [ StringPrint ];
+    meta = {
+      description = "Log::Report in its lightest form";
+      homepage = "http://perl.overmeer.net/CPAN/";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
+    };
+  };
+
+  StringPrint = buildPerlPackage {
+    pname = "String-Print";
+    version = "1.02";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/String-Print-1.02.tar.gz";
+      hash = "sha256-MElTZIZFnjjh15HAfOAiMmqRowK+rwHc2w57cDpdpsw=";
+    };
+    buildInputs = [ TestPod ];
+    propagatedBuildInputs = [
+      HTMLParser
+      TimeDate
+      UnicodeLineBreak
+    ];
+    meta = {
+      description = "printf extensions";
+      homepage = "http://perl.overmeer.net/CPAN/";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 }

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29413,12 +29413,13 @@ with self;
 
   ProtocolRedisFaster = buildPerlPackage {
     pname = "Protocol-Redis-Faster";
-    version = "0.003";
+    version = "0.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/Protocol-Redis-Faster-0.003.tar.gz";
-      hash = "sha256-a5r7PelOwczX20+eai6rolSld5AwHBe8sTuz7f4YULc=";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/Protocol-Redis-Faster-0.004.tar.gz";
+      hash = "sha256-OGyxrSm/2k0Ia+tMsDivXD+zM55HsU5eXVcf6wWl2RI=";
     };
     propagatedBuildInputs = [ ProtocolRedis ];
+    buildInputs = [ ProtocolRedis ];
     meta = {
       description = "Optimized pure-perl Redis protocol parser/encoder";
       homepage = "https://github.com/Grinnz/Protocol-Redis-Faster";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27073,10 +27073,10 @@ with self;
 
   OLEStorage_Lite = buildPerlPackage {
     pname = "OLE-Storage_Lite";
-    version = "0.22";
+    version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMCNAMARA/OLE-Storage_Lite-0.22.tar.gz";
-      hash = "sha256-0FZtbCnTl+pzY3ncUVw2hJ9rlxB89wC6glBQXJhM+WU=";
+      url = "mirror://cpan/authors/id/J/JM/JMCNAMARA/OLE-Storage_Lite-0.24.tar.gz";
+      hash = "sha256-ccO27wghdslYXmIN1I8PR4LCgr5z8qZT6kthj3V7s/0=";
     };
     meta = {
       description = "Read and write OLE storage files";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17880,10 +17880,10 @@ with self;
 
   IOInteractive = buildPerlPackage {
     pname = "IO-Interactive";
-    version = "1.025";
+    version = "1.027";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/IO-Interactive-1.025.tar.gz";
-      hash = "sha256-yh7G+6t6AnXdLpz2e3yw4ARYY/MVMyEMfcVEYxtqqqc=";
+      url = "mirror://cpan/authors/id/B/BR/BRIANDFOY/IO-Interactive-1.027.tar.gz";
+      hash = "sha256-MKqjRqD2ZPg3dQsbmztRHnjHd5KW+4874xquW3P377c=";
     };
     meta = {
       description = "Utilities for interactive I/O";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39677,12 +39677,12 @@ with self;
 
   XSParseSublike = buildPerlModule {
     pname = "XS-Parse-Sublike";
-    version = "0.37";
+    version = "0.41";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/XS-Parse-Sublike-0.37.tar.gz";
-      hash = "sha256-c2UoyIjqe2phkQEeXVp4JOw4pWIFB95u9F5LxuHPDak=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/XS-Parse-Sublike-0.41.tar.gz";
+      hash = "sha256-oQ9eByc7EF5cC0xufiptLSpor+n/T5icEfONS/OcyG0=";
     };
-    buildInputs = [ Test2Suite ];
+    buildInputs = [ ModuleBuild ];
     propagatedBuildInputs = [ FileShareDir ];
     meta = {
       description = "XS functions to assist in parsing sub-like syntax";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21607,10 +21607,10 @@ with self;
 
   Memoize = buildPerlPackage {
     pname = "Memoize";
-    version = "1.16";
+    version = "1.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/Memoize-1.16.tar.gz";
-      hash = "sha256-CRlSvPSS7O41ueW41ykgxYAjRB15IIwduHg3xcV4B74=";
+      url = "mirror://cpan/authors/id/A/AR/ARISTOTLE/Memoize-1.17.tar.gz";
+      hash = "sha256-K+7wr7JDjlQsWZtUsXooMOM39T1p/OGfKISVV0OEZpY=";
     };
     meta = {
       description = "Make functions faster by trading space for time";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20269,19 +20269,25 @@ with self;
 
   LWP = buildPerlPackage {
     pname = "libwww-perl";
-    version = "6.72";
+    version = "6.81";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/libwww-perl-6.72.tar.gz";
-      hash = "sha256-6bg1T9XiC+IHr+I93VhPzVm/gpmNwHfez2hLodrloF0=";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/libwww-perl-6.81.tar.gz";
+      hash = "sha256-qzBVLxlOi1rjrAiFEy/R1OoExMf+ZVV2W5jwGvcMFzY=";
     };
     propagatedBuildInputs = [
+      ApacheTest
+      EncodeLocale
       FileListing
       HTMLParser
-      HTTPCookies
       HTTPCookieJar
+      HTTPCookies
+      HTTPDate
+      HTTPMessage
       HTTPNegotiate
+      LWPMediaTypes
       NetHTTP
       TryTiny
+      URI
       WWWRobotRules
     ];
     preCheck = ''
@@ -20293,6 +20299,13 @@ with self;
     '';
     doCheck = !stdenv.hostPlatform.isDarwin;
     nativeCheckInputs = [
+      HTTPDaemon
+      TestFatal
+      TestNeeds
+      TestRequiresInternet
+    ];
+    buildInputs = [
+      HTTPCookieJar
       HTTPDaemon
       TestFatal
       TestNeeds

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20874,10 +20874,10 @@ with self;
 
   MailSendmail = buildPerlPackage {
     pname = "Mail-Sendmail";
-    version = "0.80";
+    version = "0.82";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/Mail-Sendmail-0.80.tar.gz";
-      hash = "sha256-W4qYy1zDnYBEGjiqsBCIXd+A5vzY5uAxQ5LLI+fCaOQ=";
+      url = "mirror://cpan/authors/id/N/NE/NEILB/Mail-Sendmail-0.82.tar.gz";
+      hash = "sha256-hsBhG+N4iv5ABdBLvAR7OfeLYlPGiZDHp2gO2V6f9RY=";
     };
     # The test suite simply loads the module and attempts to send an email to
     # the module's author, the latter of which is a) more of an integration
@@ -20886,6 +20886,7 @@ with self;
     checkPhase = ''
       perl -I blib/lib -MMail::Sendmail -e 'print "1..1\nok 1\n"'
     '';
+    propagatedBuildInputs = [ SysHostnameLong ];
     meta = {
       description = "Simple platform independent mailer";
       homepage = "https://github.com/neilb/Mail-Sendmail";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -24260,14 +24260,15 @@ with self;
 
   MooseXGetopt = buildPerlModule {
     pname = "MooseX-Getopt";
-    version = "0.76";
+    version = "0.78";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Getopt-0.76.tar.gz";
-      hash = "sha256-/4cxvSsd+DNH37av6coVwE0uzYsojleT0JXq+Va2sCg=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/MooseX-Getopt-0.78.tar.gz";
+      hash = "sha256-euiWIPOIJ9utIxOk5fc0BJlY9dYhK9Yqvby4rpNty8c=";
     };
     buildInputs = [
       ModuleBuildTiny
-      MooseXStrictConstructor
+      ModuleRuntime
+      Moose
       PathTiny
       TestDeep
       TestFatal
@@ -24277,7 +24278,10 @@ with self;
     ];
     propagatedBuildInputs = [
       GetoptLongDescriptive
+      Moose
       MooseXRoleParameterized
+      TryTiny
+      namespaceautoclean
     ];
     meta = {
       description = "Moose role for processing command line options";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -37603,11 +37603,17 @@ with self;
 
   TimeOut = buildPerlPackage {
     pname = "Time-Out";
-    version = "0.11";
+    version = "1.0.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PA/PATL/Time-Out-0.11.tar.gz";
-      hash = "sha256-k5baaY/UUtnOYNZCzaIQjxHyDtdsiWF3muEbiXroFdI=";
+      url = "mirror://cpan/authors/id/S/SV/SVW/Time-Out-1.0.0.tar.gz";
+      hash = "sha256-UUmT9VFsFkmbuRjzd6B6eYi8TIdx+Rba/TAUovJKGgY=";
     };
+    buildInputs = [
+      ExtUtilsMakeMakerCPANfile
+      TestFatal
+      TestNeeds
+    ];
+    propagatedBuildInputs = [ TryTiny ];
     meta = {
       description = "Easily timeout long running operations";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -31119,10 +31119,10 @@ with self;
 
   SetObject = buildPerlPackage {
     pname = "Set-Object";
-    version = "1.42";
+    version = "1.43";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/Set-Object-1.42.tar.gz";
-      hash = "sha256-0YxaiiM+q70CBs89pbAPzdezf+vxKpPcw9HAJub97EU=";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/Set-Object-1.43.tar.gz";
+      hash = "sha256-47PHx+y5HvbSDrBr9r/3TkHEC3W9I04QfS7PeNPeqdE=";
     };
     meta = {
       description = "Unordered collections (sets) of Perl Objects";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -36400,10 +36400,10 @@ with self;
 
   TextCSV_XS = buildPerlPackage {
     pname = "Text-CSV_XS";
-    version = "1.52";
+    version = "1.61";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HM/HMBRAND/Text-CSV_XS-1.52.tgz";
-      hash = "sha256-5BWqcFut+Es1ncTA8MmC8b9whIHaoUdW8xNufInA5B0=";
+      url = "mirror://cpan/authors/id/H/HM/HMBRAND/Text-CSV_XS-1.61.tgz";
+      hash = "sha256-LLkVHowJOSH/aKueXDdve+AUoMsTk0LwwyKaxc3Z/Do=";
     };
     meta = {
       description = "Comma-Separated Values manipulation routines";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -31952,10 +31952,10 @@ with self;
 
   StringBinaryInterpolation = buildPerlPackage {
     pname = "String-Binary-Interpolation";
-    version = "1.0.0";
+    version = "1.0.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/String-Binary-Interpolation-1.0.0.tar.gz";
-      hash = "sha256-2lXYmCTBrdniqpWP8OpILyaCLkJI7TOo1rT7vXdYivE=";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/String-Binary-Interpolation-1.0.1.tar.gz";
+      hash = "sha256-wjcN0W6ipozmRpPnXnDw1VIqyyAPWTmehxBcR1gKy2Q=";
     };
     meta = {
       description = "Make it easier to interpolate binary bytes into a string";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -38575,25 +38575,32 @@ with self;
 
   WWWMechanize = buildPerlPackage {
     pname = "WWW-Mechanize";
-    version = "2.17";
+    version = "2.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SI/SIMBABQUE/WWW-Mechanize-2.17.tar.gz";
-      hash = "sha256-nAIAPoRiHeoSyYDEEB555PjK5OOCzT2iOfqovRmPBjo=";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/WWW-Mechanize-2.20.tar.gz";
+      hash = "sha256-WtzmlfOWhWXTyOWXuYhSXuTIn0DssaIezuehZTLbtmg=";
     };
     propagatedBuildInputs = [
+      ApacheTest
       HTMLForm
+      HTMLParser
       HTMLTree
-      LWP
+      HTTPCookies
+      HTTPMessage
+      URI
+      libwwwperl
     ];
     doCheck = false;
     buildInputs = [
-      CGI
-      HTTPServerSimple
+      HTTPDaemon
       PathTiny
       TestDeep
       TestFatal
+      TestMemoryCycle
       TestOutput
       TestWarnings
+      URI
+      libwwwperl
     ];
     meta = {
       description = "Handy web browsing in a Perl object";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -33255,10 +33255,10 @@ with self;
 
   TemplatePluginAutoformat = buildPerlPackage {
     pname = "Template-Plugin-Autoformat";
-    version = "2.77";
+    version = "2.79";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KARMAN/Template-Plugin-Autoformat-2.77.tar.gz";
-      hash = "sha256-vd+0kZ8Kuyor56lmUzPg1OCYAy8OOD268ExNiWx0hu0=";
+      url = "mirror://cpan/authors/id/K/KA/KARMAN/Template-Plugin-Autoformat-2.79.tar.gz";
+      hash = "sha256-Ip0mQ+5BGQCM2NUy8qYvi2xApCohRUPO64wq95u5sjI=";
     };
     propagatedBuildInputs = [
       TemplateToolkit

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -34547,10 +34547,10 @@ with self;
 
   TestFile = buildPerlPackage {
     pname = "Test-File";
-    version = "1.993";
+    version = "1.995";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Test-File-1.993.tar.gz";
-      hash = "sha256-7y/+Gq7HtC2HStQR7GR1R7m5vC9fuT5J4zmUiEVq/Ho=";
+      url = "mirror://cpan/authors/id/B/BR/BRIANDFOY/Test-File-1.995.tar.gz";
+      hash = "sha256-jxzDa4cUk9/awpvaRZdjcRtf2CiJXA8ya2yGVLq9Xwk=";
     };
     meta = {
       description = "Test file attributes";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -23325,13 +23325,16 @@ with self;
 
   MojoJWT = buildPerlModule {
     pname = "Mojo-JWT";
-    version = "0.09";
+    version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mojo-JWT-0.09.tar.gz";
-      hash = "sha256-wE4DmD4MbyvORdCOoucph5yWee+mNLDmjLa4t7SoWIY=";
+      url = "mirror://cpan/authors/id/J/JB/JBERGER/Mojo-JWT-1.01.tar.gz";
+      hash = "sha256-+py8R85JTwGgQuDznoc/j6XKXpFHK17MT7smPMO9Jgw=";
     };
     buildInputs = [ ModuleBuildTiny ];
-    propagatedBuildInputs = [ Mojolicious ];
+    propagatedBuildInputs = [
+      CryptX
+      Mojolicious
+    ];
     meta = {
       description = "JSON Web Token the Mojo way";
       homepage = "https://github.com/jberger/Mojo-JWT";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -37795,10 +37795,10 @@ with self;
 
   TryTiny = buildPerlPackage {
     pname = "Try-Tiny";
-    version = "0.31";
+    version = "0.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Try-Tiny-0.31.tar.gz";
-      hash = "sha256-MwDTHYpAdbJtj0bOhkodkT4OhGfO66ZlXV0rLiBsEb4=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Try-Tiny-0.32.tar.gz";
+      hash = "sha256-7y1sqwutGOOrHE5hJcxfaVx+RZiZ9RJFHI+j74P6f8A=";
     };
     buildInputs = [
       CPANMetaCheck

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29984,10 +29984,10 @@ with self;
 
   PodMarkdown = buildPerlPackage {
     pname = "Pod-Markdown";
-    version = "3.300";
+    version = "3.400";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RW/RWSTAUNER/Pod-Markdown-3.300.tar.gz";
-      hash = "sha256-7HnpkIo2BXScT+tQVHY+toEt0ztUzoWlEzmqfPmZG3k=";
+      url = "mirror://cpan/authors/id/R/RW/RWSTAUNER/Pod-Markdown-3.400.tar.gz";
+      hash = "sha256-pibpm81OfSFOQ9RyKlTjqvrDcThi90ec+5Sg4oefhEI=";
     };
     buildInputs = [ TestDifferences ];
     propagatedBuildInputs = [ URI ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25560,17 +25560,19 @@ with self;
 
   NetAsyncHTTP = buildPerlModule {
     pname = "Net-Async-HTTP";
-    version = "0.49";
+    version = "0.50";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Async-HTTP-0.49.tar.gz";
-      hash = "sha256-OSBtBpSV0bhq7jeqitPJM0025ZzObPec04asDPN5jNs=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Net-Async-HTTP-0.50.tar.gz";
+      hash = "sha256-koRbj/3S3IHey+inuZID5ONJcd5mJKy1wQqp/weIW4c=";
     };
     buildInputs = [
       HTTPCookies
-      Test2Suite
+      IOAsync
+      ModuleBuild
       TestMetricsAny
     ];
     propagatedBuildInputs = [
+      ApacheTest
       Future
       HTTPMessage
       IOAsync

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17119,14 +17119,15 @@ with self;
 
   HTTPMessage = buildPerlPackage {
     pname = "HTTP-Message";
-    version = "6.45";
+    version = "7.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Message-6.45.tar.gz";
-      hash = "sha256-AcuEBmEqP3OIQtHpcxOuTYdIcNG41tZjMfFgAJQ9TL4=";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Message-7.01.tar.gz";
+      hash = "sha256-grec5oAlEEXCRO4Flib+y/mCcL7RRn8Bdf9eqRBxQ34=";
     };
     buildInputs = [
       TestNeeds
       TryTiny
+      URI
     ];
     propagatedBuildInputs = [
       Clone

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17698,10 +17698,10 @@ with self;
 
   IOAsync = buildPerlModule {
     pname = "IO-Async";
-    version = "0.802";
+    version = "0.805";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/IO-Async-0.802.tar.gz";
-      hash = "sha256-5YJzFXd2fEfqxDXvKQRmPUp1Cw5oAqSmGJo38Mswhzg";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/IO-Async-0.805.tar.gz";
+      hash = "sha256-d/mXt0lT299jp1D8/0M40b+s2JEA4fsnw0c/CiIqmgw=";
     };
     preCheck = "rm t/50resolver.t"; # this test fails with "Temporary failure in name resolution" in sandbox
     propagatedBuildInputs = [
@@ -17709,11 +17709,9 @@ with self;
       StructDumb
     ];
     buildInputs = [
-      TestFatal
+      ModuleBuild
       TestFutureIOImpl
-      TestIdentity
       TestMetricsAny
-      TestRefcount
     ];
     meta = {
       description = "Asynchronous event-driven programming";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -33028,12 +33028,13 @@ with self;
 
   TAPParserSourceHandlerpgTAP = buildPerlModule {
     pname = "TAP-Parser-SourceHandler-pgTAP";
-    version = "3.36";
+    version = "3.37";
     src = fetchurl {
       url = "mirror://cpan/authors/id/D/DW/DWHEELER/TAP-Parser-SourceHandler-pgTAP-3.37.tar.gz";
       hash = "sha256-bpKFgUQqHmhxMfe11vT/RLf43N95jS0Ha9zQfYt6WX0=";
     };
     doCheck = !stdenv.hostPlatform.isDarwin;
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "Stream TAP from pgTAP test scripts";
       homepage = "https://search.cpan.org/dist/Tap-Parser-Sourcehandler-pgTAP";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21056,10 +21056,10 @@ with self;
 
   MathBigInt = buildPerlPackage {
     pname = "Math-BigInt";
-    version = "1.999842";
+    version = "2.005003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-1.999842.tar.gz";
-      hash = "sha256-VGAcUMaZPn7hPYw6wzRs8VpNgGMUnNu+husB5WEORnU=";
+      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-2.005003.tar.gz";
+      hash = "sha256-xK3BICNJ9/zRTQHmlJ/uDslpBJ1FycpZqinsWKZZZts=";
     };
     meta = {
       description = "Arbitrary size integer/float math package";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20902,15 +20902,15 @@ with self;
 
   MailSPF = buildPerlPackage {
     pname = "Mail-SPF";
-    version = "2.9.0";
+    version = "3.20250505";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMEHNLE/mail-spf/Mail-SPF-v2.9.0.tar.gz";
-      hash = "sha256-YctZFfHHrMepMf/Bv8EpG9+sVV4qRusjkbmV6p7LYWI=";
+      url = "mirror://cpan/authors/id/A/AD/ADAVIS/Mail-SPF-3.20250505.tar.gz";
+      hash = "sha256-msYNALlX6Em6/pCo3v3u4uX/qxyHrFpKvEUodemQSGM=";
     };
     # remove this patch patches = [ ../development/perl-modules/Mail-SPF.patch ];
 
     buildInputs = [
-      ModuleBuild
+      NetDNS
       NetDNSResolverProgrammable
     ];
     propagatedBuildInputs = [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21731,12 +21731,12 @@ with self;
 
   meta = buildPerlModule {
     pname = "meta";
-    version = "0.012";
+    version = "0.015";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/meta-0.012.tar.gz";
-      hash = "sha256-Fx0J0wn4APVTTQE4tXMDmpYfEDtDaKhBC3dogzFuuFk=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/meta-0.015.tar.gz";
+      hash = "sha256-BOrj4KEk6yR569mhZzGfTbTZIL5l5Z4WrgzWz35Z5qU=";
     };
-    buildInputs = [ Test2Suite ];
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "Meta-programming API";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32588,12 +32588,13 @@ with self;
 
   SubOverride = buildPerlPackage {
     pname = "Sub-Override";
-    version = "0.09";
+    version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OV/OVID/Sub-Override-0.09.tar.gz";
-      hash = "sha256-k5pnwfcplo4MyBt0lY23UOG9t8AgvuGiYzMvQiwuJbU=";
+      url = "mirror://cpan/authors/id/M/MV/MVSJES/Sub-Override-0.12.tar.gz";
+      hash = "sha256-2SLcbvDlH2OF4RExCEXDOTvmt6TU69oqnkfAW/YveeM=";
     };
     buildInputs = [ TestFatal ];
+    propagatedBuildInputs = [ TestFatal ];
     meta = {
       description = "Perl extension for easily overriding subroutines";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20120,10 +20120,10 @@ with self;
 
   MCE = buildPerlPackage {
     pname = "MCE";
-    version = "1.901";
+    version = "1.902";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARIOROY/MCE-1.901.tar.gz";
-      hash = "sha256-3RRrHpmFPjPBzbtowgJK7nQGeseDlNUbgdH6so9Q0TU=";
+      url = "mirror://cpan/authors/id/M/MA/MARIOROY/MCE-1.902.tar.gz";
+      hash = "sha256-VZryjVMQMCymNZnlnw3XbDJHtFI0ScJ0XF7xWZaAUaE=";
     };
     meta = {
       description = "Many-Core Engine for Perl providing parallel processing capabilities";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -40032,10 +40032,10 @@ with self;
 
   ZonemasterLDNS = buildPerlPackage {
     pname = "Zonemaster-LDNS";
-    version = "3.2.0";
+    version = "5.0.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZN/ZNMSTR/Zonemaster-LDNS-3.2.0.tar.gz";
-      hash = "sha256-BpsWQRcpX6gtJSlAocqLMIrYsfPocjvk6CaqqX9wbWw=";
+      url = "mirror://cpan/authors/id/Z/ZN/ZNMSTR/Zonemaster-LDNS-5.0.1.tar.gz";
+      hash = "sha256-QSTh8plSzf3LnmyXBmIjp57aQu7ql1MrAI5hzRIAFnk=";
     };
     env.NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include -I${pkgs.libidn2}.dev}/include";
     env.NIX_CFLAGS_LINK = "-L${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.libidn2}/lib -lcrypto -lidn2";
@@ -40044,11 +40044,14 @@ with self;
 
     nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = [
-      DevelChecklib
-      ModuleInstall
+      DevelCheckLib
+      ExtUtilsPkgConfig
+      HoneyClientUtil
+      MIMEBase32
       ModuleInstallXSUtil
-      TestFatal
       TestDifferences
+      TestFatal
+      TestNoWarnings
       pkgs.ldns
       pkgs.libidn2
       pkgs.openssl
@@ -40660,6 +40663,18 @@ with self;
         artistic1
         gpl1Plus
       ];
+    };
+  };
+
+  HoneyClientUtil = buildPerlPackage {
+    pname = "HoneyClient-Util";
+    version = "0.98";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MI/MITREHC/HoneyClient-Util-0.98-stable.tar.gz";
+      hash = "sha256-Jwl1fF7pNb5xHnlHm0Exivo9rFrdgnqT+L+wgne1BgI=";
+    };
+    meta = {
+      description = "Perl extension to provide a generic interface to the HoneyClient global configuration file";
     };
   };
 }

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28322,17 +28322,19 @@ with self;
 
   PerlCriticPulp = buildPerlPackage {
     pname = "Perl-Critic-Pulp";
-    version = "99";
+    version = "100";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRYDE/Perl-Critic-Pulp-99.tar.gz";
-      hash = "sha256-uP2oQvy+100hAlfAooS23HsdBVSkej3l2X59VC4j5/4=";
+      url = "mirror://cpan/authors/id/K/KR/KRYDE/Perl-Critic-Pulp-100.tar.gz";
+      hash = "sha256-F9M63SJgrEl5ElDM0y2ovKgGO/b89AbdsSs6AHZXjpg=";
     };
     propagatedBuildInputs = [
       IOString
       ListMoreUtils
       PPI
+      PPIxIndexOffsets
       PerlCritic
       PodMinimumVersion
+      PodParser
     ];
     meta = {
       description = "Some add-on policies for Perl::Critic";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -33196,14 +33196,14 @@ with self;
 
   Tcl = buildPerlPackage {
     pname = "Tcl";
-    version = "1.27";
+    version = "1.53";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VK/VKON/Tcl-1.27.tar.gz";
-      hash = "sha256-+DhYd6Sp7Z89OQPS0PfNcPrDzmgyxg9gCmghzuP7WHI=";
+      url = "mirror://cpan/authors/id/V/VK/VKON/Tcl-1.53.tar.gz";
+      hash = "sha256-VkT4qMIvPPIdcJQQNvJMoaoP4OUAZu8IYzZeOqbyXJ0=";
     };
     propagatedBuildInputs = [
-      pkgs.tclPackages.bwidget
       pkgs.tcl
+      pkgs.tclPackages.bwidget
       pkgs.tclPackages.tix
       pkgs.tk
     ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18706,13 +18706,16 @@ with self;
 
   JSONXS = buildPerlPackage {
     pname = "JSON-XS";
-    version = "4.03";
+    version = "4.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/JSON-XS-4.03.tar.gz";
-      hash = "sha256-UVU29F8voafojIgkUzdY0BIdJnq5y0U6G1iHyKVrkGg=";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/JSON-XS-4.04.tar.gz";
+      hash = "sha256-jv8enzBMViW1mre0IlhBX20+NoHB3atrclUYoBin9eA=";
     };
     patches = [ ../development/perl-modules/JSON-XS-CVE-2025-40928.patch ];
-    propagatedBuildInputs = [ TypesSerialiser ];
+    propagatedBuildInputs = [
+      TypesSerialiser
+      commonsense
+    ];
     buildInputs = [ CanaryStability ];
     meta = {
       description = "JSON serialising/deserialising, done correctly and fast";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15975,16 +15975,15 @@ with self;
 
   HashMergeSimple = buildPerlPackage {
     pname = "Hash-Merge-Simple";
-    version = "0.051";
+    version = "0.052";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROKR/Hash-Merge-Simple-0.051.tar.gz";
-      hash = "sha256-HFYyeHPS8E1XInd/BEhj2WiRBGaZd0DVWnVAccYoe3M=";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Hash-Merge-Simple-0.052.tar.gz";
+      hash = "sha256-wn8giVgUqW4MW9DKMxW/kB15cG47q0qw2UbevCxCnAs=";
     };
     buildInputs = [
       TestDeep
       TestDifferences
       TestException
-      TestMost
       TestWarn
     ];
     propagatedBuildInputs = [ Clone ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18236,10 +18236,10 @@ with self;
 
   IPCRun = buildPerlPackage {
     pname = "IPC-Run";
-    version = "20231003.0";
+    version = "20250809.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/IPC-Run-20231003.0.tar.gz";
-      hash = "sha256-6yW731kT0pF5fvG/6ZjxUTC0VdPtAqrN5oVvCyXk/lc=";
+      url = "mirror://cpan/authors/id/N/NJ/NJM/IPC-Run-20250809.0.tar.gz";
+      hash = "sha256-sehaMEBXhu2DeLaN1XFZMVrX3cClXkMqqe7KYWbKU/4=";
     };
     doCheck = false; # attempts a network connection to localhost
     propagatedBuildInputs = [ IOTty ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -36086,10 +36086,10 @@ with self;
 
   TestWithoutModule = buildPerlPackage {
     pname = "Test-Without-Module";
-    version = "0.21";
+    version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CORION/Test-Without-Module-0.21.tar.gz";
-      hash = "sha256-PN6vraxIU+vq/miTRtVV2l36PPqdTITj5ee/7lC+7EY=";
+      url = "mirror://cpan/authors/id/C/CO/CORION/Test-Without-Module-0.23.tar.gz";
+      hash = "sha256-gonhzX9XAXqBarQSfins16dUrnzVwDfEGzs7+EnCHSE=";
     };
     meta = {
       description = "Test fallback behaviour in absence of modules";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32734,10 +32734,10 @@ with self;
 
   SymbolGet = buildPerlPackage {
     pname = "Symbol-Get";
-    version = "0.10";
+    version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FELIPE/Symbol-Get-0.10.tar.gz";
-      hash = "sha256-DuVWjFrjVzyodOCeTQUkRmz8Gtmiwk0LyR1MewbyHZw=";
+      url = "mirror://cpan/authors/id/F/FE/FELIPE/Symbol-Get-0.12.tar.gz";
+      hash = "sha256-VZXd94dtF/tHDdO7sqie1tjyofV9lFC0n7ogd2FYKl0=";
     };
     buildInputs = [
       TestDeep

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -36366,10 +36366,10 @@ with self;
 
   TextCSV = buildPerlPackage {
     pname = "Text-CSV";
-    version = "2.03";
+    version = "2.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Text-CSV-2.03.tar.gz";
-      hash = "sha256-SLvOnyNJNaiFlWGOBN0UFigkbWUPKnJgJN8cE34LZfs=";
+      url = "mirror://cpan/authors/id/I/IS/ISHIGAKI/Text-CSV-2.06.tar.gz";
+      hash = "sha256-38rsklp4iwukHlG8bRbiGw6YtMevm3k5UJCt119eUG8=";
     };
     meta = {
       description = "Comma-separated values manipulator (using XS or PurePerl)";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20192,19 +20192,24 @@ with self;
 
   LogDispatchouli = buildPerlPackage {
     pname = "Log-Dispatchouli";
-    version = "3.007";
+    version = "3.013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Log-Dispatchouli-3.007.tar.gz";
-      hash = "sha256-mIEYlllSukmo+nkaZTaIDIkBf0651ywXRe1n0VwNJyw=";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Log-Dispatchouli-3.013.tar.gz";
+      hash = "sha256-lVOXBSrylt1p1gW9TdfNEAcn1i53H3dSfDqnYoYBZ5E=";
     };
     buildInputs = [
+      JSONMaybeXS
       TestDeep
       TestFatal
     ];
     propagatedBuildInputs = [
+      LogDispatch
       LogDispatchArray
+      ParamsUtil
       StringFlogger
+      SubExporter
       SubExporterGlobExporter
+      TryTiny
     ];
     meta = {
       description = "Simple wrapper around Log::Dispatch";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29395,10 +29395,10 @@ with self;
 
   ProtocolRedis = buildPerlPackage {
     pname = "Protocol-Redis";
-    version = "1.0011";
+    version = "2.0002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/U/UN/UNDEF/Protocol-Redis-1.0011.tar.gz";
-      hash = "sha256-fOtr2ABnyQRGXU/R8XFXJDiMm9w3xsLAA6IM5Wm39Og=";
+      url = "mirror://cpan/authors/id/U/UN/UNDEF/Protocol-Redis-2.0002.tar.gz";
+      hash = "sha256-P/DgtlOSxPaBeyMGzSxi3OimHvSohu3+SdqvMeE5ziE=";
     };
     meta = {
       description = "Redis protocol parser/encoder with asynchronous capabilities";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -36285,10 +36285,10 @@ with self;
 
   TextBalanced = buildPerlPackage {
     pname = "Text-Balanced";
-    version = "2.06";
+    version = "2.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHAY/Text-Balanced-2.06.tar.gz";
-      hash = "sha256-dz4PDyHAyyz2ZM7muij/cCWbq8yJL5tlD5y9oAvgkq0=";
+      url = "mirror://cpan/authors/id/S/SH/SHAY/Text-Balanced-2.07.tar.gz";
+      hash = "sha256-fF2BvY1rLN2/YM72bX+favQXQS5esk6HpaGXwxHjMM8=";
     };
     meta = {
       description = "Extract delimited text sequences from strings";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -33382,17 +33382,14 @@ with self;
 
   TemplateToolkit = buildPerlPackage {
     pname = "Template-Toolkit";
-    version = "3.101";
+    version = "3.102";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AB/ABW/Template-Toolkit-3.101.tar.gz";
-      hash = "sha256-0qMt1sIeSzfGqT34CHyp6IDPrmE6Pl766jB7C9yu21g=";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/Template-Toolkit-3.102.tar.gz";
+      hash = "sha256-0WHIne6bITp8VXCep4Li3Vkj29EhW5V2YSiJ5udKLgY=";
     };
     doCheck = !stdenv.hostPlatform.isDarwin;
     propagatedBuildInputs = [ AppConfig ];
-    buildInputs = [
-      CGI
-      TestLeakTrace
-    ];
+    buildInputs = [ TestLeakTrace ];
     meta = {
       description = "Comprehensive template processing system";
       homepage = "http://www.template-toolkit.org";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17779,10 +17779,10 @@ with self;
 
   IOCompress = buildPerlPackage {
     pname = "IO-Compress";
-    version = "2.206";
+    version = "2.217";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMQS/IO-Compress-2.206.tar.gz";
-      hash = "sha256-fTBiuaSU91fo0GFPIg2D8icxu9oa6198/w5yqD9DPTU=";
+      url = "mirror://cpan/authors/id/P/PM/PMQS/IO-Compress-2.217.tar.gz";
+      hash = "sha256-TQdeBO7vPEUfXn9XLr1pVzi60DPozTLPUZxo7bPzncc=";
     };
     propagatedBuildInputs = [
       CompressRawBzip2

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20549,12 +20549,12 @@ with self;
 
   maatkit = callPackage ../development/perl-modules/maatkit { };
 
-  MacPasteboard = buildPerlPackage {
+  MacPasteboard = buildPerlModule {
     pname = "Mac-Pasteboard";
-    version = "0.103";
+    version = "0.105";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WY/WYANT/Mac-Pasteboard-0.103.tar.gz";
-      hash = "sha256-L16N0tsNZEVVhITKbULYOcWpfuiqGyUOaU1n1bf2Y0w=";
+      url = "mirror://cpan/authors/id/W/WY/WYANT/Mac-Pasteboard-0.105.tar.gz";
+      hash = "sha256-LVWSq7HwFSc+qm2DLt2SL4aVNovGn+qPQTuCa7HmhjM=";
     };
     meta = {
       description = "Manipulate Mac OS X pasteboards";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29517,15 +29517,19 @@ with self;
 
   PerlMinimumVersion = buildPerlPackage {
     pname = "Perl-MinimumVersion";
-    version = "1.40";
+    version = "1.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBOOK/Perl-MinimumVersion-1.40.tar.gz";
-      hash = "sha256-dYmleMtg1wykdVw5WzWStECgzWobB05OzqyTsDGhvpA=";
+      url = "mirror://cpan/authors/id/D/DB/DBOOK/Perl-MinimumVersion-1.44.tar.gz";
+      hash = "sha256-/6nIovCZZgqBNh64usVqM1eTs+Fg+lsdlweLgxQs6Ms=";
     };
     buildInputs = [ TestScript ];
     propagatedBuildInputs = [
+      FileFindRule
       FileFindRulePerl
-      PerlCritic
+      PPI
+      PPIxRegexp
+      PPIxUtils
+      ParamsUtil
     ];
     meta = {
       description = "Find a minimum required version of perl for Perl code";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26642,10 +26642,10 @@ with self;
 
   NetSSHPerl = buildPerlPackage {
     pname = "Net-SSH-Perl";
-    version = "2.142";
+    version = "2.144";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Net-SSH-Perl-2.142.tar.gz";
-      hash = "sha256-UAHbPllS/BjYXDF5Uhr2kT0VQ+tP30/ZfcYDpHSMLJY=";
+      url = "mirror://cpan/authors/id/B/BD/BDFOY/Net-SSH-Perl-2.144.tar.gz";
+      hash = "sha256-K1R7ujM2rjJKaiPEomXgG5sNbur3pFcgXGBTh9cT6T4=";
     };
     propagatedBuildInputs = [
       CryptCurve25519

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21765,10 +21765,10 @@ with self;
 
   MetaCPANClient = buildPerlPackage {
     pname = "MetaCPAN-Client";
-    version = "2.030000";
+    version = "2.039000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MICKEY/MetaCPAN-Client-2.030000.tar.gz";
-      hash = "sha256-2bdlxSN3VPFyYmljgqc4XZCy0BmGl5gXhisWZLBt068=";
+      url = "mirror://cpan/authors/id/M/MI/MICKEY/MetaCPAN-Client-2.039000.tar.gz";
+      hash = "sha256-qFWIPzxi/cxrShRAg8SIuqQv7SVGfesZZJnCjS8WbiU=";
     };
 
     # Most tests are online, so we only include offline tests
@@ -21779,7 +21779,7 @@ with self;
     '';
 
     buildInputs = [
-      LWPProtocolHttps
+      LWPProtocolhttps
       TestFatal
       TestNeeds
     ];
@@ -21787,6 +21787,7 @@ with self;
       IOSocketSSL
       JSONMaybeXS
       Moo
+      NetSSLeay
       RefUtil
       SafeIsa
       TypeTiny

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -39713,10 +39713,10 @@ with self;
 
   YAML = buildPerlPackage {
     pname = "YAML";
-    version = "1.30";
+    version = "1.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TINITA/YAML-1.30.tar.gz";
-      hash = "sha256-UDCm1sv/rxJYMFC/VSqoANRkbKlnjBh63WSSJ/V0ec0=";
+      url = "mirror://cpan/authors/id/I/IN/INGY/YAML-1.31.tar.gz";
+      hash = "sha256-oM4wOBZX3OjmlN+aCeldgY0TvrA2mP0s950MjVZKm44=";
     };
 
     buildInputs = [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32606,10 +32606,10 @@ with self;
 
   SubQuote = buildPerlPackage {
     pname = "Sub-Quote";
-    version = "2.006008";
+    version = "2.006009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/Sub-Quote-2.006008.tar.gz";
-      hash = "sha256-lL69UAr1V2LoPqLyvFlNh6+CgHI3DHEQxgwjioANFbI=";
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Sub-Quote-2.006009.tar.gz";
+      hash = "sha256-lnKC1U0tUbGYxnk1WU+T5N6j5U0eW87RWMlOKb6Giks=";
     };
     buildInputs = [ TestFatal ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -116,11 +116,11 @@ with self;
 
   ack = buildPerlPackage rec {
     pname = "ack";
-    version = "3.8.2";
+    version = "3.9.0";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/ack-v${version}.tar.gz";
-      hash = "sha256-pSOfWiwS4Me05DL/1+k2/u+UWpYhpBWRx307DPRYVgs=";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/ack-v3.9.0.tar.gz";
+      hash = "sha256-lO1Hfjs/lNEmzscynw6DmfHQzoLHxNiCqUrbFQ5//JA=";
     };
 
     outputs = [
@@ -132,6 +132,7 @@ with self;
 
     # tests fails on nixos and hydra because of different purity issues
     doCheck = false;
+    buildInputs = [ YAMLPP ];
 
     meta = {
       description = "Grep-like tool tailored to working with large trees of source code";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21072,10 +21072,10 @@ with self;
 
   MathBigIntGMP = buildPerlPackage {
     pname = "Math-BigInt-GMP";
-    version = "1.6013";
+    version = "1.7003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-GMP-1.6013.tar.gz";
-      hash = "sha256-yxqS4CJn1AUV+OA6TiEvZv0wfJdMu9MT4j3jL98Q9rU=";
+      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-GMP-1.7003.tar.gz";
+      hash = "sha256-oWViiyd9HoM/W2V8qDbbgbxE4EwQfP6fW4vZR1VkLtU=";
     };
     buildInputs = [ pkgs.gmp ];
     doCheck = false;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -31349,24 +31349,25 @@ with self;
 
   Specio = buildPerlPackage {
     pname = "Specio";
-    version = "0.48";
+    version = "0.53";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Specio-0.48.tar.gz";
-      hash = "sha256-DIV5NYDxJ07wgXMHkTHRAfd7IqzOp6+oJVIC8IEWgrI=";
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Specio-0.53.tar.gz";
+      hash = "sha256-DQ7s+56JvQ9fcQ+sQuEgCogtUTqGL5hJfq71knrGwYM=";
     };
     propagatedBuildInputs = [
+      Clone
+      ClonePP
       DevelStackTrace
       EvalClosure
       MROCompat
+      ModuleImplementation
       ModuleRuntime
       RoleTiny
       SubQuote
+      TestFatal
       TryTiny
     ];
-    buildInputs = [
-      TestFatal
-      TestNeeds
-    ];
+    buildInputs = [ TestNeeds ];
     meta = {
       description = "Type constraints and coercions for Perl";
       homepage = "https://metacpan.org/release/Specio";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -37139,10 +37139,10 @@ with self;
 
   Testutf8 = buildPerlPackage {
     pname = "Test-utf8";
-    version = "1.02";
+    version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKF/Test-utf8-1.02.tar.gz";
-      hash = "sha256-34LwnFlAgwslpJ8cgWL6JNNx5gKIDt742aTUv9Zri9c=";
+      url = "mirror://cpan/authors/id/S/SC/SCHWIGON/Test-utf8-1.03.tar.gz";
+      hash = "sha256-okc3sx7AFhiaFsfw5N4v8MvXBcyu9wZjhxlROcW8JDk=";
     };
     meta = {
       description = "Handy utf8 tests";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -33784,10 +33784,10 @@ with self;
 
   Test2Harness = buildPerlPackage rec {
     pname = "Test2-Harness";
-    version = "1.000161";
+    version = "1.000163";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test2-Harness-${version}.tar.gz";
-      hash = "sha256-SXO3mx7tUwVxXuc9itySNtp5XH1AkNg7FQ6hMc1ltBQ=";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test2-Harness-1.000163.tar.gz";
+      hash = "sha256-FoqnRPfvOAxR2M3Xuf4N4rdfxtJdBh+INUEIx95e2r0=";
     };
 
     checkPhase = ''
@@ -33806,10 +33806,8 @@ with self;
       Importer
       LongJump
       ScopeGuard
-      TermTable
       Test2PluginMemUsage
       Test2PluginUUID
-      Test2Suite
       YAMLTiny
       gotofile
     ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22311,13 +22311,18 @@ with self;
 
   ModuleBuildTiny = buildPerlModule {
     pname = "Module-Build-Tiny";
-    version = "0.047";
+    version = "0.052";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-Tiny-0.047.tar.gz";
-      hash = "sha256-cSYOlCG5PDPdGz59DPFfdZwMp8dT+oQCeew75w+PjJ0=";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-Tiny-0.052.tar.gz";
+      hash = "sha256-vRBFLJ8k1LT+WUEm460jG6ts6/FqzaQKTo3HhJB+uH8=";
     };
-    buildInputs = [ FileShareDir ];
+    buildInputs = [
+      ExtUtilsConfig
+      ExtUtilsHelpers
+      ExtUtilsInstallPaths
+    ];
     propagatedBuildInputs = [
+      ExtUtilsConfig
       ExtUtilsHelpers
       ExtUtilsInstallPaths
     ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -30909,10 +30909,10 @@ with self;
 
   SeleniumRemoteDriver = buildPerlPackage {
     pname = "Selenium-Remote-Driver";
-    version = "1.49";
+    version = "1.50";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TE/TEODESIAN/Selenium-Remote-Driver-1.49.tar.gz";
-      hash = "sha256-yg7/7s6kK72vOVqI5j5EkoWKAAZAfJTRz8QY1BOX+mI=";
+      url = "mirror://cpan/authors/id/T/TE/TEODESIAN/Selenium-Remote-Driver-1.50.tar.gz";
+      hash = "sha256-P2PnAhV5q0TGK2VKA5glKTZIesk0vrVEHE1TrVsivh0=";
     };
     buildInputs = [
       TestDeep
@@ -30927,12 +30927,12 @@ with self;
       HTTPMessage
       IOString
       JSON
-      LWP
       Moo
       SubInstall
       TestLongString
       TryTiny
       XMLSimple
+      libwwwperl
       namespaceclean
     ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17662,10 +17662,10 @@ with self;
 
   IOAIO = buildPerlPackage {
     pname = "IO-AIO";
-    version = "4.73";
+    version = "4.81";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/IO-AIO-4.73.tar.gz";
-      hash = "sha256-mltHx4Ak+rdmPR5a90ob6rRQ19Y7poV+MbP9gobkrFo=";
+      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/IO-AIO-4.81.tar.gz";
+      hash = "sha256-ZwKfIOm3NKwfSD9xddTORfkkWBx96P30TiDHm+bcByk=";
     };
     buildInputs = [ CanaryStability ];
     propagatedBuildInputs = [ commonsense ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29446,10 +29446,10 @@ with self;
 
   ProtocolHTTP2 = buildPerlModule {
     pname = "Protocol-HTTP2";
-    version = "1.11";
+    version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CR/CRUX/Protocol-HTTP2-1.11.tar.gz";
-      hash = "sha256-Vp8Fsavpl7UHyCUVMMyB0e6WvZMsxoJTS2zkhlNQCRM=";
+      url = "mirror://cpan/authors/id/C/CR/CRUX/Protocol-HTTP2-1.12.tar.gz";
+      hash = "sha256-GWhR/tL/+1DGS6WsBDyJ+NvnZjDpWgN3/Gi1eAZYzBk=";
     };
     buildInputs = [
       AnyEvent

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18368,10 +18368,10 @@ with self;
 
   Inline = buildPerlPackage {
     pname = "Inline";
-    version = "0.86";
+    version = "0.87";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/Inline-0.86.tar.gz";
-      hash = "sha256-UQp94tARsNuAsIdOjA9zkAEJkQAK4TXP90dN8ebVHjo=";
+      url = "mirror://cpan/authors/id/I/IN/INGY/Inline-0.87.tar.gz";
+      hash = "sha256-EF5CcazhwbWiZNdx/xEdi5KLJWACiIIihix76WhvOcU=";
     };
     buildInputs = [ TestWarn ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29046,10 +29046,10 @@ with self;
 
   PPI = buildPerlPackage {
     pname = "PPI";
-    version = "1.277";
+    version = "1.284";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MITHALDU/PPI-1.277.tar.gz";
-      hash = "sha256-h8efg7aHbiBgUZZdUBnSUHxVH4GahnUAgOx+xDsuCvg=";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/PPI-1.284.tar.gz";
+      hash = "sha256-jZHmbZENMJatSh+r2ISncMau3i8DTU1eVgBhfsgzu9M=";
     };
 
     # override default postPatch to avoid patchShebangs breaking tests
@@ -29057,16 +29057,16 @@ with self;
 
     buildInputs = [
       ClassInspector
-      TestDeep
       TestNoWarnings
       TestObject
       TestSubCalls
     ];
     propagatedBuildInputs = [
       Clone
-      IOString
       ParamsUtil
+      SafeIsa
       TaskWeaken
+      YAMLPP
     ];
 
     preCheck = "

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -37743,12 +37743,12 @@ with self;
 
   TreeDAGNode = buildPerlPackage {
     pname = "Tree-DAG_Node";
-    version = "1.32";
+    version = "1.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Tree-DAG_Node-1.32.tgz";
-      hash = "sha256-ItnePW5vSv2J5tglxmT5SCh4vUninLgTQqcHr0BULT0=";
+      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/Tree-DAG_Node-1.35.tgz";
+      hash = "sha256-J0Z+NkTI37sI4m5taYp173wbGoEL2p/KUPki7qVCnrE=";
     };
-    propagatedBuildInputs = [ FileSlurpTiny ];
+    propagatedBuildInputs = [ FileSlurper ];
     meta = {
       description = "N-ary tree";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19885,10 +19885,10 @@ with self;
 
   LogAny = buildPerlPackage {
     pname = "Log-Any";
-    version = "1.717";
+    version = "1.718";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PR/PREACTION/Log-Any-1.717.tar.gz";
-      hash = "sha256-VmSdoPOQAjDJ49KSUssKdIBvst3r0igFrNc2iVmmW8o=";
+      url = "mirror://cpan/authors/id/P/PR/PREACTION/Log-Any-1.718.tar.gz";
+      hash = "sha256-tlt90PfSngX0mou6atQQg9lkftfCtg2LARWwbnlu4Zo=";
     };
     # Syslog test fails.
     preCheck = "rm t/syslog.t";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27647,10 +27647,10 @@ with self;
 
   PARDist = buildPerlPackage {
     pname = "PAR-Dist";
-    version = "0.52";
+    version = "0.53";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSCHUPP/PAR-Dist-0.52.tar.gz";
-      hash = "sha256-y+ljAJ6nnSRUqF/heU9CW33cHoa3F0nIhNsp1gHqj4g=";
+      url = "mirror://cpan/authors/id/R/RS/RSCHUPP/PAR-Dist-0.53.tar.gz";
+      hash = "sha256-BMvIHnhpaPmkEJrWwvm4HoeawMa2CAqdIXRDth39JJg=";
     };
     meta = {
       description = "Create and manipulate PAR distributions";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32404,12 +32404,16 @@ with self;
 
   SubExporter = buildPerlPackage {
     pname = "Sub-Exporter";
-    version = "0.990";
+    version = "0.991";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/Sub-Exporter-0.990.tar.gz";
-      hash = "sha256-vGTsWgaGX5zGdiFcBqlEizoMizl0/7I6JPjirQkFRPw=";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Sub-Exporter-0.991.tar.gz";
+      hash = "sha256-KpVpXTXF0NU3On4UXJa5sBYRO3TpQRaDWsBUUMrk1EU=";
     };
-    propagatedBuildInputs = [ DataOptList ];
+    propagatedBuildInputs = [
+      DataOptList
+      ParamsUtil
+      SubInstall
+    ];
     meta = {
       description = "Sophisticated exporter for custom-built routines";
       homepage = "https://github.com/rjbs/Sub-Exporter";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -36640,10 +36640,10 @@ with self;
 
   TestManifest = buildPerlPackage {
     pname = "Test-Manifest";
-    version = "2.023";
+    version = "2.026";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/Test-Manifest-2.023.tar.gz";
-      hash = "sha256-0k5SVT58uc2oH5L/6MkrPkNGcY5HEIAaWzW38lGnceI=";
+      url = "mirror://cpan/authors/id/B/BR/BRIANDFOY/Test-Manifest-2.026.tar.gz";
+      hash = "sha256-4DVdoKia/hABaKwYUeK8U8g3OPDbOHpTA4sZeIKarSU=";
     };
     meta = {
       description = "Interact with a t/test_manifest file";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -27688,10 +27688,10 @@ with self;
 
   Parent = buildPerlPackage {
     pname = "parent";
-    version = "0.241";
+    version = "0.244";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CORION/parent-0.241.tar.gz";
-      hash = "sha256-sQs5YKs5l9q3Vx/+l1ukYtl50IZFB0Ch4Is5WedRKP4=";
+      url = "mirror://cpan/authors/id/C/CO/CORION/parent-0.244.tar.gz";
+      hash = "sha256-FJpl8BmQnCiXFLV/tcfK26WT57hszyXLSfflSioa8c4=";
     };
     meta = {
       description = "Establish an ISA relationship with base classes at compile time";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26886,21 +26886,20 @@ with self;
 
   NumberPhone = buildPerlPackage {
     pname = "Number-Phone";
-    version = "4.0000";
+    version = "4.0009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Number-Phone-4.0000.tar.gz";
-      hash = "sha256-H0mX/oMJSrDNgUDwvn/cHz+JGQKareajOYH4fLBIZjQ=";
+      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/Number-Phone-4.0009.tar.gz";
+      hash = "sha256-aj+OSCFrQCWEDgj/uNdO0gSSNB2QkdXdPw+82G47Elg=";
     };
     buildInputs = [
       DevelHide
       FileShareDirInstall
-      ParallelForkManager
       TestDifferences
       TestWarnings
     ];
     propagatedBuildInputs = [
-      DataDumperConcise
       DataCompactReadonly
+      DataDumperConcise
       DevelCheckOS
       DevelDeprecationsEnvironmental
       FileFindRule

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21244,10 +21244,10 @@ with self;
 
   MathInt64 = buildPerlPackage {
     pname = "Math-Int64";
-    version = "0.54";
+    version = "0.57";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SALVA/Math-Int64-0.54.tar.gz";
-      hash = "sha256-3PxR5phDfqa5zv4CdiFcVs22p/hePiSitrQYnxlg01E=";
+      url = "mirror://cpan/authors/id/S/SA/SALVA/Math-Int64-0.57.tar.gz";
+      hash = "sha256-EsYBEcHPzrJXrCzMWy4XIYee+gmhsKc+iDavyhB6fXU=";
     };
     meta = {
       description = "Manipulate 64 bits integers in Perl";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22055,14 +22055,15 @@ with self;
 
   MinionBackendmysql = buildPerlPackage {
     pname = "Minion-Backend-mysql";
-    version = "1.003";
+    version = "1.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PR/PREACTION/Minion-Backend-mysql-1.003.tar.gz";
-      hash = "sha256-aaJcJAyw5NTvTxqjKgTt+Nolt+jTqCDP1kVhWZ7aRUI=";
+      url = "mirror://cpan/authors/id/P/PR/PREACTION/Minion-Backend-mysql-1.007.tar.gz";
+      hash = "sha256-8Eh8L/JsQj4b5lqVWp2wQnpR2mcCa0T9LWMijgN21Hw=";
     };
     buildInputs = [ Testmysqld ];
     propagatedBuildInputs = [
       Minion
+      Mojolicious
       Mojomysql
     ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32567,10 +32567,10 @@ with self;
 
   SubName = buildPerlPackage {
     pname = "Sub-Name";
-    version = "0.27";
+    version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Sub-Name-0.27.tar.gz";
-      hash = "sha256-7PNvuhxHypPh2qOUlo7TnEGGhnRZ2c0XPEIeK5cgQ+g=";
+      url = "mirror://cpan/authors/id/E/ET/ETHER/Sub-Name-0.28.tar.gz";
+      hash = "sha256-OcU/azsCy8cxdlZEE7UdPA83X5dgmD/VecJ/VYsWnPw=";
     };
     buildInputs = [
       BC

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20951,12 +20951,17 @@ with self;
 
   MailTransport = buildPerlPackage {
     pname = "Mail-Transport";
-    version = "3.005";
+    version = "4.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/Mail-Transport-3.005.tar.gz";
-      hash = "sha256-0Ny5P3BcEoXYCONN59htvijR7WaqKn3oMPZlH8NRlqM=";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/Mail-Transport-4.01.tar.gz";
+      hash = "sha256-T4UUkIlvPcZdnlCMraIqmTnMRdutsVl2EqQGph52JNI=";
     };
-    propagatedBuildInputs = [ MailMessage ];
+    propagatedBuildInputs = [
+      LogReport
+      MailMessage
+      StringPrint
+    ];
+    buildInputs = [ TestPod ];
     meta = {
       description = "Email message exchange";
       homepage = "http://perl.overmeer.net/CPAN";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -21884,10 +21884,10 @@ with self;
 
   MIMELite = buildPerlPackage {
     pname = "MIME-Lite";
-    version = "3.033";
+    version = "3.038";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/MIME-Lite-3.033.tar.gz";
-      hash = "sha256-eKJ58dLiQlUcNH75ehP8Z1dmYCy4TCqAxWlAD082i6s=";
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/MIME-Lite-3.038.tar.gz";
+      hash = "sha256-ButH23TVlNIlbPR5Tywlnp8/VLn2G5AFRObh2HniRPU=";
     };
     propagatedBuildInputs = [ EmailDateFormat ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28926,10 +28926,10 @@ with self;
 
   PLS = buildPerlPackage {
     pname = "PLS";
-    version = "0.905";
+    version = "0.906";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MREISNER/PLS-0.905.tar.gz";
-      hash = "sha256-RVW1J5nBZBXDy/5eMB6gLKDrvDQhTH/lLx19ykUwLik=";
+      url = "mirror://cpan/authors/id/M/MR/MREISNER/PLS-0.906.tar.gz";
+      hash = "sha256-BjbKYRoe28ErqhHIob5UWTEQokQYfM7rB5zpe16jn4M=";
     };
     propagatedBuildInputs = [
       Future

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26022,10 +26022,10 @@ with self;
 
   NetIMAPClient = buildPerlPackage {
     pname = "Net-IMAP-Client";
-    version = "0.9507";
+    version = "0.9511";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GANGLION/Net-IMAP-Client-0.9507.tar.gz";
-      hash = "sha256-QE5vW7xQjPFnxAUqXhRwXv7sb7eTvPm1xCniX0cYNUk=";
+      url = "mirror://cpan/authors/id/G/GA/GANGLION/Net-IMAP-Client-0.9511.tar.gz";
+      hash = "sha256-iDg6OPUDccTxEDHg1Fv+c/+mV5/ascRnWGJTpUkdJOc=";
     };
     propagatedBuildInputs = [
       IOSocketSSL

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -23261,13 +23261,14 @@ with self;
 
   Mojomysql = buildPerlPackage {
     pname = "Mojo-mysql";
-    version = "1.26";
+    version = "1.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojo-mysql-1.26.tar.gz";
-      hash = "sha256-H9LjBlr4Je9N2x2W9g9MVc9NCCD77L0wrHGdTeJx5rw=";
+      url = "mirror://cpan/authors/id/J/JH/JHTHORSEN/Mojo-mysql-1.28.tar.gz";
+      hash = "sha256-2aJl7iUzYWHB8PjrgwGj0s99kHpacwz6SBBbGor/MsU=";
     };
     propagatedBuildInputs = [
       DBDmysql
+      DBI
       Mojolicious
       SQLAbstract
     ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26668,10 +26668,10 @@ with self;
 
   NetSSLeay = buildPerlPackage {
     pname = "Net-SSLeay";
-    version = "1.92";
+    version = "1.94";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHRISN/Net-SSLeay-1.92.tar.gz";
-      hash = "sha256-R8LyswDy5xYtcdaZ9jPdajWwYloAy9qMUKwBFEqTlqk=";
+      url = "mirror://cpan/authors/id/C/CH/CHRISN/Net-SSLeay-1.94.tar.gz";
+      hash = "sha256-nXvopW0b7doFxCUwbMUEuhNDB+DAm9pKeIyYdE682V0=";
     };
     buildInputs = [
       pkgs.openssl

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26325,11 +26325,12 @@ with self;
 
   NetPing = buildPerlPackage {
     pname = "Net-Ping";
-    version = "2.75";
+    version = "2.76";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/Net-Ping-2.75.tar.gz";
-      hash = "sha256-tH3zz9lpLM0Aca05/nRxjrwy9ZcBVWpgT9FaCfCeDXQ=";
+      url = "mirror://cpan/authors/id/R/RU/RURBAN/Net-Ping-2.76.tar.gz";
+      hash = "sha256-B7UhJqUpwyMa6CxOQ5YXE+y9zP9oE+J9V93eiGUGT5s=";
     };
+    buildInputs = [ TestPod ];
     meta = {
       description = "Check a remote host for reachability";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -24418,15 +24418,19 @@ with self;
 
   MooseXNonMoose = buildPerlPackage {
     pname = "MooseX-NonMoose";
-    version = "0.26";
+    version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOY/MooseX-NonMoose-0.26.tar.gz";
-      hash = "sha256-y75S7PFgOCMfvX8sxrzhZqNWnIyzlq6A7EUXwuCNqn0=";
+      url = "mirror://cpan/authors/id/P/PL/PLICEASE/MooseX-NonMoose-0.27.tar.gz";
+      hash = "sha256-b8eJO0en24EqPB/ou5DZwjUUPGk3JR5XDie9vQ2ETs4=";
     };
-    buildInputs = [ TestFatal ];
-    propagatedBuildInputs = [
-      ListMoreUtils
+    buildInputs = [
       Moose
+      TestFatal
+    ];
+    propagatedBuildInputs = [
+      ModuleRuntime
+      Moose
+      TryTiny
     ];
     meta = {
       description = "Easy subclassing of non-Moose classes";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -28761,15 +28761,16 @@ with self;
     };
   };
 
-  PlackMiddlewareDeflater = buildPerlPackage {
+  PlackMiddlewareDeflater = buildPerlModule {
     pname = "Plack-Middleware-Deflater";
-    version = "0.12";
+    version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Plack-Middleware-Deflater-0.12.tar.gz";
-      hash = "sha256-KNqV59pMi1WRrEVFCckhds0IQpYM4HT94w+aEHXcwnU=";
+      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-Deflater-0.14.tar.gz";
+      hash = "sha256-O+YLOD6eAtxfMkCbqIs3zXWEwnXQKDLardZOcxFnhYY=";
     };
     propagatedBuildInputs = [ Plack ];
     buildInputs = [
+      ModuleBuildTiny
       TestRequires
       TestSharedFork
       TestTCP

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -35318,17 +35318,17 @@ with self;
 
   TestPerlTidy = buildPerlModule {
     pname = "Test-PerlTidy";
-    version = "20230226";
+    version = "20260110";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-PerlTidy-20230226.tar.gz";
-      hash = "sha256-wOJCEQeVeV1Nu2xEFmzlV09cftuninidG8rnZoXYA8E=";
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/Test-PerlTidy-20260110.tar.gz";
+      hash = "sha256-Zx2c+NjrdLagQyVOo7ZEuR6vs6bR5YN3zdOrcOaFwSk=";
     };
     propagatedBuildInputs = [
       PathTiny
       PerlTidy
       TextDiff
     ];
-    buildInputs = [ TestPerlCritic ];
+    buildInputs = [ ModuleBuild ];
     preCheck = ''
       # Remove tests with hardcoded line numbers.
       rm t/perltidy.t

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -35169,19 +35169,19 @@ with self;
 
   Testmysqld = buildPerlModule {
     pname = "Test-mysqld";
-    version = "1.0013";
+    version = "1.0030";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SO/SONGMU/Test-mysqld-1.0013.tar.gz";
-      hash = "sha256-V61BoJBXyWO1gsgaB276UPpW664hd9gwd33oOGBePu8=";
+      url = "mirror://cpan/authors/id/S/SO/SONGMU/Test-mysqld-1.0030.tar.gz";
+      hash = "sha256-RdJgiOyilxdStPvNNQ8s8+DlQpX9k7dOETLhYVLQDAM=";
     };
     buildInputs = [
-      pkgs.which
       ModuleBuildTiny
       TestSharedFork
+      pkgs.which
     ];
     propagatedBuildInputs = [
       ClassAccessorLite
-      DBDmysql
+      DBI
       FileCopyRecursive
     ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16504,15 +16504,17 @@ with self;
 
   HTMLParser = buildPerlPackage {
     pname = "HTML-Parser";
-    version = "3.81";
+    version = "3.83";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTML-Parser-3.81.tar.gz";
-      hash = "sha256-wJEKXI+S+IF+3QbM/SJLocLr6MEPVR8DJYeh/IPWL/I=";
+      url = "mirror://cpan/authors/id/O/OA/OALDERS/HTML-Parser-3.83.tar.gz";
+      hash = "sha256-cnjOl5ElYTKyanGlcZRRhEcEu5Z0tYMCw0ht9DWE+MA=";
     };
     propagatedBuildInputs = [
       HTMLTagset
       HTTPMessage
+      URI
     ];
+    buildInputs = [ URI ];
     meta = {
       description = "HTML parser class";
       homepage = "https://github.com/libwww-perl/HTML-Parser";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -38400,10 +38400,10 @@ with self;
 
   Version = buildPerlPackage {
     pname = "version";
-    version = "0.9930";
+    version = "0.9933";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/version-0.9930.tar.gz";
-      hash = "sha256-YduVX7yzn1kC+myLlXrrJ0HiPUhA+Eq/hGrx9nCu7jA=";
+      url = "mirror://cpan/authors/id/L/LE/LEONT/version-0.9933.tar.gz";
+      hash = "sha256-3AfZOIyj0/ZxRjEpBLzbNf5Ba7MAVhWPgN8ygalPrlg=";
     };
     meta = {
       description = "Structured version objects";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17645,10 +17645,10 @@ with self;
 
   IO = buildPerlPackage {
     pname = "IO";
-    version = "1.51";
+    version = "1.55";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/IO-1.51.tar.gz";
-      hash = "sha256-VJPqVZmHKM0rfsuCNMWPtdXfJwmNDwet3KIkRNdhbOA=";
+      url = "mirror://cpan/authors/id/T/TO/TODDR/IO-1.55.tar.gz";
+      hash = "sha256-BEOv67mkjylhHpsXoBf0MLURZ6SY+kZGwH+NzgO2uV8=";
     };
     doCheck = false;
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -38183,12 +38183,16 @@ with self;
 
   UserIdentity = buildPerlPackage {
     pname = "User-Identity";
-    version = "1.02";
+    version = "4.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/User-Identity-1.02.tar.gz";
-      hash = "sha256-OySu5/UnjGXD8EEVsHyG5kaTTpnqQJJANj8wiZE+uJk=";
+      url = "mirror://cpan/authors/id/M/MA/MARKOV/User-Identity-4.00.tar.gz";
+      hash = "sha256-RuxVxLLBWPueO9XGOqoQaV/uhQjvTslYd03Y6syrOEc=";
     };
-    propagatedBuildInputs = [ HashOrdered ];
+    propagatedBuildInputs = [
+      HashOrdered
+      LogReport
+    ];
+    buildInputs = [ TestPod ];
     meta = {
       description = "Collect information about a user";
       homepage = "http://perl.overmeer.net/CPAN";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -20990,10 +20990,10 @@ with self;
 
   MathBaseConvert = buildPerlPackage {
     pname = "Math-Base-Convert";
-    version = "0.11";
+    version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKER/Math-Base-Convert-0.11.tar.gz";
-      hash = "sha256-jAlxNV8kyTt553rVSkVwCQoaWY/Lm4b1wX66QvOLQOA=";
+      url = "mirror://cpan/authors/id/M/MI/MIKER/Math-Base-Convert-0.13.tar.gz";
+      hash = "sha256-KJwMM7yYhts9ws+UnY4Ksk42xnuegzNVlB1wqvNRntI=";
     };
     meta = {
       description = "Very fast base to base conversion";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -22865,10 +22865,10 @@ with self;
 
   ModuleSignature = buildPerlPackage {
     pname = "Module-Signature";
-    version = "0.87";
+    version = "0.93";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AU/AUDREYT/Module-Signature-0.87.tar.gz";
-      hash = "sha256-IU6AVcUP7DcalXQ1IP4mlAAE52FpBjsrROyQoNRdaYI=";
+      url = "mirror://cpan/authors/id/T/TI/TIMLEGGE/Module-Signature-0.93.tar.gz";
+      hash = "sha256-0LEo7DQVJUDwUYe4QSgI7TZhqlfoHBz5WdBsNSlbHzo=";
     };
     buildInputs = [ IPCRun ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -29107,12 +29107,17 @@ with self;
 
   PPIxRegexp = buildPerlModule {
     pname = "PPIx-Regexp";
-    version = "0.088";
+    version = "0.091";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WY/WYANT/PPIx-Regexp-0.088.tar.gz";
-      hash = "sha256-iFQz+bEC+tT9NrIccyC7A2A2ERyvmYExv0FvfNXul2Q=";
+      url = "mirror://cpan/authors/id/W/WY/WYANT/PPIx-Regexp-0.091.tar.gz";
+      hash = "sha256-5y7Hnv9kApewhyJ9ancI/Khxxt4JmXFJWFqY/mXtlC8=";
     };
-    propagatedBuildInputs = [ PPI ];
+    propagatedBuildInputs = [
+      PPI
+      PPIxIndexOffsets
+      TaskWeaken
+    ];
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "Parse regular expressions";
       license = with lib.licenses; [

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -34634,12 +34634,13 @@ with self;
 
   TestFutureIOImpl = buildPerlModule {
     pname = "Test-Future-IO-Impl";
-    version = "0.14";
+    version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-Future-IO-Impl-0.14.tar.gz";
-      hash = "sha256-AH22GdPUljQyXFbvvKDh5Vdt0z95RV8t6llb5u344jU=";
+      url = "mirror://cpan/authors/id/P/PE/PEVANS/Test-Future-IO-Impl-0.20.tar.gz";
+      hash = "sha256-4McgdF78/r2Fze92wmt5ZEu0L9WMGSpVDtfW2l+2i38=";
     };
     propagatedBuildInputs = [ Test2Suite ];
+    buildInputs = [ ModuleBuild ];
     meta = {
       description = "Acceptance tests for C<Future::IO> implementations";
       license = with lib.licenses; [


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
