### PR TITLE
roborev: init at 0.39.0

### DIFF
--- a/pkgs/by-name/ro/roborev/package.nix
+++ b/pkgs/by-name/ro/roborev/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  git,
+  installShellFiles,
+  testers,
+  roborev,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "roborev";
+  version = "0.39.0";
+
+  src = fetchFromGitHub {
+    owner = "roborev-dev";
+    repo = "roborev";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oxiJwGxiEkxJH2Ao6aHXwYuqerZii26sIYydLfCZA6g=";
+  };
+
+  vendorHash = "sha256-9jLxJ4iKuuAAxF8eNbRCoTMv+WmQjGIOl3PC0HZOi6M=";
+
+  subPackages = [ "cmd/roborev" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/roborev-dev/roborev/internal/version.Version=v${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  nativeCheckInputs = [ git ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd roborev \
+      --bash <($out/bin/roborev completion bash) \
+      --fish <($out/bin/roborev completion fish) \
+      --zsh <($out/bin/roborev completion zsh)
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = roborev;
+    command = "roborev version";
+    version = "v${finalAttrs.version}";
+  };
+
+  meta = {
+    description = "Continuous background code review for coding agents";
+    homepage = "https://github.com/roborev-dev/roborev";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "roborev";
+  };
+})

--- a/pkgs/by-name/ro/roborev/package.nix
+++ b/pkgs/by-name/ro/roborev/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "roborev";
-  version = "0.39.0";
+  version = "0.46.1";
 
   src = fetchFromGitHub {
     owner = "roborev-dev";
     repo = "roborev";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oxiJwGxiEkxJH2Ao6aHXwYuqerZii26sIYydLfCZA6g=";
+    hash = "sha256-E5AcXd63sNRoRc8SCVlV5Jv5arjgpCR/8knZHJ8UG0k=";
   };
 
-  vendorHash = "sha256-9jLxJ4iKuuAAxF8eNbRCoTMv+WmQjGIOl3PC0HZOi6M=";
+  vendorHash = "sha256-chHhETsoDGJEw1CijPmKEVUIc5dhwGytFBFCWuO5GRY=";
 
   subPackages = [ "cmd/roborev" ];
 

--- a/pkgs/by-name/ro/roborev/package.nix
+++ b/pkgs/by-name/ro/roborev/package.nix
@@ -51,7 +51,7 @@ buildGoModule (finalAttrs: {
     description = "Continuous background code review for coding agents";
     homepage = "https://github.com/roborev-dev/roborev";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ cpcloud ];
     mainProgram = "roborev";
   };
 })

--- a/pkgs/by-name/ro/roborev/package.nix
+++ b/pkgs/by-name/ro/roborev/package.nix
@@ -6,7 +6,6 @@
   git,
   installShellFiles,
   testers,
-  roborev,
 }:
 
 buildGoModule (finalAttrs: {
@@ -42,8 +41,8 @@ buildGoModule (finalAttrs: {
   '';
 
   passthru.tests.version = testers.testVersion {
-    package = roborev;
-    command = "roborev version";
+    package = finalAttrs.finalPackage;
+    command = "${finalAttrs.meta.mainProgram} version";
     version = "v${finalAttrs.version}";
   };
 

--- a/pkgs/by-name/ro/roborev/package.nix
+++ b/pkgs/by-name/ro/roborev/package.nix
@@ -51,7 +51,7 @@ buildGoModule (finalAttrs: {
     description = "Continuous background code review for coding agents";
     homepage = "https://github.com/roborev-dev/roborev";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = [ ];
     mainProgram = "roborev";
   };
 })


### PR DESCRIPTION
Continuous background code review for coding agents. roborev reviews every commit as you work, catches issues before they reach a pull request, and can automatically fix what it finds.

https://github.com/roborev-dev/roborev

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Made with [Cursor](https://cursor.com)