### PR TITLE
python31{3,4}.pkgs.meshcore: 2.2.5 -> 2.2.8

### DIFF
--- a/pkgs/development/python-modules/meshcore/default.nix
+++ b/pkgs/development/python-modules/meshcore/default.nix
@@ -1,25 +1,24 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-
-  # build-system
+  fetchFromGitHub,
   hatchling,
-
   # dependencies
   bleak,
   pycayennelpp,
-  pyserial-asyncio,
+  pyserial-asyncio-fast,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "meshcore";
-  version = "2.2.5";
+  version = "2.2.8";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "sha256-FYGBUKaoOAiDwrJyNW+rrQurEH87lDjP1mW8nKA9HRc=";
+  src = fetchFromGitHub {
+    owner = "meshcore-dev";
+    repo = "meshcore_py";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-S3hyA2TsgEHwB0gv5xFMTbwnAoGbceq0C5+8MBedD70=";
   };
 
   build-system = [ hatchling ];
@@ -27,7 +26,7 @@ buildPythonPackage rec {
   dependencies = [
     bleak
     pycayennelpp
-    pyserial-asyncio
+    pyserial-asyncio-fast
   ];
 
   pythonImportsCheck = [ "meshcore" ];
@@ -35,7 +34,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for communicating with meshcore companion radios";
     homepage = "https://github.com/meshcore-dev/meshcore_py";
+    changelog = "https://github.com/meshcore-dev/meshcore_py/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.haylin ];
+    maintainers = with lib.maintainers; [ haylin ];
   };
-}
+})


### PR DESCRIPTION
Python library for interacting with MeshCore companion radio nodes.

* GitHub-tagged version instead of PyPi one. 
* updated dependencies (pyserial-asyncio -> pyserial-asyncio-fast)
* compatible with bleak 2.0+ 

ChangeLog: https://github.com/meshcore-dev/meshcore_py/releases/tag/v2.2.8

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
