### PR TITLE
nixos/torrserver: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1568,6 +1568,7 @@
   ./services/torrent/rqbit.nix
   ./services/torrent/rtorrent.nix
   ./services/torrent/torrentstream.nix
+  ./services/torrent/torrserver.nix
   ./services/torrent/transmission.nix
   ./services/tracing/tempo.nix
   ./services/ttys/getty.nix

--- a/nixos/modules/services/torrent/torrserver.nix
+++ b/nixos/modules/services/torrent/torrserver.nix
@@ -1,0 +1,188 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.torrserver;
+
+  boolFlag = name: cliName: lib.optional (cfg.${name} or false) cliName;
+  optFlag = name: cliName: lib.optional (cfg.${name} != null) "${cliName}=${toString cfg.${name}}";
+  args =
+    [ ]
+    ++ optFlag "port" "--port"
+    ++ optFlag "ip" "--ip"
+    ++ boolFlag "ssl" "--ssl"
+    ++ optFlag "sslPort" "--sslport"
+    ++ optFlag "sslCert" "--sslcert"
+    ++ optFlag "sslKey" "--sslkey"
+    ++ optFlag "dataDir" "--path"
+    ++ optFlag "logPath" "--logpath"
+    ++ optFlag "webLogPath" "--weblogpath"
+    ++ boolFlag "readOnlyDb" "--rdb"
+    ++ boolFlag "httpAuth" "--httpauth"
+    ++ boolFlag "dontKill" "--dontkill"
+    ++ optFlag "torrentsDir" "--torrentsdir"
+    ++ optFlag "torrentAddr" "--torrentaddr"
+    ++ optFlag "publicIPv4" "--pubipv4"
+    ++ optFlag "publicIPv6" "--pubipv6"
+    ++ boolFlag "allowSearchWithoutAuth" "--searchwa"
+    ++ optFlag "maxStreamSize" "--maxsize"
+    ++ optFlag "telegramToken" "--tg";
+in
+{
+  meta.maintainers = with lib.maintainers; [ r4v3n6101 ];
+
+  options.services.torrserver = {
+    enable = lib.mkEnableOption "Enable TorrServer service";
+
+    package = lib.mkPackageOption pkgs "torrserver" { };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to open the firewall for the TorrServer port.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8090;
+      description = "Web server HTTP port";
+    };
+
+    ip = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Web server bind address. Null binds to all interfaces";
+    };
+
+    ssl = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable HTTPS for web server";
+    };
+
+    sslPort = lib.mkOption {
+      type = lib.types.nullOr lib.types.port;
+      default = null;
+      description = "HTTPS port. Null uses previous DB value or default 8091";
+    };
+
+    sslCert = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "SSL certificate path. Null generates self-signed cert";
+    };
+
+    sslKey = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "SSL key path. Null generates self-signed key";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Database and configuration directory path";
+    };
+
+    workingDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/torrserver";
+      description = "Working directory for TorrServer";
+    };
+
+    logPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Server log file path";
+    };
+
+    webLogPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Web access log file path";
+    };
+
+    readOnlyDb = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Start server in read-only database mode";
+    };
+
+    httpAuth = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable HTTP authentication on all requests";
+    };
+
+    dontKill = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Do not terminate server on signal";
+    };
+
+    torrentsDir = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Directory to auto-load torrent files from";
+    };
+
+    torrentAddr = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Torrent client address ([IP]:PORT)";
+    };
+
+    publicIPv4 = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Public IPv4 address";
+    };
+
+    publicIPv6 = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Public IPv6 address";
+    };
+
+    allowSearchWithoutAuth = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Allow search without authentication";
+    };
+
+    maxStreamSize = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = null;
+      description = "Maximum allowed stream size in bytes";
+    };
+
+    telegramToken = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Telegram bot token";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.torrserver = {
+      description = "TorrServer";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} ${lib.concatStringsSep " " args}";
+        WorkingDirectory = cfg.workingDir;
+
+        StateDirectory = "torrserver";
+        StateDirectoryMode = "0755";
+
+        Restart = "on-failure";
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1647,6 +1647,7 @@ in
   tmate-ssh-server = runTest ./tmate-ssh-server.nix;
   tomcat = runTest ./tomcat.nix;
   tor = runTest ./tor.nix;
+  torrserver = runTest ./torrserver.nix;
   tpm-ek = handleTest ./tpm-ek { };
   tpm2 = import ./tpm2 { inherit runTest; };
   traccar = runTest ./traccar.nix;

--- a/nixos/tests/torrserver.nix
+++ b/nixos/tests/torrserver.nix
@@ -1,0 +1,18 @@
+{ ... }:
+{
+  name = "torrserver";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.torrserver = {
+        enable = true;
+        port = 1441;
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("torrserver.service")
+    machine.wait_for_open_port(1441)
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Created module for spinning up `torrserver` web-server.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
