### PR TITLE
python3Packages.pyscipopt: init at 6.2.1

### DIFF
--- a/pkgs/development/python-modules/pyscipopt/default.nix
+++ b/pkgs/development/python-modules/pyscipopt/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  cython,
+  numpy,
+  scipopt-scip,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pyscipopt";
+  version = "6.2.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-PaFjT/NByGZfzxAEhveWjdu/Fg3FbYPpkzhxfSJF72o=";
+  };
+
+  build-system = [
+    cython
+    setuptools
+  ];
+
+  dependencies = [ numpy ];
+
+  buildInputs = [ scipopt-scip ];
+
+  pythonImportsCheck = [ "pyscipopt" ];
+
+  meta = {
+    description = "Python interface and modeling environment for SCIP";
+    homepage = "https://github.com/scipopt/PySCIPOpt";
+    changelog = "https://github.com/scipopt/PySCIPOpt/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kilianar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15078,6 +15078,8 @@ self: super: with self; {
 
   pyschlage = callPackage ../development/python-modules/pyschlage { };
 
+  pyscipopt = callPackage ../development/python-modules/pyscipopt { };
+
   pyscreenshot = callPackage ../development/python-modules/pyscreenshot { };
 
   pyscreeze = callPackage ../development/python-modules/pyscreeze { };


### PR DESCRIPTION
This PR adds [PySCIPOpt](https://github.com/scipopt/PySCIPOpt), the Python interface for the [scip optimization suite](https://github.com/scipopt/scip) already available in nixpkgs.
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
