### PR TITLE
magi: init at 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1621,6 +1621,12 @@
     name = "Anas Elgarhy";
     keys = [ { fingerprint = "E10B D192 9231 08C7 3C35 7EC3 83E0 3DC6 F383 4086"; } ];
   };
+  anddani = {
+    email = "andredanielsson93@gmail.com";
+    github = "anddani";
+    githubId = 12611639;
+    name = "André Danielsson";
+  };
   andehen = {
     email = "git@andehen.net";
     github = "andehen";

--- a/pkgs/by-name/ma/magi/package.nix
+++ b/pkgs/by-name/ma/magi/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   meta = {
-    description = "A keyboard-driven Git TUI based on Magit";
+    description = "Keyboard-driven Git TUI based on Magit";
     homepage = "https://github.com/anddani/magi";
     changelog = "https://github.com/anddani/magi/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;

--- a/pkgs/by-name/ma/magi/package.nix
+++ b/pkgs/by-name/ma/magi/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "anddani";
     repo = "magi";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-3hJL2ewKEH5w5G4FOvXKjo9jXGQW3rQ14cEBE9+Rtzs=";
   };
 

--- a/pkgs/by-name/ma/magi/package.nix
+++ b/pkgs/by-name/ma/magi/package.nix
@@ -10,16 +10,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "magi";
-  version = "0.1.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "anddani";
     repo = "magi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3hJL2ewKEH5w5G4FOvXKjo9jXGQW3rQ14cEBE9+Rtzs=";
+    hash = "sha256-DflZiEdwd+WcMCfiYmwt/b5gujK0I+TTsdVEv3Ll7kM=";
   };
 
-  cargoHash = "sha256-vuLXA0W5MP9hylCb6nhml6EdC8WoFhjDQHJE18F+Mfo=";
+  cargoHash = "sha256-643nTZziD7Arr2MuL06Q6ZhTOFZb4zcBY5yKz2sVW68=";
 
   nativeBuildInputs = [ pkg-config ];
   nativeCheckInputs = [ git ];

--- a/pkgs/by-name/ma/magi/package.nix
+++ b/pkgs/by-name/ma/magi/package.nix
@@ -1,0 +1,40 @@
+{
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libgit2,
+  openssl,
+  lib,
+  zlib,
+  git,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "magi";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "anddani";
+    repo = "magi";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-3hJL2ewKEH5w5G4FOvXKjo9jXGQW3rQ14cEBE9+Rtzs=";
+  };
+
+  cargoHash = "sha256-vuLXA0W5MP9hylCb6nhml6EdC8WoFhjDQHJE18F+Mfo=";
+
+  nativeBuildInputs = [ pkg-config ];
+  nativeCheckInputs = [ git ];
+  buildInputs = [
+    libgit2
+    openssl
+    zlib
+  ];
+
+  meta = {
+    description = "A keyboard-driven Git TUI based on Magit";
+    homepage = "https://github.com/anddani/magi";
+    changelog = "https://github.com/anddani/magi/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ anddani ];
+    mainProgram = "magi";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Description of changes

This PR adds a new package called `magi`.

https://github.com/anddani/magi/

 `magi` is a TUI client for git with a goal of replicating the Emacs git client called "Magit" 1:1. This application is currently in a state where the most common git operations are implemented such as stage, unstage, commit, stash, fetch, pull, push, and more. This project is continuously updated and is soon on par with Magit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
