### PR TITLE
wl-tray-bridge: init at 0.1.0-unstable-2026-02-16

### DIFF
--- a/pkgs/by-name/wl/wl-tray-bridge/package.nix
+++ b/pkgs/by-name/wl/wl-tray-bridge/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  rustPlatform,
+  cairo,
+  fetchFromGitHub,
+  nix-update-script,
+  pango,
+  patchelf,
+  pkg-config,
+  wayland,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wl-tray-bridge";
+  version = "0.1.0-unstable-2026-02-16";
+
+  src = fetchFromGitHub {
+    owner = "mahkoh";
+    repo = "wl-tray-bridge";
+    rev = "04cb349720f266917b5490e4a02f08d6ddf3f233";
+    hash = "sha256-pYmFEqMMEsSTYBwxbD2l2F+lO7WuVt1FFmnkCCoaXf0=";
+  };
+
+  cargoHash = "sha256-TM3Jsgmp5idFIOMm+qz0rNEWEhcGeQywF7ZmKlg6CXg=";
+
+  nativeBuildInputs = [
+    patchelf
+    pkg-config
+  ];
+
+  buildInputs = [
+    cairo
+    pango
+  ];
+
+  postFixup = ''
+    patchelf --add-rpath ${lib.makeLibraryPath [ wayland ]} $out/bin/wl-tray-bridge
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Bridges the gap between the StatusNotifierItem protocols and wayland compositors implementing jay-tray-v1";
+    homepage = "https://github.com/mahkoh/wl-tray-bridge";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ uku3lig ];
+    mainProgram = "wl-tray-bridge";
+  };
+})


### PR DESCRIPTION
https://github.com/mahkoh/wl-tray-bridge

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
