### PR TITLE
maintainers/scripts: add systemd-analyze-security-from-nixos-config.sh

### DIFF
--- a/maintainers/scripts/systemd-analyze-security-from-nixos-config.sh
+++ b/maintainers/scripts/systemd-analyze-security-from-nixos-config.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix systemd
+# shellcheck shell=bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  systemd-analyze-security-from-nixos-config.sh <nixos-config-path> <service-name>
+
+Example:
+  systemd-analyze-security-from-nixos-config.sh \
+    nixosTests.forgejo.sqlite3.nodes.server \
+    forgejo.service
+
+This builds <nixos-config-path>.system.build.etc from the local nixpkgs checkout
+and runs systemd-analyze security in offline mode against that root.
+
+Using system.build.etc includes template units and drop-ins, so instance units
+like foo@bar.service are analyzed with foo@.service + foo@bar.service.d/*.conf.
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+if [ "${1-}" = "-h" ] || [ "${1-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+[ "$#" -eq 2 ] || {
+  usage >&2
+  die "expected 2 arguments, got $#"
+}
+
+config_path="$1"
+service_name="$2"
+
+script_dir="$(dirname "$(readlink -f "$0")")"
+repo_root="$(readlink -f "${script_dir}/../..")"
+
+etc_expr="let
+  pkgs = import ./. {};
+  lib = pkgs.lib;
+  configPath = \"${config_path}\";
+  path = lib.strings.splitString \".\" configPath;
+  cfg = lib.attrByPath path (throw \"configuration path not found: \${configPath}\") pkgs;
+in
+cfg.system.build.etc or (throw \"missing system.build.etc at: \${configPath}\")"
+
+etc_root="$(
+  cd "$repo_root"
+  nix build \
+    --impure \
+    --no-link \
+    --print-out-paths \
+    --expr "$etc_expr"
+)"
+
+exec systemd-analyze security --no-pager --offline=yes --root "$etc_root" "$service_name"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds a helper script for simplifying running systemd-analyze security.

```sh
𑁱 ./maintainers/scripts/systemd-analyze-security-from-nixos-config.sh nixosTests.forgejo.sqlite3.nodes.server forgejo.service
  NAME                                                        DESCRIPTION                                                                                            EXPOSURE
✓ SystemCallFilter=~@swap                                     System call deny list defined for service, and @swap is included                                       
✗ SystemCallFilter=~@resources                                System call deny list defined for service, and @resources is not included (e.g. ioprio_set is allowed)      0.2
✓ SystemCallFilter=~@reboot                                   System call deny list defined 
<SNIP>                                                    
✗ UMask=                                                      Files created by service are group-readable by default                                                      0.1

→ Overall exposure level for forgejo.service: 1.2 OK 🙂
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
