### PR TITLE
pineflash: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/pi/pineflash/package.nix
+++ b/pkgs/by-name/pi/pineflash/package.nix
@@ -12,6 +12,7 @@
   gtk3,
   openssl,
   systemd,
+  imagemagick,
   libGL,
   libxkbcommon,
   nix-update-script,
@@ -32,6 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
+    imagemagick
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
 
@@ -67,10 +69,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   postInstall = ''
-    mkdir -p "$out/share/applications"
-    cp ./assets/Pineflash.desktop "$out/share/applications/Pineflash.desktop"
-    mkdir -p "$out/share/pixmaps"
-    cp ./assets/pine64logo.png "$out/share/pixmaps/pine64logo.png"
+    mkdir -p $out/share/icons/hicolor/128x128/apps
+    install -D ./assets/Pineflash.desktop -t $out/share/applications
+    magick ./assets/pine64logo.png -resize 128x128 $out/share/icons/hicolor/128x128/apps/pine64logo.png
   '';
 
   passthru = {


### PR DESCRIPTION
Part of #428824 
150x150 -> 128x128
The installPhase for darwin does seem odd but I'm not gonna touch it
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
