### PR TITLE
mpvScripts.{modernx,modernx-zydezu,modernz,mpv-osc-modern}: use installFonts

### DIFF
--- a/pkgs/by-name/mp/mpv/scripts/modernx-zydezu.nix
+++ b/pkgs/by-name/mp/mpv/scripts/modernx-zydezu.nix
@@ -2,6 +2,7 @@
   lib,
   buildLua,
   fetchFromGitHub,
+  installFonts,
   makeFontsConf,
   nix-update-script,
 }:
@@ -17,10 +18,8 @@ buildLua (finalAttrs: {
     hash = "sha256-a+StfEYQwt5NuELvanvZllrD2RQ0g9JBpCznMdSDM5Y=";
   };
 
-  postInstall = ''
-    mkdir -p $out/share/fonts
-    cp -r *.ttf $out/share/fonts
-  '';
+  nativeBuildInputs = [ installFonts ];
+
   passthru.extraWrapperArgs = [
     "--set"
     "FONTCONFIG_FILE"

--- a/pkgs/by-name/mp/mpv/scripts/modernx.nix
+++ b/pkgs/by-name/mp/mpv/scripts/modernx.nix
@@ -2,6 +2,7 @@
   lib,
   buildLua,
   fetchFromGitHub,
+  installFonts,
   makeFontsConf,
   nix-update-script,
 }:
@@ -17,10 +18,8 @@ buildLua (finalAttrs: {
     hash = "sha256-q7DwyfmOIM7K1L7vvCpq1EM0RVpt9E/drhAa9rLYb1k=";
   };
 
-  postInstall = ''
-    mkdir -p $out/share/fonts
-    cp -r *.ttf $out/share/fonts
-  '';
+  nativeBuildInputs = [ installFonts ];
+
   passthru.extraWrapperArgs = [
     "--set"
     "FONTCONFIG_FILE"

--- a/pkgs/by-name/mp/mpv/scripts/modernz.nix
+++ b/pkgs/by-name/mp/mpv/scripts/modernz.nix
@@ -2,6 +2,7 @@
   lib,
   buildLua,
   fetchFromGitHub,
+  installFonts,
   makeFontsConf,
   nix-update-script,
 }:
@@ -17,9 +18,7 @@ buildLua (finalAttrs: {
     hash = "sha256-9jth8TCAx/cmbAfO8s+1WPpMDuF79gQtVlC4OG2adrA=";
   };
 
-  postInstall = ''
-    install -Dt $out/share/fonts *.ttf
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   passthru.extraWrapperArgs = [
     "--set"

--- a/pkgs/by-name/mp/mpv/scripts/mpv-osc-modern.nix
+++ b/pkgs/by-name/mp/mpv/scripts/mpv-osc-modern.nix
@@ -2,6 +2,7 @@
   lib,
   buildLua,
   fetchFromGitHub,
+  installFonts,
   makeFontsConf,
   nix-update-script,
 }:
@@ -17,10 +18,8 @@ buildLua (finalAttrs: {
     hash = "sha256-RMUy8UpSRSCEPAbnGLpJ2NjDsDdkjq8cNsdGwsQ5ANU=";
   };
 
-  postInstall = ''
-    mkdir -p $out/share/fonts
-    cp -r *.ttf $out/share/fonts
-  '';
+  nativeBuildInputs = [ installFonts ];
+
   passthru.extraWrapperArgs = [
     "--set"
     "FONTCONFIG_FILE"


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/495640

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
