### PR TITLE
tonearm: 1.2.0 -> 1.4.0

### DIFF
--- a/pkgs/by-name/to/tonearm/package.nix
+++ b/pkgs/by-name/to/tonearm/package.nix
@@ -1,5 +1,5 @@
 {
-  buildGoModule,
+  buildGo126Module,
   cairo,
   copyDesktopItems,
   fetchFromGitea,
@@ -38,17 +38,17 @@ let
     ];
   };
 in
-buildGoModule (finalAttrs: {
+buildGo126Module (finalAttrs: {
   pname = "tonearm";
-  version = "1.2.0";
+  version = "1.4.0";
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "dergs";
     repo = "Tonearm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2on27z3BRf63gjs3NKmF9H0Le7hBdaHRUp8WQgFs3QU=";
+    hash = "sha256-tfnJiEJD0SWKxi5MjGbDLVe80niMcMHpzNaOM1SNEQo=";
   };
-  vendorHash = "sha256-j+7cobxVGNuZFYeRn5ad7XT4um8WNWE1byFo7qo9zK0=";
+  vendorHash = "sha256-/pUSUfOt5heiObZNQRlZjN1a+j9JocB43F9072pyLjw=";
 
   ldflags = [
     "-X \"codeberg.org/dergs/tonearm/internal/ui.Version=${finalAttrs.version}\""


### PR DESCRIPTION
Updated version following upstream

Changelogs:
[1.3.0](https://codeberg.org/dergs/Tonearm/releases/tag/v1.3.0)
[1.3.1](https://codeberg.org/dergs/Tonearm/releases/tag/v1.3.1)
[1.4.0](https://codeberg.org/dergs/Tonearm/releases/tag/v1.4.0)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
