### PR TITLE
better-screenshots: init at 0.1.0

### DIFF
--- a/pkgs/applications/misc/better-screenshots/default.nix
+++ b/pkgs/applications/misc/better-screenshots/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, grim
+, slurp
+, wl-clipboard
+, makeWrapper
+, click
+, pillow
+, toml
+, pyyaml
+, requests
+, setuptools
+}:
+
+buildPythonPackage {
+  pname = "better-screenshots";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "snxhasish";
+    repo = "better-screenshots";
+    rev = "2f834716edd4a80504bacdbd3ddc24c1d63a20af";
+    hash = "sha256-8iydpppaonyj+pJDdjG7tFG9hKLNjey/DZenQAyubMk=";
+  };
+
+  format = "pyproject";
+
+  buildInputs = [
+    setuptools
+  ];
+
+  dependencies = [
+    click
+    pillow
+    toml
+    pyyaml
+    requests
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/better-screenshots \
+      --prefix PATH : "${lib.makeBinPath [ grim slurp wl-clipboard ]}"
+  '';
+
+  meta = with lib; {
+    description = "CLI screenshot tool for Linux with background customization";
+    homepage = "https://github.com/snxhasish/better-screenshots";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/applications/misc/better-screenshots/default.nix
+++ b/pkgs/applications/misc/better-screenshots/default.nix
@@ -1,16 +1,17 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, grim
-, slurp
-, wl-clipboard
-, makeWrapper
-, click
-, pillow
-, toml
-, pyyaml
-, requests
-, setuptools
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  grim,
+  slurp,
+  wl-clipboard,
+  makeWrapper,
+  click,
+  pillow,
+  toml,
+  pyyaml,
+  requests,
+  setuptools,
 }:
 
 buildPythonPackage {
@@ -40,7 +41,13 @@ buildPythonPackage {
 
   postInstall = ''
     wrapProgram $out/bin/better-screenshots \
-      --prefix PATH : "${lib.makeBinPath [ grim slurp wl-clipboard ]}"
+      --prefix PATH : "${
+        lib.makeBinPath [
+          grim
+          slurp
+          wl-clipboard
+        ]
+      }"
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9297,6 +9297,8 @@ with pkgs;
 
   bfcal = libsForQt5.callPackage ../applications/misc/bfcal { };
 
+  better-screenshots = python3Packages.callPackage ../applications/misc/better-screenshots { };
+
   bitlbee = callPackage ../applications/networking/instant-messengers/bitlbee { };
   bitlbee-plugins = callPackage ../applications/networking/instant-messengers/bitlbee/plugins.nix { };
 


### PR DESCRIPTION
better-screenshots: init at 0.1.0
Screenshot tool with image/background customizations and cloud uploads.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
