### PR TITLE
bird-lg: 1.3.11 -> 1.4.4

### DIFF
--- a/pkgs/by-name/bi/bird-lg/package.nix
+++ b/pkgs/by-name/bi/bird-lg/package.nix
@@ -2,6 +2,7 @@
   buildGoModule,
   fetchFromGitHub,
   lib,
+  nix-update-script,
   symlinkJoin,
 }:
 let
@@ -9,13 +10,13 @@ let
     { modRoot, vendorHash }:
     buildGoModule rec {
       pname = "bird-lg-${modRoot}";
-      version = "1.3.11";
+      version = "1.4.4";
 
       src = fetchFromGitHub {
         owner = "xddxdd";
         repo = "bird-lg-go";
         rev = "v${version}";
-        hash = "sha256-C0JC8vLLEk+d6vlrtuW7tHj06K7A3HBjKXZ5Nt+2i4I=";
+        hash = "sha256-60QyqilUI0yNCTZrCyUZhQYFio0gP/Z5Lcb3btlQRaE=";
       };
 
       doDist = false;
@@ -41,19 +42,30 @@ let
 
   bird-lg-frontend = generic {
     modRoot = "frontend";
-    vendorHash = "sha256-kNysGHtOUtYGHDFDlYNzdkCXGUll105Triy4UR7UP0M=";
+    vendorHash = "sha256-tqpDH7KfpwPuOvIfx3vVclMGOMNFroiBcNb1lN0PtQc=";
   };
 
   bird-lg-proxy = generic {
     modRoot = "proxy";
-    vendorHash = "sha256-iosWHHeJyqMPF+Y01+mj70HDKWw0FAZKDpEESAwS/i4=";
+    vendorHash = "sha256-9BpsRIIidBEm+ivwFIo00H9MTH4R3kkze/W/HaH8124=";
   };
 in
 symlinkJoin {
   pname = "bird-lg";
-  inherit (bird-lg-frontend) version meta;
+  inherit (bird-lg-frontend) version meta src;
   paths = [
     bird-lg-frontend
     bird-lg-proxy
   ];
+  passthru = {
+    inherit bird-lg-frontend bird-lg-proxy;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "bird-lg-frontend"
+        "--subpackage"
+        "bird-lg-proxy"
+      ];
+    };
+  };
 }


### PR DESCRIPTION
## Things done

* Updated `bird-lg` to [1.4.4](https://github.com/xddxdd/bird-lg-go/releases/tag/v1.4.4)
  - Adding vrf support by @frantathefranta in https://github.com/xddxdd/bird-lg-go/pull/138
  - Use more robust method to get host/port from WHOIS server setting (https://github.com/xddxdd/bird-lg-go/issues/137)
* Added an update script

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
