### PR TITLE
devenv: 1.11.2 -> 2.0

### DIFF
--- a/pkgs/by-name/de/devenv/package.nix
+++ b/pkgs/by-name/de/devenv/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   gitMinimal,
   makeBinaryWrapper,
   installShellFiles,
@@ -11,50 +11,35 @@
   nixVersions,
   openssl,
   dbus,
+  protobuf,
+  sqlite,
   pkg-config,
   glibcLocalesUtf8,
+  boehmgc,
+  llvmPackages,
+  nixd,
+  bash,
   devenv, # required to run version test
 }:
 
 let
-  version = "1.11.2";
-  devenvNixVersion = "2.30.4";
+  version = "2.0";
+  devenvNixVersion = "2.32";
+  devenvRev = "fc38277c6a89226d1bafe2963e844485a4a01726";
+  nixForkRev = "7eb6c427c7a86fdc3ebf9e6cbf2a84e80e8974fd";
 
-  devenv_nix =
-    let
-      components = (
-        nixVersions.nixComponents_git.overrideSource (fetchFromGitHub {
-          owner = "cachix";
-          repo = "nix";
-          rev = "devenv-${devenvNixVersion}";
-          hash = "sha256-3+GHIYGg4U9XKUN4rg473frIVNn8YD06bjwxKS1IPrU=";
-        })
-      );
-    in
-    # Support for mdbook >= 0.5, https://github.com/NixOS/nix/issues/14628
-    (
-      (components.appendPatches [
-        (fetchpatch2 {
-          name = "nix-2.30-14695-mdbook-0.5-support.patch";
-          url = "https://github.com/NixOS/nix/commit/5cbd7856de0a9c13351f98e32a1e26d0854d87fd.patch";
-          excludes = [ "doc/manual/package.nix" ];
-          hash = "sha256-GYaTOG9wZT9UI4G6za535PkLyjHKSxwBjJsXbjmI26g=";
-        })
-      ]).overrideScope
+  nix_components =
+    (nixVersions.nixComponents_git.overrideSource (fetchFromGitHub {
+      owner = "cachix";
+      repo = "nix";
+      rev = nixForkRev;
+      hash = "sha256-H26FQmOyvIGnedfAioparJQD8Oe+/byD6OpUpnI/hkE=";
+    })).overrideScope
       (
         finalScope: prevScope: {
           version = devenvNixVersion;
         }
-      )
-    ).nix-everything.overrideAttrs
-      (old: {
-        pname = "devenv-nix";
-        version = devenvNixVersion;
-        doCheck = false;
-        doInstallCheck = false;
-        # do override src, but the Nix way so the warning is unaware of it
-        __intentionallyOverridingVersion = true;
-      });
+      );
 in
 rustPlatform.buildRustPackage {
   pname = "devenv";
@@ -63,34 +48,61 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "cachix";
     repo = "devenv";
-    tag = "v${version}";
-    hash = "sha256-8Ivbm9ltg0hUGQYMuRDOI8hbHUzqB9xKZ9ubKAzzwE8=";
+    rev = devenvRev;
+    hash = "sha256-Lp5TruJC2GslFG1IC5bJ+VYt7ECvAP2bPhTsouws114=";
   };
 
-  cargoHash = "sha256-mMmobDZeNqrByowwrDXojVnHeUyC/YbhERpF8iOCZ0s=";
+  cargoHash = "sha256-H2npLnlpFnu5hXRI4uVXJXx5Rerbm+NxeV/4s4Ofzik=";
 
-  buildAndTestSubdir = "devenv";
+  RUSTFLAGS = "--cfg tracing_unstable";
+  LIBSQLITE3_SYS_USE_PKG_CONFIG = "1";
+  VERGEN_IDEMPOTENT = "1";
+
+  cargoBuildFlags = [ "-p devenv -p devenv-run-tests" ];
 
   nativeBuildInputs = [
     installShellFiles
     makeBinaryWrapper
     pkg-config
+    protobuf
+    rustPlatform.bindgenHook
   ];
 
   buildInputs = [
     openssl
+    sqlite
     dbus
+    boehmgc
+    llvmPackages.clang-unwrapped
+    nix_components.nix-expr-c
+    nix_components.nix-store-c
+    nix_components.nix-util-c
+    nix_components.nix-flake-c
+    nix_components.nix-cmd-c
+    nix_components.nix-fetchers-c
+    nix_components.nix-main-c
   ];
 
   nativeCheckInputs = [
     gitMinimal
+    bash
   ];
 
   preCheck = ''
-    git init
+    # Initialize git repo for tests that use git-root-relative imports
+    pushd $NIX_BUILD_TOP/source
+    git init -b main
     git config user.email "test@example.com"
     git config user.name "Test User"
+    git add -A
+    popd
   '';
+
+  useNextest = true;
+  cargoTestFlags = [
+    "-p"
+    "devenv"
+  ];
 
   postInstall =
     let
@@ -100,16 +112,20 @@ rustPlatform.buildRustPackage {
     in
     ''
       wrapProgram $out/bin/devenv \
-        --prefix PATH ":" "$out/bin:${cachix}/bin" \
-        --set DEVENV_NIX ${devenv_nix} \
+        --prefix PATH ":" "$out/bin:${lib.getBin cachix}/bin:${lib.getBin nixd}/bin" \
+        ${setDefaultLocaleArchive}
+
+      wrapProgram $out/bin/devenv-run-tests \
+        --prefix PATH ":" "$out/bin:${lib.getBin cachix}/bin:${lib.getBin nixd}/bin" \
         ${setDefaultLocaleArchive}
 
       # Generate manpages
       cargo xtask generate-manpages --out-dir man
       installManPage man/*
 
-      # Generate shell completions
+      # Generate shell completions (devenv must be in PATH)
       compdir=./completions
+      export PATH="$out/bin:$PATH"
       for shell in bash fish zsh; do
         cargo xtask generate-shell-completion $shell --out-dir $compdir
       done
@@ -128,7 +144,7 @@ rustPlatform.buildRustPackage {
   };
 
   meta = {
-    changelog = "https://github.com/cachix/devenv/releases/tag/v${version}";
+    changelog = "https://github.com/cachix/devenv/releases";
     description = "Fast, Declarative, Reproducible, and Composable Developer Environments";
     homepage = "https://github.com/cachix/devenv";
     license = lib.licenses.asl20;

--- a/pkgs/by-name/de/devenv/package.nix
+++ b/pkgs/by-name/de/devenv/package.nix
@@ -23,16 +23,15 @@
 }:
 
 let
-  version = "2.0";
+  version = "2.0.1";
   devenvNixVersion = "2.32";
-  devenvRev = "fc38277c6a89226d1bafe2963e844485a4a01726";
-  nixForkRev = "7eb6c427c7a86fdc3ebf9e6cbf2a84e80e8974fd";
+  devenvNixRev = "7eb6c427c7a86fdc3ebf9e6cbf2a84e80e8974fd";
 
   nix_components =
     (nixVersions.nixComponents_git.overrideSource (fetchFromGitHub {
       owner = "cachix";
       repo = "nix";
-      rev = nixForkRev;
+      rev = devenvNixRev;
       hash = "sha256-H26FQmOyvIGnedfAioparJQD8Oe+/byD6OpUpnI/hkE=";
     })).overrideScope
       (
@@ -48,11 +47,11 @@ rustPlatform.buildRustPackage {
   src = fetchFromGitHub {
     owner = "cachix";
     repo = "devenv";
-    rev = devenvRev;
-    hash = "sha256-Lp5TruJC2GslFG1IC5bJ+VYt7ECvAP2bPhTsouws114=";
+    tag = "v${version}";
+    hash = "sha256-cZRSu+XbZ2P91cKsjHBAc5uu6fblUyBVE1Cvk3ywPaM=";
   };
 
-  cargoHash = "sha256-H2npLnlpFnu5hXRI4uVXJXx5Rerbm+NxeV/4s4Ofzik=";
+  cargoHash = "sha256-dzho5gZmfji4n+zHwr2uCqOijCFpVj9loYr8VQNil3g=";
 
   RUSTFLAGS = "--cfg tracing_unstable";
   LIBSQLITE3_SYS_USE_PKG_CONFIG = "1";

--- a/pkgs/tools/package-management/nix/modular/packaging/components.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/components.nix
@@ -368,6 +368,8 @@ in
   nix-main-c = callPackage ../src/libmain-c/package.nix { };
 
   nix-cmd = callPackage ../src/libcmd/package.nix { };
+  # TODO: upstream nix-cmd-c to Nix from devenv
+  nix-cmd-c = callPackage ../src/libcmd-c/package.nix { };
 
   nix-cli = callPackage ../src/nix/package.nix { };
   ${whenAtLeast "2.34pre" "nix-nswrapper"} = callPackage ../src/nswrapper/package.nix { };

--- a/pkgs/tools/package-management/nix/modular/src/libcmd-c/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libcmd-c/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  mkMesonLibrary,
+
+  nix-util-c,
+  nix-store-c,
+  nix-expr-c,
+  nix-cmd,
+
+  # Configuration Options
+
+  version,
+}:
+
+mkMesonLibrary (finalAttrs: {
+  pname = "nix-cmd-c";
+  inherit version;
+
+  workDir = ./.;
+
+  propagatedBuildInputs = [
+    nix-util-c
+    nix-store-c
+    nix-expr-c
+    nix-cmd
+  ];
+
+  mesonFlags = [ ];
+
+  meta = {
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+
+})


### PR DESCRIPTION
https://github.com/cachix/devenv/releases/tag/v2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
