### PR TITLE
openrct2: 0.4.31 -> 0.5.0, add update script

### DIFF
--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -30,7 +30,9 @@
   openssl,
   pkg-config,
   speexdsp,
+  versionCheckHook,
   zlib,
+
   withDiscordRpc ? false,
   # Paths to RCT1 and RCT2 installs can be specified to have them added as a wrapped argument
   rct1Path ? null,
@@ -38,21 +40,17 @@
 }:
 
 let
-  openrct2-version = "0.4.31";
-
-  # Those versions MUST match the pinned versions within the CMakeLists.txt
-  # file. The REPLAYS repository from the CMakeLists.txt is not necessary.
-  objects-version = "1.7.6";
-  openmsx-version = "1.6.1";
+  objects-version = "1.7.9";
+  openmusic-version = "1.6.1";
   opensfx-version = "1.0.6";
   title-sequences-version = "0.4.26";
 
   objects = fetchurl {
     url = "https://github.com/OpenRCT2/objects/releases/download/v${objects-version}/objects.zip";
-    hash = "sha256-asoutEH76MAi/4TVn7Ue1+pXd1ZkCXDcmJ6raF/0VpY=";
+    hash = "sha256-VUYe0gxugvFOmiec2ERlSwJkmZu5QDTVj6kS/e4m6tY=";
   };
-  openmsx = fetchurl {
-    url = "https://github.com/OpenRCT2/OpenMusic/releases/download/v${openmsx-version}/openmusic.zip";
+  openmusic = fetchurl {
+    url = "https://github.com/OpenRCT2/OpenMusic/releases/download/v${openmusic-version}/openmusic.zip";
     hash = "sha256-mUs1DTsYDuHLlhn+J/frrjoaUjKEDEvUeonzP6id4aE=";
   };
   opensfx = fetchurl {
@@ -66,13 +64,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openrct2";
-  version = openrct2-version;
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "OpenRCT2";
-    tag = "v${openrct2-version}";
-    hash = "sha256-jXcB2lwf/2O+TMSakp32it6T8Fg0e5QFcbMU89WoMjU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sGdtiEUmZux6FCXuxefRulfIEO8FY7wYfIBOhdSYtF8=";
   };
 
   nativeBuildInputs = [
@@ -80,6 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     unzip
     makeWrapper
+    versionCheckHook
   ];
 
   buildInputs = [
@@ -110,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "DOWNLOAD_OBJECTS" false)
-    (lib.cmakeBool "DOWNLOAD_OPENMSX" false)
+    (lib.cmakeBool "DOWNLOAD_OPENMUSIC" false)
     (lib.cmakeBool "DOWNLOAD_OPENSFX" false)
     (lib.cmakeBool "DOWNLOAD_TITLE_SEQUENCES" false)
     (lib.cmakeBool "DISABLE_DISCORD_RPC" (!withDiscordRpc))
@@ -119,7 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
   postUnpack = ''
     mkdir -p $sourceRoot/data/{object,sequence}
     unzip -o ${objects} -d $sourceRoot/data/object
-    unzip -o ${openmsx} -d $sourceRoot/data
+    unzip -o ${openmusic} -d $sourceRoot/data
     unzip -o ${opensfx} -d $sourceRoot/data
     unzip -o ${title-sequences} -d $sourceRoot/data/sequence
   '';
@@ -134,16 +133,18 @@ stdenv.mkDerivation (finalAttrs: {
     # Verify that the correct version of each third party repository is used.
     (
       let
-        versionCheck = cmakeKey: version: ''
-          grep -q '^set(${cmakeKey}_VERSION "${version}")$' CMakeLists.txt \
-            || (echo "${cmakeKey} differs from expected version!"; exit 1)
+        versionCheck = assetKey: url: ''
+          grep -qF '"${url}"' assets.json \
+            || (echo "${assetKey} differs from expected version!"; exit 1)
         '';
       in
-      (versionCheck "OBJECTS" objects-version)
-      + (versionCheck "OPENMSX" openmsx-version)
-      + (versionCheck "OPENSFX" opensfx-version)
-      + (versionCheck "TITLE_SEQUENCE" title-sequences-version)
+      (versionCheck "objects" objects.url)
+      + (versionCheck "openmusic" openmusic.url)
+      + (versionCheck "opensfx" opensfx.url)
+      + (versionCheck "title-sequences" title-sequences.url)
     );
+
+  doInstallCheck = true;
 
   postInstall = ''
     wrapProgram $out/bin/openrct2 \
@@ -151,15 +152,39 @@ stdenv.mkDerivation (finalAttrs: {
       ${lib.optionalString (rct2Path != null) "--add-flags '--rct2-data-path=\"${rct2Path}\"'"}
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
-    description = "Open source re-implementation of RollerCoaster Tycoon 2 (original game required)";
-    homepage = "https://openrct2.io/";
+    description = "Open source re-implementation of RollerCoaster Tycoon 2";
+    longDescription = ''
+      OpenRCT2 is an open source re-implementation of RollerCoaster Tycoon 2, a
+      construction and management simulation video game that simulates amusement
+      park management.
+
+      The original RCT2 game data is required to play.
+
+      The path to an existing RCT1 or RCT2 installation can be provided at
+      build time via the rct1Path and rct2Path arguments respectively:
+
+        openrct2.override {
+          rct1Path = "/path/to/rct1";
+          rct2Path = "/path/to/rct2";
+        };
+
+      Alternatively, if no paths are provided, the game will prompt for the
+      RCT2 data on first launch. For RCT1, you will then need to go to
+      the game settings and specify the path to the data directory.
+    '';
+    homepage = "https://openrct2.io";
+    changelog = "https://github.com/OpenRCT2/OpenRCT2/releases/tag/v${finalAttrs.version}";
     downloadPage = "https://github.com/OpenRCT2/OpenRCT2/releases";
     license = lib.licenses.gpl3Only;
-    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       keenanweaver
       kylerisse
     ];
+    mainProgram = "openrct2";
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
   };
 })

--- a/pkgs/by-name/op/openrct2/update.sh
+++ b/pkgs/by-name/op/openrct2/update.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p coreutils gnused curl common-updater-scripts jq ripgrep
+
+set -euo pipefail
+
+package="openrct2"
+package_file="$(dirname "$0")/package.nix"
+
+current_version="$(nix eval --raw -f . $package.version)"
+latest_version=$(curl -fsSL ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/OpenRCT2/OpenRCT2/releases/latest" | jq -r '.tag_name | ltrimstr("v")')
+
+if [[ "$current_version" == "$latest_version" ]]; then
+  echo "$package is already up-to-date: $current_version"
+  exit 0
+fi
+
+echo "$package updating from $current_version to $latest_version"
+
+echo "Getting new asset versions ..."
+
+latest_assets=$(curl -fsSL "https://raw.githubusercontent.com/OpenRCT2/OpenRCT2/refs/tags/v${latest_version}/assets.json")
+
+current_objects_version="$(rg -oP 'objects-version\s*=\s*"\K[^"]+' "$package_file")"
+current_openmusic_version="$(rg -oP 'openmusic-version\s*=\s*"\K[^"]+' "$package_file")"
+current_opensfx_version="$(rg -oP 'opensfx-version\s*=\s*"\K[^"]+' "$package_file")"
+current_title_sequences_version="$(rg -oP 'title-sequences-version\s*=\s*"\K[^"]+' "$package_file")"
+
+declare -A new_versions
+declare -A new_sris
+
+for asset in objects openmusic opensfx title-sequences; do
+  url=$(echo "$latest_assets" | jq -r --arg a "$asset" '.[$a].url')
+  hex=$(echo "$latest_assets" | jq -r --arg a "$asset" '.[$a].sha256')
+  version=$(echo "$url" | grep -oP '(?<=/download/v)[^/]+')
+  sri=$(nix hash convert --hash-algo sha256 --from base16 --to sri "$hex")
+
+  new_versions[$asset]="$version"
+  new_sris[$asset]="$sri"
+
+  echo "$asset version: $version | sri: $sri"
+done
+
+# Update version strings
+sed -i \
+  -e "s|objects-version = \"${current_objects_version}\"|objects-version = \"${new_versions[objects]}\"|" \
+  -e "s|openmusic-version = \"${current_openmusic_version}\"|openmusic-version = \"${new_versions[openmusic]}\"|" \
+  -e "s|opensfx-version = \"${current_opensfx_version}\"|opensfx-version = \"${new_versions[opensfx]}\"|" \
+  -e "s|title-sequences-version = \"${current_title_sequences_version}\"|title-sequences-version = \"${new_versions[title-sequences]}\"|" \
+  "$package_file"
+
+declare -A asset_url_fragments
+asset_url_fragments[objects]="objects.zip"
+asset_url_fragments[openmusic]="openmusic.zip"
+asset_url_fragments[opensfx]="opensound.zip"
+asset_url_fragments[title-sequences]="title-sequences.zip"
+
+for asset in objects openmusic opensfx title-sequences; do
+  old_sri=$(rg -A2 "${asset_url_fragments[$asset]}" "$package_file" | rg -oP 'sha256-[^"]+')
+  sed -i "s|$old_sri|${new_sris[$asset]}|" "$package_file"
+done
+
+echo "Updating $package from $current_version to $latest_version ..."
+update-source-version "$package" "$latest_version"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Bumped to latest tag 0.5.0
- Renamed openmsx as that has now changed
- Added an update script now that the assets are loaded from an external JSON. We can now use r-ryantm for updates! See: https://github.com/OpenRCT2/OpenRCT2/commit/37545dfd5eb5fa3215b32e07abf7e63165df154e
- Modified asset detection
- Modernized with sourceProvenance, versionCheckHook, and mainProgram. Added a longDescription.

I am not in love with the update script. Any suggestions for elegance are greatly appreciated. I will change it for the next release to look at the previous tag's assets.json--might be able to clean up a lot. I used other update.sh's in the tree, but I'm really unsure what is a 'best practice' setup for a custom update script.

Changelogs:

 - https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.5.0
 - https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.4.32

Diff: https://github.com/OpenRCT2/OpenRCT2/compare/v0.4.31...v0.5.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
