### PR TITLE
nixos/swanctl: fix the cert and cacert options

### DIFF
--- a/nixos/modules/services/networking/strongswan-swanctl/param-constructors.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/param-constructors.nix
@@ -149,19 +149,4 @@ rec {
       paramsToRenderedStrings prefixedAttrs (mapAttrs (_n: _v: p) prefixedAttrs);
   };
 
-  mkPostfixedAttrsOfParams = params: description: {
-    _type = "param";
-    option = mkOption {
-      type = types.attrsOf (types.submodule { options = paramsToOptions params; });
-      default = { };
-      description = description;
-    };
-    render =
-      postfix: attrs:
-      let
-        postfixedAttrs = mapAttrs' (name: nameValuePair "${name}-${postfix}") attrs;
-      in
-      paramsToRenderedStrings postfixedAttrs (mapAttrs (_n: _v: params) postfixedAttrs);
-  };
-
 }

--- a/nixos/modules/services/networking/strongswan-swanctl/swanctl-params.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/swanctl-params.nix
@@ -433,7 +433,7 @@ in
                 located, the first certificate is used.
               '';
 
-              cert = mkPostfixedAttrsOfParams certParams ''
+              cert = mkPrefixedAttrsOfParams certParams ''
                 Section for a certificate candidate to use for
                 authentication. Certificates in certs are transmitted as binary blobs,
                 these sections offer more flexibility.
@@ -568,7 +568,7 @@ in
                 or an absolute path.
               '';
 
-              cert = mkPostfixedAttrsOfParams certParams ''
+              cert = mkPrefixedAttrsOfParams certParams ''
                 Section for a certificate candidate to use for
                 authentication. Certificates in certs are transmitted as binary blobs,
                 these sections offer more flexibility.
@@ -590,7 +590,7 @@ in
                 swanctl `x509ca` directory or an absolute path.
               '';
 
-              cacert = mkPostfixedAttrsOfParams certParams ''
+              cacert = mkPrefixedAttrsOfParams certParams ''
                 Section for a CA certificate to accept for authentication. Certificates
                 in cacerts are transmitted as binary blobs, these sections offer more
                 flexibility.


### PR DESCRIPTION
The function `mkPostfixedAttrsOfParams` was used to define these options while in the strongsan documentation, their structure is pretty similar to the `local` and `remote` options which are defined with `mkPrefixedAttrsOfParams`:

In https://github.com/strongswan/strongswan/blob/6856bfe5bc4ad47914c03febb4d69d1e1b549f17/src/swanctl/swanctl.opt, they are defined such as:

- `connections.<conn>.local<suffix>.cert<suffix>`
- `connections.<conn>.remote<suffix>.cacert<suffix>`

Since `mkPostfixedAttrsOfParams` is no longer used, it is removed.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
