### PR TITLE
python3Packages.inline-snapshot: 0.31.1 -> 0.32.4

### DIFF
--- a/pkgs/development/python-modules/inline-snapshot/default.nix
+++ b/pkgs/development/python-modules/inline-snapshot/default.nix
@@ -9,43 +9,48 @@
   freezegun,
   hatchling,
   hypothesis,
+  isort,
   pydantic,
-  pyright,
+  pytest,
   pytest-freezer,
   pytest-mock,
   pytest-xdist,
   pytestCheckHook,
   rich,
   time-machine,
-  toml,
+  typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "inline-snapshot";
-  version = "0.31.1";
+  version = "0.32.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "15r10nk";
     repo = "inline-snapshot";
     tag = version;
-    hash = "sha256-45e3M7WjGLhmn1Tdf7fD04jSA32TvB0QmFzvywJc3Ac=";
+    hash = "sha256-OuFSzrNOovQcXlZoqQFX19pNXXgRGPrLf9os12n4KfU=";
   };
 
   build-system = [ hatchling ];
+
+  buildInputs = [
+    pytest
+  ];
 
   dependencies = [
     asttokens
     executing
     rich
-    toml
+    typing-extensions
   ];
 
   nativeCheckInputs = [
     freezegun
     hypothesis
+    isort
     pydantic
-    pyright
     pytest-freezer
     pytest-mock
     pytest-xdist


### PR DESCRIPTION
Diff: https://github.com/15r10nk/inline-snapshot/compare/0.31.1...0.32.4

Changelog: https://github.com/15r10nk/inline-snapshot/blob/0.32.4/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
