### PR TITLE
nixos/uptime-kuma: Make into modular service

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11828,6 +11828,11 @@
     github = "jamerrq";
     githubId = 35697365;
   };
+  james-1701 = {
+    name = "James H";
+    github = "james-1701";
+    githubId = 76922491;
+  };
   james-atkins = {
     name = "James Atkins";
     github = "james-atkins";

--- a/nixos/modules/misc/documentation/modular-services.nix
+++ b/nixos/modules/misc/documentation/modular-services.nix
@@ -21,6 +21,8 @@ let
     _file = "${__curPos.file}:${toString __curPos.line}";
     options = {
       "<imports = [ pkgs.ghostunnel.services.default ]>" = fakeSubmodule pkgs.ghostunnel.services.default;
+      "<imports = [ pkgs.uptime-kuma.services.default ]>" =
+        fakeSubmodule pkgs.uptime-kuma.services.default;
       "<imports = [ pkgs.php.services.default ]>" = fakeSubmodule pkgs.php.services.default;
     };
   };

--- a/nixos/modules/services/monitoring/uptime-kuma.nix
+++ b/nixos/modules/services/monitoring/uptime-kuma.nix
@@ -4,97 +4,39 @@
   lib,
   ...
 }:
+
 let
   cfg = config.services.uptime-kuma;
 in
 {
-
-  meta.maintainers = [ lib.maintainers.julienmalka ];
+  imports =
+    map
+      (
+        opt:
+        lib.mkAliasOptionModule
+          [ "services" "uptime-kuma" opt ]
+          [ "system" "services" "uptime-kuma" "uptime-kuma" opt ]
+      )
+      [
+        "package"
+        "appriseSupport"
+        "settings"
+      ];
 
   options = {
     services.uptime-kuma = {
       enable = lib.mkEnableOption "Uptime Kuma, this assumes a reverse proxy to be set";
-
-      package = lib.mkPackageOption pkgs "uptime-kuma" { };
-
-      appriseSupport = lib.mkEnableOption "apprise support for notifications";
-
-      settings = lib.mkOption {
-        type = lib.types.submodule { freeformType = with lib.types; attrsOf str; };
-        default = { };
-        example = {
-          PORT = "4000";
-          NODE_EXTRA_CA_CERTS = lib.literalExpression "config.security.pki.caBundle";
-          UPTIME_KUMA_DB_TYPE = "mariadb";
-          UPTIME_KUMA_DB_HOSTNAME = "localhost";
-          UPTIME_KUMA_DB_NAME = "uptime-kuma";
-          UPTIME_KUMA_DB_USERNAME = "uptime-kuma";
-          UPTIME_KUMA_DB_PASSWORD = "uptime-kuma";
-        };
-        description = ''
-          Additional configuration for Uptime Kuma, see
-          <https://github.com/louislam/uptime-kuma/wiki/Environment-Variables>
-          for supported values.
-        '';
-      };
     };
   };
 
   config = lib.mkIf cfg.enable {
-
-    services.uptime-kuma.settings = {
-      DATA_DIR = "/var/lib/uptime-kuma/";
-      NODE_ENV = lib.mkDefault "production";
-      HOST = lib.mkDefault "127.0.0.1";
-      PORT = lib.mkDefault "3001";
-      UPTIME_KUMA_DB_TYPE = lib.mkDefault "sqlite";
-    };
-
-    systemd.services.uptime-kuma = {
-      description = "Uptime Kuma";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-      environment = cfg.settings;
-      path = with pkgs; [ unixtools.ping ] ++ lib.optional cfg.appriseSupport apprise;
-      serviceConfig = {
-        Type = "simple";
-        StateDirectory = "uptime-kuma";
-        StateDirectoryMode = "750";
-        DynamicUser = true;
-        ExecStart = "${cfg.package}/bin/uptime-kuma-server";
-        Restart = "on-failure";
-        AmbientCapabilities = "";
-        CapabilityBoundingSet = "";
-        LockPersonality = true;
-        MemoryDenyWriteExecute = false; # enabling it breaks execution
-        MountAPIVFS = true;
-        NoNewPrivileges = true;
-        PrivateDevices = true;
-        PrivateMounts = true;
-        PrivateTmp = true;
-        PrivateUsers = true;
-        ProtectClock = true;
-        ProtectControlGroups = "strict";
-        ProtectHome = true;
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        ProtectProc = "invisible";
-        ProtectSystem = "strict";
-        RemoveIPC = true;
-        RestrictAddressFamilies = [
-          "AF_INET"
-          "AF_INET6"
-          "AF_UNIX"
-          "AF_NETLINK"
-        ];
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        SystemCallArchitectures = "native";
-        UMask = 27;
-      };
+    system.services.uptime-kuma = {
+      imports = [ pkgs.uptime-kuma.services.default ];
     };
   };
+
+  meta.maintainers = with lib.maintainers; [
+    james-1701
+    julienmalka
+  ];
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1686,6 +1686,7 @@ in
   upnp.nftables = handleTest ./upnp.nix { useNftables = true; };
   uptermd = runTest ./uptermd.nix;
   uptime-kuma = runTest ./uptime-kuma.nix;
+  uptime-kuma-modular = runTest ./uptime-kuma-modular.nix;
   urn-timer = runTest ./urn-timer.nix;
   usbguard = runTest ./usbguard.nix;
   user-activation-scripts = runTest ./user-activation-scripts.nix;

--- a/nixos/tests/uptime-kuma-modular.nix
+++ b/nixos/tests/uptime-kuma-modular.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+
+{
+  _class = "nixosTest";
+
+  name = "uptime-kuma";
+
+  nodes.machine = _: {
+    services.uptime-kuma.enable = true;
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("uptime-kuma.service")
+    machine.wait_for_open_port(3001)
+    machine.succeed("curl --fail http://localhost:3001/")
+  '';
+
+  meta.maintainers = with lib.maintainers; [ james-1701 ];
+}

--- a/pkgs/by-name/up/uptime-kuma/package.nix
+++ b/pkgs/by-name/up/uptime-kuma/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pkgs,
   stdenv,
   fetchFromGitHub,
   buildNpmPackage,
@@ -39,7 +40,18 @@ buildNpmPackage (finalAttrs: {
       --chdir $out/lib/node_modules/uptime-kuma
   '';
 
-  passthru.tests.uptime-kuma = nixosTests.uptime-kuma;
+  passthru = {
+    services.default = {
+      imports = [
+        (lib.modules.importApply ./service.nix {
+          inherit (pkgs) unixtools apprise;
+        })
+      ];
+      uptime-kuma.package = lib.mkDefault finalAttrs.finalPackage;
+    };
+
+    tests.uptime-kuma = nixosTests.uptime-kuma;
+  };
 
   meta = {
     description = "Fancy self-hosted monitoring tool";
@@ -48,6 +60,7 @@ buildNpmPackage (finalAttrs: {
     changelog = "https://github.com/louislam/uptime-kuma/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      james-1701
       julienmalka
       felixsinger
     ];

--- a/pkgs/by-name/up/uptime-kuma/service.nix
+++ b/pkgs/by-name/up/uptime-kuma/service.nix
@@ -1,0 +1,123 @@
+# Non-module dependencies (importApply)
+{ unixtools, apprise }:
+
+# Service module
+{
+  options,
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.uptime-kuma;
+
+  inherit (lib)
+    mkEnableOption
+    literalExpression
+    optionalAttrs
+    optional
+    mkOption
+    maintainers
+    types
+    getExe
+    ;
+in
+{
+  _class = "service";
+
+  options.uptime-kuma = {
+    # FIXME: Should this be `mkPackageOption` or something like redlib's `mkModularPackageOption`
+    package = mkOption {
+      description = "Package to use for uptime-kuma";
+      defaultText = "The uptime-kuma package that provided this module.";
+      type = types.package;
+    };
+
+    appriseSupport = mkEnableOption "apprise support for notifications";
+
+    settings = mkOption {
+      type = types.submodule { freeformType = with types; attrsOf str; };
+      # FIXME: This needs to be looked over by someone who has more experience with modular services
+      # Im not sure if these apply the same way as `lib.mkDefault`s do
+      # Im unsure how `config.services.uptime-kuma.settings` is supposed to be scoped here so this is what I did
+      default = {
+        DATA_DIR = "/var/lib/uptime-kuma/";
+        NODE_ENV = "production";
+        HOST = "127.0.0.1";
+        PORT = "3001";
+        UPTIME_KUMA_DB_TYPE = "sqlite";
+      };
+      example = {
+        PORT = "4000";
+        NODE_EXTRA_CA_CERTS = literalExpression "config.security.pki.caBundle";
+        UPTIME_KUMA_DB_TYPE = "mariadb";
+        UPTIME_KUMA_DB_HOSTNAME = "localhost";
+        UPTIME_KUMA_DB_NAME = "uptime-kuma";
+        UPTIME_KUMA_DB_USERNAME = "uptime-kuma";
+        UPTIME_KUMA_DB_PASSWORD = "uptime-kuma";
+      };
+      description = ''
+        Additional configuration for Uptime Kuma, see
+        <https://github.com/louislam/uptime-kuma/wiki/Environment-Variables>
+        for supported values.
+      '';
+    };
+  };
+
+  config = {
+    process.argv = [
+      (getExe cfg.package)
+    ];
+  }
+  // optionalAttrs (options ? systemd) {
+    systemd.service = {
+      description = "Uptime Kuma";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = cfg.settings;
+      # FIXME: Not sure if the proper way is to get pkgs into scope here or move this elsewhere
+      path = [ unixtools.ping ] ++ optional cfg.appriseSupport apprise;
+      serviceConfig = {
+        Type = "simple";
+        StateDirectory = "uptime-kuma";
+        StateDirectoryMode = "750";
+        DynamicUser = true;
+        Restart = "on-failure";
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false; # enabling it breaks execution
+        MountAPIVFS = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = "strict";
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+          "AF_NETLINK"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        UMask = 27;
+      };
+    };
+  };
+
+  meta.maintainers = with maintainers; [ james-1701 ];
+}


### PR DESCRIPTION
Wrote a modular service to better understand the requirements for GSoC. This was pretty smooth sailing and only trouble I had was not realizing `options.services.uptime-kuma.enable` doesn't belong in `service.nix`. I pretty much just followed the procedure from `redlib` , `php` and `ghostunnel`. This shouldn't affect any user facing options at all ("tested" with `nix build .#nixosConfigurations.${test-host}.config.system.build.toplevel` where `test-host` had `services.uptime-kuma` enabled and configured using the standard user facing options).

Documented steps:

1. Added myself to `maintainers/maintainer-list.nix`
1. Found preexisting test, service and package declarations:
    - Test: `nixos/tests/uptime-kuma.nix`
    - Service: `nixos/modules/services/monitoring/uptime-kuma.nix`
    - Package: `pkgs/by-name/up/uptime-kuma/package.nix`
1. Added `passthru.services` to `pkgs/by-name/up/uptime-kuma/package.nix`
    - Replace `rec` with `(finalAttrs: ... )` if needed (didn't need it for this one, for modules that use rec you'll need to do this)
1. Cut the `systemd.services.uptime-kuma` attrset and replaced it with `system.services.uptime-kuma.imports = [ pkgs.uptime-kuma.services.default ];`
1. Created the modular service file as `service.nix` in the same dir as the package:
    - `pkgs/by-name/up/uptime-kuma/service.nix`
1. Moved the old systemd service and NixOS options to the new `service.nix`
1. Made needed adjustments to `service.nix`
1. Wrote test for modular service at `nixos/tests/uptime-kuma-modular.nix`
1. Added test to `nixos/tests/all-tests.nix`
1. Ran tests for both new and old services `nix build .#nixosTests.uptime-kuma` & `nix build .#nixosTests.uptime-kuma-modular`

All requirements for modular services meet:

- [X] Has a NixOS VM test
- [X] Has a `meta.maintainers` attribute
- [X] Systemd-specific definitions are behind `optionalAttrs (options ? systemd)` to promote portability.
- [X] `_class = "service"`
- [X] Modular services provided through `passthru.services` must override the default of the package option using `finalAttrs.finalPackage`
- [X] Is the modular services infrastructure sufficient for this service?

Also, I have some things within `service.nix` that I'm not entirely sure on how correct they are. If someone with more experience could look over this and provide feedback here, that would be very much appreciated!

On another note, I do understand that modular services may be a little controversial in the community right now. If the uptime-kuma maintainers don't wish to have the added maintenance and updated mental model, I completely understand. That being said, if merged, I will maintain the modular service for the foreseeable future.  

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [X] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
