### PR TITLE
haskell.packages.ghc914.haskell-debugger: fix compilation 

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1161,6 +1161,20 @@ with haskellLib;
   # https://github.com/ndmitchell/shake/issues/804
   shake = dontCheck super.shake;
 
+  # https://github.com/martijnbastiaan/doctest-parallel/pull/99
+  doctest-parallel = lib.pipe super.doctest-parallel [
+    (appendPatch (fetchpatch {
+      name = "ghc-9.14-fixes";
+      url = "https://github.com/martijnbastiaan/doctest-parallel/commit/f3a40202ef8d2d4927dae706bf89f11b2800202d.patch";
+      sha256 = "sha256-mKF/hpMXWq5meiBHNbIKAz6c33DWE7zzHkS+Hgl5uX4";
+    }))
+    (overrideCabal (drv: {
+      # Revision change is not present in PR target branch
+      editedCabalFile = null;
+      revision = null;
+    }))
+  ];
+
   # https://github.com/nushio3/doctest-prop/issues/1
   doctest-prop = dontCheck super.doctest-prop;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -88,7 +88,7 @@ with haskellLib;
   }) super.cpphs;
   cabal-install-parsers = doJailbreak super.cabal-install-parsers; # base, Cabal-syntax, etc.
   ghc-exactprint_1_12_0_0 = addBuildDepends [
-    # somehow buildDepends was missing
+    # cabal2nix drops conditional block: impl (ghc >= 9.12)
     self.Diff
     self.extra
     self.ghc-paths

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -121,6 +121,9 @@ with haskellLib;
   # https://github.com/sjakobi/newtype-generics/pull/28/files
   newtype-generics = warnAfterVersion "0.6.2" (doJailbreak super.newtype-generics);
 
+  # haskell-debugger only works with ghc 9.14+
+  haskell-debugger-view = doDistribute (unmarkBroken super.haskell-debugger-view);
+
   #
   # Test suite issues
   #

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -128,6 +128,7 @@ with haskellLib;
 
   # haskell-debugger only works with ghc 9.14+
   haskell-debugger-view = doDistribute (unmarkBroken super.haskell-debugger-view);
+  haskell-debugger = doJailbreak super.haskell-debugger; # hie-bios < 0.18, random >=1.3.1
 
   ghc-exactprint_1_14_0_0 = addBuildDepends [
     # cabal2nix drops conditional block: impl (ghc >= 9.14)

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -74,6 +74,7 @@ with haskellLib;
   # Version upgrades
   #
 
+  ghc-exactprint = doDistribute self.ghc-exactprint_1_14_0_0;
   parallel = doDistribute self.parallel_3_3_0_0;
   tagged = doDistribute self.tagged_0_8_10;
   unordered-containers = doDistribute self.unordered-containers_0_2_21;
@@ -123,6 +124,16 @@ with haskellLib;
 
   # haskell-debugger only works with ghc 9.14+
   haskell-debugger-view = doDistribute (unmarkBroken super.haskell-debugger-view);
+
+  ghc-exactprint_1_14_0_0 = addBuildDepends [
+    # cabal2nix drops conditional block: impl (ghc >= 9.14)
+    self.Diff
+    self.extra
+    self.ghc-paths
+    self.silently
+    self.syb
+    self.HUnit
+  ] super.ghc-exactprint_1_14_0_0;
 
   #
   # Test suite issues

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -86,6 +86,8 @@ with haskellLib;
   primitive = doJailbreak (dontCheck super.primitive); # base <4.22 and a lot of dependencies on packages not yet working.
   splitmix = doJailbreak super.splitmix; # base <4.22
 
+  # https://github.com/phadej/boring/issues/48
+  boring = doJailbreak super.boring;
   # https://github.com/haskellari/indexed-traversable/issues/49
   indexed-traversable = doJailbreak super.indexed-traversable;
   # https://github.com/haskellari/indexed-traversable/issues/50

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -75,6 +75,8 @@ with haskellLib;
   #
 
   ghc-exactprint = doDistribute self.ghc-exactprint_1_14_0_0;
+  hedgehog = doDistribute self.hedgehog_1_7;
+  lifted-async = doDistribute self.lifted-async_0_11_0;
   parallel = doDistribute self.parallel_3_3_0_0;
   tagged = doDistribute self.tagged_0_8_10;
   unordered-containers = doDistribute self.unordered-containers_0_2_21;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -128,6 +128,7 @@ package-maintainers:
     - ghcjs-dom
     - ghcjs-dom-javascript
     - ghcjs-dom-jsaddle
+    - haskell-debugger
     - jsaddle
     - jsaddle-clib
     - jsaddle-dom

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1966,6 +1966,9 @@ builtins.intersectAttrs super {
     broken = false;
   }) super.cabal-install;
 
+  # lots of errors
+  haskell-debugger = dontCheck super.haskell-debugger;
+
   keid-render-basic = addBuildTool pkgs.glslang super.keid-render-basic;
 
   # Disable checks to break dependency loop with SCalendar


### PR DESCRIPTION
```
$ $(nix-build -A haskell.packages.ghc914.haskell-debugger)/bin/hdb
Haskell debugger supporting both CLI and DAP modes

Usage: hdb (COMMAND | [-e|--entry-point ENTRY_POINT] ENTRY_FILE [ENTRY_ARGS...]
             [--extra-ghc-args GHC_ARGS] [-v|--verbosity VERBOSITY]
             [--internal-interpreter] [--debuggee-stdin FILE])

Available options:
  -e,--entry-point ENTRY_POINT
                           The name of the function that is called to start
                           execution (default: main)
(...)
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
