### PR TITLE
opengamepadui: 0.44.2 -> 0.44.3

### DIFF
--- a/pkgs/by-name/op/opengamepadui/package.nix
+++ b/pkgs/by-name/op/opengamepadui/package.nix
@@ -4,7 +4,7 @@
   dbus,
   fetchFromGitHub,
   gamescope,
-  godot_4_5,
+  godot_4_6,
   hwdata,
   lib,
   libGL,
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "opengamepadui";
-  version = "0.44.2";
+  version = "0.44.3";
 
   buildType = if withDebug then "debug" else "release";
 
@@ -30,18 +30,18 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ShadowBlip";
     repo = "OpenGamepadUI";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5Ch3j9URjf9MsGeH7x5CYojnDFQeLXJqcixcGJeDvT4=";
+    hash = "sha256-pjg5zIgytS7YxNWAJg46aOYhRG88TbK1906UK5fM3pM=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src cargoRoot;
-    hash = "sha256-xewyt1KuQ96FNYBKlC9VT7KEDDTUasavTsl+/5WXnU4=";
+    hash = "sha256-ZccqPWyyhVMenF8tLXQlwC5uKg5o66E5qkeNGAbSs1w=";
   };
   cargoRoot = "extensions";
 
   nativeBuildInputs = [
     cargo
-    godot_4_5
+    godot_4_6
     pkg-config
     rustPlatform.cargoSetupHook
   ];
@@ -50,13 +50,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   env =
     let
-      versionAndRelease = lib.splitString "-" godot_4_5.version;
+      versionAndRelease = lib.splitString "-" godot_4_6.version;
     in
     {
-      GODOT = lib.getExe godot_4_5;
+      GODOT = lib.getExe godot_4_6;
       GODOT_VERSION = lib.elemAt versionAndRelease 0;
       GODOT_RELEASE = lib.elemAt versionAndRelease 1;
-      EXPORT_TEMPLATE = "${godot_4_5.export-template}/share/godot/export_templates";
+      EXPORT_TEMPLATE = "${godot_4_6.export-template}/share/godot/export_templates";
       BUILD_TYPE = "${finalAttrs.buildType}";
     };
 


### PR DESCRIPTION
Update OpenGamepadUI to v0.44.3. This version requires Godot 4.6 to build. Changelog here:
https://github.com/ShadowBlip/OpenGamepadUI/releases/tag/v0.44.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
