### PR TITLE
cinny-unwrapped: fix cross compile

### DIFF
--- a/pkgs/by-name/ci/cinny-unwrapped/package.nix
+++ b/pkgs/by-name/ci/cinny-unwrapped/package.nix
@@ -2,13 +2,7 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  giflib,
-  python3,
-  pkg-config,
-  pixman,
   nodejs_22,
-  cairo,
-  pango,
   stdenv,
 }:
 
@@ -29,17 +23,10 @@ buildNpmPackage rec {
 
   npmDepsHash = "sha256-2Lrd0jAwAH6HkwLHyivqwaEhcpFAIALuno+MchSIfxo=";
 
-  nativeBuildInputs = [
-    python3
-    pkg-config
+  # Skip rebuilding native modules since they're not needed for the web app
+  npmRebuildFlags = [
+    "--ignore-scripts"
   ];
-
-  buildInputs = [
-    pixman
-    cairo
-    pango
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ giflib ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Things done

Fix cinny cross compile `nix build .#pkgsCross.aarch64-multiplatform.cinny`

<details>

<summary>Cross Compile logs</summary>

```bash
nix build .#pkgsCross.aarch64-multiplatform.cinny
```
```log
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/xk2xlchx4xrw7qfslh2n9xjb95ddy567-source
source root is source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Executing npmConfigHook
Configuring npm
Validating consistency between /build/source/package-lock.json and /nix/store/vrrympf2az0mryg3v14vnrbyldzf24h7-cinny-unwrapped-4.10.5-npm-deps/package-lock.json
Setting npm_config_cache to /nix/store/vrrympf2az0mryg3v14vnrbyldzf24h7-cinny-unwrapped-4.10.5-npm-deps
Installing dependencies
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated npmlog@5.0.1: This package is no longer supported.
npm warn deprecated @humanwhocodes/config-array@0.11.14: Use @eslint/config-array instead
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm warn deprecated are-we-there-yet@2.0.0: This package is no longer supported.
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated @humanwhocodes/object-schema@2.0.3: Use @eslint/object-schema instead
npm warn deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
npm warn deprecated gauge@3.0.2: This package is no longer supported.
npm warn deprecated eslint@8.29.0: This version is no longer supported. Please see https://eslint.org/version-support for other options.

added 854 packages, and audited 855 packages in 5s

173 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
patching script interpreter paths in node_modules
node_modules/@babel/core/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/@babel/helper-compilation-targets/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/@babel/helper-create-class-features-plugin/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/@babel/preset-env/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/@babel/parser/bin/babel-parser.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/@mapbox/node-pre-gyp/bin/node-pre-gyp: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/eslint/bin/eslint.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/eslint-plugin-react/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/eslint-plugin-react/node_modules/resolve/bin/resolve: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/eslint-plugin-import/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/vite/node_modules/esbuild/bin/esbuild: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/vite/bin/vite.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/workbox-build/node_modules/rollup/dist/bin/rollup: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/acorn/bin/acorn: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/browser-encrypt-attachment/test/generate_test_vectors.py: interpreter directive changed from "#! /usr/bin/env python" to "/nix/store/m1fw8l8y9ycxh5dzispbb7cwl6rra14l-python3-3.13.12/bin/python"
node_modules/browserslist/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/color-support/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/cssesc/bin/cssesc: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/damerau-levenshtein/scripts/update-changelog.sh: interpreter directive changed from "#! /usr/bin/env bash" to "/nix/store/2hjsch59amjs3nbgh7ahcfzm2bfwl8zi-bash-5.3p9/bin/bash"
node_modules/direction/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/ejs/bin/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/esbuild/bin/esbuild: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/eslint-config-airbnb/whitespace-async.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/eslint-config-prettier/bin/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/jake/bin/bash_completion.sh: interpreter directive changed from "#!/bin/bash" to "/nix/store/2hjsch59amjs3nbgh7ahcfzm2bfwl8zi-bash-5.3p9/bin/bash"
node_modules/jake/bin/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/js-yaml/bin/js-yaml.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/jsesc/bin/jsesc: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/json5/lib/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/loose-envify/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/millify/bin/millify: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/mkdirp/bin/cmd.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/nan/tools/1to2.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/nanoid/bin/nanoid.cjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/nopt/bin/nopt.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/prettier/bin-prettier.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/react-i18next/.husky/pre-commit: interpreter directive changed from "#!/usr/bin/env sh" to "/nix/store/2hjsch59amjs3nbgh7ahcfzm2bfwl8zi-bash-5.3p9/bin/sh"
node_modules/resolve/bin/resolve: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/rollup/dist/bin/rollup: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/rimraf/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/sdp-transform/checker.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/terser/bin/terser: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/terser/bin/uglifyjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/typescript/bin/tsc: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/typescript/bin/tsserver: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/update-browserslist-db/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/uuid/dist/bin/uuid: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/which/bin/node-which: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/babel-plugin-polyfill-corejs2/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/eslint-config-airbnb-base/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/eslint-config-airbnb-base/whitespace-async.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/eslint-plugin-jsx-a11y/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/eslint-plugin-jsx-a11y/scripts/create-rule.js: interpreter directive changed from "#!/usr/bin/env node --harmony" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node --harmony"
node_modules/make-dir/node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/matrix-js-sdk/node_modules/uuid/dist/esm/bin/uuid: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/regjsparser/node_modules/jsesc/bin/jsesc: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/regjsparser/bin/parser: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/tsconfig-paths/node_modules/json5/lib/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
node_modules/vite-node/vite-node.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/b87dfjnjvg932xsw4mszjg4qmvrqzlqk-nodejs-22.22.0/bin/node"
rebuilt dependencies successfully
patching script interpreter paths in node_modules
Finished npmConfigHook
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing npmBuildHook

> cinny@4.10.5 build
> vite build

The CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
vite v5.4.19 building for production...
node_modules/@tanstack/react-query-devtools/build/modern/index.js (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
node_modules/@tanstack/react-query/build/modern/useBaseQuery.js (1:0): Error when using sourcemap for reporting an error: Can't resolve original location of error.
✓ 2803 modules transformed.
[vite-plugin-static-copy] Copied 6 items.
dist/assets/apple-touch-icon-57x57-GehHPDTI.png                             2.35 kB
dist/assets/apple-touch-icon-60x60-B4t-xyyL.png                             2.48 kB
dist/assets/apple-touch-icon-72x72-BiCSJ3dR.png                             2.95 kB
dist/assets/apple-touch-icon-76x76-GfaoCnSQ.png                             3.12 kB
dist/index.html                                                             3.16 kB │ gzip:   0.95 kB
dist/assets/apple-touch-icon-114x114-Co2sJwFy.png                           4.90 kB
dist/assets/apple-touch-icon-120x120-DfOfOhD3.png                           5.10 kB
dist/assets/apple-touch-icon-144x144-CshWkKF0.png                           6.08 kB
dist/assets/apple-touch-icon-152x152-BGXG6jQy.png                           6.67 kB
dist/assets/apple-touch-icon-167x167-BnbXvJbr.png                           7.33 kB
dist/assets/apple-touch-icon-180x180-Dmlg5NyV.png                           7.89 kB
dist/assets/inter-vietnamese-variable-wghtOnly-normal-CZXuW_xV.woff2        8.64 kB
dist/assets/notification-EtLMRd0T.ogg                                      11.30 kB
dist/assets/inter-greek-ext-variable-wghtOnly-normal-vpOIeGzY.woff2        11.95 kB
dist/assets/inter-cyrillic-variable-wghtOnly-normal-DHeaknKs.woff2         17.08 kB
dist/assets/inter-greek-variable-wghtOnly-normal-RGdUHdk5.woff2            22.00 kB
dist/assets/inter-cyrillic-ext-variable-wghtOnly-normal-CBYe6022.woff2     26.69 kB
dist/assets/invite-DROg5x7-.ogg                                            32.67 kB
dist/assets/favicon-5KspoOBy.ico                                           33.31 kB
dist/assets/inter-latin-variable-wghtOnly-normal-DwMxL0mc.woff2            37.92 kB
dist/assets/inter-latin-ext-variable-wghtOnly-normal-Wjt_kzju.woff2        56.97 kB
dist/assets/Twemoji.Mozilla.v15.1.0-CM1RS90w.woff2                        491.74 kB
dist/assets/Twemoji.Mozilla.v15.1.0-DHQZm25T.ttf                        1,451.58 kB
dist/assets/matrix_sdk_crypto_wasm_bg-dMeGppz-.wasm                     5,513.88 kB
dist/assets/ReactPrism-GaPGjdOJ.css                                         1.53 kB │ gzip:   0.51 kB
dist/assets/index-DOsNsGc4.css                                             80.51 kB │ gzip:  14.57 kB
dist/assets/index-B9fWrEk-.js                                               6.12 kB │ gzip:   2.26 kB │ map:    27.20 kB
dist/assets/index-Bd3n9y53.js                                             216.63 kB │ gzip:  44.15 kB │ map:   946.23 kB
dist/assets/pdf-DEau9P_n.js                                               350.40 kB │ gzip: 102.49 kB │ map:   963.73 kB
dist/assets/ReactPrism-QlQ9aMlj.js                                        574.35 kB │ gzip: 206.32 kB │ map: 1,155.21 kB
dist/assets/index-B47ftdGJ.js                                           3,689.96 kB │ gzip: 929.97 kB │ map: 1,546.08 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 23.57s

PWA v0.20.5
Building src/sw.ts service worker ("es" format)...
vite v5.4.19 building for production...
✓ 1 modules transformed.
dist/sw.mjs  1.66 kB │ gzip: 0.83 kB │ map: 7.08 kB
✓ built in 16ms
Finished npmBuildHook
Running phase: glibPreInstallPhase
@nix { "action": "setPhase", "phase": "glibPreInstallPhase" }
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/zbyw07dhhqf6kp4w7pnnnqh2ypp8dfw0-cinny-unwrapped-aarch64-unknown-linux-gnu-4.10.5
checking for references to /build/ in /nix/store/zbyw07dhhqf6kp4w7pnnnqh2ypp8dfw0-cinny-unwrapped-aarch64-unknown-linux-gnu-4.10.5...
patching script interpreter paths in /nix/store/zbyw07dhhqf6kp4w7pnnnqh2ypp8dfw0-cinny-unwrapped-aarch64-unknown-linux-gnu-4.10.5
```

</details>


- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
  - [x] aarch64-multiplatform
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
