### PR TITLE
lanzaboote-{tool,uefi-stub}: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26880,6 +26880,11 @@
     github = "thiloho";
     githubId = 123883702;
   };
+  ThinkChaos = {
+    name = "ThinkChaos";
+    github = "ThinkChaos";
+    githubId = 4761135;
+  };
   thled = {
     name = "Thomas Le Duc";
     email = "dev@tleduc.de";

--- a/pkgs/by-name/la/lanzaboote-tool/package.nix
+++ b/pkgs/by-name/la/lanzaboote-tool/package.nix
@@ -1,0 +1,68 @@
+{
+  fetchFromGitHub,
+  binutils-unwrapped,
+  lib,
+  makeBinaryWrapper,
+  nix-update-script,
+  pkgsCross,
+  rustPlatform,
+  sbsigntool,
+  stdenv,
+  systemd,
+}:
+
+let
+  stub = pkgsCross."${stdenv.hostPlatform.qemuArch}-unknown-uefi".lanzaboote-uefi-stub;
+
+  runtimeDeps = [
+    binutils-unwrapped
+    sbsigntool
+  ];
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "lanzaboote-tool";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "lanzaboote";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RJmgVDzjRI18BWVogG6wpsl1UCuV6ui8qr4DJ1LfWZ8=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/rust/tool";
+  cargoHash = "sha256-Z2N4JSEzZ+J5itYPVYgvmZygfp41xIE8e1qEBt/SXfM=";
+
+  env.TEST_SYSTEMD = systemd;
+  doCheck = lib.meta.availableOn stdenv.hostPlatform systemd;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  postInstall = ''
+    # Clean PATH to only contain what we need to do objcopy
+    makeWrapper $out/bin/lzbt-systemd $out/bin/lzbt \
+      --set PATH ${lib.makeBinPath runtimeDeps} \
+      --set LANZABOOTE_STUB ${lib.getExe stub}
+  '';
+
+  nativeCheckInputs = runtimeDeps;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Lanzaboote UEFI tooling for SecureBoot enablement on NixOS systems";
+    homepage = "https://github.com/nix-community/lanzaboote";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "lzbt";
+    maintainers = with lib.maintainers; [
+      raitobezarius
+      ThinkChaos
+    ];
+    # Others might work but are untested ATM
+    platforms = [
+      "x86_64-linux"
+    ];
+  };
+})

--- a/pkgs/by-name/la/lanzaboote-uefi-stub/package.nix
+++ b/pkgs/by-name/la/lanzaboote-uefi-stub/package.nix
@@ -1,0 +1,48 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "lanzaboote-uefi-stub";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "lanzaboote";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RJmgVDzjRI18BWVogG6wpsl1UCuV6ui8qr4DJ1LfWZ8=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/rust/uefi";
+  cargoHash = "sha256-DQ8vnw81fW+uK1va53XTNvhoHBJv07JURumCvGGeBzQ=";
+
+  # Necessary because our `cc-wrapper` doesn't understand MSVC link options.
+  # -flavor link which will break the whole command-line processing for the ld.lld linker.
+  RUSTFLAGS = "-C linker=${stdenv.cc.bintools}/bin/${stdenv.cc.targetPrefix}ld.lld -C linker-flavor=lld-link";
+  # Does not support MSVC style options yet (?).
+  auditable = false;
+  hardeningDisable = [
+    "relro"
+    "bindnow"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Lanzaboote UEFI stub for SecureBoot enablement on NixOS systems";
+    homepage = "https://github.com/nix-community/lanzaboote";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "lanzaboote_stub.efi";
+    maintainers = with lib.maintainers; [
+      raitobezarius
+      ThinkChaos
+    ];
+    platforms = [
+      "x86_64-uefi"
+    ];
+  };
+})

--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -78,7 +78,8 @@ rec {
     passthru = rec {
       targetPlatformsWithHostTools = [
         # Platforms with host tools from
-        # https://doc.rust-lang.org/nightly/rustc/platform-support.html
+        # https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-1-with-host-tools
+        # https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-2-with-host-tools
         "x86_64-darwin"
         "aarch64-darwin"
         "i686-freebsd"
@@ -107,7 +108,7 @@ rec {
       ];
       targetPlatforms = targetPlatformsWithHostTools ++ [
         # Platforms without host tools from
-        # https://doc.rust-lang.org/nightly/rustc/platform-support.html
+        # https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-2-without-host-tools
         "armv5tel-linux"
         "armv7a-linux"
         "m68k-linux"
@@ -121,6 +122,7 @@ rec {
         "riscv64-netbsd"
         "x86_64-redox"
         "wasm32-wasi"
+        "x86_64-uefi"
       ];
       badTargetPlatforms = [
         # Rust is currently unable to target the n32 ABI

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -996,7 +996,6 @@ mapAliases {
   languageMachines.timblserver = timblserver; # Added 2025-10-7
   languageMachines.ucto = ucto; # Added 2025-10-7
   languageMachines.uctodata = uctodata; # Added 2025-10-7
-  lanzaboote-tool = throw "lanzaboote-tool has been removed due to lack of integration maintenance with nixpkgs. Consider using the Nix expressions provided by https://github.com/nix-community/lanzaboote"; # Added 2025-07-23
   larynx = throw "'larynx' has been renamed to/replaced by 'piper-tts'"; # Converted to throw 2025-10-27
   lash = throw "'lash' has been removed, as it is unmaintained upstream"; # Added 2026-01-02
   LAStools = lastools; # Added 2026-02-08


### PR DESCRIPTION
Now that we have UEFI platform support via https://github.com/NixOS/nixpkgs/pull/477645, we can build the Lanzaboote CLI (previously [packaged](https://github.com/NixOS/nixpkgs/pull/263712) and [removed](https://github.com/NixOS/nixpkgs/pull/427792)) and UEFI stub ([PR'ed but never merged](https://github.com/NixOS/nixpkgs/pull/231951)).
I've only included x86_64 support because that's what I've built and tested.

I also applied the changes proposed by https://github.com/NixOS/nixpkgs/pull/368246

Since these were packaged/proposed, pinging previous maintainers: @blitz @nikstur @raitobezarius.
Let me know if you'd like to be added as maintainers.

Supersedes: https://github.com/NixOS/nixpkgs/pull/353052 (@baloo).

Thank you to everyone who has worked on this before me. I definitely couldn't have gotten UEFI to build without all your work!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
