### PR TITLE
ncps: disable integration tests

### DIFF
--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -6,14 +6,9 @@
   jq,
   lib,
   makeWrapper,
-  mariadb,
-  minio,
-  minio-client,
   nix-update-script,
   nixosTests,
-  postgresql,
   python3,
-  redis,
   writeShellScriptBin,
   xz,
 }:
@@ -44,16 +39,7 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [
     makeWrapper # used for wrapping the binary so it can always find the xz binary
-
-    curl # used for checking MinIO health check
     dbmate # used for testing
-    jq # used for testing by the init-minio
-    mariadb # MySQL/MariaDB for integration tests
-    minio # S3-compatible storage for integration tests
-    minio-client # mc CLI for MinIO setup
-    postgresql # PostgreSQL for integration tests
-    python3 # used for generating the ports
-    redis # Redis for distributed locking integration tests
   ];
 
   postInstall = ''
@@ -77,23 +63,6 @@ buildGoModule (finalAttrs: {
   doCheck = true;
 
   checkFlags = [ "-race" ];
-
-  # pre and post checks
-  preCheck = ''
-    # Set up cleanup trap to ensure background processes are killed even if tests fail
-    cleanup() {
-      source $src/nix/packages/ncps/post-check-minio.sh
-      source $src/nix/packages/ncps/post-check-mysql.sh
-      source $src/nix/packages/ncps/post-check-postgres.sh
-      source $src/nix/packages/ncps/post-check-redis.sh
-    }
-    trap cleanup EXIT
-
-    source $src/nix/packages/ncps/pre-check-minio.sh
-    source $src/nix/packages/ncps/pre-check-mysql.sh
-    source $src/nix/packages/ncps/pre-check-postgres.sh
-    source $src/nix/packages/ncps/pre-check-redis.sh
-  '';
 
   passthru = {
     dbmate-wrapper = buildGoModule {


### PR DESCRIPTION
The integration tests, albeit quite useful, can be flaky on slow and/or busy systems (since they rely on wall clock to pass). For that reason, I will disable them in nixpkgs and leave upstream to deal with testing it.

fixes #495327

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
