### PR TITLE
home-assistant: pin psutil to 7.1.2

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -162,6 +162,23 @@ let
         };
       });
 
+      # Pinned due to API changes in psutil 7.2.x that removed named tuples from psutil._common
+      psutil = super.psutil.overridePythonAttrs (oldAttrs: rec {
+        version = "7.1.2";
+        src = fetchFromGitHub {
+          inherit (oldAttrs.src) owner repo;
+          tag = "release-${version}";
+          hash = "sha256-LyGnLrq+SzCQmz8/P5DOugoNEyuH0IC7uIp8UAPwH0U=";
+        };
+        # Restore test configuration compatible with 7.1.x
+        # (psutil 7.2.x moved tests from psutil/tests/ to tests/)
+        nativeCheckInputs = [ super.pytestCheckHook ];
+        enabledTestPaths = [
+          "${placeholder "out"}/${super.python.sitePackages}/psutil/tests/test_system.py"
+        ];
+        preCheck = "";
+      });
+
       py-madvr2 = super.py-madvr2.overridePythonAttrs (oldAttrs: rec {
         version = "1.6.40";
         src = fetchFromGitHub {


### PR DESCRIPTION
The upstream Home Assistant manifest requires psutil==7.1.2. psutil 7.2.x removed named tuples (sbattery, sdiskusage, etc.) from psutil._common, breaking the systemmonitor component at runtime.

Pin psutil within the Home Assistant Python environment to prevent breakage when the global psutil is updated past 7.1.x.

Resolves #496133

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
