### PR TITLE
pkgsi686Linux.pkgsMusl.gcc: Use libssp_nonshared from musl

### DIFF
--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -252,3 +252,4 @@ optionals noSysDirs (
     hash = "sha256-8I2G4430gkYoWgUued4unqhk8ZCajHf1dcivAeuLZ0E=";
   })
 ]
+++ optional (targetPlatform.isMusl && targetPlatform.isx86_32) ./libssp-noshared-musl32.patch

--- a/pkgs/development/compilers/gcc/patches/libssp-noshared-musl32.patch
+++ b/pkgs/development/compilers/gcc/patches/libssp-noshared-musl32.patch
@@ -1,0 +1,31 @@
+From c557286adc46536fe033df400c50a880b672cfd6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Timo=20Ter=C3=A4s?= <timo.teras@iki.fi>
+Date: Fri, 21 Aug 2020 07:03:00 +0000
+Subject: [PATCH] Alpine musl package provides libssp_nonshared.a. We link to
+ it unconditionally, as otherwise we get link failures if some objects are
+ -fstack-protector built and final link happens with -fno-stack-protector.
+ This seems to be the common case when bootstrapping gcc, the piepatches do
+ not seem to fully fix the crosstoolchain and bootstrap sequence wrt.
+ stack-protector flag usage.
+
+---
+ gcc/gcc.cc | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index 7b0d3d2743b..e46e976a2e8 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -1017,8 +1017,7 @@ proper position among the other output files.  */
+ 
+ #ifndef LINK_SSP_SPEC
+ #ifdef TARGET_LIBC_PROVIDES_SSP
+-#define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all" \
+-		       "|fstack-protector-strong|fstack-protector-explicit:}"
++#define LINK_SSP_SPEC "-lssp_nonshared"
+ #else
+ #define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all" \
+ 		       "|fstack-protector-strong|fstack-protector-explicit" \
+-- 
+2.50.1
+


### PR DESCRIPTION
Fixes build of perl on `i686-unknown-linux-musl`. Cherry-picked out of #494106.

This method of fixing libssp is used in e.g. [Alpine](https://gitlab.alpinelinux.org/alpine/aports/-/blob/20737cf25d522b188319c846ee6e53812c22c92d/main/gcc/0018-Alpine-musl-package-provides-libssp_nonshared.a.-We-.patch).

This may not have visible effects until #494106 is merged. This is because perl fails to build due to the exact same issue but for minimal-bootstrap gcc, which in turn blocks the gcc build from starting on this platform.

This should trigger 0 rebuilds on main platforms.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
