### PR TITLE
nixos/openbao: Allow openbao service sockets to be accessed by other services

### DIFF
--- a/nixos/modules/services/security/openbao.nix
+++ b/nixos/modules/services/security/openbao.nix
@@ -121,15 +121,18 @@ in
         StateDirectory = "openbao";
         StateDirectoryMode = "0700";
         RuntimeDirectory = "openbao";
-        RuntimeDirectoryMode = "0700";
+        RuntimeDirectoryMode = "0755";
+
+        DynamicUser = true;
+        User = "openbao";
+        Group = "openbao";
 
         CapabilityBoundingSet = "";
-        DynamicUser = true;
         LimitCORE = 0;
         LockPersonality = true;
         MemorySwapMax = 0;
         MemoryZSwapMax = 0;
-        PrivateUsers = true;
+        PrivateUsers = "identity";
         ProcSubset = "pid";
         ProtectClock = true;
         ProtectControlGroups = true;
@@ -152,6 +155,7 @@ in
           "@system-service"
           "@resources"
           "~@privileged"
+          "@chown"
         ];
         UMask = "0077";
       };

--- a/nixos/tests/openbao.nix
+++ b/nixos/tests/openbao.nix
@@ -33,6 +33,14 @@ in
             unix = {
               type = "unix";
             };
+
+            unix-custom = {
+              type = "unix";
+              address = "/run/openbao/world-accessible.sock";
+              socket_mode = "0222";
+              socket_user = "openbao";
+              socket_group = "openbao";
+            };
           };
 
           cluster_addr = "https://127.0.0.1:8201";
@@ -50,6 +58,9 @@ in
 
   testScript =
     { nodes, ... }:
+    let
+      inherit (nodes.machine.services.openbao.settings) listener;
+    in
     ''
       import json
 
@@ -58,7 +69,15 @@ in
       with subtest("Wait for OpenBao to start up"):
         machine.wait_for_unit("openbao.service")
         machine.wait_for_open_port(8200)
-        machine.wait_for_open_unix_socket("${nodes.machine.services.openbao.settings.listener.unix.address}")
+        machine.wait_for_open_unix_socket("${listener.unix.address}")
+        machine.wait_for_open_unix_socket("${listener.unix-custom.address}")
+
+      with subtest("Check Unix Socket listeners"):
+        t.assertEqual("srwx------ openbao:openbao", machine.succeed("stat --printf '%A %U:%G' ${listener.unix.address}"))
+        machine.fail("su -l nobody -s /bin/sh -c 'curl --fail --silent --unix-socket ${listener.unix.address} localhost'")
+
+        t.assertEqual("s-w--w--w- openbao:openbao", machine.succeed("stat --printf '%A %U:%G' ${listener.unix-custom.address}"))
+        machine.succeed("su -l nobody -s /bin/sh -c 'curl --fail --silent --unix-socket ${listener.unix-custom.address} localhost'")
 
       with subtest("Check that the web UI is being served"):
         machine.succeed("curl -L --fail --show-error --silent $BAO_ADDR | grep '<title>OpenBao</title>'")


### PR DESCRIPTION
This PR adds user and group options to the `openbao` service, and gives it the capability of `chown`. This is used for cases where the service needs a fixed user name (e.g. postgres user auth) and where openbao has unix domain sockets.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
