### PR TITLE
google-cloud-sdk: fix readlink noise in shell initialization

### DIFF
--- a/pkgs/by-name/go/google-cloud-sdk/package.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/package.nix
@@ -100,6 +100,13 @@ stdenv.mkDerivation rec {
     fi
     cp -R * .install $out/google-cloud-sdk/
 
+    # Resolve readlink noise in shell initialization
+    # We patch the source script before wrapProgram renames it.
+    # This ensures that the resulting .gcloud-wrapped binary contains the fix.
+    substituteInPlace "$out/google-cloud-sdk/bin/gcloud" \
+      --replace-fail 'while _cloudsdk_link=$(readlink "$_cloudsdk_path")' 'while _cloudsdk_link=$(readlink "$_cloudsdk_path" 2>/dev/null)' \
+      --replace-fail 'CLOUDSDK_ROOT_DIR=$(_cloudsdk_root_dir "$0")' 'CLOUDSDK_ROOT_DIR=$(realpath "$(dirname "$0")/..")'
+
     mkdir -p $out/google-cloud-sdk/lib/surface/{alpha,beta}
     cp ${./alpha__init__.py} $out/google-cloud-sdk/lib/surface/alpha/__init__.py
     cp ${./beta__init__.py} $out/google-cloud-sdk/lib/surface/beta/__init__.py


### PR DESCRIPTION
This PR fixes a persistent `readlink` stderr noise and path resolution issues during shell initialization.

The `google-cloud-sdk` preamble script uses a manual `while` loop with `readlink` to resolve its own root directory. In multi-profile NixOS environments (e.g., using both system packages and Home Manager), this resolution often fails to handle nested symlinks correctly, resulting in annoying error messages on every new shell session.

**Changes:**
1. Silenced `readlink` stderr output in the resolution loop within `bin/gcloud`.
2. Replaced the final `CLOUDSDK_ROOT_DIR` resolution with a robust `realpath` call to ensure atomic path resolution within the Nix store.

This has been tested on a local NixOS system, confirming that the SDK remains fully functional while the terminal noise is completely eliminated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
