### PR TITLE
python3Packages.ty: init at 0.0.20

### DIFF
--- a/pkgs/development/python-modules/ty/default.nix
+++ b/pkgs/development/python-modules/ty/default.nix
@@ -1,0 +1,46 @@
+{
+  buildPythonPackage,
+  hatchling,
+  lib,
+  ty,
+}:
+
+buildPythonPackage {
+  inherit (ty)
+    pname
+    version
+    src
+    meta
+    ;
+  pyproject = true;
+
+  build-system = [ hatchling ];
+
+  postPatch =
+    # Add the path to the ty binary as a fallback after other path search methods have been exhausted
+    ''
+      substituteInPlace python/ty/_find_ty.py \
+        --replace-fail \
+        'sysconfig.get_path("scripts", scheme=_user_scheme()),' \
+        'sysconfig.get_path("scripts", scheme=_user_scheme()), "${baseNameOf (lib.getExe ty)}",'
+    ''
+    # Sidestep the maturin build system in favour of reusing the binary already built by nixpkgs,
+    # to avoid rebuilding the ty binary for every active python package set.
+    + ''
+      substituteInPlace pyproject.toml \
+        --replace-fail 'requires = ["maturin>=1.0,<2.0"]' 'requires = ["hatchling"]' \
+        --replace-fail 'build-backend = "maturin"' 'build-backend = "hatchling.build"'
+
+      cat >> pyproject.toml <<EOF
+      [tool.hatch.build]
+      packages = ['python/ty']
+
+      EOF
+    '';
+
+  postInstall = ''
+    mkdir -p $out/bin && ln -s ${lib.getExe ty} $out/bin/ty
+  '';
+
+  pythonImportsCheck = [ "ty" ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19685,6 +19685,8 @@ self: super: with self; {
 
   txzmq = callPackage ../development/python-modules/txzmq { };
 
+  ty = callPackage ../development/python-modules/ty { inherit (pkgs) ty; };
+
   type-infer = callPackage ../development/python-modules/type-infer { };
 
   typechecks = callPackage ../development/python-modules/typechecks { };


### PR DESCRIPTION
Similar to `python3Packages.ruff` and `python3Packages.uv`, the Python module for ty allows for the ty binary to be searched for, e.g. for subprocess CLI invocations.

This derivation uses the same tricks to speedup its build by referencing the nixpkgs ty binary instead of rebuilding from scratch.

Requires #495888 

```console
$ nix-shell shell.nix --run "python3 -c 'import ty; print(ty.find_ty_bin())'"
/nix/store/wnnj9fzvsp3zx5277s97vc4x6l8syl30-python3-3.13.12-env/bin/ty
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
