### PR TITLE
python3Packages.moto: reduce test dependencies

### DIFF
--- a/pkgs/development/python-modules/moto/default.nix
+++ b/pkgs/development/python-modules/moto/default.nix
@@ -29,7 +29,6 @@
   pyyaml,
   requests,
   responses,
-  sagemaker,
   setuptools,
   werkzeug,
   xmltodict,
@@ -294,13 +293,21 @@ buildPythonPackage rec {
   __darwinAllowLocalNetworking = true;
 
   nativeCheckInputs = [
+    antlr4-python3-runtime
+    aws-xray-sdk
+    docker
+    flask
+    flask-cors
     freezegun
+    graphql-core
+    joserfc
+    openapi-spec-validator
+    py-partiql-parser
+    pyparsing
     pytest-order
     pytest-xdist
     pytestCheckHook
-    sagemaker
-  ]
-  ++ optional-dependencies.server;
+  ];
 
   # Some tests depend on AWS credentials environment variables to be set.
   env.AWS_ACCESS_KEY_ID = "ak";
@@ -382,8 +389,12 @@ buildPythonPackage rec {
     # botocore.exceptions.ParamValidationError: Parameter validation failed: Unknown parameter in input: "EnableWorkDocs", must be one of: [...]
     "tests/test_workspaces/test_workspaces.py"
 
-    # Requires sagemaker client
+    # Requires sagemaker which is broken on Python 3.14
     "other_langs/tests_sagemaker_client/test_model_training.py"
+    "other_langs/tests_sagemaker_client/test_pipeline_session.py"
+
+    # Requires cfn-lint which is broken on Python 3.14
+    "tests/test_cloudformation/test_validate.py"
   ];
 
   meta = {


### PR DESCRIPTION
The sagemaker package is outdated and doesn't work on Python 3.14.
related: https://github.com/NixOS/nixpkgs/issues/496451


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
