### PR TITLE
labrecorder: init at 1.17.1

### DIFF
--- a/pkgs/by-name/la/labrecorder/package.nix
+++ b/pkgs/by-name/la/labrecorder/package.nix
@@ -1,0 +1,71 @@
+{
+  cmake,
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  copyDesktopItems,
+  makeDesktopItem,
+  liblsl,
+  qt6,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pname = "labrecorder";
+  version = "1.17.1";
+  src = fetchFromGitHub {
+    owner = "labstreaminglayer";
+    repo = "App-LabRecorder";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HXgkopaeJR6KftJHq/o+m2g8UXts3+8kI2l8mGIHJIk=";
+  };
+  nativeBuildInputs = [
+    cmake
+    copyDesktopItems
+    qt6.wrapQtAppsHook
+  ];
+  buildInputs = [
+    liblsl
+    qt6.qtbase
+  ];
+
+  postPatch = ''
+    # Include LSLCMake.cmake from liblsl so the helper functions are available
+    sed -i '1i include("${liblsl}/lib/cmake/lsl/LSLCMake.cmake")' CMakeLists.txt
+  '';
+
+  cmakeFlags = [
+    "-DLSL_INSTALL_ROOT=${liblsl}"
+    "-DCMAKE_PREFIX_PATH=${liblsl}"
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "labrecorder";
+      exec = "LabRecorder";
+      desktopName = "LabRecorder";
+      genericName = "Lab Streaming Layer recorder";
+      comment = "Record Lab Streaming Layer streams";
+      categories = [ "Science" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ./LabRecorder    $out/bin/LabRecorder
+    install -Dm755 ./LabRecorderCLI $out/bin/LabRecorderCLI
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Record Lab Streaming Layer streams";
+    homepage = "https://github.com/labstreaminglayer/App-LabRecorder";
+    license = lib.licenses.mit;
+    mainProgram = "LabRecorder";
+    maintainers = with lib.maintainers; [ abcsds ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/la/labrecorder/package.nix
+++ b/pkgs/by-name/la/labrecorder/package.nix
@@ -1,0 +1,70 @@
+{
+  cmake,
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  copyDesktopItems,
+  makeDesktopItem,
+  liblsl,
+  qt6,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pname = "labrecorder";
+  version = "1.17.1";
+  src = fetchFromGitHub {
+    owner = "labstreaminglayer";
+    repo = "App-LabRecorder";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HXgkopaeJR6KftJHq/o+m2g8UXts3+8kI2l8mGIHJIk=";
+  };
+  nativeBuildInputs = [
+    cmake
+    copyDesktopItems
+    qt6.wrapQtAppsHook
+  ];
+  buildInputs = [
+    liblsl
+    qt6.qtbase
+  ];
+
+  postPatch = ''
+    # Include LSLCMake.cmake from liblsl so the helper functions are available
+    sed -i '1i include("${lib.getDev liblsl}/lib/cmake/lsl/LSLCMake.cmake")' CMakeLists.txt
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "labrecorder";
+      exec = "LabRecorder";
+      desktopName = "LabRecorder";
+      genericName = "Lab Streaming Layer recorder";
+      comment = "Record Lab Streaming Layer streams";
+      categories = [ "Science" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ./LabRecorder    $out/bin/LabRecorder
+    install -Dm755 ./LabRecorderCLI $out/bin/LabRecorderCLI
+
+    # Provide lowercase aliases following the usual binary naming convention
+    ln -s LabRecorder    $out/bin/labrecorder
+    ln -s LabRecorderCLI $out/bin/labrecordercli
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Record Lab Streaming Layer streams";
+    homepage = "https://github.com/labstreaminglayer/App-LabRecorder";
+    license = lib.licenses.mit;
+    mainProgram = "LabRecorder";
+    maintainers = with lib.maintainers; [ abcsds ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!-- Generated by nixpkgs-contribution skill, 2026-04-25 -->
<!-- Base branch: master  (set this as the PR's base on GitHub) -->

#### Things done

- [x] Built on platform(s)
   - [x] x86_64-linux
   - [ ] aarch64-linux
   - [ ] x86_64-darwin
   - [ ] aarch64-darwin
- [x] For non-Linux: Is sandboxing enabled in nix.conf? (sandbox = true)
- [ ] Tested, as applicable:
   - [ ] NixOS test(s)
   - [ ] and/or package tests
   - [x] Executed by ./result/bin/LabRecorderCLI --help
- [x] Tested compilation of all packages that depend on this change using nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
- [x] Tested basic functionality of all binary files (usually in ./result/bin/)
- [ ] Release Notes
   - [ ] (Package updates) Added a release notes entry if the change is major or breaking
   - [ ] (Module updates) Added a release notes entry if the change is significant
   - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits CONTRIBUTING.md

---

### Change summary

Initialize \`labrecorder\` (Lab Streaming Layer multi-stream recorder) at upstream v1.17.1.

Records data from any combination of LSL streams (EEG, gaze, motion, etc.) into the XDF container format, alongside optional CSV exports. Provides a Qt6 GUI (\`LabRecorder\`) and a headless command-line variant (\`LabRecorderCLI\`).

Ships a freedesktop \`.desktop\` entry via \`copyDesktopItems\` + \`makeDesktopItem\` under the **Science** category so the GUI is discoverable in desktop application menus.

\`meta.mainProgram = "LabRecorder"\` (the GUI binary). Enables \`strictDeps\` and \`__structuredAttrs\` per nixpkgs-vet NPV-164 / NPV-166.

Upstream release notes: https://github.com/labstreaminglayer/App-LabRecorder/releases/tag/v1.17.1

### \`nixpkgs-review wip\` output

\`N = 1\` rebuild (labrecorder itself — new leaf package, no reverse dependencies). 1 built, 0 failed on x86_64-linux.