### PR TITLE
Update/octave packages

### DIFF
--- a/pkgs/development/octave-modules/arduino/default.nix
+++ b/pkgs/development/octave-modules/arduino/default.nix
@@ -1,18 +1,21 @@
 {
   buildOctavePackage,
   lib,
-  fetchurl,
+  fetchFromGitHub,
   instrument-control,
   arduino-core-unwrapped,
+  nix-update-script,
 }:
 
 buildOctavePackage rec {
   pname = "arduino";
-  version = "0.10.0";
+  version = "0.12.3";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-p9SDTXkIwnrkNXeVhzAHks7EL4NdwBokrH2j9hqAJqQ=";
+  src = fetchFromGitHub {
+    owner = "gnu-octave";
+    repo = "octave-arduino";
+    tag = "release-${version}";
+    sha256 = "sha256-gYoYXJwkuoI1S2SdOu6qpemlSjgAAx7N5LYwJq9ZrU8=";
   };
 
   requiredOctavePackages = [
@@ -22,6 +25,13 @@ buildOctavePackage rec {
   propagatedBuildInputs = [
     arduino-core-unwrapped
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "release-(.*)"
+    ];
+  };
 
   meta = {
     name = "Octave Arduino Toolkit";

--- a/pkgs/development/octave-modules/audio/default.nix
+++ b/pkgs/development/octave-modules/audio/default.nix
@@ -1,7 +1,8 @@
 {
   buildOctavePackage,
   lib,
-  fetchurl,
+  fetchFromGitHub,
+  nix-update-script,
   jack2,
   alsa-lib,
   rtmidi,
@@ -10,11 +11,13 @@
 
 buildOctavePackage rec {
   pname = "audio";
-  version = "2.0.5";
+  version = "2.0.10";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-/4akeeOQnvTlk9ah+e8RJfwJG2Eq2HAGOCejhiIUjF4=";
+  src = fetchFromGitHub {
+    owner = "gnu-octave";
+    repo = "octave-audio";
+    tag = "release-${version}";
+    sha256 = "sha256-v7FKj9GSlX86zpOcw1xKxy150ivUxpjU/rvg+3OGs2s=";
   };
 
   nativeBuildInputs = [
@@ -27,11 +30,14 @@ buildOctavePackage rec {
     rtmidi
   ];
 
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=release-(.*)" ]; };
+
   meta = {
     homepage = "https://gnu-octave.github.io/packages/audio/";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ KarlJoad ];
     description = "Audio and MIDI Toolbox for GNU Octave";
     platforms = lib.platforms.linux; # Because of run-time dependency on jack2 and alsa-lib
+    broken = true;
   };
 }

--- a/pkgs/development/octave-modules/dicom/default.nix
+++ b/pkgs/development/octave-modules/dicom/default.nix
@@ -1,18 +1,21 @@
 {
   buildOctavePackage,
   lib,
-  fetchurl,
+  fetchFromGitHub,
   gdcm,
   cmake,
+  nix-update-script,
 }:
 
 buildOctavePackage rec {
   pname = "dicom";
-  version = "0.6.1";
+  version = "0.7.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-erUZudOknymgGprqUhCaSvN/WlmWZ1qgH8HDYrNOg2I=";
+  src = fetchFromGitHub {
+    owner = "gnu-octave";
+    repo = "octave-dicom";
+    tag = "release-${version}";
+    sha256 = "sha256-NNdcnIeHXDRmZZp0WvwGtfMJ4BSR6+aK6FVS0BG51U8=";
   };
 
   nativeBuildInputs = [
@@ -24,6 +27,8 @@ buildOctavePackage rec {
   propagatedBuildInputs = [
     gdcm
   ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=release-(.*)" ]; };
 
   meta = {
     homepage = "https://gnu-octave.github.io/packages/dicom/";

--- a/pkgs/development/octave-modules/general/default.nix
+++ b/pkgs/development/octave-modules/general/default.nix
@@ -8,11 +8,11 @@
 
 buildOctavePackage rec {
   pname = "general";
-  version = "2.1.3";
+  version = "2.1.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-amslJm3haXaAehdm6jYJxcGZl+ggUcnJc3i6YJ3QkyM=";
+    sha256 = "sha256-sTd31PWTLmiR8qrBPaF/IrjJuLT/jtAXllnr0ZEkFI8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/octave-modules/geometry/default.nix
+++ b/pkgs/development/octave-modules/geometry/default.nix
@@ -1,18 +1,17 @@
 {
   buildOctavePackage,
   lib,
-  fetchhg,
+  fetchurl,
   matgeom,
 }:
 
 buildOctavePackage rec {
   pname = "geometry";
-  version = "unstable-2021-07-07";
+  version = "4.1.0";
 
-  src = fetchhg {
-    url = "http://hg.code.sf.net/p/octave/${pname}";
-    rev = "04965cda30b5f9e51774194c67879e7336df1710";
-    sha256 = "sha256-ECysYOJMF4gPiCFung9hFSlyyO60X3MGirQ9FlYDix8=";
+  src = fetchurl {
+    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
+    sha256 = "sha256-28FliEXJfS1mh8FJCmG0PTWZE9M0IOR1tlnzNfejQ2A=";
   };
 
   requiredOctavePackages = [

--- a/pkgs/development/octave-modules/geometry/default.nix
+++ b/pkgs/development/octave-modules/geometry/default.nix
@@ -3,6 +3,7 @@
   lib,
   fetchurl,
   matgeom,
+  gsl,
 }:
 
 buildOctavePackage rec {
@@ -16,6 +17,10 @@ buildOctavePackage rec {
 
   requiredOctavePackages = [
     matgeom
+  ];
+
+  buildInputs = [
+    gsl
   ];
 
   meta = {

--- a/pkgs/development/octave-modules/gsl/default.nix
+++ b/pkgs/development/octave-modules/gsl/default.nix
@@ -1,6 +1,5 @@
 {
   buildOctavePackage,
-  stdenv,
   lib,
   fetchurl,
   gsl,
@@ -24,8 +23,8 @@ buildOctavePackage rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ KarlJoad ];
     description = "Octave bindings to the GNU Scientific Library";
-    # error: use of undeclared identifier 'feval'; did you mean 'octave::feval'?
-    # error: no member named 'is_real_type' in 'octave_value'
-    broken = stdenv.hostPlatform.isDarwin;
+    # When used in an `octave.withPackages` environment, octave fails to find
+    # libgsl.so from some reason.
+    broken = true;
   };
 }

--- a/pkgs/development/octave-modules/image-acquisition/default.nix
+++ b/pkgs/development/octave-modules/image-acquisition/default.nix
@@ -1,18 +1,21 @@
 {
   buildOctavePackage,
   lib,
-  fetchurl,
+  fetchFromGitHub,
   libv4l,
   fltk,
+  nix-update-script,
 }:
 
 buildOctavePackage rec {
   pname = "image-acquisition";
-  version = "0.3.0";
+  version = "0.3.3";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-vgLDbqFGlbXjDaxRtaBHAYYJ+wUjtB0NYYkQFIqTOgU=";
+  src = fetchFromGitHub {
+    owner = "Andy1978";
+    repo = "octave-image-acquisition";
+    tag = "image-acquisition-${version}";
+    sha256 = "sha256-vS1i0PNAyfkxuMSfm+OGvFXkpbD4H6VJrs4eb+LxYBA=";
   };
 
   buildInputs = [
@@ -22,6 +25,13 @@ buildOctavePackage rec {
   propagatedBuildInputs = [
     libv4l
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "image-acquisition-(.*)"
+    ];
+  };
 
   meta = {
     homepage = "https://gnu-octave.github.io/packages/image-acquisition/";

--- a/pkgs/development/octave-modules/instrument-control/default.nix
+++ b/pkgs/development/octave-modules/instrument-control/default.nix
@@ -1,16 +1,26 @@
 {
   buildOctavePackage,
   lib,
-  fetchurl,
+  fetchFromGitHub,
+  nix-update-script,
 }:
 
 buildOctavePackage rec {
   pname = "instrument-control";
-  version = "0.9.5";
+  version = "0.10.0";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-Qm1aF+dbhwrDUSh8ViJHCZIc0DiZ1jI117TnSknqzX0=";
+  src = fetchFromGitHub {
+    owner = "gnu-octave";
+    repo = "instrument-control";
+    tag = "release-${version}";
+    sha256 = "sha256-eXlH7BFRh4Vq/2LiBsmTvZNhXm4IbeCHK+OsKMQI0tY=";
+  };
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "release-(.*)"
+    ];
   };
 
   meta = {

--- a/pkgs/development/octave-modules/miscellaneous/default.nix
+++ b/pkgs/development/octave-modules/miscellaneous/default.nix
@@ -1,7 +1,8 @@
 {
   buildOctavePackage,
   lib,
-  fetchurl,
+  fetchFromGitHub,
+  nix-update-script,
   # Build-time dependencies
   ncurses, # >= 5
   units,
@@ -9,11 +10,13 @@
 
 buildOctavePackage rec {
   pname = "miscellaneous";
-  version = "1.3.1";
+  version = "1.3.2";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-VxIReiXTHRJmADZGpA6B59dCdDPCY2bkJt/6mrir1kg=";
+  src = fetchFromGitHub {
+    owner = "gnu-octave";
+    repo = "octave-miscellaneous";
+    tag = "release-${version}";
+    sha256 = "sha256-IF5kBd7RD2+gooRTNtv2XDPJcpIZlsu8QXlO3f3nD/Q=";
   };
 
   buildInputs = [
@@ -23,6 +26,13 @@ buildOctavePackage rec {
   propagatedBuildInputs = [
     units
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "release-(.*)"
+    ];
+  };
 
   meta = {
     homepage = "https://gnu-octave.github.io/packages/miscellaneous/";

--- a/pkgs/development/octave-modules/netcdf/default.nix
+++ b/pkgs/development/octave-modules/netcdf/default.nix
@@ -1,17 +1,20 @@
 {
   buildOctavePackage,
   lib,
-  fetchurl,
+  fetchFromGitHub,
   netcdf,
+  nix-update-script,
 }:
 
 buildOctavePackage rec {
   pname = "netcdf";
-  version = "1.0.18";
+  version = "1.0.19";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-ydgcKFh4uWuSlr7zw+k1JFUSzGm9tiWmOHV1IWvlgwk=";
+  src = fetchFromGitHub {
+    owner = "gnu-octave";
+    repo = "octave-netcdf";
+    tag = "v${version}";
+    sha256 = "sha256-yt39bd6EBLj7mr6EYngPfPXEMusncc9tx5So1Cp1zkM=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/octave-modules/ocl/default.nix
+++ b/pkgs/development/octave-modules/ocl/default.nix
@@ -6,11 +6,11 @@
 
 buildOctavePackage rec {
   pname = "ocl";
-  version = "1.2.3";
+  version = "1.2.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-g/HLE0qjnzYkq3t3OhxFBpL250JWbWjHJBP0SYJSOZU=";
+    sha256 = "sha256-ymahtzdCX4D3rBMThUmhWOY238yckP0bmNE0xFhK0No=";
   };
 
   meta = {
@@ -23,7 +23,5 @@ buildOctavePackage rec {
       Single-Instruction-Multiple-Data (SIMD) computations, selectively
       using available OpenCL hardware and drivers.
     '';
-    # https://savannah.gnu.org/bugs/?66964
-    broken = true;
   };
 }

--- a/pkgs/development/octave-modules/octproj/default.nix
+++ b/pkgs/development/octave-modules/octproj/default.nix
@@ -3,17 +3,18 @@
   lib,
   fetchFromBitbucket,
   proj, # >= 6.3.0
+  nix-update-script,
 }:
 
 buildOctavePackage rec {
   pname = "octproj";
-  version = "3.0.2";
+  version = "3.1.0";
 
   src = fetchFromBitbucket {
     owner = "jgpallero";
     repo = "octproj";
     rev = "OctPROJ-${version}";
-    sha256 = "sha256-d/Zf172Etj+GA0cnGsQaKMjOmirE7Hwyj4UECpg7QFM=";
+    sha256 = "sha256-0QDlpfqFTSndUPkOslugDBM0UBKiusZwKGFuDrco7X4=";
   };
 
   # The sed changes below allow for the package to be compiled.
@@ -25,6 +26,13 @@ buildOctavePackage rec {
   propagatedBuildInputs = [
     proj
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "OctPROJ-(.*)"
+    ];
+  };
 
   meta = {
     homepage = "https://gnu-octave.github.io/packages/octproj/";

--- a/pkgs/development/octave-modules/quaternion/default.nix
+++ b/pkgs/development/octave-modules/quaternion/default.nix
@@ -6,20 +6,12 @@
 
 buildOctavePackage rec {
   pname = "quaternion";
-  version = "2.4.1";
+  version = "2.4.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-kY5mU7dJuUjprub+LTc1BH6YGdEnP9ydX0lRU0fmOYE=";
+    sha256 = "sha256-S8tkdDlyaT8E7W0v6kkGs4qTU/G4DG5vLQvA9vjPOgc=";
   };
-
-  # Octave replaced many of the is_thing_type check function with isthing.
-  # The patch changes the occurrences of the old functions.
-  patchPhase = ''
-    sed -i s/is_numeric_type/isnumeric/g src/*.cc
-    sed -i s/is_real_type/isreal/g src/*.cc
-    sed -i s/is_bool_type/islogical/g src/*.cc
-  '';
 
   meta = {
     homepage = "https://gnu-octave.github.io/packages/quaternion/";

--- a/pkgs/development/octave-modules/queueing/default.nix
+++ b/pkgs/development/octave-modules/queueing/default.nix
@@ -6,11 +6,11 @@
 
 buildOctavePackage rec {
   pname = "queueing";
-  version = "1.2.7";
+  version = "1.2.8";
 
   src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "1yhw277i1qgmddf6wbfb6a4zrfhvplkmfr20q1l15z4xi8afnm6d";
+    url = "https://github.com/mmarzolla/queueing/releases/download/${version}/${pname}-${version}.tar.gz";
+    sha256 = "sha256-kJGURTYig+aImnjXu8ldyqFAJDqV+fpUzR+h6OdvwzM=";
   };
 
   meta = {

--- a/pkgs/development/octave-modules/signal/default.nix
+++ b/pkgs/development/octave-modules/signal/default.nix
@@ -1,17 +1,20 @@
 {
   buildOctavePackage,
   lib,
-  fetchurl,
+  fetchFromGitHub,
   control,
+  nix-update-script,
 }:
 
 buildOctavePackage rec {
   pname = "signal";
-  version = "1.4.6";
+  version = "1.4.7";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-lO74/qeMiWCfjd9tX/i/wuDauTK0P4bOkRR0pYtcce4=";
+  src = fetchFromGitHub {
+    owner = "gnu-octave";
+    repo = "octave-signal";
+    tag = "${version}";
+    sha256 = "sha256-4E57x2hweO1TfpjBRRvsyQA/o83XJLrRKa5vqUA0t3s=";
   };
 
   requiredOctavePackages = [

--- a/pkgs/development/octave-modules/sockets/default.nix
+++ b/pkgs/development/octave-modules/sockets/default.nix
@@ -1,16 +1,26 @@
 {
   buildOctavePackage,
   lib,
-  fetchurl,
+  fetchFromGitHub,
+  nix-update-script,
 }:
 
 buildOctavePackage rec {
   pname = "sockets";
-  version = "1.4.1";
+  version = "1.5.0";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-u5Nb9PVyMoR0lIzXEMtkZntXbBfpyXrtLB8U+dkgYrc=";
+  src = fetchFromGitHub {
+    owner = "gnu-octave";
+    repo = "octave-sockets";
+    tag = "release-${version}";
+    sha256 = "sha256-l5W/mLYVcTRYKLCzM8MQW7nad+Gq0fy2XKQmdH8GG/Y=";
+  };
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "release-(.*)"
+    ];
   };
 
   meta = {

--- a/pkgs/development/octave-modules/windows/default.nix
+++ b/pkgs/development/octave-modules/windows/default.nix
@@ -1,22 +1,28 @@
 {
   buildOctavePackage,
   lib,
-  fetchurl,
+  fetchFromGitHub,
+  nix-update-script,
 }:
 
 buildOctavePackage rec {
   pname = "windows";
-  version = "1.6.5";
+  version = "1.7.0";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-j/goQc57jcfxlCsbf31Mx8oNud1vNE0D/hNfXyvVmTc=";
+  src = fetchFromGitHub {
+    owner = "gnu-octave";
+    repo = "octave-windows";
+    tag = "release-${version}";
+    sha256 = "sha256-hr94VALlAEwpqNU7imEN63M0BdPFSu5IznhWOn/mNiQ=";
   };
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=release-(.*)" ]; };
 
   meta = {
     homepage = "https://gnu-octave.github.io/packages/windows/";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ KarlJoad ];
     description = "Provides COM interface and additional functionality on Windows";
+    broken = true;
   };
 }

--- a/pkgs/development/octave-modules/zeromq/default.nix
+++ b/pkgs/development/octave-modules/zeromq/default.nix
@@ -1,19 +1,22 @@
 {
   buildOctavePackage,
   lib,
-  fetchurl,
+  fetchFromGitHub,
   zeromq,
   pkg-config,
   autoreconfHook,
+  nix-update-script,
 }:
 
 buildOctavePackage rec {
   pname = "zeromq";
-  version = "1.5.5";
+  version = "1.5.7";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-MAZEpbVuragVuXrMJ8q5/jU5cTchosAtrAR6ElLwfss=";
+  src = fetchFromGitHub {
+    owner = "gnu-octave";
+    repo = "octave-zeromq";
+    tag = "release-${version}";
+    sha256 = "sha256-2n/Cc4E/qYeN5Ku+Lmg/UCJhiYNbXkFIY8s4/SP2J+Y=";
   };
 
   preAutoreconf = ''
@@ -32,6 +35,13 @@ buildOctavePackage rec {
   propagatedBuildInputs = [
     zeromq
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "release-(.*)"
+    ];
+  };
 
   meta = {
     homepage = "https://gnu-octave.github.io/packages/zeromq/";


### PR DESCRIPTION
## Things done
I have updated 
- octavePackages.quaternion 2.4.1 -> 2.4.2
- octavePackages.netcdf 1.0.18 -> 1.0.19
- octavePackages.miscellaneous 1.3.1 -> 1.3.2
- octavePackages.instrument-control 0.9.5 -> 0.10.0
- octavePackages.image-acquisition 0.3.0 -> 0.3.3
- octavePackages.geometry unstable-2021-07-07 -> 4.1.0
- octavePackages.general 2.1.3 -> 2.1.4
- octavePackages.dicom 0.6.1 -> 0.7.1
- octavePackages.octproj 3.0.2 -> 3.1.0
- octavePackages.ocl 1.2.3 -> 1.2.4
- octavePackages.signal 1.4.6 -> 1.4.7
- octavePackages.queueing 1.2.7 -> 1.2.8
- octavePackages.sockets 1.4.1 -> 1.5.0
- octavePackages.zeromq 1.5.5 -> 1.5.7
- octavePackages.arduino 0.10.0 -> 0.12.3

I have run the `fetchFromGitHub` with 
```
nix-shell -p nix-update --run "nix-update -u octavePackages.octproj"
```

I have tested the packages with 
```
nix shell --impure --expr  'with import ./. {}; octave.withPackages (p: with p;[ zeromq arduino sockets signal queueing quaternion octproj ocl netcdf miscellaneous instrument-control image-acquisition geometry general dicom])' --command octave --eval "pkg list"
```

There where two packages I could not update
- octavePackages.windows
- octavePackages.audio [495990](https://github.com/NixOS/nixpkgs/issues/495990)

I have not yet tested with octave-11.1.0.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
