### PR TITLE
rocmPackages.rocprof-trace-decoder: init at 0.1.7

### DIFF
--- a/pkgs/development/rocm-modules/default.nix
+++ b/pkgs/development/rocm-modules/default.nix
@@ -90,6 +90,8 @@ let
         inherit (llvm) clang;
       };
 
+      rocprof-trace-decoder = self.callPackage ./rocprof-trace-decoder { };
+
       roctracer = self.callPackage ./roctracer { };
 
       rocgdb = self.callPackage ./rocgdb { };

--- a/pkgs/development/rocm-modules/rocprof-trace-decoder/default.nix
+++ b/pkgs/development/rocm-modules/rocprof-trace-decoder/default.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rocmPackages,
+  cmake,
+  python3,
+  nlohmann_json,
+  gtest,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rocprof-trace-decoder";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "ROCm";
+    repo = "rocm-systems";
+    # No tags (yet?)
+    rev = "feeca99950c590e0b8228733405c4a1a10fa4773";
+    sparseCheckout = [
+      "projects/rocprof-trace-decoder"
+      "shared"
+    ];
+    hash = "sha256-aJhPiZf5380jj2IeCipgcTEQYogr5R19UnVwKRGnkxo=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/projects/rocprof-trace-decoder";
+
+  patches = [
+    ./use-system-dependencies.patch
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    rocmPackages.rocm-comgr
+    rocmPackages.rocm-runtime
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_TESTS" finalAttrs.doCheck)
+  ];
+
+  nativeCheckInputs = [
+    python3
+  ];
+
+  checkInputs = [
+    nlohmann_json
+    gtest
+  ];
+
+  preCheck = ''
+    patchShebangs test
+  '';
+
+  checkPhase =
+    let
+      # - Sanitize tests fail because the UBSan runtime (__ubsan_vptr_type_cache) is not available for
+      #   LD_PRELOAD in the sandbox.
+      # - Validate tests fail because they depend on execute tests producing output files first, but
+      #   CTest runs them concurrently without proper ordering.
+      skipPattern = "_(sanitize|validate)$";
+    in
+    ''
+      runHook preCheck
+
+      ctest --test-dir . --output-on-failure -E '${skipPattern}'
+
+      runHook postCheck
+    '';
+
+  doCheck = true;
+
+  meta = {
+    description = "Library for decoding ROCm thread trace data";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprof-trace-decoder";
+    license = with lib.licenses; [ mit ];
+    teams = [ lib.teams.rocm ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/development/rocm-modules/rocprof-trace-decoder/use-system-dependencies.patch
+++ b/pkgs/development/rocm-modules/rocprof-trace-decoder/use-system-dependencies.patch
@@ -1,0 +1,81 @@
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index a923cad..53b0f49 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -34,13 +34,7 @@ if(DISABLE_COMGR)
+ endif()
+ 
+ if(NOT APPLE AND BUILD_INTEGRATION_TESTS)
+-    # Add nlohmann JSON as an external dependency
+-    include(FetchContent)
+-    FetchContent_Declare(
+-        json
+-        GIT_REPOSITORY https://github.com/nlohmann/json.git
+-        GIT_TAG v3.11.3)
+-    FetchContent_MakeAvailable(json)
++    find_package(nlohmann_json REQUIRED)
+ 
+     add_subdirectory(att-tool)
+ endif()
+diff --git a/test/att-tool/CMakeLists.txt b/test/att-tool/CMakeLists.txt
+index 208af16..acd161f 100644
+--- a/test/att-tool/CMakeLists.txt
++++ b/test/att-tool/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ #
+ # ATT decoder wrapper library for use by the rocprofv3 tool
+ #
+-find_library(COMGR REQUIRED NAMES amd_comgr HINTS /opt/rocm/lib)
++find_library(COMGR REQUIRED NAMES amd_comgr)
+ 
+ set(ATT_TOOL_SOURCE_FILES
+     waitcnt/analysis.cpp
+@@ -19,8 +19,11 @@ set(ATT_TOOL_SOURCE_FILES
+ 
+ set(DECODER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../../source/)
+ 
+-set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../include/ ${DECODER_SRC} ${CMAKE_CURRENT_SOURCE_DIR} ${json_SOURCE_DIR}/include /opt/rocm/include)
+-set(LINK_LIBS ${COMGR} pthread)
++set(INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../../include/ ${DECODER_SRC} ${CMAKE_CURRENT_SOURCE_DIR})
++find_path(COMGR_INCLUDE_DIR REQUIRED NAMES amd_comgr.h PATH_SUFFIXES amd_comgr)
++find_path(HSA_INCLUDE_DIR REQUIRED NAMES hsa/amd_hsa_elf.h)
++set(LINK_LIBS ${COMGR} pthread nlohmann_json::nlohmann_json)
++list(APPEND INCLUDE_DIRS ${COMGR_INCLUDE_DIR} ${HSA_INCLUDE_DIR})
+ 
+ # Sources re-globbed only for sanitizer builds
+ file(GLOB ATT_DECODER_V3_FILES
+diff --git a/test/att-tool/sdk/disassembly.hpp b/test/att-tool/sdk/disassembly.hpp
+index c054143..ec3d6d2 100644
+--- a/test/att-tool/sdk/disassembly.hpp
++++ b/test/att-tool/sdk/disassembly.hpp
+@@ -22,7 +22,7 @@
+ 
+ #pragma once
+ 
+-#include <amd_comgr/amd_comgr.h>
++#include <amd_comgr.h>
+ #include <hsa/amd_hsa_elf.h>
+ 
+ #include <fcntl.h>
+diff --git a/test/unit/CMakeLists.txt b/test/unit/CMakeLists.txt
+index 8adafc0..9501efe 100644
+--- a/test/unit/CMakeLists.txt
++++ b/test/unit/CMakeLists.txt
+@@ -9,16 +9,7 @@ project(att-decoder-unit-tests LANGUAGES CXX)
+ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ 
+-# Fetch GoogleTest
+-include(FetchContent)
+-FetchContent_Declare(
+-    googletest
+-    GIT_REPOSITORY https://github.com/google/googletest.git
+-    GIT_TAG v1.14.0)
+-set(INSTALL_GTEST
+-    OFF
+-    CACHE BOOL "" FORCE)
+-FetchContent_MakeAvailable(googletest)
++find_package(GTest REQUIRED)
+ 
+ enable_testing()
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add the recently open-sourced `rocprof-trace-decoder`.
Homepage: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprof-trace-decoder

cc @LunNova

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
