### PR TITLE
hqplayer-desktop: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/hq/hqplayer-desktop/package.nix
+++ b/pkgs/by-name/hq/hqplayer-desktop/package.nix
@@ -14,6 +14,7 @@
   mpfr,
   wavpack,
   kdePackages,
+  imagemagick,
 }:
 
 let
@@ -40,6 +41,7 @@ stdenv.mkDerivation {
     autoPatchelfHook
     dpkg
     kdePackages.wrapQtAppsHook
+    imagemagick
   ];
 
   buildInputs = [
@@ -79,10 +81,11 @@ stdenv.mkDerivation {
     mkdir -p "$out/share/applications"
     mv ./usr/share/applications/* "$out/share/applications"
 
-    # pixmaps
-    mkdir -p "$out/share/pixmaps"
-    mv ./usr/share/pixmaps/* "$out/share/pixmaps"
-
+    # icons
+    mkdir -p $out/share/icons/hicolor/96x96/apps
+    install -D ./usr/share/pixmaps/hqplayer5client.png -t $out/share/icons/hicolor/128x128/apps
+    install -D ./usr/share/pixmaps/hqplayer5desktop.png -t $out/share/icons/hicolor/128x128/apps
+    magick ./usr/share/pixmaps/hqplayer5desktop-manual.png -resize 96x96 $out/share/icons/hicolor/96x96/apps/hqplayer5desktop-manual.png
     runHook postInstall
   '';
 


### PR DESCRIPTION
107x107 -> 96x96
Part of #428824 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
