### PR TITLE
octavePackages.gsl: Propagate libgsl to octave.withPackages environment

### DIFF
--- a/pkgs/development/octave-modules/gsl/default.nix
+++ b/pkgs/development/octave-modules/gsl/default.nix
@@ -1,5 +1,6 @@
 {
   buildOctavePackage,
+  stdenv,
   lib,
   fetchurl,
   gsl,
@@ -14,7 +15,7 @@ buildOctavePackage rec {
     sha256 = "1lvfxbqmw8h1nlrxmvrl6j4xffmbzxfhdpxz3vrc6lg2g4jwaa6h";
   };
 
-  buildInputs = [
+  propagatedBuildInputs = [
     gsl
   ];
 
@@ -23,8 +24,9 @@ buildOctavePackage rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ KarlJoad ];
     description = "Octave bindings to the GNU Scientific Library";
-    # When used in an `octave.withPackages` environment, octave fails to find
-    # libgsl.so from some reason.
-    broken = true;
+    # gsl_sf.cc:1782:11: error: no member named 'is_real_type' in 'octave_value'
+    #  1782 |     if (! ISREAL(args(i)))
+    #       |           ^~~~~~~~~~~~~~~
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

```
Summary:

  PASS                               25
  FAIL                                0

See the file fntests.log for additional details.

0 (of 1) .m files have no tests.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
