### PR TITLE
awakened-poe-trade: add commandLineArgs

### DIFF
--- a/pkgs/by-name/aw/awakened-poe-trade/package.nix
+++ b/pkgs/by-name/aw/awakened-poe-trade/package.nix
@@ -9,6 +9,7 @@
   libxt,
 
   nix-update-script,
+  commandLineArgs ? [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -43,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp -a ${finalAttrs.passthru.appImageContents}/usr/share/icons $out/share
 
     substituteInPlace $out/share/applications/awakened-poe-trade.desktop \
-      --replace-fail 'Exec=AppRun' 'Exec=awakened-poe-trade'
+      --replace-fail 'Exec=AppRun' 'Exec=awakened-poe-trade ${lib.escapeShellArgs commandLineArgs}'
 
     runHook postInstall
   '';
@@ -51,6 +52,9 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     makeWrapper ${lib.getExe electron} $out/bin/awakened-poe-trade \
       --add-flags $out/share/awakened-poe-trade/resources/app.asar \
+      ${
+        lib.optionalString (commandLineArgs != [ ]) "--add-flags ${lib.escapeShellArgs commandLineArgs}"
+      } \
       --prefix LD_LIBRARY_PATH : "${
         lib.makeLibraryPath [
           libxtst


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added a commandLineArgs argument to be able to launch the program with additional arguments.

As per the discussion in the pinned issue: https://github.com/SnosMe/awakened-poe-trade/issues/1647, I am unable to use the program without `--ozone-platform=x11`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
