### PR TITLE
python3Packages.py-netgear-plus: init at 0.4.7

### DIFF
--- a/pkgs/development/python-modules/py-netgear-plus/default.nix
+++ b/pkgs/development/python-modules/py-netgear-plus/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  lxml,
+  requests,
+  hatchling,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "py-netgear-plus";
+  version = "0.4.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "foxey";
+    repo = "py-netgear-plus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HoHXqAqVPqaw7WkRCi5AJ2dKG8IZX7l7bTp22KZBzdU=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    lxml
+    requests
+  ];
+
+  pythonImportsCheck = [ "py_netgear_plus" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/foxey/py-netgear-plus/releases/tag/${finalAttrs.src.tag}";
+    description = "Python Library for NETGEAR Plus Switches";
+    homepage = "https://github.com/foxey/py-netgear-plus";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ aiyion ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13046,6 +13046,8 @@ self: super: with self; {
 
   py-multihash = callPackage ../development/python-modules/py-multihash { };
 
+  py-netgear-plus = callPackage ../development/python-modules/py-netgear-plus { };
+
   py-nextbusnext = callPackage ../development/python-modules/py-nextbusnext { };
 
   py-nightscout = callPackage ../development/python-modules/py-nightscout { };


### PR DESCRIPTION
Package https://pypi.org/project/py-netgear-plus/ currently at `0.4.7`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - ~Module addition: when adding a new NixOS module.~
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
