### PR TITLE
tclPackages.gtkttk: init at 0.9

### DIFF
--- a/pkgs/development/tcl-modules/by-name/gt/gtkttk/package.nix
+++ b/pkgs/development/tcl-modules/by-name/gt/gtkttk/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  mkTclDerivation,
+  tk,
+  gtk2,
+  gtk_engines,
+  gdk-pixbuf-xlib,
+  nix-update-script,
+}:
+mkTclDerivation rec {
+  pname = "gtkttk";
+  version = "0.9";
+
+  src = fetchFromGitHub {
+    owner = "Geballin";
+    repo = "gtkTtk";
+    tag = version;
+    hash = "sha256-gSqd9FatF4q06r5TrhSGVJ+vh0ybNv8/9AP68v7pW1E=";
+  };
+
+  # Tk's private headers are required but Tk's src is a tarball, so it needs to be unpacked
+  postUnpack = ''
+    unpackFile "${tk.src}"
+  '';
+
+  # Do not load GTK dynamically because it relies on hard-coded paths for library directories
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'SET ( LOAD_GTK_DYNAMICALLY ON )' 'SET ( LOAD_GTK_DYNAMICALLY OFF )'
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
+  ];
+  preBuild = ''
+    NIX_CFLAGS_COMPILE+=" \
+    -I${gdk-pixbuf-xlib.dev}/include/gdk-pixbuf-2.0 \
+    -I$NIX_BUILD_TOP/tk${tk.version}/generic/ttk" \
+  '';
+
+  buildInputs = [
+    cmake
+    pkg-config
+    tk
+    gtk2
+    gtk_engines
+    gdk-pixbuf-xlib
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/Geballin/gtkTtk";
+    description = "TTK theme that gives Tk applications a native GTK look and feel";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ anomalocaris ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [gtkTtk](https://github.com/Geballin/gtkTtk), a Tk theme that uses the currently set GTK2 theme to give Tk applications a native look and feel.

It's technically a library, but it can be used without programs explicitly depending on it by adding its directory to `$TCLLIBPATH` and adding `*TkTheme: gtkTtk` to `~/.Xresources` or `~/.Xdefaults`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
