### PR TITLE
darwin.xcode: add 26.3

### DIFF
--- a/pkgs/os-specific/darwin/xcode/default.nix
+++ b/pkgs/os-specific/darwin/xcode/default.nix
@@ -125,6 +125,8 @@ lib.makeExtensible (self: {
   xcode_26_1_1_Apple_silicon = requireXcode "26.1.1_Apple_silicon" "sha256-5dZ1O7iD2CF8R4TBeBLkaKLe/WOi8CMJJ1/Bg+uitCw=";
   xcode_26_2 = requireXcode "26.2_Universal" "sha256-uCw71PjAuvtKTIpcYsiFSjUZQnIBIpIoOm1QaaYHD7k=";
   xcode_26_2_Apple_silicon = requireXcode "26.2_Apple_silicon" "sha256-YxMVppJwRzTA6xWOILxVjLdl0bNmtZSifG/KQx6inRE=";
+  xcode_26_3 = requireXcode "26.3_Universal" "sha256-qrPSc036x3tW1TWWfX10+IS2c08dRCa6KFc+++35ueM=";
+  xcode_26_3_Apple_silicon = requireXcode "26.3_Apple_silicon" "sha256-q2p45zqAZUH6Z1Q3DHbZgpuuFTjZoMPhEfFdeIUvclw=";
   xcode =
     self."xcode_${
       lib.replaceStrings [ "." ] [ "_" ] (

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -181,6 +181,8 @@ makeScopeWithSplicing' {
           xcode_26_1_1_Apple_silicon
           xcode_26_2
           xcode_26_2_Apple_silicon
+          xcode_26_3
+          xcode_26_3_Apple_silicon
           xcode
           requireXcode
           ;


### PR DESCRIPTION
<table role="table">
<thead>
<tr>
<th><code>NIXPKGS_ALLOW_UNFREE=1 nix-build -A darwin.xcode_26_3</code></th>
<th><code>NIXPKGS_ALLOW_UNFREE=1 nix-build -A darwin.xcode_26_3_Apple_silicon</code></th>
</tr>
</thead>
<tbody>
<tr>
<td>
<pre>
<code>/nix/store/x9hdz5mfp44i9b05sswp271jdv68r8vx-Xcode.app</code>
</pre>
</td>
<td>
<pre>
<code>/nix/store/pnrldljnlwgypmhj0d2an70jbcv2jm0w-Xcode.app</code>
</pre>
</td>
</tr>
<tr>
<td>
<img width="400" height="232" alt="image" src="https://github.com/user-attachments/assets/61142bf7-0b12-4ef3-a2ae-5a7930223c40" />
</td>
<td>
<img width="399" height="227" alt="image" src="https://github.com/user-attachments/assets/9b41debf-7556-4f4f-8485-18ff2dcd7eff" />
</td>
</tr>
</tbody>
</table>

<img width="530" height="219" alt="image" src="https://github.com/user-attachments/assets/96aa981f-46be-42ad-bef9-b2d7c26a185c" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
