### PR TITLE
python3Packages.tpm2-pytss: fix broken cross-compilation patch

### DIFF
--- a/pkgs/development/python-modules/tpm2-pytss/cross.patch
+++ b/pkgs/development/python-modules/tpm2-pytss/cross.patch
@@ -2,21 +2,19 @@ diff --git a/setup.py b/setup.py
 index 1b5f513..d660b9a 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -184,7 +184,8 @@ class type_generator(build_ext):
-                 f"unable to find tss2_tpm2_types.h in {pk['include_dirs']}"
+@@ -199,6 +199,7 @@
+             pdata = preprocess_file(
+                 header_path,
+                 cpp_args=["-std=c99", "-D__extension__=", "-D__attribute__(x)="],
++                cpp_path="@crossPrefix@-cpp",
              )
-         pdata = preprocess_file(
--            header_path, cpp_args=["-D__extension__=", "-D__attribute__(x)="]
-+            header_path, cpp_args=["-D__extension__=", "-D__attribute__(x)="],
-+            cpp_path="@crossPrefix@-cpp",
-         )
          parser = c_parser.CParser()
          ast = parser.parse(pdata, "tss2_tpm2_types.h")
-@@ -210,6 +211,7 @@ class type_generator(build_ext):
-                         "-D__float128=long double",
-                         "-D_FORTIFY_SOURCE=0",
-                     ],
-+                    cpp_path="@crossPrefix@-cpp",
-                 )
+@@ -238,6 +239,7 @@
+                             "-D__float128=long double",
+                             "-D_FORTIFY_SOURCE=0",
+                         ],
++                        cpp_path="@crossPrefix@-cpp",
+                     )
                  parser = c_parser.CParser()
                  past = parser.parse(pdata, "tss2_policy.h")

--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -70,6 +70,7 @@ buildPythonPackage rec {
     # when cross-compiling is turned on.
     # This patch changes the call to pycparser.preprocess_file to provide the name
     # of the cross-compiling cpp
+    # NOTE: This patch could be dropped after next release. 3.0.0-rc0 already have proper `$CC -E` invocation
     (replaceVars ./cross.patch {
       crossPrefix = stdenv.hostPlatform.config;
     })


### PR DESCRIPTION
Fix broken cross-compilation, by updating `cross.patch`.
Also upcoming release would need no patching (probably), so I add a note about this

This patch didn't affect native build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
