### PR TITLE
nixos/vscode: system-wide policies option

### DIFF
--- a/nixos/modules/programs/vscode.nix
+++ b/nixos/modules/programs/vscode.nix
@@ -7,6 +7,7 @@
 
 let
   cfg = config.programs.vscode;
+  jsonFormat = pkgs.formats.json { };
 in
 {
   options.programs.vscode = {
@@ -36,6 +37,21 @@ in
       description = "List of extensions to install.";
     };
 
+    enterprisePolicies = lib.mkOption {
+      type = jsonFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "UpdateMode" = "none";
+          "TelemetryLevel" = "off";
+        }
+      '';
+      description = ''
+        System-wide policies for VSCode in `/etc/vscode/policy.json`.
+        See <https://code.visualstudio.com/docs/setup/enterprise#_centrally-manage-vs-code-settings> for more information.
+      '';
+    };
+
     finalPackage = lib.mkOption {
       type = lib.types.package;
       visible = false;
@@ -45,13 +61,19 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [
-      cfg.finalPackage
-    ];
+    environment = {
+      systemPackages = [
+        cfg.finalPackage
+      ];
 
-    environment.sessionVariables.EDITOR = lib.mkIf cfg.defaultEditor (
-      lib.mkOverride 900 cfg.finalPackage.meta.mainProgram
-    );
+      sessionVariables.EDITOR = lib.mkIf cfg.defaultEditor (
+        lib.mkOverride 900 cfg.finalPackage.meta.mainProgram
+      );
+
+      etc."vscode/policy.json" = lib.mkIf (cfg.enterprisePolicies != { }) {
+        source = jsonFormat.generate "vscode-policy.json" cfg.enterprisePolicies;
+      };
+    };
 
     programs.vscode.finalPackage = pkgs.vscode-with-extensions.override {
       vscode = cfg.package;

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -144,6 +144,7 @@ stdenv.mkDerivation (
           extraBwrapArgs = [
             "--bind-try /etc/nixos/ /etc/nixos/"
             "--ro-bind-try /etc/xdg/ /etc/xdg/"
+            "--ro-bind-try /etc/vscode/policy.json /etc/vscode/policy.json"
           ];
 
           # symlink shared assets, including icons and desktop entries


### PR DESCRIPTION
#480362 - Github had an issue resolving the conflict in the previous PR

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
