### PR TITLE
Bulk replace `http://` with `https://`

### DIFF
--- a/pkgs/applications/emulators/kega-fusion/default.nix
+++ b/pkgs/applications/emulators/kega-fusion/default.nix
@@ -39,12 +39,12 @@ stdenv.mkDerivation {
   version = "3.63x";
 
   src = fetchurl {
-    url = "http://www.carpeludum.com/download/Fusion363x.tar.gz";
+    url = "https://www.carpeludum.com/download/Fusion363x.tar.gz";
     sha256 = "14s6czy20h5khyy7q95hd7k77v17ssafv9l6lafkiysvj2nmw94g";
   };
 
   plugins = fetchurl {
-    url = "http://www.carpeludum.com/download/PluginsLinux.tar.gz";
+    url = "https://www.carpeludum.com/download/PluginsLinux.tar.gz";
     sha256 = "0d623cvh6n5ijj3wb64g93mxx2xbichsn7hj7brbb0ndw5cs70qj";
   };
 

--- a/pkgs/applications/graphics/gimp/2.0/default.nix
+++ b/pkgs/applications/graphics/gimp/2.0/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchurl {
-    url = "http://download.gimp.org/pub/gimp/v${lib.versions.majorMinor finalAttrs.version}/gimp-${finalAttrs.version}.tar.bz2";
+    url = "https://download.gimp.org/pub/gimp/v${lib.versions.majorMinor finalAttrs.version}/gimp-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-UKhF7sEciDH+hmFweVD1uERuNfMO37ms+Y+FwRM/hW4=";
   };
 

--- a/pkgs/applications/misc/ding/default.nix
+++ b/pkgs/applications/misc/ding/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   version = "1.9";
 
   src = fetchurl {
-    url = "http://ftp.tu-chemnitz.de/pub/Local/urz/ding/ding-${version}.tar.gz";
+    url = "https://ftp.tu-chemnitz.de/pub/Local/urz/ding/ding-${version}.tar.gz";
     sha256 = "sha256-aabIH894WihsBTo1LzIBzIZxxyhRYVxLcHpDQwmwmOU=";
   };
 

--- a/pkgs/applications/networking/mailreaders/notmuch/muchsync.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/muchsync.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     inherit version;
   };
   src = fetchurl {
-    url = "http://www.muchsync.org/src/${pname}-${version}.tar.gz";
+    url = "https://www.muchsync.org/src/${pname}-${version}.tar.gz";
     hash = "sha256-+D4vb80O9IE0df3cjTkoVoZlTaX0FWWh6ams14Gjvqw=";
   };
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -93,7 +93,7 @@ let
       ;
     baseName = "thunderbird";
     basePath = "pkgs/applications/networking/mailreaders/thunderbird-bin";
-    baseUrl = "http://archive.mozilla.org/pub/thunderbird/releases/";
+    baseUrl = "https://archive.mozilla.org/pub/thunderbird/releases/";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_esr_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_esr_sources.nix
@@ -2,1189 +2,1189 @@
   version = "140.8.1esr";
   sources = [
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/af/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/af/thunderbird-140.8.1esr.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
       sha256 = "a2a6df485c32d95b71ee287593214f6fe93feadf7cf76c04c9f0172652a21cdc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ar/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ar/thunderbird-140.8.1esr.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
       sha256 = "50bfb2f9a1a27ad63732a16a6d313a9444ff4c713b84a2ce242b1c17823d3453";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ast/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ast/thunderbird-140.8.1esr.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
       sha256 = "5b423b640a278fdb381e112763e72a5f9707b49e6f009407a0a7a8a0a81f5242";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/be/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/be/thunderbird-140.8.1esr.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
       sha256 = "3e496569f5f7119f3ec6283558e9c789d105148b7dec60b2cf665cdd9fdf9435";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/bg/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/bg/thunderbird-140.8.1esr.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
       sha256 = "31bed156742b5b9262366585854fa272af840f8487b613b13dd86727b2d95390";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/br/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/br/thunderbird-140.8.1esr.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
       sha256 = "88380e0616d2d7934bf22eba46f19a64ea3bdfedda36a314cbfd5aaa8dbc8729";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ca/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ca/thunderbird-140.8.1esr.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
       sha256 = "7cbea4a762de5432bd2b61825cfe6fab2a942e3dc9ff4e0c814bc2759306cbd5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/cak/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/cak/thunderbird-140.8.1esr.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
       sha256 = "3c94e5d17e0368b6abdaa2c0b91dd111c1e2e16af55c7313a9eba8cd4ce2d6d6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/cs/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/cs/thunderbird-140.8.1esr.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
       sha256 = "7d7c7b6e32c5989199eee307aa0816eec04a5e60e4d9d3129b5adfbde9dc5e75";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/cy/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/cy/thunderbird-140.8.1esr.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
       sha256 = "9d7931783730523e3cd194e714fd8daf5fac9cde314785c72951c5cc0b4fa9ec";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/da/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/da/thunderbird-140.8.1esr.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
       sha256 = "ca5244d4a282d680d74faf6617af11d78a6f439fc778a7aada985bd704e15292";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/de/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/de/thunderbird-140.8.1esr.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
       sha256 = "997467027a0f6285000df0201b3877eb5519423e08d0701517d832321cd2e077";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/dsb/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/dsb/thunderbird-140.8.1esr.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
       sha256 = "785c88a25b3b86456e48e605707cdaf8e797560a45e9552c973a5a79ec7cd3cd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/el/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/el/thunderbird-140.8.1esr.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
       sha256 = "8c59e36dd60ee10a706a2014ce6e641470fe9860cbb26157d4c25b3bd4933149";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/en-CA/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/en-CA/thunderbird-140.8.1esr.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
       sha256 = "ac014e1627aec7ac848a858d917e778fcb9909408afbbc06e41bfda22cc74384";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/en-GB/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/en-GB/thunderbird-140.8.1esr.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
       sha256 = "620850f83520d09e58926de3b2a706be940eb897df6f750f2d5ce4efbf929f65";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/en-US/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/en-US/thunderbird-140.8.1esr.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
       sha256 = "d48bbaceb92350534dc609c68c94c202740a1166788fc6b9851ea634e6027cd1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/es-AR/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/es-AR/thunderbird-140.8.1esr.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
       sha256 = "e8ff0f9c3dabcf2d9d1721a38d9e7a2c947da4c964cf51ea71258535608e2a5e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/es-ES/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/es-ES/thunderbird-140.8.1esr.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
       sha256 = "694dbae11787f1930552d9dc1c8f4c1075fd92fe5ac4b225d90d5deb5b715563";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/es-MX/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/es-MX/thunderbird-140.8.1esr.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
       sha256 = "8a4a9028f85c1798bc8e0a74d4094a5383d8fc433af485202d79852a819f81b7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/et/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/et/thunderbird-140.8.1esr.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
       sha256 = "1f778eaac6c26b155407d68119d4b8c5b5568a0b7966cc24b1c073fbf3e7944b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/eu/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/eu/thunderbird-140.8.1esr.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
       sha256 = "33f9d1cf56652d29402b4142973493c886ba9ce3a18b3dec9f9c01c9c907a276";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/fi/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/fi/thunderbird-140.8.1esr.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
       sha256 = "23d1fe70727aac387e3599d2d87766b0b12ca80c02cf821a443bd4c81496358a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/fr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/fr/thunderbird-140.8.1esr.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
       sha256 = "986251b06821ca15d7d3902608d8d91f3b83128d1c0ef93e1420c47682f7783d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/fy-NL/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/fy-NL/thunderbird-140.8.1esr.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
       sha256 = "de17062530629435e748ac48e06c6500712bf430fdee08baa74e3fa63b7f2aab";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ga-IE/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ga-IE/thunderbird-140.8.1esr.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
       sha256 = "76044251b1260a60dd79c92b74586be48eda9912eceb8c747ba92dc51b94cc44";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/gd/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/gd/thunderbird-140.8.1esr.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
       sha256 = "005605b6fc16111393da1031498d9b90e5ed08e1832dc316f3175bd6b1eb328e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/gl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/gl/thunderbird-140.8.1esr.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
       sha256 = "b82275a2782b5167d19681c64efa3957a15893490b9e068b0e0d48580ca5b1ac";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/he/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/he/thunderbird-140.8.1esr.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
       sha256 = "b19179490601c0acabb179b006e416dec59b0babfff37c9bfa3238ee512e8fb3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/hr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/hr/thunderbird-140.8.1esr.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
       sha256 = "7be2a453115375c5e2a4e46b7f6d7f809713df402cced9483958a3a1053d676f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/hsb/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/hsb/thunderbird-140.8.1esr.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
       sha256 = "c5879ff7416edc616c3bd1362046d0650bdb20444f8b4879c06808467c260432";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/hu/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/hu/thunderbird-140.8.1esr.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
       sha256 = "0d007b516a9c09a6e48e734843df0093d6d9c92705b348feedfedd54972bd24f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/hy-AM/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/hy-AM/thunderbird-140.8.1esr.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
       sha256 = "1df90a34bca5232fb18b09fa825ac0b56f83ad61b188a80d0921c697bd04a0f7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/id/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/id/thunderbird-140.8.1esr.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
       sha256 = "4d33d6dfc17dbbc5e0643060e355a5eeab3ada4265f95af260d5449b497fe5d4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/is/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/is/thunderbird-140.8.1esr.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
       sha256 = "acfb46eedaf02978d3cfb16c568183e70bc9c82dd662e8aa5783afb00a873c2a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/it/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/it/thunderbird-140.8.1esr.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
       sha256 = "3f09a35bdd66b7606242139d2d34c9815f5abfc6d659c2909361e52ae8bd4dbb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ja/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ja/thunderbird-140.8.1esr.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
       sha256 = "d4d818cc9e73be659770f847ec2f6f3945194e04ea676bd2f8219d19c94bc89f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ka/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ka/thunderbird-140.8.1esr.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
       sha256 = "aacdb54a957b455910e2f68f684b8d5725b7232278d178247c7d3489f5fac1f1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/kab/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/kab/thunderbird-140.8.1esr.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
       sha256 = "92d1fd4160f58fdd9130758d85f571047487b5cd78f7e384de98696e894ce831";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/kk/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/kk/thunderbird-140.8.1esr.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
       sha256 = "1170c05c5868a304a9f8e83ff877a7ff467f6c9baa960bc92c259509f8e720df";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ko/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ko/thunderbird-140.8.1esr.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
       sha256 = "38cde1a5cb9b073ccd5288d9a3c0bc5215802fe464af82a5ee39aff51ef47c71";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/lt/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/lt/thunderbird-140.8.1esr.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
       sha256 = "5edb4f92f780df623d0cf38762ca7b95f101fc1024a1d6dd31559fdfa0b9c418";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/lv/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/lv/thunderbird-140.8.1esr.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
       sha256 = "958ee3279f68adcaeab5745ea0239b6d37904f6bb94bef4e01369e52d0c360fd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ms/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ms/thunderbird-140.8.1esr.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
       sha256 = "8c5e1f53f4f8c0722999f410f41cada2e349753e314bd751e8a88e3dfa22070a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/nb-NO/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/nb-NO/thunderbird-140.8.1esr.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
       sha256 = "6202a8ec3e33e0256d3031ecc4d4bbbfeb89963a27f33b465ce1ea8c6b76792c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/nl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/nl/thunderbird-140.8.1esr.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
       sha256 = "ea348f47896e87077819a7f45c9317ebba61d92f2ef50bfb29c70c5dd740a0f3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/nn-NO/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/nn-NO/thunderbird-140.8.1esr.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
       sha256 = "c02063b7160e0f8da26bbc45f55e6f4764cd2b07bf513bae234b2626d9a4b3cc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/pa-IN/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/pa-IN/thunderbird-140.8.1esr.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
       sha256 = "22e8f5d21ea31b1038a427ca2851bdf9ad4e76d61deeae747920c62497099980";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/pl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/pl/thunderbird-140.8.1esr.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
       sha256 = "d6537c1069430250b320fcb4dcb156a3972764b9007600d80726b503a9760306";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/pt-BR/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/pt-BR/thunderbird-140.8.1esr.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
       sha256 = "5214712c72d0039a0284939a9095ef2cf954c3a55ee593389da3448718999ae5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/pt-PT/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/pt-PT/thunderbird-140.8.1esr.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
       sha256 = "b6be8071e73f474f15d1f97bb7eb0d4da8673984b4862faf6aa38ebe78c6421d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/rm/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/rm/thunderbird-140.8.1esr.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
       sha256 = "f8ca0204f1883bfa141d31d6eee01fbadceb5309d186d60de0549e68ddafeff9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ro/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ro/thunderbird-140.8.1esr.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
       sha256 = "3d17493752007080913a194adcd568718be9caf295d4b7dac0185268f2172ad0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ru/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/ru/thunderbird-140.8.1esr.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
       sha256 = "e2e9b128d06430cf6154075a0876a0820d6f207dff351383e6c618da7d3b4d81";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sk/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sk/thunderbird-140.8.1esr.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
       sha256 = "ce44fc03b38f31172e5319c6f82283127d122b5d08bf3c2d40ab354d096c9764";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sl/thunderbird-140.8.1esr.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
       sha256 = "a924ec6cd3da033146a23705e8e860c53010c0dc41efa2f28156cc38430ba9af";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sq/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sq/thunderbird-140.8.1esr.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
       sha256 = "4da2f3b2dd7596ccaf7d4b00544110c4d2bc16799bc3a502f7ba916cb28a438b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sr/thunderbird-140.8.1esr.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
       sha256 = "c7b5221bdb02be1f054820ffd3775e7a00fc2e60d4bf6c3d3ab9faceaf54ec67";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sv-SE/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/sv-SE/thunderbird-140.8.1esr.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
       sha256 = "2acf672155f03b53613f9b2b399b441d92339995036542058c83bebe04b43fb7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/th/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/th/thunderbird-140.8.1esr.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
       sha256 = "e27b9c5e20f9bcacd12b69973c4d04422c5b4f6334a6d4addfcff24729f1b6ff";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/tr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/tr/thunderbird-140.8.1esr.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
       sha256 = "82074179d975bcff2975bb2c000de6f51cf00a2a603cb1253217f66ca4463055";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/uk/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/uk/thunderbird-140.8.1esr.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
       sha256 = "d0ce5add86c87ef4f97d0dd16a4a29f87eadf1266c225ec9190fd8c61faabe72";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/uz/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/uz/thunderbird-140.8.1esr.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
       sha256 = "33c343747528d6f4591f96af4894b1d85d62db6c3a552d691dcf9c2600f6c8b3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/vi/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/vi/thunderbird-140.8.1esr.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
       sha256 = "260ebc557c460796502b16e00789b6f53cdf073adc4f75533873eee2839ebfab";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/zh-CN/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/zh-CN/thunderbird-140.8.1esr.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
       sha256 = "6a77b94e6adb10ff4d93c82a75419ce04e14e07c20784d6219080cd7c45dd68d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/zh-TW/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-x86_64/zh-TW/thunderbird-140.8.1esr.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
       sha256 = "71502937adeb494e2b286b2131c2e113fa15048d3ae4cddf40e58d59af3d5959";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/af/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/af/thunderbird-140.8.1esr.tar.xz";
       locale = "af";
       arch = "linux-i686";
       sha256 = "dd2ce21bc9dc5403e12154d3dad21e744854b68aaded45db08c641f7ed5a06bb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ar/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ar/thunderbird-140.8.1esr.tar.xz";
       locale = "ar";
       arch = "linux-i686";
       sha256 = "02159d0cca4d423f6eed40c9fd14c8e915603da639103dbfe8e4dacc408879d8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ast/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ast/thunderbird-140.8.1esr.tar.xz";
       locale = "ast";
       arch = "linux-i686";
       sha256 = "09465b0a97c99b2d87491238de0e1396064ea0ba2781d6ee0a1840b3855f9eeb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/be/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/be/thunderbird-140.8.1esr.tar.xz";
       locale = "be";
       arch = "linux-i686";
       sha256 = "b49a44da05bc8e620c51c24785b25a6fe1c28dbaa1b3721e601fbc295ebd73d2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/bg/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/bg/thunderbird-140.8.1esr.tar.xz";
       locale = "bg";
       arch = "linux-i686";
       sha256 = "2a540d4545536672778f8cc59ba05d954689c28a950bf3e815cd245c1f1ddfd1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/br/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/br/thunderbird-140.8.1esr.tar.xz";
       locale = "br";
       arch = "linux-i686";
       sha256 = "e693e89b822320fc55db17c14fa464b2332c7a017db9008bd30802475de13c4e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ca/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ca/thunderbird-140.8.1esr.tar.xz";
       locale = "ca";
       arch = "linux-i686";
       sha256 = "e4d6536f3efa260a56188e2552df304feb3cd8668cfe50e580577d44610277a3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/cak/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/cak/thunderbird-140.8.1esr.tar.xz";
       locale = "cak";
       arch = "linux-i686";
       sha256 = "325c6b1cb7730beb044750664a05b205260699631c899e37093d5be866e76a71";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/cs/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/cs/thunderbird-140.8.1esr.tar.xz";
       locale = "cs";
       arch = "linux-i686";
       sha256 = "1680ae1e599e627ddd7ce4dd9d21eefcb0879390dfc9c7d52c9dce84102d8607";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/cy/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/cy/thunderbird-140.8.1esr.tar.xz";
       locale = "cy";
       arch = "linux-i686";
       sha256 = "f037c87d327cb5cdf476e977754c671a2b8eda9f895835a399c0c3a43ba4c1fe";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/da/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/da/thunderbird-140.8.1esr.tar.xz";
       locale = "da";
       arch = "linux-i686";
       sha256 = "f6ee6e8d7a8058346894292a3bf4daa59c13ef07be0d875b6f8ed016a3e85f43";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/de/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/de/thunderbird-140.8.1esr.tar.xz";
       locale = "de";
       arch = "linux-i686";
       sha256 = "267d4117268074bf5e3c4b8ce2603204c5f22b83e1b6592b0c9acd670fe0f73e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/dsb/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/dsb/thunderbird-140.8.1esr.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
       sha256 = "e886e51b2e4b0659f1093b16fa19710f16895219f1e3ae5cadfb24097f810972";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/el/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/el/thunderbird-140.8.1esr.tar.xz";
       locale = "el";
       arch = "linux-i686";
       sha256 = "a497fb0f4be8ebe738adee3510a74f5c8cefeb6935e7e6a54a049d16eb49991d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/en-CA/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/en-CA/thunderbird-140.8.1esr.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
       sha256 = "ba8ce294c3836d57261192f378869ba03de9a1da08d5d0ce9f598dd15cdad75c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/en-GB/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/en-GB/thunderbird-140.8.1esr.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
       sha256 = "86dc258e8d9b78adcc2c090eb826bf6665415a9715f9f3b735ac0c7870c0c449";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/en-US/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/en-US/thunderbird-140.8.1esr.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
       sha256 = "9a227eae275c99c794d5b47e947f2b50a45de8ff3b236f8849a9c45a7e70201e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/es-AR/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/es-AR/thunderbird-140.8.1esr.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
       sha256 = "b390377508a512261901600f8c1e19ed7e3561ba087c8e55f541fe1269aa83b5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/es-ES/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/es-ES/thunderbird-140.8.1esr.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
       sha256 = "208146545b34e6fe4c7b9cb2e1649430b6f2a29be31d9c4d8520c87e518a0d56";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/es-MX/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/es-MX/thunderbird-140.8.1esr.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
       sha256 = "f41948096e01d106629248d491e0db28aab3af5784782f8bb86e5f44f5125e2d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/et/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/et/thunderbird-140.8.1esr.tar.xz";
       locale = "et";
       arch = "linux-i686";
       sha256 = "ca36fdc6af282939a9739d188299d96fcd260fcf43b1ba4ae00944974272b19f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/eu/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/eu/thunderbird-140.8.1esr.tar.xz";
       locale = "eu";
       arch = "linux-i686";
       sha256 = "f0221f2d636d63514931c9a94c05c34f3e49170941fc61d1c320a4b9563017f0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/fi/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/fi/thunderbird-140.8.1esr.tar.xz";
       locale = "fi";
       arch = "linux-i686";
       sha256 = "d9d6888452b46a64156127909becf22646f8020cf793db4e8bfe420003c21f4f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/fr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/fr/thunderbird-140.8.1esr.tar.xz";
       locale = "fr";
       arch = "linux-i686";
       sha256 = "e2aa7355f6b4265daf1928a8e629551361e36c17f420e72092a008f9291a9991";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/fy-NL/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/fy-NL/thunderbird-140.8.1esr.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
       sha256 = "50fc5df22a97d0b9e211dc77666464f6f70d50671c3e9fddd5417abb0260a632";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ga-IE/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ga-IE/thunderbird-140.8.1esr.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
       sha256 = "c758e488dd58db908e92c414a8a0793c7a9e93ecdd1ba91ee50a97425a9d0667";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/gd/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/gd/thunderbird-140.8.1esr.tar.xz";
       locale = "gd";
       arch = "linux-i686";
       sha256 = "4cac68260c2dc303aa256d243991c11470b2d3148e8011d75d93740461a6068a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/gl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/gl/thunderbird-140.8.1esr.tar.xz";
       locale = "gl";
       arch = "linux-i686";
       sha256 = "5ef339bb02d8af1d0ed6f57e7f7d4df109cba01721e25640b4aca2834d457137";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/he/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/he/thunderbird-140.8.1esr.tar.xz";
       locale = "he";
       arch = "linux-i686";
       sha256 = "22e0ffbd1e5b2ef89f7a9d15b5f63aa6417617b416bb1117d66a00061bdd6a12";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/hr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/hr/thunderbird-140.8.1esr.tar.xz";
       locale = "hr";
       arch = "linux-i686";
       sha256 = "fdd33df5385967689f2236cf35fdd360bb12c81373fe1fef6b0e5332c0f41551";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/hsb/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/hsb/thunderbird-140.8.1esr.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
       sha256 = "79b389658e6dcd527bd814729d2c9924ea9ba03c4fbb98dc8b31812fc039d8fd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/hu/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/hu/thunderbird-140.8.1esr.tar.xz";
       locale = "hu";
       arch = "linux-i686";
       sha256 = "39ee8595f5471924b3f2b7d8e9369d6e3e4e855279236796a47fc6790326f14b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/hy-AM/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/hy-AM/thunderbird-140.8.1esr.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
       sha256 = "801b71c019427b9be7a3f3128f61a834c4c07749b495d9aa39395a5d03201611";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/id/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/id/thunderbird-140.8.1esr.tar.xz";
       locale = "id";
       arch = "linux-i686";
       sha256 = "3e00d95d75feb55a0919aea3566cd683eb9be5bd1fcbf2e906c76fc5e68090d5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/is/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/is/thunderbird-140.8.1esr.tar.xz";
       locale = "is";
       arch = "linux-i686";
       sha256 = "8d8c5cd3feb72cb2f902c894ec59e10bfca31b1f7c55692e08f1325a8fafd7e5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/it/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/it/thunderbird-140.8.1esr.tar.xz";
       locale = "it";
       arch = "linux-i686";
       sha256 = "de0705ace7da5a4a0008330b52b609170ba1c19c1724cfcebfad134012fb0311";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ja/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ja/thunderbird-140.8.1esr.tar.xz";
       locale = "ja";
       arch = "linux-i686";
       sha256 = "93393d07b9d772f74b0398a7abd6051c8d6bcbba15ea23e47af2bb5e96a80d35";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ka/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ka/thunderbird-140.8.1esr.tar.xz";
       locale = "ka";
       arch = "linux-i686";
       sha256 = "1f445699e183952bc9279d3cf693e0745548d3408be244e72a88cc5f1f3b2582";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/kab/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/kab/thunderbird-140.8.1esr.tar.xz";
       locale = "kab";
       arch = "linux-i686";
       sha256 = "d734067cd10d77a25c0ace4eae18a207d7c39392e037529060bcaf5a8a385459";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/kk/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/kk/thunderbird-140.8.1esr.tar.xz";
       locale = "kk";
       arch = "linux-i686";
       sha256 = "2154456796c62f69a2605916acbf57936e07e234c8f7d4fa2d09ffb12cf6ded4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ko/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ko/thunderbird-140.8.1esr.tar.xz";
       locale = "ko";
       arch = "linux-i686";
       sha256 = "198c498b0b486a3f482dbccdbe3c70d870d5b38854df08e839e5107db601216f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/lt/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/lt/thunderbird-140.8.1esr.tar.xz";
       locale = "lt";
       arch = "linux-i686";
       sha256 = "a3efc8209a72816e801a899afa45cb2bcd937818c250f8bb6f736487581fff57";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/lv/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/lv/thunderbird-140.8.1esr.tar.xz";
       locale = "lv";
       arch = "linux-i686";
       sha256 = "3d6158555cade4380eeab77a6d43524dd3ccd69c3e406d9ab4643b0811a941f4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ms/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ms/thunderbird-140.8.1esr.tar.xz";
       locale = "ms";
       arch = "linux-i686";
       sha256 = "d0702fd04a9aeb69aef103a356116c5d5e6b9ea1f975837c82618bc985f5e080";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/nb-NO/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/nb-NO/thunderbird-140.8.1esr.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
       sha256 = "206ac112df23f8648428781ec15a2a3d52adbab3b5d77e96f561a6e0f8940f50";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/nl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/nl/thunderbird-140.8.1esr.tar.xz";
       locale = "nl";
       arch = "linux-i686";
       sha256 = "7b4e4b489dec23c1b4e28f96f9c4da33420e3889b5b83d3b79ae2425f720ce1c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/nn-NO/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/nn-NO/thunderbird-140.8.1esr.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
       sha256 = "3d51d481f1d4fe5d054360f4240065d69f7839b3102f7a702ace47cc84224035";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/pa-IN/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/pa-IN/thunderbird-140.8.1esr.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
       sha256 = "18f18aa018e8a4b84ef45164eb6b49b9fff91dc66e96cc6bd1fc75ea54a352a0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/pl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/pl/thunderbird-140.8.1esr.tar.xz";
       locale = "pl";
       arch = "linux-i686";
       sha256 = "64eaafe5466f17cf0de7fa9cdd18dea9aa213dc237f602e95353299429879195";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/pt-BR/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/pt-BR/thunderbird-140.8.1esr.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
       sha256 = "5a89f60fecc932c4fabbf61dd43d4a8e96687125a779dfd9a8fcc5e58451c751";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/pt-PT/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/pt-PT/thunderbird-140.8.1esr.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
       sha256 = "831a72e09575094b4df9ebc6abc2f5e77d17984a64f0a81ecffb5c37ed7b53d0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/rm/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/rm/thunderbird-140.8.1esr.tar.xz";
       locale = "rm";
       arch = "linux-i686";
       sha256 = "b0b6df3c15f1fb111594ee69b0a67e971ffd41e0ebe5633e5c64f1767d1e3ba9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ro/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ro/thunderbird-140.8.1esr.tar.xz";
       locale = "ro";
       arch = "linux-i686";
       sha256 = "74dd89e782fc4ada8f70837e98171806cf8eb24500ef9d60946d65e6222c7649";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ru/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/ru/thunderbird-140.8.1esr.tar.xz";
       locale = "ru";
       arch = "linux-i686";
       sha256 = "1323e8704c5ad8491c23c8399501dbc67ed545989b83043a1ca232ac03e8fff1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sk/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sk/thunderbird-140.8.1esr.tar.xz";
       locale = "sk";
       arch = "linux-i686";
       sha256 = "5b9b506699ac3cbbf6fbb271cd305882c8fa832aa70f52511ebf71bb3d4153dd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sl/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sl/thunderbird-140.8.1esr.tar.xz";
       locale = "sl";
       arch = "linux-i686";
       sha256 = "c00a5812a416d19e7f3afa0db0ec216b10c12a2903b311fee9c0b6213ce3ac59";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sq/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sq/thunderbird-140.8.1esr.tar.xz";
       locale = "sq";
       arch = "linux-i686";
       sha256 = "f1ee8c8bfcc6fc180f295e7b37363225a1ed596b6c01876d994275286ee835cf";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sr/thunderbird-140.8.1esr.tar.xz";
       locale = "sr";
       arch = "linux-i686";
       sha256 = "0b7c3297b005736a0e52c08ccb54f8cf725c4154d5767bd4aca502e88ce1d7b1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sv-SE/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/sv-SE/thunderbird-140.8.1esr.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
       sha256 = "28885f0e6a78b85b8acbf2d040bb6405caa6701088a0742cb1197709918c38fb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/th/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/th/thunderbird-140.8.1esr.tar.xz";
       locale = "th";
       arch = "linux-i686";
       sha256 = "23645f57987965c5cd2c0128caea047be8495c727c8881a83f222bae4f00ff06";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/tr/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/tr/thunderbird-140.8.1esr.tar.xz";
       locale = "tr";
       arch = "linux-i686";
       sha256 = "917b63e9193925ba99dffca41b769099af0829b87db23e6c576f4c3c55c3d986";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/uk/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/uk/thunderbird-140.8.1esr.tar.xz";
       locale = "uk";
       arch = "linux-i686";
       sha256 = "06f7f0d59e2979b215f3d430a9a347b48dfd491c0d68375c6a8a4564a9440f8d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/uz/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/uz/thunderbird-140.8.1esr.tar.xz";
       locale = "uz";
       arch = "linux-i686";
       sha256 = "62e5bf272ed9b5870d4859368f0b69f76f94699f922b48de3993aee29db4efb0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/vi/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/vi/thunderbird-140.8.1esr.tar.xz";
       locale = "vi";
       arch = "linux-i686";
       sha256 = "efd59dfa5b3647d614decf11dbaf9319aeb3244ced0a5b576b8c8aa9191a14b7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/zh-CN/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/zh-CN/thunderbird-140.8.1esr.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
       sha256 = "c832a30626941ed31a539a7271ec40848cffe5434a0bf667e9b86e2ba4658571";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/zh-TW/thunderbird-140.8.1esr.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/linux-i686/zh-TW/thunderbird-140.8.1esr.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
       sha256 = "5abce6cbd19e6ebe40f709968f5104b539c503ae71122bff113a3e9f21fee1f6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/af/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/af/Thunderbird%20140.8.1esr.dmg";
       locale = "af";
       arch = "mac";
       sha256 = "22624183fe0d9583227a4d6c549d96fafdcbc9f3bc3a3f4e5b6ad22629ccfac0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ar/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ar/Thunderbird%20140.8.1esr.dmg";
       locale = "ar";
       arch = "mac";
       sha256 = "ce73adcba8b5651fec00e1b86f92b111db50d65a5a8306fc5b18b5e9aed965c1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ast/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ast/Thunderbird%20140.8.1esr.dmg";
       locale = "ast";
       arch = "mac";
       sha256 = "63b51337df4e38cadd6cb1ee4d1bcfaee452a5627f3471d9851365bd4de6bbbd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/be/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/be/Thunderbird%20140.8.1esr.dmg";
       locale = "be";
       arch = "mac";
       sha256 = "92934cdfb7562c3dcde41dc1911437db84a22592275fab6db853fbe0d434c7d0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/bg/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/bg/Thunderbird%20140.8.1esr.dmg";
       locale = "bg";
       arch = "mac";
       sha256 = "35aba6bcec1186922b32251661a56fd66b8431ee406169ba107221969d490585";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/br/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/br/Thunderbird%20140.8.1esr.dmg";
       locale = "br";
       arch = "mac";
       sha256 = "71c3b7018a6731e86b0c94a1013beb736fa31ef9b5b35bd359d31539d4a7063c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ca/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ca/Thunderbird%20140.8.1esr.dmg";
       locale = "ca";
       arch = "mac";
       sha256 = "0be8322568793c296025d4c345382b2ee0f58917fdcfac0aaf3ab8cac13a9e6b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/cak/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/cak/Thunderbird%20140.8.1esr.dmg";
       locale = "cak";
       arch = "mac";
       sha256 = "3fcbe75b6796395784949a514bc3853a1d86a0b6de2be984c3c73550ec4d6dea";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/cs/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/cs/Thunderbird%20140.8.1esr.dmg";
       locale = "cs";
       arch = "mac";
       sha256 = "b9a6022d702c4afa6c665d7690533ed4d9a7e58df86084af7fed49a824e53b79";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/cy/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/cy/Thunderbird%20140.8.1esr.dmg";
       locale = "cy";
       arch = "mac";
       sha256 = "d7eebea983b2110a91fd74791ab2591255564250a336d72b32b0ec9d71255dc4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/da/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/da/Thunderbird%20140.8.1esr.dmg";
       locale = "da";
       arch = "mac";
       sha256 = "d75e6dceb07a890ca71229541603320f8c07f4aed11032ba64fe19a0ff2bb4ee";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/de/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/de/Thunderbird%20140.8.1esr.dmg";
       locale = "de";
       arch = "mac";
       sha256 = "97ea7be853fe85d87f8230d4db966a20aa3f570963cc4bdaef088b15f2293906";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/dsb/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/dsb/Thunderbird%20140.8.1esr.dmg";
       locale = "dsb";
       arch = "mac";
       sha256 = "b2c9f248dcbaa4b82c0a6fb8367437fce280dc338bfce7441ab1ee295a9ebc1e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/el/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/el/Thunderbird%20140.8.1esr.dmg";
       locale = "el";
       arch = "mac";
       sha256 = "e2739ec67f2e088a3bf65916a58fc92686dff4aeec8a7af06af98a8cb06cff29";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/en-CA/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/en-CA/Thunderbird%20140.8.1esr.dmg";
       locale = "en-CA";
       arch = "mac";
       sha256 = "e4e9e100a5d7cfd17caed84fd76a16817b6776698438c88b0299a7050bb48157";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/en-GB/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/en-GB/Thunderbird%20140.8.1esr.dmg";
       locale = "en-GB";
       arch = "mac";
       sha256 = "99a4f3d1bc162eb98f4d685f1508157a59daab954f8a3103d5b2b2db20f41969";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/en-US/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/en-US/Thunderbird%20140.8.1esr.dmg";
       locale = "en-US";
       arch = "mac";
       sha256 = "41eee241cdb2405ead4feb5e676917eb40e54446e3e5db4d090a75d80465c805";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/es-AR/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/es-AR/Thunderbird%20140.8.1esr.dmg";
       locale = "es-AR";
       arch = "mac";
       sha256 = "680f8109aa6728a95e66b3eaf6eb20d17d3d62378d9ac75289aa4bc2935df55c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/es-ES/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/es-ES/Thunderbird%20140.8.1esr.dmg";
       locale = "es-ES";
       arch = "mac";
       sha256 = "7536b48665d16a9ebbb7f687532b97bd08787e0978129923c6a9dd0bf52bd864";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/es-MX/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/es-MX/Thunderbird%20140.8.1esr.dmg";
       locale = "es-MX";
       arch = "mac";
       sha256 = "5c8342b68e8a2afd6f370c9991bc29b6ccb9024e22af638a1fbfb0afd6ed5fd9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/et/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/et/Thunderbird%20140.8.1esr.dmg";
       locale = "et";
       arch = "mac";
       sha256 = "ed4beec98b1945c044cadca494f98819298cc533f656a2f4f6116f037cb18e62";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/eu/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/eu/Thunderbird%20140.8.1esr.dmg";
       locale = "eu";
       arch = "mac";
       sha256 = "2d377cac10a089d2fa2dba8452f92f1185d485076e910159b2497c2739d79eb6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/fi/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/fi/Thunderbird%20140.8.1esr.dmg";
       locale = "fi";
       arch = "mac";
       sha256 = "0f6886d531719c0cb68b318e87435a0b3c67ee2acf239a13ac055ae11c199545";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/fr/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/fr/Thunderbird%20140.8.1esr.dmg";
       locale = "fr";
       arch = "mac";
       sha256 = "cf27acf21cc6c3e9589de2ad88311643841c4e8ab01f97dceb385e17106b11f0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/fy-NL/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/fy-NL/Thunderbird%20140.8.1esr.dmg";
       locale = "fy-NL";
       arch = "mac";
       sha256 = "3fe1aa3cd3a0880523f150d7df017edeaabf1725258942aa7fead373e9044173";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ga-IE/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ga-IE/Thunderbird%20140.8.1esr.dmg";
       locale = "ga-IE";
       arch = "mac";
       sha256 = "2e072cb4b589f7451626f6de5d2fffb4bab34e73d812b94a09be322833c9a0c1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/gd/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/gd/Thunderbird%20140.8.1esr.dmg";
       locale = "gd";
       arch = "mac";
       sha256 = "b78a50e4ab1ed8fd1a46463f304c31307236a123ee8b8c64353358a371ac6f86";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/gl/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/gl/Thunderbird%20140.8.1esr.dmg";
       locale = "gl";
       arch = "mac";
       sha256 = "3d3034ad6e406318d5cfe7fcf1e46c0cefe0721892761667472ef4920dd7be78";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/he/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/he/Thunderbird%20140.8.1esr.dmg";
       locale = "he";
       arch = "mac";
       sha256 = "8eb920c4c7c91e7655d9b614e8a710a0d9087229183b96e9c028a93c5df23f83";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/hr/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/hr/Thunderbird%20140.8.1esr.dmg";
       locale = "hr";
       arch = "mac";
       sha256 = "e4637fb9397b5c642448e43089583add717e8052be3ad7d8d5f07f156b95d41a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/hsb/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/hsb/Thunderbird%20140.8.1esr.dmg";
       locale = "hsb";
       arch = "mac";
       sha256 = "1a752d30f6e0509338bc85b371109cc722e92f7c489c263b31263ab5ac26b8cc";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/hu/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/hu/Thunderbird%20140.8.1esr.dmg";
       locale = "hu";
       arch = "mac";
       sha256 = "ba75bef3a72a04511676be8074c8d00b7c9317418fae22b35455deb1234de904";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/hy-AM/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/hy-AM/Thunderbird%20140.8.1esr.dmg";
       locale = "hy-AM";
       arch = "mac";
       sha256 = "df202a70c7e6b0d59beb6095f61be4d74e9873b7222946ba3aba8845a991d60c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/id/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/id/Thunderbird%20140.8.1esr.dmg";
       locale = "id";
       arch = "mac";
       sha256 = "94f83da8e9676af52b8711e7cd48575e520d8ce61063c86da27919c504cb6043";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/is/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/is/Thunderbird%20140.8.1esr.dmg";
       locale = "is";
       arch = "mac";
       sha256 = "69b101515450ecb6e50d83c2f9f71f405b28002ad7b64a2c569a798c83bd9468";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/it/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/it/Thunderbird%20140.8.1esr.dmg";
       locale = "it";
       arch = "mac";
       sha256 = "cfc5960fc923a483105a0e3e53fc5802853dee61a4a9a392314efc80e0e13360";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ja-JP-mac/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ja-JP-mac/Thunderbird%20140.8.1esr.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
       sha256 = "9eb1f856f59b676e7cf0b7acf243fbf5c3dd29098692d07d0e9eb7bbc89b9110";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ka/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ka/Thunderbird%20140.8.1esr.dmg";
       locale = "ka";
       arch = "mac";
       sha256 = "20c809d40bb46918356ca1e4f7301ae94a6007ea83043830fd23c8b628c73b39";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/kab/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/kab/Thunderbird%20140.8.1esr.dmg";
       locale = "kab";
       arch = "mac";
       sha256 = "a27545751025fe7835bcbf8759dcb7849b50d2bb783f54543850655602d6fc84";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/kk/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/kk/Thunderbird%20140.8.1esr.dmg";
       locale = "kk";
       arch = "mac";
       sha256 = "2a74af790469d3da851798b99d2f9f1f31a942f6683e63d148ba8fa9e7397808";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ko/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ko/Thunderbird%20140.8.1esr.dmg";
       locale = "ko";
       arch = "mac";
       sha256 = "0cf9cbe7eb0a365358eb618d41ec234a2ce8a8674ebc6fe3b40a6857a13daba6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/lt/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/lt/Thunderbird%20140.8.1esr.dmg";
       locale = "lt";
       arch = "mac";
       sha256 = "3ea725b28229d2f07e1fe0daf42b8fcbda860561ca8d1c62433e450a40887db7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/lv/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/lv/Thunderbird%20140.8.1esr.dmg";
       locale = "lv";
       arch = "mac";
       sha256 = "01c8d2b9af2dba50b207eb7e62924f5a521a45bafde4e6b6a4110d9d7d28e170";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ms/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ms/Thunderbird%20140.8.1esr.dmg";
       locale = "ms";
       arch = "mac";
       sha256 = "aa686dd27733ad308af292a25b141a70174ff2cd09472d29e6280afd0d8533c5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/nb-NO/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/nb-NO/Thunderbird%20140.8.1esr.dmg";
       locale = "nb-NO";
       arch = "mac";
       sha256 = "519b5f2075ef5b8f444abb3c0e0e09620299451703c5f549c2b782493e647251";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/nl/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/nl/Thunderbird%20140.8.1esr.dmg";
       locale = "nl";
       arch = "mac";
       sha256 = "13e3db19da765d62839c72dc2032de1c9e2af2995857df7b5c11128ddc3fdca7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/nn-NO/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/nn-NO/Thunderbird%20140.8.1esr.dmg";
       locale = "nn-NO";
       arch = "mac";
       sha256 = "1e0b1965fb8dc9985472a960237492e52d09f9f54b1d9f01f467e2ff3653f764";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/pa-IN/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/pa-IN/Thunderbird%20140.8.1esr.dmg";
       locale = "pa-IN";
       arch = "mac";
       sha256 = "1c1fbdc3a8a58b2983a1e61afde4c1f3c82baace71ba3e34891acbad4d83089c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/pl/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/pl/Thunderbird%20140.8.1esr.dmg";
       locale = "pl";
       arch = "mac";
       sha256 = "9a0e1f2a232c20d9ef5abf8b8d081e9173f9b600fdfc80aaef1961c6ce5cb494";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/pt-BR/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/pt-BR/Thunderbird%20140.8.1esr.dmg";
       locale = "pt-BR";
       arch = "mac";
       sha256 = "bdef886cdf12eeca3a8d12162de97320594abed7c27b26ff4a80232a802c0bb3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/pt-PT/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/pt-PT/Thunderbird%20140.8.1esr.dmg";
       locale = "pt-PT";
       arch = "mac";
       sha256 = "05857f22c10c2da4b88e93d1d30e8fc2f8ec6c56a3653e809e9f22fcfb7e206c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/rm/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/rm/Thunderbird%20140.8.1esr.dmg";
       locale = "rm";
       arch = "mac";
       sha256 = "1983dd10fc1437b68d3ba347287f889354ed848ceda3374e0c91cb8771bebe19";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ro/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ro/Thunderbird%20140.8.1esr.dmg";
       locale = "ro";
       arch = "mac";
       sha256 = "fed16aef5cdc3fe07b90e85a2e988179e1059225b7a4a8a9d514fe80f5970041";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ru/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/ru/Thunderbird%20140.8.1esr.dmg";
       locale = "ru";
       arch = "mac";
       sha256 = "d34428fbe71cf813635490ffa8b06660a485eb4e3e9b28083bdfcca511d21b0a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sk/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sk/Thunderbird%20140.8.1esr.dmg";
       locale = "sk";
       arch = "mac";
       sha256 = "a475eed733592d48adb3287092f58333bf83d0e9ddd8165c0f2bab8b904d3989";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sl/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sl/Thunderbird%20140.8.1esr.dmg";
       locale = "sl";
       arch = "mac";
       sha256 = "42c481c28b5b37ab6b1291804a61c6ba6579d09a405fe38782eb6e38ad67e80a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sq/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sq/Thunderbird%20140.8.1esr.dmg";
       locale = "sq";
       arch = "mac";
       sha256 = "b75b09a20c9160c88205d777201ff454ec09725bc184e8e4c44ac3c3db113553";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sr/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sr/Thunderbird%20140.8.1esr.dmg";
       locale = "sr";
       arch = "mac";
       sha256 = "6e22260916ff863ec0b4b3ada5ce49e74fda15195c14cc2ac96871b9dbbfdf3a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sv-SE/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/sv-SE/Thunderbird%20140.8.1esr.dmg";
       locale = "sv-SE";
       arch = "mac";
       sha256 = "bdf06df7ba37813e9e5357eeec2b62e21cee79fd5aef34b7766b6a942e629a2d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/th/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/th/Thunderbird%20140.8.1esr.dmg";
       locale = "th";
       arch = "mac";
       sha256 = "8a34f2219e3380292760f877f2f8587662b433083bfd0f9d9c23cbdf58c85f7d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/tr/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/tr/Thunderbird%20140.8.1esr.dmg";
       locale = "tr";
       arch = "mac";
       sha256 = "bd903e7f5d23b77177d6e0f4b76be2f7d9cf96f33c098da44c0a0b703208aa8d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/uk/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/uk/Thunderbird%20140.8.1esr.dmg";
       locale = "uk";
       arch = "mac";
       sha256 = "887f8aad21bd50f6a6e3c8f1a66550a8e8561ba8e92e9ab2933c93cf6bb8be16";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/uz/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/uz/Thunderbird%20140.8.1esr.dmg";
       locale = "uz";
       arch = "mac";
       sha256 = "682a92f644c0bd50b6c614de0539c582faccf74a3052bd7810a2408cb7eecc09";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/vi/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/vi/Thunderbird%20140.8.1esr.dmg";
       locale = "vi";
       arch = "mac";
       sha256 = "9031ccf53c39a3b93ba07a080f864f09884122b0051ed9c0f58f99aa1663d51a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/zh-CN/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/zh-CN/Thunderbird%20140.8.1esr.dmg";
       locale = "zh-CN";
       arch = "mac";
       sha256 = "16aabcfbd2351429b509090894798c5fa2f6988acbcdda7cf8fc5de1a8219a82";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/zh-TW/Thunderbird%20140.8.1esr.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/140.8.1esr/mac/zh-TW/Thunderbird%20140.8.1esr.dmg";
       locale = "zh-TW";
       arch = "mac";
       sha256 = "c6de157bc45d6be2e342ddaadc8a6e24d0c61408db8c4070ff3017d4821c09d2";

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -2,793 +2,793 @@
   version = "148.0.1";
   sources = [
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/af/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/af/thunderbird-148.0.1.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
       sha256 = "452285eb74233e9775652bc3813472828dcd44d467ae6d4b16a9c7cce39c082b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ar/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ar/thunderbird-148.0.1.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
       sha256 = "cf72bfce85d9b38c6fcc71e426deffb603d1e3def18deaa1bec428fdf801ead0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ast/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ast/thunderbird-148.0.1.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
       sha256 = "55cf6c32186762059895e42a1c7c7cd5bcc7026efefc6eec51a09a91e8192a6f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/be/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/be/thunderbird-148.0.1.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
       sha256 = "35168b179085fb4e64a67c98d5283173941b74116ce668b515bb5ec6a97eb8bf";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/bg/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/bg/thunderbird-148.0.1.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
       sha256 = "b71369ed4c637f72d2e143e89f7dab72e70ad7759633947c69489e146bebe72d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/br/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/br/thunderbird-148.0.1.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
       sha256 = "db2288d18d25b157948901295cf1a4a42de4ed9b3458283ecfc93b6e1fcc1d78";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ca/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ca/thunderbird-148.0.1.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
       sha256 = "501d5d84eb25513b2aac8c4a2119b5968a1faa4a29e26c2ecd12923c5fdb0e25";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/cak/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/cak/thunderbird-148.0.1.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
       sha256 = "ca2afefe0635ffca10938ce467e93893cbe90b6294ba87dfa8096b5ab29ef2e1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/cs/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/cs/thunderbird-148.0.1.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
       sha256 = "f65660542e9dacc05f64ff5a3bc920a5377814b409c5c3116ff432b7c2cbfc71";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/cy/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/cy/thunderbird-148.0.1.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
       sha256 = "0e80e40b32de26d50a492b12ea390acaac2af1bd78d03baf81127b387715d7c9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/da/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/da/thunderbird-148.0.1.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
       sha256 = "f4f6f6554d2eca53346d5fff4804cbde7038620005ad01cb4ce2f8c9b298dd51";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/de/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/de/thunderbird-148.0.1.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
       sha256 = "95651cb1ce8626173619a0087cfeb7ab9d5e790df23582857166818e95d0cce3";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/dsb/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/dsb/thunderbird-148.0.1.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
       sha256 = "cbc87d7ed92ad1cf3a1e9552856854de68441360356ec691e2c8bb7a226f315d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/el/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/el/thunderbird-148.0.1.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
       sha256 = "1ef60149ba01eb5d3ab9532c544bde19fddbaa45b8aa6241e4b56e30169bcb7f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/en-CA/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/en-CA/thunderbird-148.0.1.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
       sha256 = "04b68817c67478537ed58bb27fb34b2c6c58802378c362074d812dd626917d27";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/en-GB/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/en-GB/thunderbird-148.0.1.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
       sha256 = "6edf076a07588800675d21cd97b91ef84745aaeda55163f07c078ae5e02ec81f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/en-US/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/en-US/thunderbird-148.0.1.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
       sha256 = "e22ab5e97d1ed20b21aa583d72fa906832fccb9d0e5655eea03c7932f92d4d25";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/es-AR/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/es-AR/thunderbird-148.0.1.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
       sha256 = "92d3f0fe3d83eb1f15cb516268dfde2a010f9cb2a2a8f96b4d0fbd5fee13b38c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/es-ES/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/es-ES/thunderbird-148.0.1.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
       sha256 = "1d904845434c3f7bf1a5f78729053e64f9f8a734803ae86b8f86ddb91ff677c7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/es-MX/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/es-MX/thunderbird-148.0.1.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
       sha256 = "5ffbc240cad1883940b01ccd3290672c5ddb32cf89d8b3561d57ca851bd1078d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/et/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/et/thunderbird-148.0.1.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
       sha256 = "802a1c89f1ee330fc924a35a325490fd53b2956749dc671dbc219edf549e836b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/eu/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/eu/thunderbird-148.0.1.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
       sha256 = "df741094e1b536395e960075a1a059ed285fdeec0be66c8c09a441bc57a81f5d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/fi/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/fi/thunderbird-148.0.1.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
       sha256 = "a7993d9282f72ef9d84acaf44db1c206bd291ca8c30617851fd2c4587017c5e7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/fr/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/fr/thunderbird-148.0.1.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
       sha256 = "812139f24778a7e58c5c1840c6f969159d4cea59b6d24004eccf6f67310d4bf1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/fy-NL/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/fy-NL/thunderbird-148.0.1.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
       sha256 = "ba543d0cea5d3953056fe0114aa09444971b8db16dc465d6bcc459f07ef1dccd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ga-IE/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ga-IE/thunderbird-148.0.1.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
       sha256 = "12b5218ad5ffb93894e70cfbda2f8b54d0eb15d8b83d3a60a52ad6d7962eb45b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/gd/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/gd/thunderbird-148.0.1.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
       sha256 = "54b9f126c19e1e864b6daccc02571458bafd161d39c99d03c29ef3a1bb52b1d1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/gl/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/gl/thunderbird-148.0.1.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
       sha256 = "35c788c302067571f90de49b471f97cc2cb48d5d667f2bf1eb84dfb3c6d51b15";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/he/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/he/thunderbird-148.0.1.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
       sha256 = "13d4b1e68c650e5f6140e42813b9daac7ed449f5ba906b827b8c491fe753fc90";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/hr/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/hr/thunderbird-148.0.1.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
       sha256 = "f773792996626c552d1d1cbef6ec0bdce7cf59523a5b83e5d1a6f7c2d336c0c9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/hsb/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/hsb/thunderbird-148.0.1.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
       sha256 = "6226b53eed067c7bbb683ef39fe322bb4eebf25c71cdcbb363d6d30934b4cae0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/hu/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/hu/thunderbird-148.0.1.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
       sha256 = "4b2dca124f862cdadc3f020ee87544b73d8b5599f48090a37b62aaa728aa19a5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/hy-AM/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/hy-AM/thunderbird-148.0.1.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
       sha256 = "c81e1c94485ee5be53943dd7ae625daa51e979096c36dd9842a1b2615eaeb9e6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/id/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/id/thunderbird-148.0.1.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
       sha256 = "c54fcc0b0d3e3859029956555b063cc9a73c766e72a3300a891b826a158f402a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/is/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/is/thunderbird-148.0.1.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
       sha256 = "5ef1a371824713425cab9be4970f7b02d37ab22dd9e4aeb38efa04ef5c134f0d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/it/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/it/thunderbird-148.0.1.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
       sha256 = "313335de72b2a88cf2269b534e6884795216e64ee1750347b82a61ab202abd24";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ja/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ja/thunderbird-148.0.1.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
       sha256 = "385feb6e38cb2243d59a7d4494ed06acc336bfd35fd7d4f2a456f531606b5712";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ka/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ka/thunderbird-148.0.1.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
       sha256 = "4b83ff7771fad33a949dc202fa3a007535354c67d115c4765a966178c6afea3b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/kab/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/kab/thunderbird-148.0.1.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
       sha256 = "5db313ad933ba271eadde24c42f518001303ba538de3f7e72df182cdb7989b8a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/kk/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/kk/thunderbird-148.0.1.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
       sha256 = "098d2e9b6cfdf4024ed167410eff4df1b60a9cc6371fc819c43e8fa55e6ad1ac";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ko/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ko/thunderbird-148.0.1.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
       sha256 = "7c9dda6fb8a17c53fb16931aa05a02cd9d9765db33f9728e27238493ff67bce2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/lt/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/lt/thunderbird-148.0.1.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
       sha256 = "39dcd64af689688edc3fd51b0b640f3fbc0f547934e4bc3b3b7810e57b30c15b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/lv/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/lv/thunderbird-148.0.1.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
       sha256 = "868f3061c03fb32ab69e50633ff1f5c493a58783287775526facfaa57c3f6ab8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ms/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ms/thunderbird-148.0.1.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
       sha256 = "872b7bd0d4b411dacd9f633e153b4629cf412541c4ae21a033539fc347ff36f9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/nb-NO/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/nb-NO/thunderbird-148.0.1.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
       sha256 = "10be343bac76cbb7bf9ca67f6cbd3f5425ee0eda6b7e9a567159546e5760ee13";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/nl/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/nl/thunderbird-148.0.1.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
       sha256 = "89fea21a2fb9c1339dcde75b75bd37de91a2a2634d024886988741b44438dce0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/nn-NO/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/nn-NO/thunderbird-148.0.1.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
       sha256 = "7d96e4fad093df9aa4186bf3c9910fc88bbcf14553016d0edafe845b072f976c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/pa-IN/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/pa-IN/thunderbird-148.0.1.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
       sha256 = "7fba3ff598436f28d742abc4e6df4b51967a9149168df8aa257c7c4b4a8043f7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/pl/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/pl/thunderbird-148.0.1.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
       sha256 = "e65b936d427b17def458bc93d02462d6031d55a91d4214e9a9253ceedbf638a5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/pt-BR/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/pt-BR/thunderbird-148.0.1.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
       sha256 = "4bd860fb707774a557987c051694388f158570542846bc14503806160adf85b6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/pt-PT/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/pt-PT/thunderbird-148.0.1.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
       sha256 = "68375fa59a6af99ba072606d7d7c63048174b946bcb01e72924aa48311f5eb2b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/rm/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/rm/thunderbird-148.0.1.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
       sha256 = "75cb0a8111652bf92fcc7fe7f1514c5295cfa478beefdf17a7c892b760004d13";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ro/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ro/thunderbird-148.0.1.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
       sha256 = "31e85481c695fd8bb6a7dd06d7067ada7f3f778aa4e0a187efbef068187a3f40";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ru/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/ru/thunderbird-148.0.1.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
       sha256 = "637ca9e8241759ca086ce996eca96fa74479a9e4c46fa0bd4ef3811931a3d00a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/sk/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/sk/thunderbird-148.0.1.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
       sha256 = "ea525cead16f814dab9539f221d573793e253fd38c8d3b6cda34726808afa68b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/sl/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/sl/thunderbird-148.0.1.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
       sha256 = "e268eb305154ce6d36c89570fa8e349e5073f27d86f82410e5a303f0cd483e69";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/sq/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/sq/thunderbird-148.0.1.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
       sha256 = "d66e4d5785940914de12946e512baafff7fb0cef1a3ab284128be035d606ae85";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/sr/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/sr/thunderbird-148.0.1.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
       sha256 = "20eb73f689c4f46fb76bbe4a2428a96bd760d553cd392dd9c26f71eb3691ae3d";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/sv-SE/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/sv-SE/thunderbird-148.0.1.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
       sha256 = "af37670b3049dc03b451d5d3f5bbd31b6a47fe2fb5e0861377c34f900ad49185";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/th/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/th/thunderbird-148.0.1.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
       sha256 = "a42416b6af640f98b33fac06ae6f7bcdc499c3bfb5713a52df659afe8edd8759";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/tr/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/tr/thunderbird-148.0.1.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
       sha256 = "89c297c77d753a342b1d59a019ad83d9cc8b26abdbc68fee05b35cd20a290a80";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/uk/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/uk/thunderbird-148.0.1.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
       sha256 = "d6b248cfcb4300af21d1e3b15a8cd958aeb6b38c519bca2ca6492f4e50672c77";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/uz/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/uz/thunderbird-148.0.1.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
       sha256 = "dc7b26a2c9965fb0c0f6c3186e9bc19b1839ad787fc5a088cff3342c8bc19c85";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/vi/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/vi/thunderbird-148.0.1.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
       sha256 = "deca8678c47bde5e5543938613cba54f29e8a669b3b160d4a670942786c86ff0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/zh-CN/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/zh-CN/thunderbird-148.0.1.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
       sha256 = "d3fac07d2e20825c52771b291ee6945ca17b04a49bc277b85f2efb9b23f39a13";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/zh-TW/thunderbird-148.0.1.tar.xz";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/linux-x86_64/zh-TW/thunderbird-148.0.1.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
       sha256 = "f62cd6f7e05a713e95a337537b9d8da48fe6158e69956af3bbe12a88b9f25e8b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/af/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/af/Thunderbird%20148.0.1.dmg";
       locale = "af";
       arch = "mac";
       sha256 = "35526c3cec825f03e85d7f05209a34556487f44fc16b7fef6990c7b226dff16c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ar/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ar/Thunderbird%20148.0.1.dmg";
       locale = "ar";
       arch = "mac";
       sha256 = "9bb4015d17581c49e623d7110667f9f31d0cbbb89840016f8394e93211113e36";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ast/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ast/Thunderbird%20148.0.1.dmg";
       locale = "ast";
       arch = "mac";
       sha256 = "60345ac71cdf38b99b8e230255d6f57a480d91180319c1b94eb26f5f5480abc1";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/be/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/be/Thunderbird%20148.0.1.dmg";
       locale = "be";
       arch = "mac";
       sha256 = "bc8f226e1ddb42b7a02b38ffe01321db8f626d11edff37a4ace2d7c8d9dc0c2b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/bg/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/bg/Thunderbird%20148.0.1.dmg";
       locale = "bg";
       arch = "mac";
       sha256 = "41523d3f75bc331a9f35b011ad1dc42d234f55626d50cfd4f3db71456690c94c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/br/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/br/Thunderbird%20148.0.1.dmg";
       locale = "br";
       arch = "mac";
       sha256 = "edb87fa82dd3281a54f781e4dbb91b4b66582e8ddc5e05a6e55fe29bb7274ff9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ca/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ca/Thunderbird%20148.0.1.dmg";
       locale = "ca";
       arch = "mac";
       sha256 = "6f9445db0e1afc4769f54c7009c9cec52d00c7c2ff3bdc6c6528d07cfea77867";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/cak/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/cak/Thunderbird%20148.0.1.dmg";
       locale = "cak";
       arch = "mac";
       sha256 = "fea52eaa6227594ca5ad6dba694001ae1d72909716b7f5946446c9c4998648fe";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/cs/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/cs/Thunderbird%20148.0.1.dmg";
       locale = "cs";
       arch = "mac";
       sha256 = "5bd0090ad793e766672c984f04e0cf8f9c53a5fe67ba5f76025090499656b4ec";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/cy/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/cy/Thunderbird%20148.0.1.dmg";
       locale = "cy";
       arch = "mac";
       sha256 = "437a5b1b81fa338f02d75e540af447543bf89d8dec79dee83c41d8251b33e1a9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/da/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/da/Thunderbird%20148.0.1.dmg";
       locale = "da";
       arch = "mac";
       sha256 = "a6bc685dc64849ba6661492a50b6f21d6b354ef71257d3e41d7b9c3cf1f6adcf";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/de/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/de/Thunderbird%20148.0.1.dmg";
       locale = "de";
       arch = "mac";
       sha256 = "17ed921402904770512effeb3818e6cb874f198fd2a66a1e2c4da3c1c5c164cd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/dsb/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/dsb/Thunderbird%20148.0.1.dmg";
       locale = "dsb";
       arch = "mac";
       sha256 = "65284f2340da6a6055a5a47755a9c1a29ec97300f24b301c0579ce65f4a957dd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/el/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/el/Thunderbird%20148.0.1.dmg";
       locale = "el";
       arch = "mac";
       sha256 = "441f7187cebf2a31ac598254d8fe85b97fef05039bca87b473dbc39c825d9c14";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/en-CA/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/en-CA/Thunderbird%20148.0.1.dmg";
       locale = "en-CA";
       arch = "mac";
       sha256 = "bfe8d53b9b042802ba504712b0195a661def0c9a84a220ee78c752238b955981";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/en-GB/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/en-GB/Thunderbird%20148.0.1.dmg";
       locale = "en-GB";
       arch = "mac";
       sha256 = "bde9c478653048023b8d512ea2ac27c85e7162a5748b5e0bf65964d8f6b033d5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/en-US/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/en-US/Thunderbird%20148.0.1.dmg";
       locale = "en-US";
       arch = "mac";
       sha256 = "45d07933d5d4a21e8d02186fa540039ce69fba14b6c026e07358a8e96da6d547";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/es-AR/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/es-AR/Thunderbird%20148.0.1.dmg";
       locale = "es-AR";
       arch = "mac";
       sha256 = "773d413057298b61d1938d4b82032315884f85d6d28a1c1035de0b0d2f2f779a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/es-ES/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/es-ES/Thunderbird%20148.0.1.dmg";
       locale = "es-ES";
       arch = "mac";
       sha256 = "a08b8130585f93443609d5ff40384ff3905bcaf6209a60e2dc2420d55b824ac8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/es-MX/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/es-MX/Thunderbird%20148.0.1.dmg";
       locale = "es-MX";
       arch = "mac";
       sha256 = "a464dbd10aa39316025b0710bd1d93a6dd06f4ed8286a756f23b4f245fcb2fe0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/et/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/et/Thunderbird%20148.0.1.dmg";
       locale = "et";
       arch = "mac";
       sha256 = "5e3f8bfffbf37bc013e676d993914e66812df34886556671842f24373832aefa";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/eu/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/eu/Thunderbird%20148.0.1.dmg";
       locale = "eu";
       arch = "mac";
       sha256 = "759cef09c3af2487b321198a37649a589778c6bf46bfdeab9a3aec8796824f81";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/fi/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/fi/Thunderbird%20148.0.1.dmg";
       locale = "fi";
       arch = "mac";
       sha256 = "5e4964778541e7756b5a2a9d6907dee3dbe1f0c3b096903ddc6e306457553786";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/fr/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/fr/Thunderbird%20148.0.1.dmg";
       locale = "fr";
       arch = "mac";
       sha256 = "7bb49597cae30d6370681cb0e24cde9d1229df65755cebc61bcc3fc47dc56029";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/fy-NL/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/fy-NL/Thunderbird%20148.0.1.dmg";
       locale = "fy-NL";
       arch = "mac";
       sha256 = "bb7e8dc83952215814d31828bcb328df345163ebe37b0ae7436f68610d411ddb";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ga-IE/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ga-IE/Thunderbird%20148.0.1.dmg";
       locale = "ga-IE";
       arch = "mac";
       sha256 = "b08e39455eef3ddd2a64ac77424515a9150ef7ba42e203f40f800202b6f33b7b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/gd/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/gd/Thunderbird%20148.0.1.dmg";
       locale = "gd";
       arch = "mac";
       sha256 = "b7cb536ed12bae89da81186c1d8f36214eadd861ba757b39915e8a64280e6e88";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/gl/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/gl/Thunderbird%20148.0.1.dmg";
       locale = "gl";
       arch = "mac";
       sha256 = "cca8c980a4e4cf4771937513bcb426ab0695583ccbd02092ca494e1dfea767b6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/he/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/he/Thunderbird%20148.0.1.dmg";
       locale = "he";
       arch = "mac";
       sha256 = "ec911c04717f26fa077f5e2ad07c32a24c6f39532b2832e9b6616687773fc703";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/hr/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/hr/Thunderbird%20148.0.1.dmg";
       locale = "hr";
       arch = "mac";
       sha256 = "ea40341e39b2bc0d3f13b68f900e23208645c5e0561d2ccc9c47fc0c7852f7d2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/hsb/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/hsb/Thunderbird%20148.0.1.dmg";
       locale = "hsb";
       arch = "mac";
       sha256 = "b2fdbf3c994c0b346847859910e8d62f761a6a7f82dd07c80500d73635a85c1b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/hu/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/hu/Thunderbird%20148.0.1.dmg";
       locale = "hu";
       arch = "mac";
       sha256 = "d8a923d4dcb8b6e50466edd5a24fc153a3f191ec4da2fb928cae303579496ce6";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/hy-AM/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/hy-AM/Thunderbird%20148.0.1.dmg";
       locale = "hy-AM";
       arch = "mac";
       sha256 = "34cca0020b42e5be70f4c062a924d1f84c32409acbe45b80a5a42cac0fcee9a9";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/id/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/id/Thunderbird%20148.0.1.dmg";
       locale = "id";
       arch = "mac";
       sha256 = "712e3557b084cb0599913cf3b24b79778f8cd347e3f628a18efd86617718a47a";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/is/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/is/Thunderbird%20148.0.1.dmg";
       locale = "is";
       arch = "mac";
       sha256 = "3ab39b983d8234e866f2b0adb8f9f6e4ada943152b4538d2dd7c82515d5e3882";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/it/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/it/Thunderbird%20148.0.1.dmg";
       locale = "it";
       arch = "mac";
       sha256 = "f38d7c8f87d837adbacb12d783a712f6cc7dc76aecad426c0b3c6806fe600dfa";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ja-JP-mac/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ja-JP-mac/Thunderbird%20148.0.1.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
       sha256 = "0e39f3778b6b4ebe26e3dc1ba6010b181ef49c0828d47568bb58ff41a4bdc492";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ka/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ka/Thunderbird%20148.0.1.dmg";
       locale = "ka";
       arch = "mac";
       sha256 = "8aa66353fcf473fc43c7ac0a238d877e52fce85a1d6e88fdd6189aa4a4e8b0f5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/kab/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/kab/Thunderbird%20148.0.1.dmg";
       locale = "kab";
       arch = "mac";
       sha256 = "a89c63562db309c3ea5da0665c2b9c8745eab26b01237eff5e738395e92c3aa8";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/kk/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/kk/Thunderbird%20148.0.1.dmg";
       locale = "kk";
       arch = "mac";
       sha256 = "d32b99d6999e37cc358d6a7854d373c35a8a76522c5670cebe627c700cc2d88b";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ko/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ko/Thunderbird%20148.0.1.dmg";
       locale = "ko";
       arch = "mac";
       sha256 = "954e5cedc319f3b197626f6c202d8fe7b7da3087a21f5767c723fa7d17d1bc6f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/lt/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/lt/Thunderbird%20148.0.1.dmg";
       locale = "lt";
       arch = "mac";
       sha256 = "2a76badf20edc565ca300de9d6ef8ec040346a5150d9999f96cc01a6b5730813";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/lv/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/lv/Thunderbird%20148.0.1.dmg";
       locale = "lv";
       arch = "mac";
       sha256 = "0bd6d7908864f69ab067bddb5cca3d876fbac45817e7640ccf487332657305a4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ms/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ms/Thunderbird%20148.0.1.dmg";
       locale = "ms";
       arch = "mac";
       sha256 = "23cd1f663a5b58700fb7b509f14b67e9ad0f447e19d0cbd59f000d06ef4647f7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/nb-NO/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/nb-NO/Thunderbird%20148.0.1.dmg";
       locale = "nb-NO";
       arch = "mac";
       sha256 = "c15dbca5b59f8805394e1674b5ceb4255aeaa0eedd8c1a6d0e725f7c70393878";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/nl/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/nl/Thunderbird%20148.0.1.dmg";
       locale = "nl";
       arch = "mac";
       sha256 = "75a6ca45fe2e58a65779457bb8245053cba4c3cc3c2f8914c4bcfa0aab8457a2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/nn-NO/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/nn-NO/Thunderbird%20148.0.1.dmg";
       locale = "nn-NO";
       arch = "mac";
       sha256 = "86b40d91c604ca800d2808017b3e025f1a279102dc135b4f08037818f62caab0";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/pa-IN/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/pa-IN/Thunderbird%20148.0.1.dmg";
       locale = "pa-IN";
       arch = "mac";
       sha256 = "db23f780620fb28a89594467ad922e76f888c8516842722d8f91e39975aea51c";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/pl/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/pl/Thunderbird%20148.0.1.dmg";
       locale = "pl";
       arch = "mac";
       sha256 = "594d8fe62e19e961dda6aceb1eb8f318bc67509dd7776b592f2c51a45b402229";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/pt-BR/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/pt-BR/Thunderbird%20148.0.1.dmg";
       locale = "pt-BR";
       arch = "mac";
       sha256 = "795439fb60115992efed8400ed78b304f5f3f406876e1b0c625fe11934c101aa";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/pt-PT/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/pt-PT/Thunderbird%20148.0.1.dmg";
       locale = "pt-PT";
       arch = "mac";
       sha256 = "2a8ebcc53821f8a130fe7369935dfa6bf7261720e2dd512715c1a9ddb0e0b635";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/rm/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/rm/Thunderbird%20148.0.1.dmg";
       locale = "rm";
       arch = "mac";
       sha256 = "d7ebb14d7b044f93861f3df6b2e9d982aace80243b4a26a58f0e69b8bc03f6f5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ro/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ro/Thunderbird%20148.0.1.dmg";
       locale = "ro";
       arch = "mac";
       sha256 = "0ef619aa1033043cd34eba0a8060966c37d83d4165f99e365c277ffb9675a4c5";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ru/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/ru/Thunderbird%20148.0.1.dmg";
       locale = "ru";
       arch = "mac";
       sha256 = "ebdaa819f2ddce483efb1d730e8aac61be0d27a6ddb69054419a3a7a8969c381";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/sk/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/sk/Thunderbird%20148.0.1.dmg";
       locale = "sk";
       arch = "mac";
       sha256 = "3191e02d1ebbe9c27de33b1636ea0d43367c814db8b97e069ae12c25b6bb404f";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/sl/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/sl/Thunderbird%20148.0.1.dmg";
       locale = "sl";
       arch = "mac";
       sha256 = "318319f833ea0ab67361e369ff52c96e65465fc21b9191dd873196435c44dbf7";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/sq/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/sq/Thunderbird%20148.0.1.dmg";
       locale = "sq";
       arch = "mac";
       sha256 = "21ff2f04469f0cfeee17d78b4791770aeeef9c29f174421d3dceef07cff3ba49";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/sr/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/sr/Thunderbird%20148.0.1.dmg";
       locale = "sr";
       arch = "mac";
       sha256 = "d4f6d75e40bc4a691e8490e277f080f165b7a083dde25b53df6c2085f5b2c7ab";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/sv-SE/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/sv-SE/Thunderbird%20148.0.1.dmg";
       locale = "sv-SE";
       arch = "mac";
       sha256 = "eb3e889e8c90273098ba0fd27369f511f7a319eb36ce9e62b0cc83e462c534ac";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/th/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/th/Thunderbird%20148.0.1.dmg";
       locale = "th";
       arch = "mac";
       sha256 = "a5c547343b650d425c9dc484895447d365220e98361b3a3f3207f8f25e7c1225";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/tr/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/tr/Thunderbird%20148.0.1.dmg";
       locale = "tr";
       arch = "mac";
       sha256 = "9ae9431d362b06c087c5bd95667b96c438dede84b435f35d97333bcf47e3effd";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/uk/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/uk/Thunderbird%20148.0.1.dmg";
       locale = "uk";
       arch = "mac";
       sha256 = "7c781df523ff5f3b5457b5508f9a7bca5484c909fb1196b82f15a7694947cce2";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/uz/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/uz/Thunderbird%20148.0.1.dmg";
       locale = "uz";
       arch = "mac";
       sha256 = "c94b894d9e9b179053b44c30a32a44f0ec986e29ec0728cfcdbdce000227d936";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/vi/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/vi/Thunderbird%20148.0.1.dmg";
       locale = "vi";
       arch = "mac";
       sha256 = "f47d75e887c8001210efdfa9c43c2c20ad5be52901c100972610ab85963b2fc4";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/zh-CN/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/zh-CN/Thunderbird%20148.0.1.dmg";
       locale = "zh-CN";
       arch = "mac";
       sha256 = "2e138c4db461358d63944f91aa3a05bf9dd669addae9d429564286287752a14e";
     }
     {
-      url = "http://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/zh-TW/Thunderbird%20148.0.1.dmg";
+      url = "https://archive.mozilla.org/pub/thunderbird/releases/148.0.1/mac/zh-TW/Thunderbird%20148.0.1.dmg";
       locale = "zh-TW";
       arch = "mac";
       sha256 = "667c0adfa78eb6de45b7946eea455de244e2bfdd233289cfb5dd1e3ba0707757";

--- a/pkgs/applications/radio/wsjtx/default.nix
+++ b/pkgs/applications/radio/wsjtx/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   version = "2.7.0";
 
   src = fetchgit {
-    url = "http://git.code.sf.net/p/wsjt/wsjtx";
+    url = "https://git.code.sf.net/p/wsjt/wsjtx";
     rev = "wsjtx-${version}";
     hash = "sha256-AAPZTJUhz3x/28B9rk2uwFs1bkcEvaj+hOzAjpsFALQ=";
   };

--- a/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
   inherit pname version;
 
   src = fetchurl {
-    url = "http://dist.schmorp.de/rxvt-unicode/Attic/rxvt-unicode-${version}.tar.bz2";
+    url = "https://dist.schmorp.de/rxvt-unicode/Attic/rxvt-unicode-${version}.tar.bz2";
     sha256 = "qqE/y8FJ/g8/OR+TMnlYD3Spb9MS1u0GuP8DwtRmcug=";
   };
 

--- a/pkgs/applications/window-managers/evilwm/default.nix
+++ b/pkgs/applications/window-managers/evilwm/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   version = "1.4.3";
 
   src = fetchurl {
-    url = "http://www.6809.org.uk/evilwm/evilwm-${version}.tar.gz";
+    url = "https://www.6809.org.uk/evilwm/evilwm-${version}.tar.gz";
     sha256 = "sha256-1ZRbILEskdskEvrA29o/ucPsjeu44bEJg4mSsrG75dQ=";
   };
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     license = {
       shortName = "evilwm";
       fullName = "Custom, inherited from aewm and 9wm";
-      url = "http://www.6809.org.uk/evilwm/";
+      url = "https://www.6809.org.uk/evilwm/";
       free = true;
     }; # like BSD/MIT, but Share-Alike'y; See README.
     maintainers = [ ];

--- a/pkgs/by-name/cf/cfr/package.nix
+++ b/pkgs/by-name/cf/cfr/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.152";
 
   src = fetchurl {
-    url = "http://www.benf.org/other/cfr/cfr_${finalAttrs.version}.jar";
+    url = "https://www.benf.org/other/cfr/cfr_${finalAttrs.version}.jar";
     sha256 = "sha256-9obo897Td9e8h9IWqQ6elRLfQVbnWwbGVaFmSK6HZbI=";
   };
 

--- a/pkgs/by-name/ch/chntpw/package.nix
+++ b/pkgs/by-name/ch/chntpw/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   version = "140201";
 
   src = fetchurl {
-    url = "http://pogostick.net/~pnh/ntpasswd/chntpw-source-${version}.zip";
+    url = "https://pogostick.net/~pnh/ntpasswd/chntpw-source-${version}.zip";
     sha256 = "1k1cxsj0221dpsqi5yibq2hr7n8xywnicl8yyaicn91y8h2hkqln";
   };
 

--- a/pkgs/by-name/ci/ciopfs/package.nix
+++ b/pkgs/by-name/ci/ciopfs/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.4";
 
   src = fetchurl {
-    url = "http://www.brain-dump.org/projects/ciopfs/ciopfs-${finalAttrs.version}.tar.gz";
+    url = "https://www.brain-dump.org/projects/ciopfs/ciopfs-${finalAttrs.version}.tar.gz";
     sha256 = "0sr9i9b3qfwbfvzvk00yrrg3x2xqk1njadbldkvn7hwwa4z5bm9l";
   };
 

--- a/pkgs/by-name/cl/cl-launch/package.nix
+++ b/pkgs/by-name/cl/cl-launch/package.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.1.4.1";
 
   src = fetchurl {
-    url = "http://common-lisp.net/project/xcvb/cl-launch/cl-launch-${finalAttrs.version}.tar.gz";
+    url = "https://common-lisp.net/project/xcvb/cl-launch/cl-launch-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-v5aURs2Verhn2HmGiijvY9br20OTPFrOGBWsb6cHhSQ=";
   };
 

--- a/pkgs/by-name/cm/cmt/package.nix
+++ b/pkgs/by-name/cm/cmt/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.18";
 
   src = fetchurl {
-    url = "http://www.ladspa.org/download/cmt_${finalAttrs.version}.tgz";
+    url = "https://www.ladspa.org/download/cmt_${finalAttrs.version}.tgz";
     sha256 = "sha256-qC+GNt4fSto4ahmaAXqc13Wkm0nnFrEejdP3I8k99so=";
   };
 

--- a/pkgs/by-name/cn/cnijfilter_4_00/package.nix
+++ b/pkgs/by-name/cn/cnijfilter_4_00/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation {
   version = "4.00";
 
   src = fetchzip {
-    url = "http://gdlp01.c-wss.com/gds/5/0100005515/01/cnijfilter-source-4.00-1.tar.gz";
+    url = "https://gdlp01.c-wss.com/gds/5/0100005515/01/cnijfilter-source-4.00-1.tar.gz";
     sha256 = "1f6vpx1z3qa88590i5m0s49j9n90vpk81xmw6pvj0nfd3qbvzkya";
   };
 

--- a/pkgs/by-name/cn/cnstrokeorder/package.nix
+++ b/pkgs/by-name/cn/cnstrokeorder/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "0.0.4.7";
 
   src = fetchurl {
-    url = "http://rtega.be/chmn/CNstrokeorder-${version}.ttf";
+    url = "https://rtega.be/chmn/CNstrokeorder-${version}.ttf";
     hash = "sha256-YYtOcUvt1V0DwAs/vf9KltcmYCFJNirvwjGyOK4JpIY=";
   };
 

--- a/pkgs/by-name/co/collapseos-cvm/package.nix
+++ b/pkgs/by-name/co/collapseos-cvm/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "collapseos-cvm";
   version = "20220316";
   src = fetchurl {
-    url = "http://collapseos.org/files/collapseos-${finalAttrs.version}.tar.gz";
+    url = "https://collapseos.org/files/collapseos-${finalAttrs.version}.tar.gz";
     hash = "sha256-8bt6wj93T82K9fqtuC/mctkMCzfvW0taxv6QAKeJb5g=";
   };
   buildInputs = [ ncurses ];

--- a/pkgs/by-name/co/colorless/package.nix
+++ b/pkgs/by-name/co/colorless/package.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
   version = "109";
 
   src = fetchurl {
-    url = "http://software.kimmo.suominen.com/colorless-${version}.tar.gz";
+    url = "https://software.kimmo.suominen.com/colorless-${version}.tar.gz";
     sha256 = "039a140fa11cf153cc4d03e4f753b7ff142cab88ff116b7600ccf9edee81927c";
   };
 

--- a/pkgs/by-name/co/corosync/package.nix
+++ b/pkgs/by-name/co/corosync/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.1.9";
 
   src = fetchurl {
-    url = "http://build.clusterlabs.org/corosync/releases/corosync-${finalAttrs.version}.tar.gz";
+    url = "https://build.clusterlabs.org/corosync/releases/corosync-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-IDNUu93uGpezxQoHbq6JxjX0Bt1nTMrvyUu5CSrNlTU=";
   };
 

--- a/pkgs/by-name/cp/cpuid/package.nix
+++ b/pkgs/by-name/cp/cpuid/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "20260220";
 
   src = fetchurl {
-    url = "http://etallen.com/cpuid/cpuid-${finalAttrs.version}.src.tar.gz";
+    url = "https://etallen.com/cpuid/cpuid-${finalAttrs.version}.src.tar.gz";
     sha256 = "sha256-52IP11rlkRcfEQxJuZo5EokzoMqtAjto1KOEub4Lj/s=";
   };
 

--- a/pkgs/by-name/cr/cryptoverif/package.nix
+++ b/pkgs/by-name/cr/cryptoverif/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.12";
 
   src = fetchurl {
-    url = "http://prosecco.gforge.inria.fr/personal/bblanche/cryptoverif/cryptoverif${finalAttrs.version}.tar.gz";
+    url = "https://prosecco.gforge.inria.fr/personal/bblanche/cryptoverif/cryptoverif${finalAttrs.version}.tar.gz";
     hash = "sha256-d3MIYb57+95bB493hdtHiGnTOronYaQo1Qqq1TcJh1c=";
   };
 

--- a/pkgs/by-name/cu/cups-dymo/package.nix
+++ b/pkgs/by-name/cu/cups-dymo/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   dl-name = "dymo-cups-drivers-1.4.0";
 
   src = fetchurl {
-    url = "http://download.dymo.com/dymo/Software/Download%20Drivers/Linux/Download/${dl-name}.tar.gz";
+    url = "https://download.dymo.com/dymo/Software/Download%20Drivers/Linux/Download/${dl-name}.tar.gz";
     sha256 = "0wagsrz3q7yrkzb5ws0m5faq68rqnqfap9p98sgk5jl6x7krf1y6";
   };
 

--- a/pkgs/by-name/cu/cups-toshiba-estudio/package.nix
+++ b/pkgs/by-name/cu/cups-toshiba-estudio/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   version = "7.89";
 
   src = fetchurl {
-    url = "http://business.toshiba.com/downloads/KB/f1Ulds/15178/TOSHIBA_ColorMFP_CUPS.tar";
+    url = "https://business.toshiba.com/downloads/KB/f1Ulds/15178/TOSHIBA_ColorMFP_CUPS.tar";
     sha256 = "0qz4r7q55i0adf4fv3aqnfqgi2pz3jb1jixkqm9x6nk4vanyjf4r";
   };
 

--- a/pkgs/by-name/cu/cutee/package.nix
+++ b/pkgs/by-name/cu/cutee/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.4.2";
 
   src = fetchurl {
-    url = "http://www.codesink.org/download/cutee-${finalAttrs.version}.tar.gz";
+    url = "https://www.codesink.org/download/cutee-${finalAttrs.version}.tar.gz";
     sha256 = "18bzvhzx8k24mpcim5669n3wg9hd0sfsxj8zjpbr24hywrlppgc2";
   };
 

--- a/pkgs/by-name/cv/cvsq/package.nix
+++ b/pkgs/by-name/cv/cvsq/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.11";
 
   src = fetchurl {
-    url = "http://www.linta.de/~aehlig/cvsq/cvsq-${finalAttrs.version}.tgz";
+    url = "https://www.linta.de/~aehlig/cvsq/cvsq-${finalAttrs.version}.tgz";
     sha256 = "0491k4skk3jyyd6plp2kcihmxxav9rsch7vd1yi697m2fqckp5ws";
   };
 

--- a/pkgs/by-name/da/daemon/package.nix
+++ b/pkgs/by-name/da/daemon/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.8.4";
 
   src = fetchurl {
-    url = "http://libslack.org/daemon/download/daemon-${finalAttrs.version}.tar.gz";
+    url = "https://libslack.org/daemon/download/daemon-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-+iiFmtNBywoLASwRwnGBT4cEggE7SfcQYAMh03mIfNE=";
   };
 

--- a/pkgs/by-name/db/dbxml/package.nix
+++ b/pkgs/by-name/db/dbxml/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "6.1.4";
 
   src = fetchurl {
-    url = "http://download.oracle.com/berkeley-db/dbxml-${finalAttrs.version}.tar.gz";
+    url = "https://download.oracle.com/berkeley-db/dbxml-${finalAttrs.version}.tar.gz";
     sha256 = "a8fc8f5e0c3b6e42741fa4dfc3b878c982ff8f5e5f14843f6a7e20d22e64251a";
   };
 

--- a/pkgs/by-name/de/detach/package.nix
+++ b/pkgs/by-name/de/detach/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.2.3";
 
   src = fetchzip {
-    url = "http://inglorion.net/download/detach-${finalAttrs.version}.tar.bz2";
+    url = "https://inglorion.net/download/detach-${finalAttrs.version}.tar.bz2";
     hash = "sha256-nnhJGtmPlTeqM20FAKRyhhSMViTXFpQT0A1ol4lhsoc=";
   };
 

--- a/pkgs/by-name/dh/dhex/package.nix
+++ b/pkgs/by-name/dh/dhex/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.69";
 
   src = fetchurl {
-    url = "http://www.dettus.net/dhex/dhex_${finalAttrs.version}.tar.gz";
+    url = "https://www.dettus.net/dhex/dhex_${finalAttrs.version}.tar.gz";
     sha256 = "06y4lrp29f2fh303ijk1xhspa1d4x4dm6hnyw3dd8szi3k6hnwsj";
   };
 

--- a/pkgs/by-name/di/dieharder/package.nix
+++ b/pkgs/by-name/di/dieharder/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.31.1";
 
   src = fetchurl {
-    url = "http://webhome.phy.duke.edu/~rgb/General/dieharder/dieharder-${finalAttrs.version}.tgz";
+    url = "https://webhome.phy.duke.edu/~rgb/General/dieharder/dieharder-${finalAttrs.version}.tgz";
     hash = "sha256-bP8P+DlMVTVJrHQzNZzPyVX7JnlCYDFGIN+l5M1Lcn8=";
   };
 

--- a/pkgs/by-name/dj/djvu2pdf/package.nix
+++ b/pkgs/by-name/dj/djvu2pdf/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "djvu2pdf";
 
   src = fetchurl {
-    url = "http://0x2a.at/site/projects/djvu2pdf/djvu2pdf-${finalAttrs.version}.tar.gz";
+    url = "https://0x2a.at/site/projects/djvu2pdf/djvu2pdf-${finalAttrs.version}.tar.gz";
     sha256 = "0v2ax30m7j1yi4m02nzn9rc4sn4vzqh5vywdh96r64j4pwvn5s5g";
   };
 

--- a/pkgs/by-name/do/docbook2mdoc/package.nix
+++ b/pkgs/by-name/do/docbook2mdoc/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.0.9";
 
   src = fetchurl {
-    url = "http://mdocml.bsd.lv/docbook2mdoc/snapshots/docbook2mdoc-${finalAttrs.version}.tgz";
+    url = "https://mdocml.bsd.lv/docbook2mdoc/snapshots/docbook2mdoc-${finalAttrs.version}.tgz";
     sha256 = "07il80sg89xf6ym4bry6hxdacfzqgbwkxzyf7bjaihmw5jj0lclk";
   };
 

--- a/pkgs/by-name/do/dog/package.nix
+++ b/pkgs/by-name/do/dog/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.7";
 
   src = fetchurl {
-    url = "http://archive.debian.org/debian/pool/main/d/dog/dog_${finalAttrs.version}.orig.tar.gz";
+    url = "https://archive.debian.org/debian/pool/main/d/dog/dog_${finalAttrs.version}.orig.tar.gz";
     sha256 = "3ef25907ec5d1dfb0df94c9388c020b593fbe162d7aaa9bd08f35d2a125af056";
   };
 

--- a/pkgs/by-name/du/duktape/package.nix
+++ b/pkgs/by-name/du/duktape/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "duktape";
   version = "2.7.0";
   src = fetchurl {
-    url = "http://duktape.org/duktape-${finalAttrs.version}.tar.xz";
+    url = "https://duktape.org/duktape-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-kPjS+otVZ8aJmDDd7ywD88J5YLEayiIvoXqnrGE8KJA=";
   };
 

--- a/pkgs/by-name/eb/ebtables/package.nix
+++ b/pkgs/by-name/eb/ebtables/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.11";
 
   src = fetchurl {
-    url = "http://ftp.netfilter.org/pub/ebtables/ebtables-${finalAttrs.version}.tar.gz";
+    url = "https://ftp.netfilter.org/pub/ebtables/ebtables-${finalAttrs.version}.tar.gz";
     sha256 = "0apxgmkhsk3vxn9q3libxn3dgrdljrxyy4mli2gk49m7hi3na7xp";
   };
 

--- a/pkgs/by-name/ec/ec2-api-tools/package.nix
+++ b/pkgs/by-name/ec/ec2-api-tools/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   version = "1.7.5.1";
 
   src = fetchurl {
-    url = "http://s3.amazonaws.com/ec2-downloads/${pname}-${version}.zip";
+    url = "https://s3.amazonaws.com/ec2-downloads/${pname}-${version}.zip";
     sha256 = "sha256-hRq+MEA+4chqPr3d9bS//X70tYcRBTD+rfAJVNmuLzo=";
   };
 

--- a/pkgs/by-name/ec/eclipse-mat/package.nix
+++ b/pkgs/by-name/ec/eclipse-mat/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   version = pVersion;
 
   src = fetchurl {
-    url = "http://ftp.halifax.rwth-aachen.de/eclipse//mat/${baseVersion}/rcp/MemoryAnalyzer-${version}-linux.gtk.x86_64.zip";
+    url = "https://ftp.halifax.rwth-aachen.de/eclipse//mat/${baseVersion}/rcp/MemoryAnalyzer-${version}-linux.gtk.x86_64.zip";
     sha256 = "sha256-icmo5zdK0XaH32kXwZUVaQ0VPSGEgvlLr7v7PtdbmCg=";
   };
 

--- a/pkgs/by-name/er/ergoscf/package.nix
+++ b/pkgs/by-name/er/ergoscf/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.8.2";
 
   src = fetchurl {
-    url = "http://www.ergoscf.org/source/tarfiles/ergo-${finalAttrs.version}.tar.gz";
+    url = "https://www.ergoscf.org/source/tarfiles/ergo-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-U0NVREEZ8HI0Q0ZcbwvZsYA76PWMh7bqgDG1uaUc01c=";
   };
 

--- a/pkgs/by-name/ex/exonerate/package.nix
+++ b/pkgs/by-name/ex/exonerate/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "exonerate";
 
   src = fetchurl {
-    url = "http://ftp.ebi.ac.uk/pub/software/vertebrategenomics/exonerate/exonerate-${finalAttrs.version}.tar.gz";
+    url = "https://ftp.ebi.ac.uk/pub/software/vertebrategenomics/exonerate/exonerate-${finalAttrs.version}.tar.gz";
     sha256 = "0hj0m9xygiqsdxvbg79wq579kbrx1mdrabi2bzqz2zn9qwfjcjgq";
   };
 

--- a/pkgs/by-name/fa/fairymax/package.nix
+++ b/pkgs/by-name/fa/fairymax/package.nix
@@ -9,12 +9,12 @@ stdenv.mkDerivation rec {
   version = "4.8";
 
   src = fetchurl {
-    url = "http://home.hccnet.nl/h.g.muller/fmax4_8w.c";
+    url = "https://home.hccnet.nl/h.g.muller/fmax4_8w.c";
     hash = "sha256-ikn+CA5lxtDYSDT+Nsv1tfORhKW6/vlmHcGAT9SFfQc=";
   };
 
   ini = fetchurl {
-    url = "http://home.hccnet.nl/h.g.muller/fmax.ini";
+    url = "https://home.hccnet.nl/h.g.muller/fmax.ini";
     hash = "sha256-lh2ivXx4jNdWn3pT1WKKNEvkVQ31JfdDx+vqNx44nf8=";
   };
 

--- a/pkgs/by-name/fa/fastjet/package.nix
+++ b/pkgs/by-name/fa/fastjet/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.4.3";
 
   src = fetchurl {
-    url = "http://fastjet.fr/repo/fastjet-${finalAttrs.version}.tar.gz";
+    url = "https://fastjet.fr/repo/fastjet-${finalAttrs.version}.tar.gz";
     hash = "sha256-zBdUcb+rhla4xhg6jl6a0F1fdQbkbzISqagjCQW49qM=";
   };
 

--- a/pkgs/by-name/fc/fcrackzip/package.nix
+++ b/pkgs/by-name/fc/fcrackzip/package.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fcrackzip";
   version = "1.0";
   src = fetchurl {
-    url = "http://oldhome.schmorp.de/marc/data/fcrackzip-${finalAttrs.version}.tar.gz";
+    url = "https://oldhome.schmorp.de/marc/data/fcrackzip-${finalAttrs.version}.tar.gz";
     sha256 = "0l1qsk949vnz18k4vjf3ppq8p497966x4c7f2yx18x8pk35whn2a";
   };
 

--- a/pkgs/by-name/ff/ffado/package.nix
+++ b/pkgs/by-name/ff/ffado/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "http://www.ffado.org/files/libffado-${version}.tgz";
+    url = "https://www.ffado.org/files/libffado-${version}.tgz";
     hash = "sha256-xELFL60Ryv1VE7tOhGyFHxAchIT4karFRe0ZDo/U0Q8=";
   };
 

--- a/pkgs/by-name/fi/fil-plugins/package.nix
+++ b/pkgs/by-name/fi/fil-plugins/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.0";
 
   src = fetchurl {
-    url = "http://kokkinizita.linuxaudio.org/linuxaudio/downloads/FIL-plugins-${finalAttrs.version}.tar.bz2";
+    url = "https://kokkinizita.linuxaudio.org/linuxaudio/downloads/FIL-plugins-${finalAttrs.version}.tar.bz2";
     hash = "sha256-HAvycSEZZfZwoVp3g7QWcwfbdyZKwWJKBuVmeWTajuk=";
   };
 

--- a/pkgs/by-name/fl/flac/package.nix
+++ b/pkgs/by-name/fl/flac/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   # This prevents huge numbers of rebuilds for pandoc / haskell-updates.
   # It also enables manpages for platforms where pandoc is not available.
   src = fetchurl {
-    url = "http://downloads.xiph.org/releases/flac/flac-${finalAttrs.version}.tar.xz";
+    url = "https://downloads.xiph.org/releases/flac/flac-${finalAttrs.version}.tar.xz";
     hash = "sha256-8sHHZZKoL//4QTujxKEpm2x6sGxzTe4D/YhjBIXCuSA=";
   };
 

--- a/pkgs/by-name/fl/flexibee/package.nix
+++ b/pkgs/by-name/fl/flexibee/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   inherit version;
 
   src = fetchurl {
-    url = "http://download.flexibee.eu/download/${majorVersion}/${version}/${pname}-${version}.tar.gz";
+    url = "https://download.flexibee.eu/download/${majorVersion}/${version}/${pname}-${version}.tar.gz";
     sha256 = "sha256-WorRyfjWucV8UhAjvuW+22CRzPcz5tjXF7Has4wrLMI=";
   };
 

--- a/pkgs/by-name/fl/flpsed/package.nix
+++ b/pkgs/by-name/fl/flpsed/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.7.3";
 
   src = fetchurl {
-    url = "http://www.flpsed.org/flpsed-${finalAttrs.version}.tar.gz";
+    url = "https://www.flpsed.org/flpsed-${finalAttrs.version}.tar.gz";
     sha256 = "0vngqxanykicabhfdznisv82k5ypkxwg0s93ms9ribvhpm8vf2xp";
   };
 

--- a/pkgs/by-name/fo/fondu/package.nix
+++ b/pkgs/by-name/fo/fondu/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fondu";
 
   src = fetchurl {
-    url = "http://fondu.sourceforge.net/fondu_src-${finalAttrs.version}.tgz";
+    url = "https://fondu.sourceforge.net/fondu_src-${finalAttrs.version}.tgz";
     sha256 = "152prqad9jszjmm4wwqrq83zk13ypsz09n02nrk1gg0fcxfm7fr2";
   };
 

--- a/pkgs/by-name/ge/gentium-book-basic/package.nix
+++ b/pkgs/by-name/ge/gentium-book-basic/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "1.102";
 
   src = fetchzip {
-    url = "http://software.sil.org/downloads/r/gentium/GentiumBasic_${lib.versions.major version}${lib.versions.minor version}.zip";
+    url = "https://software.sil.org/downloads/r/gentium/GentiumBasic_${lib.versions.major version}${lib.versions.minor version}.zip";
     hash = "sha256-oCmpl95MJRfCV25cg/4cf8AwQWnoymXasSss1ziOPoE=";
   };
 

--- a/pkgs/by-name/ge/gentium-book/package.nix
+++ b/pkgs/by-name/ge/gentium-book/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "7.000";
 
   src = fetchzip {
-    url = "http://software.sil.org/downloads/r/gentium/GentiumBook-${finalAttrs.version}.zip";
+    url = "https://software.sil.org/downloads/r/gentium/GentiumBook-${finalAttrs.version}.zip";
     hash = "sha256-A/QZX8OYrifaxChC08SNOaspdnSr8PxOtYgFAwUc5WY=";
   };
 

--- a/pkgs/by-name/ge/gentium-plus/package.nix
+++ b/pkgs/by-name/ge/gentium-plus/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "6.200";
 
   src = fetchzip {
-    url = "http://software.sil.org/downloads/r/gentium/GentiumPlus-${finalAttrs.version}.zip";
+    url = "https://software.sil.org/downloads/r/gentium/GentiumPlus-${finalAttrs.version}.zip";
     hash = "sha256-gpVOtmF4Kp3y1Rm00c4o3WQEskO7mY1Z5SVaYHI0hzg=";
   };
 

--- a/pkgs/by-name/ge/gentium/package.nix
+++ b/pkgs/by-name/ge/gentium/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "7.000";
 
   src = fetchzip {
-    url = "http://software.sil.org/downloads/r/gentium/Gentium-${finalAttrs.version}.zip";
+    url = "https://software.sil.org/downloads/r/gentium/Gentium-${finalAttrs.version}.zip";
     hash = "sha256-RBBecFdi/yyFfBk1CcQebOuAdKNUczpwOP52zVtbc2o=";
   };
 

--- a/pkgs/by-name/gf/gfan/package.nix
+++ b/pkgs/by-name/gf/gfan/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.6.2";
 
   src = fetchurl {
-    url = "http://home.math.au.dk/jensen/software/gfan/gfan${finalAttrs.version}.tar.gz";
+    url = "https://home.math.au.dk/jensen/software/gfan/gfan${finalAttrs.version}.tar.gz";
     sha256 = "02pihqb1lb76a0xbfwjzs1cd6ay3ldfxsm8dvsbl6qs3vkjxax56";
   };
 

--- a/pkgs/by-name/gg/ggz_base_libs/package.nix
+++ b/pkgs/by-name/gg/ggz_base_libs/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.99.5";
 
   src = fetchurl {
-    url = "http://mirrors.ibiblio.org/pub/mirrors/ggzgamingzone/ggz/snapshots/ggz-base-libs-snapshot-${finalAttrs.version}.tar.gz";
+    url = "https://mirrors.ibiblio.org/pub/mirrors/ggzgamingzone/ggz/snapshots/ggz-base-libs-snapshot-${finalAttrs.version}.tar.gz";
     sha256 = "1cw1vg0fbj36zyggnzidx9cbjwfc1yr4zqmsipxnvns7xa2awbdk";
   };
 

--- a/pkgs/by-name/gk/gkrellm/package.nix
+++ b/pkgs/by-name/gk/gkrellm/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.5.1";
 
   src = fetchurl {
-    url = "http://gkrellm.srcbox.net/releases/gkrellm-${finalAttrs.version}.tar.bz2";
+    url = "https://gkrellm.srcbox.net/releases/gkrellm-${finalAttrs.version}.tar.bz2";
     hash = "sha256-CJ48HtOYSC5oLJkAtQTqFmphRKbJ+gQecMW7ymsXfmM=";
   };
 

--- a/pkgs/by-name/gl/gl2ps/package.nix
+++ b/pkgs/by-name/gl/gl2ps/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.4.2";
 
   src = fetchurl {
-    url = "http://geuz.org/gl2ps/src/gl2ps-${finalAttrs.version}.tgz";
+    url = "https://geuz.org/gl2ps/src/gl2ps-${finalAttrs.version}.tgz";
     sha256 = "1sgzv547h7hrskb9qd0x5yp45kmhvibjwj2mfswv95lg070h074d";
   };
 

--- a/pkgs/by-name/go/gorilla-bin/package.nix
+++ b/pkgs/by-name/go/gorilla-bin/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     name = "gorilla1537_64.bin";
-    url = "http://gorilla.dp100.com/downloads/gorilla1537_64.bin";
+    url = "https://gorilla.dp100.com/downloads/gorilla1537_64.bin";
     sha256 = "19ir6x4c01825hpx2wbbcxkk70ymwbw4j03v8b2xc13ayylwzx0r";
   };
 

--- a/pkgs/by-name/gr/grepcidr/package.nix
+++ b/pkgs/by-name/gr/grepcidr/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0";
 
   src = fetchurl {
-    url = "http://www.pc-tools.net/files/unix/grepcidr-${finalAttrs.version}.tar.gz";
+    url = "https://www.pc-tools.net/files/unix/grepcidr-${finalAttrs.version}.tar.gz";
     sha256 = "1yzpa1nigmmp4hir6377hrkpp0z6jnxgccaw2jbqgydbglvnm231";
   };
 

--- a/pkgs/by-name/gy/gyre-fonts/package.nix
+++ b/pkgs/by-name/gy/gyre-fonts/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "2.501";
 
   src = fetchzip {
-    url = "http://www.gust.org.pl/projects/e-foundry/tex-gyre/whole/tg${
+    url = "https://www.gust.org.pl/projects/e-foundry/tex-gyre/whole/tg${
       lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version
     }otf.zip";
     hash = "sha256-mRPI/rDsx1vDVItG7h29I7VNPYqgSPqChXS6/gVgfNc=";

--- a/pkgs/by-name/he/hepmc2/package.nix
+++ b/pkgs/by-name/he/hepmc2/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.06.11";
 
   src = fetchurl {
-    url = "http://hepmc.web.cern.ch/hepmc/releases/HepMC-${finalAttrs.version}.tar.gz";
+    url = "https://hepmc.web.cern.ch/hepmc/releases/HepMC-${finalAttrs.version}.tar.gz";
     sha256 = "1pp89bs05nv60wjk1690ndwh4dsd5mk20bzsd4a2lklysdifvb6f";
   };
 

--- a/pkgs/by-name/hp/hpcg/package.nix
+++ b/pkgs/by-name/hp/hpcg/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.1";
 
   src = fetchurl {
-    url = "http://www.hpcg-benchmark.org/downloads/hpcg-${finalAttrs.version}.tar.gz";
+    url = "https://www.hpcg-benchmark.org/downloads/hpcg-${finalAttrs.version}.tar.gz";
     sha256 = "197lw2nwmzsmfsbvgvi8z7kj69n374kgfzzp8pkmk7mp2vkk991k";
   };
 

--- a/pkgs/by-name/hp/hpl/package.nix
+++ b/pkgs/by-name/hp/hpl/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.3";
 
   src = fetchurl {
-    url = "http://www.netlib.org/benchmark/hpl/hpl-${finalAttrs.version}.tar.gz";
+    url = "https://www.netlib.org/benchmark/hpl/hpl-${finalAttrs.version}.tar.gz";
     sha256 = "0c18c7fzlqxifz1bf3izil0bczv3a7nsv0dn6winy3ik49yw3i9j";
   };
 

--- a/pkgs/by-name/ic/icecast/package.nix
+++ b/pkgs/by-name/ic/icecast/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.5.0";
 
   src = fetchurl {
-    url = "http://downloads.xiph.org/releases/icecast/icecast-${finalAttrs.version}.tar.gz";
+    url = "https://downloads.xiph.org/releases/icecast/icecast-${finalAttrs.version}.tar.gz";
     hash = "sha256-2aoHx0Ka7BnZUP9v1CXDcfdxWM00/yIPwZGywYbGfHo=";
   };
 

--- a/pkgs/by-name/ic/iconnamingutils/package.nix
+++ b/pkgs/by-name/ic/iconnamingutils/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.8.90";
 
   src = fetchurl {
-    url = "http://tango.freedesktop.org/releases/icon-naming-utils-${finalAttrs.version}.tar.gz";
+    url = "https://tango.freedesktop.org/releases/icon-naming-utils-${finalAttrs.version}.tar.gz";
     sha256 = "071fj2jm5kydlz02ic5sylhmw6h2p3cgrm3gwdfabinqkqcv4jh4";
   };
 

--- a/pkgs/by-name/if/ifmetric/package.nix
+++ b/pkgs/by-name/if/ifmetric/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3";
 
   src = fetchurl {
-    url = "http://0pointer.de/lennart/projects/ifmetric/ifmetric-${finalAttrs.version}.tar.gz";
+    url = "https://0pointer.de/lennart/projects/ifmetric/ifmetric-${finalAttrs.version}.tar.gz";
     sha256 = "1v0s5x81jzwnnl7hr254d4nkyc8qcv983pzr6vqmbr9l9q553a0g";
   };
 

--- a/pkgs/by-name/if/iftop/package.nix
+++ b/pkgs/by-name/if/iftop/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0pre4";
 
   src = fetchurl {
-    url = "http://ex-parrot.com/pdw/iftop/download/iftop-${finalAttrs.version}.tar.gz";
+    url = "https://ex-parrot.com/pdw/iftop/download/iftop-${finalAttrs.version}.tar.gz";
     sha256 = "15sgkdyijb7vbxpxjavh5qm5nvyii3fqcg9mzvw7fx8s6zmfwczp";
   };
 

--- a/pkgs/by-name/il/ilbc/package.nix
+++ b/pkgs/by-name/il/ilbc/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   script = ./extract-cfile.awk;
 
   src = fetchurl {
-    url = "http://www.ietf.org/rfc/rfc3951.txt";
+    url = "https://www.ietf.org/rfc/rfc3951.txt";
     sha256 = "0zf4mvi3jzx6zjrfl2rbhl2m68pzbzpf1vbdmn7dqbfpcb67jpdy";
   };
 

--- a/pkgs/by-name/im/iml/package.nix
+++ b/pkgs/by-name/im/iml/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "iml";
   version = "1.0.5";
   src = fetchurl {
-    url = "http://www.cs.uwaterloo.ca/~astorjoh/iml-${finalAttrs.version}.tar.bz2";
+    url = "https://www.cs.uwaterloo.ca/~astorjoh/iml-${finalAttrs.version}.tar.bz2";
     sha256 = "0akwhhz9b40bz6lrfxpamp7r7wkk48p455qbn04mfnl9a1l6db8x";
   };
   buildInputs = [

--- a/pkgs/by-name/io/iozone/package.nix
+++ b/pkgs/by-name/io/iozone/package.nix
@@ -24,12 +24,12 @@ stdenv.mkDerivation rec {
   version = "3.507";
 
   src = fetchurl {
-    url = "http://www.iozone.org/src/current/iozone${lib.replaceStrings [ "." ] [ "_" ] version}.tar";
+    url = "https://www.iozone.org/src/current/iozone${lib.replaceStrings [ "." ] [ "_" ] version}.tar";
     hash = "sha256-HoCHraBW9dgBjuC8dmhtQW/CJR7QMDgFXb0K940eXOM=";
   };
 
   license = fetchurl {
-    url = "http://www.iozone.org/docs/Iozone_License.txt";
+    url = "https://www.iozone.org/docs/Iozone_License.txt";
     hash = "sha256-O/8yztxKBI/UKs6vwv9mq16Rn3cf/UHpSxdVnAPVCYw=";
   };
 

--- a/pkgs/by-name/it/itsx/package.nix
+++ b/pkgs/by-name/it/itsx/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "itsx";
 
   src = fetchurl {
-    url = "http://microbiology.se/sw/ITSx_${finalAttrs.version}.tar.gz";
+    url = "https://microbiology.se/sw/ITSx_${finalAttrs.version}.tar.gz";
     sha256 = "0lrmy2n3ax7f208k0k8l3yz0j5cpz05hv4hx1nnxzn0c51z1pc31";
   };
 

--- a/pkgs/by-name/ja/jack_oscrolloscope/package.nix
+++ b/pkgs/by-name/ja/jack_oscrolloscope/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.7";
 
   src = fetchurl {
-    url = "http://das.nasophon.de/download/jack_oscrolloscope-${finalAttrs.version}.tar.gz";
+    url = "https://das.nasophon.de/download/jack_oscrolloscope-${finalAttrs.version}.tar.gz";
     sha256 = "1pl55in0sj7h5r06n1v91im7d18pplvhbjhjm1fdl39zwnyxiash";
   };
 

--- a/pkgs/by-name/ja/java-cup/package.nix
+++ b/pkgs/by-name/ja/java-cup/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "11b-20160615";
 
   src = fetchurl {
-    url = "http://www2.cs.tum.edu/projects/cup/releases/java-cup-src-${finalAttrs.version}.tar.gz";
+    url = "https://www2.cs.tum.edu/projects/cup/releases/java-cup-src-${finalAttrs.version}.tar.gz";
     hash = "sha256-4OdzYG5FzhqorROD5jk9U+2dzyhh5D76gZT1Z+kdv/o=";
   };
 

--- a/pkgs/by-name/jd/jdom/package.nix
+++ b/pkgs/by-name/jd/jdom/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.6.1";
 
   src = fetchzip {
-    url = "http://www.jdom.org/dist/binary/jdom-${finalAttrs.version}.zip";
+    url = "https://www.jdom.org/dist/binary/jdom-${finalAttrs.version}.zip";
     stripRoot = false;
     hash = "sha256-Y++mlO+7N5EU2NhRzLl5x5WXNqu/2tDO/NpNhfRegcg=";
   };

--- a/pkgs/by-name/jf/jflex/package.nix
+++ b/pkgs/by-name/jf/jflex/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "1.9.1";
 
   src = fetchurl {
-    url = "http://jflex.de/release/jflex-${version}.tar.gz";
+    url = "https://jflex.de/release/jflex-${version}.tar.gz";
     sha256 = "sha256-4MHp7vkf9t8E1z+l6v8T86ArZ5/uFHTlzK4AciTfbfY=";
   };
 

--- a/pkgs/by-name/jy/jython/package.nix
+++ b/pkgs/by-name/jy/jython/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.7.4";
 
   src = fetchurl {
-    url = "http://search.maven.org/remotecontent?filepath=org/python/jython-standalone/${finalAttrs.version}/jython-standalone-${finalAttrs.version}.jar";
+    url = "https://search.maven.org/remotecontent?filepath=org/python/jython-standalone/${finalAttrs.version}/jython-standalone-${finalAttrs.version}.jar";
     sha256 = "sha256-H7oXae/8yLGfXhBDa8gnShWM6YhVnyV5J8JMc7sTfzw=";
   };
 

--- a/pkgs/by-name/ka/kawkab-mono-font/package.nix
+++ b/pkgs/by-name/ka/kawkab-mono-font/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation {
   version = "20151015";
 
   src = fetchzip {
-    url = "http://makkuk.com/kawkab-mono/downloads/kawkab-mono-0.1.zip";
+    url = "https://makkuk.com/kawkab-mono/downloads/kawkab-mono-0.1.zip";
     stripRoot = false;
     hash = "sha256-arZTzXj7Ba5G4WF3eZVGNaONhOsYVPih9iBgsN/lg14=";
   };

--- a/pkgs/by-name/ke/keyfuzz/package.nix
+++ b/pkgs/by-name/ke/keyfuzz/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   };
 
   src = fetchurl {
-    url = "http://0pointer.de/lennart/projects/keyfuzz/keyfuzz-0.2.tar.gz";
+    url = "https://0pointer.de/lennart/projects/keyfuzz/keyfuzz-0.2.tar.gz";
     sha256 = "0xv9ymivp8fnyc5xcyh1vamxnx90bzw66wlld813fvm6q2gsiknk";
   };
 

--- a/pkgs/by-name/lc/lcab/package.nix
+++ b/pkgs/by-name/lc/lcab/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     # Original site is no longer available
-    url = "http://deb.debian.org/debian/pool/main/l/lcab/lcab_${finalAttrs.version}.orig.tar.gz";
+    url = "https://deb.debian.org/debian/pool/main/l/lcab/lcab_${finalAttrs.version}.orig.tar.gz";
     hash = "sha256-Bl8sF5O2XyhHHA9xt88SCnBk8o0cRLB8q/SewOl/H8g=";
   };
 

--- a/pkgs/by-name/li/libaacs/package.nix
+++ b/pkgs/by-name/li/libaacs/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.11.1";
 
   src = fetchurl {
-    url = "http://get.videolan.org/libaacs/${finalAttrs.version}/libaacs-${finalAttrs.version}.tar.bz2";
+    url = "https://get.videolan.org/libaacs/${finalAttrs.version}/libaacs-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-qIqg6+TJinf3rv/ZKrPvZKxUjGuCLoJIqLkmclvqCjk=";
   };
 

--- a/pkgs/by-name/li/libagar/package.nix
+++ b/pkgs/by-name/li/libagar/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.5.0";
 
   src = fetchurl {
-    url = "http://stable.hypertriton.com/agar/agar-${finalAttrs.version}.tar.gz";
+    url = "https://stable.hypertriton.com/agar/agar-${finalAttrs.version}.tar.gz";
     sha256 = "001wcqk5z67qg0raw9zlwmv62drxiwqykvsbk10q2mrc6knjsd42";
   };
 

--- a/pkgs/by-name/li/libasyncns/package.nix
+++ b/pkgs/by-name/li/libasyncns/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.8";
 
   src = fetchurl {
-    url = "http://0pointer.de/lennart/projects/libasyncns/libasyncns-${finalAttrs.version}.tar.gz";
+    url = "https://0pointer.de/lennart/projects/libasyncns/libasyncns-${finalAttrs.version}.tar.gz";
     sha256 = "0x5b6lcic4cd7q0bx00x93kvpyzl7n2abbgvqbrlzrfb8vknc6jg";
   };
 

--- a/pkgs/by-name/li/libatasmart/package.nix
+++ b/pkgs/by-name/li/libatasmart/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.19";
 
   src = fetchurl {
-    url = "http://0pointer.de/public/libatasmart-${finalAttrs.version}.tar.xz";
+    url = "https://0pointer.de/public/libatasmart-${finalAttrs.version}.tar.xz";
     sha256 = "138gvgdwk6h4ljrjsr09pxk1nrki4b155hqdzyr8mlk3bwsfmw31";
   };
 

--- a/pkgs/by-name/li/libbdplus/package.nix
+++ b/pkgs/by-name/li/libbdplus/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.2.0";
 
   src = fetchurl {
-    url = "http://get.videolan.org/libbdplus/${finalAttrs.version}/libbdplus-${finalAttrs.version}.tar.bz2";
+    url = "https://get.videolan.org/libbdplus/${finalAttrs.version}/libbdplus-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-uT7qPq7zPW6RVdLDSwaMUFSTqlpJNuYydPQ0KrD0Clg=";
   };
 

--- a/pkgs/by-name/li/libcss/package.nix
+++ b/pkgs/by-name/li/libcss/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.9.2";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libcss-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libcss-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-LfIVu+w01R1gwaBLAbLfTV0Y9RDx86evS4DN21ZxFU4=";
   };
 

--- a/pkgs/by-name/li/libdaemon/package.nix
+++ b/pkgs/by-name/li/libdaemon/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.14";
 
   src = fetchurl {
-    url = "http://0pointer.de/lennart/projects/libdaemon/libdaemon-${finalAttrs.version}.tar.gz";
+    url = "https://0pointer.de/lennart/projects/libdaemon/libdaemon-${finalAttrs.version}.tar.gz";
     sha256 = "0d5qlq5ab95wh1xc87rqrh1vx6i8lddka1w3f1zcqvcqdxgyn8zx";
   };
 

--- a/pkgs/by-name/li/libdom/package.nix
+++ b/pkgs/by-name/li/libdom/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.4.2";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libdom-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libdom-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-0F5FrxZUcBTCsKOuzzZw+hPUGfUFs/X8esihSR/DDzw=";
   };
 

--- a/pkgs/by-name/li/libdvbcsa/package.nix
+++ b/pkgs/by-name/li/libdvbcsa/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1.0";
 
   src = fetchurl {
-    url = "http://get.videolan.org/libdvbcsa/${finalAttrs.version}/libdvbcsa-${finalAttrs.version}.tar.gz";
+    url = "https://get.videolan.org/libdvbcsa/${finalAttrs.version}/libdvbcsa-${finalAttrs.version}.tar.gz";
     sha256 = "4db78af5cdb2641dfb1136fe3531960a477c9e3e3b6ba19a2754d046af3f456d";
   };
 

--- a/pkgs/by-name/li/libdvbpsi/package.nix
+++ b/pkgs/by-name/li/libdvbpsi/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.3";
 
   src = fetchurl {
-    url = "http://get.videolan.org/libdvbpsi/${finalAttrs.version}/libdvbpsi-${finalAttrs.version}.tar.bz2";
+    url = "https://get.videolan.org/libdvbpsi/${finalAttrs.version}/libdvbpsi-${finalAttrs.version}.tar.bz2";
     sha256 = "04h1l3vrkrdsrvkgzcr51adk10g6hxcxvgjphyyxz718ry5rkd82";
   };
 

--- a/pkgs/by-name/li/libdvdcss/package.nix
+++ b/pkgs/by-name/li/libdvdcss/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.4.3";
 
   src = fetchurl {
-    url = "http://get.videolan.org/libdvdcss/${finalAttrs.version}/libdvdcss-${finalAttrs.version}.tar.bz2";
+    url = "https://get.videolan.org/libdvdcss/${finalAttrs.version}/libdvdcss-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-IzzJL13AHF06lvWzWCvn1c7lo1pS06CBWHRdPYYHAHk=";
   };
 

--- a/pkgs/by-name/li/libdvdnav/package.nix
+++ b/pkgs/by-name/li/libdvdnav/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "6.1.1";
 
   src = fetchurl {
-    url = "http://get.videolan.org/libdvdnav/${finalAttrs.version}/libdvdnav-${finalAttrs.version}.tar.bz2";
+    url = "https://get.videolan.org/libdvdnav/${finalAttrs.version}/libdvdnav-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-wZGnR1lH0yP/doDPksD7G+gjdwGIXzdlbGTQTpjRjUg=";
   };
 

--- a/pkgs/by-name/li/libdvdread/package.nix
+++ b/pkgs/by-name/li/libdvdread/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "7.0.1";
 
   src = fetchurl {
-    url = "http://get.videolan.org/libdvdread/${finalAttrs.version}/libdvdread-${finalAttrs.version}.tar.xz";
+    url = "https://get.videolan.org/libdvdread/${finalAttrs.version}/libdvdread-${finalAttrs.version}.tar.xz";
     hash = "sha256-Lj4EowXBXDljqgOuG5qDwdI5iAAD/PPd6YbTlDNV1Ac=";
   };
 

--- a/pkgs/by-name/li/libestr/package.nix
+++ b/pkgs/by-name/li/libestr/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1.11";
 
   src = fetchurl {
-    url = "http://libestr.adiscon.com/files/download/libestr-${finalAttrs.version}.tar.gz";
+    url = "https://libestr.adiscon.com/files/download/libestr-${finalAttrs.version}.tar.gz";
     sha256 = "0910ifzcs8kpd3srrr4fvbacgh2zrc6yn7i4rwfj6jpzhlkjnqs6";
   };
 

--- a/pkgs/by-name/li/libguestfs-appliance/package.nix
+++ b/pkgs/by-name/li/libguestfs-appliance/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "1.56.0";
 
   src = fetchurl {
-    url = "http://download.libguestfs.org/binaries/appliance/appliance-${version}.tar.xz";
+    url = "https://download.libguestfs.org/binaries/appliance/appliance-${version}.tar.xz";
     hash = "sha256-YbJlNaogMyutdtc7d+etyJvdd//yE8tedsZfkGXJr54=";
   };
 

--- a/pkgs/by-name/li/libhubbub/package.nix
+++ b/pkgs/by-name/li/libhubbub/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.8";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libhubbub-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libhubbub-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-isHm9fPUjAUUHVk5FxlTQpDFnNAp78JJ60/brBAs1aU=";
   };
 

--- a/pkgs/by-name/li/libjpeg_original/package.nix
+++ b/pkgs/by-name/li/libjpeg_original/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "10";
 
   src = fetchurl {
-    url = "http://www.ijg.org/files/jpegsrc.v${finalAttrs.version}.tar.gz";
+    url = "https://www.ijg.org/files/jpegsrc.v${finalAttrs.version}.tar.gz";
     hash = "sha256-i56qEyQmkOvQPhcoqx7fl6gaeO1ug2JNSTZV8xrJWrU=";
   };
 

--- a/pkgs/by-name/li/liblogging/package.nix
+++ b/pkgs/by-name/li/liblogging/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.8";
 
   src = fetchurl {
-    url = "http://download.rsyslog.com/liblogging/liblogging-${finalAttrs.version}.tar.gz";
+    url = "https://download.rsyslog.com/liblogging/liblogging-${finalAttrs.version}.tar.gz";
     hash = "sha256-ZEm3u3XcKC7GvxuYp1PJUHRupbGQ7JruCXiB5NxcS/E=";
   };
 

--- a/pkgs/by-name/li/liblognorm/package.nix
+++ b/pkgs/by-name/li/liblognorm/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.9";
 
   src = fetchurl {
-    url = "http://www.liblognorm.com/files/download/liblognorm-${finalAttrs.version}.tar.gz";
+    url = "https://www.liblognorm.com/files/download/liblognorm-${finalAttrs.version}.tar.gz";
     hash = "sha256-dsfMLLdqPVjncy4M/yORgPg/O2NQAriqBIZciBKFd5M=";
   };
 

--- a/pkgs/by-name/li/liblzf/package.nix
+++ b/pkgs/by-name/li/liblzf/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.6";
 
   src = fetchurl {
-    url = "http://dist.schmorp.de/liblzf/liblzf-${finalAttrs.version}.tar.gz";
+    url = "https://dist.schmorp.de/liblzf/liblzf-${finalAttrs.version}.tar.gz";
     hash = "sha256-nF3gH3ucyuQMP2GdJqer7JmGwGw20mDBec7dBLiftGo=";
   };
 

--- a/pkgs/by-name/li/libnsbmp/package.nix
+++ b/pkgs/by-name/li/libnsbmp/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1.7";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libnsbmp-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libnsbmp-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-VAenaCoSK6qqWhW1BSkOLTffVME8Xt70sJ0SyGLYIpM=";
   };
 

--- a/pkgs/by-name/li/libnsfb/package.nix
+++ b/pkgs/by-name/li/libnsfb/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.2.2";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libnsfb-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libnsfb-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-vkRso+tU35A/LamDEdEH11dM0R9awHE+YZFW1NGeo5o=";
   };
 

--- a/pkgs/by-name/li/libnsgif/package.nix
+++ b/pkgs/by-name/li/libnsgif/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.0";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libnsgif-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libnsgif-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-YBTIQvYUVNL1oPgkPXqNe96bfaPM/cotNGx8CyxMBhs=";
   };
 

--- a/pkgs/by-name/li/libnslog/package.nix
+++ b/pkgs/by-name/li/libnslog/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1.3";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libnslog-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libnslog-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-/JjcqdfvpnCWRwpdlsAjFG4lv97AjA23RmHHtNsEU9A=";
   };
 

--- a/pkgs/by-name/li/libnspsl/package.nix
+++ b/pkgs/by-name/li/libnspsl/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1.7";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libnspsl-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libnspsl-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-NoTOwy9VXa7UMZk+C/bL2TdPbJCERiN+CJ8LYdaUrIA=";
   };
 

--- a/pkgs/by-name/li/libnsutils/package.nix
+++ b/pkgs/by-name/li/libnsutils/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1.1";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libnsutils-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libnsutils-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-VpS0Um5FjtAAQTzmAnWJy+EKJXp+zwZaAUIdxymd6pI=";
   };
 

--- a/pkgs/by-name/li/libogg/package.nix
+++ b/pkgs/by-name/li/libogg/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.6";
 
   src = fetchurl {
-    url = "http://downloads.xiph.org/releases/ogg/libogg-${finalAttrs.version}.tar.xz";
+    url = "https://downloads.xiph.org/releases/ogg/libogg-${finalAttrs.version}.tar.xz";
     hash = "sha256-XIJTQo4YGEDNINQfPKFlV6nMBLrUo9BMzoSAhnf6EGE=";
   };
 

--- a/pkgs/by-name/li/libparserutils/package.nix
+++ b/pkgs/by-name/li/libparserutils/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.2.5";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libparserutils-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libparserutils-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-MX7VxxjxeSe1chl0uuXeMsP9bQVdsTGtMbQxKgMu0Tk=";
   };
 

--- a/pkgs/by-name/li/libpst/package.nix
+++ b/pkgs/by-name/li/libpst/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.6.76";
 
   src = fetchurl {
-    url = "http://www.five-ten-sg.com/libpst/packages/libpst-${finalAttrs.version}.tar.gz";
+    url = "https://www.five-ten-sg.com/libpst/packages/libpst-${finalAttrs.version}.tar.gz";
     hash = "sha256-PSkb7rvbSNK5NGCLwGGVtkHaY9Ko9eDThvLp1tBaC0I=";
   };
 

--- a/pkgs/by-name/li/libptytty/package.nix
+++ b/pkgs/by-name/li/libptytty/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0";
 
   src = fetchurl {
-    url = "http://dist.schmorp.de/libptytty/libptytty-${finalAttrs.version}.tar.gz";
+    url = "https://dist.schmorp.de/libptytty/libptytty-${finalAttrs.version}.tar.gz";
     sha256 = "1xrikmrsdkxhdy9ggc0ci6kg5b1hn3bz44ag1mk5k1zjmlxfscw0";
   };
 

--- a/pkgs/by-name/li/libroxml/package.nix
+++ b/pkgs/by-name/li/libroxml/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.3.0";
 
   src = fetchurl {
-    url = "http://download.libroxml.net/pool/v2.x/libroxml-${finalAttrs.version}.tar.gz";
+    url = "https://download.libroxml.net/pool/v2.x/libroxml-${finalAttrs.version}.tar.gz";
     sha256 = "0y0vc9n4rfbimjp28nx4kdfzz08j5xymh5xjy84l9fhfac5z5a0x";
   };
 

--- a/pkgs/by-name/li/libsvgtiny/package.nix
+++ b/pkgs/by-name/li/libsvgtiny/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1.8";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libsvgtiny-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libsvgtiny-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-w1cifwLoP7KnaxK5ARkaCCIp2x8Ac2Lo8xx1RRDCoBw=";
   };
 

--- a/pkgs/by-name/li/libtermkey/package.nix
+++ b/pkgs/by-name/li/libtermkey/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.22";
 
   src = fetchzip {
-    url = "http://www.leonerd.org.uk/code/libtermkey/libtermkey-${finalAttrs.version}.tar.gz";
+    url = "https://www.leonerd.org.uk/code/libtermkey/libtermkey-${finalAttrs.version}.tar.gz";
     sha256 = "02dks6bj7n23lj005yq41azf95wh3hapmgc2lzyh12vigkjh67rg";
   };
 

--- a/pkgs/by-name/li/libtirpc/package.nix
+++ b/pkgs/by-name/li/libtirpc/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.7";
 
   src = fetchurl {
-    url = "http://git.linux-nfs.org/?p=steved/libtirpc.git;a=snapshot;h=refs/tags/libtirpc-${
+    url = "https://git.linux-nfs.org/?p=steved/libtirpc.git;a=snapshot;h=refs/tags/libtirpc-${
       lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version
     };sf=tgz";
     hash = "sha256-VGftEr3xzCp8O3oqCjIZozlq599gxN5IsHBRaG37GP4=";

--- a/pkgs/by-name/li/libutempter/package.nix
+++ b/pkgs/by-name/li/libutempter/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.2.1";
 
   src = fetchurl {
-    url = "http://ftp.altlinux.org/pub/people/ldv/utempter/libutempter-${finalAttrs.version}.tar.gz";
+    url = "https://ftp.altlinux.org/pub/people/ldv/utempter/libutempter-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-ln/vNy85HeUBhDrYdXDGz12r2WUfAPF4MJD7wSsqNMs=";
   };
 

--- a/pkgs/by-name/li/libutf8proc/package.nix
+++ b/pkgs/by-name/li/libutf8proc/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.4.0-1";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libutf8proc-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libutf8proc-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-AasdaYnBx3VQkNskw/ZOSflcVgrknCa+xRQrrGgCxHI=";
   };
 

--- a/pkgs/by-name/li/libwapcaplet/package.nix
+++ b/pkgs/by-name/li/libwapcaplet/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.4.3";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/libwapcaplet-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/libwapcaplet-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-myqh3W1mRfjpkrNpf9vYfwwOHaVyH6VO0ptITRMWDFw=";
   };
 

--- a/pkgs/by-name/li/libzmf/package.nix
+++ b/pkgs/by-name/li/libzmf/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.0.2";
 
   src = fetchurl {
-    url = "http://dev-www.libreoffice.org/src/libzmf/libzmf-${finalAttrs.version}.tar.xz";
+    url = "https://dev-www.libreoffice.org/src/libzmf/libzmf-${finalAttrs.version}.tar.xz";
     sha256 = "08mg5kmkjrmqrd8j5rkzw9vdqlvibhb1ynp6bmfxnzq5rcq1l197";
   };
 

--- a/pkgs/by-name/li/lilypond/package.nix
+++ b/pkgs/by-name/li/lilypond/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchzip {
-    url = "http://lilypond.org/download/sources/v${lib.versions.majorMinor finalAttrs.version}/lilypond-${finalAttrs.version}.tar.gz";
+    url = "https://lilypond.org/download/sources/v${lib.versions.majorMinor finalAttrs.version}/lilypond-${finalAttrs.version}.tar.gz";
     hash = "sha256-UYdORvodrVchxslOxpMiXrAh7DtB9sWp9yqZU/jeB9Y=";
   };
 

--- a/pkgs/by-name/li/links2/package.nix
+++ b/pkgs/by-name/li/links2/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "links2";
 
   src = fetchurl {
-    url = "http://links.twibright.com/download/links-${finalAttrs.version}.tar.bz2";
+    url = "https://links.twibright.com/download/links-${finalAttrs.version}.tar.bz2";
     hash = "sha256-xGMca1oRUnzcPLeHL8I7fyslwrAh1Za+QQ2ttAMV8WY=";
   };
 

--- a/pkgs/by-name/li/linux-libertine-g/package.nix
+++ b/pkgs/by-name/li/linux-libertine-g/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "20120116";
 
   src = fetchzip {
-    url = "http://www.numbertext.org/linux/e7a384790b13c29113e22e596ade9687-LinLibertineG-${finalAttrs.version}.zip";
+    url = "https://www.numbertext.org/linux/e7a384790b13c29113e22e596ade9687-LinLibertineG-${finalAttrs.version}.zip";
     hash = "sha256-UGTB7jsI6peivCtEt96RCSi5XHCrnjCSs0Ud5bF7uxk=";
   };
 

--- a/pkgs/by-name/li/liquidwar5/package.nix
+++ b/pkgs/by-name/li/liquidwar5/package.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "5.6.6";
   pname = "liquidwar5";
   src = fetchurl {
-    url = "http://www.ufoot.org/download/liquidwar/v5/${finalAttrs.version}/liquidwar-${finalAttrs.version}.tar.gz";
+    url = "https://www.ufoot.org/download/liquidwar/v5/${finalAttrs.version}/liquidwar-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-JF2AZuzDiCm9EQ8AiQ6230TgmMgML7yJpG80BFqsQ/c=";
   };
 

--- a/pkgs/by-name/lk/lkproof/package.nix
+++ b/pkgs/by-name/lk/lkproof/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   version = "3.1";
 
   src = fetchurl {
-    url = "http://mirror.ctan.org/macros/latex/contrib/lkproof.zip";
+    url = "https://mirror.ctan.org/macros/latex/contrib/lkproof.zip";
     sha256 = "1qjkjhpc4rm62qxn18r83zdlwnj1wvnkcpdiqlv7w4bakh0gvjly";
   };
 

--- a/pkgs/by-name/lr/lrs/package.nix
+++ b/pkgs/by-name/lr/lrs/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   version = "7.3";
 
   src = fetchurl {
-    url = "http://cgm.cs.mcgill.ca/~avis/C/lrslib/archive/lrslib-073.tar.gz";
+    url = "https://cgm.cs.mcgill.ca/~avis/C/lrslib/archive/lrslib-073.tar.gz";
     sha256 = "sha256-xJpOvYVhg0c9HVpieF/N/hBX1dZx1LlvOhJQ6xr+ToM=";
   };
 

--- a/pkgs/by-name/ls/lsscsi/package.nix
+++ b/pkgs/by-name/ls/lsscsi/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.32";
 
   src = fetchurl {
-    url = "http://sg.danny.cz/scsi/lsscsi-${finalAttrs.version}.tgz";
+    url = "https://sg.danny.cz/scsi/lsscsi-${finalAttrs.version}.tgz";
     sha256 = "sha256-CoAOnpTcoqtwLWXXJ3eujK4Hjj100Ly+1kughJ6AKaE=";
   };
 

--- a/pkgs/by-name/lv/lv2-cpp-tools/package.nix
+++ b/pkgs/by-name/lv/lv2-cpp-tools/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.5";
 
   src = fetchzip {
-    url = "http://deb.debian.org/debian/pool/main/l/lv2-c++-tools/lv2-c++-tools_${finalAttrs.version}.orig.tar.bz2";
+    url = "https://deb.debian.org/debian/pool/main/l/lv2-c++-tools/lv2-c++-tools_${finalAttrs.version}.orig.tar.bz2";
     sha256 = "039bq7d7s2bhfcnlsfq0mqxr9a9iqwg5bwcpxfi24c6yl6krydsi";
   };
 

--- a/pkgs/by-name/lw/lwm/package.nix
+++ b/pkgs/by-name/lw/lwm/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.2.4";
 
   src = fetchurl {
-    url = "http://www.jfc.org.uk/files/lwm/lwm-${finalAttrs.version}.tar.gz";
+    url = "https://www.jfc.org.uk/files/lwm/lwm-${finalAttrs.version}.tar.gz";
     sha256 = "1bcdr173f0gl61fyl43p3gr145angci7lvjqb8rl00y9f9amvh3y";
   };
 

--- a/pkgs/by-name/ma/macopix/package.nix
+++ b/pkgs/by-name/ma/macopix/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   # GitHub does not contain tags
   # https://github.com/chimari/MaCoPiX/issues/6
   src = fetchurl {
-    url = "http://rosegray.sakura.ne.jp/macopix/macopix-${finalAttrs.version}.tar.gz";
+    url = "https://rosegray.sakura.ne.jp/macopix/macopix-${finalAttrs.version}.tar.gz";
     hash = "sha256-1AjqdPPCc9UQWqLdWlA+Va+MmvKL8dAIfJURPifN7RI=";
   };
 

--- a/pkgs/by-name/ma/maelstrom/package.nix
+++ b/pkgs/by-name/ma/maelstrom/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.0.7";
 
   src = fetchurl {
-    url = "http://www.libsdl.org/projects/Maelstrom/src/Maelstrom-${finalAttrs.version}.tar.gz";
+    url = "https://www.libsdl.org/projects/Maelstrom/src/Maelstrom-${finalAttrs.version}.tar.gz";
     sha256 = "0dm0m5wd7amrsa8wnrblkv34sq4v4lglc2wfx8klfkdhyhi06s4k";
   };
 

--- a/pkgs/by-name/ma/marvin/package.nix
+++ b/pkgs/by-name/ma/marvin/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     name = "marvin-${finalAttrs.version}.deb";
-    url = "http://dl.chemaxon.com/marvin/${finalAttrs.version}/marvin_linux_${finalAttrs.version}.deb";
+    url = "https://dl.chemaxon.com/marvin/${finalAttrs.version}/marvin_linux_${finalAttrs.version}.deb";
     hash = "sha256-+fTO6cEJL4QRFpLQ9CXZFt7Jg3otR3ZMWN5vH+3QXmA=";
   };
 

--- a/pkgs/by-name/mb/mbuffer/package.nix
+++ b/pkgs/by-name/mb/mbuffer/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchurl {
-    url = "http://www.maier-komor.de/software/mbuffer/mbuffer-${finalAttrs.version}.tgz";
+    url = "https://www.maier-komor.de/software/mbuffer/mbuffer-${finalAttrs.version}.tgz";
     sha256 = "sha256-R+UWtBFgOZlnN8T4iV9m563iS37sXpN1SGY3psirNgE=";
   };
 

--- a/pkgs/by-name/me/memtester/package.nix
+++ b/pkgs/by-name/me/memtester/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   src = fetchurl {
-    url = "http://pyropus.ca/software/memtester/old-versions/memtester-${finalAttrs.version}.tar.gz";
+    url = "https://pyropus.ca/software/memtester/old-versions/memtester-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-5CfeZj970i0evuivElBqhSwBC9T8vKHg5rApctKYtbs=";
   };
 

--- a/pkgs/by-name/me/mencal/package.nix
+++ b/pkgs/by-name/me/mencal/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.0";
 
   src = fetchurl {
-    url = "http://kyberdigi.cz/projects/mencal/files/mencal-${finalAttrs.version}.tar.gz";
+    url = "https://kyberdigi.cz/projects/mencal/files/mencal-${finalAttrs.version}.tar.gz";
     sha256 = "9328d0b2f3f57847e8753c5184531f4832be7123d1b6623afdff892074c03080";
   };
 

--- a/pkgs/by-name/mi/mimetic/package.nix
+++ b/pkgs/by-name/mi/mimetic/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.9.8";
 
   src = fetchurl {
-    url = "http://www.codesink.org/download/mimetic-${finalAttrs.version}.tar.gz";
+    url = "https://www.codesink.org/download/mimetic-${finalAttrs.version}.tar.gz";
     sha256 = "003715lvj4nx23arn1s9ss6hgc2yblkwfy5h94li6pjz2a6xc1rs";
   };
 

--- a/pkgs/by-name/mo/molotov/package.nix
+++ b/pkgs/by-name/mo/molotov/package.nix
@@ -8,7 +8,7 @@ let
   pname = "molotov";
   version = "4.4.0";
   src = fetchurl {
-    url = "http://desktop-auto-upgrade.molotov.tv/linux/${version}/molotov.AppImage";
+    url = "https://desktop-auto-upgrade.molotov.tv/linux/${version}/molotov.AppImage";
     sha256 = "sha256-l4Il6i8uXSeJqH3ITC8ZUpKXPQb0qcW7SpKx1R46XDc=";
   };
   appimageContents = appimageTools.extractType2 { inherit pname version src; };

--- a/pkgs/by-name/mo/moon-buggy/package.nix
+++ b/pkgs/by-name/mo/moon-buggy/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchurl {
-    url = "http://www.seehuhn.de/programs/moon-buggy/moon-buggy-${finalAttrs.version}.tar.gz";
+    url = "https://www.seehuhn.de/programs/moon-buggy/moon-buggy-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-JZrm57GDjEBTKvXA8gzXxhc81cVS7eQIEUBkR1vPxbY=";
   };
 

--- a/pkgs/by-name/ms/mscgen/package.nix
+++ b/pkgs/by-name/ms/mscgen/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.20";
 
   src = fetchurl {
-    url = "http://www.mcternan.me.uk/mscgen/software/mscgen-src-${finalAttrs.version}.tar.gz";
+    url = "https://www.mcternan.me.uk/mscgen/software/mscgen-src-${finalAttrs.version}.tar.gz";
     sha256 = "3c3481ae0599e1c2d30b7ed54ab45249127533ab2f20e768a0ae58d8551ddc23";
   };
 

--- a/pkgs/by-name/ms/msr/package.nix
+++ b/pkgs/by-name/ms/msr/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   src = fetchzip {
     inherit pname version;
-    url = "http://www.etallen.com/msr/msr-${version}.src.tar.gz";
+    url = "https://www.etallen.com/msr/msr-${version}.src.tar.gz";
     hash = "sha256-e01qYWbOALkXp5NpexuVodMxA3EBySejJ6ZBpZjyT+E=";
   };
 

--- a/pkgs/by-name/my/mystem/package.nix
+++ b/pkgs/by-name/my/mystem/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   version = "3.1";
 
   src = fetchurl {
-    url = "http://download.cdn.yandex.net/mystem/${pname}-${version}-linux-64bit.tar.gz";
+    url = "https://download.cdn.yandex.net/mystem/${pname}-${version}-linux-64bit.tar.gz";
     sha256 = "0qha7jvkdmil3jiwrpsfhkqsbkqn9dzgx3ayxwjdmv73ikmg95j6";
   };
 

--- a/pkgs/by-name/n2/n2048/package.nix
+++ b/pkgs/by-name/n2/n2048/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1";
 
   src = fetchurl {
-    url = "http://www.dettus.net/n2048/n2048_v${finalAttrs.version}.tar.gz";
+    url = "https://www.dettus.net/n2048/n2048_v${finalAttrs.version}.tar.gz";
     hash = "sha256-c4bHWmdQuwyRXIm/sqw3p71pMv6VLAzIuUTaDHIWn6A=";
   };
 

--- a/pkgs/by-name/nb/nbench/package.nix
+++ b/pkgs/by-name/nb/nbench/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.2.3";
 
   src = fetchurl {
-    url = "http://www.math.utah.edu/~mayer/linux/nbench-byte-${finalAttrs.version}.tar.gz";
+    url = "https://www.math.utah.edu/~mayer/linux/nbench-byte-${finalAttrs.version}.tar.gz";
     sha256 = "1b01j7nmm3wd92ngvsmn2sbw43sl9fpx4xxmkrink68fz1rx0gbj";
   };
 

--- a/pkgs/by-name/ne/netsurf-browser/package.nix
+++ b/pkgs/by-name/ne/netsurf-browser/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.11";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/netsurf/releases/source/netsurf-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/netsurf/releases/source/netsurf-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-wopiau/uQo0FOxP4i1xECSIkWXZSLRLq8TfP0y0gHLI=";
   };
 

--- a/pkgs/by-name/ne/netsurf-buildsystem/package.nix
+++ b/pkgs/by-name/ne/netsurf-buildsystem/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.10";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/buildsystem-${finalAttrs.version}.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/buildsystem-${finalAttrs.version}.tar.gz";
     hash = "sha256-PT451WnkRnfEsXkSm95hTGV5jis+YlMWAjnR/W6uTXk=";
   };
 

--- a/pkgs/by-name/nl/nload/package.nix
+++ b/pkgs/by-name/nl/nload/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "nload";
 
   src = fetchurl {
-    url = "http://www.roland-riegel.de/nload/nload-${finalAttrs.version}.tar.gz";
+    url = "https://www.roland-riegel.de/nload/nload-${finalAttrs.version}.tar.gz";
     sha256 = "1rb9skch2kgqzigf19x8bzk211jdfjfdkrcvaqyj89jy2pkm3h61";
   };
 

--- a/pkgs/by-name/ns/nsf-ordlista/package.nix
+++ b/pkgs/by-name/ns/nsf-ordlista/package.nix
@@ -7,7 +7,7 @@ stdenvNoCC.mkDerivation {
   pname = "nsf-ordlista";
   version = "unstable-2023-08-20";
   src = fetchzip {
-    url = "http://www2.scrabbleforbundet.no/wp-content/uploads/2023/08/nsf2023.zip";
+    url = "https://www2.scrabbleforbundet.no/wp-content/uploads/2023/08/nsf2023.zip";
     hash = "sha256-bcVqZ2yPHurl6sRNgeLNAyyR8WR9ewmtn85Xuw/rZ3s=";
   };
 

--- a/pkgs/by-name/ns/nsgenbind/package.nix
+++ b/pkgs/by-name/ns/nsgenbind/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.9";
 
   src = fetchurl {
-    url = "http://download.netsurf-browser.org/libs/releases/nsgenbind-${finalAttrs.version}-src.tar.gz";
+    url = "https://download.netsurf-browser.org/libs/releases/nsgenbind-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-Iyzg9my8LD7tYoiuJt4sVnu/u8Adiw9vxsHBZJ1LOF0=";
   };
 

--- a/pkgs/by-name/nt/ntl/package.nix
+++ b/pkgs/by-name/nt/ntl/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "11.6.0";
 
   src = fetchurl {
-    url = "http://www.shoup.net/ntl/ntl-${finalAttrs.version}.tar.gz";
+    url = "https://www.shoup.net/ntl/ntl-${finalAttrs.version}.tar.gz";
     hash = "sha256-vA75rOsHWmoGc6yNj0fV+EWMcv6AbkRo+9XT2v8FYYI=";
   };
 

--- a/pkgs/by-name/nu/nuttcp/package.nix
+++ b/pkgs/by-name/nu/nuttcp/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "8.2.2";
 
   src = fetchurl {
-    url = "http://nuttcp.net/nuttcp/nuttcp-${finalAttrs.version}.tar.bz2";
+    url = "https://nuttcp.net/nuttcp/nuttcp-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-fq16ieeqoFnSDjQELFihmMKYHK1ylVDROI3fyQNtOYM=";
   };
 

--- a/pkgs/by-name/op/openbox/package.nix
+++ b/pkgs/by-name/op/openbox/package.nix
@@ -52,12 +52,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchurl {
-    url = "http://openbox.org/dist/openbox/openbox-${finalAttrs.version}.tar.gz";
+    url = "https://openbox.org/dist/openbox/openbox-${finalAttrs.version}.tar.gz";
     sha256 = "1xvyvqxlhy08n61rjkckmrzah2si1i7nmc7s8h07riqq01vc0jlb";
   };
 
   setlayoutSrc = fetchurl {
-    url = "http://openbox.org/dist/tools/setlayout.c";
+    url = "https://openbox.org/dist/tools/setlayout.c";
     sha256 = "1ci9lq4qqhl31yz1jwwjiawah0f7x0vx44ap8baw7r6rdi00pyiv";
   };
 

--- a/pkgs/by-name/op/opencsg/package.nix
+++ b/pkgs/by-name/op/opencsg/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.8.2";
 
   src = fetchurl {
-    url = "http://www.opencsg.org/OpenCSG-${finalAttrs.version}.tar.gz";
+    url = "https://www.opencsg.org/OpenCSG-${finalAttrs.version}.tar.gz";
     hash = "sha256-WsXfc7GtM0DdZwX/kOAJ8alGu5U2whwiY6b5dCZWZMA=";
   };
 

--- a/pkgs/by-name/op/optar/package.nix
+++ b/pkgs/by-name/op/optar/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "20150210";
 
   src = fetchurl {
-    url = "http://ronja.twibright.com/optar.tgz";
+    url = "https://ronja.twibright.com/optar.tgz";
     sha256 = "10lr31k3xfcpa6vxkbl3abph7j3gks2210489khnnzmhmfdnm1a4";
   };
 

--- a/pkgs/by-name/op/opusfile/package.nix
+++ b/pkgs/by-name/op/opusfile/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "opusfile";
   version = "0.12";
   src = fetchurl {
-    url = "http://downloads.xiph.org/releases/opus/opusfile-${finalAttrs.version}.tar.gz";
+    url = "https://downloads.xiph.org/releases/opus/opusfile-${finalAttrs.version}.tar.gz";
     sha256 = "02smwc5ah8nb3a67mnkjzqmrzk43j356hgj2a97s9midq40qd38i";
   };
 

--- a/pkgs/by-name/ot/otf2/package.nix
+++ b/pkgs/by-name/ot/otf2/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchurl {
-    url = "http://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-${finalAttrs.version}/otf2-${finalAttrs.version}.tar.gz";
+    url = "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-${finalAttrs.version}/otf2-${finalAttrs.version}.tar.gz";
     hash = "sha256-Wk4BOlGsTteU/jXFW3AM1yA0b9p/M+yEx2uGpfuICm4=";
   };
 

--- a/pkgs/by-name/p0/p0f/package.nix
+++ b/pkgs/by-name/p0/p0f/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.09b";
 
   src = fetchurl {
-    url = "http://lcamtuf.coredump.cx/p0f3/releases/p0f-${finalAttrs.version}.tgz";
+    url = "https://lcamtuf.coredump.cx/p0f3/releases/p0f-${finalAttrs.version}.tgz";
     sha256 = "0zqfq3gdnha29ckvlqmyp36c0jhj7f69bhqqx31yb6vkirinhfsl";
   };
 

--- a/pkgs/by-name/pa/palp/package.nix
+++ b/pkgs/by-name/pa/palp/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.21";
 
   src = fetchurl {
-    url = "http://hep.itp.tuwien.ac.at/~kreuzer/CY/palp/palp-${finalAttrs.version}.tar.gz";
+    url = "https://hep.itp.tuwien.ac.at/~kreuzer/CY/palp/palp-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-fkp78hmZioRMC8zgoXbknQdDy0tQWg4ZUym/LsGW3dc=";
   };
 

--- a/pkgs/by-name/pa/pam_tmpdir/package.nix
+++ b/pkgs/by-name/pa/pam_tmpdir/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.09";
 
   src = fetchurl {
-    url = "http://deb.debian.org/debian/pool/main/p/pam-tmpdir/pam-tmpdir_${finalAttrs.version}.tar.gz";
+    url = "https://deb.debian.org/debian/pool/main/p/pam-tmpdir/pam-tmpdir_${finalAttrs.version}.tar.gz";
     hash = "sha256-MXa1CY6alD83E/Q+MJmsv8NaImWd0pPJKZd/7nbe4J8=";
   };
 

--- a/pkgs/by-name/pa/papi/package.nix
+++ b/pkgs/by-name/pa/papi/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "papi";
 
   src = fetchurl {
-    url = "http://icl.utk.edu/projects/papi/downloads/papi-${finalAttrs.version}.tar.gz";
+    url = "https://icl.utk.edu/projects/papi/downloads/papi-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-qb/4nM85kV1yngiuCgxqcc4Ou+mEEemi6zyDyNsK85w=";
   };
 

--- a/pkgs/by-name/pa/pari-galdata/package.nix
+++ b/pkgs/by-name/pa/pari-galdata/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   pname = "pari-galdata";
 
   src = fetchurl {
-    url = "http://pari.math.u-bordeaux.fr/pub/pari/packages/galdata.tgz";
+    url = "https://pari.math.u-bordeaux.fr/pub/pari/packages/galdata.tgz";
     sha256 = "1pch6bk76f1i6cwwgm7hhxi5h71m52lqayp4mnyj0jmjk406bhdp";
   };
 

--- a/pkgs/by-name/pa/pari-seadata-small/package.nix
+++ b/pkgs/by-name/pa/pari-seadata-small/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   pname = "pari-seadata-small";
 
   src = fetchurl {
-    url = "http://pari.math.u-bordeaux.fr/pub/pari/packages/seadata-small.tgz";
+    url = "https://pari.math.u-bordeaux.fr/pub/pari/packages/seadata-small.tgz";
     sha256 = "13qafribxwkz8h3haa0cng7arz0kh7398br4y7vqs9ib8w9yjnxz";
   };
 

--- a/pkgs/by-name/pa/paup-cli/package.nix
+++ b/pkgs/by-name/pa/paup-cli/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "4.0a168";
 
   src = fetchurl {
-    url = "http://phylosolutions.com/paup-test/paup4a168_centos64.gz";
+    url = "https://phylosolutions.com/paup-test/paup4a168_centos64.gz";
     hash = "sha256-41dZswlrIQ05f1zJzId78DKmPf0QH1SfrexzvCAUxq8=";
   };
 

--- a/pkgs/by-name/pc/pcg_c/package.nix
+++ b/pkgs/by-name/pc/pcg_c/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "pcg-c";
 
   src = fetchzip {
-    url = "http://www.pcg-random.org/downloads/pcg-c-${finalAttrs.version}.zip";
+    url = "https://www.pcg-random.org/downloads/pcg-c-${finalAttrs.version}.zip";
     sha256 = "0smm811xbvs03a5nc2668zd0178wnyri2h023pqffy767bpy1vlv";
   };
 

--- a/pkgs/by-name/pc/pcsc-scm-scl011/package.nix
+++ b/pkgs/by-name/pc/pcsc-scm-scl011/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   version = "2.09";
 
   src = fetchurl {
-    url = "http://files.identiv.com/products/smart-card-readers/contactless/scl010-011/Linux_Driver_Ver${version}.zip";
+    url = "https://files.identiv.com/products/smart-card-readers/contactless/scl010-011/Linux_Driver_Ver${version}.zip";
     sha256 = "0ik26sxgqgsqplksl87z61vwmx51k7plaqmrkdid7xidgfhfxr42";
   };
 

--- a/pkgs/by-name/pe/pecita/package.nix
+++ b/pkgs/by-name/pe/pecita/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation {
   version = "5.4";
 
   src = fetchurl {
-    url = "http://pecita.eu/b/Pecita.otf";
+    url = "https://pecita.eu/b/Pecita.otf";
     hash = "sha256-D9IZ+p4UFHUNt9me7D4vv0x6rMK9IaViKPliCEyX6t4=";
   };
 

--- a/pkgs/by-name/pe/pencil/package.nix
+++ b/pkgs/by-name/pe/pencil/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "pencil";
 
   src = fetchurl {
-    url = "http://pencil.evolus.vn/dl/V${finalAttrs.version}.ga/pencil_${finalAttrs.version}.ga_amd64.deb";
+    url = "https://pencil.evolus.vn/dl/V${finalAttrs.version}.ga/pencil_${finalAttrs.version}.ga_amd64.deb";
     sha256 = "01ae54b1a1351b909eb2366c6ec00816e1deba370e58f35601cf7368f10aaba3";
   };
 

--- a/pkgs/by-name/pe/perseus/package.nix
+++ b/pkgs/by-name/pe/perseus/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   hardeningDisable = [ "stackprotector" ];
 
   src = fetchurl {
-    url = "http://people.maths.ox.ac.uk/nanda/source/perseus_4_beta.zip";
+    url = "https://people.maths.ox.ac.uk/nanda/source/perseus_4_beta.zip";
     sha256 = "sha256-cnkJEIC4tu+Ni7z0cKdjmLdS8QLe8iKpdA8uha2MeSU=";
   };
 

--- a/pkgs/by-name/ph/phrasendrescher/package.nix
+++ b/pkgs/by-name/ph/phrasendrescher/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.2.2c";
 
   src = fetchurl {
-    url = "http://leidecker.info/projects/phrasendrescher/phrasendrescher-${finalAttrs.version}.tar.gz";
+    url = "https://leidecker.info/projects/phrasendrescher/phrasendrescher-${finalAttrs.version}.tar.gz";
     sha256 = "18vg6h294219v14x5zqm8ddmq5amxlbz7pw81lcmpz8v678kwyph";
   };
 

--- a/pkgs/by-name/pi/pinpoint/package.nix
+++ b/pkgs/by-name/pi/pinpoint/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "pinpoint";
   version = "0.1.8";
   src = fetchurl {
-    url = "http://ftp.gnome.org/pub/GNOME/sources/pinpoint/0.1/pinpoint-${finalAttrs.version}.tar.xz";
+    url = "https://ftp.gnome.org/pub/GNOME/sources/pinpoint/0.1/pinpoint-${finalAttrs.version}.tar.xz";
     sha256 = "1jp8chr9vjlpb5lybwp5cg6g90ak5jdzz9baiqkbg0anlg8ps82s";
   };
   nativeBuildInputs = [

--- a/pkgs/by-name/po/pod2mdoc/package.nix
+++ b/pkgs/by-name/po/pod2mdoc/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.2";
 
   src = fetchurl {
-    url = "http://mdocml.bsd.lv/pod2mdoc/snapshots/pod2mdoc-${finalAttrs.version}.tgz";
+    url = "https://mdocml.bsd.lv/pod2mdoc/snapshots/pod2mdoc-${finalAttrs.version}.tgz";
     hash = "sha256-dPH+MfYdyHauClcD7N1zwjw4EPdtt9uQGCUh9OomsPw=";
   };
 

--- a/pkgs/by-name/po/polygraph/package.nix
+++ b/pkgs/by-name/po/polygraph/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.13.0";
 
   src = fetchurl {
-    url = "http://www.web-polygraph.org/downloads/srcs/polygraph-${finalAttrs.version}-src.tgz";
+    url = "https://www.web-polygraph.org/downloads/srcs/polygraph-${finalAttrs.version}-src.tgz";
     sha256 = "1rwzci3n7q33hw3spd79adnclzwgwlxcisc9szzjmcjqhbkcpj1a";
   };
 

--- a/pkgs/by-name/po/popa3d/package.nix
+++ b/pkgs/by-name/po/popa3d/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.3";
 
   src = fetchurl {
-    url = "http://www.openwall.com/popa3d/popa3d-${finalAttrs.version}.tar.gz";
+    url = "https://www.openwall.com/popa3d/popa3d-${finalAttrs.version}.tar.gz";
     hash = "sha256-A7hT2vnyQm/RjUENM76C7zofCcFQ0spNIhRiTU5jiLw=";
   };
 

--- a/pkgs/by-name/pu/pulseaudio/package.nix
+++ b/pkgs/by-name/pu/pulseaudio/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
   version = "17.0";
 
   src = fetchurl {
-    url = "http://freedesktop.org/software/pulseaudio/releases/pulseaudio-${version}.tar.xz";
+    url = "https://freedesktop.org/software/pulseaudio/releases/pulseaudio-${version}.tar.xz";
     hash = "sha256-BTeU1mcaPjl9hJ5HioC4KmPLnYyilr01tzMXu1zrh7U=";
   };
 

--- a/pkgs/by-name/rr/rrootage/package.nix
+++ b/pkgs/by-name/rr/rrootage/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   pname = "rrootage";
   inherit version;
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/rrootage/rRootage-${version}.tar.gz";
+    url = "https://downloads.sourceforge.net/rrootage/rRootage-${version}.tar.gz";
     sha256 = "01zzg4ih3kmbhsn1p9zr7g8srv1d2dhrp8cdd86y9qq233idnkln";
   };
 

--- a/pkgs/by-name/ru/runit/package.nix
+++ b/pkgs/by-name/ru/runit/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   version = "2.2.0";
 
   src = fetchurl {
-    url = "http://smarden.org/runit/${pname}-${version}.tar.gz";
+    url = "https://smarden.org/runit/${pname}-${version}.tar.gz";
     sha256 = "sha256-le9NKGi5eMcXn+R5AeXFeOEc8nPSkr1iCL06fMsCkpA=";
   };
 

--- a/pkgs/by-name/sa/safefile/package.nix
+++ b/pkgs/by-name/sa/safefile/package.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.5";
 
   src = fetchurl {
-    url = "http://research.cs.wisc.edu/mist/safefile/releases/safefile-${finalAttrs.version}.tar.gz";
+    url = "https://research.cs.wisc.edu/mist/safefile/releases/safefile-${finalAttrs.version}.tar.gz";
     sha256 = "1y0gikds2nr8jk8smhrl617njk23ymmpxyjb2j1xbj0k82xspv78";
   };
 

--- a/pkgs/by-name/sa/saleae-logic/package.nix
+++ b/pkgs/by-name/sa/saleae-logic/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     name = "saleae-logic-${version}-64bit.zip";
-    url = "http://downloads.saleae.com/logic/${version}/Logic%20${version}%20(64-bit).zip";
+    url = "https://downloads.saleae.com/logic/${version}/Logic%20${version}%20(64-bit).zip";
     sha256 = "0lhair2vsg8sjvzicvfcjfmvy30q7i01xj4z02iqh7pgzpb025h8";
   };
 

--- a/pkgs/by-name/sa/samsung-unified-linux-driver_1_00_36/package.nix
+++ b/pkgs/by-name/sa/samsung-unified-linux-driver_1_00_36/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     sha256 = "1a7ngd03x0bkdl7pszy5zqqic0plxvdxqm5w7klr6hbdskx1lir9";
-    url = "http://www.bchemnet.com/suldr/driver/UnifiedLinuxDriver-${finalAttrs.version}.tar.gz";
+    url = "https://www.bchemnet.com/suldr/driver/UnifiedLinuxDriver-${finalAttrs.version}.tar.gz";
   };
 
   buildInputs = [

--- a/pkgs/by-name/sc/scheherazade/package.nix
+++ b/pkgs/by-name/sc/scheherazade/package.nix
@@ -22,7 +22,7 @@ stdenvNoCC.mkDerivation rec {
   inherit pname version;
 
   src = fetchzip {
-    url = "http://software.sil.org/downloads/r/scheherazade/Scheherazade${lib.optionalString new "New"}-${version}.zip";
+    url = "https://software.sil.org/downloads/r/scheherazade/Scheherazade${lib.optionalString new "New"}-${version}.zip";
     inherit hash;
   };
 

--- a/pkgs/by-name/sd/sdparm/package.nix
+++ b/pkgs/by-name/sd/sdparm/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.12";
 
   src = fetchurl {
-    url = "http://sg.danny.cz/sg/p/sdparm-${finalAttrs.version}.tar.xz";
+    url = "https://sg.danny.cz/sg/p/sdparm-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-xMnvr9vrZi4vlxJwfsSQkyvU0BC7ESmueplSZUburb4=";
   };
 

--- a/pkgs/by-name/se/selenium-server-standalone/package.nix
+++ b/pkgs/by-name/se/selenium-server-standalone/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   version = "${minorVersion}.${patchVersion}";
 
   src = fetchurl {
-    url = "http://selenium-release.storage.googleapis.com/${minorVersion}/selenium-server-standalone-${version}.jar";
+    url = "https://selenium-release.storage.googleapis.com/${minorVersion}/selenium-server-standalone-${version}.jar";
     sha256 = "1jzkx0ahsb27zzzfvjqv660x9fz2pbcddgmhdzdmasxns5vipxxc";
   };
 

--- a/pkgs/by-name/se/serviio/package.nix
+++ b/pkgs/by-name/se/serviio/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   version = "2.4";
 
   src = fetchurl {
-    url = "http://download.serviio.org/releases/${pname}-${version}-linux.tar.gz";
+    url = "https://download.serviio.org/releases/${pname}-${version}-linux.tar.gz";
     sha256 = "sha256-ssi2fKbAMizr5eLAMng+G25ui3v98zCNWzMg7uLgGas=";
   };
 

--- a/pkgs/by-name/sf/sfxr/package.nix
+++ b/pkgs/by-name/sf/sfxr/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.2.1";
 
   src = fetchurl {
-    url = "http://www.drpetter.se/files/sfxr-sdl-${finalAttrs.version}.tar.gz";
+    url = "https://www.drpetter.se/files/sfxr-sdl-${finalAttrs.version}.tar.gz";
     sha256 = "0dfqgid6wzzyyhc0ha94prxax59wx79hqr25r6if6by9cj4vx4ya";
   };
 

--- a/pkgs/by-name/sg/sgt-puzzles/package.nix
+++ b/pkgs/by-name/sg/sgt-puzzles/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "20260309.06e37f1";
 
   src = fetchurl {
-    url = "http://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles-${finalAttrs.version}.tar.gz";
+    url = "https://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles-${finalAttrs.version}.tar.gz";
     hash = "sha256-3Z/Qp8D/0DeJL9oZlKL6vx9BXvMVFa6MMnkStds/VHI=";
   };
 

--- a/pkgs/by-name/si/siege/package.nix
+++ b/pkgs/by-name/si/siege/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.1.7";
 
   src = fetchurl {
-    url = "http://download.joedog.org/siege/siege-${finalAttrs.version}.tar.gz";
+    url = "https://download.joedog.org/siege/siege-${finalAttrs.version}.tar.gz";
     hash = "sha256-7BQM7dFZl5OD1g2+h6AVHCwSraeHkQlaj6hK5jW5MCY=";
   };
 

--- a/pkgs/by-name/si/sipcalc/package.nix
+++ b/pkgs/by-name/si/sipcalc/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1.6";
 
   src = fetchurl {
-    url = "http://www.routemeister.net/projects/sipcalc/files/sipcalc-${finalAttrs.version}.tar.gz";
+    url = "https://www.routemeister.net/projects/sipcalc/files/sipcalc-${finalAttrs.version}.tar.gz";
     sha256 = "cfd476c667f7a119e49eb5fe8adcfb9d2339bc2e0d4d01a1d64b7c229be56357";
   };
 

--- a/pkgs/by-name/sm/smack/package.nix
+++ b/pkgs/by-name/sm/smack/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.1.9";
 
   src = fetchurl {
-    url = "http://www.igniterealtime.org/downloadServlet?filename=smack/smack_${
+    url = "https://www.igniterealtime.org/downloadServlet?filename=smack/smack_${
       lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version
     }.tar.gz";
     sha256 = "009x0qcxd4dkvwcjz2nla470pwbabwvg37wc21pslpw42ldi0bzp";

--- a/pkgs/by-name/sn/snmpcheck/package.nix
+++ b/pkgs/by-name/sn/snmpcheck/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "snmpcheck";
   version = "1.9";
   src = fetchurl {
-    url = "http://www.nothink.org/codes/snmpcheck/snmpcheck-${finalAttrs.version}.rb";
+    url = "https://www.nothink.org/codes/snmpcheck/snmpcheck-${finalAttrs.version}.rb";
     sha256 = "sha256-9xkLqbgxU1uykx+M9QsbPAH8OI/Cqn9uw6ALe23Lbq0=";
     executable = true;
   };

--- a/pkgs/by-name/sp/spass/package.nix
+++ b/pkgs/by-name/sp/spass/package.nix
@@ -20,7 +20,7 @@ gccStdenv.mkDerivation {
   version = "${baseVersion}.${minorVersion}";
 
   src = fetchurl {
-    url = "http://www.spass-prover.org/download/sources/spass${baseVersion}${minorVersion}.tgz";
+    url = "https://www.spass-prover.org/download/sources/spass${baseVersion}${minorVersion}.tgz";
     sha256 = "11cyn3kcff4r79rsw2s0xm6rdb8bi0kpkazv2b48jhcms7xw75qp";
   };
 

--- a/pkgs/by-name/sp/sphinxsearch/package.nix
+++ b/pkgs/by-name/sp/sphinxsearch/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.2.11";
 
   src = fetchurl {
-    url = "http://sphinxsearch.com/files/sphinx-${finalAttrs.version}-release.tar.gz";
+    url = "https://sphinxsearch.com/files/sphinx-${finalAttrs.version}-release.tar.gz";
     sha256 = "1aa1mh32y019j8s3sjzn4vwi0xn83dwgl685jnbgh51k16gh6qk6";
   };
 

--- a/pkgs/by-name/sp/spooles/package.nix
+++ b/pkgs/by-name/sp/spooles/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.2";
 
   src = fetchurl {
-    url = "http://www.netlib.org/linalg/spooles/spooles.${finalAttrs.version}.tgz";
+    url = "https://www.netlib.org/linalg/spooles/spooles.${finalAttrs.version}.tgz";
     sha256 = "1pf5z3vvwd8smbpibyabprdvcmax0grzvx2y0liy98c7x6h5jid8";
   };
 

--- a/pkgs/by-name/st/stacks/package.nix
+++ b/pkgs/by-name/st/stacks/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "stacks";
   version = "2.68";
   src = fetchurl {
-    url = "http://catchenlab.life.illinois.edu/stacks/source/stacks-${finalAttrs.version}.tar.gz";
+    url = "https://catchenlab.life.illinois.edu/stacks/source/stacks-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-ncUeo1bWDrRVewstGohUqvrkkq7Yf5dOAknMCapedlA=";
   };
 

--- a/pkgs/by-name/st/statserial/package.nix
+++ b/pkgs/by-name/st/statserial/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1";
 
   src = fetchurl {
-    url = "http://www.ibiblio.org/pub/Linux/system/serial/statserial-${finalAttrs.version}.tar.gz";
+    url = "https://www.ibiblio.org/pub/Linux/system/serial/statserial-${finalAttrs.version}.tar.gz";
     sha256 = "0rrrmxfba5yn836zlgmr8g9xnrpash7cjs7lk2m44ac50vakpks0";
   };
 

--- a/pkgs/by-name/st/stone/package.nix
+++ b/pkgs/by-name/st/stone/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.4";
 
   src = fetchurl {
-    url = "http://www.gcd.org/sengoku/stone/stone-${finalAttrs.version}.tar.gz";
+    url = "https://www.gcd.org/sengoku/stone/stone-${finalAttrs.version}.tar.gz";
     hash = "sha256-1dwa9uxdpQPypAs98/4ZqPv5085pa49G9NU9KsjY628=";
   };
 

--- a/pkgs/by-name/sw/swfmill/package.nix
+++ b/pkgs/by-name/sw/swfmill/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.6";
 
   src = fetchurl {
-    url = "http://swfmill.org/releases/swfmill-${finalAttrs.version}.tar.gz";
+    url = "https://swfmill.org/releases/swfmill-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-2yT2OWOVf67AK7FLi2HNr3CWd0+M/eudNXPi4ZIxVI4=";
   };
 

--- a/pkgs/by-name/sw/swiften/package.nix
+++ b/pkgs/by-name/sw/swiften/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.0.3";
 
   src = fetchurl {
-    url = "http://swift.im/git/swift/snapshot/swift-${finalAttrs.version}.tar.bz2";
+    url = "https://swift.im/git/swift/snapshot/swift-${finalAttrs.version}.tar.bz2";
     hash = "sha256-aj+T6AevtR8birbsj+83nfzFC6cf72q+7nwSM0jaZrA=";
   };
 

--- a/pkgs/by-name/ta/tango-icon-theme/package.nix
+++ b/pkgs/by-name/ta/tango-icon-theme/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.8.90";
 
   src = fetchurl {
-    url = "http://tango.freedesktop.org/releases/tango-icon-theme-${finalAttrs.version}.tar.gz";
+    url = "https://tango.freedesktop.org/releases/tango-icon-theme-${finalAttrs.version}.tar.gz";
     sha256 = "13n8cpml71w6zfm2jz5fa7r1z18qlzk4gv07r6n1in2p5l1xi63f";
   };
 

--- a/pkgs/by-name/te/ted/package.nix
+++ b/pkgs/by-name/te/ted/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   version = "2.23";
 
   src = fetchurl {
-    url = "http://ftp.nluug.nl/pub/editors/ted/ted-${version}.src.tar.gz";
+    url = "https://ftp.nluug.nl/pub/editors/ted/ted-${version}.src.tar.gz";
     hash = "sha256-P6mSwryWrzyniO+UHLUxT0odhDIC79AgG4tO6a2/MWw=";
   };
 

--- a/pkgs/by-name/te/telepathy-idle/package.nix
+++ b/pkgs/by-name/te/telepathy-idle/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.2.2";
 
   src = fetchurl {
-    url = "http://telepathy.freedesktop.org/releases/telepathy-idle/telepathy-idle-${finalAttrs.version}.tar.gz";
+    url = "https://telepathy.freedesktop.org/releases/telepathy-idle/telepathy-idle-${finalAttrs.version}.tar.gz";
     hash = "sha256-g4fiXl+wtMvnAeXcCS1mbWUQuDP9Pn5GLpFw027DwV8=";
   };
 

--- a/pkgs/by-name/te/tetgen/package.nix
+++ b/pkgs/by-name/te/tetgen/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.6.0";
 
   src = fetchurl {
-    url = "http://wias-berlin.de/software/tetgen/1.5/src/tetgen${finalAttrs.version}.tar.gz";
+    url = "https://wias-berlin.de/software/tetgen/1.5/src/tetgen${finalAttrs.version}.tar.gz";
     sha256 = "sha256-h7XmHr06Rx/E8s3XEkwrEd1mOfT+sflBpdL1EQ0Fzjk=";
   };
 

--- a/pkgs/by-name/te/texi2mdoc/package.nix
+++ b/pkgs/by-name/te/texi2mdoc/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1.2";
 
   src = fetchurl {
-    url = "http://mdocml.bsd.lv/texi2mdoc/snapshots/texi2mdoc-${finalAttrs.version}.tgz";
+    url = "https://mdocml.bsd.lv/texi2mdoc/snapshots/texi2mdoc-${finalAttrs.version}.tgz";
     sha256 = "1zjb61ymwfkw6z5g0aqmsn6qpw895zdxv7fv3059gj3wqa3zsibs";
   };
 

--- a/pkgs/by-name/te/texmaker/package.nix
+++ b/pkgs/by-name/te/texmaker/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "6.0.1";
 
   src = fetchurl {
-    url = "http://www.xm1math.net/texmaker/texmaker-${finalAttrs.version}.tar.bz2";
+    url = "https://www.xm1math.net/texmaker/texmaker-${finalAttrs.version}.tar.bz2";
     hash = "sha256-uMI13wzY/XcUzXDTte42MWOwJUqd6pGAeBuPDi5GyvY=";
   };
 

--- a/pkgs/by-name/ti/tie/package.nix
+++ b/pkgs/by-name/ti/tie/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.4";
 
   src = fetchurl {
-    url = "http://mirrors.ctan.org/web/tie/tie-${finalAttrs.version}.tar.gz";
+    url = "https://mirrors.ctan.org/web/tie/tie-${finalAttrs.version}.tar.gz";
     sha256 = "1m5952kdfffiz33p1jw0wv7dh272mmw28mpxw9v7lkb352zv4xsj";
   };
 

--- a/pkgs/by-name/ti/tigerjython/package.nix
+++ b/pkgs/by-name/ti/tigerjython/package.nix
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   # - Unselect "Save Error Pages" and hit "Save Page" again.
   # - Wait for the archive link to be generated and copy it to the url field - adjust hash accordingly.
   src = fetchurl {
-    url = "http://web.archive.org/web/20250104142121/https://tjgroup.ch/download/TigerJython.tar.gz";
+    url = "https://web.archive.org/web/20250104142121/https://tjgroup.ch/download/TigerJython.tar.gz";
     hash = "sha256-V/POFftRs/jjgNaHOrKcW2AdlQY2yjO+xiwJi63oECo=";
   };
 

--- a/pkgs/by-name/ti/titanion/package.nix
+++ b/pkgs/by-name/ti/titanion/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3";
 
   src = fetchurl {
-    url = "http://abagames.sakura.ne.jp/windows/ttn${
+    url = "https://abagames.sakura.ne.jp/windows/ttn${
       lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version
     }.zip";
     hash = "sha256-fR0cufi6dU898wP8KGl/vxbfQJzMmMxlYZ3QNGLajfM=";

--- a/pkgs/by-name/to/torus-trooper/package.nix
+++ b/pkgs/by-name/to/torus-trooper/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.22";
 
   src = fetchurl {
-    url = "http://abagames.sakura.ne.jp/windows/tt${
+    url = "https://abagames.sakura.ne.jp/windows/tt${
       lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version
     }.zip";
     sha256 = "1yhki1fdp3fi4y2iq12vca69f6k38dqjaw9z4lwcxky5kbgb7jvg";

--- a/pkgs/by-name/tt/ttf-envy-code-r/package.nix
+++ b/pkgs/by-name/tt/ttf-envy-code-r/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "PR7";
 
   src = fetchzip {
-    url = "http://download.damieng.com/fonts/original/EnvyCodeR-${version}.zip";
+    url = "https://download.damieng.com/fonts/original/EnvyCodeR-${version}.zip";
     hash = "sha256-pJqC/sbNjxEwbVf2CVoXMBI5zvT3DqzRlKSqFT8I2sM=";
   };
 

--- a/pkgs/by-name/tu/tumiki-fighters/package.nix
+++ b/pkgs/by-name/tu/tumiki-fighters/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.21";
 
   src = fetchurl {
-    url = "http://abagames.sakura.ne.jp/windows/tf${
+    url = "https://abagames.sakura.ne.jp/windows/tf${
       lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version
     }.zip";
     sha256 = "0djykfc1r8ysapklm621h89ana1c4qzc1m5nr9bqw4iccnmvwk3p";

--- a/pkgs/by-name/ud/udns/package.nix
+++ b/pkgs/by-name/ud/udns/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = "make staticlib sharedlib rblcheck_s dnsget_s";
 
   src = fetchurl {
-    url = "http://www.corpit.ru/mjt/udns/udns-${finalAttrs.version}.tar.gz";
+    url = "https://www.corpit.ru/mjt/udns/udns-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-aWotDVGNqYXZdaZeEdFm8/V829HUI3aguFMH9JYBxug=";
   };
 

--- a/pkgs/by-name/ui/uif2iso/package.nix
+++ b/pkgs/by-name/ui/uif2iso/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "0.1.7";
 
   src = fetchurl {
-    url = "http://aluigi.altervista.org/mytoolz/uif2iso.zip";
+    url = "https://aluigi.altervista.org/mytoolz/uif2iso.zip";
     sha256 = "1v18fmlzhkkhv8xdc9dyvl8vamwg3ka4dsrg7vvmk1f2iczdx3dp";
   };
 

--- a/pkgs/by-name/un/uni-vga/package.nix
+++ b/pkgs/by-name/un/uni-vga/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2002-10-31";
 
   src = fetchurl {
-    url = "http://www.inp.nsk.su/~bolkhov/files/fonts/univga/uni-vga.tgz";
+    url = "https://www.inp.nsk.su/~bolkhov/files/fonts/univga/uni-vga.tgz";
     sha256 = "05sns8h5yspa7xkl81ri7y1yxf5icgsnl497f3xnaryhx11s2rv6";
   };
 

--- a/pkgs/by-name/vd/vdmfec/package.nix
+++ b/pkgs/by-name/vd/vdmfec/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0";
 
   src = fetchurl {
-    url = "http://members.tripod.com/professor_tom/archives/vdmfec-${finalAttrs.version}.tgz";
+    url = "https://members.tripod.com/professor_tom/archives/vdmfec-${finalAttrs.version}.tgz";
     sha256 = "0i7q4ylx2xmzzq778anpkj4nqir5gf573n1lbpxnbc10ymsjq2rm";
   };
 

--- a/pkgs/by-name/vn/vncrec/package.nix
+++ b/pkgs/by-name/vn/vncrec/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   version = "0.2"; # version taken from Arch AUR
 
   src = fetchurl {
-    url = "http://ronja.twibright.com/utils/vncrec-twibright.tgz";
+    url = "https://ronja.twibright.com/utils/vncrec-twibright.tgz";
     sha256 = "1yp6r55fqpdhc8cgrgh9i0mzxmkls16pgf8vfcpng1axr7cigyhc";
   };
 

--- a/pkgs/by-name/vo/vorbis-tools/package.nix
+++ b/pkgs/by-name/vo/vorbis-tools/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.4.3";
 
   src = fetchurl {
-    url = "http://downloads.xiph.org/releases/vorbis/vorbis-tools-${finalAttrs.version}.tar.gz";
+    url = "https://downloads.xiph.org/releases/vorbis/vorbis-tools-${finalAttrs.version}.tar.gz";
     hash = "sha256-of493Gd3vc6/a3l+ft/gQ3lUskdW/8yMa4FrY+BGDd4=";
   };
 

--- a/pkgs/by-name/wd/wdfs/package.nix
+++ b/pkgs/by-name/wd/wdfs/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.4.2";
 
   src = fetchurl {
-    url = "http://noedler.de/projekte/wdfs/wdfs-${finalAttrs.version}.tar.gz";
+    url = "https://noedler.de/projekte/wdfs/wdfs-${finalAttrs.version}.tar.gz";
     sha256 = "fcf2e1584568b07c7f3683a983a9be26fae6534b8109e09167e5dff9114ba2e5";
   };
   nativeBuildInputs = [

--- a/pkgs/by-name/we/weather/package.nix
+++ b/pkgs/by-name/we/weather/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "weather";
 
   src = fetchurl {
-    url = "http://fungi.yuggoth.org/weather/src/weather-${finalAttrs.version}.tar.xz";
+    url = "https://fungi.yuggoth.org/weather/src/weather-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-wn3cpgfrlqntMIiVFh4317DrbGgQ4YRnFz3KHXacTw4=";
   };
 

--- a/pkgs/by-name/wo/wordnet/package.nix
+++ b/pkgs/by-name/wo/wordnet/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.0";
   pname = "wordnet";
   src = fetchurl {
-    url = "http://wordnetcode.princeton.edu/${finalAttrs.version}/WordNet-${finalAttrs.version}.tar.bz2";
+    url = "https://wordnetcode.princeton.edu/${finalAttrs.version}/WordNet-${finalAttrs.version}.tar.bz2";
     sha256 = "08pgjvd2vvmqk3h641x63nxp7wqimb9r30889mkyfh2agc62sjbc";
   };
 

--- a/pkgs/by-name/x1/x11_ssh_askpass/package.nix
+++ b/pkgs/by-name/x1/x11_ssh_askpass/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchurl {
-    url = "http://pkgs.fedoraproject.org/repo/pkgs/openssh/x11-ssh-askpass-${finalAttrs.version}.tar.gz/8f2e41f3f7eaa8543a2440454637f3c3/x11-ssh-askpass-${finalAttrs.version}.tar.gz";
+    url = "https://pkgs.fedoraproject.org/repo/pkgs/openssh/x11-ssh-askpass-${finalAttrs.version}.tar.gz/8f2e41f3f7eaa8543a2440454637f3c3/x11-ssh-askpass-${finalAttrs.version}.tar.gz";
     sha256 = "620de3c32ae72185a2c9aeaec03af24242b9621964e38eb625afb6cdb30b8c88";
   };
 

--- a/pkgs/by-name/x3/x3270/package.nix
+++ b/pkgs/by-name/x3/x3270/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "${majorVersion}.${minorVersion}${versionSuffix}";
 
   src = fetchurl {
-    url = "http://x3270.bgp.nu/download/0${majorVersion}.0${minorVersion}/suite3270-${finalAttrs.version}-src.tgz";
+    url = "https://x3270.bgp.nu/download/0${majorVersion}.0${minorVersion}/suite3270-${finalAttrs.version}-src.tgz";
     hash = "sha256-hDju5ZeVzTv78ZYwUzabmqMK9rheTZJ7clTSTpkkM7E=";
   };
 

--- a/pkgs/by-name/xc/xchainkeys/package.nix
+++ b/pkgs/by-name/xc/xchainkeys/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.11";
 
   src = fetchurl {
-    url = "http://henning-bekel.de/download/xchainkeys/xchainkeys-${finalAttrs.version}.tar.gz";
+    url = "https://henning-bekel.de/download/xchainkeys/xchainkeys-${finalAttrs.version}.tar.gz";
     sha256 = "1rpqs7h5krral08vqxwb0imy33z17v5llvrg5hy8hkl2ap7ya0mn";
   };
 

--- a/pkgs/by-name/xc/xcowsay/package.nix
+++ b/pkgs/by-name/xc/xcowsay/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.6";
 
   src = fetchurl {
-    url = "http://www.nickg.me.uk/files/xcowsay-${finalAttrs.version}.tar.gz";
+    url = "https://www.nickg.me.uk/files/xcowsay-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-RqzoZP8o0tIfS3BY8CleGNAEGhIMEHipUfpDxOD1yMU=";
   };
 

--- a/pkgs/by-name/xe/xearth/package.nix
+++ b/pkgs/by-name/xe/xearth/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1";
 
   src = fetchurl {
-    url = "http://xearth.org/xearth-${finalAttrs.version}.tar.gz";
+    url = "https://xearth.org/xearth-${finalAttrs.version}.tar.gz";
     hash = "sha256-vLFAfMNbP23TYGssYHInO2qRLL2e0a4i+y0maUVBMJw=";
   };
 

--- a/pkgs/by-name/xm/xmage/package.nix
+++ b/pkgs/by-name/xm/xmage/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.4.58-dev_2025-10-06_20-40";
 
   src = fetchurl {
-    url = "http://xmage.today/files/mage-full_${finalAttrs.version}.zip";
+    url = "https://xmage.today/files/mage-full_${finalAttrs.version}.zip";
     sha256 = "sha256-UOtxV+ykDIH+PLjLrC66Rut92IIw2iDHWwvJ2ytmUAs=";
   };
 

--- a/pkgs/by-name/xv/xvkbd/package.nix
+++ b/pkgs/by-name/xv/xvkbd/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "xvkbd";
   version = "4.1";
   src = fetchurl {
-    url = "http://t-sato.in.coocan.jp/xvkbd/xvkbd-${finalAttrs.version}.tar.gz";
+    url = "https://t-sato.in.coocan.jp/xvkbd/xvkbd-${finalAttrs.version}.tar.gz";
     sha256 = "1x5yldv9y99cw5hzzs73ygdn1z80zns9hz0baa355r711zghfbcm";
   };
 

--- a/pkgs/by-name/ya/yabasic/package.nix
+++ b/pkgs/by-name/ya/yabasic/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.91.4";
 
   src = fetchurl {
-    url = "http://www.yabasic.de/download/yabasic-${finalAttrs.version}.tar.gz";
+    url = "https://www.yabasic.de/download/yabasic-${finalAttrs.version}.tar.gz";
     hash = "sha256-3JUTNOFmZpSlAx40BHAT6YQgYLxdVPPXLwyfzDoYdlc=";
   };
 

--- a/pkgs/by-name/zi/zita-alsa-pcmi/package.nix
+++ b/pkgs/by-name/zi/zita-alsa-pcmi/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "zita-alsa-pcmi";
   version = "0.6.1";
   src = fetchurl {
-    url = "http://kokkinizita.linuxaudio.org/linuxaudio/downloads/zita-alsa-pcmi-${finalAttrs.version}.tar.bz2";
+    url = "https://kokkinizita.linuxaudio.org/linuxaudio/downloads/zita-alsa-pcmi-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-iil6zj16R0Ex7T+jIQacExM3eFtWojfW8WjIXueW1Ww=";
   };
 

--- a/pkgs/by-name/zp/zpaqd/package.nix
+++ b/pkgs/by-name/zp/zpaqd/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "715";
 
   src = fetchurl {
-    url = "http://mattmahoney.net/dc/zpaqd${finalAttrs.version}.zip";
+    url = "https://mattmahoney.net/dc/zpaqd${finalAttrs.version}.zip";
     sha256 = "sha256-Mx87Zt0AASk0ZZCjyTzYbhlYJAXBlb59OpUWsqynyCA=";
   };
 

--- a/pkgs/by-name/zt/ztools/package.nix
+++ b/pkgs/by-name/zt/ztools/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "7/3.1";
 
   src = fetchurl {
-    url = "http://mirror.ifarchive.org/if-archive/infocom/tools/ztools/ztools731.tar.gz";
+    url = "https://mirror.ifarchive.org/if-archive/infocom/tools/ztools/ztools731.tar.gz";
     hash = "sha256-vlQX0/fCAr88KJwMnYUSROFOg9tfVK5Hz58AUDuhNXg=";
   };
 

--- a/pkgs/data/fonts/tex-gyre-math/default.nix
+++ b/pkgs/data/fonts/tex-gyre-math/default.nix
@@ -48,7 +48,7 @@ let
       inherit version;
 
       src = fetchzip {
-        url = "http://www.gust.org.pl/projects/e-foundry/tg-math/download/texgyre${variant}-math-${dotless_version}.zip";
+        url = "https://www.gust.org.pl/projects/e-foundry/tg-math/download/texgyre${variant}-math-${dotless_version}.zip";
         inherit sha256;
       };
 

--- a/pkgs/data/fonts/tex-gyre/default.nix
+++ b/pkgs/data/fonts/tex-gyre/default.nix
@@ -18,7 +18,7 @@ let
       inherit version;
 
       src = fetchzip {
-        url = "http://www.gust.org.pl/projects/e-foundry/tex-gyre/${variant}/${abbreviation}${version}otf.zip";
+        url = "https://www.gust.org.pl/projects/e-foundry/tex-gyre/${variant}/${abbreviation}${version}otf.zip";
         stripRoot = false;
         inherit sha256;
       };

--- a/pkgs/desktops/enlightenment/ecrire/default.nix
+++ b/pkgs/desktops/enlightenment/ecrire/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   version = "0.2.0";
 
   src = fetchurl {
-    url = "http://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
+    url = "https://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
     sha256 = "1pszk583rzclfqy3dyjh1m9pz1hnr84vqz8vw9kngcnmj23mjr6r";
   };
 

--- a/pkgs/desktops/enlightenment/efl/default.nix
+++ b/pkgs/desktops/enlightenment/efl/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
   version = "1.28.1";
 
   src = fetchurl {
-    url = "http://download.enlightenment.org/rel/libs/${pname}/${pname}-${version}.tar.xz";
+    url = "https://download.enlightenment.org/rel/libs/${pname}/${pname}-${version}.tar.xz";
     sha256 = "sha256-hM9hRfnMgr//aQAFviQ5LI88UvjgD/BNjuo3FCnAlCQ=";
   };
 

--- a/pkgs/desktops/enlightenment/ephoto/default.nix
+++ b/pkgs/desktops/enlightenment/ephoto/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   version = "1.6.0";
 
   src = fetchurl {
-    url = "http://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
+    url = "https://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
     sha256 = "1lvhcs4ba8h3z78nyycbww8mj4cscb8k200dcc3cdy8vrvrp7g1n";
   };
 

--- a/pkgs/desktops/enlightenment/rage/default.nix
+++ b/pkgs/desktops/enlightenment/rage/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   version = "0.4.0";
 
   src = fetchurl {
-    url = "http://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
+    url = "https://download.enlightenment.org/rel/apps/${pname}/${pname}-${version}.tar.xz";
     sha256 = "03yal7ajh57x2jhmygc6msf3gzvqkpmzkqzj6dnam5sim8cq9rbw";
   };
 

--- a/pkgs/development/compilers/ocaml/ber-metaocaml.nix
+++ b/pkgs/development/compilers/ocaml/ber-metaocaml.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   metaocaml = fetchurl {
-    url = "http://okmij.org/ftp/ML/ber-metaocaml-${metaocamlPatch}.tar.gz";
+    url = "https://okmij.org/ftp/ML/ber-metaocaml-${metaocamlPatch}.tar.gz";
     sha256 = "sha256-vvq3xI4jSAsrXcDk97TPbFDYgO9NcQeN/yBcUbcb/y0=";
   };
 

--- a/pkgs/development/interpreters/python/cpython/docs/2.7-html.nix
+++ b/pkgs/development/interpreters/python/cpython/docs/2.7-html.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "2.7.18";
 
   src = fetchurl {
-    url = "http://www.python.org/ftp/python/doc/2.7.18/python-2.7.18-docs-html.tar.bz2";
+    url = "https://www.python.org/ftp/python/doc/2.7.18/python-2.7.18-docs-html.tar.bz2";
     sha256 = "03igxwpqc2lvzspnj78zz1prnmfwwj00jbvh1wsxvb0wayd5wi10";
   };
   installPhase = ''

--- a/pkgs/development/interpreters/python/cpython/docs/2.7-pdf-a4.nix
+++ b/pkgs/development/interpreters/python/cpython/docs/2.7-pdf-a4.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "2.7.18";
 
   src = fetchurl {
-    url = "http://www.python.org/ftp/python/doc/2.7.18/python-2.7.18-docs-pdf-a4.tar.bz2";
+    url = "https://www.python.org/ftp/python/doc/2.7.18/python-2.7.18-docs-pdf-a4.tar.bz2";
     sha256 = "0rxb2fpxwivjpk5wi2pl1fqibr4khf9s0yq6a49k9b4awi9nkb6v";
   };
   installPhase = ''

--- a/pkgs/development/interpreters/python/cpython/docs/2.7-pdf-letter.nix
+++ b/pkgs/development/interpreters/python/cpython/docs/2.7-pdf-letter.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "2.7.18";
 
   src = fetchurl {
-    url = "http://www.python.org/ftp/python/doc/2.7.18/python-2.7.18-docs-pdf-letter.tar.bz2";
+    url = "https://www.python.org/ftp/python/doc/2.7.18/python-2.7.18-docs-pdf-letter.tar.bz2";
     sha256 = "07hbqvrdlq01cb95r1574bxqqhiqbkj4f92wzlq4d6dq1l272nan";
   };
   installPhase = ''

--- a/pkgs/development/interpreters/python/cpython/docs/2.7-text.nix
+++ b/pkgs/development/interpreters/python/cpython/docs/2.7-text.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "2.7.18";
 
   src = fetchurl {
-    url = "http://www.python.org/ftp/python/doc/2.7.18/python-2.7.18-docs-text.tar.bz2";
+    url = "https://www.python.org/ftp/python/doc/2.7.18/python-2.7.18-docs-text.tar.bz2";
     sha256 = "1wj7mxs52kp5lmn5mvv574sygkfnk00kbz9ya9c03yfq5dd5nvy8";
   };
   installPhase = ''

--- a/pkgs/development/interpreters/python/cpython/docs/3.10-html.nix
+++ b/pkgs/development/interpreters/python/cpython/docs/3.10-html.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "3.10.7";
 
   src = fetchurl {
-    url = "http://www.python.org/ftp/python/doc/3.10.7/python-3.10.7-docs-html.tar.bz2";
+    url = "https://www.python.org/ftp/python/doc/3.10.7/python-3.10.7-docs-html.tar.bz2";
     sha256 = "0j86z1vmaghzj5i4frvzyfb9qwsmm09g4f4ssx5w27cm30b8k0v1";
   };
   installPhase = ''

--- a/pkgs/development/interpreters/python/cpython/docs/3.10-pdf-a4.nix
+++ b/pkgs/development/interpreters/python/cpython/docs/3.10-pdf-a4.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "3.10.7";
 
   src = fetchurl {
-    url = "http://www.python.org/ftp/python/doc/3.10.7/python-3.10.7-docs-pdf-a4.tar.bz2";
+    url = "https://www.python.org/ftp/python/doc/3.10.7/python-3.10.7-docs-pdf-a4.tar.bz2";
     sha256 = "1gvi457dsj3ywwvxysp7idkk9ndngnby1dnfh1q8f5gv3kg4093r";
   };
   installPhase = ''

--- a/pkgs/development/interpreters/python/cpython/docs/3.10-pdf-letter.nix
+++ b/pkgs/development/interpreters/python/cpython/docs/3.10-pdf-letter.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "3.10.7";
 
   src = fetchurl {
-    url = "http://www.python.org/ftp/python/doc/3.10.7/python-3.10.7-docs-pdf-letter.tar.bz2";
+    url = "https://www.python.org/ftp/python/doc/3.10.7/python-3.10.7-docs-pdf-letter.tar.bz2";
     sha256 = "0hzq5n6absqsh21jp6j5iaim9a1wq69d8lc2assldzb2zg4i75hr";
   };
   installPhase = ''

--- a/pkgs/development/interpreters/python/cpython/docs/3.10-texinfo.nix
+++ b/pkgs/development/interpreters/python/cpython/docs/3.10-texinfo.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "3.10.7";
 
   src = fetchurl {
-    url = "http://www.python.org/ftp/python/doc/3.10.7/python-3.10.7-docs-texinfo.tar.bz2";
+    url = "https://www.python.org/ftp/python/doc/3.10.7/python-3.10.7-docs-texinfo.tar.bz2";
     sha256 = "0p0fifi84ijz4ng6krw7c1x965jhgysprkijblmlnax7x9rmqrdf";
   };
   installPhase = ''

--- a/pkgs/development/interpreters/python/cpython/docs/3.10-text.nix
+++ b/pkgs/development/interpreters/python/cpython/docs/3.10-text.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "3.10.7";
 
   src = fetchurl {
-    url = "http://www.python.org/ftp/python/doc/3.10.7/python-3.10.7-docs-text.tar.bz2";
+    url = "https://www.python.org/ftp/python/doc/3.10.7/python-3.10.7-docs-text.tar.bz2";
     sha256 = "1zbmm2fvdjnl214y41yffyqw3ywfai5r5npc00n1wkfxsdp7gcc3";
   };
   installPhase = ''

--- a/pkgs/development/libraries/celt/0.5.1.nix
+++ b/pkgs/development/libraries/celt/0.5.1.nix
@@ -6,7 +6,7 @@ callPackage ./generic.nix (
     version = "0.5.1.3";
 
     src = fetchurl {
-      url = "http://downloads.xiph.org/releases/celt/celt-${version}.tar.gz";
+      url = "https://downloads.xiph.org/releases/celt/celt-${version}.tar.gz";
       sha256 = "0bkam9z5vnrxpbxkkh9kw6yzjka9di56h11iijikdd1f71l5nbpw";
     };
 

--- a/pkgs/development/libraries/celt/0.7.nix
+++ b/pkgs/development/libraries/celt/0.7.nix
@@ -6,7 +6,7 @@ callPackage ./generic.nix (
     version = "0.7.1";
 
     src = fetchurl {
-      url = "http://downloads.xiph.org/releases/celt/celt-${version}.tar.gz";
+      url = "https://downloads.xiph.org/releases/celt/celt-${version}.tar.gz";
       sha256 = "0rihjgzrqcprsv8a1pmiglwik7xqbs2yw3fwd6gb28chnpgy5w4k";
     };
   }

--- a/pkgs/development/libraries/celt/default.nix
+++ b/pkgs/development/libraries/celt/default.nix
@@ -6,7 +6,7 @@ callPackage ./generic.nix (
     version = "0.11.3";
 
     src = fetchurl {
-      url = "http://downloads.xiph.org/releases/celt/celt-${version}.tar.gz";
+      url = "https://downloads.xiph.org/releases/celt/celt-${version}.tar.gz";
       sha256 = "0dh893wqbh0q4a0x1xyqryykmnhpv7mkblpch019s04a99fq2r3y";
     };
   }

--- a/pkgs/development/libraries/librdf/rasqal.nix
+++ b/pkgs/development/libraries/librdf/rasqal.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.9.33";
 
   src = fetchurl {
-    url = "http://download.librdf.org/source/rasqal-${finalAttrs.version}.tar.gz";
+    url = "https://download.librdf.org/source/rasqal-${finalAttrs.version}.tar.gz";
     sha256 = "0z6rrwn4jsagvarg8d5zf0j352kjgi33py39jqd29gbhcnncj939";
   };
 

--- a/pkgs/development/libraries/librdf/redland.nix
+++ b/pkgs/development/libraries/librdf/redland.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   version = "1.0.17";
 
   src = fetchurl {
-    url = "http://download.librdf.org/source/redland-${version}.tar.gz";
+    url = "https://download.librdf.org/source/redland-${version}.tar.gz";
     sha256 = "de1847f7b59021c16bdc72abb4d8e2d9187cd6124d69156f3326dd34ee043681";
   };
 

--- a/pkgs/development/libraries/libunique/3.x.nix
+++ b/pkgs/development/libraries/libunique/3.x.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   srcName = "libunique-${version}";
 
   src = fetchurl {
-    url = "http://ftp.gnome.org/pub/GNOME/sources/libunique/${majorVer}/${srcName}.tar.xz";
+    url = "https://ftp.gnome.org/pub/GNOME/sources/libunique/${majorVer}/${srcName}.tar.xz";
     sha256 = "0f70lkw66v9cj72q0iw1s2546r6bwwcd8idcm3621fg2fgh2rw58";
   };
 

--- a/pkgs/development/libraries/physics/hepmc3/default.nix
+++ b/pkgs/development/libraries/physics/hepmc3/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   version = "3.3.1";
 
   src = fetchurl {
-    url = "http://hepmc.web.cern.ch/hepmc/releases/HepMC3-${version}.tar.gz";
+    url = "https://hepmc.web.cern.ch/hepmc/releases/HepMC3-${version}.tar.gz";
     sha256 = "sha256-CCQBYLDyjcMpOqTWHOZeLWfNWXrPb6ykOfLkZiX355M=";
   };
 

--- a/pkgs/development/libraries/speex/default.nix
+++ b/pkgs/development/libraries/speex/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   version = "1.2.1";
 
   src = fetchurl {
-    url = "http://downloads.us.xiph.org/releases/speex/speex-${version}.tar.gz";
+    url = "https://downloads.us.xiph.org/releases/speex/speex-${version}.tar.gz";
     sha256 = "sha256-S0TU8rOKNwotmKeDKf78VqDPk9HBvnACkhe6rmYo/uo=";
   };
 

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -246,7 +246,7 @@ let
         pname = "clx-truetype";
         version = "20160825-git";
         src = pkgs.fetchzip {
-          url = "http://beta.quicklisp.org/archive/clx-truetype/2016-08-25/clx-truetype-20160825-git.tgz";
+          url = "https://beta.quicklisp.org/archive/clx-truetype/2016-08-25/clx-truetype-20160825-git.tgz";
           sha256 = "079hyp92cjkdfn6bhkxsrwnibiqbz4y4af6nl31lzw6nm91j5j37";
         };
         lispLibs = with self; [

--- a/pkgs/development/misc/msp430/mspds/binary.nix
+++ b/pkgs/development/misc/msp430/mspds/binary.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   pname = "msp-debug-stack-bin";
   version = "3.15.1.1";
   src = fetchurl {
-    url = "http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPDS/3_15_1_001/export/MSP430_DLL_Developer_Package_Rev_3_15_1_1.zip";
+    url = "https://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPDS/3_15_1_001/export/MSP430_DLL_Developer_Package_Rev_3_15_1_1.zip";
     sha256 = "1m1ssrwbhqvqwbp3m4hnjyxnz3f9d4acz9vl1av3fbnhvxr0d2hb";
   };
   sourceRoot = ".";

--- a/pkgs/development/misc/msp430/mspds/default.nix
+++ b/pkgs/development/misc/msp430/mspds/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   version = "3.15.1.1";
 
   src = fetchurl {
-    url = "http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPDS/3_15_1_001/export/MSPDebugStack_OS_Package_3_15_1_1.zip";
+    url = "https://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPDS/3_15_1_001/export/MSPDebugStack_OS_Package_3_15_1_1.zip";
     sha256 = "1j5sljqwc20zrb50mrji4mnmw5i680qc7n0lb0pakrrxqjc9m9g3";
   };
   sourceRoot = ".";

--- a/pkgs/development/ocaml-modules/elina/default.nix
+++ b/pkgs/development/ocaml-modules/elina/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   version = "1.1";
   pname = "ocaml${ocaml.version}-elina";
   src = fetchurl {
-    url = "http://files.sri.inf.ethz.ch/elina-${version}.tar.gz";
+    url = "https://files.sri.inf.ethz.ch/elina-${version}.tar.gz";
     sha256 = "1nymykskq1yx87y4xl6hl9i4q6kv0qaq25rniqgl1bfn883p1ysc";
   };
 

--- a/pkgs/development/ocaml-modules/hmap/default.nix
+++ b/pkgs/development/ocaml-modules/hmap/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-${pname}-${version}";
 
   src = fetchurl {
-    url = "http://erratique.ch/software/hmap/releases/${pname}-${version}.tbz";
+    url = "https://erratique.ch/software/hmap/releases/${pname}-${version}.tbz";
     sha256 = "10xyjy4ab87z7jnghy0wnla9wrmazgyhdwhr4hdmxxdn28dxn03a";
   };
 

--- a/pkgs/development/ocaml-modules/lutils/default.nix
+++ b/pkgs/development/ocaml-modules/lutils/default.nix
@@ -13,7 +13,7 @@ buildDunePackage rec {
   minimalOCamlVersion = "4.02";
 
   src = fetchurl {
-    url = "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutils.v${version}.tgz";
+    url = "https://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutils.v${version}.tgz";
     hash = "sha512:d3c3b80286b1aa236ba922d9e18a133721fc80126c8b89520fb811dce9400e217aaa75b5d49e03988be7f6bf5f2e1a391d02ceeaa5ec0a0cd5ce218083a29514";
   };
 

--- a/pkgs/development/ocaml-modules/rdbg/default.nix
+++ b/pkgs/development/ocaml-modules/rdbg/default.nix
@@ -24,7 +24,7 @@ buildDunePackage rec {
       };
 
   src = fetchurl {
-    url = "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/rdbg.v${version}.tgz";
+    url = "https://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/rdbg.v${version}.tgz";
     hash = "sha512:6076eaa3608a313f8ac71a4f5aa4fcc64aeb0c646d581e5035110d4c80f94de34f2ba26f90a9a1e92a7f788c9e799f1f7b0e3728c853a21983ad732f0ee60352";
   };
 

--- a/pkgs/development/python-modules/omniorbpy/default.nix
+++ b/pkgs/development/python-modules/omniorbpy/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   pyproject = false;
 
   src = fetchurl {
-    url = "http://downloads.sourceforge.net/omniorb/omniORBpy-${version}.tar.bz2";
+    url = "https://downloads.sourceforge.net/omniorb/omniORBpy-${version}.tar.bz2";
     hash = "sha256-y1cX1BKhAbr0MPWYysfWkjGITa5DctjirfPd7rxffrs=";
   };
 

--- a/pkgs/development/tcl-modules/by-name/td/tdom/package.nix
+++ b/pkgs/development/tcl-modules/by-name/td/tdom/package.nix
@@ -12,7 +12,7 @@ mkTclDerivation rec {
   version = "0.9.6";
 
   src = fetchzip {
-    url = "http://tdom.org/downloads/tdom-${version}-src.tgz";
+    url = "https://tdom.org/downloads/tdom-${version}-src.tgz";
     hash = "sha256-zN855tb9JQUtcB7K1DeAjUBrqhoNH44KbeHwp3qewqw=";
   };
 

--- a/pkgs/development/tools/ocaml/findlib/default.nix
+++ b/pkgs/development/tools/ocaml/findlib/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   version = "1.9.8";
 
   src = fetchurl {
-    url = "http://download.camlcity.org/download/findlib-${version}.tar.gz";
+    url = "https://download.camlcity.org/download/findlib-${version}.tar.gz";
     hash = "sha256-ZiyRD3dOn+46GcTgV/OAWBqy/E7lLaR2EwSsnDG4hp0=";
   };
 

--- a/pkgs/misc/cups/drivers/cnijfilter_2_80/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter_2_80/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
   version = "2.80";
 
   src = fetchzip {
-    url = "http://gdlp01.c-wss.com/gds/1/0100000841/01/cnijfilter-common-2.80-1.tar.gz";
+    url = "https://gdlp01.c-wss.com/gds/1/0100000841/01/cnijfilter-common-2.80-1.tar.gz";
     sha256 = "06s9nl155yxmx56056y22kz1p5b2sb5fhr3gf4ddlczjkd1xch53";
   };
 

--- a/pkgs/misc/cups/drivers/samsung/1.00.37.nix
+++ b/pkgs/misc/cups/drivers/samsung/1.00.37.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     sha256 = "0r66l9zp0p1qgakh4j08hynwsr4lsgq5yrpxyr0x4ldvl0z2b1bb";
-    url = "http://www.bchemnet.com/suldr/driver/UnifiedLinuxDriver-${finalAttrs.version}.tar.gz";
+    url = "https://www.bchemnet.com/suldr/driver/UnifiedLinuxDriver-${finalAttrs.version}.tar.gz";
   };
 
   buildInputs = [

--- a/pkgs/misc/cups/drivers/samsung/4.01.17.nix
+++ b/pkgs/misc/cups/drivers/samsung/4.01.17.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.01.17";
 
   src = fetchurl {
-    url = "http://www.bchemnet.com/suldr/driver/UnifiedLinuxDriver-${finalAttrs.version}.tar.gz";
+    url = "https://www.bchemnet.com/suldr/driver/UnifiedLinuxDriver-${finalAttrs.version}.tar.gz";
     sha256 = "1vv3pzvqpg1dq3xjr8161x2yp3v7ca75vil56ranhw5pkjwq66x0";
   };
 

--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   version = "${cfg.version}-${kernel.version}";
 
   src = fetchurl {
-    url = "http://downloads.open-mesh.org/batman/releases/${pname}-${cfg.version}/${pname}-${cfg.version}.tar.gz";
+    url = "https://downloads.open-mesh.org/batman/releases/${pname}-${cfg.version}/${pname}-${cfg.version}.tar.gz";
     sha256 = cfg.sha256.${pname};
   };
 

--- a/pkgs/tools/typesetting/tex/tetex/default.nix
+++ b/pkgs/tools/typesetting/tex/tetex/default.nix
@@ -16,12 +16,12 @@ stdenv.mkDerivation rec {
   version = "3.0";
 
   src = fetchurl {
-    url = "http://mirrors.ctan.org/obsolete/systems/unix/teTeX/${version}/distrib/tetex-src-${version}.tar.gz";
+    url = "https://mirrors.ctan.org/obsolete/systems/unix/teTeX/${version}/distrib/tetex-src-${version}.tar.gz";
     sha256 = "16v44465ipd9yyqri9rgxp6rbgs194k4sh1kckvccvdsnnp7w3ww";
   };
 
   texmf = fetchurl {
-    url = "http://mirrors.ctan.org/obsolete/systems/unix/teTeX/${version}/distrib/tetex-texmf-${version}.tar.gz";
+    url = "https://mirrors.ctan.org/obsolete/systems/unix/teTeX/${version}/distrib/tetex-texmf-${version}.tar.gz";
     sha256 = "1hj06qvm02a2hx1a67igp45kxlbkczjlg20gr8lbp73l36k8yfvc";
   };
 


### PR DESCRIPTION
This is a branch I generated with custom tooling to discover the bulk of opportunities to replace `http://` sources with `https://`. Each commit has been verified to produce the same `src` as the original. For more information on the scripting involved, see https://discourse.nixos.org/t/http-links-in-nixpkgs/75799

Summary of verification done so far:
- `nix build .#package.src --rebuild` (original method)
- Yank hashes and verify a hash mismatch is found
- `curl $(nix eval .#package.src.url)` (using curl options from fetchurl)
- `nix build --option store ./rebuild-store --option substitute false` of closure of all changed packages

Hash yanking and curl each found false positives. The mass closure rebuild succeeded with no issues aside from the patches in the linked PR. The curl one is probably the most trustworthy verification method.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
