### PR TITLE
stdenv: Fix handleEvalIssue for error problems

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -662,7 +662,13 @@ let
               "Refusing to evaluate package '${getNameWithVersion attrs}' in ${pos_str meta} because it ${error.msg}"
               + lib.optionalString (!inHydra && error.remediation != "") "\n${error.remediation}";
           in
-          if config ? handleEvalIssue then config.handleEvalIssue error.reason msg else throw msg;
+          if config ? handleEvalIssue then
+            if error.reason == "problem" then
+              error.handleProblem config.handleEvalIssue
+            else
+              config.handleEvalIssue error.reason msg
+          else
+            throw msg;
 
       giveWarning =
         acc: warning:

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -485,6 +485,11 @@ rec {
           null
         else
           {
+            reason = "problem";
+            # Only there for PR CI evaluation
+            handleProblem =
+              handleEvalIssue:
+              lib.foldl' (result: problem: handleEvalIssue problem.kind (fullMessage problem)) true errorProblems;
             msg = ''
               has problems:
               ${concatMapStringsSep "\n" (x: "- ${fullMessage x}") errorProblems}

--- a/pkgs/test/problems/cases/handleEvalIssue/default.nix
+++ b/pkgs/test/problems/cases/handleEvalIssue/default.nix
@@ -1,0 +1,30 @@
+{
+  nixpkgs ? ../../../../..,
+}:
+let
+  pkgs = import nixpkgs {
+    system = "x86_64-linux";
+    overlays = [ ];
+    config = {
+      checkMeta = true;
+      handleEvalIssue = reason: errormsg: builtins.trace "reason: ${reason}, errormsg: ${errormsg}" true;
+      problems.matchers = [
+        {
+          kind = "deprecated";
+          handler = "error";
+        }
+        {
+          kind = "removal";
+          handler = "error";
+        }
+      ];
+    };
+  };
+in
+pkgs.stdenvNoCC.mkDerivation {
+  pname = "a";
+  version = "0";
+  meta.description = "Some package";
+  meta.problems.removal.message = "To be removed.";
+  meta.problems.deprecated.message = "To be deprecated.";
+}

--- a/pkgs/test/problems/cases/handleEvalIssue/expected-stderr
+++ b/pkgs/test/problems/cases/handleEvalIssue/expected-stderr
@@ -1,0 +1,3 @@
+trace: reason: deprecated, errormsg: deprecated: To be deprecated.
+trace: reason: removal, errormsg: removal: To be removed.
+warning: you did not specify '--add-root'; the result might be removed by the garbage collector


### PR DESCRIPTION
This was an oversight in https://github.com/NixOS/nixpkgs/pull/478539 that became apparent in https://github.com/NixOS/nixpkgs/pull/494416:

If there's a failing problem in Nixpkgs packages, CI will call handleEvalIssue on it, but the problem error was missing a `.reason`.

Though even if it did have a reason, we need to do more to make sure we don't break any code that uses it, so the new code uses the problem kind as the reason, which happens to match with the reason for all expected problem kinds.

## Things done

- [x] Wrote a test