### PR TITLE
Bulk replace `http://` with `https://` (rebuilds)

### DIFF
--- a/pkgs/by-name/da/dash/package.nix
+++ b/pkgs/by-name/da/dash/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.5.13.1";
 
   src = fetchurl {
-    url = "http://gondor.apana.org.au/~herbert/dash/files/dash-${finalAttrs.version}.tar.gz";
+    url = "https://gondor.apana.org.au/~herbert/dash/files/dash-${finalAttrs.version}.tar.gz";
     hash = "sha256-2ScbzgnBJ9mGbiXAEVgt3HWrmIlYoEvE2FU6O48w43A=";
   };
 

--- a/pkgs/by-name/do/docbook5/package.nix
+++ b/pkgs/by-name/do/docbook5/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "5.0.1";
 
   src = fetchurl {
-    url = "http://www.docbook.org/xml/${finalAttrs.version}/docbook-${finalAttrs.version}.zip";
+    url = "https://www.docbook.org/xml/${finalAttrs.version}/docbook-${finalAttrs.version}.zip";
     sha256 = "1iz3hq1lqgnshvlz4j9gvh4jy1ml74qf90vqf2ikbq0h4i2xzybs";
   };
 

--- a/pkgs/by-name/ge/getopt/package.nix
+++ b/pkgs/by-name/ge/getopt/package.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "getopt";
   version = "1.1.6";
   src = fetchurl {
-    url = "http://frodo.looijaard.name/system/files/software/getopt/getopt-${finalAttrs.version}.tar.gz";
+    url = "https://frodo.looijaard.name/system/files/software/getopt/getopt-${finalAttrs.version}.tar.gz";
     sha256 = "1zn5kp8ar853rin0ay2j3p17blxy16agpp8wi8wfg4x98b31vgyh";
   };
 

--- a/pkgs/by-name/it/itstool/package.nix
+++ b/pkgs/by-name/it/itstool/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.7";
 
   src = fetchurl {
-    url = "http://files.itstool.org/itstool/itstool-${finalAttrs.version}.tar.bz2";
+    url = "https://files.itstool.org/itstool/itstool-${finalAttrs.version}.tar.bz2";
     hash = "sha256-a5p80poSu5VZj1dQ6HY87niDahogf4W3TYsydbJ+h8o=";
   };
 

--- a/pkgs/by-name/li/libev/package.nix
+++ b/pkgs/by-name/li/libev/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.33";
 
   src = fetchurl {
-    url = "http://dist.schmorp.de/libev/Attic/libev-${finalAttrs.version}.tar.gz";
+    url = "https://dist.schmorp.de/libev/Attic/libev-${finalAttrs.version}.tar.gz";
     sha256 = "1sjs4324is7fp21an4aas2z4dwsvs6z4xwrmp72vwpq1s6wbfzjh";
   };
 

--- a/pkgs/tools/text/patchutils/generic.nix
+++ b/pkgs/tools/text/patchutils/generic.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   inherit version patches;
 
   src = fetchurl {
-    url = "http://cyberelk.net/tim/data/patchutils/stable/${pname}-${version}.tar.xz";
+    url = "https://cyberelk.net/tim/data/patchutils/stable/${pname}-${version}.tar.xz";
     inherit sha256;
   };
 


### PR DESCRIPTION
These are the commits that cause rebuilds separated from https://github.com/NixOS/nixpkgs/pull/496560

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
