### PR TITLE
python313Packages.nipype: 1.10.0 -> 1.11.0

### DIFF
--- a/pkgs/development/python-modules/etelemetry/default.nix
+++ b/pkgs/development/python-modules/etelemetry/default.nix
@@ -21,9 +21,15 @@ buildPythonPackage rec {
     hash = "sha256-UaE5JQhv2AtzXKY7YD2/g6Kj1igKhmnY3zlf1P9B/iQ=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  postPatch = ''
+    substituteInPlace setup.py --replace-fail "versioneer.get_version()" "'${version}'"
+  '';
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     ci-info
     ci-py
     requests

--- a/pkgs/development/python-modules/nipype/default.nix
+++ b/pkgs/development/python-modules/nipype/default.nix
@@ -3,95 +3,120 @@
   stdenv,
   buildPythonPackage,
   fetchPypi,
+
+  # build-system
+  hatchling,
+  hatch-vcs,
+
   # python dependencies
+  acres,
   click,
   python-dateutil,
   etelemetry,
   filelock,
   looseversion,
-  mock,
+  lxml,
   networkx,
   nibabel,
   numpy,
   packaging,
   prov,
-  psutil,
   puremagic,
   pybids,
   pydot,
-  pytest,
+  pytestCheckHook,
   pytest-xdist,
-  pytest-forked,
+  pytest-cov-stub,
   rdflib,
   scipy,
   simplejson,
   traits,
+
+  # optional-dependencies
+  datalad,
+  duecredit,
+  pandas,
+  paramiko,
+  psutil,
+  sphinx,
   xvfbwrapper,
+
   # other dependencies
   which,
   bash,
   glibcLocales,
-  # causes Python packaging conflict with any package requiring rdflib,
-  # so use the unpatched rdflib by default (disables Nipype provenance tracking);
-  # see https://github.com/nipy/nipype/issues/2888:
-  useNeurdflib ? false,
 }:
 
 buildPythonPackage rec {
   pname = "nipype";
-  version = "1.10.0";
-  format = "setuptools";
+  version = "1.11.0";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-GeXWzvpwmXGY94vGZe9NPTy1MyW1uYpy5Rrvra9rPg4=";
+    hash = "sha256-ZwfsTDz44Zg673+O6nlifue3q0qklkmZFVDhKcFlt6c=";
   };
 
   postPatch = ''
     substituteInPlace nipype/interfaces/base/tests/test_core.py \
       --replace-fail "/usr/bin/env bash" "${bash}/bin/bash"
+    substituteInPlace nipype/pipeline/engine/tests/test_nodes.py \
+      --replace-fail "/bin/bash" "${bash}/bin/bash"
   '';
 
-  pythonRelaxDeps = [ "traits" ];
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
 
   dependencies = [
+    acres
     click
-    python-dateutil
     etelemetry
     filelock
     looseversion
+    lxml
     networkx
     nibabel
     numpy
     packaging
     prov
-    psutil
     puremagic
     pydot
+    python-dateutil
     rdflib
     scipy
     simplejson
     traits
-    xvfbwrapper
   ];
 
+  passthru.optional-dependencies = {
+    data = [ datalad ];
+    duecredit = [ duecredit ];
+    profiler = [ psutil ];
+    pybids = [ pybids ];
+    ssh = [ paramiko ];
+    xvfbwrapper = [ xvfbwrapper ];
+  };
+
   nativeCheckInputs = [
-    pybids
     glibcLocales
-    mock
-    pytest
-    pytest-forked
+    pandas
+    pytestCheckHook
+    pytest-cov-stub
     pytest-xdist
+    sphinx
     which
   ];
 
   # checks on darwin inspect memory which doesn't work in build environment
   doCheck = !stdenv.hostPlatform.isDarwin;
-  # ignore tests which incorrect fail to detect xvfb
-  checkPhase = ''
-    pytest nipype/tests -k 'not display and not test_no_et_multiproc'
-  '';
-  pythonImportsCheck = [ "nipype" ];
+
+  pythonImportsCheck = [
+    "nipype"
+    "nipype.algorithms"
+    "nipype.interfaces"
+  ];
 
   meta = {
     homepage = "https://nipy.org/nipype";


### PR DESCRIPTION
python313Packages.etelemetry: correctly set version in .dist-info file

Routine update/refactoring.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
