### PR TITLE
nixos/forgejo.runner: initialize module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -146,6 +146,8 @@
 
 - [perses](https://perses.dev/), the open dashboard tool for Prometheus and other data sources. Available as [services.perses](#opt-services.perses.enable).
 
+- [Forgejo Runner](https://code.forgejo.org/forgejo/runner), a dedicated Forgejo Actions runner module for multi-instance deployments is now available as [services.forgejo.runner.instances](#opt-services.forgejo.runner.instances).
+
 - [Drasl](https://github.com/unmojang/drasl), an alternative authentication server for Minecraft. Available as [services.drasl](#opt-services.drasl.enable).
 
 - [tabbyAPI](https://github.com/theroyallab/tabbyAPI), the official OpenAI compatible API server for Exllama. Available as [services.tabbyapi](#opt-services.tabbyapi.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -509,6 +509,7 @@
   ./services/continuous-integration/buildbot/master.nix
   ./services/continuous-integration/buildbot/worker.nix
   ./services/continuous-integration/buildkite-agents.nix
+  ./services/continuous-integration/forgejo-runner.nix
   ./services/continuous-integration/gitea-actions-runner.nix
   ./services/continuous-integration/github-runners.nix
   ./services/continuous-integration/gitlab-runner/runner.nix

--- a/nixos/modules/services/continuous-integration/forgejo-runner.nix
+++ b/nixos/modules/services/continuous-integration/forgejo-runner.nix
@@ -1,0 +1,300 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  inherit (lib)
+    any
+    attrValues
+    concatStringsSep
+    escapeShellArg
+    hasInfix
+    hasSuffix
+    literalExpression
+    mapAttrs'
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    mkRenamedOptionModule
+    nameValuePair
+    optionalAttrs
+    optionals
+    teams
+    types
+    ;
+
+  inherit (utils)
+    escapeSystemdPath
+    ;
+
+  cfg = config.services.forgejo.runner;
+
+  settingsFormat = pkgs.formats.yaml { };
+
+  # Empty label strings result in upstream default labels, which require docker.
+  hasDockerScheme =
+    instance: instance.labels == [ ] || any (label: hasInfix ":docker:" label) instance.labels;
+  wantsContainerRuntime = any hasDockerScheme (attrValues cfg.instances);
+
+  hasHostScheme = instance: any (label: hasSuffix ":host" label) instance.labels;
+
+  hasDocker = config.virtualisation.docker.enable;
+  hasPodman = config.virtualisation.podman.enable;
+in
+{
+  meta.maintainers = teams.forgejo.members;
+
+  imports = [
+    (mkRenamedOptionModule [ "services" "forgejo-runner" ] [ "services" "forgejo" "runner" ])
+  ];
+
+  options.services.forgejo.runner = with types; {
+    package = mkPackageOption pkgs "forgejo-runner" { };
+
+    instances = mkOption {
+      default = { };
+      description = ''
+        Forgejo Actions Runner instances.
+      '';
+      type = attrsOf (
+        submodule (
+          { name, ... }:
+          {
+            options = {
+              enable = mkEnableOption "Forgejo Actions Runner instance";
+
+              name = mkOption {
+                type = str;
+                example = literalExpression "config.networking.hostName";
+                description = ''
+                  The name identifying the runner instance towards the Forgejo instance.
+                '';
+                default = name;
+              };
+
+              url = mkOption {
+                type = str;
+                example = "https://forge.example.com";
+                description = ''
+                  Base URL of your Forgejo instance.
+                '';
+              };
+
+              tokenFile = mkOption {
+                type = nullOr (either str path);
+                default = null;
+                description = ''
+                  Path to a file containing only the token that will be used to register
+                  with the the configured Forgejo instance.
+                '';
+              };
+
+              labels = mkOption {
+                type = listOf str;
+                example = literalExpression ''
+                  [
+                    # provide a debian base with nodejs for actions
+                    "debian-latest:docker://node:18-bullseye"
+                    # fake the ubuntu name, because node provides no ubuntu builds
+                    "ubuntu-latest:docker://node:18-bullseye"
+                    # provide native execution on the host
+                    #"native:host"
+                  ]
+                '';
+                description = ''
+                  Labels used to map jobs to their runtime environment. Changing these
+                  labels currently requires a new registration token.
+
+                  Many common actions require bash, git and nodejs, as well as a filesystem
+                  that follows the filesystem hierarchy standard.
+                '';
+              };
+
+              settings = mkOption {
+                description = ''
+                  Configuration for `forgejo-runner daemon`.
+                  See <https://code.forgejo.org/forgejo/runner/src/branch/main/internal/pkg/config/config.example.yaml> for an example configuration.
+                '';
+
+                type = types.submodule {
+                  freeformType = settingsFormat.type;
+                };
+
+                default = { };
+              };
+
+              hostPackages = mkOption {
+                type = listOf package;
+                default = with pkgs; [
+                  bash
+                  coreutils
+                  curl
+                  gawk
+                  gitMinimal
+                  gnused
+                  nodejs
+                  wget
+                ];
+                defaultText = literalExpression ''
+                  with pkgs; [
+                    bash
+                    coreutils
+                    curl
+                    gawk
+                    gitMinimal
+                    gnused
+                    nodejs
+                    wget
+                  ]
+                '';
+                description = ''
+                  List of packages that are available to actions, when the runner is configured
+                  with a host execution label.
+                '';
+              };
+            };
+          }
+        )
+      );
+    };
+  };
+
+  config = mkIf (cfg.instances != { }) {
+    assertions = [
+      {
+        assertion = wantsContainerRuntime -> hasDocker || hasPodman;
+        message = "Label configuration on forgejo.runner instance requires either docker or podman.";
+      }
+    ];
+
+    systemd.services =
+      let
+        mkRunnerInstance =
+          _: instance:
+          let
+            escapedName = escapeSystemdPath instance.name;
+            wantsContainer = hasDockerScheme instance;
+            wantsHost = hasHostScheme instance;
+            wantsDocker = wantsContainer && hasDocker;
+            wantsPodman = wantsContainer && hasPodman;
+            configFile = settingsFormat.generate "forgejo-runner-${escapedName}.yaml" instance.settings;
+          in
+          nameValuePair "forgejo-runner@${escapedName}" {
+            overrideStrategy = "asDropin";
+            inherit (instance) enable;
+            wants = [
+              "network-online.target"
+            ]
+            ++ optionals wantsDocker [ "docker.service" ]
+            ++ optionals wantsPodman [ "podman.service" ];
+            after = [
+              "network-online.target"
+            ]
+            ++ optionals wantsDocker [ "docker.service" ]
+            ++ optionals wantsPodman [ "podman.service" ];
+            wantedBy = [ "multi-user.target" ];
+
+            environment = optionalAttrs wantsPodman {
+              DOCKER_HOST = "unix:///run/podman/podman.sock";
+            };
+
+            path = [ pkgs.coreutils ] ++ lib.optionals wantsHost instance.hostPackages;
+
+            serviceConfig = {
+              MemoryDenyWriteExecute = !wantsHost;
+
+              LoadCredential = [ "TOKEN:${instance.tokenFile}" ];
+
+              ExecStartPre = [
+                (lib.getExe (
+                  pkgs.writeShellApplication {
+                    name = "forgejo-register-runner-${escapedName}";
+                    text = ''
+                      INSTANCE_DIR="$STATE_DIRECTORY"
+                      mkdir -vp "$INSTANCE_DIR"
+                      cd "$INSTANCE_DIR"
+
+                      LABELS_FILE="$INSTANCE_DIR/.labels.sha256"
+                      LABELS_WANTED="$(echo ${escapeShellArg (concatStringsSep "\n" instance.labels)} | sort)"
+                      LABELS_WANTED_HASH="$(printf '%s' "$LABELS_WANTED" | sha256sum | cut -d' ' -f1)"
+                      LABELS_CURRENT_HASH="$(cat "$LABELS_FILE" 2>/dev/null || true)"
+
+                      if [ ! -e "$INSTANCE_DIR/.runner" ] || [ "$LABELS_WANTED_HASH" != "$LABELS_CURRENT_HASH" ]; then
+                        rm -vf "$INSTANCE_DIR/.runner" || true
+
+                        ${cfg.package}/bin/forgejo-runner register \
+                          --no-interactive \
+                          --instance ${escapeShellArg instance.url} \
+                          --token "$(cat "$CREDENTIALS_DIRECTORY/TOKEN")" \
+                          --name ${escapeShellArg instance.name} \
+                          --labels ${escapeShellArg (concatStringsSep "," instance.labels)} \
+                          --config ${configFile}
+
+                        printf '%s' "$LABELS_WANTED_HASH" > "$LABELS_FILE"
+                      fi
+                    '';
+                  }
+                ))
+              ];
+              ExecStart = lib.mkForce "${cfg.package}/bin/forgejo-runner daemon --config ${configFile}";
+              SupplementaryGroups = optionals wantsDocker [ "docker" ] ++ optionals wantsPodman [ "podman" ];
+              ExecPaths = lib.optionals wantsHost [ "/var/lib/forgejo-runner/${escapedName}" ];
+            };
+          };
+      in
+      {
+        "forgejo-runner@" = {
+          description = "Forgejo Actions Runner (%I)";
+
+          environment = {
+            HOME = "/var/lib/forgejo-runner/%i";
+          };
+
+          serviceConfig = {
+            DynamicUser = true;
+            User = "forgejo-runner-%i";
+            StateDirectory = "forgejo-runner/%i";
+            WorkingDirectory = "/var/lib/forgejo-runner/%i";
+
+            Restart = "on-failure";
+            RestartSec = 2;
+
+            AmbientCapabilities = "";
+            CapabilityBoundingSet = "";
+            LockPersonality = true;
+            NoNewPrivileges = true;
+            PrivateDevices = true;
+            PrivateTmp = true;
+            ProcSubset = "pid";
+            ProtectClock = true;
+            ProtectControlGroups = true;
+            ProtectHome = true;
+            ProtectHostname = true;
+            ProtectKernelLogs = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            ProtectProc = "invisible";
+            ProtectSystem = "strict";
+            RemoveIPC = true;
+            RestrictAddressFamilies = [
+              "AF_INET"
+              "AF_INET6"
+              "AF_UNIX"
+            ];
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            SystemCallArchitectures = "native";
+            SystemCallFilter = [ "@system-service" ];
+            UMask = "0077";
+          };
+        };
+      }
+      // mapAttrs' mkRunnerInstance cfg.instances;
+  };
+}

--- a/nixos/modules/services/continuous-integration/forgejo-runner.nix
+++ b/nixos/modules/services/continuous-integration/forgejo-runner.nix
@@ -75,7 +75,7 @@ let
     description = ''
       Base URL of your Forgejo instance.
 
-      Can also be specified in `settings.servier.connections`
+      Can also be specified in `settings.server.connections`
     '';
   };
 
@@ -220,10 +220,10 @@ in
             type = types.nullOr (types.either types.str types.path);
             default = null;
             description = ''
+              **DEPRECATED** Replaced by `settings.server.connections`
+
               Path to a file containing only the token that will be used to register
               on start with the the configured Forgejo instance.
-
-              **Deprecated** Replaced by `settings.server.connections`
 
               <https://forgejo.org/docs/latest/admin/actions/registration/>
             '';
@@ -267,7 +267,7 @@ in
                           Path to the Forgejo v15+ pre-registered runner token.
                           Supports a single placeholder: `$CREDENTIALS_DIRECTORY`
 
-                          Can be combined with `instances.<instance>.credentails`
+                          Can be combined with `instances.<instance>.credentials`
 
                           <https://forgejo.org/docs/latest/admin/actions/registration/>
                         '';
@@ -353,6 +353,10 @@ in
           {
             assertion = connection.url != null;
             message = "forgejo.runner.instances.${name_inst}.settings.server.connections.${name} requires `url` to be set.";
+          }
+          {
+            assertion = connection.labels != null;
+            message = "forgejo.runner.instances.${name_inst}.settings.server.connections.${name} requires `labels` to be set.";
           }
           {
             assertion = !(connection ? token);

--- a/nixos/modules/services/continuous-integration/forgejo-runner.nix
+++ b/nixos/modules/services/continuous-integration/forgejo-runner.nix
@@ -78,6 +78,125 @@ let
       Can also be specified in `settings.servier.connections`
     '';
   };
+
+  mkRunnerInstance =
+    name: instance:
+    let
+      allLabels = instanceLabels instance;
+      wantsContainer = hasDockerScheme allLabels;
+      wantsHost = hasHostScheme allLabels;
+      wantsDocker = wantsContainer && hasDocker;
+      wantsPodman = wantsContainer && hasPodman;
+      configFile = settingsFormat.generate "forgejo-runner-${name}.yaml" instance.settings;
+    in
+    nameValuePair "forgejo-runner-${escapeSystemdPath name}" {
+      inherit (instance) enable;
+
+      description = "Forgejo Actions Runner (${name})";
+
+      environment = {
+        HOME = "/var/lib/forgejo-runner/${name}";
+      }
+      // optionalAttrs wantsPodman {
+        DOCKER_HOST = "unix:///run/podman/podman.sock";
+      };
+
+      wants = [
+        "network-online.target"
+      ]
+      ++ optionals wantsDocker [ "docker.service" ]
+      ++ optionals wantsPodman [ "podman.service" ];
+      after = [
+        "network-online.target"
+      ]
+      ++ optionals wantsDocker [ "docker.service" ]
+      ++ optionals wantsPodman [ "podman.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      path = [ pkgs.coreutils ] ++ lib.optionals wantsHost instance.hostPackages;
+
+      serviceConfig = {
+        DynamicUser = true;
+        StateDirectory = "forgejo-runner/${name}";
+        WorkingDirectory = "/var/lib/forgejo-runner/${name}";
+
+        Restart = "on-failure";
+        RestartSec = 2;
+
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" ];
+        UMask = "0077";
+        MemoryDenyWriteExecute = !wantsHost;
+
+        LoadCredential =
+          lib.optionals (instance.registrationTokenFile != null) [
+            "REGISTRATION_TOKEN:${instance.registrationTokenFile}"
+          ]
+          ++ lib.mapAttrsToList (name: value: "${name}:${value}") instance.credentials;
+
+        SupplementaryGroups = optionals wantsDocker [ "docker" ] ++ optionals wantsPodman [ "podman" ];
+        ExecPaths = lib.optionals wantsHost [ "/var/lib/forgejo-runner/${name}" ];
+
+        ExecStartPre = lib.optionals (instance.registrationTokenFile != null) [
+          (lib.getExe (
+            pkgs.writeShellApplication {
+              name = "forgejo-register-runner-${name}";
+              text = ''
+                INSTANCE_DIR="$STATE_DIRECTORY"
+                mkdir -vp "$INSTANCE_DIR"
+                cd "$INSTANCE_DIR"
+
+                LABELS_FILE="$INSTANCE_DIR/.labels.sha256"
+                LABELS_WANTED="$(echo ${escapeShellArg (concatStringsSep "\n" instance.labels)} | sort)"
+                LABELS_WANTED_HASH="$(printf '%s' "$LABELS_WANTED" | sha256sum | cut -d' ' -f1)"
+                LABELS_CURRENT_HASH="$(cat "$LABELS_FILE" 2>/dev/null || true)"
+
+                if [ ! -e "$INSTANCE_DIR/.runner" ] || [ "$LABELS_WANTED_HASH" != "$LABELS_CURRENT_HASH" ]; then
+                  rm -vf "$INSTANCE_DIR/.runner" || true
+
+                  ${cfg.package}/bin/forgejo-runner register \
+                    --no-interactive \
+                    --instance ${escapeShellArg instance.url} \
+                    --token "$(cat "$CREDENTIALS_DIRECTORY/REGISTRATION_TOKEN")" \
+                    --name ${escapeShellArg name} \
+                    --labels ${escapeShellArg (concatStringsSep "," instance.labels)} \
+                    --config ${configFile}
+
+                  printf '%s' "$LABELS_WANTED_HASH" > "$LABELS_FILE"
+                fi
+              '';
+            }
+          ))
+        ];
+
+        ExecStart = lib.mkForce "${cfg.package}/bin/forgejo-runner daemon --config '${configFile}'";
+      };
+    };
 in
 {
   meta.maintainers = teams.forgejo.members;
@@ -90,164 +209,154 @@ in
       description = ''
         Forgejo Actions Runner instances.
       '';
-      type = attrsOf (
-        submodule (
-          { name, ... }:
-          {
-            options = {
-              labels = labelsOption;
-              enable = mkEnableOption "Forgejo Actions Runner instance";
+      type = attrsOf (submodule {
+        options = {
+          labels = labelsOption;
+          enable = mkEnableOption "Forgejo Actions Runner instance";
 
-              name = mkOption {
-                type = types.str;
-                example = literalExpression "config.networking.hostName";
-                description = ''
-                  The name identifying the runner instance towards the Forgejo instance.
-                '';
-                default = name;
-              };
+          url = urlOption;
 
-              url = urlOption;
+          registrationTokenFile = mkOption {
+            type = types.nullOr (types.either types.str types.path);
+            default = null;
+            description = ''
+              Path to a file containing only the token that will be used to register
+              on start with the the configured Forgejo instance.
 
-              registrationTokenFile = mkOption {
-                type = types.nullOr (types.either types.str types.path);
-                default = null;
-                description = ''
-                  Path to a file containing only the token that will be used to register
-                  on start with the the configured Forgejo instance.
+              **Deprecated** Replaced by `settings.server.connections`
 
-                  **Deprecated** Replaced by `settings.server.connections`
+              <https://forgejo.org/docs/latest/admin/actions/registration/>
+            '';
+          };
 
-                  <https://forgejo.org/docs/latest/admin/actions/registration/>
-                '';
-              };
-
-              credentials = mkOption {
-                type = types.attrsOf types.path;
-                default = { };
-                example = {
-                  WORKER1_TOKEN = "/run/keys/worker1";
-                };
-                description = ''
-                  Environment variables with absolute paths to credentials files to load
-                  on runner startup.
-
-                  Use with Forgejo v15+ pre-registered server connections:
-
-                  `settings.server.connections.<connection>.token_url = "file:$CREDENTIALS_DIRECTORY/WORKER1_TOKEN"`
-                '';
-              };
-
-              settings = mkOption {
-                description = ''
-                  Configuration for `forgejo-runner daemon`.
-                  See <https://code.forgejo.org/forgejo/runner/src/branch/main/internal/pkg/config/config.example.yaml> for an example configuration.
-                '';
-
-                type = types.submodule {
-                  freeformType = settingsFormat.type;
-
-                  options.server.connections = mkOption {
-                    type = types.attrsOf (
-                      types.submodule {
-                        freeformType = settingsFormat.type;
-                        options = {
-                          url = urlOption;
-                          labels = labelsOption;
-                          token_url = mkOption {
-                            type = types.either types.str types.path;
-                            description = ''
-                              Path to the Forgejo v15+ pre-registered runner token.
-                              Supports a single placeholder: `$CREDENTIALS_DIRECTORY`
-
-                              Can be combined with `instances.<instance>.credentails`
-
-                              <https://forgejo.org/docs/latest/admin/actions/registration/>
-                            '';
-                          };
-                        };
-                      }
-                    );
-                    default = { };
-                    description = ''
-                      Forgejo v15+ pre-registered server connections.
-
-                      See <https://forgejo.org/docs/latest/admin/actions/registration>
-                    '';
-                    example = literalExpression ''
-                      {
-                        worker1 = {
-                          url = "https://forgejo.mine";
-                          uuid = "4708f0f2-4185-49b4-8552-bc7261ec26aa";
-                          token_url = "file:$CREDENTIALS_DIRECTORY/WORKER1_TOKEN";
-                          labels = [
-                            "debian:docker://docker.io/library/node:lts"
-                            "local/x86_64-linux:host"
-                          ];
-                        };
-                      };
-                    '';
-                  };
-
-                };
-
-                default = { };
-              };
-
-              hostPackages = mkOption {
-                type = types.listOf types.package;
-                default = with pkgs; [
-                  bash
-                  coreutils
-                  curl
-                  gawk
-                  gitMinimal
-                  gnused
-                  nodejs
-                  wget
-                ];
-                defaultText = literalExpression ''
-                  with pkgs; [
-                    bash
-                    coreutils
-                    curl
-                    gawk
-                    gitMinimal
-                    gnused
-                    nodejs
-                    wget
-                  ]
-                '';
-                description = ''
-                  List of packages that are available to actions, when the runner is configured
-                  with a host execution label.
-                '';
-              };
+          credentials = mkOption {
+            type = types.attrsOf types.path;
+            default = { };
+            example = {
+              WORKER1_TOKEN = "/run/keys/worker1";
             };
-          }
-        )
-      );
+            description = ''
+              Environment variables with absolute paths to credentials files to load
+              on runner startup.
+
+              Use with Forgejo v15+ pre-registered server connections:
+
+              `settings.server.connections.<connection>.token_url = "file:$CREDENTIALS_DIRECTORY/WORKER1_TOKEN"`
+            '';
+          };
+
+          settings = mkOption {
+            description = ''
+              Configuration for `forgejo-runner daemon`.
+              See <https://code.forgejo.org/forgejo/runner/src/branch/main/internal/pkg/config/config.example.yaml> for an example configuration.
+            '';
+
+            type = types.submodule {
+              freeformType = settingsFormat.type;
+
+              options.server.connections = mkOption {
+                type = types.attrsOf (
+                  types.submodule {
+                    freeformType = settingsFormat.type;
+                    options = {
+                      url = urlOption;
+                      labels = labelsOption;
+                      token_url = mkOption {
+                        type = types.pathWith { inStore = false; };
+                        description = ''
+                          Path to the Forgejo v15+ pre-registered runner token.
+                          Supports a single placeholder: `$CREDENTIALS_DIRECTORY`
+
+                          Can be combined with `instances.<instance>.credentails`
+
+                          <https://forgejo.org/docs/latest/admin/actions/registration/>
+                        '';
+                      };
+                      uuid = mkOption {
+                        type = types.str;
+                        description = ''
+                          UUID of runner provided by Forgejo server during pre-registration.
+
+                          <https://forgejo.org/docs/latest/admin/actions/registration/>
+                        '';
+                      };
+                    };
+                  }
+                );
+                default = { };
+                description = ''
+                  Forgejo v15+ pre-registered server connections.
+
+                  See <https://forgejo.org/docs/latest/admin/actions/registration>
+                '';
+                example = literalExpression ''
+                  {
+                    worker1 = {
+                      url = "https://forgejo.mine";
+                      uuid = "4708f0f2-4185-49b4-8552-bc7261ec26aa";
+                      token_url = "file:$CREDENTIALS_DIRECTORY/WORKER1_TOKEN";
+                      labels = [
+                        "debian:docker://docker.io/library/node:lts"
+                        "local/x86_64-linux:host"
+                      ];
+                    };
+                  };
+                '';
+              };
+
+            };
+
+            default = { };
+          };
+
+          hostPackages = mkOption {
+            type = types.listOf types.package;
+            default = with pkgs; [
+              bash
+              coreutils
+              curl
+              gawk
+              gitMinimal
+              gnused
+              nodejs
+              wget
+            ];
+            defaultText = literalExpression ''
+              with pkgs; [
+                bash
+                coreutils
+                curl
+                gawk
+                gitMinimal
+                gnused
+                nodejs
+                wget
+              ]
+            '';
+            description = ''
+              List of packages that are available to actions, when the runner is configured
+              with a host execution label.
+            '';
+          };
+        };
+      });
     };
   };
 
   config = mkIf (cfg.instances != { }) {
     assertions = lib.foldlAttrs (
-      acc_inst: _: instance:
+      acc_inst: name_inst: instance:
       (lib.foldlAttrs (
         acc_conn: name: connection:
         acc_conn
         ++ [
           {
             assertion = connection.url != null;
-            message = "forgejo.runner.instances.${instance.name}.settings.server.connections.${name} requires `url` to be set.";
+            message = "forgejo.runner.instances.${name_inst}.settings.server.connections.${name} requires `url` to be set.";
           }
           {
             assertion = !(connection ? token);
-            message = "forgejo.runner.instances.${instance.name}.settings.server.connections.${name}.token cannot be used, use token_url instead.";
-          }
-          {
-            assertion = connection ? uuid;
-            message = "forgejo.runner.instances.${instance.name}.settings.server.connections.${name}.uuid is required.";
+            message = "forgejo.runner.instances.${name_inst}.settings.server.connections.${name}.token cannot be used, use token_url instead.";
           }
         ]
       ) acc_inst instance.settings.server.connections)
@@ -256,153 +365,23 @@ in
           assertion =
             instance.settings.server.connections != { }
             -> instance.registrationTokenFile == null && instance.url == null && instance.labels == null;
-          message = "forgejo.runner.instances.${instance.name} cannot contain both url/registrationTokenFile and settings.server.connections";
+          message = "forgejo.runner.instances.${name_inst} cannot contain both url/registrationTokenFile and settings.server.connections";
         }
         {
           assertion = instance.registrationTokenFile != null -> instance.url != null;
-          message = "forgejo.runner.instances.${instance.name}.registrationTokenFile requires `url` to be set.";
+          message = "forgejo.runner.instances.${name_inst}.registrationTokenFile requires `url` to be set.";
         }
         {
           assertion = instance.labels != null -> instance.registrationTokenFile != null;
-          message = "forgejo.runner.instances.${instance.name}.labels requires `registrationTokenFile` to be set.";
+          message = "forgejo.runner.instances.${name_inst}.labels requires `registrationTokenFile` to be set.";
         }
         {
           assertion = hasDockerScheme (instanceLabels instance) -> hasDocker || hasPodman;
-          message = "forgejo.runner.instances.${instance.name} label configuration requires either docker or podman.";
+          message = "forgejo.runner.instances.${name_inst} label configuration requires either docker or podman.";
         }
       ]
     ) [ ] cfg.instances;
 
-    systemd.services =
-      let
-        mkRunnerInstance =
-          _: instance:
-          let
-            allLabels = instanceLabels instance;
-            escapedName = escapeSystemdPath instance.name;
-            wantsContainer = hasDockerScheme allLabels;
-            wantsHost = hasHostScheme allLabels;
-            wantsDocker = wantsContainer && hasDocker;
-            wantsPodman = wantsContainer && hasPodman;
-            configFile = settingsFormat.generate "forgejo-runner-${escapedName}.yaml" instance.settings;
-          in
-          nameValuePair "forgejo-runner@${escapedName}" {
-            overrideStrategy = "asDropin";
-            inherit (instance) enable;
-            wants = [
-              "network-online.target"
-            ]
-            ++ optionals wantsDocker [ "docker.service" ]
-            ++ optionals wantsPodman [ "podman.service" ];
-            after = [
-              "network-online.target"
-            ]
-            ++ optionals wantsDocker [ "docker.service" ]
-            ++ optionals wantsPodman [ "podman.service" ];
-            wantedBy = [ "multi-user.target" ];
-
-            environment = optionalAttrs wantsPodman {
-              DOCKER_HOST = "unix:///run/podman/podman.sock";
-            };
-
-            path = [ pkgs.coreutils ] ++ lib.optionals wantsHost instance.hostPackages;
-
-            serviceConfig = {
-              MemoryDenyWriteExecute = !wantsHost;
-
-              LoadCredential =
-                lib.optionals (instance.registrationTokenFile != null) [
-                  "REGISTRATION_TOKEN:${instance.registrationTokenFile}"
-                ]
-                ++ lib.mapAttrsToList (name: value: "${name}:${value}") instance.credentials;
-
-              SupplementaryGroups = optionals wantsDocker [ "docker" ] ++ optionals wantsPodman [ "podman" ];
-              ExecPaths = lib.optionals wantsHost [ "/var/lib/forgejo-runner/${escapedName}" ];
-
-              ExecStartPre = lib.optionals (instance.registrationTokenFile != null) [
-                (lib.getExe (
-                  pkgs.writeShellApplication {
-                    name = "forgejo-register-runner-${escapedName}";
-                    text = ''
-                      INSTANCE_DIR="$STATE_DIRECTORY"
-                      mkdir -vp "$INSTANCE_DIR"
-                      cd "$INSTANCE_DIR"
-
-                      LABELS_FILE="$INSTANCE_DIR/.labels.sha256"
-                      LABELS_WANTED="$(echo ${escapeShellArg (concatStringsSep "\n" instance.labels)} | sort)"
-                      LABELS_WANTED_HASH="$(printf '%s' "$LABELS_WANTED" | sha256sum | cut -d' ' -f1)"
-                      LABELS_CURRENT_HASH="$(cat "$LABELS_FILE" 2>/dev/null || true)"
-
-                      if [ ! -e "$INSTANCE_DIR/.runner" ] || [ "$LABELS_WANTED_HASH" != "$LABELS_CURRENT_HASH" ]; then
-                        rm -vf "$INSTANCE_DIR/.runner" || true
-
-                        ${cfg.package}/bin/forgejo-runner register \
-                          --no-interactive \
-                          --instance ${escapeShellArg instance.url} \
-                          --token "$(cat "$CREDENTIALS_DIRECTORY/REGISTRATION_TOKEN")" \
-                          --name ${escapeShellArg instance.name} \
-                          --labels ${escapeShellArg (concatStringsSep "," instance.labels)} \
-                          --config ${configFile}
-
-                        printf '%s' "$LABELS_WANTED_HASH" > "$LABELS_FILE"
-                      fi
-                    '';
-                  }
-                ))
-              ];
-
-              ExecStart = lib.mkForce "${cfg.package}/bin/forgejo-runner daemon --config ${configFile}";
-            };
-          };
-      in
-      {
-        "forgejo-runner@" = {
-          description = "Forgejo Actions Runner (%I)";
-
-          environment = {
-            HOME = "/var/lib/forgejo-runner/%i";
-          };
-
-          serviceConfig = {
-            DynamicUser = true;
-            User = "forgejo-runner-%i";
-            StateDirectory = "forgejo-runner/%i";
-            WorkingDirectory = "/var/lib/forgejo-runner/%i";
-
-            Restart = "on-failure";
-            RestartSec = 2;
-
-            AmbientCapabilities = "";
-            CapabilityBoundingSet = "";
-            LockPersonality = true;
-            NoNewPrivileges = true;
-            PrivateDevices = true;
-            PrivateTmp = true;
-            ProcSubset = "pid";
-            ProtectClock = true;
-            ProtectControlGroups = true;
-            ProtectHome = true;
-            ProtectHostname = true;
-            ProtectKernelLogs = true;
-            ProtectKernelModules = true;
-            ProtectKernelTunables = true;
-            ProtectProc = "invisible";
-            ProtectSystem = "strict";
-            RemoveIPC = true;
-            RestrictAddressFamilies = [
-              "AF_INET"
-              "AF_INET6"
-              "AF_UNIX"
-            ];
-            RestrictNamespaces = true;
-            RestrictRealtime = true;
-            RestrictSUIDSGID = true;
-            SystemCallArchitectures = "native";
-            SystemCallFilter = [ "@system-service" ];
-            UMask = "0077";
-          };
-        };
-      }
-      // mapAttrs' mkRunnerInstance cfg.instances;
+    systemd.services = mapAttrs' mkRunnerInstance cfg.instances;
   };
 }

--- a/nixos/modules/services/continuous-integration/forgejo-runner.nix
+++ b/nixos/modules/services/continuous-integration/forgejo-runner.nix
@@ -36,20 +36,48 @@ let
 
   instanceLabels =
     instance:
-    instance.labels
-    ++ lib.concatMap (connection: connection.labels or [ ]) (
+    (lib.defaultTo [ ] instance.labels)
+    ++ lib.concatMap (connection: lib.defaultTo [ ] (connection.labels or [ ])) (
       lib.attrValues (instance.settings.server.connections or { })
     );
 
   hasDockerScheme = labels: any (label: hasInfix ":docker:" label) labels;
   hasHostScheme = labels: any (label: hasSuffix ":host" label) labels;
 
-  wantsContainerRuntime = any (instance: hasDockerScheme (instanceLabels instance)) (
-    lib.attrValues cfg.instances
-  );
-
   hasDocker = config.virtualisation.docker.enable;
   hasPodman = config.virtualisation.podman.enable;
+
+  labelsOption = mkOption {
+    type = types.nullOr (types.listOf types.str);
+    default = null;
+    example = literalExpression ''
+      [
+        # provide a debian base with nodejs for actions
+        "debian-latest:docker://node:18-bullseye"
+        # fake the ubuntu name, because node provides no ubuntu builds
+        "ubuntu-latest:docker://node:18-bullseye"
+        # provide native execution on the host
+        #"native:host"
+      ]
+    '';
+    description = ''
+      Labels used to map jobs to their runtime environment. Changing these
+      labels currently requires a new registration token.
+
+      Many common actions require bash, git and nodejs, as well as a filesystem
+      that follows the filesystem hierarchy standard.
+    '';
+  };
+  urlOption = mkOption {
+    type = types.nullOr types.str;
+    default = null;
+    example = "https://forge.example.com";
+    description = ''
+      Base URL of your Forgejo instance.
+
+      Can also be specified in `settings.servier.connections`
+    '';
+  };
 in
 {
   meta.maintainers = teams.forgejo.members;
@@ -67,10 +95,11 @@ in
           { name, ... }:
           {
             options = {
+              labels = labelsOption;
               enable = mkEnableOption "Forgejo Actions Runner instance";
 
               name = mkOption {
-                type = str;
+                type = types.str;
                 example = literalExpression "config.networking.hostName";
                 description = ''
                   The name identifying the runner instance towards the Forgejo instance.
@@ -78,19 +107,10 @@ in
                 default = name;
               };
 
-              url = mkOption {
-                type = nullOr str;
-                default = null;
-                example = "https://forge.example.com";
-                description = ''
-                  Base URL of your Forgejo instance.
-
-                  Can also be specified in `settings.servier.connections`
-                '';
-              };
+              url = urlOption;
 
               registrationTokenFile = mkOption {
-                type = nullOr (either str path);
+                type = types.nullOr (types.either types.str types.path);
                 default = null;
                 description = ''
                   Path to a file containing only the token that will be used to register
@@ -102,8 +122,8 @@ in
                 '';
               };
 
-              credentials = lib.mkOption {
-                type = attrsOf lib.types.path;
+              credentials = mkOption {
+                type = types.attrsOf types.path;
                 default = { };
                 example = {
                   WORKER1_TOKEN = "/run/keys/worker1";
@@ -111,28 +131,10 @@ in
                 description = ''
                   Environment variables with absolute paths to credentials files to load
                   on runner startup.
-                '';
-              };
 
-              labels = mkOption {
-                type = listOf str;
-                default = [ ];
-                example = literalExpression ''
-                  [
-                    # provide a debian base with nodejs for actions
-                    "debian-latest:docker://node:18-bullseye"
-                    # fake the ubuntu name, because node provides no ubuntu builds
-                    "ubuntu-latest:docker://node:18-bullseye"
-                    # provide native execution on the host
-                    #"native:host"
-                  ]
-                '';
-                description = ''
-                  Labels used to map jobs to their runtime environment. Changing these
-                  labels currently requires a new registration token.
+                  Use with Forgejo v15+ pre-registered server connections:
 
-                  Many common actions require bash, git and nodejs, as well as a filesystem
-                  that follows the filesystem hierarchy standard.
+                  `settings.server.connections.<connection>.token_url = "file:$CREDENTIALS_DIRECTORY/WORKER1_TOKEN"`
                 '';
               };
 
@@ -144,13 +146,56 @@ in
 
                 type = types.submodule {
                   freeformType = settingsFormat.type;
+
+                  options.server.connections = mkOption {
+                    type = types.attrsOf (
+                      types.submodule {
+                        freeformType = settingsFormat.type;
+                        options = {
+                          url = urlOption;
+                          labels = labelsOption;
+                          token_url = mkOption {
+                            type = types.either types.str types.path;
+                            description = ''
+                              Path to the Forgejo v15+ pre-registered runner token.
+                              Supports a single placeholder: `$CREDENTIALS_DIRECTORY`
+
+                              Can be combined with `instances.<instance>.credentails`
+
+                              <https://forgejo.org/docs/latest/admin/actions/registration/>
+                            '';
+                          };
+                        };
+                      }
+                    );
+                    default = { };
+                    description = ''
+                      Forgejo v15+ pre-registered server connections.
+
+                      See <https://forgejo.org/docs/latest/admin/actions/registration>
+                    '';
+                    example = literalExpression ''
+                      {
+                        worker1 = {
+                          url = "https://forgejo.mine";
+                          uuid = "4708f0f2-4185-49b4-8552-bc7261ec26aa";
+                          token_url = "file:$CREDENTIALS_DIRECTORY/WORKER1_TOKEN";
+                          labels = [
+                            "debian:docker://docker.io/library/node:lts"
+                            "local/x86_64-linux:host"
+                          ];
+                        };
+                      };
+                    '';
+                  };
+
                 };
 
                 default = { };
               };
 
               hostPackages = mkOption {
-                type = listOf package;
+                type = types.listOf types.package;
                 default = with pkgs; [
                   bash
                   coreutils
@@ -186,22 +231,47 @@ in
   };
 
   config = mkIf (cfg.instances != { }) {
-    assertions = [
-      {
-        assertion = wantsContainerRuntime -> hasDocker || hasPodman;
-        message = "Label configuration on forgejo.runner instance requires either docker or podman.";
-      }
-    ]
-    ++ (lib.foldlAttrs (
-      acc: _: instance:
-      acc
+    assertions = lib.foldlAttrs (
+      acc_inst: _: instance:
+      (lib.foldlAttrs (
+        acc_conn: name: connection:
+        acc_conn
+        ++ [
+          {
+            assertion = connection.url != null;
+            message = "forgejo.runner.instances.${instance.name}.settings.server.connections.${name} requires `url` to be set.";
+          }
+          {
+            assertion = !(connection ? token);
+            message = "forgejo.runner.instances.${instance.name}.settings.server.connections.${name}.token cannot be used, use token_url instead.";
+          }
+          {
+            assertion = connection ? uuid;
+            message = "forgejo.runner.instances.${instance.name}.settings.server.connections.${name}.uuid is required.";
+          }
+        ]
+      ) acc_inst instance.settings.server.connections)
       ++ [
+        {
+          assertion =
+            instance.settings.server.connections != { }
+            -> instance.registrationTokenFile == null && instance.url == null && instance.labels == null;
+          message = "forgejo.runner.instances.${instance.name} cannot contain both url/registrationTokenFile and settings.server.connections";
+        }
         {
           assertion = instance.registrationTokenFile != null -> instance.url != null;
           message = "forgejo.runner.instances.${instance.name}.registrationTokenFile requires `url` to be set.";
         }
+        {
+          assertion = instance.labels != null -> instance.registrationTokenFile != null;
+          message = "forgejo.runner.instances.${instance.name}.labels requires `registrationTokenFile` to be set.";
+        }
+        {
+          assertion = hasDockerScheme (instanceLabels instance) -> hasDocker || hasPodman;
+          message = "forgejo.runner.instances.${instance.name} label configuration requires either docker or podman.";
+        }
       ]
-    ) [ ] cfg.instances);
+    ) [ ] cfg.instances;
 
     systemd.services =
       let

--- a/nixos/modules/services/continuous-integration/forgejo-runner.nix
+++ b/nixos/modules/services/continuous-integration/forgejo-runner.nix
@@ -49,10 +49,6 @@ in
 {
   meta.maintainers = teams.forgejo.members;
 
-  imports = [
-    (mkRenamedOptionModule [ "services" "forgejo-runner" ] [ "services" "forgejo" "runner" ])
-  ];
-
   options.services.forgejo.runner = with types; {
     package = mkPackageOption pkgs "forgejo-runner" { };
 
@@ -78,24 +74,43 @@ in
               };
 
               url = mkOption {
-                type = str;
+                type = nullOr str;
+                default = null;
                 example = "https://forge.example.com";
                 description = ''
                   Base URL of your Forgejo instance.
+
+                  Can also be specified in `settings.servier.connections`
                 '';
               };
 
-              tokenFile = mkOption {
+              registrationTokenFile = mkOption {
                 type = nullOr (either str path);
                 default = null;
                 description = ''
                   Path to a file containing only the token that will be used to register
-                  with the the configured Forgejo instance.
+                  on start with the the configured Forgejo instance.
+
+                  **Deprecated** Replaced by `settings.server.connections`
+
+                  <https://forgejo.org/docs/latest/admin/actions/registration/>
+                '';
+              };
+
+              credentials = lib.mkOption {
+                type = attrsOf lib.types.path;
+                default = { };
+                example = {
+                  WORKER1_TOKEN = "/run/keys/worker1";
+                };
+                description = ''
+                  Environment variables with absolute paths to credentials files to load
+                  on runner startup.
                 '';
               };
 
               labels = mkOption {
-                type = listOf str;
+                type = nullOr (listOf str);
                 example = literalExpression ''
                   [
                     # provide a debian base with nodejs for actions
@@ -170,7 +185,17 @@ in
         assertion = wantsContainerRuntime -> hasDocker || hasPodman;
         message = "Label configuration on forgejo.runner instance requires either docker or podman.";
       }
-    ];
+    ]
+    ++ (lib.foldlAttrs (
+      acc: _: instance:
+      acc
+      ++ [
+        {
+          assertion = instance.registrationTokenFile != null -> instance.url != null;
+          message = "forgejo.runner.instances.${instance.name}.registrationTokenFile requires `url` to be set.";
+        }
+      ]
+    ) [ ] cfg.instances);
 
     systemd.services =
       let
@@ -208,9 +233,16 @@ in
             serviceConfig = {
               MemoryDenyWriteExecute = !wantsHost;
 
-              LoadCredential = [ "TOKEN:${instance.tokenFile}" ];
+              LoadCredential =
+                lib.optionals (instance.registrationTokenFile != null) [
+                  "REGISTRATION_TOKEN:${instance.registrationTokenFile}"
+                ]
+                ++ lib.mapAttrsToList (name: value: "${name}:${value}") instance.credentials;
 
-              ExecStartPre = [
+              SupplementaryGroups = optionals wantsDocker [ "docker" ] ++ optionals wantsPodman [ "podman" ];
+              ExecPaths = lib.optionals wantsHost [ "/var/lib/forgejo-runner/${escapedName}" ];
+
+              ExecStartPre = lib.optionals (instance.registrationTokenFile != null) [
                 (lib.getExe (
                   pkgs.writeShellApplication {
                     name = "forgejo-register-runner-${escapedName}";
@@ -230,7 +262,7 @@ in
                         ${cfg.package}/bin/forgejo-runner register \
                           --no-interactive \
                           --instance ${escapeShellArg instance.url} \
-                          --token "$(cat "$CREDENTIALS_DIRECTORY/TOKEN")" \
+                          --token "$(cat "$CREDENTIALS_DIRECTORY/REGISTRATION_TOKEN")" \
                           --name ${escapeShellArg instance.name} \
                           --labels ${escapeShellArg (concatStringsSep "," instance.labels)} \
                           --config ${configFile}
@@ -241,9 +273,8 @@ in
                   }
                 ))
               ];
+
               ExecStart = lib.mkForce "${cfg.package}/bin/forgejo-runner daemon --config ${configFile}";
-              SupplementaryGroups = optionals wantsDocker [ "docker" ] ++ optionals wantsPodman [ "podman" ];
-              ExecPaths = lib.optionals wantsHost [ "/var/lib/forgejo-runner/${escapedName}" ];
             };
           };
       in

--- a/nixos/modules/services/continuous-integration/forgejo-runner.nix
+++ b/nixos/modules/services/continuous-integration/forgejo-runner.nix
@@ -9,7 +9,6 @@
 let
   inherit (lib)
     any
-    attrValues
     concatStringsSep
     escapeShellArg
     hasInfix
@@ -20,7 +19,6 @@ let
     mkIf
     mkOption
     mkPackageOption
-    mkRenamedOptionModule
     nameValuePair
     optionalAttrs
     optionals
@@ -36,12 +34,19 @@ let
 
   settingsFormat = pkgs.formats.yaml { };
 
-  # Empty label strings result in upstream default labels, which require docker.
-  hasDockerScheme =
-    instance: instance.labels == [ ] || any (label: hasInfix ":docker:" label) instance.labels;
-  wantsContainerRuntime = any hasDockerScheme (attrValues cfg.instances);
+  instanceLabels =
+    instance:
+    instance.labels
+    ++ lib.concatMap (connection: connection.labels or [ ]) (
+      lib.attrValues (instance.settings.server.connections or { })
+    );
 
-  hasHostScheme = instance: any (label: hasSuffix ":host" label) instance.labels;
+  hasDockerScheme = labels: any (label: hasInfix ":docker:" label) labels;
+  hasHostScheme = labels: any (label: hasSuffix ":host" label) labels;
+
+  wantsContainerRuntime = any (instance: hasDockerScheme (instanceLabels instance)) (
+    lib.attrValues cfg.instances
+  );
 
   hasDocker = config.virtualisation.docker.enable;
   hasPodman = config.virtualisation.podman.enable;
@@ -110,7 +115,8 @@ in
               };
 
               labels = mkOption {
-                type = nullOr (listOf str);
+                type = listOf str;
+                default = [ ];
                 example = literalExpression ''
                   [
                     # provide a debian base with nodejs for actions
@@ -202,9 +208,10 @@ in
         mkRunnerInstance =
           _: instance:
           let
+            allLabels = instanceLabels instance;
             escapedName = escapeSystemdPath instance.name;
-            wantsContainer = hasDockerScheme instance;
-            wantsHost = hasHostScheme instance;
+            wantsContainer = hasDockerScheme allLabels;
+            wantsHost = hasHostScheme allLabels;
             wantsDocker = wantsContainer && hasDocker;
             wantsPodman = wantsContainer && hasPodman;
             configFile = settingsFormat.generate "forgejo-runner-${escapedName}.yaml" instance.settings;

--- a/nixos/tests/forgejo.nix
+++ b/nixos/tests/forgejo.nix
@@ -60,28 +60,47 @@ let
             ];
             services.openssh.enable = true;
 
-            specialisation.runner = {
-              inheritParentConfig = true;
-              configuration.services.gitea-actions-runner = {
-                package = pkgs.forgejo-runner;
-                instances."test" = {
-                  enable = true;
-                  name = "ci";
-                  url = "http://localhost:3000";
-                  labels = [
-                    # type ":host" does not depend on docker/podman/lxc
-                    "native:host"
-                  ];
-                  tokenFile = "/var/lib/forgejo/runner_token";
+            specialisation = {
+              runner = {
+                inheritParentConfig = true;
+                configuration.services.forgejo.runner = {
+                  package = pkgs.forgejo-runner;
+                  instances."test" = {
+                    enable = true;
+                    url = "http://localhost:3000";
+                    labels = [
+                      # type ":host" does not depend on docker/podman/lxc
+                      "native:host"
+                    ];
+                    tokenFile = "/var/lib/forgejo/runner_token";
+                  };
                 };
               };
-            };
-            specialisation.dump = {
-              inheritParentConfig = true;
-              configuration.services.forgejo.dump = {
-                enable = true;
-                type = "tar.zst";
-                file = "dump.tar.zst";
+
+              giteaRunner = {
+                inheritParentConfig = true;
+                configuration.services.gitea-actions-runner = {
+                  package = pkgs.forgejo-runner;
+                  instances."test" = {
+                    enable = true;
+                    name = "ci";
+                    url = "http://localhost:3000";
+                    labels = [
+                      # type ":host" does not depend on docker/podman/lxc
+                      "native:host"
+                    ];
+                    tokenFile = "/var/lib/forgejo/gitea_runner_token";
+                  };
+                };
+              };
+
+              dump = {
+                inheritParentConfig = true;
+                configuration.services.forgejo.dump = {
+                  enable = true;
+                  type = "tar.zst";
+                  file = "dump.tar.zst";
+                };
               };
             };
           };
@@ -125,7 +144,15 @@ let
                 steps:
                   - uses: http://localhost:3000/test/checkout@main
                   - run: cat testfile
+                  - run: ./exec-test.sh
           '';
+
+          execTestScript = pkgs.writeScript "exec-test.sh" ''
+            #!${lib.getExe pkgs.bash}
+            echo "Running exec test script ensures we can execute files from checkout"
+            true
+          '';
+
           # https://github.com/actions/checkout/releases
           checkoutActionSource = pkgs.fetchFromGitHub {
             owner = "actions";
@@ -172,7 +199,7 @@ let
               + "Please contact your site administrator.'"
           )
           server.succeed(
-              "su -l forgejo -c 'GITEA_WORK_DIR=/var/lib/forgejo forgejo admin user create "
+              "su -l forgejo -c 'FORGEJO_WORK_DIR=/var/lib/forgejo forgejo admin user create "
               + "--username test --password totallysafe --email test@localhost --must-change-password=false'"
           )
 
@@ -217,13 +244,33 @@ let
               server.fail("curl --fail http://localhost:3000/metrics")
               server.succeed('curl --fail http://localhost:3000/metrics -H "Authorization: Bearer ${metricSecret}"')
 
-          with subtest("Testing runner registration and action workflow"):
+          def wait_for_workflow_id(id):
+              def poll_workflow_action_status(_) -> bool:
+                  try:
+                      response = server.succeed("curl --fail http://localhost:3000/api/v1/repos/test/repo/actions/tasks")
+                      status = json.loads(response).get("workflow_runs")[id].get("status")
+
+                  except IndexError:
+                      status = "???"
+
+                  server.log(f"Workflow status: {status}")
+
+                  if status == "failure":
+                      raise Exception("Workflow failed")
+
+                  return status == "success"
+
+              with server.nested("Waiting for the workflow run to be successful"):
+                  retry(poll_workflow_action_status, 60)
+
+          with subtest("Testing forgejo runner registration and action workflow"):
               server.succeed(
-                  "su -l forgejo -c 'GITEA_WORK_DIR=/var/lib/forgejo forgejo actions generate-runner-token' | sed 's/^/TOKEN=/' | tee /var/lib/forgejo/runner_token"
+                  "su -l forgejo -c 'FORGEJO_WORK_DIR=/var/lib/forgejo forgejo actions generate-runner-token' | tee /var/lib/forgejo/runner_token"
               )
+
               server.succeed("${serverSystem}/specialisation/runner/bin/switch-to-configuration test")
-              server.wait_for_unit("gitea-runner-test.service")
-              server.succeed("journalctl -o cat -u gitea-runner-test.service | grep -q 'Runner registered successfully'")
+              server.wait_for_unit("forgejo-runner@test.service")
+              server.succeed("journalctl -o cat -u forgejo-runner@test.service | grep -q 'Runner registered successfully'")
 
               # enable actions feature for this repository, defaults to disabled
               server.succeed(
@@ -244,27 +291,30 @@ let
               # push workflow to initial repo
               client.succeed("mkdir -p /tmp/repo/.forgejo/workflows")
               client.succeed("cp ${pkgs.writeText "dummy-workflow.yml" actionsWorkflowYaml} /tmp/repo/.forgejo/workflows/")
+              client.succeed("cp ${execTestScript} /tmp/repo/exec-test.sh")
               client.succeed("git -C /tmp/repo add .")
               client.succeed("git -C /tmp/repo commit -m 'Add dummy workflow'")
               client.succeed("git -C /tmp/repo push origin main")
 
-              def poll_workflow_action_status(_) -> bool:
-                  try:
-                      response = server.succeed("curl --fail http://localhost:3000/api/v1/repos/test/repo/actions/tasks")
-                      status = json.loads(response).get("workflow_runs")[0].get("status")
+              wait_for_workflow_id(0)
 
-                  except IndexError:
-                      status = "???"
 
-                  server.log(f"Workflow status: {status}")
+          with subtest("Testing gitea runner registration and action workflow"):
+              server.succeed(
+                  "su -l forgejo -c 'FORGEJO_WORK_DIR=/var/lib/forgejo forgejo actions generate-runner-token' | sed 's/^/TOKEN=/' | tee /var/lib/forgejo/gitea_runner_token"
+              )
 
-                  if status == "failure":
-                      raise Exception("Workflow failed")
+              server.succeed("${serverSystem}/specialisation/giteaRunner/bin/switch-to-configuration test")
+              server.wait_for_unit("gitea-runner-test.service")
+              server.succeed("journalctl -o cat -u gitea-runner-test.service | grep -q 'Runner registered successfully'")
 
-                  return status == "success"
+              # push workflow to initial repo
+              client.succeed("touch /tmp/repo/gitea-change-file")
+              client.succeed("git -C /tmp/repo add gitea-change-file")
+              client.succeed("git -C /tmp/repo commit -m 'Add gitea-change-file'")
+              client.succeed("git -C /tmp/repo push origin main")
 
-              with server.nested("Waiting for the workflow run to be successful"):
-                  retry(poll_workflow_action_status, 60)
+              wait_for_workflow_id(1)
 
           with subtest("Testing backup service"):
               server.succeed("${serverSystem}/specialisation/dump/bin/switch-to-configuration test")

--- a/nixos/tests/forgejo.nix
+++ b/nixos/tests/forgejo.nix
@@ -72,7 +72,7 @@ let
                       # type ":host" does not depend on docker/podman/lxc
                       "native:host"
                     ];
-                    tokenFile = "/var/lib/forgejo/runner_token";
+                    registrationTokenFile = "/var/lib/forgejo/runner_token";
                   };
                 };
               };

--- a/nixos/tests/forgejo.nix
+++ b/nixos/tests/forgejo.nix
@@ -63,16 +63,21 @@ let
             specialisation = {
               runner = {
                 inheritParentConfig = true;
-                configuration.services.forgejo.runner = {
-                  package = pkgs.forgejo-runner;
-                  instances."test" = {
-                    enable = true;
-                    url = "http://localhost:3000";
-                    labels = [
-                      # type ":host" does not depend on docker/podman/lxc
-                      "native:host"
-                    ];
-                    registrationTokenFile = "/var/lib/forgejo/runner_token";
+                configuration = {
+                  services.forgejo.runner = {
+                    package = pkgs.forgejo-runner;
+
+                    instances = {
+                      legacy-registration = {
+                        enable = true;
+                        url = "http://localhost:3000";
+                        labels = [
+                          # type ":host" does not depend on docker/podman/lxc
+                          "native:host"
+                        ];
+                        registrationTokenFile = "/var/lib/forgejo/runner_token";
+                      };
+                    };
                   };
                 };
               };
@@ -81,7 +86,7 @@ let
                 inheritParentConfig = true;
                 configuration.services.gitea-actions-runner = {
                   package = pkgs.forgejo-runner;
-                  instances."test" = {
+                  instances.test = {
                     enable = true;
                     name = "ci";
                     url = "http://localhost:3000";
@@ -269,8 +274,8 @@ let
               )
 
               server.succeed("${serverSystem}/specialisation/runner/bin/switch-to-configuration test")
-              server.wait_for_unit("forgejo-runner@test.service")
-              server.succeed("journalctl -o cat -u forgejo-runner@test.service | grep -q 'Runner registered successfully'")
+              server.wait_for_unit("forgejo-runner-legacy\\\\x2dregistration.service", timeout=10)
+              server.succeed("journalctl -o cat -u forgejo-runner-legacy\\\\x2dregistration.service | grep -q 'Runner registered successfully'")
 
               # enable actions feature for this repository, defaults to disabled
               server.succeed(


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I couldn't remember exactly where we left the discussion, and couldn't find the context looking at github/matrix, so I went ahead with an initial implementation. This is based off the gitea-actions-runner, but using a template service and applying maximum hardening. It's possible this is too much hardening and will need to be tuned back, but the basic tests at least are passing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
