### PR TITLE
musescore-evolution: 3.7.0-unstable-2026-01-12 -> 3.7.0-unstable-2026-03-03

### DIFF
--- a/pkgs/by-name/mu/musescore-evolution/package.nix
+++ b/pkgs/by-name/mu/musescore-evolution/package.nix
@@ -22,21 +22,26 @@
   libopus,
   tinyxml-2,
   qt5, # Needed for musescore 3.X
+  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "musescore-evolution";
-  version = "3.7.0-unstable-2026-01-12";
+  version = "3.7.0-unstable-2026-03-03";
 
   src = fetchFromGitHub {
     owner = "Jojo-Schmitz";
     repo = "MuseScore";
-    rev = "0b4543baca9b1b70d54cecb33cbf846dabc073d1";
-    hash = "sha256-piOXHKlnfCO1n0kAgeszqa6JVoHgF8B2OF7agpadGKQ=";
+    rev = "67504236fa073783f6616545185ec8bde6c22647";
+    hash = "sha256-QUUvUkdrJ4iL6cgDob+PdVRZp44kzHeoOi2N0Xb51To=";
   };
 
   patches = [
     ./musescore-evolution-pch-fix.patch
+    (fetchpatch {
+      url = "https://github.com/Jojo-Schmitz/MuseScore/commit/bbaa38ba2babb339043f87d50cec3240ca49fe0b.patch";
+      hash = "sha256-TbbrBo4uWCHeAs0Er3eYL+i0JWafI0zhetLpFjN0xg8=";
+    })
   ];
 
   # From top-level CMakeLists.txt:

--- a/pkgs/by-name/mu/musescore-evolution/update.sh
+++ b/pkgs/by-name/mu/musescore-evolution/update.sh
@@ -3,24 +3,25 @@
 
 set -euo pipefail
 
+# Fallback to default attribute path if not set
+attr_path="${UPDATE_NIX_ATTR_PATH:-musescore-evolution}"
+
 # Run nix-update on the default branch (updates rev and sha256)
-nix-update musescore-evolution --version=branch
+nix-update $attr_path --version=branch
 
 # Now we need to update the version name
 
 # Find the new version generated from the nix-update command (e.g. "0-unstable-2026-01-12")
-generated_version=$(nix eval --raw -f . ${UPDATE_NIX_ATTR_PATH}.version)
+generated_version=$(nix eval --raw -f . ${attr_path}.version)
 
-# Extract only the date part (after the last dash) (e.g. 0-unstable-2026-01-12)
-parts=(${generated_version//-/ }) # Split up by dashes
-clean_date="${parts[2]}-${parts[3]}-${parts[4]}" # Get clean date in YYYY-MM-DD format (e.g. "2026-01-12")
+# Extract the last ISO date (YYYY-MM-DD) found in the generated version (e.g. 2026-01-12)
+clean_date=$(printf '%s\n' "$generated_version" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | tail -n1 || true)
 
-# Compute version prefix based on previous version
-old_version="$UPDATE_NIX_OLD_VERSION"
-prefix="${old_version%-*}" # e.g. "3.7.0-unstable"
+# Version prefix remains unchanged
+prefix="3.7.0-unstable"
 
-new_version="${prefix}-${clean_date}"
+new_version="${prefix}-${clean_date}" # (e.g. "3.7.0-unstable-2026-01-12")
 
 # Patch version in nix file
 # Strip any existing version line and replace with new one
-sed -i "s/version = \".*\"/version = \"${new_version}\"/" $(nix eval --raw -f . ${UPDATE_NIX_ATTR_PATH}.meta.position | cut -d: -f1)
+sed -i "s/version = \".*\"/version = \"${new_version}\"/" $(nix eval --raw -f . ${attr_path}.meta.position | cut -d: -f1)


### PR DESCRIPTION
Fixed the update script and updated to latest version. Also applied another patch to get it building on Darwin again.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
