### PR TITLE
palantir-java-format: init at 2.91.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27278,6 +27278,12 @@
     githubId = 2027925;
     name = "Thomas Gebert";
   };
+  tomeraberbach = {
+    email = "tomer@aberba.ch";
+    github = "TomerAberbach";
+    githubId = 23299544;
+    name = "Tomer Aberbach";
+  };
   tomfitzhenry = {
     email = "tom@tom-fitzhenry.me.uk";
     github = "tomfitzhenry";

--- a/pkgs/by-name/pa/palantir-java-format/package.nix
+++ b/pkgs/by-name/pa/palantir-java-format/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenvNoCC,
+  jre,
+  coursier,
+  makeWrapper,
+  setJavaClassPath,
+}:
+
+let
+  pname = "palantir-java-format";
+  version = "2.91.0";
+  deps = stdenvNoCC.mkDerivation {
+    name = "${pname}-deps-${version}";
+    buildCommand = ''
+      export COURSIER_CACHE=$(pwd)
+      ${coursier}/bin/cs fetch com.palantir.javaformat:palantir-java-format:${version} > deps
+      mkdir -p $out/share/java
+      cp $(< deps) $out/share/java/
+    '';
+    outputHashMode = "recursive";
+    outputHash = "sha256-qegnfU/Q7MC7EHi3pJ9f+Wse+pps8rRilvtCWbrHVWY=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  inherit pname version;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    setJavaClassPath
+  ];
+  buildInputs = [ deps ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+      --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED" \
+      --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED" \
+      --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED" \
+      --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED" \
+      --add-flags "--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED" \
+      --add-flags "-cp $CLASSPATH com.palantir.javaformat.java.Main"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/palantir-java-format --version 2>&1 | grep -q "${version}"
+  '';
+
+  meta = {
+    description = "Modern, lambda-friendly, 120 character Java formatter based on google-java-format";
+    homepage = "https://github.com/palantir/palantir-java-format";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.tomeraberbach ];
+    platforms = lib.platforms.all;
+    mainProgram = "palantir-java-format";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds [`palantir-java-format`](https://github.com/palantir/palantir-java-format) to nixpkgs.

As far as I can tell, `palantir-java-format` does not provide an "all deps JAR" so I am using Coursier like [`scalafmt`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/sc/scalafmt/package.nix) does. I generally took a lot of inspiration from how `scalafmt` is set up.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
