### PR TITLE
mkosi: only provide libs from nix if path exists

### DIFF
--- a/pkgs/by-name/mk/mkosi/0002-Fix-library-resolving.patch
+++ b/pkgs/by-name/mk/mkosi/0002-Fix-library-resolving.patch
@@ -11,7 +11,7 @@ Signed-off-by: Moritz Sanft <58110325+msanft@users.noreply.github.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/mkosi/sandbox.py b/mkosi/sandbox.py
-index 4a41f333a764bc41abbd36302bd9fe86baa45a3f..1ce102597f1935deadcec475ec873eab9ca03c22 100755
+index 4a41f333a764bc41abbd36302bd9fe86baa45a3f..1f7f133912c022a9fb3258437f4ed09872d79dd4 100755
 --- a/mkosi/sandbox.py
 +++ b/mkosi/sandbox.py
 @@ -124,7 +124,7 @@ class cap_user_data_t(ctypes.Structure):
@@ -19,7 +19,7 @@ index 4a41f333a764bc41abbd36302bd9fe86baa45a3f..1ce102597f1935deadcec475ec873eab
  
  
 -libc = ctypes.CDLL(None, use_errno=True)
-+libc = ctypes.CDLL("@LIBC@", use_errno=True)
++libc = ctypes.CDLL("@LIBC@" if os.path.exists("@LIBC@") else None, use_errno=True)
  
  libc.syscall.restype = ctypes.c_long
  libc.unshare.argtypes = (ctypes.c_int,)
@@ -28,7 +28,7 @@ index 4a41f333a764bc41abbd36302bd9fe86baa45a3f..1ce102597f1935deadcec475ec873eab
          return
  
 -    libseccomp = ctypes.CDLL("libseccomp.so.2")
-+    libseccomp = ctypes.CDLL("@LIBSECCOMP@")
++    libseccomp = ctypes.CDLL("@LIBSECCOMP@" if os.path.exists("@LIBSECCOMP@") else "libseccomp.so.2")
      if libseccomp is None:
          raise FileNotFoundError("libseccomp.so.2")
  


### PR DESCRIPTION
When using a tools tree, we may not be able to access this location and actually want the normal lookup to happen.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
