### PR TITLE
libvirt: fix virt-secret-init-encryption

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -530,7 +530,10 @@ in
           "nix-helpers"
           "nix-ovmf"
         ];
-        StateDirectory = subDirs [ "dnsmasq" ];
+        StateDirectory = subDirs [
+          "dnsmasq"
+          "secrets"
+        ];
       };
     };
 

--- a/pkgs/by-name/li/libvirt/package.nix
+++ b/pkgs/by-name/li/libvirt/package.nix
@@ -33,11 +33,13 @@
   python3,
   readline,
   rpcsvc-proto,
+  runtimeShell,
   stdenv,
   replaceVars,
   xhtml1,
   json_c,
   writeScript,
+  writeShellApplication,
   nixosTests,
 
   # Linux
@@ -179,7 +181,23 @@ stdenv.mkDerivation rec {
     sed -i '/libxlxml2domconfigtest/d' tests/meson.build
     substituteInPlace src/libxl/libxl_capabilities.h \
      --replace-fail /usr/lib/xen ${xen}/libexec/xen
-  '';
+  ''
+  + lib.optionalString isLinux (
+    let
+      script = writeShellApplication {
+        name = "virt-secret-init-encryption-sh";
+        runtimeInputs = [
+          coreutils
+          systemd
+        ];
+        text = ''exec ${runtimeShell} "$@"'';
+      };
+    in
+    ''
+      substituteInPlace src/secret/virt-secret-init-encryption.service.in \
+        --replace-fail /usr/bin/sh ${lib.getExe script}
+    ''
+  );
 
   strictDeps = true;
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/pull/496509#issuecomment-4002323318
Fixes #496836

Tested and working.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
