### PR TITLE
argagg: move NIX_CFLAGS_COMPILE into env for structuredAttrs

### DIFF
--- a/pkgs/by-name/ar/argagg/package.nix
+++ b/pkgs/by-name/ar/argagg/package.nix
@@ -25,8 +25,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "cmake_minimum_required( VERSION 2.8 )" "cmake_minimum_required(VERSION 3.10)"
   '';
 
-  # fixes: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.
-  NIX_CFLAGS_COMPILE = lib.optional stdenv.cc.isClang "-Wno-error=deprecated-declarations";
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    # fixes: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.
+    NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+  };
 
   meta = {
     homepage = "https://github.com/vietjtnguyen/argagg";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
