### PR TITLE
python3Packages.idasen-ha: 2.6.3 -> 2.6.4

### DIFF
--- a/pkgs/development/python-modules/idasen-ha/default.nix
+++ b/pkgs/development/python-modules/idasen-ha/default.nix
@@ -1,7 +1,6 @@
 {
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   idasen,
   lib,
   pytest-asyncio,
@@ -11,23 +10,15 @@
 
 buildPythonPackage rec {
   pname = "idasen-ha";
-  version = "2.6.3";
+  version = "2.6.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "abmantis";
     repo = "idasen-ha";
     tag = version;
-    hash = "sha256-Z4MfJGL2uDqY1ddoV2fB+Ty/dKFhCUY8qBfP/i/naJs=";
+    hash = "sha256-CBm9vCsfiVYj7tFTXWC+I3QYUdQ9EsjDJ6ed/BDf4S4=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "bleak-1.0.0-compat.patch";
-      url = "https://github.com/abmantis/idasen-ha/commit/57e5ba4affb99b17ffc95a33a0aec60c7518be2b.patch";
-      hash = "sha256-Jc6e9uYrifXZ91aNhoxqyquq1WMzHWrVKPBXYhosbRM=";
-    })
-  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
Diff: https://github.com/abmantis/idasen-ha/compare/2.6.3...2.6.4

Changelog: https://github.com/abmantis/idasen-ha/releases/tag/2.6.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
