### PR TITLE
discord-rich-presence-plex: 2.16.0 -> 3.0.0

### DIFF
--- a/pkgs/by-name/di/discord-rich-presence-plex/package.nix
+++ b/pkgs/by-name/di/discord-rich-presence-plex/package.nix
@@ -1,62 +1,56 @@
 {
   lib,
-  python3Packages,
-  python3,
   fetchFromGitHub,
-  makeWrapper,
+  buildGo126Module,
+  buildNpmPackage,
 }:
 
-python3Packages.buildPythonApplication (finalAttrs: {
+let
+  version = "3.0.0";
+
   pname = "discord-rich-presence-plex";
-  version = "2.16.0";
-  pyproject = false;
+
   src = fetchFromGitHub {
     owner = "phin05";
     repo = "discord-rich-presence-plex";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-e1r0w72IOEY5XsjANkAHbfPYEf1B8n6KYVLMWFSLs0g=";
+    rev = "v${version}";
+    hash = "sha256-RvsS47059YdxKSo6sy+zglY1YxzyJmZTmo/DIKX1xqU=";
   };
 
-  nativeBuildInputs = [
-    makeWrapper
-  ];
-  dontBuild = true;
-  dontUseSetuptoolsBuild = true;
-  dontUseSetuptoolsCheck = true;
-
-  dependencies = with python3Packages; [
-    requests
-    pillow
-    plexapi
-    pyyaml
-    websocket-client
-  ];
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/lib/discord-rich-presence-plex
-    cp -r * $out/lib/discord-rich-presence-plex/
-
-    mkdir -p $out/bin
-    makeWrapper ${lib.getExe python3} \
-      $out/bin/discord-rich-presence-plex \
-      --add-flags "$out/lib/discord-rich-presence-plex/main.py" \
-      --prefix PYTHONPATH : "$out/lib/discord-rich-presence-plex:$PYTHONPATH" \
-      --set DRPP_NO_PIP_INSTALL "true"
-
-    runHook postInstall
+  webAssets = buildNpmPackage {
+    pname = "${pname}-web";
+    inherit version src;
+    sourceRoot = "${src.name}/web";
+    npmDepsHash = "sha256-7cp4LeXUAiIHGvLfwsIWpdqjUzemlCKVCsBZxTnPlDk=";
+    installPhase = ''
+      cp -r dist $out
+    '';
+  };
+in
+buildGo126Module {
+  inherit version src pname;
+  subPackages = [ "server/main" ];
+  env.GOEXPERIMENT = "jsonv2";
+  vendorHash = "sha256-B1XHMqyih3eBlRsU6s5HcGv9WY8OcXj2yGwB2jpP9HI=";
+  preBuild = ''
+    mkdir -p web/dist
+    cp -r ${webAssets}/* web/dist/
   '';
 
-  # No tests
-  doCheck = false;
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
 
+  postInstall = ''
+    mv $out/bin/main $out/bin/drpp
+  '';
   meta = {
     homepage = "https://github.com/phin05/discord-rich-presence-plex";
-    changelog = "https://github.com/phin05/discord-rich-presence-plex/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.gpl3Only;
     description = "Displays your Plex status on Discord using Rich Presence";
-    maintainers = with lib.maintainers; [ hogcycle ];
+    license = lib.licenses.gpl3Only;
     mainProgram = "discord-rich-presence-plex";
+    maintainers = with lib.maintainers; [ hogcycle ];
   };
-})
+}


### PR DESCRIPTION
Bumped phin05/discord-rich-presence-plex from 2.16.0 to 3.0.0. The original software has been rewritten in Go, hence the new package.nix. See changelog: https://github.com/phin05/discord-rich-presence-plex/releases/tag/v3.0.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [*] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
