### PR TITLE
qt5.{qtModule, various modules}: prepare for structuredAttrs

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
@@ -36,5 +36,7 @@ qtModule {
     "out"
   ];
   qmakeFlags = [ "GST_VERSION=1.0" ];
-  NIX_LDFLAGS = lib.optionalString (stdenv.hostPlatform.isDarwin) "-lobjc";
+  env = lib.optionalAttrs (stdenv.hostPlatform.isDarwin) {
+    NIX_LDFLAGS = "-lobjc";
+  };
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -330,10 +330,12 @@ qtModule (
       "--"
       "-system-ffmpeg"
     ]
-    ++ lib.optional (
-      pipewireSupport && stdenv.buildPlatform == stdenv.hostPlatform
-    ) "-webengine-webrtc-pipewire"
-    ++ lib.optional enableProprietaryCodecs "-proprietary-codecs";
+    ++ lib.optionals (pipewireSupport && stdenv.buildPlatform == stdenv.hostPlatform) [
+      "-webengine-webrtc-pipewire"
+    ]
+    ++ lib.optionals enableProprietaryCodecs [
+      "-proprietary-codecs"
+    ];
 
     propagatedBuildInputs = [
       qtdeclarative
@@ -402,7 +404,9 @@ qtModule (
 
     # FIXME These dependencies shouldn't be needed but can't find a way
     # around it. Chromium pulls this in while bootstrapping GN.
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools.libtool ];
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      cctools.libtool
+    ];
 
     buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
       cups

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -115,7 +115,7 @@ qtModule (
       (lib.getDev pkgsBuildTarget.targetPackages.qt5.qtquickcontrols)
       pkg-config-wrapped-without-prefix
     ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin [
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
       bootstrap_cmds
       xcbuild
     ];

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -51,7 +51,9 @@ qtModule {
     qtsensors
     qtwebchannel
   ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin qtmultimedia;
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    qtmultimedia
+  ];
   buildInputs = [
     fontconfig
     libwebp
@@ -90,12 +92,16 @@ qtModule {
       "-Wno-expansion-to-defined"
     ]
     # with gcc8, -Wclass-memaccess became part of -Wall and this too exceeds the logging limit
-    ++ lib.optional stdenv.cc.isGNU "-Wno-class-memaccess"
+    ++ lib.optionals stdenv.cc.isGNU [
+      "-Wno-class-memaccess"
+    ]
     # with clang this warning blows the log over Hydra's limit
-    ++ lib.optional stdenv.hostPlatform.isDarwin "-Wno-inconsistent-missing-override"
-    ++ lib.optional (
-      !stdenv.hostPlatform.isDarwin
-    ) ''-DNIXPKGS_LIBUDEV="${lib.getLib systemd}/lib/libudev"''
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      "-Wno-inconsistent-missing-override"
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      ''-DNIXPKGS_LIBUDEV="${lib.getLib systemd}/lib/libudev"''
+    ]
   );
 
   doCheck = false; # fails 13 out of 13 tests (ctest)

--- a/pkgs/development/libraries/qt-5/modules/qtwebview.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebview.nix
@@ -17,5 +17,7 @@ qtModule {
     "dev"
     "bin"
   ];
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-framework CoreFoundation -framework WebKit";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = "-framework CoreFoundation -framework WebKit";
+  };
 }

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -97,10 +97,13 @@ mkDerivation (
           done
       fi
 
+      ${lib.optionalString (lib.hasAttr "devTools" args) ''devTools="${lib.concatStringsSep " " args.devTools}"''}
       moveQtDevTools
 
       ${args.postFixup or ""}
     '';
+
+    __structuredAttrs = true;
 
     meta = {
       homepage = "https://www.qt.io";


### PR DESCRIPTION
Followup / companion to https://github.com/NixOS/nixpkgs/pull/472655 .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
