### PR TITLE
xdg-user-dirs: split outputs

### DIFF
--- a/pkgs/by-name/xd/xdg-user-dirs-gtk/package.nix
+++ b/pkgs/by-name/xd/xdg-user-dirs-gtk/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Fetch “xdg-user-dirs” translations from correct localedir.
     substituteInPlace update.c --replace-fail \
       'bindtextdomain ("xdg-user-dirs", GLIBLOCALEDIR);' \
-      'bindtextdomain ("xdg-user-dirs", "${xdg-user-dirs}/share/locale");'
+      'bindtextdomain ("xdg-user-dirs", "${lib.getLib xdg-user-dirs}/share/locale");'
 
     patchShebangs meson_custom_install_desktop_file.sh
   '';

--- a/pkgs/by-name/xd/xdg-user-dirs/package.nix
+++ b/pkgs/by-name/xd/xdg-user-dirs/package.nix
@@ -22,6 +22,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-6S3rkpwQ1LKTKTl6+KJYUQEkf35hd6xvHSjoITDtjBk=";
   };
 
+  outputs = [
+    "out"
+    "lib"
+    "man"
+  ];
+
   nativeBuildInputs = [
     meson
     ninja


### PR DESCRIPTION
This change is required to fix locales, as without the `lib` output `localedir` is set to `share/locale`, causing xdg-user-dirs to fall back to searching for locales in `$XDG_DATA_DIRS`, unsuccessfully.

Before:
```
$ strings result/bin/.xdg-user-dirs-update-wrapped | grep share
share/locale
```

After:
```
$ strings result/bin/.xdg-user-dirs-update-wrapped | grep share
/nix/store/9m66155g6hpnnhn7mz5ac70qbdspkjfl-xdg-user-dirs-0.19-lib/share/locale
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
