### PR TITLE
logstalgia: 1.1.4 -> 1.1.5

### DIFF
--- a/pkgs/by-name/lo/logstalgia/package.nix
+++ b/pkgs/by-name/lo/logstalgia/package.nix
@@ -21,19 +21,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "logstalgia";
-  version = "1.1.4";
+  version = "1.1.5";
 
   src = fetchurl {
     url = "https://github.com/acaudwell/Logstalgia/releases/download/logstalgia-${finalAttrs.version}/logstalgia-${finalAttrs.version}.tar.gz";
-    hash = "sha256-wEnv9AXpJANSIu2ya8xse18AoIkmq9t7Rn4kSSQnkKk=";
+    hash = "sha256-Aok26fZjyHfWlprSXxRce0IHl+mj4BxsGEgV7YMJ9IE=";
   };
-
-  postPatch = ''
-    # Fix build with boost 1.89
-    rm m4/ax_boost_system.m4
-    substituteInPlace configure.ac \
-      --replace-fail "AX_BOOST_SYSTEM" ""
-  '';
 
   nativeBuildInputs = [
     autoreconfHook
@@ -57,7 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   configureFlags = [
-    "--with-boost-system=boost_system"
     "--with-boost-filesystem=boost_filesystem"
   ];
 


### PR DESCRIPTION
This upstream release includes the previously-unreleased fix for boost 1.89, which was recently patched by @iedame in #494897

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
