### PR TITLE
nixos/utils: add regressions tests to genJqSecretsReplacement

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1698,6 +1698,7 @@ in
   userborn-mutable-users = runTest ./userborn-mutable-users.nix;
   userborn-static = runTest ./userborn-static.nix;
   ustreamer = runTest ./ustreamer.nix;
+  utils = import ./utils { inherit runTest; };
   uwsgi = runTest ./uwsgi.nix;
   v2ray = runTest ./v2ray.nix;
   varnish60 = runTest {

--- a/nixos/tests/utils/default.nix
+++ b/nixos/tests/utils/default.nix
@@ -1,0 +1,5 @@
+{ runTest }:
+
+{
+  genJqSecretsReplacement = runTest ./genJqSecretsReplacement.nix;
+}

--- a/nixos/tests/utils/genJqSecretsReplacement.nix
+++ b/nixos/tests/utils/genJqSecretsReplacement.nix
@@ -1,0 +1,177 @@
+{ lib, pkgs, ... }:
+
+let
+  secretA = pkgs.writeText "secretA" "AAAAA";
+  secretJSON = pkgs.writeText "secretA" (
+    builtins.toJSON [
+      { "a" = "topsecretpassword1234"; }
+      { "b" = "topsecretpassword5678"; }
+    ]
+  );
+
+  tests = {
+    simple = {
+      set = {
+        example = [
+          {
+            irrelevant = "not interesting";
+          }
+          {
+            ignored = "ignored attr";
+            relevant = {
+              secret = {
+                _secret = secretA;
+              };
+            };
+          }
+        ];
+      };
+      expect = {
+        example = [
+          {
+            irrelevant = "not interesting";
+          }
+          {
+            ignored = "ignored attr";
+            relevant = {
+              secret = "AAAAA";
+            };
+          }
+        ];
+      };
+    };
+
+    structured = {
+      set = {
+        example = [
+          {
+            irrelevant = "not interesting";
+          }
+          {
+            ignored = "ignored attr";
+            relevant = {
+              secret = {
+                _secret = secretJSON;
+                quote = false;
+              };
+            };
+          }
+        ];
+      };
+      expect = {
+        example = [
+          {
+            irrelevant = "not interesting";
+          }
+          {
+            ignored = "ignored attr";
+            relevant = {
+              secret = [
+                { "a" = "topsecretpassword1234"; }
+                { "b" = "topsecretpassword5678"; }
+              ];
+            };
+          }
+        ];
+      };
+    };
+
+    loadCredentials = {
+      set = {
+        example = [
+          {
+            irrelevant = "not interesting";
+          }
+          {
+            ignored = "ignored attr";
+            relevant = {
+              secret = {
+                _secret = secretJSON;
+                quote = false;
+              };
+            };
+          }
+        ];
+      };
+      opts = {
+        loadCredential = true;
+      };
+      expect = {
+        example = [
+          {
+            irrelevant = "not interesting";
+          }
+          {
+            ignored = "ignored attr";
+            relevant = {
+              secret = [
+                { "a" = "topsecretpassword1234"; }
+                { "b" = "topsecretpassword5678"; }
+              ];
+            };
+          }
+        ];
+      };
+    };
+  };
+in
+{
+  name = "utils-genJqSecretsReplacement";
+  meta.maintainers = [ pkgs.lib.maintainers.ibizaman ];
+
+  nodes.machine =
+    { lib, utils, ... }:
+    let
+      secretsReplacements = lib.mapAttrs (
+        name: test:
+        (utils.genJqSecretsReplacement (test.opts or { }) test.set "/var/lib/genJqTest-${name}/file")
+      ) tests;
+    in
+    {
+      systemd.services = lib.mapAttrs' (
+        name: secretsReplacement:
+        lib.nameValuePair "genJqTest-${name}" {
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            LoadCredential = secretsReplacement.credentials;
+          };
+          script = "echo 'Done generating files'";
+          preStart = ''
+            mkdir -p /var/lib/genJqTest-${name}
+          ''
+          + secretsReplacement.script;
+        }
+      ) secretsReplacements;
+    };
+
+  testScript = ''
+    import json
+    machine.start()
+  ''
+  + lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (
+      name: test:
+      let
+        expect = pkgs.writeText "expect" (builtins.toJSON test.expect);
+      in
+      ''
+        with subtest("${name}"):
+            machine.wait_for_unit("genJqTest-${name}.service")
+            gotRaw = machine.succeed("cat /var/lib/genJqTest-${name}/file")
+            try:
+                got = json.loads(gotRaw)
+            except Exception:
+                print(f"raw file: {gotRaw}")
+                raise
+            print(got)
+            with open("${expect}", "r") as file:
+                expect = json.loads(file.read())
+            if got != expect:
+                raise Exception(f"Unexpected file:\ngot={got}\n!=\nexpect={expect}")
+      ''
+    ) tests
+  );
+
+}


### PR DESCRIPTION
This PR adds regression tests for all 3 variant calls of `genJqSecretsReplacement` I could find:
- `quotes = true && loadCredentials = false` (default)
- `quotes = false && loadCredentials = false`
- `loadCredentials = true`

My goal of adding this, on top of just for the sake of good software engineering practices, is because I will create a subsequent PR that modifies the internals of `genJqSecretsReplacement` to actually work on any type of files, not just JSON. Having those regression tests will make any such kind of modification much more safe in the future.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
