### PR TITLE
gwe: migrate to by-name, modernize derivation

### DIFF
--- a/pkgs/by-name/gw/gwe/package.nix
+++ b/pkgs/by-name/gw/gwe/package.nix
@@ -14,7 +14,7 @@
   libdazzle,
   libappindicator-gtk3,
   libnotify,
-  nvidia_x11,
+  linuxPackages,
 }:
 
 let
@@ -34,15 +34,16 @@ let
       setuptools
     ]
   );
+  nvidia_x11 = linuxPackages.nvidia_x11;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gwe";
   version = "0.15.9";
 
   src = fetchFromGitLab {
     owner = "leinardi";
-    repo = pname;
-    rev = version;
+    repo = "gwe";
+    tag = finalAttrs.version;
     hash = "sha256-agq967QN1nsAOn+1Ce64+id7UlSS/K3XGsUUihWOztk=";
   };
 
@@ -100,4 +101,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     mainProgram = "gwe";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4313,10 +4313,6 @@ with pkgs;
 
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix { });
 
-  gwe = callPackage ../tools/misc/gwe {
-    nvidia_x11 = linuxPackages.nvidia_x11;
-  };
-
   gwt240 = callPackage ../development/compilers/gwt/2.4.0.nix { };
 
   idrisPackages = recurseIntoAttrs (


### PR DESCRIPTION
This pull request refactors the packaging of the `gwe` application to follow the new directory structure and simplifies how its dependencies are handled. The main changes involve moving the package definition, updating how the NVIDIA driver is referenced, and cleaning up the top-level package list.

**Package structure and dependency management:**

* Moved the `gwe` package from `pkgs/tools/misc/gwe/default.nix` to the new location `pkgs/by-name/gw/gwe/package.nix`, aligning with the updated package organization.
* Updated the NVIDIA driver reference: now uses `linuxPackages.nvidia_x11` within the package definition instead of requiring it to be passed in externally.

**Top-level package list cleanup:**

* Removed the old `gwe` entry from `pkgs/top-level/all-packages.nix` since the new structure no longer requires it to be listed this way.

**Build system modernization:**

* Updated the derivation definition to use the `finalAttrs` argument style for improved maintainability and consistency with modern Nix packaging practices.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
