### PR TITLE
python3Packages.unstructured-inference: Fix build

### DIFF
--- a/pkgs/development/python-modules/unstructured-inference/default.nix
+++ b/pkgs/development/python-modules/unstructured-inference/default.nix
@@ -5,13 +5,11 @@
   setuptools,
   # runtime dependencies
   accelerate,
-  detectron2,
   huggingface-hub,
   layoutparser,
   onnx,
   onnxruntime,
   opencv-python,
-  paddleocr,
   python-multipart,
   rapidfuzz,
   transformers,
@@ -38,6 +36,11 @@ buildPythonPackage rec {
   };
 
   build-system = [ setuptools ];
+
+  pythonRelaxDeps = [
+    # Wants >= 4.13.0.90 but the latest release is 4.13.0
+    "opencv-python"
+  ];
 
   dependencies = [
     accelerate

--- a/pkgs/development/python-modules/unstructured-inference/default.nix
+++ b/pkgs/development/python-modules/unstructured-inference/default.nix
@@ -23,7 +23,7 @@
   pdf2image,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "unstructured-inference";
   version = "1.1.7";
   pyproject = true;
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Unstructured-IO";
     repo = "unstructured-inference";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-RY+acfyAGP2r8axfifQkTSkbwkrZ0u6KvFwds24IkMc=";
   };
 
@@ -101,7 +101,7 @@ buildPythonPackage rec {
   meta = {
     description = "Hosted model inference code for layout parsing models";
     homepage = "https://github.com/Unstructured-IO/unstructured-inference";
-    changelog = "https://github.com/Unstructured-IO/unstructured-inference/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/Unstructured-IO/unstructured-inference/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ happysalada ];
     platforms = [
@@ -110,4 +110,4 @@ buildPythonPackage rec {
       "aarch64-darwin"
     ];
   };
-}
+})


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/323074015

1. Relax dependency based on build numbers, not release number
2. Migrate to finalAttrs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
