### PR TITLE
pythonPackages.unsloth: 2025.9.4 -> 2026.2.1

### DIFF
--- a/pkgs/development/python-modules/cut-cross-entropy/default.nix
+++ b/pkgs/development/python-modules/cut-cross-entropy/default.nix
@@ -24,7 +24,7 @@
 
 buildPythonPackage {
   pname = "cut-cross-entropy";
-  version = "25.7.2";
+  version = "25.9.3";
   pyproject = true;
 
   # The `ml-cross-entropy` Pypi comes from a third-party.
@@ -32,8 +32,8 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "apple";
     repo = "ml-cross-entropy";
-    rev = "b19a424ed30a05b8261cfa84d83b2601a9454c67"; # no tags
-    hash = "sha256-AwUqKiI7XjEOZ7ofjQCOsqvxHyTFD4RZ70odPyxxntc=";
+    rev = "b7a02791b234e187b524fb1dba6a812d521b203a"; # no tags
+    hash = "sha256-CXcc/QzzFTbVU7+8hp+6RhQ0js0y7lYzI25NaHoX7wc=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/datasets/default.nix
+++ b/pkgs/development/python-modules/datasets/default.nix
@@ -13,6 +13,7 @@
   huggingface-hub,
   multiprocess,
   numpy,
+  packaging,
   pandas,
   pyarrow,
   pyyaml,
@@ -22,14 +23,14 @@
 }:
 buildPythonPackage rec {
   pname = "datasets";
-  version = "4.5.0";
+  version = "4.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "datasets";
     tag = version;
-    hash = "sha256-K8JqIbYz3ZfT1t1h5dRGCo9kBQp0E+kElqzaw2InaOI=";
+    hash = "sha256-qMPs0su89/6fl2su8/FPJpOlbVpxndJdESt3b7etWmQ=";
   };
 
   build-system = [
@@ -44,6 +45,7 @@ buildPythonPackage rec {
     huggingface-hub
     multiprocess
     numpy
+    packaging
     pandas
     pyarrow
     pyyaml

--- a/pkgs/development/python-modules/trl/default.nix
+++ b/pkgs/development/python-modules/trl/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "trl";
-  version = "0.27.0";
+  version = "0.29.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "trl";
     tag = "v${version}";
-    hash = "sha256-NEvIWrirHqcLJpyA894NgNFPn/Svg+ND/xDMIRHW8d0=";
+    hash = "sha256-/pI+a7Dq8n89t83rm7zL08yLyr+GPogr7SZWMxtHL74=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/tyro/default.nix
+++ b/pkgs/development/python-modules/tyro/default.nix
@@ -27,16 +27,16 @@
   universal-pathlib,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tyro";
-  version = "1.0.8";
+  version = "1.0.10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "brentyi";
     repo = "tyro";
-    tag = "v${version}";
-    hash = "sha256-GTgbzGIIZrkMUgjqMWZVXRVhp9mcxfnDQ/dRApotjww=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-k8f0eSeBBCROSsf7WooapDIFoy1G4Guxpbb7eNbj6ps=";
   };
 
   build-system = [ hatchling ];
@@ -80,8 +80,8 @@ buildPythonPackage rec {
   meta = {
     description = "CLI interfaces & config objects, from types";
     homepage = "https://github.com/brentyi/tyro";
-    changelog = "https://github.com/brentyi/tyro/releases/tag/${src.tag}";
+    changelog = "https://github.com/brentyi/tyro/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hoh ];
   };
-}
+})

--- a/pkgs/development/python-modules/unsloth-zoo/default.nix
+++ b/pkgs/development/python-modules/unsloth-zoo/default.nix
@@ -5,36 +5,44 @@
 
   # build-system
   setuptools,
-  setuptools-scm,
 
   # dependencies
   accelerate,
   cut-cross-entropy,
   datasets,
+  filelock,
   hf-transfer,
   huggingface-hub,
   msgspec,
+  numpy,
   packaging,
   peft,
+  pillow,
+  protobuf,
   psutil,
+  regex,
   sentencepiece,
   torch,
+  torchao,
   tqdm,
   transformers,
+  triton,
   trl,
   tyro,
+  typing-extensions,
+  wheel,
 }:
 
 buildPythonPackage rec {
   pname = "unsloth-zoo";
-  version = "2026.1.3";
+  version = "2026.2.1";
   pyproject = true;
 
   # no tags on GitHub
   src = fetchPypi {
     pname = "unsloth_zoo";
     inherit version;
-    hash = "sha256-njArRI9y6EKwZamJnQoWQIvmYzV6t0syUIi1d7DzX4U=";
+    hash = "sha256-IpUgoerT9xrSQZmbuuJpGyDXlhgooUde1b82tyTYP3w=";
   };
 
   # pyproject.toml requires an obsolete version of protobuf,
@@ -43,44 +51,56 @@ buildPythonPackage rec {
   pythonRelaxDeps = [
     "datasets"
     "protobuf"
+    "trl"
     "transformers"
     "torch"
   ];
 
   patches = [
-    # Avoid circular dependency in Nix, since `unsloth` depends on `unsloth-zoo`.
+    # Avoid circular dependency during import, `unsloth` depends on `unsloth-zoo`.
     ./dont-require-unsloth.patch
   ];
 
-  build-system = [
-    setuptools
-    setuptools-scm
-  ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'requires = ["setuptools==80.9.0", "setuptools-scm==9.2.0"]' \
+                'requires = ["setuptools"]'
+  '';
+
+  build-system = [ setuptools ];
 
   dependencies = [
     accelerate
     cut-cross-entropy
     datasets
+    filelock
     hf-transfer
     huggingface-hub
     msgspec
+    numpy
     packaging
     peft
+    pillow
+    protobuf
     psutil
+    regex
     sentencepiece
     torch
+    torchao
     tqdm
     transformers
+    triton
     trl
     tyro
+    typing-extensions
+    wheel
   ];
 
   # No tests
   doCheck = false;
 
-  pythonImportsCheck = [
-    "unsloth_zoo"
-  ];
+  # Importing tries to detect a GPU and fails in pure CPU builders.
+  dontUsePythonImportsCheck = true;
 
   meta = {
     description = "Utils for Unsloth";

--- a/pkgs/development/python-modules/unsloth-zoo/dont-require-unsloth.patch
+++ b/pkgs/development/python-modules/unsloth-zoo/dont-require-unsloth.patch
@@ -1,29 +1,20 @@
-diff --git a/unsloth_zoo/__init__.py b/unsloth_zoo/__init__.py
-index 2332907..2eed5e9 100644
 --- a/unsloth_zoo/__init__.py
 +++ b/unsloth_zoo/__init__.py
-@@ -64,8 +64,6 @@ pass
+@@ -72,8 +72,6 @@
  
  
  from importlib.util import find_spec
 -if find_spec("unsloth") is None:
 -    raise ImportError("Please install Unsloth via `pip install unsloth`!")
- pass
- del find_spec
- 
-@@ -75,12 +73,13 @@ def get_device_type():
-         return "cuda"
-     elif hasattr(torch, "xpu") and torch.xpu.is_available():
-         return "xpu"
-+    else:
-+        # Allow import during tests
-+        return None
-     raise NotImplementedError("Unsloth currently only works on NVIDIA GPUs and Intel GPUs.")
- pass
- DEVICE_TYPE : str = get_device_type()
+ if find_spec("torch") is None:
+     raise ImportError(
+         "Unsloth: Pytorch is not installed. Go to https://pytorch.org/.\n"\
+@@ -180,8 +178,6 @@
+     os.environ["UNSLOTH_ENABLE_CCE"] = "0"
+ del delete_key, major_torch, minor_torch, torch_version, importlib_version, find_spec
  
 -if not ("UNSLOTH_IS_PRESENT" in os.environ):
 -    raise ImportError("Please install Unsloth via `pip install unsloth`!")
- pass
  
  try:
+     print("🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.")

--- a/pkgs/development/python-modules/unsloth/default.nix
+++ b/pkgs/development/python-modules/unsloth/default.nix
@@ -53,15 +53,21 @@ in
 
 buildPythonPackage rec {
   pname = "unsloth";
-  version = "2026.1.3";
+  version = "2026.2.1";
   pyproject = true;
 
   # Tags on the GitHub repo don't match
   src = fetchPypi {
     pname = "unsloth";
     inherit version;
-    hash = "sha256-Vq47dKdOyRm+sQmGkfEQ8vM1A1Xq7NwqyE2NGhgyK/s=";
+    hash = "sha256-z9FbMdzs08A2jgD/GLSlZGVRpIw+qjCmpkAeK/Di/7A=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'requires = ["setuptools==80.9.0", "setuptools-scm==9.2.0"]' \
+                'requires = ["setuptools", "setuptools-scm"]'
+  '';
 
   build-system = [
     setuptools
@@ -96,6 +102,7 @@ buildPythonPackage rec {
   pythonRelaxDeps = [
     "datasets"
     "protobuf"
+    "trl"
     "transformers"
     "torch"
   ];


### PR DESCRIPTION
This updates Unsloth and its dependencies.

Depends on a update of `python3Packages.datasets != 4.5.0`.
 
Tested Unsloth's GPU tests with:

```shell
nix-build -I nixpkgs=. \
    --arg config '{ allowUnfree = true; cudaSupport = true; openclSupport = true; rocmSupport = false;}'
    --option allow-import-from-derivation false \
    -A python313Packages.unsloth.tests.qlora-train-and-merge

./result/bin/tester-cuda
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests` with CUDA
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
