### PR TITLE
speed-dreams: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/sp/speed-dreams/package.nix
+++ b/pkgs/by-name/sp/speed-dreams/package.nix
@@ -100,13 +100,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     substituteInPlace "$out/share/applications/speed-dreams.desktop" \
-      --replace-fail "Exec=$out/games/speed-dreams-2" "Exec=$out/bin/speed-dreams"
+      --replace-fail "Exec=$out/games/speed-dreams-2" "Exec=speed-dreams"
     ${lib.optionalString stdenv.isLinux ''
       # Symlink for desktop icon
-      mkdir -p $out/share/pixmaps/
-      ln -s "$out/share/games/speed-dreams-2/data/icons/icon.png" "$out/share/pixmaps/speed-dreams-2.png"
+      mkdir -p $out/share/icons/hicolor/{96x96,scalable}/apps
+      ln -s "$out/share/games/speed-dreams-2/data/icons/icon.png" "$out/share/icons/hicolor/96x96/apps/speed-dreams-2.png"
+      ln -s "$out/share/games/speed-dreams-2/data/icons/icon.svg" "$out/share/icons/hicolor/scalable/apps/speed-dreams-2.svg"
       substituteInPlace "$out/share/applications/speed-dreams.desktop" \
-        --replace-fail "Icon=/build/speed-dreams-code/speed-dreams-data/data/data/icons/icon.png" "Icon=$out/share/pixmaps/speed-dreams-2.png"
+        --replace-fail "Icon=/build/speed-dreams-code/speed-dreams-data/data/data/icons/icon.png" "Icon=speed-dreams-2"
     ''}
   '';
 


### PR DESCRIPTION
Part of #428824 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
