### PR TITLE
buildkite-cli: 3.13.0 -> 3.31.1

### DIFF
--- a/pkgs/by-name/bu/buildkite-cli/package.nix
+++ b/pkgs/by-name/bu/buildkite-cli/package.nix
@@ -1,39 +1,71 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "buildkite-cli";
-  version = "3.13.0";
+  version = "3.31.1";
 
   src = fetchFromGitHub {
     owner = "buildkite";
     repo = "cli";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-SX80Hw9iaYvdrprI/Y1lYXTaKeGTkeVIBk2UujB//cs=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rWJU29v+3neb1d0Hdajxbq4v/QLE22sqjWeDaonIjdo=";
   };
 
-  vendorHash = "sha256-9doJSApHYYU9GrXi++WIqtUP743mZeRUCuy2xqO/kGo=";
-
-  doCheck = false;
-
-  postPatch = ''
-    patchShebangs .buildkite/steps/{lint,run-local}.sh
-  '';
-
-  subPackages = [ "cmd/bk" ];
+  vendorHash = "sha256-pYdo9jAJldAwGmWup27BDZ9Wd9BpK6ILTXioAGWOERo=";
 
   ldflags = [
     "-s"
-    "-w"
-    "-X main.VERSION=${finalAttrs.version}"
+    "-X github.com/buildkite/cli/v3/cmd/version.Version=${finalAttrs.version}"
   ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        # Require internet access
+        "TestConversionAPIEndpoint"
+
+        # Requires a git repository (which is removed by nix after fetching the source)
+        "TestResolvePipelinesFromPath"
+      ]
+      ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+        # Expected timeout error but got none
+        "TestPollJobStatus"
+        "TestPollJobStatusTimeout"
+      ];
+    in
+    [
+      "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$"
+    ];
+
+  __darwinAllowLocalNetworking = true;
+
+  postInstall = ''
+    mv $out/bin/cli $out/bin/bk
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Command line interface for Buildkite";
     homepage = "https://github.com/buildkite/cli";
+    changelog = "https://github.com/buildkite/cli/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ groodt ];
     mainProgram = "bk";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/buildkite/cli/compare/v3.13.0...v3.31.1

cc @groodt

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test