### PR TITLE
pythonPackages.pyhumps: revert PR breaking the tests

### DIFF
--- a/pkgs/development/python-modules/pyhumps/default.nix
+++ b/pkgs/development/python-modules/pyhumps/default.nix
@@ -4,12 +4,22 @@
   fetchFromGitHub,
   poetry-core,
   pytestCheckHook,
+  fetchpatch2,
 }:
 
 buildPythonPackage rec {
   pname = "pyhumps";
   version = "3.9.0";
   pyproject = true;
+
+  patches = [
+    (fetchpatch2 {
+      name = "revert_decamelize_ignore_numeric_characters.patch";
+      revert = true;
+      url = "https://github.com/nficano/humps/commit/661828b8b3e6fac15236b14ffbdf038aef516d4c.patch";
+      hash = "sha256-5+ZKEqydN+SF2ihWUf7B8TBY2DK7xFIU/WRDS3+pD0k=";
+    })
+  ];
 
   src = fetchFromGitHub {
     owner = "nficano";


### PR DESCRIPTION
fixes the tests 
fixes #494075
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
