### PR TITLE
httm: clean up optional scripts

### DIFF
--- a/pkgs/by-name/ht/httm/package.nix
+++ b/pkgs/by-name/ht/httm/package.nix
@@ -28,9 +28,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     installManPage httm.1
 
-    installShellCompletion --cmd httm \
-      --zsh scripts/httm-key-bindings.zsh
-
     for script in scripts/*.bash; do
       install -Dm755 "$script" "$out/bin/$(basename "$script" .bash)"
     done

--- a/pkgs/by-name/ht/httm/package.nix
+++ b/pkgs/by-name/ht/httm/package.nix
@@ -28,8 +28,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     installManPage httm.1
 
-    for script in scripts/*.bash; do
-      install -Dm755 "$script" "$out/bin/$(basename "$script" .bash)"
+    for script in bowie equine nicotine ounce; do
+      install -Dm755 "scripts/$script.bash" "$out/bin/$script"
     done
 
     install -Dm644 README.md $out/share/doc/README.md


### PR DESCRIPTION
## Summary

- ZSH key binding script should not be installed as shell completion. It's now removed. It can be generated at runtime using `httm --install-zsh-hot-keys` command.
- Only install recommended optional bash scripts, according to https://github.com/kimono-koans/httm#install-via-source.

> [!NOTE]
> The package contains `nicotine` script, which conflicts with the main binary provided by [nicotine-plus](https://search.nixos.org/packages?channel=unstable&query=nicotine&show=nicotine-plus) package. I don't know what we should do to resolve this though. I don't mind keeping the scripts' `.bash` extension in the output.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
