### PR TITLE
aaa: 1.1.1 -> 2.1.0

### DIFF
--- a/pkgs/by-name/aa/aaa/package.nix
+++ b/pkgs/by-name/aa/aaa/package.nix
@@ -6,19 +6,19 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "aaa";
-  version = "1.1.1";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "asciimoth";
     repo = "aaa";
-    tag = "v${finalAttrs.version}";
-    sha256 = "sha256-gIOlPjZOcmVLi9oOn4gBv6F+3Eq6t5b/3fKzoFqxclw=";
+    tag = "${finalAttrs.version}";
+    sha256 = "sha256-z8PXkX6Bh3oD8tRf+tsLJHbx5wIz2mBYhJSEL88hBDc=";
   };
 
-  cargoHash = "sha256-CHX+Ugy4ND36cpxNEFpnqid6ALHMPXmfXi+D4aktPRk=";
+  cargoHash = "sha256-dt3nbVS8i075O8m9x+FsDi3VeihVKVIV0wnPqyYUaIk=";
 
   meta = {
-    description = "Terminal viewer for 3a format";
+    description = "Swiss Army knife for animated ascii art";
     homepage = "https://github.com/asciimoth/aaa";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ asciimoth ];


### PR DESCRIPTION
Bump aaa version and update link to owner's GH profile to actual one.  
[Changelog](https://github.com/asciimoth/aaa/releases/tag/2.1.0)

## Things done
- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.