### PR TITLE
linux-firmware: Fix hardware sleep regression in amdnpu firmware

### DIFF
--- a/pkgs/by-name/li/linux-firmware/package.nix
+++ b/pkgs/by-name/li/linux-firmware/package.nix
@@ -1,6 +1,7 @@
 {
   stdenvNoCC,
   fetchFromGitLab,
+  fetchpatch,
   lib,
   python3,
   rdfind,
@@ -30,6 +31,15 @@ stdenvNoCC.mkDerivation rec {
     tag = version;
     hash = "sha256-QHoS9+WS9IjRVhTJEFF/X8+4ZKjKwpJAvf7EqsV+qEY=";
   };
+
+  patches = [
+    # amdnpu: Restore old NPU firmware for compatibility
+    # https://gitlab.com/kernel-firmware/linux-firmware/-/merge_requests/935
+    (fetchpatch {
+      url = "https://gitlab.com/kernel-firmware/linux-firmware/-/commit/58cf579b98c0c4878deeda1acb5db70e699875b5.patch";
+      hash = "sha256-2UO9CxGM2Asb/fRAST4zRlMBSVjM+N/87NzSkSoQrQ0=";
+    })
+  ];
 
   postUnpack = ''
     patchShebangs .


### PR DESCRIPTION
linux-firmware 20260221 introduced new AMD NPU firmware that’s incompatible with kernels before the unreleased 7.0-rc versions, preventing affected devices from going into sleep, leading to battery drain and overheating for closed laptops (whether or not one is actually trying to use the NPU). Apply the upstream patch that restores the old files for current kernels and renames the new files for unreleased kernels.

https://gitlab.freedesktop.org/drm/amd/-/issues/5009
https://gitlab.com/kernel-firmware/linux-firmware/-/merge_requests/935

Tested using `amd-s2idle test` from the `amd-debug-tools` package on my Framework Laptop 13 with Ryzen AI 9 HX 370.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
