### PR TITLE
space-grotesk: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2,15 +2,15 @@
   List of active NixOS maintainers.
    ```nix
    handle = {
-     # Required
-     name = "Your name";
-     github = "GithubUsername";
-     githubId = your-github-id;
+   # Required
+   name = "Your name";
+   github = "GithubUsername";
+   githubId = your-github-id;
 
-     # Optional
-     email = "address@example.org";
-     matrix = "@user:example.org";
-     keys = [ { fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333"; } ];
+   # Optional
+   email = "address@example.org";
+   matrix = "@user:example.org";
+   keys = [ { fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333"; } ];
    };
    ```
 
@@ -34,7 +34,7 @@
    If `github` begins with a numeral, `handle` should be prefixed with an underscore.
    ```nix
    _1example = {
-     github = "1example";
+   github = "1example";
    };
    ```
 
@@ -21843,6 +21843,12 @@
     github = "q3k";
     githubId = 315234;
     name = "Serge Bazanski";
+  };
+  qaaxaap = {
+    email = "1515784026@qq.com";
+    github = "qaaxaap";
+    githubId = 175310223;
+    name = "KangNing Lei";
   };
   qaidvoid = {
     email = "contact@qaidvoid.dev";

--- a/pkgs/by-name/sp/space-grotesk/package.nix
+++ b/pkgs/by-name/sp/space-grotesk/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "space-grotesk";
+  version = "2.0.0";
+
+  src = fetchzip {
+    url = "https://github.com/floriankarsten/space-grotesk/releases/download/${finalAttrs.version}/SpaceGrotesk-${finalAttrs.version}.zip";
+    hash = "sha256-niwd5E3rJdGmoyIFdNcK5M9A9P2rCbpsyZCl7CDv7I8=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/fonts/opentype
+    find . -type f \( -name "*.otf" -o -name "*.ttf" \) -exec cp -v {} $out/share/fonts/opentype/ \;
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A proportional sans-serif typeface variant based on Space Mono";
+    homepage = "https://github.com/floriankarsten/space-grotesk";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ qaaxaap ];
+  };
+})


### PR DESCRIPTION
**space-grotesk: init at 2.0.0**

Add the [Space Grotesk](https://github.com/floriankarsten/space-grotesk) font family, a proportional sans-serif typeface based on Space Mono.

- **License**: [SIL Open Font License v1.1](https://github.com/floriankarsten/space-grotesk/blob/master/OFL.txt)
- **Homepage**: https://github.com/floriankarsten/space-grotesk

Basic functionality tested locally: font files install correctly and are recognized by `fc-list`.

---