### PR TITLE
mealie: 3.9.2 -> 3.12.0

### DIFF
--- a/pkgs/by-name/me/mealie/mealie-frontend.nix
+++ b/pkgs/by-name/me/mealie/mealie-frontend.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${src}/frontend/yarn.lock";
-    hash = "sha256-sZk7OEkJdBZRU9ysRDCetzv09XrK5GhPaxxEBD8k5rw=";
+    hash = "sha256-aYgTdHrorLNBYVNwVyYSTfAqtvn1JB0FBAkoem0vNSU=";
   };
 
   nativeBuildInputs = [
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
 
     yarn config --offline set yarn-offline-mirror "$yarnOfflineCache"
     fixup-yarn-lock yarn.lock
-    yarn install --frozen-lockfile --offline --no-progress --non-interactive --ignore-scripts
+    yarn install --offline --frozen-lockfile --no-progress --non-interactive --ignore-scripts
     patchShebangs node_modules
 
     substituteInPlace node_modules/sass-embedded/dist/lib/src/compiler-path.js \
@@ -60,6 +60,9 @@ stdenv.mkDerivation {
   meta = {
     description = "Frontend for Mealie";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ litchipi ];
+    maintainers = with lib.maintainers; [
+      litchipi
+      esch
+    ];
   };
 }

--- a/pkgs/by-name/me/mealie/package.nix
+++ b/pkgs/by-name/me/mealie/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pkgs,
   callPackage,
   fetchFromGitHub,
   makeWrapper,
@@ -11,18 +12,26 @@
 }:
 
 let
-  version = "3.9.2";
+  version = "3.12.0";
   src = fetchFromGitHub {
     owner = "mealie-recipes";
     repo = "mealie";
     tag = "v${version}";
-    hash = "sha256-jR9NGguxobUenjnvh6vhZztntxNM2rkwkWcq/DeB4JY=";
+    hash = "sha256-HjXEoLrjmf4ZfBm6/7f5SJzH7nHSKiMOOMRVrYW0vKY=";
   };
 
   frontend = callPackage (import ./mealie-frontend.nix src version) { };
 
   pythonpkgs = python3Packages;
   python = pythonpkgs.python;
+  pyhumps38 = python3Packages.pyhumps.overrideAttrs (oldAttrs: {
+    src = pkgs.fetchFromGitHub {
+      owner = "nficano";
+      repo = "humps";
+      tag = "v3.8.0";
+      hash = "sha256-ElL/LY2V2Z3efdV5FnDy9dSoBltULrzxsjaOx+7W9Oo=";
+    };
+  });
 in
 pythonpkgs.buildPythonApplication rec {
   pname = "mealie";
@@ -50,6 +59,7 @@ pythonpkgs.buildPythonApplication rec {
       beautifulsoup4
       extruct
       fastapi
+      freezegun
       html2text
       httpx
       ingredient-parser-nlp
@@ -65,7 +75,7 @@ pythonpkgs.buildPythonApplication rec {
       psycopg2 # pgsql optional-dependencies
       pydantic
       pydantic-settings
-      pyhumps
+      pyhumps38
       pyjwt
       python-dateutil
       python-dotenv
@@ -88,7 +98,7 @@ pythonpkgs.buildPythonApplication rec {
     rm -rf dev # Do not need dev scripts & code
 
     substituteInPlace pyproject.toml \
-     --replace-fail '"setuptools==80.9.0"' '"setuptools"'
+     --replace-fail '"setuptools==82.0.0"' '"setuptools"'
 
     substituteInPlace mealie/__init__.py \
       --replace-fail '__version__ = ' '__version__ = "v${version}" #'
@@ -147,11 +157,12 @@ pythonpkgs.buildPythonApplication rec {
       the UI editor.
     '';
     homepage = "https://mealie.io";
-    changelog = "https://github.com/mealie-recipes/mealie/releases/tag/${src.rev}";
+    changelog = "https://github.com/mealie-recipes/mealie/releases/tag/${src.tag}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [
       litchipi
       anoa
+      esch
     ];
     mainProgram = "mealie";
   };


### PR DESCRIPTION
- Updates mealie to 3.11.0
- Patches pyhump to 3.8 for functionality. 
- Add esch to maintainers
 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
