### PR TITLE
ocamlPackages.mparser-re: init at 1.3

### DIFF
--- a/pkgs/development/ocaml-modules/mparser/re.nix
+++ b/pkgs/development/ocaml-modules/mparser/re.nix
@@ -1,0 +1,19 @@
+{
+  buildDunePackage,
+  mparser,
+  re,
+}:
+
+buildDunePackage {
+  pname = "mparser-re";
+  inherit (mparser) src version;
+
+  propagatedBuildInputs = [
+    mparser
+    re
+  ];
+
+  meta = mparser.meta // {
+    description = "MParser plugin: RE-based regular expressions";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1371,6 +1371,8 @@ let
 
         mparser-pcre = callPackage ../development/ocaml-modules/mparser/pcre.nix { };
 
+        mparser-re = callPackage ../development/ocaml-modules/mparser/re.nix { };
+
         msgpck = callPackage ../development/ocaml-modules/msgpck { };
 
         mrmime = callPackage ../development/ocaml-modules/mrmime { };


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
