### PR TITLE
cosmic-ext-applet-clipboard-manager: init at 0-unstable-2026-03-04

### DIFF
--- a/pkgs/by-name/co/cosmic-ext-applet-clipboard-manager/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-applet-clipboard-manager/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  libcosmicAppHook,
+  pkg-config,
+  just,
+  libxkbcommon,
+  wayland,
+  stdenv,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cosmic-ext-applet-clipboard-manager";
+  version = "0-unstable-2026-03-04";
+
+  src = fetchFromGitHub {
+    owner = "cosmic-utils";
+    repo = "clipboard-manager";
+    rev = "d8840236acbaf3679acd7c4b10102b86e7da27f6";
+    hash = "sha256-GTSz0NRRImdweLx0PdgrwJ/iL5ujeyysbxAuHlX5AUQ=";
+  };
+
+  cargoHash = "sha256-0CziruLYJrku1FO7tBSJRNtS5JyhjDWxTEcOwUVYmSk=";
+
+  nativeBuildInputs = [
+    libcosmicAppHook
+    pkg-config
+    just
+  ];
+
+  buildInputs = [
+    libxkbcommon
+    wayland
+  ];
+
+  postPatch = ''
+    substituteInPlace justfile \
+      --replace-warn '`git rev-parse --short HEAD`' '"${version}"'
+  '';
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  justFlags = [
+    "--set"
+    "prefix"
+    (placeholder "out")
+    "--set"
+    "cargo-target-dir"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}"
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version"
+      "branch=HEAD"
+    ];
+  };
+
+  meta = with lib; {
+    description = "Clipboard manager applet for COSMIC";
+    homepage = "https://github.com/cosmic-utils/clipboard-manager";
+    license = licenses.gpl3Only;
+    mainProgram = "cosmic-ext-applet-clipboard-manager";
+    maintainers = with maintainers; [ krit ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Add [`cosmic-ext-applet-clipboard-manager`](https://github.com/cosmic-utils/clipboard-manager), a clipboard manager applet for COSMIC.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
