### PR TITLE
libweaver.updateScript: fix the eval

### DIFF
--- a/pkgs/by-name/li/libweaver/package.nix
+++ b/pkgs/by-name/li/libweaver/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   passthru = {
-    updateScript = unstableGitUpdater { harcodeZeroVersion = true; };
+    updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
     tests.cmake-config = testers.hasCmakeConfigModules {
       package = finalAttrs.finalPackage;
       moduleNames = [ "libweaver" ];


### PR DESCRIPTION
Without the change the eval fails as:

    $ nix eval --impure  --expr 'with import ./. {}; libweaver.updateScript'
    error:
       … while evaluating the attribute 'updateScript'
         at pkgs/by-name/li/libweaver/package.nix:34:5:
           33|   passthru = {
           34|     updateScript = unstableGitUpdater { harcodeZeroVersion = true; };
             |     ^
           35|     tests.cmake-config = testers.hasCmakeConfigModules {

       … while calling a functor (an attribute set with a '__functor' attribute)
         at pkgs/by-name/li/libweaver/package.nix:34:20:
           33|   passthru = {
           34|     updateScript = unstableGitUpdater { harcodeZeroVersion = true; };
             |                    ^
           35|     tests.cmake-config = testers.hasCmakeConfigModules {

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: function 'anonymous lambda' called with unexpected argument 'harcodeZeroVersion'
       at pkgs/common-updater/unstable-updater.nix:16:1:
           15|
           16| {
             | ^
           17|   url ? null, # The git url, if empty it will be set to src.gitRepoUrl
       Did you mean hardcodeZeroVersion?


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
