### PR TITLE
cm_unicode: use installFonts

### DIFF
--- a/pkgs/by-name/cm/cm_unicode/package.nix
+++ b/pkgs/by-name/cm/cm_unicode/package.nix
@@ -5,12 +5,12 @@
   installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "cm-unicode";
   version = "0.7.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/cm-unicode/cm-unicode/${version}/${pname}-${version}-otf.tar.xz";
+    url = "mirror://sourceforge/cm-unicode/cm-unicode/${finalAttrs.version}/cm-unicode-${finalAttrs.version}-otf.tar.xz";
     hash = "sha256-VIp+vk1IYbEHW15wMrfGVOPqg1zBZDpgFx+jlypOHCg=";
   };
 
@@ -19,7 +19,7 @@ stdenvNoCC.mkDerivation rec {
   InstallPhase = ''
     runHook preInstall
 
-    install -m444 -Dt $out/share/doc/${pname}-${version}    README FontLog.txt
+    install -m444 -Dt $out/share/doc/$cm-unicode-${finalAttrs.version}    README FontLog.txt
 
     runHook postInstall
   '';
@@ -34,4 +34,4 @@ stdenvNoCC.mkDerivation rec {
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/cm/cm_unicode/package.nix
+++ b/pkgs/by-name/cm/cm_unicode/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchurl,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -13,10 +14,11 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-VIp+vk1IYbEHW15wMrfGVOPqg1zBZDpgFx+jlypOHCg=";
   };
 
-  installPhase = ''
+  nativeBuildInputs = [ installFonts ];
+
+  InstallPhase = ''
     runHook preInstall
 
-    install -m444 -Dt $out/share/fonts/opentype *.otf
     install -m444 -Dt $out/share/doc/${pname}-${version}    README FontLog.txt
 
     runHook postInstall


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/495640

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
