### PR TITLE
bcompare: migrate to by-name, hardcode pname

### DIFF
--- a/pkgs/by-name/bc/bcompare/package.nix
+++ b/pkgs/by-name/bc/bcompare/package.nix
@@ -8,10 +8,7 @@
   glibc,
   pango,
   gtk2,
-  kcoreaddons,
-  ki18n,
-  kio,
-  kservice,
+  libsForQt5,
   stdenv,
   runtimeShell,
   unzip,
@@ -75,10 +72,10 @@ let
       gtk2
       pango
       cairo
-      kio
-      kservice
-      ki18n
-      kcoreaddons
+      libsForQt5.kio
+      libsForQt5.kservice
+      libsForQt5.ki18n
+      libsForQt5.kcoreaddons
       gdk-pixbuf
       bzip2
     ];

--- a/pkgs/by-name/bc/bcompare/package.nix
+++ b/pkgs/by-name/bc/bcompare/package.nix
@@ -22,7 +22,7 @@ let
 
   srcs = {
     x86_64-linux = fetchurl {
-      url = "https://www.scootersoftware.com/${pname}-${version}_amd64.deb";
+      url = "https://www.scootersoftware.com/bcompare-${version}_amd64.deb";
       sha256 = "sha256-4AWTSoYpVhGmBBxcwHXdg1CGd/04+8yL9pu+gHrsj6U";
     };
 
@@ -56,7 +56,7 @@ let
       # Remove library that refuses to be autoPatchelf'ed
       rm $out/lib/beyondcompare/ext/bcompare_ext_kde.amd64.so
 
-      substituteInPlace $out/bin/${pname} \
+      substituteInPlace $out/bin/bcompare \
         --replace "/usr/lib/beyondcompare" "$out/lib/beyondcompare" \
         --replace "ldd" "${glibc.bin}/bin/ldd" \
         --replace "/bin/bash" "${runtimeShell}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12495,8 +12495,6 @@ with pkgs;
 
   openbsd = callPackage ../os-specific/bsd/openbsd { };
 
-  bcompare = libsForQt5.callPackage ../applications/version-management/bcompare { };
-
   xp-pen-deco-01-v2-driver = libsForQt5.xp-pen-deco-01-v2-driver;
 
   radicle-node-unstable = callPackage ../by-name/ra/radicle-node/unstable.nix { };


### PR DESCRIPTION
This pull request reorganizes and updates the packaging for the `bcompare` (Beyond Compare) application in Nixpkgs. The package definition was moved to the `by-name` directory, and its dependencies and build instructions were updated to use the modern `libsForQt5` namespace for KDE libraries. Additionally, the download URL and some build script details were corrected for consistency and reliability.

**Package migration and dependency updates:**

* The `bcompare` package was moved from `pkgs/applications/version-management/bcompare/default.nix` to `pkgs/by-name/bc/bcompare/package.nix`, aligning with the by-name directory structure.
* KDE dependencies (`kio`, `kservice`, `ki18n`, `kcoreaddons`) were updated to use the `libsForQt5` namespace, improving compatibility and maintainability.

**Build and packaging improvements:**

* The download URL for the `.deb` source was corrected to use the proper filename format (`bcompare-${version}_amd64.deb`).
* The build script was updated to reference the correct binary name (`bcompare`) in the `substituteInPlace` command, ensuring proper patching.

**Top-level package reference update:**

* The package reference in `all-packages.nix` was removed, likely to be replaced by a new reference in the by-name structure or to avoid duplication.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
