### PR TITLE
python3Packages.arviz: 0.23.4 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/arviz-base/default.nix
+++ b/pkgs/development/python-modules/arviz-base/default.nix
@@ -7,6 +7,7 @@
   flit-core,
 
   # dependencies
+  lazy-loader,
   numpy,
   typing-extensions,
   xarray,
@@ -23,14 +24,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "arviz-base";
-  version = "0.8.2";
+  version = "1.1.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "arviz-devs";
     repo = "arviz-base";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-g2DmhYqO9dgvDZwAXXSDFn5wHU0BvxXNgOzk6mmEmsw=";
+    hash = "sha256-/v1LPgM2rDw9Z0en0MYGELGiRlmwQX4ILKsBEqOhhSs=";
   };
 
   build-system = [
@@ -38,6 +40,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   dependencies = [
+    lazy-loader
     numpy
     typing-extensions
     xarray

--- a/pkgs/development/python-modules/arviz-plots/default.nix
+++ b/pkgs/development/python-modules/arviz-plots/default.nix
@@ -43,6 +43,7 @@ buildPythonPackage (finalAttrs: {
   pname = "arviz-plots";
   version = "1.1.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "arviz-devs";

--- a/pkgs/development/python-modules/arviz-plots/default.nix
+++ b/pkgs/development/python-modules/arviz-plots/default.nix
@@ -41,14 +41,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "arviz-plots";
-  version = "0.8.0";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "arviz-devs";
     repo = "arviz-plots";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-x4UoUSKz+MAI082afnGhfoy2ad/hPK89Y1B2oEnxhsg=";
+    hash = "sha256-ti1wD/aPNCk59wkad+xkvIKTB2Wkupovlo0Hg0YqK1o=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/arviz-stats/default.nix
+++ b/pkgs/development/python-modules/arviz-stats/default.nix
@@ -38,14 +38,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "arviz-stats";
-  version = "0.8.0";
+  version = "1.1.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "arviz-devs";
     repo = "arviz-stats";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-FAZXnKxNb/DPkcpIRJRIzSbthS8Djf75hd5WMxegdhY=";
+    hash = "sha256-81duRavbPUKsqTWaeD0G6ieWLtyoZm7sRk06QkG5dKQ=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/arviz/default.nix
+++ b/pkgs/development/python-modules/arviz/default.nix
@@ -1,134 +1,47 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
-  # nativeBuildInputs
-  writableTmpDirAsHomeHook,
-
   # build-system
-  packaging,
-  setuptools,
+  flit-core,
 
   # dependencies
-  h5netcdf,
-  matplotlib,
-  numpy,
-  pandas,
-  platformdirs,
-  scipy,
-  typing-extensions,
-  xarray,
-  xarray-einstats,
+  arviz-base,
+  arviz-plots,
+  arviz-stats,
 
   # tests
-  bokeh,
-  cloudpickle,
-  emcee,
-  ffmpeg,
-  h5py,
-  jax,
-  jaxlib,
-  numba,
-  numpyro,
-  #, pymc3 (circular dependency)
-  pyro-ppl,
-  #, pystan (not packaged)
   pytestCheckHook,
-  torchvision,
-  zarr,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "arviz";
-  version = "0.23.4";
+  version = "1.1.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "arviz-devs";
     repo = "arviz";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YQ5i+CSuznbWAQ29jgqrOs+zgOAS5U4wSNEIquJQkvY=";
+    hash = "sha256-M9tj1X65hiLpI32X+t/gPYZHGwmAQ+9n52e8lVptg7k=";
   };
 
-  nativeBuildInputs = [
-    # Arviz wants to write a stamp file to the homedir at import time.
-    # Without $HOME being writable, `pythonImportsCheck` fails.
-    # https://github.com/arviz-devs/arviz/commit/4db612908f588d89bb5bfb6b83a08ada3d54fd02
-    writableTmpDirAsHomeHook
-  ];
-
   build-system = [
-    packaging
-    setuptools
+    flit-core
   ];
 
   dependencies = [
-    h5netcdf
-    h5py
-    matplotlib
-    numpy
-    pandas
-    platformdirs
-    scipy
-    typing-extensions
-    xarray
-    xarray-einstats
-  ];
+    arviz-base
+    arviz-plots
+    arviz-stats
+  ]
+  ++ arviz-stats.optional-dependencies.xarray;
 
   nativeCheckInputs = [
-    bokeh
-    cloudpickle
-    emcee
-    ffmpeg
-    jax
-    jaxlib
-    numba
-    numpyro
-    # pymc3 (circular dependency)
-    pyro-ppl
-    # pystan (not packaged)
     pytestCheckHook
-    torchvision
-    zarr
   ];
-
-  enabledTestPaths = [
-    "arviz/tests/base_tests/"
-  ];
-
-  disabledTestPaths = [
-    # AttributeError: module 'zarr.storage' has no attribute 'DirectoryStore'
-    # https://github.com/arviz-devs/arviz/issues/2357
-    "arviz/tests/base_tests/test_data_zarr.py::TestDataZarr::test_io_function"
-    "arviz/tests/base_tests/test_data_zarr.py::TestDataZarr::test_io_method"
-  ];
-
-  disabledTests = [
-    # TypeError: only 0-dimensional arrays can be converted to Python scalars
-    "test_deterministic"
-    "test_mcse_array"
-    "test_mcse_dataset"
-    "test_mcse_nan"
-    "test_multichain_summary_array"
-    "test_numba_mcse"
-    "test_plot_mcse"
-
-    # Tests require network access
-    "test_plot_ppc_transposed"
-    "test_plot_separation"
-    "test_plot_trace_legend"
-    "test_cov"
-
-    # countourpy is not available at the moment
-    "test_plot_kde"
-    "test_plot_kde_2d"
-    "test_plot_pair"
-  ];
-
-  # Tests segfault on darwin
-  doCheck = !stdenv.hostPlatform.isDarwin;
 
   pythonImportsCheck = [ "arviz" ];
 

--- a/pkgs/development/python-modules/pymc/default.nix
+++ b/pkgs/development/python-modules/pymc/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  writableTmpDirAsHomeHook,
 
   # build-system
   setuptools,
@@ -23,7 +22,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pymc";
-  version = "5.28.5";
+  version = "6.0.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -31,7 +30,7 @@ buildPythonPackage (finalAttrs: {
     owner = "pymc-devs";
     repo = "pymc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-neySWgFxnebW9v0Fa6+ZaxQeFQ0v6wpRvQrBj0zOHJs=";
+    hash = "sha256-djioOgEtfKxXcbxYJGjPjCQOxcXi54xXNowJJhUWjE4=";
   };
 
   build-system = [
@@ -50,13 +49,6 @@ buildPythonPackage (finalAttrs: {
     scipy
     threadpoolctl
     typing-extensions
-  ];
-
-  nativeBuildInputs = [
-    # Arviz (imported by pymc) wants to write a stamp file to the homedir at import time.
-    # Without $HOME being writable, `pythonImportsCheck` fails.
-    # https://github.com/arviz-devs/arviz/commit/4db612908f588d89bb5bfb6b83a08ada3d54fd02
-    writableTmpDirAsHomeHook
   ];
 
   # The test suite is computationally intensive and test failures are not

--- a/pkgs/development/python-modules/pytensor/default.nix
+++ b/pkgs/development/python-modules/pytensor/default.nix
@@ -33,8 +33,9 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pytensor";
-  version = "2.38.3";
+  version = "3.0.2";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "pymc-devs";
@@ -43,7 +44,7 @@ buildPythonPackage (finalAttrs: {
     postFetch = ''
       sed -i 's/git_refnames = "[^"]*"/git_refnames = " (tag: ${finalAttrs.src.tag})"/' $out/pytensor/_version.py
     '';
-    hash = "sha256-+yfALDxNIjQUgzEJ3/ZtvLIGNmx6bPYRQ9zGXFbcMNM=";
+    hash = "sha256-JPBNqgNrd892aVVEVipehMjZwQ4fktf9/gM/eAohD3Y=";
   };
 
   build-system = [
@@ -84,18 +85,7 @@ buildPythonPackage (finalAttrs: {
     rm -rf pytensor
   '';
 
-  disabledTests = [
-    # TypeError: jax_funcified_fgraph() takes 2 positional arguments but 3 were given
-    "test_jax_Reshape_shape_graph_input"
-
-    # AssertionError: equal_computations failed
-    "test_infer_shape_db_handles_xtensor_lowering"
-
-    # Crashes with jax>=0.9.0
-    # in .../jax/_src/compiler.py", line 362 in backend_compile_and_load
-    "test_higher_order_derivatives"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # Numerical assertion error
     # tests.unittest_tools.WrongValue: WrongValue
     "test_op_sd"


### PR DESCRIPTION
## Things done

- **python3Packages.arviz-base: 0.8.2 -> 1.1.0**
  - Diff: https://github.com/arviz-devs/arviz-base/compare/v0.8.2...v1.1.0
  - Changelog: https://github.com/arviz-devs/arviz-base/blob/v1.1.0/CHANGELOG.md
- **python3Packages.arviz-stats: 0.8.0 -> 1.1.0**
  - Diff: https://github.com/arviz-devs/arviz-stats/compare/v0.8.0...v1.1.0
  - Changelog: https://github.com/arviz-devs/arviz-stats/blob/v1.1.0/CHANGELOG.md
- **python3Packages.arviz-plots: 0.8.0 -> 1.1.0**
  - Diff: https://github.com/arviz-devs/arviz-plots/compare/v0.8.0...v1.1.0
  - Changelog: https://github.com/arviz-devs/arviz-plots/blob/v1.1.0/CHANGELOG.md
- **python3Packages.arviz: 0.23.4 -> 1.1.0**
  - Diff: https://github.com/arviz-devs/arviz/compare/v0.23.4...v1.0.0
  - Changelog: https://github.com/arviz-devs/arviz/blob/v1.0.0/CHANGELOG.md
- **python3Packages.pytensor: 2.38.3 -> 3.0.2**
  - Diff: https://github.com/pymc-devs/pytensor/compare/rel-2.38.3...rel-3.0.2
  - Changelog: https://github.com/pymc-devs/pytensor/releases/tag/rel-3.0.2
- **python3Packages.pymc: 5.28.5 -> 6.0.0**
  - Diff: https://github.com/pymc-devs/pymc/compare/v5.28.5...v6.0.0
  - Changelog: https://github.com/pymc-devs/pymc/releases/tag/v6.0.0

cc @OmnipotentEntity

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test