### PR TITLE
bpf-linker: 0.9.15 -> 0.10.3

### DIFF
--- a/pkgs/by-name/bp/bpf-linker/package.nix
+++ b/pkgs/by-name/bp/bpf-linker/package.nix
@@ -1,40 +1,42 @@
 {
   lib,
-  stdenv,
   rustPlatform,
   fetchFromGitHub,
   btfdump,
   rustc,
+  # Override this if you are compiling your BPF programs with a version of
+  # rustc that uses a different LLVM version, for example when using a rust
+  # overlay.
+  llvmPackagesForLinker ? rustc.llvmPackages,
   zlib,
   libxml2,
 }:
-
 rustPlatform.buildRustPackage rec {
   pname = "bpf-linker";
-  version = "0.9.15";
+  version = "0.10.3";
 
   src = fetchFromGitHub {
     owner = "aya-rs";
     repo = "bpf-linker";
     tag = "v${version}";
-    hash = "sha256-5HXYtAn6KaFXsiA3Nt0IwmFLOXBhZWYrD8cMZ8rZ1fk=";
+    hash = "sha256-QqJtiKQgU1rgiQOTw5kn0LhxiGrGz65y9wzMMpqEBz8=";
   };
 
-  cargoHash = "sha256-coIcd6WjVQM/b51jwkG8It/wubXx6wuuPlzzelPFE38=";
+  cargoHash = "sha256-zA3R34QS3wAALEIo7k37BjDgyfzqg0n12Z0rZ/GTIIk=";
 
   buildNoDefaultFeatures = true;
-  buildFeatures = [ "llvm-${lib.versions.major rustc.llvm.version}" ];
-
-  nativeBuildInputs = [ rustc.llvm ];
+  buildFeatures = [ "llvm-${lib.versions.major llvmPackagesForLinker.llvm.version}" ];
 
   buildInputs = [
     zlib
     libxml2
+    (lib.getLib llvmPackagesForLinker.llvm)
   ];
 
   nativeCheckInputs = [
     btfdump
-    rustc.llvmPackages.clang.cc
+    llvmPackagesForLinker.clang.cc
+    llvmPackagesForLinker.llvm
   ];
 
   meta = {
@@ -46,8 +48,5 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     maintainers = with lib.maintainers; [ nickcao ];
-    # llvm-sys crate locates llvm by calling llvm-config
-    # which is not available when cross compiling
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hey!

Last weekend I tried to write some eBPF programs with aya but got some linker errors. It turned out that it was a mismatch in the LLVM version but first I thought it was the outdated version of `bpf-linker`.

After updating, I noticed two different problems, one with building and one with testing. From v0.9.5 -> v0.10 they seem to have changed quite a bit.

**As I am quite new to the rustc/llvm stuff in nixpkgs, I have tried to document (hopefully) all the thoughts behind my decisions and also formulated some questions. Would be really happy to get your feedback and learn something new! ;)**

Thanks a lot

#### **Problem 1**: Building

New version of `bpf-linker` has a `build.rs` which performs the linking steps with llvm and does not rely the `llvm-sys` crate anymore.

Relevant commit (including reasons): https://github.com/aya-rs/bpf-linker/commit/d71ea887177de8efb1091c3692b66ccaa4375c3d

In order to locate the LLVM installation they look up the location of `llvm-config` and try to figure out the location of `libLLVM` from there.

Relevant code: https://github.com/aya-rs/bpf-linker/blob/59f7feb4da77563b30737ddd444e8eae2c80895f/build.rs#L588C5-L588C7

However, since nixpkgs's `llvm` is split into multiple outputs (namely `lib`, which contains `lib/libLLVM*`, and `dev`, which contains `bin/llvm-config`) this path resolution fails (since they are two different store paths).

First, I used `symlinkJoin` (as shown below) to create a new store path which includes both `lib/*` and `bin/*`.
However, adding this to `buildInputs` didn't seem to add `llvm-config` to `$PATH`, again failing the resolution.

I didn't have more time to look into this, because I thought `stdenv` automatically inserts `bin/*` into `$PATH` when it exists -- please correct me here if I am wrong!

```nix
symlinkJoin {
  name = "llvm-config-and-lib";
  paths = [
    rustc.llvm.lib
    rustc.llvm.dev
  ];
};
```

Therefore, I used the `LLVM_PREFIX` variable that `bpf-linker` allows builders to set to set the path to the "combined LLVM" store path.

##### Remaining questions:
- While removing the reliance to `llvm-sys` may mean that we can cross compile (see note in `broken`), I am not 100% sure. Because `symlinkJoin` derivation is not in `buildInputs`, does this break cross compilation?
- `bpf-linker` issues a warning `bpf-linker@0.10.2: found multiple libLLVM files in directory /nix/store/rd8qn5527k5hcvgyxa52yrjmx04fjjqq-llvm-config-and-lib/lib:`

#### **Problem 2**: Testing

First of all, I am unsure how this was not a problem earlier, but the tests now need the `FileCheck` binary to be available.

```
thread 'compile_test' (3040) panicked at tests/tests.rs:20:28:
could not find ^FileCheck(-\d+)?$
```

What is more, [`rustc-build-sysroot` used to be a feature](https://github.com/aya-rs/bpf-linker/blob/20917d1da48659e9cd54bc80ee9bc930b6568809/tests/tests.rs#L144) (which was enabled by default).
However, because we build with `buildNoDefaultFeatures = true;`, it was never actually enabled.

Problem with using `rustc-build-sysroot` crate: looks for source files that are not there in nixpkgs `rustc`.

```
thread 'compile_test' (3094) panicked at tests/tests.rs:145:14:
failed to build sysroot: "/nix/store/5gk010lr12bwp64cm9rj3pj21c0hviw8-rustc-1.93.0/lib/rustlib/src/rust/library" does not seem to be a rust library source folder: `src/Cargo.toml` not found
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

There is also a prior discussion with the gentoo package mantainers, which are unhappy about `rustc-build-sysroot`: see [this issue](https://github.com/aya-rs/bpf-linker/issues/272)

Because of that, setting the env variable `BPFEL_SYSROOT_DIR = "${rustc.unwrapped}/lib/rustlib/bpfel-unknown-none"` resolves the problem (because we actually build sysroots for WASM and BPF by default -- is this a problem?).

Setting that however, is not enough, since `BPFEL_SYSROOT_DIR/lib` is not in the library include path (I guess when installing the target through rustup this is done automatically).
That is why I added the patch to ensure the `-L` argument is set.
Not sure if this is something for upstream, or it is to `nixpkgs` specific.

Is there a way to signal our intend to use the BPF sysroot to the `rustc` used in building the package, so it does it automatically?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
