### PR TITLE
mesa: only build GLX on darwin when targetting x11

### DIFF
--- a/pkgs/development/libraries/mesa/darwin.nix
+++ b/pkgs/development/libraries/mesa/darwin.nix
@@ -45,6 +45,7 @@
 
 let
   common = import ./common.nix { inherit lib fetchFromGitLab; };
+  withGLX = lib.elem "x11" eglPlatforms;
 in
 stdenv.mkDerivation {
   inherit (common)
@@ -90,12 +91,14 @@ stdenv.mkDerivation {
     python3Packages.python # for shebang
     spirv-llvm-translator
     spirv-tools
+    zlib
+  ]
+  ++ lib.optionals withGLX [
     libx11
     libxext
     libxfixes
     libxcb
     libxshmfence
-    zlib
   ];
 
   mesonAutoFeatures = "disabled";
@@ -121,6 +124,10 @@ stdenv.mkDerivation {
     (lib.mesonEnable "shared-llvm" true)
     (lib.mesonEnable "spirv-tools" true)
 
+    # Mesa OpenGL can't be built without GLX on darwin
+    (lib.mesonBool "opengl" withGLX)
+  ]
+  ++ lib.optionals withGLX [
     # Needed for Apple GLX support
     (lib.mesonOption "glx" "dri")
   ];


### PR DESCRIPTION
This keeps X11 support by default but makes it easy to remove any X11 dependencies when just wanting KosmicKrisp on darwin.

If we decide to disable X11 for mesa on darwin by default, we can then simply remove it from `eglPlatforms`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
