### PR TITLE
home-assistant: 2026.2.3 -> 2026.3.1

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -566,6 +566,16 @@ in
       '';
     };
 
+    finalPackage = mkOption {
+      default = package;
+      internal = true;
+      readOnly = true;
+      type = types.package;
+      description = ''
+        The final Home Assistant package which is being used in the service.
+      '';
+    };
+
     openFirewall = mkOption {
       default = false;
       type = types.bool;

--- a/pkgs/development/python-modules/aioamazondevices/default.nix
+++ b/pkgs/development/python-modules/aioamazondevices/default.nix
@@ -1,5 +1,6 @@
 {
   aiohttp,
+  anyio,
   beautifulsoup4,
   buildPythonPackage,
   colorlog,
@@ -15,20 +16,21 @@
 
 buildPythonPackage rec {
   pname = "aioamazondevices";
-  version = "12.0.1";
+  version = "13.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "chemelli74";
     repo = "aioamazondevices";
     tag = "v${version}";
-    hash = "sha256-QLIn5pI6Mol+dPDGZpAnCfG3dMoxzKLJ6d77uyn8Cvk=";
+    hash = "sha256-ZqGRUxEKaqTO5V5KP75mT9BeOZVir9618Mi+1/GxHEM=";
   };
 
   build-system = [ poetry-core ];
 
   dependencies = [
     aiohttp
+    anyio
     beautifulsoup4
     colorlog
     langcodes

--- a/pkgs/development/python-modules/aiohomematic-config/default.nix
+++ b/pkgs/development/python-modules/aiohomematic-config/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "aiohomematic-config";
-  version = "2026.3.0";
+  version = "2026.3.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sukramj";
     repo = "aiohomematic-config";
     tag = finalAttrs.version;
-    hash = "sha256-lIvyFS/m1TwAj8und8EoX2E9ngM4rUw9BkfpETuwUGc=";
+    hash = "sha256-0TfRaTL+oxukl4nMPTxrtLMqCxAOcAW/brXxCeP9NB4=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/aiohomematic/default.nix
+++ b/pkgs/development/python-modules/aiohomematic/default.nix
@@ -12,19 +12,22 @@
   pytest-xdist,
   pytestCheckHook,
   python-slugify,
+  pythonOlder,
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "aiohomematic";
-  version = "2026.3.0";
+  version = "2026.3.4";
   pyproject = true;
+
+  disabled = pythonOlder "3.14";
 
   src = fetchFromGitHub {
     owner = "SukramJ";
     repo = "aiohomematic";
     tag = version;
-    hash = "sha256-7CN1/yB4vkY/B7k3kq6Qevlnff4pqr106pBu2t1j7tM=";
+    hash = "sha256-WN2Blfzt2sAYqSBqT3v3/bu2FOtfZtoAddl2H0efqvM=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/aiohttp-cors/default.nix
+++ b/pkgs/development/python-modules/aiohttp-cors/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   aiohttp,
   pytestCheckHook,
   pytest-aiohttp,
@@ -19,6 +20,15 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-AbMuUeCNM8+oZj/hutG3zxHOwYN8uZlLFBeYTlu1fh4=";
   };
+
+  patches = [
+    # https://github.com/aio-libs/aiohttp-cors/pull/563
+    (fetchpatch {
+      name = "replace-deprecated-asyncio.iscoroutinefunction-with-its-counterpart-from-inspect.patch";
+      url = "https://github.com/aio-libs/aiohttp-cors/commit/efafc0f780a494377910f2328057f83e95f8bf74.patch";
+      hash = "sha256-BvE5qqAx83+084khkHt4zjXgR7Bu/ceqMOOh/6fe5TA=";
+    })
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/aiohttp-sse/default.nix
+++ b/pkgs/development/python-modules/aiohttp-sse/default.nix
@@ -28,6 +28,11 @@ buildPythonPackage rec {
       url = "https://github.com/aio-libs/aiohttp-sse/commit/22c8041f5f737f76bdba2f2fded58abacf04c913.patch";
       hash = "sha256-CZjXgDKbm3XmS0tn3MGZMnZ84ZLt4o6v9boAYXYa6A4=";
     })
+    # Fix build with python 3.14
+    (fetchpatch {
+      url = "https://github.com/aio-libs/aiohttp-sse/commit/9eec5f5b0355bb3853d0e4f2af6486c9a5887e38.patch";
+      hash = "sha256-KDMhKxomfrHOOUHSkaZCr3+FUod+N2YRR+33VsrjtYM=";
+    })
   ];
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/aiomealie/default.nix
+++ b/pkgs/development/python-modules/aiomealie/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "aiomealie";
-  version = "1.2.0";
+  version = "1.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "joostlek";
     repo = "python-mealie";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Q+8EZHZqbv5IEqhwCKhRPgr1Cfs/zVhLiwFgCZnNcW4=";
+    hash = "sha256-TwzE5GAP4DNxj3DZdu83eSobcYYbrOn9tPb+8904a/8=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/aiopvapi/default.nix
+++ b/pkgs/development/python-modules/aiopvapi/default.nix
@@ -19,6 +19,11 @@ buildPythonPackage rec {
     hash = "sha256-yystaH2HRsJoYh2aTpOBA7DLiC2xwpBUccHwmJ0FlaY=";
   };
 
+  patches = [
+    # https://github.com/sander76/aio-powerview-api/pull/46
+    ./fix-tests.patch
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [ aiohttp ];
@@ -26,11 +31,6 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "aiopvapi" ];
-
-  disabledTests = [
-    # AssertionError
-    "test_remove_shade_from_scene"
-  ];
 
   meta = {
     description = "Python API for the PowerView API";

--- a/pkgs/development/python-modules/aiopvapi/fix-tests.patch
+++ b/pkgs/development/python-modules/aiopvapi/fix-tests.patch
@@ -1,0 +1,114 @@
+From 13b4b685de1ad6c4cb518d751150c573e4edeff7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Sandro=20J=C3=A4ckel?= <sandro.jaeckel@gmail.com>
+Date: Thu, 5 Mar 2026 03:07:15 +0100
+Subject: [PATCH 1/2] Fix test fixture
+
+Closes #39
+---
+ tests/test_scene_members.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tests/test_scene_members.py b/tests/test_scene_members.py
+index e137396..18452fb 100644
+--- a/tests/test_scene_members.py
++++ b/tests/test_scene_members.py
+@@ -39,4 +39,5 @@ async def go():
+         _del_mock.mock.assert_called_once_with(
+             'http://{}/api/scenemembers'.format(self.fake_ip),
+             params={"sceneId": 5678,
+-                    'shadeId': 1234})
++                    'shadeId': 1234},
++            timeout=15)
+
+From 51f813eca4566cf08ab36d60ce693cade92cea28 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Sandro=20J=C3=A4ckel?= <sandro.jaeckel@gmail.com>
+Date: Thu, 5 Mar 2026 03:07:28 +0100
+Subject: [PATCH 2/2] Fix Python 3.14 compatibility
+
+---
+ aiopvapi/helpers/aiorequest.py | 4 ++--
+ tests/fake_server.py           | 4 ++--
+ tests/test_room.py             | 2 +-
+ tests/test_scene.py            | 2 +-
+ tests/test_scene_members.py    | 2 +-
+ 5 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/aiopvapi/helpers/aiorequest.py b/aiopvapi/helpers/aiorequest.py
+index 9fcb7df..b2b7b3a 100644
+--- a/aiopvapi/helpers/aiorequest.py
++++ b/aiopvapi/helpers/aiorequest.py
+@@ -45,11 +45,11 @@ def __init__(
+         if loop:
+             self.loop = loop
+         else:
+-            self.loop = asyncio.get_event_loop()
++            self.loop = asyncio.new_event_loop()
+         if websession:
+             self.websession = websession
+         else:
+-            self.websession = aiohttp.ClientSession()
++            self.websession = aiohttp.ClientSession(loop=self.loop)
+         self.api_version: int | None = api_version
+         self._last_request_status: int = 0
+         _LOGGER.debug("Powerview api version: %s", self.api_version)
+diff --git a/tests/fake_server.py b/tests/fake_server.py
+index f9d3803..e8e5b9e 100644
+--- a/tests/fake_server.py
++++ b/tests/fake_server.py
+@@ -355,7 +355,7 @@ async def main(loop, api_version=2):
+ 
+ 
+ if __name__ == "__main__":
+-    loop = asyncio.get_event_loop()
++    loop = asyncio.new_event_loop()
+     loop.run_until_complete(main(loop))
+ 
+ 
+@@ -365,7 +365,7 @@ def __init__(self, methodName: str = "runTest") -> None:
+         self.api_version = 2
+ 
+     def setUp(self):
+-        self.loop = asyncio.get_event_loop()
++        self.loop = asyncio.new_event_loop()
+         self.server = FakePowerViewHub(loop=self.loop, api_version=self.api_version)
+         self.request = None
+ 
+diff --git a/tests/test_room.py b/tests/test_room.py
+index 58b0bc9..2ffd51b 100644
+--- a/tests/test_room.py
++++ b/tests/test_room.py
+@@ -62,7 +62,7 @@ async def go():
+             await self.start_fake_server()
+             # room = self.get_resource()
+ 
+-            loop = asyncio.get_event_loop()
++            loop = asyncio.new_event_loop()
+             request = AioRequest(FAKE_BASE_URL, loop, api_version=2)
+ 
+             response = Mock(spec=ClientResponse)
+diff --git a/tests/test_scene.py b/tests/test_scene.py
+index e7f2212..904f605 100644
+--- a/tests/test_scene.py
++++ b/tests/test_scene.py
+@@ -68,7 +68,7 @@ async def go():
+             await self.start_fake_server()
+             # scene = self.get_resource()
+ 
+-            loop = asyncio.get_event_loop()
++            loop = asyncio.new_event_loop()
+             request = AioRequest(FAKE_BASE_URL, loop, api_version=2)
+ 
+             response = Mock(spec=ClientResponse)
+diff --git a/tests/test_scene_members.py b/tests/test_scene_members.py
+index 18452fb..10ca437 100644
+--- a/tests/test_scene_members.py
++++ b/tests/test_scene_members.py
+@@ -24,7 +24,7 @@ def setUp(self):
+     @mock.patch('aiopvapi.helpers.aiorequest.AioRequest.check_response', new=AsyncMock())
+     def test_remove_shade_from_scene(self):
+         """Tests create new scene."""
+-        loop = asyncio.get_event_loop()
++        loop = asyncio.new_event_loop()
+         request = AioRequest(self.fake_ip, loop)
+ 
+         _del_mock = AsyncMock(return_value=None)

--- a/pkgs/development/python-modules/aranet4/default.nix
+++ b/pkgs/development/python-modules/aranet4/default.nix
@@ -8,7 +8,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "aranet4";
   version = "2.6.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Anrijs";
     repo = "Aranet4-Python";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-9dVa2RCsA+cs0fA8rLaOnikedEDz6fSfQ1tfAV0A7Eo=";
   };
 
@@ -39,9 +39,9 @@ buildPythonPackage rec {
   meta = {
     description = "Module to interact with Aranet4 devices";
     homepage = "https://github.com/Anrijs/Aranet4-Python";
-    changelog = "https://github.com/Anrijs/Aranet4-Python/releases/tag/v${version}";
+    changelog = "https://github.com/Anrijs/Aranet4-Python/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "aranetctl";
   };
-}
+})

--- a/pkgs/development/python-modules/aranet4/default.nix
+++ b/pkgs/development/python-modules/aranet4/default.nix
@@ -3,7 +3,6 @@
   bleak,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   pytestCheckHook,
   requests,
   setuptools,
@@ -11,24 +10,15 @@
 
 buildPythonPackage rec {
   pname = "aranet4";
-  version = "2.5.1";
+  version = "2.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Anrijs";
     repo = "Aranet4-Python";
     tag = "v${version}";
-    hash = "sha256-/FBrP4aceIX9dcZmm+k13PSAPuK4SQenjWqOAFPSvL8=";
+    hash = "sha256-9dVa2RCsA+cs0fA8rLaOnikedEDz6fSfQ1tfAV0A7Eo=";
   };
-
-  patches = [
-    # https://github.com/Anrijs/Aranet4-Python/pull/62
-    (fetchpatch {
-      name = "fix-for-failing-test-with-bleak-1.1.0.patch";
-      url = "https://github.com/Anrijs/Aranet4-Python/pull/62/commits/0117633682050c77cd00ead1bce93375367d7a3c.patch";
-      hash = "sha256-S4Di6bKbapCpDdOIy4sSiG9dO7OZq5ixjjK+ux4EEp0=";
-    })
-  ];
 
   build-system = [ setuptools ];
 
@@ -49,7 +39,8 @@ buildPythonPackage rec {
   meta = {
     description = "Module to interact with Aranet4 devices";
     homepage = "https://github.com/Anrijs/Aranet4-Python";
-    license = with lib.licenses; [ mit ];
+    changelog = "https://github.com/Anrijs/Aranet4-Python/releases/tag/v${version}";
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "aranetctl";
   };

--- a/pkgs/development/python-modules/bimmer-connected/default.nix
+++ b/pkgs/development/python-modules/bimmer-connected/default.nix
@@ -76,5 +76,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/bimmerconnected/bimmer_connected";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ dotlambda ];
+    # https://github.com/bimmerconnected/bimmer_connected#library-not-working-anymore-due-to-changes-at-bmw-side
+    broken = true;
   };
 }

--- a/pkgs/development/python-modules/bumble/default.nix
+++ b/pkgs/development/python-modules/bumble/default.nix
@@ -28,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = "bumble";
-  version = "0.0.223";
+  version = "0.0.226";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "bumble";
     tag = "v${version}";
-    hash = "sha256-Iei2RBk7Tpb8yeTKdtftJfbG3DwuGjvBZuhhs+nMKcU=";
+    hash = "sha256-sZFP/Vdk8L7oL6+AbsyqmEar3K4oR9rp78mDBxIVdeY=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/bx-py-utils/default.nix
+++ b/pkgs/development/python-modules/bx-py-utils/default.nix
@@ -76,15 +76,18 @@ buildPythonPackage rec {
     "test_happy_path"
     # cli_base module not found
     "test_doctests"
+    # leaks unix timestamp of 1980 into test fixtures
+    "test_xlsx2dict_complex"
+    "test_xlsx2dict_simple"
   ];
 
   disabledTestPaths = [
     # depends on cli-base-utilities, which depends on bx-py-utils
     "bx_py_utils_tests/tests/test_project_setup.py"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # processify() doesn't work under darwin
     # https://github.com/boxine/bx_py_utils/issues/80
+    # Also not working under Linux anymore
+    # _pickle.PicklingError: Can't pickle local object <function processify.<locals>.process_func at 0x7ffff36deda0>
     "bx_py_utils_tests/tests/test_processify.py"
   ];
 

--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -25,14 +25,14 @@
 
 buildPythonPackage rec {
   pname = "certbot";
-  version = "5.2.2";
+  version = "5.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "certbot";
     repo = "certbot";
     tag = "v${version}";
-    hash = "sha256-+LQX845Qw/T+kR846bNu9xTJ0zcL76rtp48e/Cgu6Vk=";
+    hash = "sha256-u9qzZFhvIapXQwxehvMieCV+4uigteSOeHVw7ycMCEU=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/devolo-plc-api/default.nix
+++ b/pkgs/development/python-modules/devolo-plc-api/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   httpx,
   protobuf,
   pytest-asyncio_0,
@@ -26,6 +27,18 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-bmZcjvqZwVJzDsdtSbQvJpry2QSSuB6/jOTWG1+jyV4=";
   };
+
+  patches = [
+    # Add Python 3.14 support
+    (fetchpatch {
+      url = "https://github.com/2Fake/devolo_plc_api/commit/3b1c167e2df5909910e97bf1626de88b17fb94d1.patch";
+      hash = "sha256-oaLYMvRl2Zcum9XkFQ1Dm1/F/BhURLGKrwh6FguVL9Y=";
+    })
+    (fetchpatch {
+      url = "https://github.com/2Fake/devolo_plc_api/pull/224.patch";
+      hash = "sha256-fDGYhjA/tMFKQnEtix1no8Wf+cp9Ph7keXRq1+sH6YA=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \

--- a/pkgs/development/python-modules/google-geo-type/default.nix
+++ b/pkgs/development/python-modules/google-geo-type/default.nix
@@ -27,6 +27,10 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
+  pythonRelaxDeps = [
+    "protobuf"
+  ];
+
   dependencies = [
     google-api-core
     google-auth

--- a/pkgs/development/python-modules/google-maps-routing/default.nix
+++ b/pkgs/development/python-modules/google-maps-routing/default.nix
@@ -29,6 +29,10 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
+  pythonRelaxDeps = [
+    "protobuf"
+  ];
+
   dependencies = [
     google-api-core
     google-auth

--- a/pkgs/development/python-modules/hass-nabucasa/default.nix
+++ b/pkgs/development/python-modules/hass-nabucasa/default.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "hass-nabucasa";
-  version = "1.14.0";
+  version = "1.15.0";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -41,7 +41,7 @@ buildPythonPackage (finalAttrs: {
     owner = "nabucasa";
     repo = "hass-nabucasa";
     tag = finalAttrs.version;
-    hash = "sha256-uTADu6IK8X+oQVvGdprmijR+MUJuWG9KMclq7zveC8o=";
+    hash = "sha256-WwpCAIfl/2fp01v9Rq4tQW70aoVlvhEJl31XQTAENmA=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/home-assistant-chip-wheels/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-wheels/default.nix
@@ -65,6 +65,7 @@
 stdenv.mkDerivation rec {
   pname = "home-assistant-chip-wheels";
   version = "2025.7.0";
+
   src = fetchFromGitHub {
     owner = "home-assistant-libs";
     repo = "chip-wheels";
@@ -262,7 +263,7 @@ stdenv.mkDerivation rec {
     "chip_config_memory_debug_dmalloc=false"
     ''chip_mdns="minimal"''
     ''chip_minmdns_default_policy="libnl"''
-    ''chip_python_version="${lib.versions.majorMinor python.version}"''
+    ''chip_python_version="${version}"''
     ''chip_python_platform_tag="any"''
     ''chip_python_package_prefix="home-assistant-chip"''
     ''custom_toolchain="custom"''

--- a/pkgs/development/python-modules/imgw-pib/default.nix
+++ b/pkgs/development/python-modules/imgw-pib/default.nix
@@ -13,7 +13,7 @@
   syrupy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "imgw-pib";
   version = "2.0.2";
   pyproject = true;
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "bieniu";
     repo = "imgw-pib";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-CXBeKckm73nDuncLbJywgV7SUckISqmESNHPis0n700=";
   };
 
@@ -44,10 +44,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/bieniu/imgw-pib/releases/tag/${src.tag}";
+    changelog = "https://github.com/bieniu/imgw-pib/releases/tag/${finalAttrs.src.tag}";
     description = "Python async wrapper for IMGW-PIB API";
     homepage = "https://github.com/bieniu/imgw-pib";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})

--- a/pkgs/development/python-modules/imgw-pib/default.nix
+++ b/pkgs/development/python-modules/imgw-pib/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "imgw-pib";
-  version = "2.0.1";
+  version = "2.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bieniu";
     repo = "imgw-pib";
     tag = version;
-    hash = "sha256-scpMdJJMwoKcNdjM9YQsgxkhYOtjjnQjJOS2JhELxvA=";
+    hash = "sha256-CXBeKckm73nDuncLbJywgV7SUckISqmESNHPis0n700=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/librehardwaremonitor-api/default.nix
+++ b/pkgs/development/python-modules/librehardwaremonitor-api/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "librehardwaremonitor-api";
-  version = "1.9.1";
+  version = "1.10.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Sab44";
     repo = "librehardwaremonitor-api";
     tag = "v${version}";
-    hash = "sha256-fj+373+e4X8B7OrejeDe0SXRMQR7vsPO4DoGrmxBu7I=";
+    hash = "sha256-l9xfO6PzJSYCoZWLdYpeZFpVK0x3ysvS+VM/9BPKlFs=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/matter-python-client/default.nix
+++ b/pkgs/development/python-modules/matter-python-client/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  aiohttp,
+  orjson,
+  home-assistant-chip-clusters,
+
+  # tests
+  pytest-asyncio,
+  pytest-aiohttp,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "matter-python-client";
+  version = "0.4.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "matter-js";
+    repo = "matterjs-server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SnOo6AQzkIqlZPTDe/dhA1EJ8oTBg37zfjiqheGYxIM=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python_client";
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace 'version = "0.0.0"' 'version = "${finalAttrs.version}"'
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    orjson
+    home-assistant-chip-clusters
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-aiohttp
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # requires npx and network access to start matterjs
+    "tests/test_client_integration.py"
+    "tests/test_integration.py"
+  ];
+
+  pythonImportsCheck = [
+    "matter_server.client"
+  ];
+
+  meta = {
+    description = "Python Client for the OHF Matter Server";
+    homepage = "https://github.com/matter-js/matterjs-server/tree/main/python_client";
+    license = lib.licenses.asl20;
+    teams = [ lib.teams.home-assistant ];
+  };
+})

--- a/pkgs/development/python-modules/mozart-api/default.nix
+++ b/pkgs/development/python-modules/mozart-api/default.nix
@@ -18,13 +18,13 @@
 
 buildPythonPackage rec {
   pname = "mozart-api";
-  version = "5.3.1.108.1";
+  version = "5.3.1.108.2";
   pyproject = true;
 
   src = fetchPypi {
     pname = "mozart_api";
     inherit version;
-    hash = "sha256-e4tlcwYC1AQA29uPg+UgFcy2ahIZuIaNlhicJiemVgo=";
+    hash = "sha256-ilUSGgc4m6iMBUuSI7qt7c4DAE8cOPTzLGeQ4JQAB8U=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/praw/default.nix
+++ b/pkgs/development/python-modules/praw/default.nix
@@ -5,6 +5,7 @@
   betamax,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   flit-core,
   mock,
   prawcore,
@@ -25,6 +26,15 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-jxF7rlMwKIKwyYv35vYWAdtClsVhnIkywoyMQeggGBc=";
   };
+
+  patches = [
+    # fix tests under python 3.14
+    (fetchpatch {
+      url = "https://github.com/praw-dev/praw/commit/9edc0bfa62c1878c395d8bc225edfe87e4fc4cd4.patch";
+      includes = [ "tests/unit/test_reddit.py" ];
+      hash = "sha256-QozdHz8WPCsuBgFgx1j0NwFsPFBmq9KhKiW7B5/QmfE=";
+    })
+  ];
 
   build-system = [ flit-core ];
 

--- a/pkgs/development/python-modules/pycec/default.nix
+++ b/pkgs/development/python-modules/pycec/default.nix
@@ -4,12 +4,13 @@
   fetchFromGitHub,
   libcec,
   pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "pycec";
   version = "0.6.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "konikvranik";
@@ -18,7 +19,14 @@ buildPythonPackage rec {
     hash = "sha256-5KQyHjAvHWeHFqcFHFJxDOPwWuVcFAN2wVdz9a77dzU=";
   };
 
-  propagatedBuildInputs = [ libcec ];
+  patches = [
+    # https://github.com/konikvranik/pyCEC/pull/84
+    ./python-3.14-compat.patch
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [ libcec ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/pycec/python-3.14-compat.patch
+++ b/pkgs/development/python-modules/pycec/python-3.14-compat.patch
@@ -1,0 +1,31 @@
+From 1384a554579747c0f91a859f1992aa7015db2dc7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Sandro=20J=C3=A4ckel?= <sandro.jaeckel@gmail.com>
+Date: Thu, 5 Mar 2026 01:17:28 +0100
+Subject: [PATCH] Fix tests under Python 3.14
+
+---
+ tests/test_hdmi_network.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/test_hdmi_network.py b/tests/test_hdmi_network.py
+index 972b9ec..48ba8bb 100644
+--- a/tests/test_hdmi_network.py
++++ b/tests/test_hdmi_network.py
+@@ -12,7 +12,7 @@
+ 
+ 
+ def test_devices():
+-    loop = asyncio.get_event_loop()
++    loop = asyncio.new_event_loop()
+     network = HDMINetwork(
+         MockAdapter(
+             [
+@@ -56,7 +56,7 @@ def test_devices():
+ 
+ 
+ def test_scan():
+-    loop = asyncio.get_event_loop()
++    loop = asyncio.new_event_loop()
+     network = HDMINetwork(
+         MockAdapter(
+             [

--- a/pkgs/development/python-modules/pymonoprice/default.nix
+++ b/pkgs/development/python-modules/pymonoprice/default.nix
@@ -20,6 +20,11 @@ buildPythonPackage rec {
     hash = "sha256-kyFOWG/Jvn+h9ludzd2Zul9/lkwPxReH76nnDIGD+fM=";
   };
 
+  patches = [
+    # https://github.com/etsinko/pymonoprice/pull/14
+    ./python-3.14-compat.patch
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/pymonoprice/python-3.14-compat.patch
+++ b/pkgs/development/python-modules/pymonoprice/python-3.14-compat.patch
@@ -1,0 +1,22 @@
+From 834cb4f51555f3e027ad0632970e0fdd8ec38a85 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Sandro=20J=C3=A4ckel?= <sandro.jaeckel@gmail.com>
+Date: Thu, 5 Mar 2026 03:19:19 +0100
+Subject: [PATCH] Fix Python 3.14 compatibility
+
+---
+ tests/test_monoprice.py | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/tests/test_monoprice.py b/tests/test_monoprice.py
+index 60def3b..3039895 100644
+--- a/tests/test_monoprice.py
++++ b/tests/test_monoprice.py
+@@ -332,7 +332,7 @@ class TestAsyncMonoprice(TestMonoprice):
+ 
+     def setUp(self):
+         self.responses = {}
+-        loop = asyncio.get_event_loop()
++        loop = asyncio.new_event_loop()
+         monoprice = loop.run_until_complete(get_async_monoprice(create_dummy_port(self.responses)))
+ 
+         # Dummy monoprice that converts async to sync

--- a/pkgs/development/python-modules/pyrainbird/default.nix
+++ b/pkgs/development/python-modules/pyrainbird/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "pyrainbird";
-  version = "6.0.5";
+  version = "6.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "allenporter";
     repo = "pyrainbird";
     tag = version;
-    hash = "sha256-8zEbj6n16ZBLPLMNFQxOXObz4GisKQMEh03sdSNtDHs=";
+    hash = "sha256-s4AZXhub1VM4zHvUnhBjmZREE0O3FcK27PPHLzCE2mU=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pyserial-asyncio-fast/default.nix
+++ b/pkgs/development/python-modules/pyserial-asyncio-fast/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonAtLeast,
 
   # build-system
   setuptools,
@@ -20,15 +19,14 @@ buildPythonPackage rec {
   version = "0.16";
   pyproject = true;
 
-  # https://github.com/home-assistant-libs/pyserial-asyncio-fast/pull/37
-  disabled = pythonAtLeast "3.14";
-
   src = fetchFromGitHub {
     owner = "bdraco";
     repo = "pyserial-asyncio-fast";
     rev = version;
     hash = "sha256-bEJySiVVy77vSF/M5f3WGxjeay/36vU8oBbmkpDCFrI=";
   };
+
+  patches = [ ./python3.14-compat.patch ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/pyserial-asyncio-fast/python3.14-compat.patch
+++ b/pkgs/development/python-modules/pyserial-asyncio-fast/python3.14-compat.patch
@@ -1,0 +1,14 @@
+diff --git a/test/test_asyncio.py b/test/test_asyncio.py
+index f14bc0b..f2034ef 100644
+--- a/test/test_asyncio.py
++++ b/test/test_asyncio.py
+@@ -34,7 +34,8 @@ class Test_asyncio(unittest.TestCase):
+     """Test asyncio related functionality"""
+ 
+     def setUp(self):
+-        self.loop = asyncio.get_event_loop()
++        self.loop = asyncio.new_event_loop()
++        asyncio.set_event_loop(self.loop)
+         # create a closed serial port
+ 
+     def tearDown(self):

--- a/pkgs/development/python-modules/pysmarlaapi/default.nix
+++ b/pkgs/development/python-modules/pysmarlaapi/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pysmarlaapi";
-  version = "0.13.0";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Explicatis-GmbH";
     repo = "pysmarlaapi";
     tag = version;
-    hash = "sha256-paOBRcTpVMLHB3HCP8JolvebC+xD19x1wieFjZCw4Ko=";
+    hash = "sha256-mDcBIRs2tJ5BWNQY/G4qN/nBrnKqz9PsW+teNYut9Pc=";
   };
 
   build-system = [ flit-core ];

--- a/pkgs/development/python-modules/pysyncthru/default.nix
+++ b/pkgs/development/python-modules/pysyncthru/default.nix
@@ -5,7 +5,7 @@
   setuptools,
   aiohttp,
   demjson3,
-  unittestCheckHook,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -21,14 +21,14 @@ buildPythonPackage rec {
     hash = "sha256-IJfj65p80Q4LwWkGV0A0QPtK2+FPkNVz9/WaNGzgTy8=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     aiohttp
     demjson3
   ];
 
-  nativeCheckInputs = [ unittestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "pysyncthru" ];
 

--- a/pkgs/development/python-modules/python-bsblan/default.nix
+++ b/pkgs/development/python-modules/python-bsblan/default.nix
@@ -6,9 +6,8 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
-  mashumaro,
-  orjson,
   packaging,
+  pydantic,
   pytest-asyncio,
   pytest-cov-stub,
   pytest-mock,
@@ -20,14 +19,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "python-bsblan";
-  version = "4.1.0";
+  version = "5.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "liudger";
     repo = "python-bsblan";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-t60WMq1kbCIkcQSfr03K9Z6ro3zFGaDxCnl/84by+Qw=";
+    hash = "sha256-P7c+5x5wQaWfNeeYKkylhV2AQESp40duSQfwsTDVW6M=";
   };
 
   postPatch = ''
@@ -42,9 +41,8 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     aiohttp
     backoff
-    mashumaro
-    orjson
     packaging
+    pydantic
     yarl
   ];
 

--- a/pkgs/development/python-modules/python-overseerr/default.nix
+++ b/pkgs/development/python-modules/python-overseerr/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "python-overseerr";
-  version = "0.8.0";
+  version = "0.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "joostlek";
     repo = "python-overseerr";
     tag = "v${version}";
-    hash = "sha256-izgUTgRG63FUjb8mH1W4yXFRvwPWIWPKsSiY9awq9SM=";
+    hash = "sha256-9sJWglF1EqwXG0Cj1hOtNE2dYTmxIZoVWHYT5I4RQu0=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/python-picnic-api2/default.nix
+++ b/pkgs/development/python-modules/python-picnic-api2/default.nix
@@ -4,22 +4,27 @@
   hatchling,
   lib,
   pytestCheckHook,
-  python-dotenv,
+  pythonAtLeast,
   requests,
   typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "python-picnic-api2";
-  version = "1.3.2";
+  version = "1.3.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "codesalatdev";
     repo = "python-picnic-api";
     tag = "v${version}";
-    hash = "sha256-GFxs2ZjyGADMG8YWtpy+sAZClLOYt70KtEp5MCgY+7I=";
+    hash = "sha256-ytzzGr/z0jrsudtCBrcvGITo4DxxC8JCmSmQ8ybeomM=";
   };
+
+  postPatch = lib.optionalString (pythonAtLeast "3.14") ''
+    substituteInPlace tests/test_session.py \
+      --replace-fail '"Accept-Encoding": "gzip, deflate",' '"Accept-Encoding": "gzip, deflate, zstd",'
+  '';
 
   build-system = [ hatchling ];
 

--- a/pkgs/development/python-modules/pythonkuma/default.nix
+++ b/pkgs/development/python-modules/pythonkuma/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "pythonkuma";
-  version = "0.3.2";
+  version = "0.5.0";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "tr4nt0r";
     repo = "pythonkuma";
     tag = "v${version}";
-    hash = "sha256-0/5nN2ddN1UrJdRq8zXiKzELUT6DXWeXx/6X4uusYDI=";
+    hash = "sha256-7c2TYGRlHn9stAd5Xe1aZP08WyKTtKKfKPGT7OoNmSQ=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/pyuptimerobot/default.nix
+++ b/pkgs/development/python-modules/pyuptimerobot/default.nix
@@ -4,29 +4,35 @@
   aresponses,
   buildPythonPackage,
   fetchFromGitHub,
+  hatchling,
   pytestCheckHook,
   pytest-asyncio,
+  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "pyuptimerobot";
-  version = "23.1.0";
-  format = "setuptools";
+  version = "24.0.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.14";
 
   src = fetchFromGitHub {
     owner = "ludeeus";
     repo = "pyuptimerobot";
     tag = version;
-    hash = "sha256-hy/hmXxxEb44X8JUszoA1YF/41y7GkQqC4uS+Pax6WA=";
+    hash = "sha256-vlEXUwGCmscasdWyCxF1bFjA3weR74Zf3RCk5W5ljFg=";
   };
 
   postPatch = ''
     # Upstream doesn't set version in the repo
-    substituteInPlace setup.py \
-      --replace 'version="main",' 'version="${version}",'
+    substituteInPlace pyproject.toml \
+      --replace-fail 'version = "0"' 'version = "${version}"'
   '';
 
-  propagatedBuildInputs = [ aiohttp ];
+  build-system = [ hatchling ];
+
+  dependencies = [ aiohttp ];
 
   nativeCheckInputs = [
     aresponses

--- a/pkgs/development/python-modules/pyvicare/default.nix
+++ b/pkgs/development/python-modules/pyvicare/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pyvicare";
-  version = "2.56.0";
+  version = "2.58.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "openviess";
     repo = "PyViCare";
     tag = finalAttrs.version;
-    hash = "sha256-DRCetTR7sFaShau3in0548FoR+rOaG28SGqfAjAVsn4=";
+    hash = "sha256-+uXn8bFV8tf1j7McdZ4js3SYsi2C2RUdDdooW5bkCLM=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pyvlx/default.nix
+++ b/pkgs/development/python-modules/pyvlx/default.nix
@@ -5,23 +5,32 @@
   pytestCheckHook,
   pyyaml,
   setuptools,
+  setuptools-scm,
   typing-extensions,
   zeroconf,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pyvlx";
-  version = "0.2.28";
+  version = "0.2.30";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Julius2342";
     repo = "pyvlx";
     tag = finalAttrs.version;
-    hash = "sha256-l+Yfp8s6x+l/1ssL0wgyzd8QbA4ikr+ZUVMdTEaIjYE=";
+    hash = "sha256-owrWYBAb/5JAangGwt56gdjJf99C3i04IiKAh1P/MYY=";
   };
 
-  build-system = [ setuptools ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools-scm>=8.0" "setuptools-scm"
+  '';
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   dependencies = [
     pyyaml

--- a/pkgs/development/python-modules/securetar/default.nix
+++ b/pkgs/development/python-modules/securetar/default.nix
@@ -3,25 +3,29 @@
   buildPythonPackage,
   cryptography,
   fetchFromGitHub,
+  pynacl,
   pytestCheckHook,
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "securetar";
-  version = "2025.2.1";
+  version = "2026.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "home-assistant-libs";
     repo = "securetar";
     tag = version;
-    hash = "sha256-uVzyVgS8bWxS7jhwVyv7wTNF8REW+dJIhkRaS/8/FmY=";
+    hash = "sha256-76JZN0Y9uW0+HUX+j1aCIz9qOjogZ0KXOXXK8rR8Z/4=";
   };
 
   build-system = [ setuptools ];
 
-  dependencies = [ cryptography ];
+  dependencies = [
+    cryptography
+    pynacl
+  ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/snitun/default.nix
+++ b/pkgs/development/python-modules/snitun/default.nix
@@ -8,7 +8,6 @@
   pytest-aiohttp,
   pytest-codspeed,
   pytestCheckHook,
-  pythonAtLeast,
   setuptools,
 }:
 
@@ -23,6 +22,11 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-luXv5J0PUvW+AGTecwkEq+qkG1N5Ja5NbBKJ3M6HC0I=";
   };
+
+  patches = [
+    # https://github.com/NabuCasa/snitun/pull/459
+    ./fix-python-3.14-compatibility.diff
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \

--- a/pkgs/development/python-modules/snitun/fix-python-3.14-compatibility.diff
+++ b/pkgs/development/python-modules/snitun/fix-python-3.14-compatibility.diff
@@ -1,0 +1,23 @@
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 78594e7..1b9c184 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -5,9 +5,11 @@
+ from dataclasses import dataclass, field
+ from datetime import UTC, datetime, timedelta
+ import logging
++import multiprocessing
+ import os
+ import select
+ import socket
++import sys
+ from threading import Thread
+ from unittest.mock import patch
+ 
+@@ -338,3 +340,6 @@ async def test_client_peer(peer_listener: PeerListener) -> AsyncGenerator[Client
+     yield Client(reader, writer)
+ 
+     writer.close()
++
++if sys.platform == "linux":
++    multiprocessing.set_start_method("fork", force=True)

--- a/pkgs/development/python-modules/spotifyaio/default.nix
+++ b/pkgs/development/python-modules/spotifyaio/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "spotifyaio";
-  version = "1.0.0";
+  version = "2.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "joostlek";
     repo = "python-spotify";
     tag = "v${version}";
-    hash = "sha256-wl8THtmdJ2l6XNDtmmnk/MF+qTZL0UsbL8o6i/Vwf5k=";
+    hash = "sha256-Bob6JpbUaQkeH2c5YKVSUkY/FNyVTf+qtB2Rm1xCRX0=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/typedmonarchmoney/default.nix
+++ b/pkgs/development/python-modules/typedmonarchmoney/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "typedmonarchmoney";
-  version = "0.5.0";
+  version = "0.7.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jeeftor";
     repo = "monarchmoney-typed";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pe/j6UnW9N3x/TYp4VyyVTwk2hTGHLTlnEYL6MNziuw=";
+    hash = "sha256-Tx5JxHAJeNWLzCSAXOvb2+QsS8PU5hK28141BnooZps=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/universal-silabs-flasher/default.nix
+++ b/pkgs/development/python-modules/universal-silabs-flasher/default.nix
@@ -62,6 +62,11 @@ buildPythonPackage rec {
     pytest-timeout
   ];
 
+  disabledTests = [
+    # timing sensitive
+    "test_xmodem_happy_path"
+  ];
+
   pythonImportsCheck = [ "universal_silabs_flasher" ];
 
   meta = {

--- a/pkgs/development/python-modules/victron-ble-ha-parser/default.nix
+++ b/pkgs/development/python-modules/victron-ble-ha-parser/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  bluetooth-sensor-state-data,
+  buildPythonPackage,
+  fetchFromGitHub,
+  sensor-state-data,
+  setuptools,
+  victron-ble,
+}:
+
+buildPythonPackage rec {
+  pname = "victron-ble-ha-parser";
+  version = "0.4.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "rajlaud";
+    repo = "victron-ble-ha-parser";
+    tag = "v${version}";
+    hash = "sha256-mvQrY1f3Da621yMgTzxduZQ0pxCJN6j7+6pgFwgl4Rs=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    bluetooth-sensor-state-data
+    sensor-state-data
+    victron-ble
+  ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "victron_ble_ha_parser" ];
+
+  meta = {
+    description = "Parser for Victron BLE messages suitable for use with Home Assistant";
+    homepage = "https://github.com/rajlaud/victron-ble-ha-parser";
+    changelog = "https://github.com/rajlaud/victron-ble-ha-parser/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/development/python-modules/victron-ble/default.nix
+++ b/pkgs/development/python-modules/victron-ble/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  bleak,
+  buildPythonPackage,
+  click,
+  fetchFromGitHub,
+  pycryptodome,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "victron-ble";
+  version = "0.9.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "keshavdv";
+    repo = "victron-ble";
+    tag = "v${version}";
+    hash = "sha256-ALdNM6U9bEX/KHcQu+7vM8Z42dEdxYtuxQRZMf10DyI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    bleak
+    click
+    pycryptodome
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "victron_ble" ];
+
+  meta = {
+    description = "Python library to parse Instant Readout advertisement data from Victron devices";
+    homepage = "https://github.com/keshavdv/victron-ble";
+    changelog = "https://github.com/keshavdv/victron-ble/releases/tag/${src.tag}";
+    license = lib.licenses.unlicense;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/development/python-modules/zha-quirks/default.nix
+++ b/pkgs/development/python-modules/zha-quirks/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "zha-quirks";
-  version = "0.0.157";
+  version = "1.0.1";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha-device-handlers";
     tag = version;
-    hash = "sha256-3rUYF4FSEeccvoTDdOVIX3G9QwwB8D4TSnUHL2vP6/A=";
+    hash = "sha256-u57Bv3oK0yAQLijlEG18brCfJXZghaA9OhbcGJ+GtCk=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/zha/default.nix
+++ b/pkgs/development/python-modules/zha/default.nix
@@ -23,7 +23,7 @@
 
 buildPythonPackage rec {
   pname = "zha";
-  version = "0.0.90";
+  version = "1.0.1";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     owner = "zigpy";
     repo = "zha";
     tag = version;
-    hash = "sha256-w5pWVkFDxnVzH5BX7VpfjStv1BabGTWE0aFysReWNqA=";
+    hash = "sha256-vYa8IPlk4C6pwxRYM69LMo5Nm23XBvMDWIuJZ01sWWQ=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/zigpy/default.nix
+++ b/pkgs/development/python-modules/zigpy/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "zigpy";
-  version = "0.92.0";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zigpy";
     repo = "zigpy";
     tag = version;
-    hash = "sha256-6rbjv91mkTSEAKndDy/2a8bGpzw/5g57FEZvZdt9ARI=";
+    hash = "sha256-N0zGN8Ci6lEqZNuHUtKfB9fIkW3H8+LiAiXlKgtrx2I=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2026.2.3";
+  version = "2026.3.1";
   components = {
     "3_day_blinds" =
       ps: with ps; [
@@ -469,11 +469,11 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         openai
         pymicro-vad
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
         yalexs
@@ -524,6 +524,9 @@
     "aws_s3" =
       ps: with ps; [
         aiobotocore
+        aiohasupervisor
+        cronsim
+        securetar
       ];
     "axis" =
       ps: with ps; [
@@ -759,6 +762,9 @@
         ifaddr
         zeroconf
       ];
+    "brands" =
+      ps: with ps; [
+      ];
     "brandt" =
       ps: with ps; [
       ];
@@ -886,6 +892,7 @@
         hassil
         home-assistant-intents
         ifaddr
+        matter-python-client
         mutagen
         openai
         plexapi
@@ -894,7 +901,6 @@
         pychromecast
         pymicro-vad
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
         zeroconf
@@ -954,11 +960,11 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         openai
         pymicro-vad
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
       ];
@@ -1157,6 +1163,7 @@
         home-assistant-frontend
         home-assistant-intents
         ifaddr
+        matter-python-client
         mutagen
         numpy
         openai
@@ -1166,7 +1173,6 @@
         pynacl
         pyserial
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
         sqlalchemy
@@ -1559,7 +1565,9 @@
       ];
     "enocean" =
       ps: with ps; [
+        aiousbwatcher
         enocean
+        pyserial
       ];
     "enphase_envoy" =
       ps: with ps; [
@@ -2093,6 +2101,9 @@
       ps: with ps; [
         aio-geojson-geonetnz-volcano
       ];
+    "ghost" =
+      ps: with ps; [
+      ]; # missing inputs: aioghost
     "gios" =
       ps: with ps; [
         gios
@@ -2143,7 +2154,7 @@
     "google_assistant" =
       ps: with ps; [
         aiohasupervisor
-        python-matter-server
+        matter-python-client
         pyturbojpeg
       ];
     "google_assistant_sdk" =
@@ -2338,6 +2349,9 @@
       ps: with ps; [
         heatmiserv3
       ];
+    "hegel" =
+      ps: with ps; [
+      ]; # missing inputs: hegel-ip-client
     "heicko" =
       ps: with ps; [
       ];
@@ -2518,6 +2532,9 @@
       ps: with ps; [
         homematicip
       ];
+    "homevolt" =
+      ps: with ps; [
+      ]; # missing inputs: homevolt
     "homewizard" =
       ps: with ps; [
         python-homewizard-energy
@@ -2540,6 +2557,7 @@
       ];
     "html5" =
       ps: with ps; [
+        py-vapid
         pywebpush
       ];
     "http" =
@@ -2643,6 +2661,9 @@
       ps: with ps; [
         hyperion-py
       ];
+    "hypontech" =
+      ps: with ps; [
+      ]; # missing inputs: hyponcloud
     "ialarm" =
       ps: with ps; [
         pyialarm
@@ -2714,6 +2735,10 @@
         pyspeex-noise
         zeroconf
       ];
+    "idrive_e2" =
+      ps: with ps; [
+        aiobotocore
+      ]; # missing inputs: idrive-e2-client
     "idteck_prox" =
       ps: with ps; [
         rfk101py
@@ -2797,6 +2822,9 @@
       ps: with ps; [
         incomfort-client
       ];
+    "indevolt" =
+      ps: with ps; [
+      ]; # missing inputs: indevolt-api
     "indianamichiganpower" =
       ps: with ps; [
       ];
@@ -2870,6 +2898,9 @@
     "integration" =
       ps: with ps; [
       ];
+    "intelliclima" =
+      ps: with ps; [
+      ]; # missing inputs: pyintelliclima
     "intellifire" =
       ps: with ps; [
         intellifire4py
@@ -3388,6 +3419,9 @@
       ps: with ps; [
         aiopyarr
       ];
+    "liebherr" =
+      ps: with ps; [
+      ]; # missing inputs: pyliebherrhomeapi
     "life360" =
       ps: with ps; [
       ];
@@ -3505,11 +3539,11 @@
         hassil
         home-assistant-intents
         loqedapi
+        matter-python-client
         mutagen
         openai
         pymicro-vad
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
       ];
@@ -3593,7 +3627,7 @@
     "matter" =
       ps: with ps; [
         aiohasupervisor
-        python-matter-server
+        matter-python-client
       ];
     "maxcube" =
       ps: with ps; [
@@ -3834,13 +3868,13 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         openai
         pillow
         pymicro-vad
         pynacl
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
       ];
@@ -3987,6 +4021,9 @@
       ps: with ps; [
         pymsteams
       ];
+    "mta" =
+      ps: with ps; [
+      ]; # missing inputs: py-nymta
     "mullvad" =
       ps: with ps; [
         mullvad-api
@@ -4007,6 +4044,9 @@
       ps: with ps; [
         home-assistant-frontend
       ];
+    "myneomitis" =
+      ps: with ps; [
+      ]; # missing inputs: pyaxencoapi
     "myq" =
       ps: with ps; [
       ];
@@ -4041,8 +4081,7 @@
       ];
     "nanoleaf" =
       ps: with ps; [
-        aionanoleaf
-      ];
+      ]; # missing inputs: aionanoleaf2
     "nasweb" =
       ps: with ps; [
         webio-api
@@ -4081,12 +4120,12 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         openai
         pyatmo
         pymicro-vad
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
       ];
@@ -4331,12 +4370,29 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         onedrive-personal-sdk
         openai
         pymicro-vad
         pyspeex-noise
-        python-matter-server
+        pyturbojpeg
+        securetar
+      ];
+    "onedrive_for_business" =
+      ps: with ps; [
+        aiohasupervisor
+        cronsim
+        ha-ffmpeg
+        hass-nabucasa
+        hassil
+        home-assistant-intents
+        matter-python-client
+        mutagen
+        onedrive-personal-sdk
+        openai
+        pymicro-vad
+        pyspeex-noise
         pyturbojpeg
         securetar
       ];
@@ -4528,11 +4584,11 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         openai
         pymicro-vad
         pyspeex-noise
-        python-matter-server
         python-overseerr
         pyturbojpeg
         securetar
@@ -4549,13 +4605,13 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         openai
         paho-mqtt
         pymicro-vad
         pynacl
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
       ];
@@ -4675,12 +4731,12 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         openai
         pymicro-vad
         pyplaato
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
       ];
@@ -4732,6 +4788,10 @@
       ps: with ps; [
       ];
     "powerfox" =
+      ps: with ps; [
+        powerfox
+      ];
+    "powerfox_local" =
       ps: with ps; [
         powerfox
       ];
@@ -4978,11 +5038,11 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         openai
         pymicro-vad
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         rachiopy
         securetar
@@ -5081,20 +5141,6 @@
       ];
     "recovery_mode" =
       ps: with ps; [
-        aiohasupervisor
-        cronsim
-        ha-ffmpeg
-        hass-nabucasa
-        hassil
-        home-assistant-frontend
-        home-assistant-intents
-        mutagen
-        openai
-        pymicro-vad
-        pyspeex-noise
-        python-matter-server
-        pyturbojpeg
-        securetar
       ];
     "recswitch" =
       ps: with ps; [
@@ -5104,6 +5150,9 @@
       ps: with ps; [
         praw
       ];
+    "redgtech" =
+      ps: with ps; [
+      ]; # missing inputs: redgtech-api
     "refoss" =
       ps: with ps; [
         refoss-ha
@@ -6048,6 +6097,9 @@
         psutil
         psutil-home-assistant
       ];
+    "systemnexa2" =
+      ps: with ps; [
+      ]; # missing inputs: python-sn2
     "tado" =
       ps: with ps; [
         python-tado
@@ -6130,6 +6182,9 @@
     "telnet" =
       ps: with ps; [
       ];
+    "teltonika" =
+      ps: with ps; [
+      ]; # missing inputs: teltasync
     "temper" =
       ps: with ps; [
         temperusb
@@ -6344,11 +6399,11 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         openai
         pymicro-vad
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
         toonapi
@@ -6428,6 +6483,9 @@
       ps: with ps; [
         pytrafikverket
       ];
+    "trane" =
+      ps: with ps; [
+      ]; # missing inputs: steamloop
     "transmission" =
       ps: with ps; [
         transmission-rpc
@@ -6457,7 +6515,7 @@
       ps: with ps; [
         ha-ffmpeg
         tuya-device-sharing-sdk
-      ];
+      ]; # missing inputs: tuya-device-handlers
     "twentemilieu" =
       ps: with ps; [
         twentemilieu
@@ -6682,8 +6740,9 @@
         pymicro-vad
         pyserial
         pyspeex-noise
+        victron-ble-ha-parser
         zeroconf
-      ]; # missing inputs: victron-ble-ha-parser
+      ];
     "victron_remote_monitoring" =
       ps: with ps; [
         victron-vrm
@@ -6779,11 +6838,11 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         openai
         pymicro-vad
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
         visionpluspython
@@ -6872,11 +6931,11 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         openai
         pymicro-vad
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
       ];
@@ -7001,11 +7060,11 @@
         hass-nabucasa
         hassil
         home-assistant-intents
+        matter-python-client
         mutagen
         openai
         pymicro-vad
         pyspeex-noise
-        python-matter-server
         pyturbojpeg
         securetar
         yalexs
@@ -7143,6 +7202,9 @@
       ps: with ps; [
         zcc-helper
       ];
+    "zinvolt" =
+      ps: with ps; [
+      ]; # missing inputs: zinvolt
     "zodiac" =
       ps: with ps; [
       ];
@@ -7275,6 +7337,7 @@
     "bond"
     "bosch_alarm"
     "bosch_shc"
+    "brands"
     "braviatv"
     "bring"
     "broadlink"
@@ -7509,6 +7572,7 @@
     "growatt_server"
     "guardian"
     "habitica"
+    "hanna"
     "hardkernel"
     "hardware"
     "harmony"
@@ -7746,7 +7810,6 @@
     "myuplink"
     "nam"
     "namecheapdns"
-    "nanoleaf"
     "nasweb"
     "neato"
     "nederlandse_spoorwegen"
@@ -7797,6 +7860,7 @@
     "oncue"
     "ondilo_ico"
     "onedrive"
+    "onedrive_for_business"
     "onewire"
     "onkyo"
     "onvif"
@@ -7855,6 +7919,7 @@
     "poolsense"
     "portainer"
     "powerfox"
+    "powerfox_local"
     "powerwall"
     "private_ble_device"
     "probe_plus"
@@ -8007,6 +8072,7 @@
     "spc"
     "speedtestdotnet"
     "spider"
+    "splunk"
     "spotify"
     "sql"
     "squeezebox"
@@ -8103,7 +8169,6 @@
     "trend"
     "triggercmd"
     "tts"
-    "tuya"
     "twentemilieu"
     "twilio"
     "twinkly"
@@ -8139,6 +8204,7 @@
     "version"
     "vesync"
     "vicare"
+    "victron_ble"
     "victron_remote_monitoring"
     "vilfo"
     "vivotek"
@@ -8211,6 +8277,7 @@
     "zimi"
     "zodiac"
     "zone"
+    "zoneminder"
     "zwave_js"
     "zwave_me"
   ];

--- a/pkgs/servers/home-assistant/custom-components/homematicip_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/homematicip_local/package.nix
@@ -14,13 +14,13 @@
 buildHomeAssistantComponent rec {
   owner = "SukramJ";
   domain = "homematicip_local";
-  version = "2.3.2";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "SukramJ";
     repo = "custom_homematic";
     tag = version;
-    hash = "sha256-MQ3jzAq8GNy22/qovLpmUZSyyATnejweFWxue2xsZ+s=";
+    hash = "sha256-jc2Y6COt6xwoaCuuvx/LGtS/Av86Zeb3ujIPyFvTCec=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -4,7 +4,7 @@
   callPackage,
   fetchFromGitHub,
   fetchPypi,
-  python313,
+  python314,
   replaceVars,
   ffmpeg-headless,
   inetutils,
@@ -244,7 +244,7 @@ let
     })
   ];
 
-  python = python313.override {
+  python = python314.override {
     self = python;
     packageOverrides = lib.composeManyExtensions (defaultOverrides ++ [ packageOverrides ]);
   };
@@ -263,7 +263,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2026.2.3";
+  hassVersion = "2026.3.1";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -284,13 +284,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-BEE27D1P3cbxjQMRh3VHL6KDXa7bZDfqK316VQg0/SM=";
+    hash = "sha256-UQRKwJUyQKHoVyxQrEpQ8Eb9/dxbpjs7ZaruPQNRogs=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-UkIxZx3IU0IZh8gbjZ9xRkEZS97UW85FT5isNyPyiHQ=";
+    hash = "sha256-JMYpobwMUm+Rj0kzDIicyvUHKl8ndrYNxzdp26h427o=";
   };
 
   build-system = with python.pkgs; [
@@ -335,6 +335,7 @@ python.pkgs.buildPythonApplication rec {
   dependencies = with python.pkgs; [
     # Only packages required in pyproject.toml
     aiodns
+    aiogithubapi
     aiohasupervisor
     aiohttp
     aiohttp-asyncmdnsresolver

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20260128.6";
+  version = "20260304.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-H9MHB4uVhKfPo9zi5XRDl1IjyUWKeXr3lSU8PEcm/7s=";
+    hash = "sha256-GuKydiiyv5RrouSCJ+4P83j4atHdowXii/Ab72dB448=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/intents.nix
+++ b/pkgs/servers/home-assistant/intents.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-intents";
-  version = "2026.1.28";
+  version = "2026.3.3";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     repo = "intents-package";
     tag = version;
     fetchSubmodules = true;
-    hash = "sha256-5n2B9HeEiuNHlaTHzpl18zaXB3ocWKC2Bs4aEoda7aQ=";
+    hash = "sha256-jueZ+GmoVcQcvCYsKQVqKdPVl4U32stcwv0N4QTspoE=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.316";
+  version = "0.13.317";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     tag = version;
-    hash = "sha256-wsL/85klBl6tHOZ0fq/AaUskIsqvKIJQ8fEtnQDZnF0=";
+    hash = "sha256-hn6gy4DWeO/E5I/F7F/CJXNO/O8BIhDnN+8RRmdQ+oU=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2026.2.3";
+  version = "2026.3.1";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-WImlT+rtIXwdVpph4T1VIksNPQ9U4nn0Bl23LRBaP/k=";
+    hash = "sha256-l9ECa6hcJWtZDGTpQVuvZDiGaAn2nlywqVFy1Eg1p3E=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -100,6 +100,7 @@ let
       av
     ];
     number = getComponentDeps "conversation";
+    ntfy = getComponentDeps "camera" ++ getComponentDeps "tts";
     octoprint = getComponentDeps "camera";
     ollama = getComponentDeps "ai_task";
     onboarding = getComponentDeps "tts" ++ [
@@ -132,6 +133,7 @@ let
     songpal = [
       isal
     ];
+    sonos = getComponentDeps "frontend";
     swiss_public_transport = getComponentDeps "cookidoo";
     switch = getComponentDeps "camera" ++ getComponentDeps "conversation";
     switch_as_x = getComponentDeps "camera" ++ getComponentDeps "conversation";
@@ -160,6 +162,7 @@ let
     yolink = getComponentDeps "cloud";
     zeroconf = getComponentDeps "shelly";
     zha = getComponentDeps "deconz" ++ getComponentDeps "frontend";
+    zoneminder = getComponentDeps "camera";
     zwave_js = getComponentDeps "frontend";
   };
 

--- a/pkgs/servers/home-assistant/update-component-packages.py
+++ b/pkgs/servers/home-assistant/update-component-packages.py
@@ -41,6 +41,7 @@ PKG_SET = "home-assistant.python.pkgs"
 PKG_PREFERENCES = {
     "av": "av",
     "fiblary3": "fiblary3-fork",  # https://github.com/home-assistant/core/issues/66466
+    "fints": "fints",
     "HAP-python": "hap-python",
     "ha-av": "av",
     "numpy": "numpy",

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20625,6 +20625,10 @@ self: super: with self; {
 
   viaggiatreno-ha = callPackage ../development/python-modules/viaggiatreno-ha { };
 
+  victron-ble = callPackage ../development/python-modules/victron-ble { };
+
+  victron-ble-ha-parser = callPackage ../development/python-modules/victron-ble-ha-parser { };
+
   victron-mqtt = callPackage ../development/python-modules/victron-mqtt { };
 
   victron-vrm = callPackage ../development/python-modules/victron-vrm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9537,6 +9537,8 @@ self: super: with self; {
 
   matrix-nio = callPackage ../development/python-modules/matrix-nio { };
 
+  matter-python-client = callPackage ../development/python-modules/matter-python-client { };
+
   mattermostdriver = callPackage ../development/python-modules/mattermostdriver { };
 
   maubot = callPackage ../development/python-modules/maubot { };


### PR DESCRIPTION
https://www.home-assistant.io/blog/2026/03/04/release-20263/

depends on https://github.com/NixOS/nixpkgs/pull/496457 and https://github.com/NixOS/nixpkgs/pull/496488 and https://github.com/NixOS/nixpkgs/pull/497914

Closes #491659
Closes #495670
Closes #491969
Closes #490765
Closes #492951
closes https://github.com/NixOS/nixpkgs/pull/496381


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
