### PR TITLE
vscode-extensions.elijah-potter.harper: pin architecture to linux-x64 

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/elijah-potter.harper/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/elijah-potter.harper/default.nix
@@ -23,7 +23,9 @@ vscode-utils.buildVscodeMarketplaceExtension {
 
   postInstall = ''
     cd "$out/$installPrefix"
-    jq '.contributes.configuration.properties."harper.path".default = "${harper}/bin/harper-ls"' package.json | sponge package.json
+    jq '.contributes.configuration.properties."harper.path".default = "${lib.getExe harper}"' package.json | sponge package.json
+
+    rm ./bin/harper-ls
   '';
   passthru.updateScript = vscode-extension-update-script { };
 

--- a/pkgs/applications/editors/vscode/extensions/elijah-potter.harper/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/elijah-potter.harper/default.nix
@@ -1,4 +1,5 @@
 {
+  stdenvNoCC,
   lib,
   vscode-utils,
   vscode-extension-update-script,
@@ -13,7 +14,12 @@ vscode-utils.buildVscodeMarketplaceExtension {
     name = "harper";
     publisher = "elijah-potter";
     version = harper.version;
-    hash = "sha256-nK97C9ZYSI6dh4w1ntDP0mbmv6ez3pyAfv/4D30I2sA=";
+
+    # Because the binary is removed in favor of the harper package,
+    # it does not matter which binary is fetched. Using only a single
+    # hash makes this easier to maintain.
+    arch = "linux-x64";
+    hash = "sha256-xCkGgDc2XfM1A2RkXC4CiMadVCuizrCqR7ZKAjh34RE=";
   };
 
   nativeBuildInputs = [
@@ -27,6 +33,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
 
     rm ./bin/harper-ls
   '';
+
   passthru.updateScript = vscode-extension-update-script { };
 
   meta = {
@@ -36,5 +43,11 @@ vscode-utils.buildVscodeMarketplaceExtension {
     homepage = "https://github.com/automattic/harper";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ MasterEvarior ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
   };
 }

--- a/pkgs/by-name/ha/harper/package.nix
+++ b/pkgs/by-name/ha/harper/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   nix-update-script,
   versionCheckHook,
+  vscode-extensions,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -29,7 +30,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--package=harper-ls"
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = vscode-extensions.elijah-potter.harper;
+    updateScript = nix-update-script { };
+  };
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR does two things:
- it addresses #477368 and makes the build for the vcode extension specific for each architecture
- it removes the unused binary, which gets packaged into the vscode extension, as we simply use the `harper` package

I do not think this qualifies for the release notes as (in theory) nothing should change in any perceivable way.

pbsds edit: closes https://github.com/NixOS/nixpkgs/pull/530900

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
