### PR TITLE
oneanime: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/on/oneanime/package.nix
+++ b/pkgs/by-name/on/oneanime/package.nix
@@ -13,6 +13,7 @@
   libpulseaudio,
   mpv-unwrapped,
   mimalloc,
+  imagemagick,
   runCommand,
   yq-go,
   _experimental-update-script-combinators,
@@ -129,6 +130,7 @@ flutter338.buildFlutterApplication {
   nativeBuildInputs = [
     autoPatchelfHook
     desktop-file-utils
+    imagemagick
   ];
 
   buildInputs = [
@@ -141,8 +143,9 @@ flutter338.buildFlutterApplication {
   ];
 
   postInstall = ''
+    mkdir -p $out/share/icons/hicolor/128x128/apps
     ln --symbolic --no-dereference --force ${mpv-unwrapped}/lib/libmpv.so.2 $out/app/oneanime/lib/libmpv.so.2
-    install -D --mode=0644 assets/images/logo/logo_android_2.png  $out/share/pixmaps/oneanime.png
+    magick assets/images/logo/logo_android_2.png -resize 128x128 $out/share/icons/hicolor/128x128/apps/oneanime.png
     desktop-file-edit oneAnime.desktop \
       --set-key="Icon" --set-value="oneanime"
     install -D --mode=0644 oneAnime.desktop --target-directory $out/share/applications


### PR DESCRIPTION
Part of #428824 
152x152 -> 128x128
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
