### PR TITLE
fuseftp: init at 0.1.0

### DIFF
--- a/pkgs/by-name/fu/fuseftp/package.nix
+++ b/pkgs/by-name/fu/fuseftp/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  rustPlatform,
+  makeBinaryWrapper,
+  installShellFiles,
+  fuse,
+  openssl,
+  pkg-config,
+  fetchFromCodeberg,
+  nix-update-script,
+  tlsSupport ? true,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fuseftp";
+  version = "0.1.0";
+
+  src = fetchFromCodeberg {
+    owner = "nettika";
+    repo = "fuseftp";
+    tag = finalAttrs.version;
+    hash = "sha256-e2OgiB+g4d8c3mlTi9xVQgyYw62RGfR725C2QYxVgs8=";
+  };
+
+  cargoHash = "sha256-fByvf6ypfkWDTZoXxCF8ovsDN9CggNTblV3rYq4dKu4=";
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = lib.optional tlsSupport "tls";
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    installShellFiles
+  ]
+  ++ lib.optional tlsSupport pkg-config;
+
+  buildInputs = lib.optional tlsSupport openssl;
+
+  postInstall = ''
+    wrapProgram $out/bin/mount_fuse_ftp --prefix PATH : $out/bin
+    ln -s $out/bin/mount_fuse_ftp $out/bin/mount.fuse.ftp
+    installManPage man/fuseftp.1 man/mount.fuse.ftp.8
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    inherit (fuse.meta) platforms;
+    description = "Mount FTP servers as local filesystems";
+    homepage = "https://codeberg.org/nettika/fuseftp";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ nettika ];
+    mainProgram = "fuseftp";
+  };
+})


### PR DESCRIPTION
Creates a package for [fuseftp](https://codeberg.org/nettika/fuseftp). The package includes the [fuseftp CLI](https://crates.io/crates/fuseftp-cli), the [mount helper](https://crates.io/crates/fuseftp-mount-helper), and man pages. TLS support can be optionally disabled.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
