### PR TITLE
nixos/environment.pointerCursor: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -124,6 +124,8 @@
 
 - [whois](https://packages.qa.debian.org/w/whois.html), an intelligent WHOIS client. Available as `programs.whois`.
 
+- `environment.pointerCursor`, a module for configuring system-wide pointer settings with various backends.
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/config/system-cursor.nix
+++ b/nixos/modules/config/system-cursor.nix
@@ -1,0 +1,151 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.environment.pointerCursor;
+
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    mkDefault
+    mkIf
+    types
+    literalExpression
+    ;
+in
+{
+  options.environment.pointerCursor = {
+    enable = mkEnableOption ''
+      cursor config generation.
+
+      Top-level options declared under this this module are backend independent
+      options. Options declared under namespaces such as ‘gdm’ are backend
+      specific options. You can disable configurations for specific backends via
+      their ‘enable’ option. For example, set
+      [](#opt-environment.pointerCursor.gdm.enable) to ‘false’ to disable GDM
+      cursor configurations.
+
+      To apply the configurations, the relevant subsytems must also be
+      configured. For example, [](#opt-services.displayManager.gdm.enable) needs
+      to be set in order for [](#opt-environment.pointerCursor.gdm.enable) to
+      apply GDM cursor configuration'';
+
+    package = mkPackageOption pkgs "cursor theme" {
+      default = null;
+      nullable = true;
+      example = "vanilla-dmz";
+    };
+
+    name = mkOption {
+      type = types.str;
+      example = "Vanilla-DMZ";
+      description = "The cursor name within the package.";
+    };
+
+    size = mkOption {
+      type = types.ints.positive;
+      default = 32;
+      example = 64;
+      description = "The cursor size.";
+    };
+
+    gdm.enable = mkEnableOption "GDM config generation for {option}`environment.pointerCursor`" // {
+      default = true;
+    };
+
+    sddm.enable = mkEnableOption "SDDM config generation for {option}`environment.pointerCursor`" // {
+      default = true;
+    };
+
+    lightdm.greeters = {
+      gtk.enable =
+        mkEnableOption "LightDM GTK Greeter config generation for {option}`environment.pointerCursor`"
+        // {
+          default = true;
+        };
+
+      slick.enable =
+        mkEnableOption "Slick-Greeter config generation for {option}`environment.pointerCursor`"
+        // {
+          default = true;
+        };
+    };
+
+    dms-greeter.enable =
+      mkEnableOption "DankMaterialShell greeter config generation for {option}`environment.pointerCursor`"
+      // {
+        default = true;
+      };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    environment.sessionVariables = {
+      XCURSOR_THEME = mkDefault cfg.name;
+      XCURSOR_SIZE = mkDefault cfg.size;
+      # Set directory to look for cursors in, needed for some applications
+      # that are unable to find cursors otherwise. See:
+      # https://github.com/nix-community/home-manager/issues/2812
+      # https://wiki.archlinux.org/title/Cursor_themes#Environment_variable
+      XCURSOR_PATH = [ "/run/current-system/sw/share/icons" ];
+    };
+
+    programs.dconf.profiles.gdm.databases =
+      mkIf (config.services.displayManager.gdm.enable && cfg.gdm.enable)
+        [
+          {
+            settings."org/gnome/desktop/interface" = {
+              cursor-theme = cfg.name;
+              cursor-size = lib.gvariant.mkInt32 cfg.size;
+            };
+          }
+        ];
+
+    services.displayManager.sddm.settings =
+      mkIf (config.services.displayManager.sddm.enable && cfg.sddm.enable)
+        {
+          Theme = {
+            CursorTheme = cfg.name;
+            CursorSize = cfg.size;
+          };
+        };
+
+    services.xserver.displayManager.lightdm.greeters.gtk.cursorTheme =
+      mkIf
+        (
+          config.services.xserver.displayManager.lightdm.enable
+          && config.services.xserver.displayManager.lightdm.greeters.gtk.enable
+          && cfg.lightdm.greeters.gtk.enable
+        )
+        {
+          inherit (cfg) package name size;
+        };
+
+    services.xserver.displayManager.lightdm.greeters.slick.cursorTheme =
+      mkIf
+        (
+          config.services.xserver.displayManager.lightdm.enable
+          && config.services.xserver.displayManager.lightdm.greeters.slick.enable
+          && cfg.lightdm.greeters.gtk.enable
+        )
+        {
+          inherit (cfg) package name size;
+        };
+
+    services.displayManager.dms-greeter.compositor.customConfig =
+      mkIf (config.services.displayManager.dms-greeter.enable && cfg.dms-greeter.enable)
+        ''
+          include "${pkgs.writeText "dms-greeter-cursor-config.kdl" ''
+            cursor {
+                xcursor-theme "${cfg.name}"
+                xcursor-size ${toString cfg.size}
+            }
+          ''}"
+        '';
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -32,6 +32,7 @@
   ./config/swap.nix
   ./config/sysctl.nix
   ./config/sysfs.nix
+  ./config/system-cursor.nix
   ./config/system-environment.nix
   ./config/system-path.nix
   ./config/terminfo.nix


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A system-wide cursor configuration module, inspired by home-manager's [`home.pointerCursor`](https://nix-community.github.io/home-manager/options.xhtml#opt-home.pointerCursor) module.

For this initial PR, the following backends are implemented:

- [GDM](https://gitlab.gnome.org/GNOME/gdm)
- [SDDM](https://github.com/sddm/sddm)
- [LightDM](https://github.com/ubuntu/lightdm)
  - [LightDM GTK Greeter](https://github.com/Xubuntu/lightdm-gtk-greeter)
  - [Slick-Greeter](https://github.com/linuxmint/slick-greeter)
- [DankMaterialShell greeter](https://danklinux.com/docs/dankgreeter)

More backends can be implemented in the future, as needed.

Ref: https://github.com/NixOS/nixpkgs/issues/22652

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
