### PR TITLE
python3Packages.anthropic: 0.79.0 -> 0.84.0

### DIFF
--- a/pkgs/development/python-modules/anthropic/default.nix
+++ b/pkgs/development/python-modules/anthropic/default.nix
@@ -38,14 +38,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "anthropic";
-  version = "0.79.0";
+  version = "0.84.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "anthropics";
     repo = "anthropic-sdk-python";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-//VKkn9M2uOj8PBoWTY872ZOyTc+OjBgEUGtKsYDWpk=";
+    hash = "sha256-03nvs97JNQrOu2rxOXWpJiUj+DCI5I/PTcKLuZUZ3t0=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/anthropic/default.nix
+++ b/pkgs/development/python-modules/anthropic/default.nix
@@ -16,7 +16,6 @@
   jiter,
   pydantic,
   sniffio,
-  tokenizers,
   typing-extensions,
 
   # optional dependencies
@@ -28,6 +27,7 @@
 
   # test
   dirty-equals,
+  http-snapshot,
   inline-snapshot,
   nest-asyncio,
   pytest-asyncio,
@@ -66,7 +66,6 @@ buildPythonPackage (finalAttrs: {
     jiter
     pydantic
     sniffio
-    tokenizers
     typing-extensions
   ];
 
@@ -84,6 +83,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     dirty-equals
+    http-snapshot
     inline-snapshot
     nest-asyncio
     pytest-asyncio

--- a/pkgs/development/python-modules/http-snapshot/default.nix
+++ b/pkgs/development/python-modules/http-snapshot/default.nix
@@ -1,0 +1,58 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  httpx,
+  inline-snapshot,
+  lib,
+  pytest,
+  pytestCheckHook,
+  requests,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "http-snapshot";
+  version = "0.1.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "karpetrosyan";
+    repo = "http-snapshot";
+    tag = finalAttrs.version;
+    hash = "sha256-4roxtwzB3HXwvlBqjdHEit4flXlogVwzlYNgQE8vFwE=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [
+    pytest
+  ];
+
+  dependencies = [
+    inline-snapshot
+  ];
+
+  optional-dependencies = {
+    httpx = [ httpx ];
+    requests = [ requests ];
+  };
+
+  pythonImportsCheck = [ "http_snapshot" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  pytestFlags = [
+    "--inline-snapshot=disable"
+  ];
+
+  meta = {
+    changelog = "https://github.com/karpetrosyan/http-snapshot/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Pytest plugin that snapshots requests made with popular Python HTTP clients";
+    homepage = "https://github.com/karpetrosyan/http-snapshot";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7156,6 +7156,8 @@ self: super: with self; {
 
   http-sfv = callPackage ../development/python-modules/http-sfv { };
 
+  http-snapshot = callPackage ../development/python-modules/http-snapshot { };
+
   httpagentparser = callPackage ../development/python-modules/httpagentparser { };
 
   httpauth = callPackage ../development/python-modules/httpauth { };


### PR DESCRIPTION
Diff: https://github.com/anthropics/anthropic-sdk-python/compare/v0.79.0...v0.84.0

Changelog: https://github.com/anthropics/anthropic-sdk-python/releases/tag/v0.84.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
