### PR TITLE
python3Packages.behave: disable broken feature test

### DIFF
--- a/pkgs/development/python-modules/behave/default.nix
+++ b/pkgs/development/python-modules/behave/default.nix
@@ -67,8 +67,11 @@ buildPythonPackage rec {
     "test_step_decorator_async_run_until_complete"
   ];
 
+  # -e disables tags.help.feature from being executed (due to stdout formatting differences)
   postCheck = ''
-    ${python.interpreter} bin/behave -f progress3 --stop --tags='~@xfail' features/
+    ${python.interpreter} bin/behave -f progress3 --stop --tags='~@xfail' \
+      -e tags.help.feature \
+      features/
     ${python.interpreter} bin/behave -f progress3 --stop --tags='~@xfail' tools/test-features/
     ${python.interpreter} bin/behave -f progress3 --stop --tags='~@xfail' issue.features/
   '';


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/323046312

`features/tags.help.feature` fails due to a formatting change in stdout. Disabled.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
