### PR TITLE
{nss,nss_latest}: Fix baseline violation on non-ppc64le POWER

### DIFF
--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -108,6 +108,7 @@ stdenv.mkDerivation rec {
       target = getArch stdenv.hostPlatform;
       target_system = stdenv.hostPlatform.uname.system;
       host = getArch stdenv.buildPlatform;
+      targetIsPpc64le = stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian;
 
       buildFlags = [
         "-v"
@@ -126,6 +127,10 @@ stdenv.mkDerivation rec {
       ++ lib.optional stdenv.hostPlatform.isDarwin "--clang"
       ++ lib.optionals (target_system != stdenv.buildPlatform.uname.system) [
         "-DOS=${target_system}"
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isPower [
+        "-Ddisable_altivec=${if targetIsPpc64le then "0" else "1"}"
+        "-Ddisable_crypto_vsx=${if targetIsPpc64le then "0" else "1"}"
       ]
       ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
         "--disable-tests"


### PR DESCRIPTION
AltiVec was standardised in Power ISA v2.03 (POWER5+?). VSX was first standardised in Power ISA v2.06 (POWER7), and further expanded on in later versions (POWER8,9,...).

The baseline (that I aim for at least) on 32-bit POWER and 64-bit big-endian POWER is older than these ISA versions, so AltiVec and VSX support may not be present, leading to SIGILLs when using NSS. Disable usage of these extensions on those targets.

---

Fixes SIGILLs in `poppler` tests that use NSS (all signature-checking ones).

```
The following tests FAILED:
         16 - signature/valid/detached.pdf (ILLEGAL)
         17 - signature/valid/etsi.pdf (ILLEGAL)
         18 - signature/valid/sha1.pdf (ILLEGAL)
         19 - signature/valid/sha1_mixed_functions.pdf (ILLEGAL)
         20 - signature/invalid/detached_rsa_mismatch.pdf (ILLEGAL)
         21 - signature/invalid/etsi_rsa_mismatch.pdf (ILLEGAL)
         22 - signature/invalid/mismatch_detached_vs_sha1.pdf (ILLEGAL)
         23 - signature/invalid/mismatch_etsi_vs_sha1.pdf (ILLEGAL)
         24 - signature/invalid/mismatch_sha1_vs_detached.pdf (ILLEGAL)
         25 - signature/invalid/sha1_rsa_mismatch.pdf (ILLEGAL)
         26 - signature/digest_mismatch/detached_hash_mismatch.pdf (ILLEGAL)
         27 - signature/digest_mismatch/etsi_hash_mismatch.pdf (ILLEGAL)
         28 - signature/digest_mismatch/sha1_function_mismatch.pdf (ILLEGAL)
         29 - signature/digest_mismatch/sha1_hash_mismatch.pdf (ILLEGAL)
```

My hardware has early AltiVec support, so I imagine disabling VSX is primarily what does the trick here.

I checked the build log, the `-maltivec -mcrypto -mvsx` flags are now gone. I *think* I should be seeing some `-DNSS_DISABLE_ALTIVEC -DNSS_DISABLE_CRYPTO_VSX` flags instead, but I don't… Maybe I'm just missing smth though - totally unfamiliar with this `.gyp` build system…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (no rebuilds)
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
