### PR TITLE
lib: add type signature to some of the functions and normalize existing ones

### DIFF
--- a/lib/asserts.nix
+++ b/lib/asserts.nix
@@ -70,7 +70,7 @@ rec {
     # Type
 
     ```
-    assertOneOf :: String -> ComparableVal -> List ComparableVal -> Bool
+    assertOneOf :: String -> ComparableVal -> [ComparableVal] -> Bool
     ```
 
     # Examples
@@ -115,7 +115,7 @@ rec {
     # Type
 
     ```
-    assertEachOneOf :: String -> List ComparableVal -> List ComparableVal -> Bool
+    assertEachOneOf :: String -> [ComparableVal] -> [ComparableVal] -> Bool
     ```
 
     # Examples
@@ -164,7 +164,7 @@ rec {
     # Type
 
     ```
-    checkAssertWarn :: [ { assertion :: Bool; message :: String } ] -> [ String ] -> Any -> Any
+    checkAssertWarn :: [{ assertion :: Bool; message :: String; }] -> [String] -> a -> a
     ```
 
     # Examples

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -4,9 +4,8 @@
 { lib }:
 
 let
-  inherit (builtins) head length typeOf;
-  inherit (lib.asserts) assertMsg;
-  inherit (lib.trivial) oldestSupportedReleaseIsAtLeast mergeAttrs;
+  inherit (builtins) head length;
+  inherit (lib.trivial) mergeAttrs;
   inherit (lib.strings)
     concatStringsSep
     concatMapStringsSep

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -201,7 +201,7 @@ rec {
     # Type
 
     ```
-    attrsets.longestValidPathPrefix :: [String] -> Value -> [String]
+    longestValidPathPrefix :: [String] -> Value -> [String]
     ```
 
     # Examples

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -201,7 +201,7 @@ rec {
     # Type
 
     ```
-    longestValidPathPrefix :: [String] -> Value -> [String]
+    longestValidPathPrefix :: [String] -> AttrSet -> [String]
     ```
 
     # Examples
@@ -352,7 +352,7 @@ rec {
     # Type
 
     ```
-    concatMapAttrs :: (String -> a -> AttrSet) -> AttrSet -> AttrSet
+    concatMapAttrs :: (String -> Any -> AttrSet) -> AttrSet -> AttrSet
     ```
 
     # Examples
@@ -514,7 +514,7 @@ rec {
     # Type
 
     ```
-    attrVals :: [String] -> AttrSet -> [Any]
+    attrVals :: [String] -> { [String] :: a } -> [a]
     ```
 
     # Examples
@@ -537,7 +537,7 @@ rec {
     # Type
 
     ```
-    attrValues :: AttrSet -> [Any]
+    attrValues :: { [String] :: a } -> [a]
     ```
 
     # Examples
@@ -570,7 +570,7 @@ rec {
     # Type
 
     ```
-    getAttrs :: [String] -> AttrSet -> AttrSet
+    getAttrs :: [String] -> { [String] :: a } -> { [String] :: a }
     ```
 
     # Examples
@@ -603,7 +603,7 @@ rec {
     # Type
 
     ```
-    catAttrs :: String -> [AttrSet] -> [Any]
+    catAttrs :: String -> [{ [String] :: a }] -> [a]
     ```
 
     # Examples
@@ -646,7 +646,7 @@ rec {
     # Type
 
     ```
-    filterAttrs :: (String -> Any -> Bool) -> AttrSet -> AttrSet
+    filterAttrs :: (String -> a -> Bool) -> { [String] :: a } -> { [String] :: a }
     ```
 
     # Examples
@@ -737,7 +737,7 @@ rec {
     # Type
 
     ```
-    foldlAttrs :: ( a -> String -> b -> a ) -> a -> { ... :: b } -> a
+    foldlAttrs :: ( a -> String -> b -> a ) -> a -> { [String] :: b } -> a
     ```
 
     # Examples
@@ -812,7 +812,7 @@ rec {
     # Type
 
     ```
-    foldAttrs :: (Any -> Any -> Any) -> Any -> [AttrSets] -> Any
+    foldAttrs :: (a -> b -> b) -> b -> [{ [String] :: a }] -> { [String] :: b }
     ```
 
     # Examples
@@ -850,7 +850,7 @@ rec {
     # Type
 
     ```
-    collect :: (AttrSet -> Bool) -> AttrSet -> [x]
+    collect :: (AttrSet -> Bool) -> AttrSet -> [Any]
     ```
 
     # Examples
@@ -889,7 +889,7 @@ rec {
     # Type
 
     ```
-    cartesianProduct :: AttrSet -> [AttrSet]
+    cartesianProduct :: { [String] :: [a] } -> [{ [String] :: a }]
     ```
 
     # Examples
@@ -934,7 +934,7 @@ rec {
     # Type
 
     ```
-    mapCartesianProduct :: (AttrSet -> a) -> AttrSet -> [a]
+    mapCartesianProduct :: ({ [String] :: a } -> b) -> { [String] :: a } -> [b]
     ```
 
     # Examples
@@ -966,7 +966,7 @@ rec {
     # Type
 
     ```
-    nameValuePair :: String -> Any -> { name :: String; value :: Any; }
+    nameValuePair :: String -> a -> { name :: String; value :: a; }
     ```
 
     # Examples
@@ -998,7 +998,7 @@ rec {
     # Type
 
     ```
-    mapAttrs :: (String -> Any -> Any) -> AttrSet -> AttrSet
+    mapAttrs :: (String -> a -> b) -> { [String] :: a } -> { [String] :: b }
     ```
 
     # Examples
@@ -1033,7 +1033,7 @@ rec {
     # Type
 
     ```
-    mapAttrs' :: (String -> Any -> { name :: String; value :: Any; }) -> AttrSet -> AttrSet
+    mapAttrs' :: (String -> a -> { name :: String; value :: b; }) -> { [String] :: a } -> { [String] :: b }
     ```
 
     # Examples
@@ -1067,7 +1067,7 @@ rec {
     # Type
 
     ```
-    mapAttrsToList :: (String -> a -> b) -> AttrSet -> [b]
+    mapAttrsToList :: (String -> a -> b) -> { [String] :: a } -> [b]
     ```
 
     # Examples
@@ -1113,7 +1113,7 @@ rec {
     # Type
 
     ```
-    attrsToList :: AttrSet -> [ { name :: String; value :: Any; } ]
+    attrsToList :: { [String] :: a } -> [{ name :: String; value :: a; }]
     ```
 
     # Examples
@@ -1327,7 +1327,7 @@ rec {
     # Type
 
     ```
-    genAttrs :: [ String ] -> (String -> Any) -> AttrSet
+    genAttrs :: [String] -> (String -> a) -> { [String] :: a }
     ```
 
     # Examples
@@ -1364,7 +1364,7 @@ rec {
     # Type
 
     ```
-    genAttrs' :: [ Any ] -> (Any -> { name :: String; value :: Any; }) -> AttrSet
+    genAttrs' :: [a] -> (a -> { name :: String; value :: b; }) -> { [String] :: b }
     ```
 
     # Examples
@@ -1498,7 +1498,7 @@ rec {
     # Type
 
     ```
-    zipAttrsWithNames :: [ String ] -> (String -> [ Any ] -> Any) -> [ AttrSet ] -> AttrSet
+    zipAttrsWithNames :: [String] -> (String -> [a] -> b) -> [{ [String] :: a }] -> { [String] :: b }
     ```
 
     # Examples
@@ -1533,7 +1533,7 @@ rec {
     # Type
 
     ```
-    zipAttrsWith :: (String -> [ Any ] -> Any) -> [ AttrSet ] -> AttrSet
+    zipAttrsWith :: (String -> [a] -> b) -> [{ [String] :: a }] -> { [String] :: b }
     ```
 
     # Examples
@@ -1558,7 +1558,7 @@ rec {
     # Type
 
     ```
-    zipAttrs :: [ AttrSet ] -> AttrSet
+    zipAttrs :: [{ [String] :: a }] -> { [String] :: [a] }
     ```
 
     # Examples
@@ -1589,7 +1589,7 @@ rec {
     # Type
 
     ```
-    mergeAttrsList :: [ Attrs ] -> Attrs
+    mergeAttrsList :: [AttrSet] -> AttrSet
     ```
 
     # Examples
@@ -1609,7 +1609,7 @@ rec {
     list:
     let
       # `binaryMerge start end` merges the elements at indices `index` of `list` such that `start <= index < end`
-      # Type: Int -> Int -> Attrs
+      # Type: Int -> Int -> AttrSet
       binaryMerge =
         start: end:
         # assert start < end; # Invariant
@@ -1669,7 +1669,7 @@ rec {
     # Type
 
     ```
-    recursiveUpdateUntil :: ( [ String ] -> AttrSet -> AttrSet -> Bool ) -> AttrSet -> AttrSet -> AttrSet
+    recursiveUpdateUntil :: ([String] -> AttrSet -> AttrSet -> Bool) -> AttrSet -> AttrSet -> AttrSet
     ```
 
     # Examples

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -20,7 +20,6 @@ let
     take
     length
     filterAttrs
-    optionalString
     flip
     head
     pipe

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -626,7 +626,7 @@ rec {
     # Type
 
     ```
-    makeScope :: (AttrSet -> ((AttrSet -> a) | Path) -> AttrSet -> a) -> (AttrSet -> AttrSet) -> scope
+    makeScope :: (AttrSet -> ((AttrSet -> a) | Path) -> AttrSet -> a) -> (AttrSet -> AttrSet) -> Scope
     ```
   */
   makeScope =
@@ -689,20 +689,20 @@ rec {
 
     ```
     makeScopeWithSplicing' ::
-      { splicePackages :: Splice -> AttrSet
-      , newScope :: AttrSet -> ((AttrSet -> a) | Path) -> AttrSet -> a
+      { splicePackages :: Splice -> AttrSet;
+        newScope :: AttrSet -> ((AttrSet -> a) | Path) -> AttrSet -> a;
       }
-      -> { otherSplices :: Splice, keep :: AttrSet -> AttrSet, extra :: AttrSet -> AttrSet }
+      -> { otherSplices :: Splice; keep :: AttrSet -> AttrSet; extra :: AttrSet -> AttrSet; }
       -> AttrSet
 
-    Splice ::
-      { pkgsBuildBuild :: AttrSet
-      , pkgsBuildHost :: AttrSet
-      , pkgsBuildTarget :: AttrSet
-      , pkgsHostHost :: AttrSet
-      , pkgsHostTarget :: AttrSet
-      , pkgsTargetTarget :: AttrSet
-      }
+    Splice :: {
+      pkgsBuildBuild :: AttrSet;
+      pkgsBuildHost :: AttrSet;
+      pkgsBuildTarget :: AttrSet;
+      pkgsHostHost :: AttrSet;
+      pkgsHostTarget :: AttrSet;
+      pkgsTargetTarget :: AttrSet;
+    }
     ```
   */
   makeScopeWithSplicing' =
@@ -806,17 +806,16 @@ rec {
     ```
     extendMkDerivation ::
       {
-        constructDrv :: ((FixedPointArgs | AttrSet) -> a)
-        excludeDrvArgNames :: [ String ],
-        excludeFunctionArgNames :: [ String ]
-        extendDrvArgs :: (AttrSet -> AttrSet -> AttrSet)
-        inheritFunctionArgs :: Bool,
-        transformDrv :: a -> a,
+        constructDrv :: (FixedPointArgs | AttrSet) -> Derivation;
+        excludeDrvArgNames :: [String];
+        excludeFunctionArgNames :: [String];
+        extendDrvArgs :: AttrSet -> AttrSet -> AttrSet;
+        inheritFunctionArgs :: Bool;
+        transformDrv :: Derivation -> Derivation;
       }
-      -> (FixedPointArgs | AttrSet) -> a
+      -> ((FixedPointArgs | AttrSet) -> Derivation)
 
-    FixedPointArgs = AttrSet -> AttrSet
-    a = Derivation when defining a build helper
+    FixedPointArgs :: AttrSet -> AttrSet
     ```
 
     # Examples
@@ -998,7 +997,21 @@ rec {
     # Type
 
     ```
-    mapCrossIndex :: (a -> b) -> AttrSet -> AttrSet
+    mapCrossIndex :: (a -> b) -> {
+      buildBuild :: a;
+      buildHost :: a;
+      buildTarget :: a;
+      hostHost :: a;
+      hostTarget :: a;
+      targetTarget :: a;
+    } -> {
+      buildBuild :: b;
+      buildHost :: b;
+      buildTarget :: b;
+      hostHost :: b;
+      hostTarget :: b;
+      targetTarget :: b;
+    }
     ```
 
     # Examples

--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -60,7 +60,7 @@ rec {
     # Type
 
     ```
-    traceIf :: bool -> string -> a -> a
+    traceIf :: Bool -> String -> a -> a
     ```
 
     # Examples
@@ -327,7 +327,7 @@ rec {
     # Type
 
     ```
-    traceValSeqNFn :: (a -> b) -> int -> a -> a
+    traceValSeqNFn :: (a -> b) -> Int -> a -> a
     ```
 
     # Examples
@@ -362,7 +362,7 @@ rec {
     # Type
 
     ```
-    traceValSeqN :: int -> a -> a
+    traceValSeqN :: Int -> a -> a
     ```
 
     # Examples
@@ -407,7 +407,7 @@ rec {
     # Type
 
     ```
-    traceFnSeqN :: int -> string -> (a -> b) -> a -> b
+    traceFnSeqN :: Int -> String -> (a -> b) -> a -> b
     ```
 
     # Examples
@@ -466,7 +466,7 @@ rec {
 
     ```
     runTests :: {
-      tests = [ String ];
+      tests :: [String];
       ${testName} :: {
         expr :: a;
         expected :: a;
@@ -566,7 +566,7 @@ rec {
       ];
     }
     ->
-    null
+    Null
     ```
 
     # Examples

--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -167,7 +167,7 @@ rec {
 
     ```nix
     trace { a.b.c = 3; } null
-    trace: { a = <CODE>; }
+    trace: { a = <thunk>; }
     => null
     traceSeq { a.b.c = 3; } null
     trace: { a = { b = { c = 3; }; }; }
@@ -257,6 +257,23 @@ rec {
     `v`
 
     : Value to trace
+
+    # Type
+
+    ```
+    traceValSeqFn :: (a -> b) -> a -> a
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.debug.traceValSeqFn` usage example
+
+    ```nix
+    traceValSeqFn (v: v // { d = "foo";}) { a.b.c = 3; }
+    trace: { a = { b = { c = 3; }; }; d = "foo"; }
+    => { a = { ... }; }
+
+    :::
   */
   traceValSeqFn = f: v: traceValFn f (builtins.deepSeq v v);
 
@@ -268,6 +285,24 @@ rec {
     `v`
 
     : Value to trace
+
+    # Type
+
+    ```
+    traceValSeq :: a -> a
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.debug.traceValSeq` usage example
+
+    ```nix
+    traceValSeq { a.b.c = 3; }
+    trace: { a = { b = { c = 3; }; }; }
+    => { a = { ... }; }
+    ```
+
+    :::
   */
   traceValSeq = traceValSeqFn id;
 
@@ -288,6 +323,24 @@ rec {
     `v`
 
     : Value to trace
+
+    # Type
+
+    ```
+    traceValSeqNFn :: (a -> b) -> int -> a -> a
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.debug.traceValSeqNFn` usage example
+
+    ```nix
+    traceValSeqNFn (v: v // { d = "foo";}) 2 { a.b.c = 3; }
+    trace: { a = { b = {…}; }; d = "foo"; }
+    => { a = { ... }; }
+    ```
+
+    :::
   */
   traceValSeqNFn =
     f: depth: v:
@@ -305,6 +358,24 @@ rec {
     `v`
 
     : Value to trace
+
+    # Type
+
+    ```
+    traceValSeqN :: int -> a -> a
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.debug.traceValSeqN` usage example
+
+    ```nix
+    traceValSeqN 2 { a.b.c = 3; }
+    trace: { a = { b = {…}; }; }
+    => { a = { ... }; }
+    ```
+
+    :::
   */
   traceValSeqN = traceValSeqNFn id;
 
@@ -333,6 +404,12 @@ rec {
 
     : 4\. Function argument
 
+    # Type
+
+    ```
+    traceFnSeqN :: int -> string -> (a -> b) -> a -> b
+    ```
+
     # Examples
     :::{.example}
     ## `lib.debug.traceFnSeqN` usage example
@@ -340,7 +417,7 @@ rec {
     ```nix
     traceFnSeqN 2 "id" (x: x) { a.b.c = 3; }
     trace: { fn = "id"; from = { a.b = {…}; }; to = { a.b = {…}; }; }
-    => { a.b.c = 3; }
+    => { a = { ... }; }
     ```
 
     :::

--- a/lib/deprecated/misc.nix
+++ b/lib/deprecated/misc.nix
@@ -6,26 +6,20 @@ let
     any
     attrByPath
     attrNames
-    compare
     concat
-    concatMap
     elem
     filter
     foldl
     foldr
-    genericClosure
     head
     imap1
-    init
     isAttrs
     isFunction
     isInt
     isList
-    lists
     listToAttrs
     mapAttrs
     mergeAttrs
-    meta
     nameValuePair
     tail
     toList

--- a/lib/derivations.nix
+++ b/lib/derivations.nix
@@ -233,6 +233,12 @@ in
     `drv`
     : The derivation to wrap.
 
+    # Type
+
+    ```
+    warnOnInstantiate :: string -> Derivation -> Derivation
+    ```
+
     # Examples
     :::{.example}
     ## `lib.derivations.warnOnInstantiate` usage example

--- a/lib/derivations.nix
+++ b/lib/derivations.nix
@@ -195,7 +195,7 @@ in
     # Type
 
     ```
-    optionalDrvAttr :: Bool -> a -> a | Null
+    optionalDrvAttr :: Bool -> a -> (a | Null)
     ```
 
     # Examples
@@ -236,7 +236,7 @@ in
     # Type
 
     ```
-    warnOnInstantiate :: string -> Derivation -> Derivation
+    warnOnInstantiate :: String -> Derivation -> Derivation
     ```
 
     # Examples

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -45,7 +45,7 @@ rec {
 
     # Type
     ```
-    normalizeHash :: { hashTypes :: List String, required :: Bool } -> AttrSet -> AttrSet
+    normalizeHash :: { hashTypes :: [String]; required :: Bool; } -> AttrSet -> AttrSet
     ```
 
     # Arguments
@@ -157,7 +157,7 @@ rec {
 
     # Type
     ```
-    withNormalizedHash :: { hashTypes :: List String } -> (AttrSet -> T) -> (AttrSet -> T)
+    withNormalizedHash :: { hashTypes :: [String]; } -> (AttrSet -> a) -> (AttrSet -> a)
     ```
 
     # Arguments

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -7,7 +7,6 @@ let
     isAttrs
     isPath
     isString
-    nixVersion
     pathExists
     readDir
     split
@@ -21,7 +20,6 @@ let
     attrValues
     mapAttrs
     mapAttrsToList
-    optionalAttrs
     zipAttrsWith
     ;
 
@@ -48,7 +46,6 @@ let
     append
     splitRoot
     hasStorePathPrefix
-    splitStorePath
     ;
 
   inherit (lib.path.subpath)
@@ -62,11 +59,6 @@ let
     substring
     stringLength
     hasSuffix
-    versionAtLeast
-    ;
-
-  inherit (lib.trivial)
-    inPureEvalMode
     ;
 in
 # Rare case of justified usage of rec:

--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -139,8 +139,15 @@ rec {
     _noEval = throw _noEvalMessage;
   };
 
-  # Create a fileset, see ./README.md#fileset
-  # Type: path -> filesetTree -> fileset
+  /**
+    Create a fileset, see ./README.md#fileset
+
+    # Type
+
+    ```
+    _create :: Path -> FileSetTree -> FileSet
+    ```
+  */
   _create =
     base: tree:
     let
@@ -165,12 +172,18 @@ rec {
       _noEval = throw _noEvalMessage;
     };
 
-  # Coerce a value to a fileset. Return a set containing the attribute `success`
-  # indicating whether coercing succeeded, and either `value` when `success ==
-  # true`, or an error `message` when `success == false`. The string gives the
-  # context for error messages.
-  #
-  # Type: String -> (fileset | Path) -> { success :: Bool, value :: fileset } ] -> { success :: Bool, message :: String }
+  /**
+    Coerce a value to a fileset. Return a set containing the attribute `success`
+    indicating whether coercing succeeded, and either `value` when `success ==
+    true`, or an error `message` when `success == false`. The string gives the
+    context for error messages.
+
+    # Type
+
+    ```
+    _coerceResult :: String -> (FileSet | Path) -> ({ success :: Bool; value :: FileSet; } | { success :: Bool; message :: String; })
+    ```
+  */
   _coerceResult =
     let
       ok = value: {
@@ -219,9 +232,16 @@ rec {
     else
       ok (_singleton value);
 
-  # Coerce a value to a fileset, erroring when the value cannot be coerced.
-  # The string gives the context for error messages.
-  # Type: String -> (fileset | Path) -> fileset
+  /**
+    Coerce a value to a fileset, erroring when the value cannot be coerced.
+    The string gives the context for error messages.
+
+    # Type
+
+    ```
+    _coerce :: String -> (FileSet | Path) -> FileSet
+    ```
+  */
   _coerce =
     context: value:
     let
@@ -229,9 +249,16 @@ rec {
     in
     if result.success then result.value else throw result.message;
 
-  # Coerce many values to filesets, erroring when any value cannot be coerced,
-  # or if the filesystem root of the values doesn't match.
-  # Type: String -> [ { context :: String, value :: fileset | Path } ] -> [ fileset ]
+  /**
+    Coerce many values to filesets, erroring when any value cannot be coerced,
+    or if the filesystem root of the values doesn't match.
+
+    # Type
+
+    ```
+    _coerceMany :: String -> [{ context :: String; value :: FileSet | Path; }] -> [FileSet]
+    ```
+  */
   _coerceMany =
     functionContext: list:
     let
@@ -259,8 +286,15 @@ rec {
     else
       filesets;
 
-  # Create a file set from a path.
-  # Type: Path -> fileset
+  /**
+    Create a file set from a path.
+
+    # Type
+
+    ```
+    _singleton :: Path -> FileSet
+    ```
+  */
   _singleton =
     path:
     let
@@ -279,9 +313,16 @@ rec {
         ${baseNameOf path} = type;
       };
 
-  # Expand a directory representation to an equivalent one in attribute set form.
-  # All directory entries are included in the result.
-  # Type: Path -> filesetTree -> { <name> = filesetTree; }
+  /**
+    Expand a directory representation to an equivalent one in attribute set form.
+    All directory entries are included in the result.
+
+    # Type
+
+    ```
+    _directoryEntries :: Path -> FileSetTree -> { [String] :: FileSetTree }
+    ```
+  */
   _directoryEntries =
     path: value:
     if value == "directory" then
@@ -312,7 +353,7 @@ rec {
     # Type
 
     ```
-    Path -> filesetTree -> filesetTree
+    _normaliseTreeFilter :: Path -> FileSetTree -> FileSetTree
     ```
   */
   _normaliseTreeFilter =
@@ -357,7 +398,7 @@ rec {
     # Type
 
     ```
-    Path -> filesetTree -> filesetTree (with "emptyDir"'s)
+    _normaliseTreeMinimal :: Path -> FileSetTree -> FileSetTree (with "emptyDir"'s)
     ```
   */
   _normaliseTreeMinimal =
@@ -391,9 +432,16 @@ rec {
     else
       tree;
 
-  # Trace a filesetTree in a pretty way when the resulting value is evaluated.
-  # This can handle both normal filesetTree's, and ones returned from _normaliseTreeMinimal
-  # Type: Path -> filesetTree (with "emptyDir"'s) -> Null
+  /**
+    Trace a filesetTree in a pretty way when the resulting value is evaluated.
+    This can handle both normal filesetTree's, and ones returned from _normaliseTreeMinimal
+
+    # Type
+
+    ```
+    _printMinimalTree :: Path -> FileSetTree (with "emptyDir"'s) -> Null
+    ```
+  */
   _printMinimalTree =
     base: tree:
     let
@@ -443,8 +491,15 @@ rec {
     in
     if isAttrs tree then traceTreeAttrs firstLine "" tree else firstLine;
 
-  # Pretty-print a file set in a pretty way when the resulting value is evaluated
-  # Type: fileset -> Null
+  /**
+    Pretty-print a file set in a pretty way when the resulting value is evaluated
+
+    # Type
+
+    ```
+    _printFileset :: FileSet -> Null
+    ```
+  */
   _printFileset =
     fileset:
     if fileset._internalIsEmptyWithoutBase then
@@ -454,9 +509,16 @@ rec {
         _normaliseTreeMinimal fileset._internalBase fileset._internalTree
       );
 
-  # Turn a fileset into a source filter function suitable for `builtins.path`
-  # Only directories recursively containing at least one files are recursed into
-  # Type: fileset -> (String -> String -> Bool)
+  /**
+    Turn a fileset into a source filter function suitable for `builtins.path`
+    Only directories recursively containing at least one files are recursed into
+
+    # Type
+
+    ```
+    _toSourceFilter :: FileSet -> (String -> String -> Bool)
+    ```
+  */
   _toSourceFilter =
     fileset:
     let
@@ -476,7 +538,7 @@ rec {
 
       # Check whether a list of path components under the base path exists in the tree.
       # This function is called often, so it should be fast.
-      # Type: [ String ] -> Bool
+      # Type: [String] -> Bool
       inTree =
         components:
         let
@@ -551,10 +613,17 @@ rec {
     # This also forces the tree before returning the filter, leads to earlier error messages
     if fileset._internalIsEmptyWithoutBase || tree == null then empty else nonEmpty;
 
-  # Turn a builtins.filterSource-based source filter on a root path into a file set
-  # containing only files included by the filter.
-  # The filter is lazily called as necessary to determine whether paths are included
-  # Type: Path -> (String -> String -> Bool) -> fileset
+  /**
+    Turn a builtins.filterSource-based source filter on a root path into a file set
+    containing only files included by the filter.
+    The filter is lazily called as necessary to determine whether paths are included
+
+    # Type
+
+    ```
+    _fromSourceFilter :: Path -> (String -> String -> Bool) -> FileSet
+    ```
+  */
   _fromSourceFilter =
     root: sourceFilter:
     let
@@ -606,8 +675,15 @@ rec {
         ${baseNameOf root} = rootPathType;
       };
 
-  # Turns a file set into the list of file paths it includes.
-  # Type: fileset -> [ Path ]
+  /**
+    Turns a file set into the list of file paths it includes.
+
+    # Type
+
+    ```
+    _toList :: FileSet -> [Path]
+    ```
+  */
   _toList =
     fileset:
     let
@@ -668,9 +744,16 @@ rec {
     in
     recurse (length fileset._internalBaseComponents) fileset._internalTree;
 
-  # Computes the union of a list of filesets.
-  # The filesets must already be coerced and validated to be in the same filesystem root
-  # Type: [ Fileset ] -> Fileset
+  /**
+    Computes the union of a list of filesets.
+    The filesets must already be coerced and validated to be in the same filesystem root
+
+    # Type
+
+    ```
+    _unionMany :: [FileSet] -> FileSet
+    ```
+  */
   _unionMany =
     filesets:
     let
@@ -715,9 +798,16 @@ rec {
     # If there's no values with a base, we have no files
     if filesetsWithBase == [ ] then _emptyWithoutBase else _create commonBase resultTree;
 
-  # The union of multiple filesetTree's with the same base path.
-  # Later elements are only evaluated if necessary.
-  # Type: [ filesetTree ] -> filesetTree
+  /**
+    The union of multiple filesetTree's with the same base path.
+    Later elements are only evaluated if necessary.
+
+    # Type
+
+    ```
+    _unionTrees :: [FileSetTree] -> FileSetTree
+    ```
+  */
   _unionTrees =
     trees:
     let
@@ -736,9 +826,16 @@ rec {
       # We need to recurse into those
       zipAttrsWith (name: _unionTrees) withoutNull;
 
-  # Computes the intersection of a list of filesets.
-  # The filesets must already be coerced and validated to be in the same filesystem root
-  # Type: Fileset -> Fileset -> Fileset
+  /**
+    Computes the intersection of two filesets.
+    The filesets must already be coerced and validated to be in the same filesystem root
+
+    # Type
+
+    ```
+    _intersection :: FileSet -> FileSet -> FileSet
+    ```
+  */
   _intersection =
     fileset1: fileset2:
     let
@@ -787,9 +884,16 @@ rec {
     else
       _create longestBaseFileset._internalBase resultTree;
 
-  # The intersection of two filesetTree's with the same base path
-  # The second element is only evaluated as much as necessary.
-  # Type: filesetTree -> filesetTree -> filesetTree
+  /**
+    The intersection of two filesetTree's with the same base path
+    The second element is only evaluated as much as necessary.
+
+    # Type
+
+    ```
+    _intersectTree :: FileSetTree -> FileSetTree -> FileSetTree
+    ```
+  */
   _intersectTree =
     lhs: rhs:
     if isAttrs lhs && isAttrs rhs then
@@ -804,9 +908,16 @@ rec {
       # In all other cases it's the rhs
       rhs;
 
-  # Compute the set difference between two file sets.
-  # The filesets must already be coerced and validated to be in the same filesystem root.
-  # Type: Fileset -> Fileset -> Fileset
+  /**
+    Compute the set difference between two file sets.
+    The filesets must already be coerced and validated to be in the same filesystem root.
+
+    # Type
+
+    ```
+    _difference :: FileSet -> FileSet -> FileSet
+    ```
+  */
   _difference =
     positive: negative:
     let
@@ -862,8 +973,15 @@ rec {
       # which is what base path is for
       _create positive._internalBase resultingTree;
 
-  # Computes the set difference of two filesetTree's
-  # Type: Path -> filesetTree -> filesetTree
+  /**
+    Computes the set difference of two filesetTree's
+
+    # Type
+
+    ```
+    _differenceTree :: Path -> FileSetTree -> FileSetTree -> FileSetTree
+    ```
+  */
   _differenceTree =
     path: lhs: rhs:
     # If the lhs doesn't have any files, or the right hand side includes all files
@@ -880,13 +998,20 @@ rec {
         _directoryEntries path lhs
       );
 
-  # Filters all files in a path based on a predicate
-  # Type: ({ name, type, ... } -> Bool) -> Path -> FileSet
+  /**
+    Filters all files in a path based on a predicate
+
+    # Type
+
+    ```
+    _fileFilter :: ({ name :: String; type :: String; hasExt :: String -> Bool; ... } -> Bool) -> Path -> FileSet
+    ```
+  */
   _fileFilter =
     predicate: root:
     let
       # Check the predicate for a single file
-      # Type: String -> String -> filesetTree
+      # Type: String -> String -> FileSetTree
       fromFile =
         name: type:
         if
@@ -905,7 +1030,7 @@ rec {
           null;
 
       # Check the predicate for all files in a directory
-      # Type: Path -> filesetTree
+      # Type: Path -> FileSetTree
       fromDir =
         path:
         mapAttrs (
@@ -922,12 +1047,18 @@ rec {
         ${baseNameOf root} = fromFile (baseNameOf root) rootType;
       };
 
-  # Mirrors the contents of a Nix store path relative to a local path as a file set.
-  # Some notes:
-  # - The store path is read at evaluation time.
-  # - The store path must not include files that don't exist in the respective local path.
-  #
-  # Type: Path -> String -> FileSet
+  /**
+    Mirrors the contents of a Nix store path relative to a local path as a file set.
+    Some notes:
+    - The store path is read at evaluation time.
+    - The store path must not include files that don't exist in the respective local path.
+
+    # Type
+
+    ```
+    _mirrorStorePath :: Path -> String -> FileSet
+    ```
+  */
   _mirrorStorePath =
     localPath: storePath:
     let
@@ -939,8 +1070,15 @@ rec {
     in
     _create localPath (recurse storePath);
 
-  # Create a file set from the files included in the result of a fetchGit call
-  # Type: String -> String -> Path -> Attrs -> FileSet
+  /**
+    Create a file set from the files included in the result of a fetchGit call
+
+    # Type
+
+    ```
+    _fromFetchGit :: String -> String -> Path -> AttrSet -> FileSet
+    ```
+  */
   _fromFetchGit =
     function: argument: path: extraFetchGitAttrs:
     let

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -152,7 +152,7 @@ in
     # Type
 
     ```
-    Path -> Map String Path
+    haskellPathsInDir :: Path -> { [String] :: Path }
     ```
   */
   haskellPathsInDir =
@@ -189,7 +189,7 @@ in
     # Type
 
     ```
-    RegExp -> Path -> Nullable { path : Path; matches : [ MatchResults ]; }
+    locateDominatingFile :: RegExp -> Path -> ({ path :: Path; matches :: [MatchResults]; } | Null)
     ```
   */
   locateDominatingFile =
@@ -229,7 +229,7 @@ in
     # Type
 
     ```
-    Path -> [ Path ]
+    listFilesRecursive :: Path -> [Path]
     ```
   */
   listFilesRecursive =
@@ -320,9 +320,9 @@ in
 
     ```
     packagesFromDirectoryRecursive :: {
-      callPackage :: Path -> {} -> a,
-      newScope? :: AttrSet -> scope,
-      directory :: Path,
+      callPackage :: Path -> AttrSet -> Any;
+      newScope? :: AttrSet -> Scope;
+      directory :: Path;
     } -> AttrSet
     ```
 

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -302,16 +302,6 @@ in
       - Other files are ignored, including symbolic links to directories and to regular `.nix`
         files; this is because nixlang code cannot distinguish the type of a link's target.
 
-    # Type
-
-    ```
-    packagesFromDirectoryRecursive :: {
-      callPackage :: Path -> {} -> a,
-      newScope? :: AttrSet -> scope,
-      directory :: Path,
-    } -> AttrSet
-    ```
-
     # Inputs
 
     `callPackage`
@@ -325,6 +315,16 @@ in
 
     `directory`
     : The directory to read package files from.
+
+    # Type
+
+    ```
+    packagesFromDirectoryRecursive :: {
+      callPackage :: Path -> {} -> a,
+      newScope? :: AttrSet -> scope,
+      directory :: Path,
+    } -> AttrSet
+    ```
 
     # Examples
     :::{.example}
@@ -450,12 +450,6 @@ in
   /**
     Append `/default.nix` if the passed path is a directory.
 
-    # Type
-
-    ```
-    resolveDefaultNix :: (Path | String) -> (Path | String)
-    ```
-
     # Inputs
 
     A single argument which can be a [path](https://nix.dev/manual/nix/stable/language/types#type-path) value or a string containing an absolute path.
@@ -465,6 +459,12 @@ in
     If the input refers to a directory that exists, the output is that same path with `/default.nix` appended.
     Furthermore, if the input is a string that ends with `/`, `default.nix` is appended to it.
     Otherwise, the input is returned unchanged.
+
+    # Type
+
+    ```
+    resolveDefaultNix :: (Path | String) -> (Path | String)
+    ```
 
     # Examples
     :::{.example}

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -7,14 +7,12 @@
 # Tested in lib/tests/filesystem.sh
 let
   inherit (builtins)
-    readDir
     pathExists
     toString
     ;
 
   inherit (lib.filesystem)
     pathIsDirectory
-    pathIsRegularFile
     pathType
     packagesFromDirectoryRecursive
     ;

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -108,6 +108,12 @@ rec {
     `f`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    fix' :: (a -> a) -> a
+    ```
   */
   fix' =
     f:

--- a/lib/fixed-points.nix
+++ b/lib/fixed-points.nix
@@ -146,7 +146,7 @@ rec {
     # Type
 
     ```
-    (a -> a) -> a -> a
+    converge :: (a -> a) -> a -> a
     ```
   */
   converge =
@@ -295,9 +295,9 @@ rec {
     # Type
 
     ```
-    extends :: (Attrs -> Attrs -> Attrs) # The overlay to apply to the fixed-point function
-            -> (Attrs -> Attrs) # A fixed-point function
-            -> (Attrs -> Attrs) # The resulting fixed-point function
+    extends :: (AttrSet -> AttrSet -> AttrSet) # The overlay to apply to the fixed-point function
+            -> (AttrSet -> AttrSet) # A fixed-point function
+            -> (AttrSet -> AttrSet) # The resulting fixed-point function
     ```
 
     # Examples
@@ -376,7 +376,7 @@ rec {
       #                 ↓          ↓
       OverlayFn = { ... } -> { ... } -> { ... };
     in
-      composeManyExtensions :: ListOf OverlayFn -> OverlayFn
+    composeManyExtensions :: [OverlayFn] -> OverlayFn
     ```
 
     # Examples
@@ -480,14 +480,11 @@ rec {
     # Type
 
     ```
-    toExtension ::
-      b' -> Any -> Any -> b'
+    toExtension :: b' -> Any -> Any -> b'
     or
-    toExtension ::
-      (a -> b') -> Any -> a -> b'
+    toExtension :: (a -> b') -> Any -> a -> b'
     or
-    toExtension ::
-      (a -> a -> b) -> a -> a -> b
+    toExtension :: (a -> a -> b) -> a -> a -> b
     where b' = ! Callable
 
     Set a = b = b' = AttrSet & ! Callable to make toExtension return an extending function.

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -778,7 +778,7 @@ rec {
     # Type
 
     ```
-    toLua :: AttrSet -> Any -> String
+    toLua :: { multiline :: Bool; indent :: String; asBindings :: Bool; } -> Any -> String
     ```
 
     # Examples
@@ -879,7 +879,7 @@ rec {
     # Type
 
     ```
-    mkLuaInline :: String -> AttrSet
+    mkLuaInline :: String -> { _type = "lua-inline"; expr :: String; }
     ```
   */
   mkLuaInline = expr: {

--- a/lib/gvariant.nix
+++ b/lib/gvariant.nix
@@ -128,7 +128,7 @@ rec {
     # Type
 
     ```
-    mkValue :: Any -> gvariant
+    mkValue :: Any -> GVariant
     ```
   */
   mkValue =
@@ -174,7 +174,7 @@ rec {
     # Type
 
     ```
-    mkArray :: [Any] -> gvariant
+    mkArray :: [Any] -> GVariant
     ```
 
     # Examples
@@ -213,7 +213,7 @@ rec {
     # Type
 
     ```
-    mkEmptyArray :: gvariant.type -> gvariant
+    mkEmptyArray :: GVariantType -> GVariant
     ```
 
     # Examples
@@ -247,7 +247,7 @@ rec {
     # Type
 
     ```
-    mkVariant :: Any -> gvariant
+    mkVariant :: Any -> GVariant
     ```
 
     # Examples
@@ -289,7 +289,7 @@ rec {
     # Type
 
     ```
-    mkDictionaryEntry :: String -> Any -> gvariant
+    mkDictionaryEntry :: String -> Any -> GVariant
     ```
 
     # Examples
@@ -335,7 +335,7 @@ rec {
     # Type
 
     ```
-    mkMaybe :: gvariant.type -> Any -> gvariant
+    mkMaybe :: GVariantType -> Any -> GVariant
     ```
   */
   mkMaybe =
@@ -358,7 +358,7 @@ rec {
     # Type
 
     ```
-    mkNothing :: gvariant.type -> gvariant
+    mkNothing :: GVariantType -> GVariant
     ```
   */
   mkNothing = elemType: mkMaybe elemType null;
@@ -375,7 +375,7 @@ rec {
     # Type
 
     ```
-    mkJust :: Any -> gvariant
+    mkJust :: Any -> GVariant
     ```
   */
   mkJust =
@@ -397,7 +397,7 @@ rec {
     # Type
 
     ```
-    mkTuple :: [Any] -> gvariant
+    mkTuple :: [Any] -> GVariant
     ```
   */
   mkTuple =
@@ -423,7 +423,7 @@ rec {
     # Type
 
     ```
-    mkBoolean :: Bool -> gvariant
+    mkBoolean :: Bool -> GVariant
     ```
   */
   mkBoolean =
@@ -445,7 +445,7 @@ rec {
     # Type
 
     ```
-    mkString :: String -> gvariant
+    mkString :: String -> GVariant
     ```
   */
   mkString =
@@ -470,7 +470,7 @@ rec {
     # Type
 
     ```
-    mkObjectpath :: String -> gvariant
+    mkObjectpath :: String -> GVariant
     ```
   */
   mkObjectpath =
@@ -486,7 +486,7 @@ rec {
     # Type
 
     ```
-    mkUchar :: Int -> gvariant
+    mkUchar :: Int -> GVariant
     ```
   */
   mkUchar = mkPrimitive type.uchar;
@@ -497,7 +497,7 @@ rec {
     # Type
 
     ```
-    mkInt16 :: Int -> gvariant
+    mkInt16 :: Int -> GVariant
     ```
   */
   mkInt16 = mkPrimitive type.int16;
@@ -508,7 +508,7 @@ rec {
     # Type
 
     ```
-    mkUint16 :: Int -> gvariant
+    mkUint16 :: Int -> GVariant
     ```
   */
   mkUint16 = mkPrimitive type.uint16;
@@ -525,7 +525,7 @@ rec {
     # Type
 
     ```
-    mkInt32 :: Int -> gvariant
+    mkInt32 :: Int -> GVariant
     ```
   */
   mkInt32 =
@@ -541,7 +541,7 @@ rec {
     # Type
 
     ```
-    mkUint32 :: Int -> gvariant
+    mkUint32 :: Int -> GVariant
     ```
   */
   mkUint32 = mkPrimitive type.uint32;
@@ -552,7 +552,7 @@ rec {
     # Type
 
     ```
-    mkInt64 :: Int -> gvariant
+    mkInt64 :: Int -> GVariant
     ```
   */
   mkInt64 = mkPrimitive type.int64;
@@ -563,7 +563,7 @@ rec {
     # Type
 
     ```
-    mkUint64 :: Int -> gvariant
+    mkUint64 :: Int -> GVariant
     ```
   */
   mkUint64 = mkPrimitive type.uint64;
@@ -580,7 +580,7 @@ rec {
     # Type
 
     ```
-    mkDouble :: Float -> gvariant
+    mkDouble :: Float -> GVariant
     ```
   */
   mkDouble =

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -423,6 +423,12 @@ rec {
 
     : 1\. Function argument
 
+    # Type
+
+    ```
+    flatten :: [a | [a | [a | ...]]] -> [a]
+    ```
+
     # Examples
     :::{.example}
     ## `lib.lists.flatten` usage example
@@ -823,6 +829,12 @@ rec {
 
     : 1\. Function argument
 
+    # Type
+
+    ```
+    toList :: (a | [a]) -> [a]
+    ```
+
     # Examples
     :::{.example}
     ## `lib.lists.toList` usage example
@@ -961,6 +973,12 @@ rec {
     `lst`
 
     : 4\. Function argument
+
+    # Type
+
+    ```
+    groupBy' :: (b -> a -> b) -> b -> (a -> string) -> [a] -> Map string b
+    ```
 
     # Examples
     :::{.example}
@@ -1128,6 +1146,12 @@ rec {
 
     : 3\. Function argument
 
+    # Type
+
+    ```
+    listDfs :: bool -> (a -> a -> bool) -> [a] -> attrs
+    ```
+
     # Examples
     :::{.example}
     ## `lib.lists.listDfs` usage example
@@ -1192,6 +1216,12 @@ rec {
     `list`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    toposort :: (a -> a -> bool) -> [a] -> attrs
+    ```
 
     # Examples
     :::{.example}
@@ -1364,6 +1394,12 @@ rec {
 
     : The second list
 
+    # Type
+
+    ```
+    compareLists :: (a -> a -> int) -> [a] -> [a] -> int
+    ```
+
     # Examples
     :::{.example}
     ## `lib.lists.compareLists` usage examples
@@ -1402,6 +1438,12 @@ rec {
     `lst`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    naturalSort :: [str] -> [str]
+    ```
 
     # Examples
     :::{.example}
@@ -1940,6 +1982,12 @@ rec {
 
     : Second list
 
+    # Type
+
+    ```
+    intersectLists :: [a] -> [a] -> [a]
+    ```
+
     # Examples
     :::{.example}
     ## `lib.lists.intersectLists` usage example
@@ -1968,6 +2016,12 @@ rec {
 
     : Second list
 
+    # Type
+
+    ```
+    subtractLists :: [a] -> [a] -> [a]
+    ```
+
     # Examples
     :::{.example}
     ## `lib.lists.subtractLists` usage example
@@ -1994,6 +2048,12 @@ rec {
     `b`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    mutuallyExclusive :: [a] -> [a] -> bool
+    ```
   */
   mutuallyExclusive = a: b: length a == 0 || !(any (x: elem x a) b);
 
@@ -2006,6 +2066,12 @@ rec {
     `set`
 
     : Attribute set with attributes that are lists
+
+    # Type
+
+    ```
+    concatAttrValues :: (Map string a) -> [a]
+    ```
 
     # Examples
     :::{.example}

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -261,7 +261,7 @@ rec {
     # Type
 
     ```
-    foldl' :: (acc -> x -> acc) -> acc -> [x] -> acc
+    foldl' :: (a -> b -> a) -> a -> [b] -> a
     ```
 
     # Examples
@@ -298,7 +298,7 @@ rec {
     # Type
 
     ```
-    imap0 :: (int -> a -> b) -> [a] -> [b]
+    imap0 :: (Int -> a -> b) -> [a] -> [b]
     ```
 
     # Examples
@@ -330,7 +330,7 @@ rec {
     # Type
 
     ```
-    imap1 :: (int -> a -> b) -> [a] -> [b]
+    imap1 :: (Int -> a -> b) -> [a] -> [b]
     ```
 
     # Examples
@@ -372,7 +372,7 @@ rec {
 
     # Type
     ```
-    ifilter0 :: (int -> a -> bool) -> [a] -> [a]
+    ifilter0 :: (Int -> a -> Bool) -> [a] -> [a]
     ```
 
     # Examples
@@ -504,7 +504,7 @@ rec {
     # Type
 
     ```
-    findSingle :: (a -> bool) -> a -> a -> [a] -> a
+    findSingle :: (a -> Bool) -> a -> a -> [a] -> a
     ```
 
     # Examples
@@ -626,7 +626,7 @@ rec {
     # Type
 
     ```
-    findFirst :: (a -> bool) -> a -> [a] -> a
+    findFirst :: (a -> Bool) -> a -> [a] -> a
     ```
 
     # Examples
@@ -666,7 +666,7 @@ rec {
     # Type
 
     ```
-    any :: (a -> bool) -> [a] -> bool
+    any :: (a -> Bool) -> [a] -> Bool
     ```
 
     # Examples
@@ -701,7 +701,7 @@ rec {
     # Type
 
     ```
-    all :: (a -> bool) -> [a] -> bool
+    all :: (a -> Bool) -> [a] -> Bool
     ```
 
     # Examples
@@ -732,7 +732,7 @@ rec {
     # Type
 
     ```
-    count :: (a -> bool) -> [a] -> int
+    count :: (a -> Bool) -> [a] -> Int
     ```
 
     # Examples
@@ -766,7 +766,7 @@ rec {
     # Type
 
     ```
-    optional :: bool -> a -> [a]
+    optional :: Bool -> a -> [a]
     ```
 
     # Examples
@@ -800,7 +800,7 @@ rec {
     # Type
 
     ```
-    optionals :: bool -> [a] -> [a]
+    optionals :: Bool -> [a] -> [a]
     ```
 
     # Examples
@@ -866,7 +866,7 @@ rec {
     # Type
 
     ```
-    range :: int -> int -> [int]
+    range :: Int -> Int -> [Int]
     ```
 
     # Examples
@@ -900,7 +900,7 @@ rec {
     # Type
 
     ```
-    replicate :: int -> a -> [a]
+    replicate :: Int -> a -> [a]
     ```
 
     # Examples
@@ -935,7 +935,7 @@ rec {
     # Type
 
     ```
-    (a -> bool) -> [a] -> { right :: [a]; wrong :: [a]; }
+    partition :: (a -> Bool) -> [a] -> { right :: [a]; wrong :: [a]; }
     ```
 
     # Examples
@@ -977,7 +977,7 @@ rec {
     # Type
 
     ```
-    groupBy' :: (b -> a -> b) -> b -> (a -> string) -> [a] -> Map string b
+    groupBy' :: (a -> b -> a) -> a -> (b -> String) -> [b] -> { [String] :: a }
     ```
 
     # Examples
@@ -1149,7 +1149,7 @@ rec {
     # Type
 
     ```
-    listDfs :: bool -> (a -> a -> bool) -> [a] -> attrs
+    listDfs :: Bool -> (a -> a -> Bool) -> [a] -> ({ minimal :: a; visited :: [a]; rest :: [a]; } | { cycle :: a; loops :: [a]; visited :: [a]; rest :: [a]; })
     ```
 
     # Examples
@@ -1220,7 +1220,7 @@ rec {
     # Type
 
     ```
-    toposort :: (a -> a -> bool) -> [a] -> attrs
+    toposort :: (a -> a -> Bool) -> [a] -> ({ result :: [a]; } | { cycle :: [a]; loops :: [a]; })
     ```
 
     # Examples
@@ -1397,7 +1397,7 @@ rec {
     # Type
 
     ```
-    compareLists :: (a -> a -> int) -> [a] -> [a] -> int
+    compareLists :: (a -> a -> Int) -> [a] -> [a] -> Int
     ```
 
     # Examples
@@ -1442,7 +1442,7 @@ rec {
     # Type
 
     ```
-    naturalSort :: [str] -> [str]
+    naturalSort :: [String] -> [String]
     ```
 
     # Examples
@@ -1488,7 +1488,7 @@ rec {
     # Type
 
     ```
-    take :: int -> [a] -> [a]
+    take :: Int -> [a] -> [a]
     ```
 
     # Examples
@@ -1522,7 +1522,7 @@ rec {
     # Type
 
     ```
-    takeEnd :: int -> [a] -> [a]
+    takeEnd :: Int -> [a] -> [a]
     ```
 
     # Examples
@@ -1556,7 +1556,7 @@ rec {
     # Type
 
     ```
-    drop :: int -> [a] -> [a]
+    drop :: Int -> [a] -> [a]
     ```
 
     # Examples
@@ -1624,7 +1624,7 @@ rec {
     # Type
 
     ```
-    hasPrefix :: [a] -> [a] -> bool
+    hasPrefix :: [a] -> [a] -> Bool
     ```
 
     # Examples
@@ -1703,7 +1703,7 @@ rec {
     # Type
 
     ```
-    sublist :: int -> int -> [a] -> [a]
+    sublist :: Int -> Int -> [a] -> [a]
     ```
 
     # Examples
@@ -1921,7 +1921,7 @@ rec {
     # Type
 
     ```
-    uniqueStrings :: [ String ] -> [ String ]
+    uniqueStrings :: [String] -> [String]
     ```
 
     # Examples
@@ -1949,7 +1949,7 @@ rec {
     # Type
 
     ```
-    allUnique :: [a] -> bool
+    allUnique :: [a] -> Bool
     ```
 
     # Examples
@@ -2052,7 +2052,7 @@ rec {
     # Type
 
     ```
-    mutuallyExclusive :: [a] -> [a] -> bool
+    mutuallyExclusive :: [a] -> [a] -> Bool
     ```
   */
   mutuallyExclusive = a: b: length a == 0 || !(any (x: elem x a) b);
@@ -2070,7 +2070,7 @@ rec {
     # Type
 
     ```
-    concatAttrValues :: (Map string a) -> [a]
+    concatAttrValues :: { [String] :: [a] } -> [a]
     ```
 
     # Examples
@@ -2103,7 +2103,7 @@ rec {
     # Type
 
     ```
-    replaceElemAt :: [a] -> int - b -> [a]
+    replaceElemAt :: [a] -> Int -> a -> [a]
     ```
 
     # Examples

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -39,6 +39,12 @@ rec {
 
     : 2\. Function argument
 
+    # Type
+
+    ```
+    addMetaAttrs :: attrs -> Derivation -> Derivation
+    ```
+
     # Examples
     :::{.example}
     ## `lib.meta.addMetaAttrs` usage example
@@ -66,6 +72,12 @@ rec {
     `drv`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    dontDistribute :: Derivation -> Derivation
+    ```
   */
   dontDistribute = drv: addMetaAttrs { hydraPlatforms = [ ]; } drv;
 
@@ -85,6 +97,12 @@ rec {
     `drv`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    setName :: string -> Derivation -> Derivation
+    ```
   */
   setName = name: drv: drv // { inherit name; };
 
@@ -100,6 +118,12 @@ rec {
     `drv`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    updateName :: (string -> string) -> Derivation -> Derivation
+    ```
 
     # Examples
     :::{.example}
@@ -122,6 +146,12 @@ rec {
     `suffix`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    appendToName :: string -> Derivation -> Derivation
+    ```
   */
   appendToName =
     suffix:
@@ -145,6 +175,12 @@ rec {
     `set`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    mapDerivationAttrset :: (Derivation -> a) -> attrs -> attrs
+    ```
   */
   mapDerivationAttrset =
     f: set: lib.mapAttrs (name: pkg: if lib.isDerivation pkg then (f pkg) else pkg) set;
@@ -164,6 +200,12 @@ rec {
 
     `drv`
     : 2\. Function argument
+
+    # Type
+
+    ```
+    setPrio :: int -> Derivation -> Derivation
+    ```
   */
   setPrio = priority: addMetaAttrs { inherit priority; };
 
@@ -176,6 +218,12 @@ rec {
     `drv`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    lowPrio :: Derivation -> Derivation
+    ```
   */
   lowPrio = setPrio 10;
 
@@ -187,6 +235,12 @@ rec {
     `set`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    lowPrioSet :: (Map string Derivation) -> (Map string Derivation)
+    ```
   */
   lowPrioSet = set: mapDerivationAttrset lowPrio set;
 
@@ -199,6 +253,12 @@ rec {
     `drv`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    hiPrio :: Derivation -> Derivation
+    ```
   */
   hiPrio = setPrio (-10);
 
@@ -210,6 +270,12 @@ rec {
     `set`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    hiPrioSet :: (Map string Derivation) -> (Map string Derivation)
+    ```
   */
   hiPrioSet = set: mapDerivationAttrset hiPrio set;
 

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -42,7 +42,7 @@ rec {
     # Type
 
     ```
-    addMetaAttrs :: attrs -> Derivation -> Derivation
+    addMetaAttrs :: AttrSet -> Derivation -> Derivation
     ```
 
     # Examples
@@ -101,7 +101,7 @@ rec {
     # Type
 
     ```
-    setName :: string -> Derivation -> Derivation
+    setName :: String -> Derivation -> Derivation
     ```
   */
   setName = name: drv: drv // { inherit name; };
@@ -122,7 +122,7 @@ rec {
     # Type
 
     ```
-    updateName :: (string -> string) -> Derivation -> Derivation
+    updateName :: (String -> String) -> Derivation -> Derivation
     ```
 
     # Examples
@@ -150,7 +150,7 @@ rec {
     # Type
 
     ```
-    appendToName :: string -> Derivation -> Derivation
+    appendToName :: String -> Derivation -> Derivation
     ```
   */
   appendToName =
@@ -179,7 +179,7 @@ rec {
     # Type
 
     ```
-    mapDerivationAttrset :: (Derivation -> a) -> attrs -> attrs
+    mapDerivationAttrset :: (Derivation -> a) -> AttrSet -> AttrSet
     ```
   */
   mapDerivationAttrset =
@@ -204,7 +204,7 @@ rec {
     # Type
 
     ```
-    setPrio :: int -> Derivation -> Derivation
+    setPrio :: Int -> Derivation -> Derivation
     ```
   */
   setPrio = priority: addMetaAttrs { inherit priority; };
@@ -239,7 +239,7 @@ rec {
     # Type
 
     ```
-    lowPrioSet :: (Map string Derivation) -> (Map string Derivation)
+    lowPrioSet :: { [String] :: Derivation } -> { [String] :: Derivation }
     ```
   */
   lowPrioSet = set: mapDerivationAttrset lowPrio set;
@@ -274,7 +274,7 @@ rec {
     # Type
 
     ```
-    hiPrioSet :: (Map string Derivation) -> (Map string Derivation)
+    hiPrioSet :: { [String] :: Derivation } -> { [String] :: Derivation }
     ```
   */
   hiPrioSet = set: mapDerivationAttrset hiPrio set;
@@ -404,7 +404,15 @@ rec {
     # Type
 
     ```
-    getLicenseFromSpdxId :: str -> AttrSet
+    getLicenseFromSpdxId :: String -> {
+      deprecated :: Bool;
+      free :: Bool;
+      fullName :: String;
+      redistributable :: Bool;
+      shortName :: String;
+      spdxId :: String;
+      url :: String;
+    }
     ```
 
     # Examples
@@ -449,7 +457,15 @@ rec {
     # Type
 
     ```
-    getLicenseFromSpdxIdOr :: str -> Any -> Any
+    getLicenseFromSpdxIdOr :: String -> a -> ({
+      deprecated :: Bool;
+      free :: Bool;
+      fullName :: String;
+      redistributable :: Bool;
+      shortName :: String;
+      spdxId :: String;
+      url :: String;
+    } | a)
     ```
 
     # Examples
@@ -491,7 +507,7 @@ rec {
     # Type
 
     ```
-    getExe :: package -> string
+    getExe :: Derivation -> StorePath
     ```
 
     # Examples
@@ -537,7 +553,7 @@ rec {
     # Type
 
     ```
-    getExe' :: derivation -> string -> string
+    getExe' :: Derivation -> String -> StorePath
     ```
 
     # Examples
@@ -579,7 +595,7 @@ rec {
     # Type
 
     ```
-    cpeFullVersionWithVendor :: string -> string -> AttrSet
+    cpeFullVersionWithVendor :: String -> String -> { update :: String; vendor :: String; version :: String; }
     ```
 
     # Examples
@@ -634,7 +650,7 @@ rec {
     # Type
 
     ```
-    tryCPEPatchVersionInUpdateWithVendor :: string -> string -> AttrSet
+    tryCPEPatchVersionInUpdateWithVendor :: String -> String -> ({ success = true; value :: { update :: String; vendor :: String; version :: String; }; } | { success = false; error :: String; })
     ```
 
     # Examples
@@ -705,7 +721,7 @@ rec {
     # Type
 
     ```
-    cpePatchVersionInUpdateWithVendor :: string -> string -> AttrSet
+    cpePatchVersionInUpdateWithVendor :: String -> String -> { update :: String; vendor :: String; version :: String; }
     ```
 
     # Examples

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1461,7 +1461,7 @@ let
     # Type
 
     ```
-    option -> attrsOf { highestPrio, value }
+    mergeAttrDefinitionsWithPrio :: Option -> { [String] :: { highestPrio :: Int; value :: Any; } }
     ```
   */
   mergeAttrDefinitionsWithPrio =

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -12,7 +12,6 @@ let
     concatMap
     concatStringsSep
     elem
-    elemAt
     filter
     foldl'
     functionArgs

--- a/lib/network/internal.nix
+++ b/lib/network/internal.nix
@@ -33,7 +33,7 @@ let
     the list of strings which then can be parsed using `_parseExpanded`.
     Throws an error when the address is malformed.
 
-    # Type: String -> [ String ]
+    # Type: String -> [String]
 
     # Example:
 
@@ -94,7 +94,7 @@ let
     functions.
     Throws an error some element is not an u16 integer.
 
-    # Type: [ String ] -> IPv6
+    # Type: [String] -> IPv6
 
     # Example:
 
@@ -168,7 +168,7 @@ in
       prefix length are validated and converted to an internal representation
       that can be used by other functions.
 
-      # Type: String -> [ {address :: IPv6, prefixLength :: Int} ]
+      # Type: String -> [{ address :: IPv6; prefixLength :: Int; }]
 
       # Example:
 

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -71,7 +71,7 @@ rec {
     # Type
 
     ```
-    isOption :: a -> Bool
+    isOption :: Any -> Bool
     ```
   */
   isOption = lib.isType "option";
@@ -258,7 +258,7 @@ rec {
     # Type
 
     ```
-    mkPackageOption :: pkgs -> (string|[string]) -> { nullable? :: bool, default? :: string|[string], example? :: null|string|[string], extraDescription? :: string, pkgsText? :: string } -> option
+    mkPackageOption :: Pkgs -> (String | [String]) -> { nullable? :: Bool; default? :: String | [String]; example? :: Null | String | [String]; extraDescription? :: String; pkgsText? :: String; } -> Option
     ```
 
     # Examples
@@ -525,7 +525,7 @@ rec {
     # Type
 
     ```
-    getValues :: [ { value :: a; } ] -> [a]
+    getValues :: [{ value :: a; ... }] -> [a]
     ```
 
     # Examples
@@ -547,7 +547,7 @@ rec {
     # Type
 
     ```
-    getFiles :: [ { file :: a; } ] -> [a]
+    getFiles :: [{ file :: a; ... }] -> [a]
     ```
 
     # Examples
@@ -885,7 +885,7 @@ rec {
     # Type
 
     ```
-    showDefsSep :: { files :: [ String ]; loc :: [ String ]; ... } -> string
+    showOptionWithDefLocs :: { files :: [String]; loc :: [String]; ... } -> String
     ```
   */
   showOptionWithDefLocs = opt: ''

--- a/lib/path/default.nix
+++ b/lib/path/default.nix
@@ -115,7 +115,7 @@ let
       # An empty string is not a valid relative path, so we need to return a `.` when we have no components
       (if components == [ ] then "." else concatStringsSep "/" components);
 
-  # Type: Path -> { root :: Path, components :: [ String ] }
+  # Type: Path -> { root :: Path; components :: [String]; }
   #
   # Deconstruct a path value type into:
   # - root: The filesystem root of the path, generally `/`
@@ -143,7 +143,7 @@ let
   # The number of store directory components, typically 2
   storeDirLength = length storeDirComponents;
 
-  # Type: [ String ] -> Bool
+  # Type: [String] -> Bool
   #
   # Whether path components have a store path as a prefix, according to
   # https://nixos.org/manual/nix/stable/store/store-path.html#store-path.
@@ -395,7 +395,7 @@ in
     # Type
 
     ```
-    splitRoot :: Path -> { root :: Path, subpath :: String }
+    splitRoot :: Path -> { root :: Path; subpath :: String; }
     ```
 
     # Examples
@@ -607,7 +607,7 @@ in
     # Type
 
     ```
-    subpath.join :: [ String ] -> String
+    subpath.join :: [String] -> String
     ```
 
     # Examples
@@ -679,7 +679,7 @@ in
     # Type
 
     ```
-    subpath.components :: String -> [ String ]
+    subpath.components :: String -> [String]
     ```
 
     # Examples

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -131,7 +131,7 @@ let
       # that src.filter is called lazily.
       # For implementing a filter, see
       # https://nixos.org/nix/manual/#builtin-filterSource
-      # Type: A function (path -> type -> bool)
+      # Type: A function (Path -> Type -> Bool)
       filter ? _path: _type: true,
       # Optional name to use as part of the store path.
       # This defaults to `src.name` or otherwise `"source"`.
@@ -158,7 +158,7 @@ let
     # Type
 
     ```
-    sources.trace :: sourceLike -> Source
+    sources.trace :: SourceLike -> Source
     ```
   */
   trace =
@@ -241,7 +241,7 @@ let
     # Type
 
     ```
-    sourceLike -> [String] -> Source
+    sourceFilesBySuffices :: SourceLike -> [String] -> Source
     ```
 
     # Examples

--- a/lib/strings-with-deps.nix
+++ b/lib/strings-with-deps.nix
@@ -77,7 +77,7 @@ rec {
     # Type
 
     ```
-    textClosureList :: { ${phase} :: { deps :: [String]; text :: String; } | String; } -> [String] -> [String]
+    textClosureList :: { [String] :: { deps :: [String]; text :: String; } | String; } -> [String] -> [String]
     ```
 
     # Examples

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -56,7 +56,7 @@ rec {
     # Type
 
     ```
-    join :: string -> [ string ] -> string
+    join :: String -> [String] -> String
     ```
 
     # Examples
@@ -78,7 +78,7 @@ rec {
     # Type
 
     ```
-    concatStrings :: [string] -> string
+    concatStrings :: [String] -> String
     ```
 
     # Examples
@@ -108,7 +108,7 @@ rec {
     # Type
 
     ```
-    concatMapStrings :: (a -> string) -> [a] -> string
+    concatMapStrings :: (a -> String) -> [a] -> String
     ```
 
     # Examples
@@ -139,7 +139,7 @@ rec {
     # Type
 
     ```
-    concatImapStrings :: (int -> a -> string) -> [a] -> string
+    concatImapStrings :: (Int -> a -> String) -> [a] -> String
     ```
 
     # Examples
@@ -209,7 +209,7 @@ rec {
     # Type
 
     ```
-    concatStringsSep :: string -> [string] -> string
+    concatStringsSep :: String -> [String] -> String
     ```
 
     # Examples
@@ -244,7 +244,7 @@ rec {
     # Type
 
     ```
-    concatMapStringsSep :: string -> (a -> string) -> [a] -> string
+    concatMapStringsSep :: String -> (a -> String) -> [a] -> String
     ```
 
     # Examples
@@ -280,7 +280,7 @@ rec {
     # Type
 
     ```
-    concatIMapStringsSep :: string -> (int -> a -> string) -> [a] -> string
+    concatIMapStringsSep :: String -> (Int -> a -> String) -> [a] -> String
     ```
 
     # Examples
@@ -316,7 +316,7 @@ rec {
     # Type
 
     ```
-    concatMapAttrsStringSep :: String -> (String -> Any -> String) -> AttrSet -> String
+    concatMapAttrsStringSep :: String -> (String -> a -> String) -> { [String] :: a } -> String
     ```
 
     # Examples
@@ -347,7 +347,7 @@ rec {
     # Type
 
     ```
-    concatLines :: [string] -> string
+    concatLines :: [String] -> String
     ```
 
     # Examples
@@ -380,7 +380,7 @@ rec {
     # Type
 
     ```
-    replaceString :: string -> string -> string -> string
+    replaceString :: String -> String -> String -> String
     ```
 
     # Examples
@@ -413,7 +413,7 @@ rec {
     # Type
 
     ```
-    replicate :: int -> string -> string
+    replicate :: Int -> String -> String
     ```
 
     # Examples
@@ -445,7 +445,7 @@ rec {
     # Type
 
     ```
-    trim :: string -> string
+    trim :: String -> String
     ```
 
     # Examples
@@ -487,7 +487,7 @@ rec {
     # Type
 
     ```
-    trimWith :: { start :: Bool; end :: Bool } -> String -> String
+    trimWith :: { start :: Bool; end :: Bool; } -> String -> String
     ```
 
     # Examples
@@ -548,7 +548,7 @@ rec {
     # Type
 
     ```
-    makeSearchPath :: string -> [string] -> string
+    makeSearchPath :: String -> [String] -> String
     ```
 
     # Examples
@@ -588,7 +588,7 @@ rec {
     # Type
 
     ```
-    makeSearchPathOutput :: string -> string -> [package] -> string
+    makeSearchPathOutput :: String -> String -> [Derivation] -> String
     ```
 
     # Examples
@@ -618,7 +618,7 @@ rec {
     # Type
 
     ```
-    makeLibraryPath :: [package] -> string
+    makeLibraryPath :: [Derivation] -> String
     ```
 
     # Examples
@@ -649,7 +649,7 @@ rec {
     # Type
 
     ```
-    makeIncludePath :: [package] -> string
+    makeIncludePath :: [Derivation] -> String
     ```
 
     # Examples
@@ -680,7 +680,7 @@ rec {
     # Type
 
     ```
-    makeBinPath :: [package] -> string
+    makeBinPath :: [Derivation] -> String
     ```
 
     # Examples
@@ -707,7 +707,7 @@ rec {
     # Type
 
     ```
-    normalizePath :: string -> string
+    normalizePath :: String -> String
     ```
 
     # Examples
@@ -748,7 +748,7 @@ rec {
     # Type
 
     ```
-    optionalString :: bool -> string -> string
+    optionalString :: Bool -> String -> String
     ```
 
     # Examples
@@ -780,7 +780,7 @@ rec {
     # Type
 
     ```
-    hasPrefix :: string -> string -> bool
+    hasPrefix :: String -> String -> Bool
     ```
 
     # Examples
@@ -823,7 +823,7 @@ rec {
     # Type
 
     ```
-    hasSuffix :: string -> string -> bool
+    hasSuffix :: String -> String -> Bool
     ```
 
     # Examples
@@ -869,7 +869,7 @@ rec {
     # Type
 
     ```
-    hasInfix :: string -> string -> bool
+    hasInfix :: String -> String -> Bool
     ```
 
     # Examples
@@ -918,7 +918,7 @@ rec {
     # Type
 
     ```
-    stringToCharacters :: string -> [string]
+    stringToCharacters :: String -> [String]
     ```
 
     # Examples
@@ -953,7 +953,7 @@ rec {
     # Type
 
     ```
-    stringAsChars :: (string -> string) -> string -> string
+    stringAsChars :: (String -> String) -> String -> String
     ```
 
     # Examples
@@ -985,7 +985,7 @@ rec {
     # Type
 
     ```
-    charToInt :: string -> int
+    charToInt :: String -> Int
     ```
 
     # Examples
@@ -1018,7 +1018,7 @@ rec {
     # Type
 
     ```
-    escape :: [string] -> string -> string
+    escape :: [String] -> String -> String
     ```
 
     # Examples
@@ -1050,7 +1050,7 @@ rec {
     # Type
 
     ```
-    escapeC = [string] -> string -> string
+    escapeC :: [String] -> String -> String
     ```
 
     # Examples
@@ -1082,7 +1082,7 @@ rec {
     # Type
 
     ```
-    escapeURL :: string -> string
+    escapeURL :: String -> String
     ```
 
     # Examples
@@ -1184,7 +1184,7 @@ rec {
     # Type
 
     ```
-    escapeShellArg :: string -> string
+    escapeShellArg :: String -> String
     ```
 
     # Examples
@@ -1220,7 +1220,7 @@ rec {
     # Type
 
     ```
-    escapeShellArgs :: [string] -> string
+    escapeShellArgs :: [String] -> String
     ```
 
     # Examples
@@ -1247,7 +1247,7 @@ rec {
     # Type
 
     ```
-    string -> bool
+    isValidPosixName :: String -> Bool
     ```
 
     # Examples
@@ -1287,7 +1287,7 @@ rec {
     # Type
 
     ```
-    string -> ( string | [string] | { ${name} :: string; } ) -> string
+    toShellVar :: String -> (String | [String] | { [String] :: String }) -> String
     ```
 
     # Examples
@@ -1329,8 +1329,8 @@ rec {
 
     ```
     toShellVars :: {
-      ${name} :: string | [ string ] | { ${key} :: string; };
-    } -> string
+      [String] :: String | [String] | { [String] :: String };
+    } -> String
     ```
 
     # Examples
@@ -1362,7 +1362,7 @@ rec {
     # Type
 
     ```
-    escapeNixString :: string -> string
+    escapeNixString :: String -> String
     ```
 
     # Examples
@@ -1389,7 +1389,7 @@ rec {
     # Type
 
     ```
-    escapeRegex :: string -> string
+    escapeRegex :: String -> String
     ```
 
     # Examples
@@ -1416,7 +1416,7 @@ rec {
     # Type
 
     ```
-    escapeNixIdentifier :: string -> string
+    escapeNixIdentifier :: String -> String
     ```
 
     # Examples
@@ -1467,7 +1467,7 @@ rec {
     # Type
 
     ```
-    escapeXML :: string -> string
+    escapeXML :: String -> String
     ```
 
     # Examples
@@ -1501,7 +1501,7 @@ rec {
     # Type
 
     ```
-    toLower :: string -> string
+    toLower :: String -> String
     ```
 
     # Examples
@@ -1528,7 +1528,7 @@ rec {
     # Type
 
     ```
-    toUpper :: string -> string
+    toUpper :: String -> String
     ```
 
     # Examples
@@ -1555,7 +1555,7 @@ rec {
     # Type
 
     ```
-    toSentenceCase :: string -> string
+    toSentenceCase :: String -> String
     ```
 
     # Examples
@@ -1593,7 +1593,7 @@ rec {
     # Type
 
     ```
-    toCamelCase :: string -> string
+    toCamelCase :: String -> String
     ```
 
     # Examples
@@ -1664,7 +1664,7 @@ rec {
     # Type
 
     ```
-    addContextFrom :: string -> string -> string
+    addContextFrom :: String -> String -> String
     ```
 
     # Examples
@@ -1705,7 +1705,7 @@ rec {
     # Type
 
     ```
-    splitString :: string -> string -> [string]
+    splitString :: String -> String -> [String]
     ```
 
     # Examples
@@ -1759,7 +1759,7 @@ rec {
     # Type
 
     ```
-    splitStringBy :: (string -> string -> bool) -> bool -> string -> [string]
+    splitStringBy :: (String -> String -> Bool) -> Bool -> String -> [String]
     ```
 
     # Examples
@@ -1835,7 +1835,7 @@ rec {
     # Type
 
     ```
-    removePrefix :: string -> string -> string
+    removePrefix :: String -> String -> String
     ```
 
     # Examples
@@ -1886,7 +1886,7 @@ rec {
     # Type
 
     ```
-    removeSuffix :: string -> string -> string
+    removeSuffix :: String -> String -> String
     ```
 
     # Examples
@@ -2125,7 +2125,7 @@ rec {
     # Type
 
     ```
-    cmakeOptionType :: string -> string -> string -> string
+    cmakeOptionType :: String -> String -> String -> String
     ```
 
     # Examples
@@ -2171,7 +2171,7 @@ rec {
     # Type
 
     ```
-    cmakeBool :: string -> bool -> string
+    cmakeBool :: String -> Bool -> String
     ```
 
     # Examples
@@ -2207,7 +2207,7 @@ rec {
     # Type
 
     ```
-    cmakeFeature :: string -> string -> string
+    cmakeFeature :: String -> String -> String
     ```
 
     # Examples
@@ -2242,7 +2242,7 @@ rec {
     # Type
 
     ```
-    mesonOption :: string -> string -> string
+    mesonOption :: String -> String -> String
     ```
 
     # Examples
@@ -2277,7 +2277,7 @@ rec {
     # Type
 
     ```
-    mesonBool :: string -> bool -> string
+    mesonBool :: String -> Bool -> String
     ```
 
     # Examples
@@ -2314,7 +2314,7 @@ rec {
     # Type
 
     ```
-    mesonEnable :: string -> bool -> string
+    mesonEnable :: String -> Bool -> String
     ```
 
     # Examples
@@ -2351,7 +2351,7 @@ rec {
     # Type
 
     ```
-    enableFeature :: bool -> string -> string
+    enableFeature :: Bool -> String -> String
     ```
 
     # Examples
@@ -2391,7 +2391,7 @@ rec {
     # Type
 
     ```
-    enableFeatureAs :: bool -> string -> string -> string
+    enableFeatureAs :: Bool -> String -> String -> String
     ```
 
     # Examples
@@ -2426,7 +2426,7 @@ rec {
     # Type
 
     ```
-    withFeature :: bool -> string -> string
+    withFeature :: Bool -> String -> String
     ```
 
     # Examples
@@ -2465,7 +2465,7 @@ rec {
     # Type
 
     ```
-    withFeatureAs :: bool -> string -> string -> string
+    withFeatureAs :: Bool -> String -> String -> String
     ```
 
     # Examples
@@ -2506,7 +2506,7 @@ rec {
     # Type
 
     ```
-    fixedWidthString :: int -> string -> string -> string
+    fixedWidthString :: Int -> String -> String -> String
     ```
 
     # Examples
@@ -2544,7 +2544,7 @@ rec {
     # Type
 
     ```
-    fixedWidthNumber :: int -> int -> string
+    fixedWidthNumber :: Int -> Int -> String
     ```
 
     # Examples
@@ -2572,7 +2572,7 @@ rec {
     # Type
 
     ```
-    floatToString :: float -> string
+    floatToString :: Float -> String
     ```
 
     # Examples
@@ -2611,7 +2611,7 @@ rec {
     # Type
 
     ```
-    isConvertibleWithToString :: a -> bool
+    isConvertibleWithToString :: Any -> Bool
     ```
   */
   isConvertibleWithToString =
@@ -2640,7 +2640,7 @@ rec {
     # Type
 
     ```
-    isStringLike :: a -> bool
+    isStringLike :: Any -> Bool
     ```
   */
   isStringLike = x: isString x || isPath x || x ? outPath || x ? __toString;
@@ -2656,7 +2656,7 @@ rec {
     # Type
 
     ```
-    isStorePath :: a -> bool
+    isStorePath :: Any -> Bool
     ```
 
     # Examples
@@ -2707,7 +2707,7 @@ rec {
     # Type
 
     ```
-    toInt :: string -> int
+    toInt :: String -> Int
     ```
 
     # Examples
@@ -2777,7 +2777,7 @@ rec {
     # Type
 
     ```
-    toIntBase10 :: string -> int
+    toIntBase10 :: String -> Int
     ```
 
     # Examples
@@ -2848,7 +2848,7 @@ rec {
     # Type
 
     ```
-    fileContents :: path -> string
+    fileContents :: Path -> String
     ```
 
     # Examples
@@ -2939,7 +2939,7 @@ rec {
     # Type
 
     ```
-    levenshtein :: string -> string -> int
+    levenshtein :: String -> String -> Int
     ```
 
     # Examples
@@ -2991,7 +2991,7 @@ rec {
     # Type
 
     ```
-    commonPrefixLength :: string -> string -> int
+    commonPrefixLength :: String -> String -> Int
     ```
   */
   commonPrefixLength =
@@ -3023,7 +3023,7 @@ rec {
     # Type
 
     ```
-    commonSuffixLength :: string -> string -> int
+    commonSuffixLength :: String -> String -> Int
     ```
   */
   commonSuffixLength =
@@ -3060,7 +3060,7 @@ rec {
     # Type
 
     ```
-    levenshteinAtMost :: int -> string -> string -> bool
+    levenshteinAtMost :: Int -> String -> String -> Bool
     ```
 
     # Examples

--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -554,7 +554,7 @@ rec {
     # Type
 
     ```
-    hasInferior :: string -> string -> bool
+    hasInferior :: String -> String -> Bool
     ```
 
     # Examples
@@ -586,7 +586,7 @@ rec {
     # Type
 
     ```
-    canExecute :: string -> string -> bool
+    canExecute :: String -> String -> Bool
     ```
 
     # Examples

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -47,13 +47,9 @@ let
 
   inherit (lib.types)
     enum
-    float
     isType
     mkOptionType
-    number
     setType
-    string
-    types
     ;
 
   setTypes =

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -200,6 +200,12 @@ in
     `y`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    or :: bool -> bool -> bool
+    ```
   */
   "or" = x: y: x || y;
 
@@ -215,6 +221,12 @@ in
     `y`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    and :: bool -> bool -> bool
+    ```
   */
   and = x: y: x && y;
 
@@ -230,6 +242,12 @@ in
     `y`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    xor :: bool -> bool -> bool
+    ```
   */
   # We explicitly invert the arguments purely as a type assertion.
   # This is invariant under XOR, so it does not affect the result.
@@ -237,6 +255,12 @@ in
 
   /**
     bitwise “not”
+
+    # Type
+
+    ```
+    bitNot :: number -> number
+    ```
   */
   bitNot = builtins.sub (-1);
 
@@ -284,12 +308,6 @@ in
   /**
     Merge two attribute sets shallowly, right side trumps left
 
-    # Type
-
-    ```
-    mergeAttrs :: attrs -> attrs -> attrs
-    ```
-
     # Inputs
 
     `x`
@@ -299,6 +317,12 @@ in
     `y`
 
     : Right attribute set (higher precedence for equal keys)
+
+    # Type
+
+    ```
+    mergeAttrs :: attrs -> attrs -> attrs
+    ```
 
     # Examples
     :::{.example}
@@ -364,6 +388,12 @@ in
 
     : 2\. Function argument
 
+    # Type
+
+    ```
+    defaultTo :: a -> Nullable b -> (a | b)
+    ```
+
     # Examples
     :::{.example}
     ## `lib.trivial.defaultTo` usage example
@@ -393,6 +423,12 @@ in
     `a`
 
     : Argument to check for null before passing it to `f`
+
+    # Type
+
+    ```
+    mapNullable :: (a -> b) -> Nullable a -> Nullable b
+    ```
 
     # Examples
     :::{.example}
@@ -547,6 +583,12 @@ in
     `y`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    min :: number -> number -> number
+    ```
   */
   min = x: y: if x < y then x else y;
 
@@ -562,6 +604,12 @@ in
     `y`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    max :: number -> number -> number
+    ```
   */
   max = x: y: if x > y then x else y;
 
@@ -577,6 +625,12 @@ in
     `int`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    mod :: int -> int -> int
+    ```
 
     # Examples
     :::{.example}
@@ -611,6 +665,12 @@ in
     `b`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    compare :: a -> a -> int
+    ```
   */
   compare =
     a: b:
@@ -1000,12 +1060,6 @@ in
     function of the `{ a, b ? foo, ... }:` format, but some facilities
     like `callPackage` expect to be able to query expected arguments.
 
-    # Type
-
-    ```
-    setFunctionArgs : (a -> b) -> Map String Bool -> (a -> b)
-    ```
-
     # Inputs
 
     `f`
@@ -1015,6 +1069,12 @@ in
     `args`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    setFunctionArgs : (a -> b) -> (Map String Bool) -> (a -> b)
+    ```
   */
   setFunctionArgs = f: args: {
     # TODO: Should we add call-time "type" checking like built in?
@@ -1028,17 +1088,17 @@ in
     functions and functions with args set with `setFunctionArgs`. It
     has the same return type and semantics as `builtins.functionArgs`.
 
-    # Type
-
-    ```
-    functionArgs : (a -> b) -> Map String Bool
-    ```
-
     # Inputs
 
     `f`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    functionArgs : (a -> b) -> Map String Bool
+    ```
   */
   functionArgs =
     f:
@@ -1056,6 +1116,12 @@ in
     `f`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    isFunction : a -> bool
+    ```
   */
   isFunction = f: builtins.isFunction f || (f ? __functor && isFunction (f.__functor f));
 
@@ -1178,6 +1244,12 @@ in
     Convert the given positive integer to a string of its hexadecimal
     representation.
 
+    # Type
+
+    ```
+    toHexString :: int -> string
+    ```
+
     # Examples
     :::{.example}
     ## `lib.trivial.toHexString` usage example
@@ -1218,6 +1290,12 @@ in
     `i`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    toBaseDigits :: int -> int -> [int]
+    ```
 
     # Examples
     :::{.example}

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -111,7 +111,7 @@ in
     # Type
 
     ```
-    pipe :: a -> [<functions>] -> <return type of last function>
+    pipe :: a -> [(a -> b) (b -> c) ... (x -> y) (y -> z)] -> z
     ```
 
     # Examples
@@ -204,7 +204,7 @@ in
     # Type
 
     ```
-    or :: bool -> bool -> bool
+    or :: Bool -> Bool -> Bool
     ```
   */
   "or" = x: y: x || y;
@@ -225,7 +225,7 @@ in
     # Type
 
     ```
-    and :: bool -> bool -> bool
+    and :: Bool -> Bool -> Bool
     ```
   */
   and = x: y: x && y;
@@ -259,7 +259,7 @@ in
     # Type
 
     ```
-    bitNot :: number -> number
+    bitNot :: Number -> Number
     ```
   */
   bitNot = builtins.sub (-1);
@@ -280,7 +280,7 @@ in
     # Type
 
     ```
-    boolToString :: bool -> string
+    boolToString :: Bool -> String
     ```
   */
   boolToString = b: if b then "true" else "false";
@@ -300,7 +300,7 @@ in
     # Type
 
     ```
-    boolToYesNo :: bool -> string
+    boolToYesNo :: Bool -> String
     ```
   */
   boolToYesNo = b: if b then "yes" else "no";
@@ -321,7 +321,7 @@ in
     # Type
 
     ```
-    mergeAttrs :: attrs -> attrs -> attrs
+    mergeAttrs :: AttrSet -> AttrSet -> AttrSet
     ```
 
     # Examples
@@ -391,7 +391,7 @@ in
     # Type
 
     ```
-    defaultTo :: a -> Nullable b -> (a | b)
+    defaultTo :: a -> (b | Null) -> (b | a)
     ```
 
     # Examples
@@ -427,7 +427,7 @@ in
     # Type
 
     ```
-    mapNullable :: (a -> b) -> Nullable a -> Nullable b
+    mapNullable :: (a -> b) -> (a | Null) -> (b | Null)
     ```
 
     # Examples
@@ -526,7 +526,7 @@ in
     # Type
 
     ```
-    revisionWithDefault :: string -> string
+    revisionWithDefault :: String -> String
     ```
   */
   revisionWithDefault =
@@ -551,7 +551,7 @@ in
     # Type
 
     ```
-    inNixShell :: bool
+    inNixShell :: Bool
     ```
   */
   inNixShell = builtins.getEnv "IN_NIX_SHELL" != "";
@@ -564,7 +564,7 @@ in
     # Type
 
     ```
-    inPureEvalMode :: bool
+    inPureEvalMode :: Bool
     ```
   */
   inPureEvalMode = !builtins ? currentSystem;
@@ -587,7 +587,7 @@ in
     # Type
 
     ```
-    min :: number -> number -> number
+    min :: Number -> Number -> Number
     ```
   */
   min = x: y: if x < y then x else y;
@@ -608,7 +608,7 @@ in
     # Type
 
     ```
-    max :: number -> number -> number
+    max :: Number -> Number -> Number
     ```
   */
   max = x: y: if x > y then x else y;
@@ -629,7 +629,7 @@ in
     # Type
 
     ```
-    mod :: int -> int -> int
+    mod :: Int -> Int -> Int
     ```
 
     # Examples
@@ -669,7 +669,7 @@ in
     # Type
 
     ```
-    compare :: a -> a -> int
+    compare :: a -> a -> Int
     ```
   */
   compare =
@@ -712,7 +712,7 @@ in
     # Type
 
     ```
-    (a -> bool) -> (a -> a -> int) -> (a -> a -> int) -> (a -> a -> int)
+    splitByAndCompare :: (a -> Bool) -> (a -> a -> Int) -> (a -> a -> Int) -> (a -> a -> Int)
     ```
 
     # Examples
@@ -786,7 +786,7 @@ in
     # Type
 
     ```
-    importJSON :: path -> any
+    importJSON :: Path -> Any
     ```
   */
   importJSON = path: builtins.fromJSON (builtins.readFile path);
@@ -833,7 +833,7 @@ in
     # Type
 
     ```
-    importTOML :: path -> any
+    importTOML :: Path -> Any
     ```
   */
   importTOML = path: fromTOML (builtins.readFile path);
@@ -859,7 +859,7 @@ in
     # Type
 
     ```
-    String -> a -> a
+    warn :: String -> a -> a
     ```
   */
   warn =
@@ -906,7 +906,7 @@ in
     # Type
 
     ```
-    Bool -> String -> a -> a
+    warnIf :: Bool -> String -> a -> a
     ```
   */
   warnIf = cond: msg: if cond then warn msg else x: x;
@@ -933,7 +933,7 @@ in
     # Type
 
     ```
-    Boolean -> String -> a -> a
+    warnIfNot :: Bool -> String -> a -> a
     ```
   */
   warnIfNot = cond: msg: if cond then x: x else warn msg;
@@ -962,7 +962,7 @@ in
     # Type
 
     ```
-    bool -> string -> a -> a
+    throwIfNot :: Bool -> String -> a -> (a | Never)
     ```
 
     # Examples
@@ -995,7 +995,7 @@ in
     # Type
 
     ```
-    bool -> string -> a -> a
+    throwIf :: Bool -> String -> a -> (a | Never)
     ```
   */
   throwIf = cond: msg: if cond then throw msg else x: x;
@@ -1020,7 +1020,7 @@ in
     # Type
 
     ```
-    String -> List ComparableVal -> List ComparableVal -> a -> a
+    checkListOfEnum :: String -> [a] -> [a] -> ((b -> b) | Never)
     ```
 
     # Examples
@@ -1073,7 +1073,7 @@ in
     # Type
 
     ```
-    setFunctionArgs : (a -> b) -> (Map String Bool) -> (a -> b)
+    setFunctionArgs : (a -> b) -> { [String] :: Bool } -> (a -> b)
     ```
   */
   setFunctionArgs = f: args: {
@@ -1097,7 +1097,7 @@ in
     # Type
 
     ```
-    functionArgs : (a -> b) -> Map String Bool
+    functionArgs : (a -> b) -> { [String] :: Bool }
     ```
   */
   functionArgs =
@@ -1120,7 +1120,7 @@ in
     # Type
 
     ```
-    isFunction : a -> bool
+    isFunction : Any -> Bool
     ```
   */
   isFunction = f: builtins.isFunction f || (f ? __functor && isFunction (f.__functor f));
@@ -1247,7 +1247,7 @@ in
     # Type
 
     ```
-    toHexString :: int -> string
+    toHexString :: Int -> String
     ```
 
     # Examples
@@ -1294,7 +1294,7 @@ in
     # Type
 
     ```
-    toBaseDigits :: int -> int -> [int]
+    toBaseDigits :: Int -> Int -> [Int]
     ```
 
     # Examples

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -11,7 +11,7 @@ rec {
     # Type
 
     ```
-    splitVersion :: string -> [string]
+    splitVersion :: String -> [String]
     ```
 
     # Examples
@@ -39,7 +39,7 @@ rec {
     # Type
 
     ```
-    major :: string -> string
+    major :: String -> String
     ```
 
     # Examples
@@ -67,7 +67,7 @@ rec {
     # Type
 
     ```
-    minor :: string -> string
+    minor :: String -> String
     ```
 
     # Examples
@@ -95,7 +95,7 @@ rec {
     # Type
 
     ```
-    patch :: string -> string
+    patch :: String -> String
     ```
 
     # Examples
@@ -124,7 +124,7 @@ rec {
     # Type
 
     ```
-    mmajorMinor :: string -> string
+    majorMinor :: String -> String
     ```
 
     # Examples
@@ -156,7 +156,7 @@ rec {
     # Type
 
     ```
-    pad :: int -> string -> string
+    pad :: Int -> String -> String
     ```
 
     # Examples

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -8,6 +8,12 @@ rec {
   /**
     Break a version string into its component parts.
 
+    # Type
+
+    ```
+    splitVersion :: string -> [string]
+    ```
+
     # Examples
     :::{.example}
     ## `splitVersion` usage example
@@ -29,6 +35,12 @@ rec {
     `v`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    major :: string -> string
+    ```
 
     # Examples
     :::{.example}
@@ -52,6 +64,12 @@ rec {
 
     : 1\. Function argument
 
+    # Type
+
+    ```
+    minor :: string -> string
+    ```
+
     # Examples
     :::{.example}
     ## `minor` usage example
@@ -73,6 +91,12 @@ rec {
     `v`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    patch :: string -> string
+    ```
 
     # Examples
     :::{.example}
@@ -96,6 +120,12 @@ rec {
     `v`
 
     : 1\. Function argument
+
+    # Type
+
+    ```
+    mmajorMinor :: string -> string
+    ```
 
     # Examples
     :::{.example}
@@ -122,6 +152,12 @@ rec {
     `version`
 
     : 2\. Function argument
+
+    # Type
+
+    ```
+    pad :: int -> string -> string
+    ```
 
     # Examples
     :::{.example}

--- a/pkgs/build-support/compress-drv/default.nix
+++ b/pkgs/build-support/compress-drv/default.nix
@@ -31,7 +31,7 @@
   # Type
 
   ```
-  compressDrv :: Derivation -> { formats :: [ String ]; compressors :: { ${fileExtension} :: String; } } -> Derivation
+  compressDrv :: Derivation -> { formats :: [String]; compressors :: { ${fileExtension} :: String; } } -> Derivation
   ```
 
   # Examples

--- a/pkgs/build-support/compress-drv/web.nix
+++ b/pkgs/build-support/compress-drv/web.nix
@@ -23,7 +23,7 @@
 
   : See compressDrv for details.
 
-  `extraFormats` ([ String ])
+  `extraFormats` ([String])
 
   : Extra extensions to compress in addition to `formats`.
 
@@ -34,7 +34,7 @@
   # Type
 
   ```
-  compressDrvWeb :: Derivation -> { formats :: [ String ]; extraFormats :: [ String ]; compressors :: { ${fileExtension} :: String; } } -> Derivation
+  compressDrvWeb :: Derivation -> { formats :: [String]; extraFormats :: [String]; compressors :: { ${fileExtension} :: String; } } -> Derivation
   ```
 
   # Examples

--- a/pkgs/build-support/setup-systemd-units.nix
+++ b/pkgs/build-support/setup-systemd-units.nix
@@ -13,7 +13,7 @@
 }:
 {
   units,
-  # : AttrSet String (Either Path { path : Path, wanted-by : [ String ] })
+  # : { [String] :: Path | { path :: Path; wanted-by :: [String]; } }
   # ^ A set whose names are unit names and values are
   # either paths to the corresponding unit files or a set
   # containing the path and the list of units this unit

--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -31,7 +31,7 @@ rec {
       : the [interpreter](https://en.wikipedia.org/wiki/Shebang_(Unix)) to use for the script.
     : `check` (String)
       : A command to check the script. For example, this could be a linting check.
-    : `makeWrapperArgs` (Optional, [ String ], Default: [])
+    : `makeWrapperArgs` (Optional, [String], Default: [])
       : Arguments forwarded to (`makeWrapper`)[#fun-makeWrapper].
 
     `nameOrPath` (String)
@@ -195,7 +195,7 @@ rec {
     : `strip` (Boolean, Default: true)
       : Whether to [strip](https://nixos.org/manual/nixpkgs/stable/#ssec-fixup-phase) the executable or not.
 
-    : `makeWrapperArgs` (Optional, [ String ], Default: [])
+    : `makeWrapperArgs` (Optional, [String], Default: [])
       : Arguments forwarded to (`makeWrapper`)[#fun-makeWrapper]
 
     `nameOrPath` (String)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I was looking for the list difference function using noogle and couldn't find `subtractLists` initially, because it lacks a type signature.

I tried to add type signatures to most of the non-module or non-internal functions, as best as I could.

---

Also normalized the existing type signatures according to these rules:
- concrete types start with uppercase: `Int`, `String`, `Bool`, `Derivation`, etc.
- type variables start with lowercase: `a`, `b`, etc.
- list:
  - use `[x]` for homogeneous lists instead of `List x` or `[ x ]`
  - use `List` for heterogeneous lists (not that common in `lib`)
- attr:
  - use `AttrSet` for a generic attribute set type
  - use `{ key1 :: Type1; key2 :: Type2; ... }` for adding signatures for known attribute names and types
  - use `{ key1 = value1; key2 = value2; ... }` for adding attributes with known literal values
  - end with an ellipsis (`...`) if the set can contain other attributes
  - use `{ [String] :: x }`[^1] if all the attributes has the same type `x`
- prefer `Any` over `a` if the latter is not reused 

[^1]: used by Noogle for the builtin functions, e.g. https://noogle.dev/f/builtins/groupBy
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
