### PR TITLE
pkgs/modsecurity-crs: 3.3.4 -> 4.24.0

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -74,6 +74,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `modsecurity-crs` has been updated from v3 to v4. You may need to integrate changes into your crs-setup.conf file.
+
 - `xfce.mkXfceDerivation` has been deprecated (i.e. conditioned behind `nixpkgs.config.allowAliases`)
   and will be removed in NixOS 26.11, please use `stdenv.mkDerivation` directly. You can migrate by
   adding `pkg-config`, `xfce4-dev-tools`, and `wrapGAppsHook3` to your `nativeBuildInputs` and

--- a/pkgs/by-name/mo/modsecurity-crs/package.nix
+++ b/pkgs/by-name/mo/modsecurity-crs/package.nix
@@ -5,21 +5,21 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "3.3.4";
   pname = "modsecurity-crs";
+  version = "4.24.0";
 
   src = fetchFromGitHub {
     owner = "coreruleset";
     repo = "coreruleset";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-WDJW4K85YdHrw9cys3LrnZUoTxc0WhiuCW6CiC1cAbk=";
+    sha256 = "sha256-BUkeQPXjS5t+UQEBjj2p0SC89q38xDLOcnsSshcgdFg=";
   };
 
   installPhase = ''
     install -D -m444 -t $out/rules ${finalAttrs.src}/rules/*.conf
     install -D -m444 -t $out/rules ${finalAttrs.src}/rules/*.data
     install -D -m444 -t $out/share/doc/modsecurity-crs ${finalAttrs.src}/*.md
-    install -D -m444 -t $out/share/doc/modsecurity-crs ${finalAttrs.src}/{CHANGES,INSTALL,LICENSE}
+    install -D -m444 -t $out/share/doc/modsecurity-crs ${finalAttrs.src}/LICENSE
     install -D -m444 -t $out/share/modsecurity-crs ${finalAttrs.src}/rules/*.example
     install -D -m444 -t $out/share/modsecurity-crs ${finalAttrs.src}/crs-setup.conf.example
     cat > $out/share/modsecurity-crs/modsecurity-crs.load.example <<EOF


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update the ModSecurity Core Rule Set from v3 to v4. This adds many new rules and enhancements that improve the security of the user's web services, including some CVE mitigations.

[Changes](https://github.com/coreruleset/coreruleset/blob/318e529357d6d1ab19bd0d26baf3ffcc5a472c04/CHANGES.md)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
