### PR TITLE
karma: 0.115 -> 0.125

### DIFF
--- a/pkgs/by-name/ka/karma/package.nix
+++ b/pkgs/by-name/ka/karma/package.nix
@@ -10,20 +10,20 @@
 
 buildGoModule (finalAttrs: {
   pname = "karma";
-  version = "0.115";
+  version = "0.125";
 
   src = fetchFromGitHub {
     owner = "prymitive";
     repo = "karma";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-SW/nmJcSk/LmoKLuD5stsSaRGaJctl6hVSODNCT9i64=";
+    hash = "sha256-/Iv7/CUwY/RlunXOd9H5xu4AzL/iXUEu+extyqinJ7M=";
   };
 
-  vendorHash = "sha256-Y55AaB8KRV+Tq/Trg1BOOwziyt+yJ2b3iVYA6bDebQY=";
+  vendorHash = "sha256-O+f8drIs+XOvLo8ifB/SHkBBxj0KPg2H1MAcCyJvLe4=";
 
   npmDeps = fetchNpmDeps {
     src = "${finalAttrs.src}/ui";
-    hash = "sha256-/L+eU0xwaopL2im9epiZiZ23dUqJ+3OwhWw/rIZC6hI=";
+    hash = "sha256-wcQ6QWoRm+aQRf1L7xkmQIbYnfN+Fr/D0LeRlEK5nbE=";
   };
 
   npmRoot = "ui";
@@ -65,6 +65,9 @@ buildGoModule (finalAttrs: {
     mainProgram = "karma";
     homepage = "https://karma-dashboard.io/";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ nukaduka ];
+    maintainers = with lib.maintainers; [
+      nukaduka
+      kraftnix
+    ];
   };
 })


### PR DESCRIPTION
## Things done

Updates karma to the latest release: https://github.com/prymitive/karma/releases/tag/v0.125

Also as a suggestion from the previous PR #265185, adding myself as a maintainer as I do use this and wish to keep this package up to date.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
