### PR TITLE
gnuradioPackages.osmosdr: fix build with boost 1.89

### DIFF
--- a/pkgs/development/gnuradio-modules/lora_sdr/default.nix
+++ b/pkgs/development/gnuradio-modules/lora_sdr/default.nix
@@ -15,13 +15,13 @@
 
 mkDerivation {
   pname = "gr-lora_sdr";
-  version = "unstable-2025-01-09";
+  version = "0-unstable-2026-01-05";
 
   src = fetchFromGitHub {
     owner = "tapparelj";
     repo = "gr-lora_sdr";
-    rev = "9befbad3e6120529918acf1a742e25465f6b95e4";
-    hash = "sha256-9oBdzoS2aWWXmiUk5rI0gG3g+BJqUDgMu3/PmZSUkuU=";
+    rev = "862746dd1cf635c9c8a4bfbaa2c3a0ec3a5306c9";
+    hash = "sha256-12IqFNMLvqTN2R8+M9bXiteG4nQ8TwIMECSQPpgKCxM=";
   };
   disabled = gnuradioOlder "3.10";
 

--- a/pkgs/development/gnuradio-modules/osmosdr/default.nix
+++ b/pkgs/development/gnuradio-modules/osmosdr/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   mkDerivation,
   fetchgit,
+  fetchpatch,
   gnuradio,
   cmake,
   pkg-config,
@@ -33,6 +34,15 @@ mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-jCUzBY1pYiEtcRQ97t9F6uEMVYw2NU0eoB5Xc2H6pGQ=";
   };
+
+  patches = [
+    # Fixes build with boost 1.89, see:
+    # https://github.com/osmocom/gr-osmosdr/pull/29
+    (fetchpatch {
+      url = "https://github.com/osmocom/gr-osmosdr/commit/06249f1f0930aa553ef8877b50503b9f5c77b4a0.patch";
+      hash = "sha256-ofjuDvTT2PzRTR6UWchTQzmr9a83ka5TfUdlCBe4Is0=";
+    })
+  ];
 
   disabled = gnuradioAtLeast "3.11";
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test