### PR TITLE
wacli: init at 0.6.0

### DIFF
--- a/pkgs/by-name/wa/wacli/package.nix
+++ b/pkgs/by-name/wa/wacli/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "wacli";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "steipete";
+    repo = "wacli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tJ5d33VVW5aYvacHJEVm8cVKVtpdWCIOdHNy2WTR4Cg=";
+  };
+
+  vendorHash = "sha256-0mHZjZHQBHTlPzVT4ScyRBSaQ4Z8FEm2GFfsPF6Tjrw=";
+
+  # Enables SQLite FTS5 (full-text search) in mattn/go-sqlite3 for message history search
+  tags = [ "sqlite_fts5" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  subPackages = [ "cmd/wacli" ];
+
+  meta = {
+    description = "WhatsApp CLI built on whatsmeow";
+    homepage = "https://github.com/steipete/wacli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ macalinao ];
+    mainProgram = "wacli";
+  };
+})

--- a/pkgs/by-name/wa/wacli/package.nix
+++ b/pkgs/by-name/wa/wacli/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "wacli";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "steipete";
+    repo = "wacli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qEEiqX0r6iIm5STYxpaHuXdbtaQKigSGD8jLECbsW/0=";
+  };
+
+  vendorHash = "sha256-A5XDBUYHsNVnIJ5TBt8ePSY5oWlyjsYxp6u9169vy9I=";
+
+  # Enables SQLite FTS5 (full-text search) in mattn/go-sqlite3 for message history search
+  tags = [ "sqlite_fts5" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  subPackages = [ "cmd/wacli" ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "WhatsApp CLI built on whatsmeow";
+    homepage = "https://github.com/steipete/wacli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ macalinao ];
+    mainProgram = "wacli";
+  };
+})


### PR DESCRIPTION
## Description

Add [wacli](https://github.com/steipete/wacli), WhatsApp CLI built on whatsmeow.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test