### PR TITLE
compress-pptx: init at 1.3.1

### DIFF
--- a/pkgs/by-name/co/compress-pptx/inject-dependency-paths.patch
+++ b/pkgs/by-name/co/compress-pptx/inject-dependency-paths.patch
@@ -1,0 +1,49 @@
+diff --git a/src/compress_pptx/__main__.py b/src/compress_pptx/__main__.py
+index 433b6d8..f86c2e2 100644
+--- a/src/compress_pptx/__main__.py
++++ b/src/compress_pptx/__main__.py
+@@ -101,7 +101,7 @@ def main():
+         "--ffmpeg-path",
+         type=str,
+         help="Path to ffmpeg executable",
+-        default="ffmpeg",
++        default="@ffmpeg@",
+     )
+     cli_args = parser.parse_args()
+ 
+diff --git a/src/compress_pptx/compress_pptx.py b/src/compress_pptx/compress_pptx.py
+index 0cb5b42..0845aef 100644
+--- a/src/compress_pptx/compress_pptx.py
++++ b/src/compress_pptx/compress_pptx.py
+@@ -131,7 +131,7 @@ class CompressPptx:
+         ffmpeg_video_codec: Optional[str] = None,
+         ffmpeg_audio_codec: Optional[str] = None,
+         ffmpeg_extra_options: Optional[str] = None,
+-        ffmpeg_path: str = "ffmpeg",
++        ffmpeg_path: str = "@ffmpeg@",
+     ) -> None:
+         """
+         Compress images in a PowerPoint file or extract media.
+@@ -187,19 +187,9 @@ class CompressPptx:
+ 
+         self.file_list: List[FileObj] = []
+ 
+-        # Check for ImageMagick - prefer 'magick' but fall back to 'convert'/'identify'
+-        if which("magick") is not None:
+-            self.magick_cmd = "magick"
+-            self.convert_cmd = ["magick", "convert"]
+-            self.identify_cmd = ["magick", "identify"]
+-        elif which("convert") is not None and which("identify") is not None:
+-            self.magick_cmd = "convert"
+-            self.convert_cmd = ["convert"]
+-            self.identify_cmd = ["identify"]
+-        else:
+-            raise CompressPptxError(
+-                "ImageMagick not found in PATH. Make sure you have installed ImageMagick and that either 'magick' or 'convert'/'identify' commands are available."
+-            )
++        self.magick_cmd = "@magick@"
++        self.convert_cmd = ["@magick@", "convert"]
++        self.identify_cmd = ["@magick@", "identify"]
+ 
+         required_executables = []
+         # add ffmpeg to required executables if user wants media files to be compressed

--- a/pkgs/by-name/co/compress-pptx/package.nix
+++ b/pkgs/by-name/co/compress-pptx/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+
+  # patches
+  replaceVars,
+  ffmpeg,
+  imagemagick,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "compress-pptx";
+  version = "1.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "slhck";
+    repo = "compress-pptx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+67EdAEWsRY11Pkie6AOz7Sl7MSTMGxZoQYS+M2x07Y=";
+  };
+
+  patches = [
+    (replaceVars ./inject-dependency-paths.patch {
+      ffmpeg = lib.getExe ffmpeg;
+      magick = lib.getExe imagemagick;
+    })
+  ];
+
+  build-system = with python3Packages; [ uv-build ];
+
+  dependencies = with python3Packages; [
+    ffmpeg-progress-yield
+    tqdm
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
+  meta = {
+    description = "Compress PPTX files";
+    longDescription = ''
+      Compress a PPTX or POTX file, converting all PNG/TIFF images to lossy
+      JPEGs.
+    '';
+    homepage = "https://github.com/slhck/compress-pptx";
+    license = lib.licenses.mit;
+    changelog = "https://github.com/slhck/compress-pptx/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "compress-pptx";
+    maintainers = with lib.maintainers; [ artur-sannikov ];
+  };
+})


### PR DESCRIPTION
Homepage: https://github.com/slhck/compress-pptx
Changelog: https://github.com/slhck/compress-pptx

Description: Compress a PPTX or POTX file, converting all PNG/TIFF images to JPEGs.

## Things done

I tested the basic functionality of compression (including audio and video).

I'm not entirely sure about:

```nix
  # Not sure here. uv-build is a Python dependency, so should be correct?
  build-system = [ uv-build ];
  # nativeBuildInputs = [ uv-build ];

  # Better with a patch or just submit an upstream PR?
  postPatch = ''
    substituteInPlace pyproject.toml \
      --replace 'uv_build>=0.8.14,<0.9.0' 'uv_build>=0.8.14,<1.0.0'
  '';
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
