### PR TITLE
plater: move icon to spec-compliant location, use copyDesktopItems

### DIFF
--- a/pkgs/by-name/pl/plater/package.nix
+++ b/pkgs/by-name/pl/plater/package.nix
@@ -5,6 +5,7 @@
   lib,
   libGLU,
   makeDesktopItem,
+  copyDesktopItems,
   qt5,
 }:
 
@@ -22,28 +23,29 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     qt5.wrapQtAppsHook
+    copyDesktopItems
   ];
   buildInputs = [
     libGLU
     qt5.qtbase
   ];
 
-  desktopItem = makeDesktopItem {
-    name = "plater";
-    exec = "plater";
-    icon = "plater";
-    desktopName = "Ideamaker";
-    genericName = meta.description;
-    categories = [
-      "Utility"
-      "Engineering"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "plater";
+      exec = "plater";
+      icon = "plater";
+      desktopName = "Ideamaker";
+      genericName = meta.description;
+      categories = [
+        "Utility"
+        "Engineering"
+      ];
+    })
+  ];
 
   postInstall = ''
-    mkdir -p $out/share/pixmaps
-    ln -s ${desktopItem}/share/applications $out/share/
-    cp $src/gui/img/plater.png $out/share/pixmaps/${pname}.png
+    install -D $src/gui/img/plater.png -t $out/share/icons/hicolor/128x128/apps
   '';
 
   meta = {


### PR DESCRIPTION
Part of #428824 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
