### PR TITLE
earlyoom: fix patch for version 1.9.0

### DIFF
--- a/pkgs/by-name/ea/earlyoom/0000-fix-dbus-path.patch
+++ b/pkgs/by-name/ea/earlyoom/0000-fix-dbus-path.patch
@@ -1,6 +1,15 @@
 --- a/kill.c
 +++ b/kill.c
-@@ -175,7 +175,7 @@ static void notify_dbus(const char* body)
+@@ -153,7 +153,7 @@ static void notify_spawn_subprocess(const char* script, char* const argv[], cons
+     }
+ 
+     debug("%s: exec %s\n", __func__, script);
+-    execv(script, argv);
++    execvp(script, argv);
+     warn("%s: exec %s failed: %s\n", __func__, script, strerror(errno));
+     exit(1);
+ }
+@@ -177,7 +177,7 @@ static void notify_dbus(const char* body)
          body2,
          NULL
      };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Replace `execv` with `execvp` to fix the "dbus-send not found" regression.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
