### PR TITLE
feat: make npm dep fetch consistency error more helpful

### DIFF
--- a/pkgs/build-support/node/prefetch-npm-deps/src/main.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/main.rs
@@ -250,7 +250,9 @@ fn fixup_lockfile(
                     } else if let Some(cache_hashes) = cache {
                         let cache_hash = cache_hashes
                             .get(resolved)
-                            .expect("dependency should have a hash");
+                            .unwrap_or_else(|| {
+                                panic!("dependency '{resolved}' should have a hash")
+                            });
 
                         if integrity != cache_hash {
                             fixed = true;
@@ -300,7 +302,9 @@ fn fixup_v1_deps(
             } else if let Some(cache_hashes) = cache {
                 let cache_hash = cache_hashes
                     .get(resolved)
-                    .expect("dependency should have a hash");
+                    .unwrap_or_else(|| {
+                        panic!("dependency '{resolved}' should have a hash")
+                    });
 
                 if integrity != cache_hash {
                     *fixed = true;


### PR DESCRIPTION
Previously, this would simply error with
```
thread 'main' (8933822) panicked at src/main.rs:79:34:
dependency should have a hash
```
which isn't _super_ helpful.

With this change it will at least print out the package that is missing a cache hash.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
