### PR TITLE
strictdoc: 0.10.1 -> 0.18.1

### DIFF
--- a/pkgs/by-name/st/strictdoc/package.nix
+++ b/pkgs/by-name/st/strictdoc/package.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "strictdoc";
-  version = "0.10.1";
+  version = "0.18.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "strictdoc-project";
     repo = "strictdoc";
     tag = finalAttrs.version;
-    hash = "sha256-TXrSv6V5fMhcx4YolTfsFwgGL5qxNp67iv62KDC5H00=";
+    hash = "sha256-pfKEPdEYCW8pMOD5DH9oNVK1ypQKfFMUOXryte+JdCs=";
   };
 
   build-system = [
@@ -32,6 +32,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     lark
     lxml
     openpyxl
+    orjson
+    pandas
+    plotly
     pybtex
     pygments
     python-multipart
@@ -46,6 +49,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     tree-sitter
     tree-sitter-grammars.tree-sitter-cpp
     tree-sitter-grammars.tree-sitter-python
+    tree-sitter-grammars.tree-sitter-rust
     uvicorn
     webdriver-manager
     websockets
@@ -76,7 +80,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/strictdoc-project/strictdoc";
     changelog = "https://github.com/strictdoc-project/strictdoc/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.puzzlewolf ];
     mainProgram = "strictdoc";
   };
 })

--- a/pkgs/development/python-modules/html2pdf4doc/default.nix
+++ b/pkgs/development/python-modules/html2pdf4doc/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
+  pypdf,
   requests,
   selenium,
   versionCheckHook,
@@ -26,6 +27,7 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
+    pypdf
     requests
     selenium
     webdriver-manager


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Since `docutils` is now at 0.22.4 we can update strictdoc :)
Also fixed the dependency `html2pdf4doc`, added a missing dependency.
Also added myself as a maintainer.

Changelog since last version in nixpkgs: https://github.com/strictdoc-project/strictdoc/compare/0.10.1...0.18.1
Release notes for this release: https://github.com/strictdoc-project/strictdoc/releases/tag/0.18.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
