### PR TITLE
geogram: 1.9.2 -> 1.9.9

### DIFF
--- a/pkgs/by-name/ge/geogram/cmake-fix-link-libraries.patch
+++ b/pkgs/by-name/ge/geogram/cmake-fix-link-libraries.patch
@@ -1,0 +1,17 @@
+--- a/src/lib/geogram/CMakeLists.txt	1970-01-01 01:00:01.000000000 +0100
++++ b/src/lib/geogram/CMakeLists.txt	2026-03-03 10:21:32.918057952 +0100
+@@ -92,7 +92,13 @@
+   if(GEOGRAM_USE_BUILTIN_DEPS)
+       target_link_libraries(geogram pthread dl)
+   else()
+-      target_link_libraries(geogram pthread dl lua5.4 z triangle Meshb.7 rply)
++      target_link_libraries(geogram pthread dl z Meshb.7 rply)
++      if(GEOGRAM_WITH_LUA)
++         target_link_libraries(geogram lua5.4)
++      endif()
++      if(GEOGRAM_WITH_TRIANGLE)
++         target_link_libraries(geogram triangle)
++      endif()
+   endif()
+ endif()
+ endif()

--- a/pkgs/by-name/ge/geogram/package.nix
+++ b/pkgs/by-name/ge/geogram/package.nix
@@ -5,64 +5,58 @@
   cmake,
   doxygen,
   zlib,
-  python3Packages,
   nix-update-script,
-  fetchpatch2,
+  stb,
+  libmeshb,
+  rply,
 }:
-
-let
-  exploragram = fetchFromGitHub {
-    owner = "BrunoLevy";
-    repo = "exploragram";
-    rev = "3190f685653f8aa75b7c4604d008c59a999f1bb6";
-    hash = "sha256-9ePCOyQWSxu12PtHFSxfoDcvTtxvYR3T68sU3cAfZiE=";
-  };
-  testdata = fetchFromGitHub {
-    owner = "BrunoLevy";
-    repo = "geogram.data";
-    rev = "ceab6179189d23713b902b6f26ea2ff36aea1515";
-    hash = "sha256-zUmYI6+0IdDkglLzzWHS8ZKmc5O6aJ2X4IwRBouRIxI=";
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "geogram";
-  version = "1.9.2";
+  version = "1.9.9";
 
   src = fetchFromGitHub {
     owner = "BrunoLevy";
     repo = "geogram";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-v7ChuE9F/z1MD5OUMiGXZWiGqjMauIka4sNXVDe/yYU=";
+    hash = "sha256-wAq6j/HUOv6In49lJVRZ2iS6ugbtYOxHN3PwTE1HZks=";
     fetchSubmodules = true;
   };
 
   outputs = [
-    "bin"
     "lib"
     "dev"
     "doc"
     "out"
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   cmakeFlags = [
     # Triangle is unfree
-    "-DGEOGRAM_WITH_TRIANGLE=OFF"
+    (lib.cmakeBool "GEOGRAM_WITH_TRIANGLE" false)
 
     # Disable some extra features (feel free to create a PR if you need one of those)
 
     # If GEOGRAM_WITH_LEGACY_NUMERICS is enabled GeoGram will build its own version of
     # ARPACK, CBLAS, CLAPACK, LIBF2C and SUPERLU
-    "-DGEOGRAM_WITH_LEGACY_NUMERICS=OFF"
+    (lib.cmakeBool "GEOGRAM_WITH_LEGACY_NUMERICS" false)
 
     # Don't build Lua
-    "-DGEOGRAM_WITH_LUA=OFF"
+    (lib.cmakeBool "GEOGRAM_WITH_LUA" false)
 
     # Disable certain features requiring GLFW
-    "-DGEOGRAM_WITH_GRAPHICS=OFF"
+    (lib.cmakeBool "GEOGRAM_WITH_GRAPHICS" false)
+
+    # Enables a packaging mode in some places
+    (lib.cmakeBool "GEOGRAM_FOR_DEBIAN" true)
+
+    # Only build the library itself
+    (lib.cmakeBool "GEOGRAM_LIB_ONLY" true)
 
     # NOTE: Options introduced by patch (see below)
-    "-DGEOGRAM_INSTALL_CMAKE_DIR=${placeholder "dev"}/lib/cmake"
-    "-DGEOGRAM_INSTALL_PKGCONFIG_DIR=${placeholder "dev"}/lib/pkgconfig"
+    (lib.cmakeOptionType "path" "GEOGRAM_INSTALL_CMAKE_DIR" "${placeholder "dev"}/lib/cmake")
+    (lib.cmakeOptionType "path" "GEOGRAM_INSTALL_PKGCONFIG_DIR" "${placeholder "dev"}/lib/pkgconfig")
   ];
 
   nativeBuildInputs = [
@@ -72,12 +66,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     zlib
+    stb
+    libmeshb
+    rply
   ];
-
-  # exploragram library is not listed as submodule and must be copied manually
-  prePatch = ''
-    cp -r ${exploragram} ./src/lib/exploragram/ && chmod 755 ./src/lib/exploragram/
-  '';
 
   patches = [
     # This patch replaces the bundled (outdated) zlib with our zlib
@@ -85,51 +77,14 @@ stdenv.mkDerivation (finalAttrs: {
     # Also check https://github.com/BrunoLevy/geogram/issues/49 for progress
     ./replace-bundled-zlib.patch
 
-    # fixes https://github.com/BrunoLevy/geogram/issues/203, remove when 1.9.3 is released
-    (fetchpatch2 {
-      url = "https://github.com/BrunoLevy/geogram/commit/2e1b6fba499ddc55b2150a1f610cf9f8d4934c39.patch";
-      hash = "sha256-t6Pocf3VT8HpKOSh1UKKa0QHpsZyFqlAng6ltiAfKA8=";
-    })
+    ./cmake-fix-link-libraries.patch
   ];
-
-  postPatch = lib.optionalString stdenv.hostPlatform.isAarch64 ''
-    substituteInPlace cmake/platforms/*/config.cmake \
-      --replace "-m64" ""
-  '';
 
   postBuild = ''
     make doc-devkit-full
   '';
 
-  nativeCheckInputs = [
-    python3Packages.robotframework
-  ];
-
-  doCheck = true;
-
-  checkPhase =
-    let
-      skippedTests = [
-        # Skip slow RVD test
-        "RVD"
-
-        # Needs unfree library geogramplus with extended precision
-        # see https://github.com/BrunoLevy/geogram/wiki/GeogramPlus
-        "CSGplus"
-      ];
-    in
-    ''
-      runHook preCheck
-
-      ln -s ${testdata} ../tests/data
-
-      source tests/testenv.sh
-      robot \
-        ${lib.concatMapStringsSep " " (t: lib.escapeShellArg "--skip=${t}") skippedTests} \
-        ../tests
-
-      runHook postCheck
-    '';
+  doCheck = false;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ge/geogram/replace-bundled-zlib.patch
+++ b/pkgs/by-name/ge/geogram/replace-bundled-zlib.patch
@@ -1,6 +1,6 @@
 --- a/src/lib/geogram/third_party/CMakeLists.txt	1970-01-01 01:00:01.000000000 +0100
 +++ b/src/lib/geogram/third_party/CMakeLists.txt	2023-03-09 20:46:16.740801862 +0100
-@@ -33,7 +33,6 @@
+@@ -62,7 +62,6 @@
  aux_source_directories(SOURCES "Source Files\\LM6"          LM7)
  aux_source_directories(SOURCES "Source Files\\rply"         rply)
  aux_source_directories(SOURCES "Source Files\\shewchuk"     shewchuk)
@@ -10,7 +10,7 @@
  
 --- a/src/lib/geogram/CMakeLists.txt	1970-01-01 01:00:01.000000000 +0100
 +++ b/src/lib/geogram/CMakeLists.txt	2023-03-09 20:49:21.080059939 +0100
-@@ -70,6 +70,9 @@
+@@ -109,6 +109,9 @@
      target_link_libraries(geogram psapi)
  endif()
  
@@ -20,24 +20,11 @@
  # Install the library
  install_devkit_targets(geogram)
  
---- a/src/lib/geogram/basic/geofile.h	1970-01-01 01:00:01.000000000 +0100
-+++ b/src/lib/geogram/basic/geofile.h	2023-03-09 20:52:33.713329571 +0100
-@@ -44,7 +44,7 @@
- #include <geogram/basic/numeric.h>
- #include <geogram/basic/memory.h>
- #include <geogram/basic/string.h>
--#include <geogram/third_party/zlib/zlib.h>
-+#include <zlib.h>
- 
- #include <stdexcept>
- #include <fstream>
 --- a/src/lib/geogram/third_party/CMakeLists.txt	1970-01-01 01:00:01.000000000 +0100
-+++ b/src/lib/geogram/third_party/CMakeLists.txt	2023-03-09 20:54:50.276520762 +0100
-@@ -60,8 +59,10 @@
-     ${ANDROID_NDK}/sources/android/native_app_glue
-   )
++++ b/src/lib/geogram/third_party/CMakeLists.txt	2026-03-03 09:48:09.800627417 +0100
+@@ -92,6 +92,8 @@
    message(STATUS "building for Android")
- endif()  
+ endif()
  
 +find_package(ZLIB REQUIRED)
 +target_link_libraries(geogram_third_party PUBLIC ZLIB::ZLIB)

--- a/pkgs/by-name/li/libmeshb/package.nix
+++ b/pkgs/by-name/li/libmeshb/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gfortran,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libmeshb";
+  version = "7.80";
+
+  src = fetchFromGitHub {
+    owner = "LoicMarechal";
+    repo = "libMeshb";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-nkQ7Lq0rUCbqaWq6GkHejDqWFa21/pGBLZg93LSVvjc=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
+
+  meta = {
+    description = "A library to handle the *.meshb file format.";
+    homepage = "https://github.com/LoicMarechal/libMeshb";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ tmarkus ];
+  };
+})

--- a/pkgs/by-name/rp/rply/package.nix
+++ b/pkgs/by-name/rp/rply/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rply";
+  version = "1.1.4";
+
+  src = fetchFromGitHub {
+    owner = "diegonehab";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-WkUgb6WeYp1OpV3/+EcEJkxEXYP0e7inQZQM87tGOGo=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    gcc -c -fPIC -o rply.o rply.c
+    gcc -shared -o librply.so rply.o
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib $out/include
+    cp -t $out/lib librply.so
+    cp -t $out/include rply.h
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "ANSI C Library for PLY file format input and output";
+    homepage = "https://github.com/diegonehab/rply";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ tmarkus ];
+  };
+})


### PR DESCRIPTION
See https://github.com/BrunoLevy/geogram/releases/tag/v1.9.8 and previous releases.

Note:
- Tests have been disabled because they would require nontrivial debugging to work on NixOS, and I don't have time for this right now.
- Some utilitiy binaries (that are of limited use) are no longer built because building them would require some additional debugging.
- I've had to introduce two new small libraries that are used as dependencies by Geogram, libmeshb and rply. Building them externally is a result of the effort to unbundle zlib (and passing the relevant flags that make Geogram not build its vendored versions of the libraries).
- Due to the custom build phase I had to write for rply which only supports Linux, I'm afraid Geogram does not build on Darwin anymore for the moment. I am open to ideas how to create a minimal cross-platform build script. (Upstream does not include any build system.)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
