### PR TITLE
Zitadel: add start subcommand option

### DIFF
--- a/nixos/modules/services/web-apps/zitadel.nix
+++ b/nixos/modules/services/web-apps/zitadel.nix
@@ -73,6 +73,16 @@ in
         '';
       };
 
+      startCommand = mkOption {
+        type = types.enum [
+          "start-from-init"
+          "start-from-setup"
+          "start"
+        ];
+        default = "start-from-init";
+        description = "The ZITADEL subcommand to run.";
+      };
+
       settings = mkOption {
         type = lib.types.submodule {
           freeformType = settingsFormat.type;
@@ -220,7 +230,7 @@ in
         wantedBy = [ "multi-user.target" ];
 
         script = ''
-          zitadel start-from-init ${args}
+          zitadel ${cfg.startCommand} ${args}
         '';
 
         serviceConfig = {


### PR DESCRIPTION
Just added an option to specify start subcommand.

Resolves #393873 

Can specify start-from-setup, will not try to create database and in turn won't have to use admin credentials

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
