### PR TITLE
retool: 2.4.5 -> 2.4.8

### DIFF
--- a/pkgs/by-name/re/retool/package.nix
+++ b/pkgs/by-name/re/retool/package.nix
@@ -8,17 +8,33 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "retool";
-  version = "2.4.5";
+  version = "2.4.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "unexpectedpanda";
     repo = "retool";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-q1v/VPcKIMGcAtnELKUpVgRGPyMmL8zJr5RdOClCwoc=";
+    hash = "sha256-SSSHYwQtDtCONvM5Ze3G5JJ4TW5aCziS3EbxhliXx+g=";
   };
 
   pythonRelaxDeps = true;
+
+  postPatch = ''
+    # Upstream uses hatch-pyinstaller for a separate frozen-app target, but nixpkgs
+    # only builds the wheel. Keeping it in build-system.requires makes the wheel build
+    # fail unless the optional plugin is packaged too.
+    substituteInPlace pyproject.toml \
+      --replace-fail '"hatch-pyinstaller",' ""
+
+    # Retool derives its config/download directory from sys.argv[0], which points
+    # into the immutable Nix store. Redirect its mutable state to RETOOL_HOME or
+    # the current working directory instead.
+    substituteInPlace modules/config/config.py \
+      --replace-fail \
+        "self.retool_location: pathlib.Path = pathlib.Path(sys.argv[0]).resolve().parent" \
+        "self.retool_location: pathlib.Path = pathlib.Path(os.environ.get('RETOOL_HOME', pathlib.Path.cwd())).expanduser()"
+  '';
 
   build-system = with python3.pkgs; [ hatchling ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
