### PR TITLE
git-annex-metadata-gui: migrate to by-name, modernize, switch to PEP517

### DIFF
--- a/pkgs/by-name/gi/git-annex-metadata-gui/package.nix
+++ b/pkgs/by-name/gi/git-annex-metadata-gui/package.nix
@@ -1,13 +1,11 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
-  pyqt5,
   qt5,
-  git-annex-adapter,
 }:
 
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "git-annex-metadata-gui";
   version = "0.2.0";
   format = "setuptools";
@@ -30,8 +28,8 @@ buildPythonApplication rec {
   '';
 
   propagatedBuildInputs = [
-    pyqt5
-    git-annex-adapter
+    python3Packages.pyqt5
+    python3Packages.git-annex-adapter
   ];
 
   meta = {

--- a/pkgs/by-name/gi/git-annex-metadata-gui/package.nix
+++ b/pkgs/by-name/gi/git-annex-metadata-gui/package.nix
@@ -5,16 +5,16 @@
   qt5,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "git-annex-metadata-gui";
   version = "0.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "alpernebbi";
     repo = "git-annex-metadata-gui";
-    rev = "v${version}";
-    sha256 = "03kch67k0q9lcs817906g864wwabkn208aiqvbiyqp1qbg99skam";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VU2d0ls4XOzj2jgqBISdS3FODHoGpBOQZjRhMI+BbA4=";
   };
 
   prePatch = ''
@@ -27,7 +27,11 @@ python3Packages.buildPythonApplication rec {
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';
 
-  propagatedBuildInputs = [
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  dependencies = [
     python3Packages.pyqt5
     python3Packages.git-annex-adapter
   ];
@@ -43,4 +47,4 @@ python3Packages.buildPythonApplication rec {
     license = lib.licenses.gpl3Plus;
     platforms = with lib.platforms; linux;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1123,12 +1123,6 @@ with pkgs;
 
   github-cli = gh;
 
-  git-annex-metadata-gui =
-    libsForQt5.callPackage ../applications/version-management/git-annex-metadata-gui
-      {
-        inherit (python3Packages) buildPythonApplication pyqt5 git-annex-adapter;
-      };
-
   git-annex-remote-dbx = callPackage ../applications/version-management/git-annex-remote-dbx {
     inherit (python3Packages)
       buildPythonApplication


### PR DESCRIPTION
This pull request refactors the packaging of `git-annex-metadata-gui` to modernize its Python build process and update its location in the repository. The main changes involve switching to the `python3Packages.buildPythonApplication` style, adopting the new dependency specification, and relocating the package to the by-name directory.

**Packaging modernization:**

* Refactored `git-annex-metadata-gui` to use `python3Packages.buildPythonApplication` with the `pyproject` format and explicit `build-system` declaration, aligning with modern Python packaging standards.
* Updated dependency specification from `propagatedBuildInputs` to the new `dependencies` attribute, referencing dependencies via `python3Packages`.
* Changed the source hash to the new format and updated the source reference to use `tag` instead of `rev`.

**Repository structure:**

* Moved the package definition from `pkgs/applications/version-management/git-annex-metadata-gui/default.nix` to `pkgs/by-name/gi/git-annex-metadata-gui/package.nix` for improved organization.

**Top-level package list cleanup:**

* Removed the old top-level reference to `git-annex-metadata-gui` in `all-packages.nix`, reflecting the updated packaging approach.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
