### PR TITLE
maintainers: drop muscaln

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18331,12 +18331,6 @@
     githubId = 25388474;
     name = "Matej Urbas";
   };
-  muscaln = {
-    email = "muscaln@protonmail.com";
-    github = "muscaln";
-    githubId = 96225281;
-    name = "Mustafa Çalışkan";
-  };
   mushrowan = {
     email = "roarch@proton.me";
     name = "Rowan";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -783,7 +783,6 @@ with lib.maintainers;
     members = [
       bobby285271
       romildo
-      muscaln
     ];
     scope = "Maintain Xfce desktop environment and related packages.";
     shortName = "Xfce";

--- a/pkgs/by-name/ad/adriconf/package.nix
+++ b/pkgs/by-name/ad/adriconf/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://gitlab.freedesktop.org/mesa/adriconf/-/releases/v${finalAttrs.version}";
     description = "GUI tool used to configure open source graphics drivers";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ muscaln ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "adriconf";
   };

--- a/pkgs/by-name/bo/bootiso/package.nix
+++ b/pkgs/by-name/bo/bootiso/package.nix
@@ -67,7 +67,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Script for securely creating a bootable USB device from one image file";
     homepage = "https://github.com/jsamr/bootiso";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ muscaln ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     mainProgram = "bootiso";
   };

--- a/pkgs/by-name/fr/fritzing/package.nix
+++ b/pkgs/by-name/fr/fritzing/package.nix
@@ -131,7 +131,6 @@ stdenv.mkDerivation {
     ];
     maintainers = with lib.maintainers; [
       robberer
-      muscaln
     ];
     platforms = lib.platforms.unix;
     mainProgram = "Fritzing";

--- a/pkgs/by-name/he/headset/package.nix
+++ b/pkgs/by-name/he/headset/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://headsetapp.co/";
     license = lib.licenses.mit;
     platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ muscaln ];
+    maintainers = [ ];
     mainProgram = "headset";
   };
 })

--- a/pkgs/by-name/pi/pico-sdk/package.nix
+++ b/pkgs/by-name/pi/pico-sdk/package.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/raspberrypi/pico-sdk";
     changelog = "https://github.com/raspberrypi/pico-sdk/releases/tag/${finalAttrs.version}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ muscaln ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/pi/picotool/package.nix
+++ b/pkgs/by-name/pi/picotool/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/raspberrypi/picotool/releases/tag/${finalAttrs.version}";
     mainProgram = "picotool";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ muscaln ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/qd/qdl/package.nix
+++ b/pkgs/by-name/qd/qdl/package.nix
@@ -39,7 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Tool for flashing images to Qualcomm devices";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
-      muscaln
       anas
       numinit
     ];

--- a/pkgs/by-name/te/teams-for-linux/package.nix
+++ b/pkgs/by-name/te/teams-for-linux/package.nix
@@ -127,7 +127,6 @@ buildNpmPackage rec {
     homepage = "https://github.com/IsmaelMartinez/teams-for-linux";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
-      muscaln
       qjoly
       chvp
       khaneliman

--- a/pkgs/by-name/ti/tinygo/package.nix
+++ b/pkgs/by-name/ti/tinygo/package.nix
@@ -143,8 +143,7 @@ buildGoModule rec {
     homepage = "https://tinygo.org/";
     description = "Go compiler for small places";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [
-      muscaln
+    maintainers = [
     ];
   };
 }

--- a/pkgs/by-name/vk/vkmark/package.nix
+++ b/pkgs/by-name/vk/vkmark/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/vkmark/vkmark";
     license = with lib.licenses; [ lgpl21Plus ];
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ muscaln ];
+    maintainers = [ ];
     mainProgram = "vkmark";
   };
 })


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Amuscaln) since August 2025 despite over 70 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2025-09-01+user-review-requested%3Amuscaln). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@muscaln if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
