### PR TITLE
python3Packages.textstat: 0.7.12 -> 0.7.13

### DIFF
--- a/pkgs/development/python-modules/textstat/default.nix
+++ b/pkgs/development/python-modules/textstat/default.nix
@@ -2,14 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  cmudict,
+  nltk,
   setuptools,
   pyphen,
   pytestCheckHook,
   pytest,
 }:
 buildPythonPackage rec {
-  version = "0.7.12";
+  version = "0.7.13";
   pname = "textstat";
   pyproject = true;
 
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "textstat";
     repo = "textstat";
     tag = version;
-    hash = "sha256-HOYeWpyWPLUEwnj21WfMNmIg9x+jQUtY1o+Sl5zJRq4=";
+    hash = "sha256-VMWwhwyGMFaKNLHoDG3gw1/jzSYCDBH3Yq4pE4JZTTo=";
   };
 
   build-system = [
@@ -32,7 +32,7 @@ buildPythonPackage rec {
   dependencies = [
     setuptools
     pyphen
-    cmudict
+    nltk
   ];
 
   pythonImportsCheck = [
@@ -42,6 +42,8 @@ buildPythonPackage rec {
   enabledTestPaths = [
     "tests/"
   ];
+
+  NLTK_DATA = nltk.data.cmudict;
 
   meta = {
     description = "Python package to calculate readability statistics of a text object";


### PR DESCRIPTION
Updated python3Packages.textstat and fixed it's dependencies
Fixes: https://github.com/NixOS/nixpkgs/issues/494468
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
