### PR TITLE
roboto*: use installFonts

### DIFF
--- a/pkgs/by-name/ro/roboto-flex/package.nix
+++ b/pkgs/by-name/ro/roboto-flex/package.nix
@@ -2,25 +2,21 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "roboto-flex";
   version = "3.200";
 
   src = fetchzip {
-    url = "https://github.com/googlefonts/roboto-flex/releases/download/${version}/roboto-flex-fonts.zip";
-    stripRoot = false;
+    url = "https://github.com/googlefonts/roboto-flex/releases/download/${finalAttrs.version}/roboto-flex-fonts.zip";
     hash = "sha256-p8BvE4f6zQLygl49hzYTXXVQFZEJjrlfUvjNW+miar4=";
   };
 
-  installPhase = ''
-    runHook preInstall
+  sourceRoot = "${finalAttrs.src.name}/roboto-flex-fonts/fonts";
 
-    install -Dm644 roboto-flex-fonts/fonts/variable/*.ttf -t $out/share/fonts/truetype
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     homepage = "https://github.com/googlefonts/roboto-flex";
@@ -29,4 +25,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.romildo ];
   };
-}
+})

--- a/pkgs/by-name/ro/roboto-mono/package.nix
+++ b/pkgs/by-name/ro/roboto-mono/package.nix
@@ -2,12 +2,18 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  installFonts,
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "roboto-mono";
   version = "3.001";
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
   src = fetchFromGitHub {
     owner = "googlefonts";
@@ -16,11 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-i0r8x4VgaOYW/pYXK+AXw7jMwhA8Hs9VQ1lq5f/xTe0=";
   };
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm644 fonts/ttf/*.ttf -t $out/share/fonts/truetype/RobotoMono
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ro/roboto-serif/package.nix
+++ b/pkgs/by-name/ro/roboto-serif/package.nix
@@ -3,14 +3,20 @@
   stdenvNoCC,
   fetchurl,
   unzip,
+  installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "roboto-serif";
   version = "1.008";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchurl {
-    url = "https://github.com/googlefonts/roboto-serif/releases/download/v${version}/RobotoSerifFonts-v${version}.zip";
+    url = "https://github.com/googlefonts/roboto-serif/releases/download/v${finalAttrs.version}/RobotoSerifFonts-v${finalAttrs.version}.zip";
     hash = "sha256-Nm9DcxL0CgA51nGeZJPWSCipgqwnNPlhj0wHyGhLaYQ=";
   };
 
@@ -18,15 +24,8 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [
     unzip
+    installFonts
   ];
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 variable/*.ttf -t $out/share/fonts/truetype
-
-    runHook postInstall
-  '';
 
   meta = {
     description = "Roboto family of fonts";
@@ -40,4 +39,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with lib.maintainers; [ wegank ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ro/roboto-slab/package.nix
+++ b/pkgs/by-name/ro/roboto-slab/package.nix
@@ -1,10 +1,11 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
 }:
 
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "roboto-slab";
   version = "2.000";
 
@@ -15,14 +16,15 @@ stdenv.mkDerivation {
     sha256 = "1v6z0a2xgwgf9dyj62sriy8ckwpbwlxkki6gfax1f4h4livvzpdn";
   };
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp -a fonts/static/*.ttf $out/share/fonts/truetype/
-  '';
-
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
   outputHash = "0g663npi5lkvwcqafd4cjrm90ph0nv1lig7d19xzfymnj47qpj8x";
+
+  postPatch = ''
+    rm -r ./old
+  '';
+
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     homepage = "https://fonts.google.com/specimen/Roboto+Slab";

--- a/pkgs/by-name/ro/roboto/package.nix
+++ b/pkgs/by-name/ro/roboto/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -14,13 +15,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-vfn4KmOHHSVYT9XK+mDz5f4s8LnkCAY/IyTa3Rmir2k=";
   };
 
-  installPhase = ''
-    runHook preInstall
+  nativeBuildInputs = [ installFonts ];
 
-    install -Dm644 unhinted/static/*.ttf -t $out/share/fonts/truetype
-
-    runHook postInstall
-  '';
+  sourceRoot = "${finalAttrs.src.name}/unhinted/static";
 
   meta = {
     homepage = "https://github.com/googlefonts/roboto-3-classic";


### PR DESCRIPTION
#495640 
In the `roboto` package itself, it specifically uses `unhinted/static` subdir, which I don't know the reasoning behind but left it the same because there's a ton of subfolders for different builds and I wanted to preserve it just in case it's important.

The rest of them I let install as the hook wanted, which just sometimes got ttf AND otf versions. Also added the webfont outputs where applicable
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
