### PR TITLE
haskell.packages.ghc902Binary: fix evaluation of package set

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -37,4 +37,21 @@ self: super: {
   unix = null;
   xhtml = null;
   Win32 = null;
+
+  # core pkgs on later GHCs that we can reasonably provide a stub
+  # or Hackage released version for (though they may not build).
+  Cabal-syntax = self.Cabal-syntax_3_6_0_0;
+  semaphore-compat = self.semaphore-compat_2_0_0;
+  os-string = self.os-string_2_0_10;
+  file-io = self.file-io_0_2_0;
+  # Would need 2.25.*, but let's not bother
+  haddock-api = self.haddock-api_2_29_1;
+  haddock-library = self.haddock-library_1_11_0;
+
+  # core pkgs on later GHCs we can't provide at all
+  system-cxx-std-lib = null;
+  ghc-experimental = null;
+  ghc-internal = null;
+  ghc-platform = null;
+  ghc-toolchain = null;
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -78,6 +78,7 @@ extra-packages:
   - Cabal == 3.14.*
   - Cabal == 3.16.*                     # version required for cabal-install and other packages
   - cabal-add == 0.1                    # 2025-09-09: Only needed for hls 2.11 can be removed once we are past it.
+  - Cabal-syntax == 3.6.*               # required for the GHC 9.0.2 package set
   - Cabal-syntax == 3.10.*
   - Cabal-syntax == 3.12.*
   - Cabal-syntax == 3.14.*


### PR DESCRIPTION
These attributes need to be present, so that callPackage doesn't fail with an unrecoverable error on some members of the package set. This is not necessary for any package Hydra builds, but helps for listing/ inspecting the package set.

cc @trofi 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
