### PR TITLE
stdenvAdapters: add `overrideMkDerivationArgs`

### DIFF
--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -216,6 +216,23 @@ rec {
     });
 
   /*
+    Modify a stdenv so as to extend `mkDerivation`'s arguments.
+    A stronger version of `addAttrsToDerivation`.
+
+    Example:
+      requireCcache =
+        overrideMkDerivationArgs
+           (oldAttrs: {
+             requiredSystemFeatures = oldAttrs.requiredSystemFeatures or [ ] ++ [ "ccache" ];
+           });
+  */
+  overrideMkDerivationArgs =
+    extension: stdenv:
+    stdenv.override (old: {
+      mkDerivationFromStdenv = extendMkDerivationArgs old extension;
+    });
+
+  /*
     Use the trace output to report all processed derivations with their
     license name.
   */


### PR DESCRIPTION
This commit exposes a function `overrideMkDerivationArgs` from `pkgs/stdenv/adapters.nix`.

This function is strictly more powerful than the already present `addAttrsToDerivation`, and useful in order to override attributes based on the final attrset passed to `mkDerivation`.

This change has been attempted before and was met generally with agreement, and this commit is explicitly a copy of the changes in @SomeoneSerge's PR [1], which ultimately stalled for non-technical reasons.

I've added interested parties of that PR as reviewers here.

[1] https://github.com/NixOS/nixpkgs/pull/350350

_Follow up commit: https://github.com/NixOS/nixpkgs/pull/499232_


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
