### PR TITLE
bogofilter: fix and enable checks; adopt package

### DIFF
--- a/pkgs/by-name/bo/bogofilter/package.nix
+++ b/pkgs/by-name/bo/bogofilter/package.nix
@@ -2,11 +2,13 @@
   lib,
   stdenv,
   fetchurl,
-  flex,
   db,
+  flex,
+  gnugrep,
   makeWrapper,
   pax,
   perl,
+  valgrind,
   database ? db,
 }:
 
@@ -22,6 +24,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-MkihNzv/VSxQCDStvqS2yu4EIkUWrlgfslpMam3uieo=";
   };
 
+  # bogofilter's test-cases hard-code the search path for grep.
+  postPatch = ''
+    substituteInPlace ./src/tests/t.frame \
+      --replace-fail 'GREP=/bin/grep' 'GREP=${lib.getExe gnugrep}'
+  '';
+
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [
@@ -34,7 +42,16 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-database=${dbName}"
   ];
 
-  doCheck = false; # needs "y" tool
+  nativeCheckInputs = [
+    valgrind
+  ];
+
+  doCheck = true;
+  checkFlags = [
+    "BF_RUN_VALGRIND=1"
+    "BF_CHECKTOOL=glibc"
+    "VERBOSE=-x"
+  ];
 
   postInstall = ''
     wrapProgram "$out/bin/bf_tar" --prefix PATH : "${lib.makeBinPath [ pax ]}"

--- a/pkgs/by-name/bo/bogofilter/package.nix
+++ b/pkgs/by-name/bo/bogofilter/package.nix
@@ -73,6 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Plus;
     mainProgram = "bogofilter";
+    maintainers = with lib.maintainers; [ Stebalien ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION

1. Run (and fix) checks.
2. Add myself as a maintainer (I use bogofilter in my local email pipeline).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
