### PR TITLE
haskell.packages.ghc914.haskell-debugger: fix most test cases 

### DIFF
--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -254,6 +254,10 @@ self: super:
     # Tests fail on macOS https://github.com/mrkkrp/zip/issues/112
     zip = dontCheck super.zip;
 
+    haskell-debugger = overrideCabal (drv: {
+      __darwinAllowLocalNetworking = true; # `runInTerminal` test launches local server
+    }) super.haskell-debugger;
+
     http-streams = super.http-streams.overrideAttrs (drv: {
       __darwinAllowLocalNetworking = true;
     });

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1992,8 +1992,19 @@ builtins.intersectAttrs super {
     broken = false;
   }) super.cabal-install;
 
-  # lots of errors
-  haskell-debugger = dontCheck super.haskell-debugger;
+  haskell-debugger = overrideCabal (drv: {
+    preCheck = ''
+      export HOME=$TMPDIR
+      export PATH="$PWD/dist/build/hdb:$PATH"
+    '';
+    testFlags = drv.testFlags or [ ] ++ builtins.concatMap (x: ["-p" x]) [
+      "! /T79/"            # needs sandbox off and has --package-db related error
+      "! /T130/"           # strange haskell-debugger-view related error
+      "! /T130b/"          # cabal repl errors and has --package-db related error
+      "! /T135/"           # needs sandbox off
+      "! /T169c.internal/" # seems like a stray newline sneaks in somewhere
+    ];
+  }) (addTestToolDepend pkgs.cabal-install super.haskell-debugger);
 
   keid-render-basic = addBuildTool pkgs.glslang super.keid-render-basic;
 


### PR DESCRIPTION
One single commit on top of ~#496489~ ~#498910~ .

Needs ~hackage release of~ LTS bump for  
- https://github.com/well-typed/haskell-debugger/pull/203 (can workaround with `addBuildTools`)
- https://github.com/well-typed/haskell-debugger/pull/204
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
