### PR TITLE
python3Packages.llama-cloud-services: 0.6.77 -> 0.6.94

### DIFF
--- a/pkgs/development/python-modules/llama-cloud-services/default.nix
+++ b/pkgs/development/python-modules/llama-cloud-services/default.nix
@@ -13,7 +13,7 @@
   python-dotenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "llama-cloud-services";
   version = "0.6.94";
   pyproject = true;
@@ -21,11 +21,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "run-llama";
     repo = "llama_cloud_services";
-    tag = "llama-cloud-services-py%40${version}";
+    tag = "llama-cloud-services-py%40${finalAttrs.version}";
     hash = "sha256-BjwXdv7ekehYGGnKk0ElVlxmGkmtam9RLECgxfM7lYc=";
   };
 
-  sourceRoot = "${src.name}/py";
+  sourceRoot = "${finalAttrs.src.name}/py";
 
   pythonRelaxDeps = [ "llama-cloud" ];
 
@@ -57,8 +57,8 @@ buildPythonPackage rec {
   meta = {
     description = "Knowledge Agents and Management in the Cloud";
     homepage = "https://github.com/run-llama/llama_cloud_services";
-    changelog = "https://github.com/run-llama/llama_cloud_services/releases/tag/${src.tag}";
+    changelog = "https://github.com/run-llama/llama_cloud_services/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/llama-cloud-services/default.nix
+++ b/pkgs/development/python-modules/llama-cloud-services/default.nix
@@ -2,22 +2,20 @@
   lib,
   buildPythonPackage,
   click,
-  deepdiff,
   eval-type-backport,
   fetchFromGitHub,
+  gitUpdater,
   llama-cloud,
   llama-index-core,
   platformdirs,
   hatchling,
   pydantic,
-  pytest-asyncio,
-  pytestCheckHook,
   python-dotenv,
 }:
 
 buildPythonPackage rec {
   pname = "llama-cloud-services";
-  version = "0.6.79";
+  version = "0.6.94";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -47,6 +45,14 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonImportsCheck = [ "llama_cloud_services" ];
+
+  # update script sets wrong version
+  passthru = {
+    skipBulkUpdate = true;
+    updateScript = gitUpdater {
+      rev-prefix = "llama-cloud-services-py@";
+    };
+  };
 
   meta = {
     description = "Knowledge Agents and Management in the Cloud";

--- a/pkgs/development/python-modules/llama-index-indices-managed-llama-cloud/default.nix
+++ b/pkgs/development/python-modules/llama-index-indices-managed-llama-cloud/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  deprecated,
   hatchling,
   llama-cloud,
   llama-index-core,
@@ -18,11 +19,15 @@ buildPythonPackage rec {
     hash = "sha256-teAHUqswVkq/GcV1laIQf1aXw7A7CFgXtPyoSjjrvVk=";
   };
 
-  pythonRelaxDeps = [ "llama-cloud" ];
+  pythonRelaxDeps = [
+    "deprecated"
+    "llama-cloud"
+  ];
 
   build-system = [ hatchling ];
 
   dependencies = [
+    deprecated
     llama-cloud
     llama-index-core
   ];

--- a/pkgs/development/python-modules/llama-parse/default.nix
+++ b/pkgs/development/python-modules/llama-parse/default.nix
@@ -21,6 +21,9 @@ buildPythonPackage rec {
 
   dependencies = [ llama-cloud-services ];
 
+  # llama-cloud-services fails to read
+  pythonRelaxDeps = [ "llama-cloud-services" ];
+
   pythonImportsCheck = [ "llama_parse" ];
 
   meta = {


### PR DESCRIPTION
1. Version bump https://github.com/run-llama/llama_cloud_services/releases/tag/llama-cloud-services-py%400.6.94
2. `update.nix` updates the version incorrectly. Configured `gitUpdater` to handle future updates.
3. Migrated to finalAttrs.
4. `python3Packages.llama-cloud-parse` was misreading the version of `python3Packages.llama-cloud-services` during the dependency check and failing. Relaxed   the dependency requirement.
5. `python3Packages.llama-index-indices-managed-llama-cloud` was failing due to expecting a specific version of `python3Packages.outdated`.

Heads-up that `llama-cloud-parse` and its ecosystem are deprecated and reach EOL in May.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
