### PR TITLE
nextflow: fix NXF_OPTS wrapper to expand $USER at runtime

### DIFF
--- a/pkgs/by-name/ne/nextflow/package.nix
+++ b/pkgs/by-name/ne/nextflow/package.nix
@@ -84,6 +84,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  # --run is used instead of --set to avoid makeWrapper's single-quote escaping,
+  # which prevents $USER from expanding at runtime. See #192396
   postFixup = ''
     wrapProgram $out/bin/nextflow \
       --prefix PATH : ${
@@ -96,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
         ]
       } \
       --set JAVA_HOME ${openjdk.home} \
-      --set NXF_OPTS "-Duser.name=\''${USER}"
+      --run 'export NXF_OPTS="-Duser.name=''$USER''${NXF_OPTS:+ ''$NXF_OPTS}"'
   '';
 
   passthru.tests.default = nixosTests.nextflow;


### PR DESCRIPTION
Fix #491970
Related: #192396

The current wrapper uses `makeWrapper --set NXF_OPTS` to pass `-Duser.name` to the JVM.
However, `--set` internally applies `${value@Q}` quoting, which single-quotes the value
and prevents `$USER` from expanding at runtime:

```bash
# current wrapper output (upstream master)
export NXF_OPTS='-Duser.name=${USER}'

JVM receives the literal string ${USER} as user.name, which breaks any functionality
relying on System.getProperty("user.name") (e.g. job submission on HPC schedulers).

This PR replaces --set NXF_OPTS with --run 'export NXF_OPTS=...' so that $USER
expands at runtime. It also preserves any user-defined NXF_OPTS:

# patched wrapper output
export NXF_OPTS="-Duser.name=$USER${NXF_OPTS:+ $NXF_OPTS}"
```

cc @apraga @rollf

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
