### PR TITLE
linuxPackages.nvidiaPackages.dc_5{3,7}5.fabricmanager: dontFixup

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -119,7 +119,7 @@ rec {
     url = "https://us.download.nvidia.com/tesla/${version}/NVIDIA-Linux-x86_64-${version}.run";
     sha256_64bit = "sha256-8gwy/W7NH3BcbfJ5fAwIQlPs9/9I8sNH+Co5YZiC7OE=";
     persistencedSha256 = "sha256-q061VN6om3UzbpWD7+tJJVgU/e2YCJF4IgEv53qx9ZA=";
-    fabricmanagerSha256 = "sha256-mIFlY4JHPIkTH18mpciU+ueH8Nj6Ts+2g2xv+BfyUEI=";
+    fabricmanagerSha256 = "sha256-bVOnPmAa2ADGC1FCIz0TAyS9lccNPa3K5pJQhgX45pQ=";
     useSettings = false;
     usePersistenced = true;
     useFabricmanager = true;

--- a/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
@@ -52,6 +52,9 @@ stdenv.mkDerivation rec {
       ${ldd} $b | grep -vqz "not found"
     done
   '';
+  # Default stdenv fixup shrinkings cause undefined symbols when trying to run
+  # meta.mainProgram
+  dontFixup = true;
 
   meta = {
     homepage = "https://www.nvidia.com/object/unix.html";

--- a/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/{bin,share/nvidia-fabricmanager}
     for bin in nv{-fabricmanager,switch-audit};do
       ${patchelf}/bin/patchelf \
@@ -47,6 +49,8 @@ stdenv.mkDerivation rec {
       mv $d $out/.
     done
     patchShebangs $out/bin
+
+    runHook postInstall
   '';
 
   doCheck = true;

--- a/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
@@ -47,10 +47,17 @@ stdenv.mkDerivation rec {
       mv $d $out/.
     done
     patchShebangs $out/bin
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
 
     for b in $out/bin/*;do
       ${ldd} $b | grep -vqz "not found"
     done
+
+    runHook postCheck
   '';
   # Default stdenv fixup shrinkings cause undefined symbols when trying to run
   # meta.mainProgram

--- a/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
@@ -7,6 +7,7 @@ nvidia_x11: sha256:
   patchelf,
   zlib,
   glibc,
+  versionCheckHook,
 }:
 
 let
@@ -63,6 +64,12 @@ stdenv.mkDerivation rec {
 
     runHook postCheck
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
   # Default stdenv fixup shrinkings cause undefined symbols when trying to run
   # meta.mainProgram
   dontFixup = true;


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test