### PR TITLE
premid: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/pr/premid/package.nix
+++ b/pkgs/by-name/pr/premid/package.nix
@@ -123,7 +123,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
-    mkdir -p $out/{bin,opt/PreMiD,share/pixmaps}
+    runHook preInstall
+    mkdir -p $out/{bin,opt/PreMiD,share/icons/hicolor/1024x1024/apps}
     mv * $out/opt/PreMiD
 
     chmod +x $out/opt/PreMiD/${pname}
@@ -136,11 +137,12 @@ stdenv.mkDerivation rec {
         --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/${pname}
 
     ln -s $out/opt/PreMiD/${pname} $out/bin/
+    runHook postInstall
   '';
 
   # This is the icon used by the desktop file
   postInstall = ''
-    ln -s $out/opt/PreMiD/assets/appIcon.png $out/share/pixmaps/${pname}.png
+    ln -s $out/opt/PreMiD/assets/appIcon.png $out/share/icons/hicolor/1024x1024/apps/premid.png
   '';
 
   desktopItems = [


### PR DESCRIPTION
Part of #428824 
runHooks were missing so that postInstall for the icon never happened !!
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
