### PR TITLE
irpf: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/ir/irpf/package.nix
+++ b/pkgs/by-name/ir/irpf/package.nix
@@ -8,6 +8,7 @@
   makeWrapper,
   unzip,
   xdg-utils,
+  imagemagick,
   writeScript,
 }:
 
@@ -40,13 +41,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     unzip
     makeWrapper
     copyDesktopItems
+    imagemagick
   ];
 
   desktopItems = [
     (makeDesktopItem {
       name = "irpf";
       exec = "irpf";
-      icon = "rfb64";
+      icon = "rfb";
       desktopName = "Imposto de Renda Pessoa Física";
       comment = "Programa Oficial da Receita para elaboração do IRPF";
       categories = [ "Office" ];
@@ -72,9 +74,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --set _JAVA_AWT_WM_NONREPARENTING 1 \
       --set AWT_TOOLKIT MToolkit
 
-    mkdir -p $out/share/pixmaps
-    unzip -j lib/ppgd-icones-4.0.jar icones/rfb64.png -d $out/share/pixmaps
-
+    mkdir -p $out/share/icons/hicolor/{96x96,72x72,32x32}/apps
+    unzip -jp lib/ppgd-icones-4.0.jar icones/rfb64.png | magick - -background none -gravity center -extent 96x96 $out/share/icons/hicolor/96x96/apps/rfb.png
+    unzip -jp lib/ppgd-icones-4.0.jar icones/rfb48.png | magick - -background none -gravity center -extent 72x72 $out/share/icons/hicolor/72x72/apps/rfb.png
+    unzip -j lib/ppgd-icones-4.0.jar icones/rfb.png -d $out/share/icons/hicolor/32x32/apps
     runHook postInstall
   '';
 


### PR DESCRIPTION
Part of #428824 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
