### PR TITLE
librelane: 3.0.0.dev52 -> 3.0.0rc0

### DIFF
--- a/pkgs/by-name/li/librelane/package.nix
+++ b/pkgs/by-name/li/librelane/package.nix
@@ -23,14 +23,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "librelane";
-  version = "3.0.0.dev52";
+  version = "3.0.0rc0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "librelane";
     repo = "librelane";
     tag = finalAttrs.version;
-    hash = "sha256-0Sh5KR0Yc4gVT2d88z1GCJZmnsE4CYMsecLjQwm/Rxs=";
+    hash = "sha256-YG1/Exm1sXqydBvXQcSvRH3DcJbBMxu4P/AHytu9JMI=";
   };
 
   build-system = [


### PR DESCRIPTION
https://github.com/librelane/librelane/releases/tag/3.0.0rc0
https://github.com/librelane/librelane/blob/3.0.0rc0/Changelog.md
https://github.com/librelane/librelane/compare/3.0.0.dev52...3.0.0rc0

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

```librelane --smoke-test``` passes.