### PR TITLE
lib/cli: allow passing extra optionsFormat args

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -226,17 +226,21 @@
     :::
   */
   toCommandLineGNU =
-    {
+    args@{
       isLong ? optionName: builtins.stringLength optionName > 1,
       explicitBool ? false,
       formatArg ? lib.generators.mkValueStringDefault { },
+      ...
     }:
     let
-      optionFormat = optionName: {
-        option = if isLong optionName then "--${optionName}" else "-${optionName}";
-        sep = if isLong optionName then "=" else "";
-        inherit explicitBool formatArg;
-      };
+      optionFormat =
+        optionName:
+        {
+          option = if isLong optionName then "--${optionName}" else "-${optionName}";
+          sep = if isLong optionName then "=" else "";
+          inherit explicitBool formatArg;
+        }
+        // args;
     in
     lib.cli.toCommandLine optionFormat;
 


### PR DESCRIPTION
The new GNU command line format enforces `--long-option=value` rather than `--long-option value` of the previous "GNU" command line format. It is quite common for applications to not allow the `=` separator and you'd need to define a custom format for each. Simply allow overriding the optionsFormat params so that small deviations can be declared in a light-weight manner.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
