### PR TITLE
kubebuilder: 4.10.1 -> 4.13.1

### DIFF
--- a/pkgs/by-name/ku/kubebuilder/package.nix
+++ b/pkgs/by-name/ku/kubebuilder/package.nix
@@ -8,7 +8,6 @@
   gnumake,
   installShellFiles,
   testers,
-  kubebuilder,
 }:
 
 buildGoModule (finalAttrs: {
@@ -59,8 +58,8 @@ buildGoModule (finalAttrs: {
   '';
 
   passthru.tests.version = testers.testVersion {
-    command = "${kubebuilder}/bin/kubebuilder version";
-    package = kubebuilder;
+    command = "${finalAttrs.finalPackage}/bin/kubebuilder version";
+    package = finalAttrs.finalPackage;
     version = "v${finalAttrs.version}";
   };
 

--- a/pkgs/by-name/ku/kubebuilder/package.nix
+++ b/pkgs/by-name/ku/kubebuilder/package.nix
@@ -13,31 +13,28 @@
 
 buildGoModule (finalAttrs: {
   pname = "kubebuilder";
-  version = "4.10.1";
+  version = "4.13.1";
 
   src = fetchFromGitHub {
     owner = "kubernetes-sigs";
     repo = "kubebuilder";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-GAHuaUVtdLvyWNeOxu46+IOw2Mf42z3yUjZNiyeE1xs=";
+    hash = "sha256-WOqrQb2haoEp57OHFo1Y1fon0lJedI/hEYKE4xrIbpM=";
   };
 
-  vendorHash = "sha256-NsD2yt73+uRitegezTWwBhF0iMCQ8XhDf6WM/j7kT0o=";
+  vendorHash = "sha256-1lbf1hXJfhdTu6Gm7dcbJlB3beITxBD83gMltZgg7Pg=";
 
   subPackages = [
-    "cmd"
+    "internal/cli/cmd"
     "."
   ];
 
   allowGoReference = true;
 
-  ldflags = [
-    "-X sigs.k8s.io/kubebuilder/v4/cmd.kubeBuilderVersion=v${finalAttrs.version}"
-    "-X sigs.k8s.io/kubebuilder/v4/cmd.goos=${go.GOOS}"
-    "-X sigs.k8s.io/kubebuilder/v4/cmd.goarch=${go.GOARCH}"
-    "-X sigs.k8s.io/kubebuilder/v4/cmd.gitCommit=unknown"
-    "-X sigs.k8s.io/kubebuilder/v4/cmd.buildDate=unknown"
-  ];
+  postPatch = ''
+    substituteInPlace internal/cli/version/version.go \
+      --replace-fail "return main.Version" 'return "v${finalAttrs.version}"'
+  '';
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
Changelog: https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v4.13.0

Closes #482291 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
