### PR TITLE
reaper: fix xdg-open

### DIFF
--- a/pkgs/applications/audio/reaper/default.nix
+++ b/pkgs/applications/audio/reaper/default.nix
@@ -17,6 +17,7 @@
   xdg-utils,
   xdotool,
   which,
+  openssl,
 
   jackSupport ? stdenv.hostPlatform.isLinux,
   jackLibrary,
@@ -59,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     which
     autoPatchelfHook
-    xdg-utils # Required for desktop integration
+    xdg-utils # Required for install script
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     undmg
@@ -112,6 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
         # We opt for wrapping the executable with LD_LIBRARY_PATH prefix.
         # Note that libcurl and libxml2_13 are needed for ReaPack to run.
         wrapProgram $out/opt/REAPER/reaper \
+          --prefix PATH : "${lib.makeBinPath [ xdg-utils ]}" \
           --prefix LD_LIBRARY_PATH : "${
             lib.makeLibraryPath [
               curl
@@ -121,6 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
               vlc
               xdotool
               stdenv.cc.cc
+              openssl
             ]
           }"
 


### PR DESCRIPTION
Supercedes #464248 which has been stalled for several months, this takes only the bits that are still relevant. Technically, now that reaper reads from PATH for these programs, this bug shouldn't be hitting near as many people to begin with, but we shouldn't rely on this in general.

Closes #341752 (as mentioned, libswell now using PATH means this was mostly covered since the bump to 7.55, but this should solve it for good) 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
