### PR TITLE
ant: revert "use upstream launcher script"

### DIFF
--- a/pkgs/by-name/an/ant/package.nix
+++ b/pkgs/by-name/an/ant/package.nix
@@ -2,7 +2,7 @@
   fetchurl,
   lib,
   stdenv,
-  jre,
+  coreutils,
   makeWrapper,
   gitUpdater,
 }:
@@ -10,8 +10,6 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "ant";
   version = "1.10.15";
-
-  buildInputs = [ jre ];
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -21,23 +19,60 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   installPhase = ''
-    mkdir -p $out/share/ant
+    mkdir -p $out/bin $out/share/ant
     mv * $out/share/ant/
 
     # Get rid of the manual (35 MiB).  Maybe we should put this in a
-    # separate output.
-    rm -rf $out/share/ant/{manual,WHATSNEW}
+    # separate output.  Keep the antRun script since it's vanilla sh
+    # and needed for the <exec/> task (but since we set ANT_HOME to
+    # a weird value, we have to move antRun to a weird location).
+    # Get rid of the other Ant scripts since we provide our own.
+    mv $out/share/ant/bin/antRun $out/bin/
+    rm -rf $out/share/ant/{manual,bin,WHATSNEW}
+    mkdir $out/share/ant/bin
+    mv $out/bin/antRun $out/share/ant/bin/
 
-    # Link Ant's special $ANT_HOME/bin to the standard /bin location
-    ln -s $out/share/ant/bin $out
+    cat >> $out/bin/ant <<EOF
+    #! ${stdenv.shell} -e
 
-    # Wrap the wrappers.
-    for wrapper in ant runant.py runant.pl; do
-      wrapProgram "$out/share/ant/bin/$wrapper" \
-        --set-default JAVA_HOME "${jre.home}" \
-        --set-default ANT_HOME "$out/share/ant" \
-        --prefix CLASSPATH : "$out/share/ant/lib"
-    done
+    ANT_HOME=$out/share/ant
+
+    # Find the JDK by looking for javac.  As a fall-back, find the
+    # JRE by looking for java.  The latter allows just the JRE to be
+    # used with (say) ECJ as the compiler.  Finally, allow the GNU
+    # JVM.
+    if [ -z "\''${JAVA_HOME-}" ]; then
+        for i in javac java gij; do
+            if p="\$(type -p \$i)"; then
+                export JAVA_HOME="\$(${coreutils}/bin/dirname \$(${coreutils}/bin/dirname \$(${coreutils}/bin/readlink -f \$p)))"
+                break
+            fi
+        done
+        if [ -z "\''${JAVA_HOME-}" ]; then
+            echo "\$0: cannot find the JDK or JRE" >&2
+            exit 1
+        fi
+    fi
+
+    if [ -z \$NIX_JVM ]; then
+        if [ -e \$JAVA_HOME/bin/java ]; then
+            NIX_JVM=\$JAVA_HOME/bin/java
+        elif [ -e \$JAVA_HOME/bin/gij ]; then
+            NIX_JVM=\$JAVA_HOME/bin/gij
+        else
+            NIX_JVM=java
+        fi
+    fi
+
+    LOCALCLASSPATH="\$ANT_HOME/lib/ant-launcher.jar\''${LOCALCLASSPATH:+:}\$LOCALCLASSPATH"
+
+    exec \$NIX_JVM \$NIX_ANT_OPTS \$ANT_OPTS -classpath "\$LOCALCLASSPATH" \
+        -Dant.home=\$ANT_HOME -Dant.library.dir="\$ANT_LIB" \
+        org.apache.tools.ant.launch.Launcher \$NIX_ANT_ARGS \$ANT_ARGS \
+        -cp "\$CLASSPATH" "\$@"
+    EOF
+
+    chmod +x $out/bin/ant
   '';
 
   passthru = {


### PR DESCRIPTION
This reverts commit d6c13b5cf4751b57c09d2fe0aa4f96ea905e09c7.

Fixes: #495521
Reopens: #4105
Reverts: #364094


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
