### PR TITLE
worktrunk: init at 0.29.0

### DIFF
--- a/pkgs/by-name/wo/worktrunk/package.nix
+++ b/pkgs/by-name/wo/worktrunk/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  gitMinimal,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "worktrunk";
+  version = "0.29.0";
+
+  src = fetchFromGitHub {
+    owner = "max-sixty";
+    repo = "worktrunk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JawxnNoEv8ZDLaZmOlMrvsa/cEzmOFYv7oHWmPeOIbc=";
+  };
+
+  cargoHash = "sha256-aEUnR3Dk3LFo3vJf+k550YiP3pSN6a7175d91yEned0=";
+
+  cargoBuildFlags = [ "--package=worktrunk" ];
+
+  # vergen-gitcl calls `git describe` at build time; VERGEN_IDEMPOTENT makes it
+  # fall back gracefully when no git history is available (Nix sandbox).
+  env.VERGEN_IDEMPOTENT = "1";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    # wt reads config from $HOME; provide a throwaway dir so it doesn't fail.
+    export HOME="$(mktemp -d)"
+
+    installShellCompletion --cmd wt \
+      --bash <($out/bin/wt config shell completions bash) \
+      --fish <($out/bin/wt config shell completions fish) \
+      --zsh  <($out/bin/wt config shell completions zsh)
+  '';
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  checkFlags = [
+    # Expects to run inside a git repository
+    "--skip=git::recover::tests::test_current_or_recover_returns_repo_when_cwd_exists"
+    # Insta snapshot mismatch across git versions
+    "--skip=git::recover::tests::test_hint_for_repo_suggests_switch"
+    # Expects `which` on PATH
+    "--skip=output::commit_generation::tests::test_command_exists_known_command"
+    # Integration tests use insta snapshots with environment-specific paths
+    "--skip=integration_tests::"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Git worktree manager for parallel AI agent workflows";
+    longDescription = ''
+      worktrunk wraps git worktree with a simpler interface and integrates with
+      AI coding tools like Claude Code, Cursor, and Aider.
+    '';
+    homepage = "https://worktrunk.dev/";
+    changelog = "https://github.com/max-sixty/worktrunk/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    platforms = lib.platforms.unix;
+    mainProgram = "wt";
+    maintainers = with lib.maintainers; [ siriobalmelli ];
+  };
+})


### PR DESCRIPTION
[worktrunk](https://github.com/max-sixty/worktrunk) is a git worktree manager designed for running parallel AI agent workflows.

The `wt` CLI wraps `git worktree` with a simpler interface and integrates with tools like Claude Code, Cursor, and Aider.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test