### PR TITLE
calendar-cli: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/by-name/ca/calendar-cli/package.nix
+++ b/pkgs/by-name/ca/calendar-cli/package.nix
@@ -11,17 +11,21 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "calendar-cli";
-  version = "1.0.1";
+  version = "1.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tobixen";
     repo = "calendar-cli";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-w35ySLnfxXZR/a7BrPLYqXs2kqkuYhh5PcgNxJqjDtE=";
+    # https://github.com/tobixen/calendar-cli/pull/113#issuecomment-3977892432
+    tag = "v0.15.0";
+    hash = "sha256-P6ClvX6C5VargAvudgSvBwObIUouTRg7SQ62KxhcKiE=";
   };
 
   postPatch = ''
+    substituteInPlace calendar_cli/metadata.py \
+      --replace-fail '"version": "1.0.1"' '"version": "${finalAttrs.version}"'
+
     patchShebangs tests
     substituteInPlace tests/test_calendar-cli.sh \
       --replace-fail "../bin/calendar-cli.py" "$out/bin/calendar-cli" \
@@ -66,6 +70,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   };
 
   meta = {
+    changelog = "https://github.com/tobixen/calendar-cli/releases/tag/${finalAttrs.src.tag}";
     description = "Simple command-line CalDav client";
     homepage = "https://github.com/tobixen/calendar-cli";
     license = lib.licenses.gpl3Plus;

--- a/pkgs/by-name/ca/calendar-cli/package.nix
+++ b/pkgs/by-name/ca/calendar-cli/package.nix
@@ -5,6 +5,7 @@
   nixosTests,
   perl,
   radicale,
+  versionCheckHook,
   which,
   xandikos,
 }:
@@ -51,18 +52,21 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   nativeCheckInputs = [
     perl
     (python3.pkgs.toPythonModule (radicale.override { inherit python3; }))
+    versionCheckHook
     which
     xandikos
   ];
 
   checkPhase = ''
     runHook preCheck
+    runHook preInstallCheck
 
     pushd tests
     ./test_calendar-cli.sh
     popd
 
     runHook postCheck
+    runHook postInstallCheck
   '';
 
   passthru.tests = {


### PR DESCRIPTION
Diff: https://github.com/tobixen/calendar-cli/compare/v1.0.1...v0.15.0

Changelog: https://github.com/tobixen/calendar-cli/releases/tag/v0.15.0

closes https://github.com/NixOS/nixpkgs/pull/495668
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
