### PR TITLE
python3Packages.langsmith: 0.6.4 -> 0.7.12

### DIFF
--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -14,6 +13,7 @@
   requests,
   requests-toolbelt,
   uuid-utils,
+  xxhash,
   zstandard,
 
   # tests
@@ -23,6 +23,7 @@
   multipart,
   opentelemetry-sdk,
   pytest-asyncio,
+  pytest-httpx,
   pytest-socket,
   pytest-vcr,
   pytestCheckHook,
@@ -30,14 +31,14 @@
 
 buildPythonPackage rec {
   pname = "langsmith";
-  version = "0.6.4";
+  version = "0.7.12";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langsmith-sdk";
     tag = "v${version}";
-    hash = "sha256-325A2kEx2UrykxVRzp6WQCPrg92Vy+6R1CfgnCLV2V8=";
+    hash = "sha256-5BVQYlp/RMFN1Ja75gz9iFneqkSuoDpqXilHbyEAPdA=";
   };
 
   sourceRoot = "${src.name}/python";
@@ -53,6 +54,7 @@ buildPythonPackage rec {
     requests
     requests-toolbelt
     uuid-utils
+    xxhash
     zstandard
   ];
 
@@ -60,9 +62,10 @@ buildPythonPackage rec {
     anthropic
     attrs
     dataclasses-json
+    multipart
     opentelemetry-sdk
     pytest-asyncio
-    multipart
+    pytest-httpx
     pytest-socket
     pytest-vcr
     pytestCheckHook
@@ -93,6 +96,8 @@ buildPythonPackage rec {
     # flaky time comparisons
     # https://github.com/langchain-ai/langsmith-sdk/issues/2245
     "tests/unit_tests/test_uuid_v7.py"
+    # google-adk isn't packaged (and has an enormous number of dependencies)
+    "tests/unit_tests/wrappers/test_google_adk.py"
   ];
 
   pythonImportsCheck = [ "langsmith" ];

--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -29,7 +29,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "langsmith";
   version = "0.7.12";
   pyproject = true;
@@ -37,11 +37,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langsmith-sdk";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-5BVQYlp/RMFN1Ja75gz9iFneqkSuoDpqXilHbyEAPdA=";
   };
 
-  sourceRoot = "${src.name}/python";
+  sourceRoot = "${finalAttrs.src.name}/python";
 
   pythonRelaxDeps = [ "orjson" ];
 
@@ -107,7 +107,7 @@ buildPythonPackage rec {
   meta = {
     description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform";
     homepage = "https://github.com/langchain-ai/langsmith-sdk";
-    changelog = "https://github.com/langchain-ai/langsmith-sdk/releases/tag/${src.tag}";
+    changelog = "https://github.com/langchain-ai/langsmith-sdk/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       natsukium
@@ -115,4 +115,4 @@ buildPythonPackage rec {
     ];
     mainProgram = "langsmith";
   };
-}
+})


### PR DESCRIPTION
Unblocks the rest of the langchain/langgraph packages from updating.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
