### PR TITLE
python3Packages.onedrive-personal-sdk: 0.1.2 -> 0.1.4

### DIFF
--- a/pkgs/development/python-modules/onedrive-personal-sdk/default.nix
+++ b/pkgs/development/python-modules/onedrive-personal-sdk/default.nix
@@ -4,19 +4,20 @@
   fetchFromGitHub,
   lib,
   mashumaro,
+  numpy,
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "onedrive-personal-sdk";
-  version = "0.1.2";
+  version = "0.1.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zweckj";
     repo = "onedrive-personal-sdk";
     tag = "v${version}";
-    hash = "sha256-EiIDxgfYqumHdLskF1LJGelQ2omXbuHZ/+qyVy1SZZU=";
+    hash = "sha256-+TfBc8SPzeVIXnocOZBvVd4LI37+fQBaKvnDz7X2iqo=";
   };
 
   build-system = [ setuptools ];
@@ -24,6 +25,7 @@ buildPythonPackage rec {
   dependencies = [
     aiohttp
     mashumaro
+    numpy
   ];
 
   pythonImportsCheck = [ "onedrive_personal_sdk" ];


### PR DESCRIPTION
Diff: https://github.com/zweckj/onedrive-personal-sdk/compare/v0.1.2...v0.1.4

Changelog: https://github.com/zweckj/onedrive-personal-sdk/releases/tag/v0.1.4

closes https://github.com/NixOS/nixpkgs/pull/483642
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
