### PR TITLE
searchix: init at 0.4.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -895,6 +895,12 @@
     githubId = 37664775;
     name = "Yuto Oguchi";
   };
+  airone01 = {
+    name = "Erwann Lagouche";
+    github = "airone01";
+    githubId = 21955960;
+    email = "airone01@proton.me";
+  };
   airrnot = {
     name = "airRnot";
     github = "airRnot1106";

--- a/pkgs/by-name/se/searchix/package.nix
+++ b/pkgs/by-name/se/searchix/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitea,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+let
+  simpleCss = fetchFromGitHub {
+    owner = "kevquirk";
+    repo = "simple.css";
+    rev = "ba4af949057d489331759e0118de596222e0f5b7";
+    hash = "sha256-rihjNW1gf0k7DI8x+vaFUR4ehI3gXDV9zWV3DGSg4y8=";
+  };
+in
+
+buildGoModule (finalAttrs: {
+  pname = "searchix";
+  version = "0.4.4";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "alinnow";
+    repo = "searchix";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-R8/iR8QoeUwNQCFkr+JtoPq/iKkJRIe8dsbvGfFqinE=";
+  };
+
+  vendorHash = "sha256-yfcQgy4cQFRvtsyLHLojnJaWhle1ZR3unmaFQj8ljuw=";
+
+  subPackages = [ "cmd/searchix-web" ];
+
+  tags = [ "embed" ];
+
+  ldflags = [
+    "-s"
+    "-X=alin.ovh/searchix/internal/config.Version=${finalAttrs.version}"
+  ];
+
+  preBuild = ''
+    rm -f frontend/static/base.css
+    cp ${simpleCss}/simple.css frontend/static/base.css
+  '';
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+    $out/bin/searchix-web generate-error-page --outdir $out/share/searchix/
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Search tool for options and packages in the NixOS ecosystem";
+    homepage = "https://searchix.ovh/";
+    downloadPage = "https://codeberg.org/alinnow/searchix";
+    changelog = "https://codeberg.org/alinnow/searchix/src/tag/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      airone01
+      BatteredBunny
+    ];
+    mainProgram = "searchix-web";
+  };
+})


### PR DESCRIPTION
This PR adds a package for [Searchix](https://codeberg.org/alinnow/searchix), a webapp search engine for nix options and packages.
It allows searching NixOS, Home Manager, Darwin (and more by adding custom sources) options, as well as nixpkgs packages in the same web interface. 

The source code can be found [here](https://codeberg.org/alinnow/searchix) with a mirror [here](https://git.sr.ht/~alanpearce/searchix). The [author](https://alanpearce.eu/)'s instance is hosted [here](https://searchix.ovh/) and mine [here](https://searchix.air1.one/).
I believe Searchix is popular with nix users, and that it's a good idea to add it to nixpkgs.

(*I also have a module ready for this package, but priority imo is the package.*)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
