### PR TITLE
tree-sitter-grammars.tree-sitter-vue: pin to 2026-01-24 commit

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
@@ -2874,6 +2874,9 @@
     hash = "sha256-pCoyDRuRCpfpJh7vQIM8yZz5aPcqrdYlTJGM/K5oQFs=";
     meta = {
       license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        jeafleohj
+      ];
     };
   };
 

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
@@ -2867,10 +2867,11 @@
   };
 
   vue = {
-    version = "0.2.1-unstable-2021-04-04";
-    url = "github:ikatyang/tree-sitter-vue";
-    rev = "91fe2754796cd8fba5f229505a23fa08f3546c06";
-    hash = "sha256-NeuNpMsKZUP5mrLCjJEOSLD6tlJpNO4Z/rFUqZLHE1A=";
+    version = "0.1.0";
+    url = "github:tree-sitter-grammars/tree-sitter-vue";
+    # NOTE: no upstream tag; using commit from 2026-01-24
+    rev = "ce8011a414fdf8091f4e4071752efc376f4afb08";
+    hash = "sha256-pCoyDRuRCpfpJh7vQIM8yZz5aPcqrdYlTJGM/K5oQFs=";
     meta = {
       license = lib.licenses.mit;
     };


### PR DESCRIPTION
Switch tree-sitter-vue source to tree-sitter-grammars/tree-sitter-vue and pin it to commit `ce8011a414fdf8091f4e4071752efc376f4afb08`(2026-01-24), while keeping version at 0.1.0 because upstream does not provide a newer tag/release version


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
