### PR TITLE
python3Packages.sigtools: disable failing test

### DIFF
--- a/pkgs/development/python-modules/sigtools/default.nix
+++ b/pkgs/development/python-modules/sigtools/default.nix
@@ -2,33 +2,41 @@
   lib,
   attrs,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   mock,
   repeated-test,
   setuptools-scm,
   sphinx,
   unittestCheckHook,
+  pythonAtLeast,
 }:
-
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "sigtools";
   version = "4.0.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-S44TWpzU0uoA2mcMCTNy105nK6OruH9MmNjnPepURFw=";
+  src = fetchFromGitHub {
+    owner = "epsy";
+    repo = "sigtools";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-q5Bzc6fgDJCqt0SA/C/mg2fbUFyXLcsRU+tSl8FdZdI=";
   };
 
-  nativeBuildInputs = [ setuptools-scm ];
+  build-system = [ setuptools-scm ];
 
-  propagatedBuildInputs = [ attrs ];
+  dependencies = [ attrs ];
 
   nativeCheckInputs = [
     mock
     repeated-test
     sphinx
     unittestCheckHook
+  ];
+
+  unittestFlags = lib.optionals (pythonAtLeast "3.14") [
+    "-s sigtools/tests"
+    # python314 only: NameError: name 'o' is not defined
+    "-k [!RoundTripTests.test_locals]"
   ];
 
   pythonImportsCheck = [ "sigtools" ];
@@ -39,4 +47,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Disabled failing test in python314. All other tests run fine.
Changed: fetchFromPypi -> fetchFromGitHub
Use finalAttrs pattern.

Ref: https://github.com/NixOS/nixpkgs/pull/493089
Tracking: https://github.com/NixOS/nixpkgs/issues/475732
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
