### PR TITLE
proxydetox: init at 0.13.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1343,6 +1343,7 @@
   ./services/networking/pptpd.nix
   ./services/networking/privoxy.nix
   ./services/networking/prosody.nix
+  ./services/networking/proxydetox.nix
   ./services/networking/pyload.nix
   ./services/networking/quassel.nix
   ./services/networking/quicktun.nix

--- a/nixos/modules/services/networking/proxydetox.nix
+++ b/nixos/modules/services/networking/proxydetox.nix
@@ -1,0 +1,223 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    attrNames
+    escapeShellArgs
+    flatten
+    getExe
+    isBool
+    isList
+    map
+    mkEnableOption
+    mkIf
+    mkOption
+    optional
+    removeAttrs
+    types
+    ;
+
+  cfg = config.services.proxydetox;
+
+  mkTcpKeepAliveField =
+    name: side:
+    mkOption {
+      type = with types; nullOr ints.positive;
+      default = null;
+      description = ''
+        TCP keep alive ${name} for ${side} sockets
+      '';
+    };
+
+  mkTcpKeepAlive = side: {
+    time = mkTcpKeepAliveField "time (in seconds)" side;
+    interval = mkTcpKeepAliveField "interval (in seconds)" side;
+    retries = mkTcpKeepAliveField "retries" side;
+  };
+
+  mkArg =
+    cfg: cname: aname:
+    let
+      val = (cfg."${cname}".enable or cfg."${cname}");
+    in
+    optional (val != null) (
+      if isBool val then
+        optional val "--${aname}"
+      else if isList val then
+        map (val: [
+          "--${aname}"
+          (toString val)
+        ]) val
+      else
+        [
+          "--${aname}"
+          (toString val)
+        ]
+    );
+
+  mkArgsFrom = cfg: names: flatten (map (name: mkArg cfg name name) names);
+
+  mkArgsIgnore = cfg: blackList: mkArgsFrom cfg (attrNames (removeAttrs cfg blackList));
+
+  mkTcpKeepAliveArgs =
+    cfg: side:
+    flatten (
+      map (name: mkArg cfg."${side}-tcp-keepalive" name "${side}-tcp-keepalive-${name}") (
+        attrNames cfg."${side}-tcp-keepalive"
+      )
+    );
+in
+{
+  options.services.proxydetox = {
+
+    enable = mkEnableOption ''
+      proxydetox service, which can evaluate PAC files and
+      forward to the correct parent proxy with authentication
+    '';
+
+    negotiate = mkOption {
+      type = with types; either bool str;
+      default = false;
+      description = "Enables Negotiate (SPNEGO) authentication";
+    };
+
+    listen = mkOption {
+      type = with types; listOf str;
+      default = [ "127.0.0.1:3128" ];
+      description = "Listening interface";
+    };
+
+    pac-file = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        PAC file to be used to decide which upstream proxy to forward the
+        request (local file path, http://, or https:// URI are accepted)
+      '';
+    };
+
+    my-ip-address = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        Custom IP address to be returned by the myIpAddress PAC function
+      '';
+    };
+
+    netrc-file = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        Custom IP address to be returned by the myIpAddress PAC function
+      '';
+    };
+
+    proxytunnel.enable = mkEnableOption ''
+      always use CONNECT method even for http resources
+    '';
+
+    direct-fallback.enable = mkEnableOption ''
+      falling back to direct connection when connecting via proxies fails
+    '';
+
+    connect-timeout = mkOption {
+      type = types.ints.positive;
+      default = 10;
+      description = ''
+        Timeout to establish a connection in fraction seconds
+      '';
+    };
+
+    race-connect.enable = mkEnableOption ''
+      race multiple connections at the same time
+    '';
+
+    parallel-connect = mkOption {
+      type = types.ints.positive;
+      default = 1;
+      description = ''
+        Number of connect attempts to perform in parallel
+      '';
+    };
+
+    client-tcp-keepalive = mkTcpKeepAlive "client";
+
+    server-tcp-keepalive = mkTcpKeepAlive "server";
+
+    extraArgs = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      description = "Extra arguments to proxydetox";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "proxydetox";
+      description = "User account under which proxydetox runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "proxydetox";
+      description = "Group under which proxydetox runs.";
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.proxydetox;
+      defaultText = "pkgs.proxydetox";
+      description = "The proxydetox derivation to use";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.proxydetox = {
+      description = "A http proxy with PAC files and authentication support";
+      after = [ "network.target" ];
+      wantedBy = [ "default.target" ];
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        Restart = "on-failure";
+        ExecStart =
+          let
+            genericArgs = mkArgsIgnore cfg [
+              "enable"
+              "client-tcp-keepalive"
+              "server-tcp-keepalive"
+              "extraArgs"
+              "user"
+              "group"
+              "package"
+            ];
+            client-tcp-keepalive-args = mkTcpKeepAliveArgs cfg "client";
+            server-tcp-keepalive-args = mkTcpKeepAliveArgs cfg "server";
+            allArgs = genericArgs ++ client-tcp-keepalive-args ++ server-tcp-keepalive-args ++ cfg.extraArgs;
+          in
+          ''
+            ${getExe cfg.package} ${escapeShellArgs allArgs}
+          '';
+      };
+    };
+
+    users.users = mkIf (cfg.user == "proxydetox") {
+      proxydetox = {
+        inherit (cfg) group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "proxydetox") {
+      proxydetox = { };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    shved
+  ];
+}

--- a/pkgs/by-name/pr/proxydetox/package.nix
+++ b/pkgs/by-name/pr/proxydetox/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+
+  krb5,
+
+  with-negotiate ? true,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "proxydetox";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "kiron1";
+    repo = "proxydetox";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-czc91fIIgMfOY0kjj/gbc1zUD9xjpWMhFDfeWfa7BW4=";
+  };
+  cargoHash = "sha256-nr9+DAa5B35UnkJM3fLnEVGlmhaZSLwP0qjAKP654lY=";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    krb5
+  ];
+
+  buildFeatures = lib.optional with-negotiate "negotiate";
+
+  # To build libgssapi-sys
+  env.LD_LIBRARY_PATH = lib.makeLibraryPath finalAttrs.buildInputs;
+
+  meta = {
+    description = "Http proxy with atomatic configuration and authentication";
+    longDescription = ''
+      A http proxy which can evaluate PAC files and forward to the correct
+      parent proxy with authentication.
+    '';
+    homepage = "https://proxydetox.colorto.cc/";
+    downloadPage = "https://github.com/kiron1/proxydetox/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/kiron1/proxydetox/commits/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux; # TODO: This could be used under darwin
+    maintainers = with lib.maintainers; [ maxmosk ];
+    mainProgram = "proxydetox";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A http proxy which can evaluate PAC files and forward to the correct parent proxy with authentication

This PR fully based on https://github.com/NixOS/nixpkgs/pull/409479

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
