### PR TITLE
vtk_9_6: init at 9.6.0

### DIFF
--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -10,4 +10,9 @@ in
     version = "9.5.2";
     sourceSha256 = "sha256-zuZLmNJw/3MC2vHvE0WN/11awey0XUdyODX399ViyYk=";
   };
+
+  vtk_9_6 = mkVtk {
+    version = "9.6.0";
+    sourceSha256 = "sha256-130YBpT6r9yBZXi5pTZR9nkOeZYVgRv7uRAYZho7uPI=";
+  };
 }

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -39,6 +39,7 @@
   # filters
   openturns,
   openslide,
+  onnxruntime,
 
   # io modules
   cgns,
@@ -65,6 +66,7 @@
   hdf5,
   netcdf,
   opencascade-occt,
+  openusd,
 
   # threading
   onetbb,
@@ -113,6 +115,9 @@ let
     viskores = self.callPackage viskores.override { };
     gdal = self.callPackage gdal.override { useMinimalFeatures = true; };
     pdal = self.callPackage pdal.override { };
+    # vtk fail to configure with openusd with materialX support
+    # see https://github.com/AcademySoftwareFoundation/MaterialX/pull/2752
+    openusd = openusd.override { withMaterialX = false; };
   });
   vtkBool = feature: bool: lib.cmakeFeature feature "${if bool then "YES" else "NO"}";
 in
@@ -155,6 +160,10 @@ stdenv.mkDerivation (finalAttrs: {
     vtkPackages.gdal
     vtkPackages.pdal
   ]
+  ++ lib.optionals (lib.versionAtLeast finalAttrs.version "9.6.0") [
+    vtkPackages.openusd
+    onnxruntime
+  ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libxfixes
     libxrender
@@ -169,7 +178,11 @@ stdenv.mkDerivation (finalAttrs: {
     eigen
     boost
     verdict
+  ]
+  ++ lib.optionals (lib.versionOlder finalAttrs.version "9.6.0") [
     double-conversion
+  ]
+  ++ [
     freetype
     lz4
     xz

--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -36,9 +36,10 @@
   stdenv,
   onetbb,
   withDocs ? false,
-  withOsl ? true,
+  withOsl ? !stdenv.hostPlatform.isDarwin,
   withTools ? false,
   withUsdView ? false,
+  withMaterialX ? true,
   writeShellScriptBin,
 }:
 
@@ -96,8 +97,8 @@ buildPythonPackage rec {
     (lib.cmakeBool "PXR_BUILD_PYTHON_DOCUMENTATION" withDocs)
     (lib.cmakeBool "PXR_BUILD_USDVIEW" withUsdView)
     (lib.cmakeBool "PXR_BUILD_USD_TOOLS" withTools)
-    (lib.cmakeBool "PXR_ENABLE_MATERIALX_SUPPORT" true)
-    (lib.cmakeBool "PXR_ENABLE_OSL_SUPPORT" (!stdenv.hostPlatform.isDarwin && withOsl))
+    (lib.cmakeBool "PXR_ENABLE_MATERIALX_SUPPORT" withMaterialX)
+    (lib.cmakeBool "PXR_ENABLE_OSL_SUPPORT" withOsl)
   ];
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7641,7 +7641,7 @@ with pkgs;
     gtkVersion = "4";
   };
 
-  inherit (callPackage ../development/libraries/vtk { }) vtk_9_5;
+  inherit (callPackage ../development/libraries/vtk { }) vtk_9_5 vtk_9_6;
 
   vtk = vtk_9_5;
 


### PR DESCRIPTION
changelog: https://docs.vtk.org/en/latest/release_details/9.6.html

vtk_9_6 support New USD exporter and ONNX Inference is now available. double-conversion is removed in favor of vendored fmt.

for the usd io module, i need to further minimize openusd's closure size in a later pr. (e.g. migrate to pkgs/by-name make python support optional)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
