### PR TITLE
pegasus-frontend: 0-unstable-2024-11-11 -> 0-unstable-2025-03-02

### DIFF
--- a/pkgs/by-name/pe/pegasus-frontend/package.nix
+++ b/pkgs/by-name/pe/pegasus-frontend/package.nix
@@ -7,17 +7,16 @@
   sqlite,
   libsForQt5,
 }:
-
 stdenv.mkDerivation {
   pname = "pegasus-frontend";
-  version = "0-unstable-2024-11-11";
+  version = "0-unstable-2025-03-02";
 
   src = fetchFromGitHub {
     owner = "mmatyas";
     repo = "pegasus-frontend";
-    rev = "54362976fd4c6260e755178d97e9db51f7a896af";
+    rev = "7d08fdc5578c4cd499d696ea734809185c05a9c1";
     fetchSubmodules = true;
-    hash = "sha256-DqtkvDg0oQL9hGB+6rNXe3sDBywvnqy9N31xfyl6nbI=";
+    hash = "sha256-TBdmvCcIKfueTUxMzMvrle5+MRjjs4yDLTpKiQ2WUk0=";
   };
 
   nativeBuildInputs = [
@@ -33,6 +32,7 @@ stdenv.mkDerivation {
       qtsvg
       qtgraphicaleffects
       qtx11extras
+      qtimageformats
     ])
     ++ [
       sqlite


### PR DESCRIPTION
Upgrades to the latest commit of pegasus-frontend.
Also adds `qtimageformats` as a dependency, which is required for image formats like webp to load in the application.
Update does not include breaking changes. [[CHANGELOG]](https://github.com/mmatyas/pegasus-frontend/compare/54362976fd4c6260e755178d97e9db51f7a896af...7d08fdc5578c4cd499d696ea734809185c05a9c1)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
