### PR TITLE
python31{3,4}.pkgs.retry-requests: init at 2.0.0-unstable-2023-05-28

### DIFF
--- a/pkgs/development/python-modules/retry-requests/default.nix
+++ b/pkgs/development/python-modules/retry-requests/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  # dependencies
+  urllib3,
+  requests,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "retry-requests";
+  version = "2.0.0-unstable-2023-05-28";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bustawin";
+    repo = "retry-requests";
+    rev = "543ceaf451df8268717eb929372439a4e48cff66";
+    hash = "sha256-MbvxHH+fdB4JGLEuZ5SclBUrw04JxzR5zdX/EyaMEnU=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail 'setup_requires=["pytest-runner"],' ""
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    requests
+    urllib3
+  ];
+
+  pythonImportsCheck = [ "retry_requests" ];
+
+  meta = {
+    description = "A Python library that makes HTTP requests with retry by using requests package";
+    homepage = "https://github.com/bustawin/retry-requests";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ robertjakub ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16675,6 +16675,8 @@ self: super: with self; {
 
   retry-decorator = callPackage ../development/python-modules/retry-decorator { };
 
+  retry-requests = callPackage ../development/python-modules/retry-requests { };
+
   retry2 = callPackage ../development/python-modules/retry2 { };
 
   retryhttp = callPackage ../development/python-modules/retryhttp { };


### PR DESCRIPTION
A Python library that makes HTTP requests with retry by using requests package.

Configures the passed-in requests' Session to retry on failed requests due to connection errors, timeouts, specific HTTP response codes (5XX by default) and 30X redirections —anything that could fail.

homepage: https://github.com/bustawin/retry-requests

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
