### PR TITLE
worldmonitor: init at 2.5.23

### DIFF
--- a/pkgs/by-name/wo/worldmonitor/package.nix
+++ b/pkgs/by-name/wo/worldmonitor/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  appimageTools,
+}:
+
+let
+  version = "2.5.23";
+  pname = "worldmonitor";
+  cpu_name = stdenv.hostPlatform.parsed.cpu.name;
+  throwSystem = throw "Unsupported system: ${cpu_name}";
+
+  arch =
+    {
+      x86_64 = "amd64";
+    }
+    .${cpu_name} or cpu_name;
+
+  hash =
+    {
+      amd64 = "sha256-QEuPgOX1D0m08upP544NLCv5jXLnrHcCRT1TJIHKNY0=";
+      aarch64 = "sha256-ZISYarD8Kwgd9pulfbeId7gmL3YUDVtxAPlcecw19lQ=";
+    }
+    .${arch} or throwSystem;
+
+  src = fetchurl {
+    url = "https://github.com/koala73/worldmonitor/releases/download/v${version}/World.Monitor_${version}_${arch}.AppImage";
+    hash = hash;
+  };
+
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  meta = {
+    description = "Real-time global intelligence dashboard";
+    mainProgram = "worldmonitor";
+    homepage = "https://github.com/koala73/worldmonitor";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ skohtv ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Homepage: https://github.com/koala73/worldmonitor
Built on x86_64, not tested on aarch64 but there's an Appimage available

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
