### PR TITLE
octavePackages: Run autoreconf hook on compiled sources

### DIFF
--- a/pkgs/development/octave-modules/audio/default.nix
+++ b/pkgs/development/octave-modules/audio/default.nix
@@ -7,6 +7,7 @@
   alsa-lib,
   rtmidi,
   pkg-config,
+  autoreconfHook,
 }:
 
 buildOctavePackage rec {
@@ -22,6 +23,7 @@ buildOctavePackage rec {
 
   nativeBuildInputs = [
     pkg-config
+    autoreconfHook
   ];
 
   propagatedBuildInputs = [
@@ -29,6 +31,21 @@ buildOctavePackage rec {
     alsa-lib
     rtmidi
   ];
+
+  # autoreconfHook provides an autoreconfPhase that is run as a
+  # preconfigurePhase, which means it runs AFTER the source is un-tarred, and
+  # before buildOctavePackage's buildPhase re-tars it up into a format for later
+  # consumption by Octave's "pkg build" command.
+  preAutoreconf = ''
+    pushd src
+    # Upstream's bootstrap script uses wget to fetch config.guess & config.sub
+    # and has them committed to the repository. We must remove them so autoreconf
+    # actually fires for our environment.
+    rm config.*
+  '';
+  postAutoreconf = ''
+    popd
+  '';
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=release-(.*)" ]; };
 
@@ -38,6 +55,5 @@ buildOctavePackage rec {
     maintainers = with lib.maintainers; [ KarlJoad ];
     description = "Audio and MIDI Toolbox for GNU Octave";
     platforms = lib.platforms.linux; # Because of run-time dependency on jack2 and alsa-lib
-    broken = true;
   };
 }

--- a/pkgs/development/octave-modules/windows/default.nix
+++ b/pkgs/development/octave-modules/windows/default.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitHub,
   nix-update-script,
+  autoreconfHook,
 }:
 
 buildOctavePackage rec {
@@ -15,6 +16,25 @@ buildOctavePackage rec {
     tag = "release-${version}";
     sha256 = "sha256-hr94VALlAEwpqNU7imEN63M0BdPFSu5IznhWOn/mNiQ=";
   };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  # autoreconfHook provides an autoreconfPhase that is run as a
+  # preconfigurePhase, which means it runs AFTER the source is un-tarred, and
+  # before buildOctavePackage's buildPhase re-tars it up into a format for later
+  # consumption by Octave's "pkg build" command.
+  preAutoreconf = ''
+    pushd src
+    # Upstream's bootstrap script uses wget to fetch config.guess & config.sub
+    # and has them committed to the repository. We must remove them so autoreconf
+    # actually fires for our environment.
+    rm config.*
+  '';
+  postAutoreconf = ''
+    popd
+  '';
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=release-(.*)" ]; };
 

--- a/pkgs/development/octave-modules/windows/default.nix
+++ b/pkgs/development/octave-modules/windows/default.nix
@@ -43,6 +43,6 @@ buildOctavePackage rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ KarlJoad ];
     description = "Provides COM interface and additional functionality on Windows";
-    broken = true;
+    platforms = lib.platforms.windows;
   };
 }


### PR DESCRIPTION
Nixpkgs commit a0b51629f9e6a43a0312299f11dd9597dd936484 switched where audio gets it sources, from a release tarball to the actual upstream sources. These sources include leftover config.guess and config.sub scripts generated by upstream maintainer's bootstrap script. Their bootstrap script uses wget to grab config.guess and config.sub files, which we cannot do inside the Nix build environment. So we forcibly remove the config.* scripts and run autoreconf ourselves (through autoreconfHook).

Closes #495990.

```
Integrated test scripts:
                                                                                  [ CPU    |  CLOCK ]
  ..v/share/octave/octave_packages/audio-2.0.10/audioOscillator.m  pass    8/8    [ 0.072s |  0.072s]
  ..1.1.0-env/share/octave/octave_packages/audio-2.0.10/bark2hz.m  pass    4/4    [ 0.028s |  0.028s]
  ..11.1.0-env/share/octave/octave_packages/audio-2.0.10/erb2hz.m  pass    4/4    [ 0.020s |  0.020s]
  ..1.1.0-env/share/octave/octave_packages/audio-2.0.10/hz2bark.m  pass    4/4    [ 0.020s |  0.020s]
  ..11.1.0-env/share/octave/octave_packages/audio-2.0.10/hz2erb.m  pass    5/5    [ 0.022s |  0.022s]
  ..11.1.0-env/share/octave/octave_packages/audio-2.0.10/hz2mel.m  pass    4/4    [ 0.021s |  0.021s]
  ...0-env/share/octave/octave_packages/audio-2.0.10/ismidifile.m  pass    3/3    [ 0.008s |  0.008s]
  ..11.1.0-env/share/octave/octave_packages/audio-2.0.10/mel2hz.m  pass    4/4    [ 0.021s |  0.021s]
  ..-env/share/octave/octave_packages/audio-2.0.10/midicallback.m  pass    2/2    [ 0.017s |  0.017s]
  ..-env/share/octave/octave_packages/audio-2.0.10/midicontrols.m  pass    1/1    [ 0.008s |  0.009s]
  ...0-env/share/octave/octave_packages/audio-2.0.10/mididevice.m  pass    1/1    [ 0.007s |  0.007s]
  ..0-env/share/octave/octave_packages/audio-2.0.10/mididevinfo.m  pass    1/1    [ 0.005s |  0.005s]
  ..-env/share/octave/octave_packages/audio-2.0.10/midifileinfo.m  pass    1/1    [ 0.021s |  0.021s]
  ..-env/share/octave/octave_packages/audio-2.0.10/midifileread.m  pass    4/4    [ 0.089s |  0.089s]
  ..env/share/octave/octave_packages/audio-2.0.10/midifilewrite.m  pass    3/3    [ 0.061s |  0.061s]
  ..1.0-env/share/octave/octave_packages/audio-2.0.10/midiflush.m  pass    2/2    [ 0.006s |  0.007s]
  ..1.1.0-env/share/octave/octave_packages/audio-2.0.10/midimsg.m  pass   47/47   [ 0.241s |  0.241s]
  ..0-env/share/octave/octave_packages/audio-2.0.10/midimsgtype.m  pass    5/5    [ 0.012s |  0.012s]
  ..1.0-env/share/octave/octave_packages/audio-2.0.10/phon2sone.m  pass    6/6    [ 0.031s |  0.031s]
  ..1.0-env/share/octave/octave_packages/audio-2.0.10/sone2phon.m  pass    6/6    [ 0.026s |  0.026s]

Fixed test scripts:

                                                        total time (CPU | CLOCK)  [   0.9s |    0.9s]
Summary:

  PASS                              115
  FAIL                                0

See the file fntests.log for additional details.

10 (of 30) .m files have no tests.
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
