### PR TITLE
kcgi: 0.10.8 -> 1.0.1; adopted

### DIFF
--- a/pkgs/by-name/kc/kcgi/package.nix
+++ b/pkgs/by-name/kc/kcgi/package.nix
@@ -6,6 +6,7 @@
   bmake,
   zlib,
   libbsd,
+  curl,
   nix-update-script,
 }:
 
@@ -30,6 +31,18 @@ stdenv.mkDerivation (finalAttrs: {
     bmake
   ];
   buildInputs = [ zlib ] ++ lib.optionals stdenv.hostPlatform.isLinux [ libbsd ];
+
+  nativeCheckInputs = [ bmake ];
+  checkInputs = [ curl ];
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    bmake regress
+
+    runHook postCheck
+  '';
 
   dontAddPrefix = true;
 

--- a/pkgs/by-name/kc/kcgi/package.nix
+++ b/pkgs/by-name/kc/kcgi/package.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Minimal CGI and FastCGI library for C/C++";
     license = lib.licenses.isc;
     platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ chillcicada ];
     mainProgram = "kfcgi";
   };
 })

--- a/pkgs/by-name/kc/kcgi/package.nix
+++ b/pkgs/by-name/kc/kcgi/package.nix
@@ -3,38 +3,46 @@
   stdenv,
   pkg-config,
   fetchFromGitHub,
+  bmake,
+  zlib,
   libbsd,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kcgi";
-  version = "0.10.8";
-  underscoreVersion = lib.replaceStrings [ "." ] [ "_" ] version;
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "kristapsdz";
     repo = "kcgi";
-    rev = "VERSION_${underscoreVersion}";
-    sha256 = "0ha6r7bcgf6pcn5gbd2sl7835givhda1jql49c232f1iair1yqyp";
+    tag = "VERSION_${lib.replaceString "." "_" finalAttrs.version}";
+    hash = "sha256-XFcag1oRsw+Qu9tjJvRcg2gAg0E0wh3poI/2mksSok4=";
   };
+
   patchPhase = ''
     substituteInPlace configure \
-      --replace /usr/local /
+      --replace-fail PREFIX=\"/usr/local\" PREFIX=
   '';
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ] ++ lib.optionals stdenv.hostPlatform.isLinux [ libbsd ];
+  nativeBuildInputs = [
+    pkg-config
+    bmake
+  ];
+  buildInputs = [ zlib ] ++ lib.optionals stdenv.hostPlatform.isLinux [ libbsd ];
 
   dontAddPrefix = true;
 
   installFlags = [ "DESTDIR=$(out)" ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
-    broken = (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
     homepage = "https://kristaps.bsd.lv/kcgi";
+    changelog = "https://kristaps.bsd.lv/kcgi/archive.html";
     description = "Minimal CGI and FastCGI library for C/C++";
     license = lib.licenses.isc;
     platforms = lib.platforms.all;
     mainProgram = "kfcgi";
   };
-}
+})


### PR DESCRIPTION
close #230577

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
