### PR TITLE
emacsPackages.org-publish-rss: init at 0-unstable-2026-01-09

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/org-publish-rss/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/org-publish-rss/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  melpaBuild,
+  fetchFromSourcehut,
+  unstableGitUpdater,
+}:
+
+melpaBuild {
+  pname = "org-publish-rss";
+  version = "0-unstable-2026-01-09";
+
+  src = fetchFromSourcehut {
+    vc = "git";
+    owner = "~taingram";
+    repo = "org-publish-rss";
+    rev = "92aa98cb41635f7dd577295223a64ae44b80c99d";
+    hash = "sha256-OPAyTLcYSKYqCcO6DP0yfoNYsIZzOwhZ0u9YcE4+TFU=";
+  };
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Automatically generate RSS feeds for org-publish projects";
+    homepage = "https://git.sr.ht/~taingram/org-publish-rss";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ tetov ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
