### PR TITLE
feishu-cli: init at 1.7.0

### DIFF
--- a/pkgs/by-name/fe/feishu-cli/package.nix
+++ b/pkgs/by-name/fe/feishu-cli/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "feishu-cli";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "riba2534";
+    repo = "feishu-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MO9RpMEJcWIrOoJ+O4IpF7wmnhYNNYpLJC/2IhkrQeg=";
+  };
+
+  vendorHash = "sha256-j2X9sPUYLqOdHzXJCXP2s4uL6rerjZboEwKHofIE1sE=";
+
+  subPackages = [ "." ];
+
+  ldflags = [ "-X main.Version=${finalAttrs.src.tag}" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI for Feishu (Lark) Open Platform";
+    homepage = "https://github.com/riba2534/feishu-cli";
+    changelog = "https://github.com/riba2534/feishu-cli/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ chillcicada ];
+    mainProgram = "feishu-cli";
+  };
+})


### PR DESCRIPTION
init [feishu-cli](https://github.com/riba2534/feishu-cli)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
