### PR TITLE
ocamlPackages.conan: 0.0.6 → 0.0.7

### DIFF
--- a/pkgs/development/ocaml-modules/conan/default.nix
+++ b/pkgs/development/ocaml-modules/conan/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchurl,
   buildDunePackage,
-  version ? "0.0.6",
   ptime,
   re,
   uutf,
@@ -12,13 +11,13 @@
   rresult,
 }:
 
-buildDunePackage {
+buildDunePackage (finalAttrs: {
   pname = "conan";
-  inherit version;
+  version = "0.0.7";
 
   src = fetchurl {
-    url = "https://github.com/mirage/conan/releases/download/v${version}/conan-${version}.tbz";
-    hash = "sha256-shAle4gXFf+53L+IZ4yFWewq7yZ5WlMEr9WotLvxHhY=";
+    url = "https://github.com/mirage/conan/releases/download/v${finalAttrs.version}/conan-${finalAttrs.version}.tbz";
+    hash = "sha256-4ZbyGLnPRImRQ8vO71i+jlEWYB/FJCSelY7uBuH4dBU=";
   };
 
   propagatedBuildInputs = [
@@ -44,4 +43,4 @@ buildDunePackage {
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.vbgl ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/conan/lwt.nix
+++ b/pkgs/development/ocaml-modules/conan/lwt.nix
@@ -2,7 +2,7 @@
   buildDunePackage,
   conan,
   lwt,
-  bigstringaf,
+  bstr,
   alcotest,
   crowbar,
   fmt,
@@ -16,7 +16,7 @@ buildDunePackage {
   propagatedBuildInputs = [
     conan
     lwt
-    bigstringaf
+    bstr
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/conan/unix.nix
+++ b/pkgs/development/ocaml-modules/conan/unix.nix
@@ -1,7 +1,7 @@
 {
   buildDunePackage,
-  fetchpatch,
   conan,
+  cachet,
   alcotest,
   crowbar,
   fmt,
@@ -12,12 +12,8 @@ buildDunePackage {
   pname = "conan-unix";
   inherit (conan) version src meta;
 
-  patches = fetchpatch {
-    url = "https://github.com/mirage/conan/commit/16872a71be3ef2870d32df849e7abcbaec4fe95d.patch";
-    hash = "sha256-/j9nNGOklzNrdIPW7SMNhKln9EMXiXmvPmNRpXc/l/Y=";
-  };
-
   propagatedBuildInputs = [
+    cachet
     conan
   ];
 


### PR DESCRIPTION
Fixes & improvements: https://github.com/mirage/conan/releases/tag/v0.0.7

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
