### PR TITLE
osu-lazer{,-bin}: 2026.119.0 -> 2026.305.0

### DIFF
--- a/pkgs/by-name/os/osu-lazer-bin/package.nix
+++ b/pkgs/by-name/os/osu-lazer-bin/package.nix
@@ -10,23 +10,23 @@
 
 let
   pname = "osu-lazer-bin";
-  version = "2026.119.0";
+  version = "2026.305.0";
 
   src =
     {
       aarch64-darwin = fetchzip {
         url = "https://github.com/ppy/osu/releases/download/${version}-lazer/osu.app.Apple.Silicon.zip";
-        hash = "sha256-pM+dqCihHkUCu4xNZpZVIuP7UWwJ5a2DntA2S5PmxT4=";
+        hash = "sha256-UmlqeuO5VeboR0zrxBOS5AiZl/rYw+Xb5L4tbofn6T0=";
         stripRoot = false;
       };
       x86_64-darwin = fetchzip {
         url = "https://github.com/ppy/osu/releases/download/${version}-lazer/osu.app.Intel.zip";
-        hash = "sha256-wPFUH7Hy9sMPqCRoG8RMV6fZE6xtEKJGSBD7/XSTa34=";
+        hash = "sha256-h1Z+XD0bHECmPCJrxzfwJfdLiuieq/RBg2DytKOOg+c=";
         stripRoot = false;
       };
       x86_64-linux = fetchurl {
         url = "https://github.com/ppy/osu/releases/download/${version}-lazer/osu.AppImage";
-        hash = "sha256-lx8lU9tNXD90rpaKlIyR0C4eSivfmVAJP7Wq+n3Ht08=";
+        hash = "sha256-azI3PS5LIVq1H02P1Z4Bny2VFqVLUC6pwCj1UD5HA6g=";
       };
     }
     .${stdenvNoCC.system} or (throw "osu-lazer-bin: ${stdenvNoCC.system} is unsupported.");

--- a/pkgs/by-name/os/osu-lazer/deps.json
+++ b/pkgs/by-name/os/osu-lazer/deps.json
@@ -300,11 +300,6 @@
     "hash": "sha256-Nn3imJvnqLe02gR1GyUHYH4+XkrNnhLy9dyCjJCkB7M="
   },
   {
-    "pname": "managed-midi",
-    "version": "1.10.1",
-    "hash": "sha256-iuqpyp8vM7ZjtcM9KNqx9se/UhQHsYrQ+lxL4EntyXU="
-  },
-  {
     "pname": "Markdig",
     "version": "0.23.0",
     "hash": "sha256-4Kjeb54eyas0pCMbTHGPK13vW9zEnFyZ5VStwwtClq8="
@@ -605,6 +600,11 @@
     "hash": "sha256-diVAckS1zNyVE1UGkbiu9jH/25j/c+Ad5XC3EjdLDsg="
   },
   {
+    "pname": "ppy.managed-midi",
+    "version": "1.10.2",
+    "hash": "sha256-JqKDea1yCsMIlQGu8OUxw+6J0ZxmHz+VysVzcsZBd4w="
+  },
+  {
     "pname": "ppy.ManagedBass",
     "version": "2022.1216.0",
     "hash": "sha256-yG3IWNixzv+kFgYw6yAkjw9PWMpyR0tvrkFsgWGQ1qY="
@@ -626,8 +626,8 @@
   },
   {
     "pname": "ppy.osu.Framework",
-    "version": "2026.108.0",
-    "hash": "sha256-3xYUwhcZJKT446AX3Vvbb2kQaNDTGGR/efGy/E32NP8="
+    "version": "2026.303.0",
+    "hash": "sha256-wkbRfNuatxkweNe+62I3gkq9KYBbT/mVOPXOK7LRhPw="
   },
   {
     "pname": "ppy.osu.Framework.NativeLibs",
@@ -641,8 +641,8 @@
   },
   {
     "pname": "ppy.osu.Game.Resources",
-    "version": "2026.108.0",
-    "hash": "sha256-1kM2v5AqHXS2G8xD++28tcHZe9QPB4946wpG7s6dVeo="
+    "version": "2026.305.0",
+    "hash": "sha256-f79dXDjW5AH+T77mP1s36kuMZ+ukjjCnn/3Wfd7d6ys="
   },
   {
     "pname": "ppy.osuTK.NS20",
@@ -656,8 +656,8 @@
   },
   {
     "pname": "ppy.SDL3-CS",
-    "version": "2025.1205.0",
-    "hash": "sha256-Mu5kn/yC7afo3+Nz755UzspUmOOEKtZ6/N4ENCzshtM="
+    "version": "2026.302.0",
+    "hash": "sha256-7e+HN9StGkK4je1QITNT2Fsk/wrPVDEXb97xjlZx6yY="
   },
   {
     "pname": "ppy.Veldrid",

--- a/pkgs/by-name/os/osu-lazer/package.nix
+++ b/pkgs/by-name/os/osu-lazer/package.nix
@@ -22,13 +22,13 @@
 
 buildDotnetModule rec {
   pname = "osu-lazer";
-  version = "2026.119.0";
+  version = "2026.305.0";
 
   src = fetchFromGitHub {
     owner = "ppy";
     repo = "osu";
     tag = "${version}-lazer";
-    hash = "sha256-aAWWq4nX8AeWTT8/aRbHccq+Zx87qP4izxXL3fE7QMg=";
+    hash = "sha256-vUFaazcaaVRp5r/S0iAMnUa6hLHgoTauhK9KGD5/txg=";
   };
 
   projectFile = "osu.Desktop/osu.Desktop.csproj";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[compare upstream changes on GitHub](https://github.com/ppy/osu/compare/2026.119.0-lazer...2026.305.0-lazer)

the diffs were generated using [nixpkgs-update](https://github.com/nix-community/nixpkgs-update)

<details><summary>relevant check output (click to expand)</summary>

```
- built on NixOS
- The tests defined in `passthru.tests`, if any, passed
- found 2026.305.0 with grep in /nix/store/id92mc2wjbx8vn8lhlh7xzbyw00gxis1-osu-lazer-bin-2026.305.0
- found 2026.305.0 in filename of file in /nix/store/id92mc2wjbx8vn8lhlh7xzbyw00gxis1-osu-lazer-bin-2026.305.0

[...]

Nixpkgs review skipped

[...]

- found 2026.305.0 with grep in /nix/store/j53irn96iw9f49i6x6s2wx028rgzss6q-osu-lazer-2026.305.0
- found 2026.305.0 in filename of file in /nix/store/j53irn96iw9f49i6x6s2wx028rgzss6q-osu-lazer-2026.305.0
```

</details>

<details>
<summary>
<b>Instructions to test osu-lazer</b> (click to expand)
</summary>

build the derivation with:
```
nix-build -A osu-lazer https://github.com/Walavouchey/nixpkgs/archive/1795b6306e5bcf7b4b876e76d90e5e857f7db608.tar.gz
```
or
```
nix build github:Walavouchey/nixpkgs/1795b6306e5bcf7b4b876e76d90e5e857f7db608#osu-lazer
```

if it complains about unfree software, set `export NIXPKGS_ALLOW_UNFREE=1` and add `--impure` to the above command

you can then run it either from the symlink:

```
./result/bin/osu!
```

or from the store path:

```
/nix/store/j53irn96iw9f49i6x6s2wx028rgzss6q-osu-lazer-2026.305.0/bin/osu!
```

</details>
<details>
<summary>
<b>Instructions to test osu-lazer-bin</b> (click to expand)
</summary>

build the derivation with:
```
nix-build -A osu-lazer-bin https://github.com/Walavouchey/nixpkgs/archive/a1e7c760fb4332577e76909448966c116f7b9ade.tar.gz
```
or:
```
nix build github:Walavouchey/nixpkgs/a1e7c760fb4332577e76909448966c116f7b9ade#osu-lazer-bin
```

if it complains about unfree software, set `export NIXPKGS_ALLOW_UNFREE=1` and add `--impure` to the above command

you can then run it either from the symlink:

```
./result/bin/osu!
```

or from the store path:

```
/nix/store/id92mc2wjbx8vn8lhlh7xzbyw00gxis1-osu-lazer-bin-2026.305.0/bin/osu!
```

</details>

cc maintainers @gepbird @thiagokokada @Guanran928 @stepbrobd

nixpkgs-review:

```
--------- Report for 'x86_64-linux' ---------
2 packages built:
osu-lazer osu-lazer-bin
```