### PR TITLE
gws: init at 0.6.3

### DIFF
--- a/pkgs/by-name/gw/gws/package.nix
+++ b/pkgs/by-name/gw/gws/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  dbus,
+  apple-sdk_14,
+  darwinMinVersionHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gws";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "googleworkspace";
+    repo = "cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8vRBW7RUwHHAvAiF8WahkRh0pH205UiuJloY0DgFwLM=";
+  };
+
+  cargoHash = "sha256-tIJikoRFbUYYlkOjfWoPogoB+yhY80TTtSzEXgSEP8A=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [ dbus ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      apple-sdk_14
+      (darwinMinVersionHook "10.15")
+    ];
+
+  doCheck = false;
+
+  meta = {
+    description = "One CLI for all of Google Workspace";
+    homepage = "https://github.com/googleworkspace/cli";
+    changelog = "https://github.com/googleworkspace/cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "gws";
+    maintainers = with lib.maintainers; [ imalison ];
+  };
+})


### PR DESCRIPTION
## Summary
- add new package `gws` (Google Workspace CLI) at `0.6.3`
- package from `googleworkspace/cli` using `rustPlatform.buildRustPackage`
- set `mainProgram = "gws"` and metadata

## Testing
- `nix-build -A gws --no-out-link` (x86_64-linux)

## Notes
- existing packaging was found in NUR (`yasunori0418/nur-packages`) but not in nixpkgs
- updated this PR from the original `0.4.1` submission after upstream released newer tags, latest verified as `v0.6.3` on 2026-03-06
