### PR TITLE
maintainers: drop smironov

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25080,12 +25080,6 @@
     githubId = 12636891;
     name = "Akhil Indurti";
   };
-  smironov = {
-    email = "grrwlf@gmail.com";
-    github = "sergei-mironov";
-    githubId = 4477729;
-    name = "Sergey Mironov";
-  };
   smissingham = {
     email = "sean@missingham.com";
     github = "smissingham";

--- a/pkgs/applications/misc/zathura/wrapper.nix
+++ b/pkgs/applications/misc/zathura/wrapper.nix
@@ -67,7 +67,6 @@ symlinkJoin {
     license = lib.licenses.zlib;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
-      smironov
       TethysSvensson
     ];
     mainProgram = "zathura";

--- a/pkgs/applications/science/math/lp_solve/default.nix
+++ b/pkgs/applications/science/math/lp_solve/default.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
     mainProgram = "lp_solve";
     homepage = "https://lpsolve.sourceforge.net";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ smironov ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/applications/science/misc/openmodelica/combined/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/combined/default.nix
@@ -45,7 +45,6 @@ symlinkJoin {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       balodja
-      smironov
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/applications/science/misc/openmodelica/omcompiler/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/omcompiler/default.nix
@@ -74,7 +74,6 @@ mkOpenModelicaDerivation (
       license = lib.licenses.gpl3Only;
       maintainers = with lib.maintainers; [
         balodja
-        smironov
       ];
       platforms = lib.platforms.linux;
     };

--- a/pkgs/applications/science/misc/openmodelica/omedit/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/omedit/default.nix
@@ -52,7 +52,6 @@ mkOpenModelicaDerivation {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       balodja
-      smironov
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/applications/science/misc/openmodelica/omlibrary/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/omlibrary/default.nix
@@ -38,7 +38,6 @@ including Modelica Standard Library";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       balodja
-      smironov
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/applications/science/misc/openmodelica/omparser/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/omparser/default.nix
@@ -28,7 +28,6 @@ suite";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       balodja
-      smironov
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/applications/science/misc/openmodelica/omplot/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/omplot/default.nix
@@ -36,7 +36,6 @@ mkOpenModelicaDerivation {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       balodja
-      smironov
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/applications/science/misc/openmodelica/omshell/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/omshell/default.nix
@@ -51,7 +51,6 @@ mkOpenModelicaDerivation {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       balodja
-      smironov
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/applications/science/misc/openmodelica/omsimulator/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/omsimulator/default.nix
@@ -41,7 +41,6 @@ mkOpenModelicaDerivation {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       balodja
-      smironov
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/om/omniorb/package.nix
+++ b/pkgs/by-name/om/omniorb/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
       gpl2Plus
       lgpl21Plus
     ];
-    maintainers = with lib.maintainers; [ smironov ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/vi/viewnior/package.nix
+++ b/pkgs/by-name/vi/viewnior/package.nix
@@ -86,7 +86,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl3;
     homepage = "https://siyanpanayotov.com/project/viewnior/";
     maintainers = with lib.maintainers; [
-      smironov
       artturin
     ];
     platforms = lib.platforms.gnu ++ lib.platforms.linux;

--- a/pkgs/by-name/xk/xkb-switch/package.nix
+++ b/pkgs/by-name/xk/xkb-switch/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Switch your X keyboard layouts from the command line";
     homepage = "https://github.com/ierton/xkb-switch";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ smironov ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "xkb-switch";
   };

--- a/pkgs/by-name/ya/yad/package.nix
+++ b/pkgs/by-name/ya/yad/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     license = lib.licenses.gpl3;
     mainProgram = "yad";
-    maintainers = with lib.maintainers; [ smironov ];
+    maintainers = [ ];
     platforms = with lib.platforms; linux;
   };
 })

--- a/pkgs/by-name/ya/yandex-disk/package.nix
+++ b/pkgs/by-name/ya/yandex-disk/package.nix
@@ -69,8 +69,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://help.yandex.com/disk/cli-clients.xml";
     description = "Free cloud file storage service";
-    maintainers = with lib.maintainers; [
-      smironov
+    maintainers = [
     ];
     platforms = [
       "i686-linux"

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -177,7 +177,6 @@ stdenv.mkDerivation (finalAttrs: {
       mainProgram = "lua";
       maintainers = with lib.maintainers; [
         thoughtpolice
-        smironov
         vcunat
         lblasc
       ];


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Asergei-mironov) since 2022 despite 37 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2023-01-01+user-review-requested%3Asergei-mironov). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@sergei-mironov if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
