### PR TITLE
postgresql: out-of-cycle minor releases

### DIFF
--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "14.21";
-  rev = "refs/tags/REL_14_21";
-  hash = "sha256-9uG32BVzXOL2yAJmFVkIvEZJrmI5ToL7ojtivWmufL8=";
+  version = "14.22";
+  rev = "refs/tags/REL_14_22";
+  hash = "sha256-0vZEdsrj2WAdXFpZAli5sd0liAfvp9/Os93GjVTy7wk=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/disable-test-collate.icu.utf8.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "15.16";
-  rev = "refs/tags/REL_15_16";
-  hash = "sha256-ju/KkeBOumYHCarhqNA8jq+ceUo4y8g/SzjAMWm80ak=";
+  version = "15.17";
+  rev = "refs/tags/REL_15_17";
+  hash = "sha256-IxvCNJfTbbKT/2dFnNLk3fNUYDaRwHQeeAmvGc1w/OY=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql15/dont-use-locale-a-on-musl.patch?id=f424e934e6d076c4ae065ce45e734aa283eecb9c";

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "16.12";
-  rev = "refs/tags/REL_16_12";
-  hash = "sha256-1jkVElZTtp60Jgl5RyPT+8lalDYtjRDe9MxO3KMYJmU=";
+  version = "16.13";
+  rev = "refs/tags/REL_16_13";
+  hash = "sha256-Ue117xTq4RMQfq70mnXRBwqJ+IUigW27FvHY7I519ng=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql16/dont-use-locale-a-on-musl.patch?id=08a24be262339fd093e641860680944c3590238e";

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "17.8";
-  rev = "refs/tags/REL_17_8";
-  hash = "sha256-4lV1/xRmMsc5rgY3RB6WMigTXHgHjh9bmR6nzL82Rs4=";
+  version = "17.9";
+  rev = "refs/tags/REL_17_9";
+  hash = "sha256-kmESMgxYL5FsDjg3MLHaginIu6IWMo20kNdOLMM1x4w=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";

--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "18.2";
-  rev = "refs/tags/REL_18_2";
-  hash = "sha256-cvBXxA7/kEwDGxFv/YoZCIh17jzUujrCtfKAmtSxKTw=";
+  version = "18.3";
+  rev = "refs/tags/REL_18_3";
+  hash = "sha256-3cu3oyPJ5q6ewv7RFY7Nys5l+10dsQv5f1HNIoYtrO8=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";


### PR DESCRIPTION
Out-of-cycle release to fix regressions in the last set of releases.

Release Notes:
https://www.postgresql.org/about/news/out-of-cycle-release-scheduled-for-february-26-2026-3241/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
