### PR TITLE
netbird: do not update child packages

### DIFF
--- a/pkgs/by-name/ne/netbird-management/package.nix
+++ b/pkgs/by-name/ne/netbird-management/package.nix
@@ -1,3 +1,5 @@
+# nixpkgs-update: no auto update
+# updated via the parent 'netbird' derivation
 { netbird }:
 
 netbird.override {

--- a/pkgs/by-name/ne/netbird-relay/package.nix
+++ b/pkgs/by-name/ne/netbird-relay/package.nix
@@ -1,3 +1,5 @@
+# nixpkgs-update: no auto update
+# updated via the parent 'netbird' derivation
 { netbird }:
 
 netbird.override {

--- a/pkgs/by-name/ne/netbird-signal/package.nix
+++ b/pkgs/by-name/ne/netbird-signal/package.nix
@@ -1,3 +1,5 @@
+# nixpkgs-update: no auto update
+# updated via the parent 'netbird' derivation
 { netbird }:
 
 netbird.override {

--- a/pkgs/by-name/ne/netbird-ui/package.nix
+++ b/pkgs/by-name/ne/netbird-ui/package.nix
@@ -1,3 +1,5 @@
+# nixpkgs-update: no auto update
+# updated via the parent 'netbird' derivation
 { netbird }:
 
 netbird.override {

--- a/pkgs/by-name/ne/netbird-upload/package.nix
+++ b/pkgs/by-name/ne/netbird-upload/package.nix
@@ -1,3 +1,5 @@
+# nixpkgs-update: no auto update
+# updated via the parent 'netbird' derivation
 { netbird }:
 
 netbird.override {

--- a/pkgs/by-name/ne/netbird/package.nix
+++ b/pkgs/by-name/ne/netbird/package.nix
@@ -19,7 +19,6 @@
   netbird-ui,
   netbird-upload,
   componentName ? "client",
-  needsUpdateScript ? componentName == "client",
 }:
 let
   /*
@@ -152,8 +151,6 @@ buildGoModule (finalAttrs: {
         netbird-upload
         ;
     };
-  }
-  // lib.attrsets.optionalAttrs needsUpdateScript {
     updateScript = nix-update-script { };
   };
 


### PR DESCRIPTION
This PR attempts to suppress automatic update PRs for `netbird-management`, `netbird-relay`, `netbird-signal`, `netbird-ui` and `netbird-upload`. All these packages are derived from `netbird`, which is the only one that needs updates.

#433303 was meant to do this as it seems, which didn't work because `passthru.updateScript` only tells `nixpkgs-update` _how_ to update, not if updates are needed at all.

This doesn't affect derivations themselves, hence no rebuilds and empty `nixpkgs-review` result.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
