### PR TITLE
libe57format: 3.2.0 -> 3.3.0

### DIFF
--- a/pkgs/by-name/li/libe57format/package.nix
+++ b/pkgs/by-name/li/libe57format/package.nix
@@ -3,21 +3,26 @@
   stdenv,
   cmake,
   fetchFromGitHub,
-  fetchpatch,
+  nix-update-script,
   xercesc,
+  gtest,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libe57format";
-  version = "3.2.0";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "asmaloney";
     repo = "libE57Format";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-GyzfJshL2cOTEDp8eR0sqQq4GSnOdskiLi5mY1a2KW0=";
-    fetchSubmodules = true; # for submodule-vendored libraries such as `gtest`
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rEX251cgb6GMToGzcZcwDzjLZBGcwN8+ij1nCIpK2ZE=";
   };
+
+  postPatch = lib.optionalString finalAttrs.finalPackage.doCheck ''
+    rmdir test/extern/googletest
+    ln -s ${gtest.src} test/extern/googletest
+  '';
 
   # Repository of E57 files used for testing.
   libE57Format-test-data_src = fetchFromGitHub {
@@ -27,16 +32,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-JARpxp6Z2VioBfY0pZSyQU2mG/EllbaF3qteSFM9u8o=";
   };
 
-  env.CXXFLAGS = toString [
-    # GCC 13: error: 'int16_t' has not been declared in 'std'
-    "-include cstdint"
-  ];
-
   nativeBuildInputs = [
     cmake
   ];
 
-  buildInputs = [
+  propagatedBuildInputs = [
     xercesc
   ];
 
@@ -72,10 +72,12 @@ stdenv.mkDerivation (finalAttrs: {
     g++ -Wl,--no-undefined -shared -o libE57FormatShared.so -L. -Wl,-whole-archive -lE57Format -Wl,-no-whole-archive -lxerces-c
     mv libE57FormatShared.so libE57Format.so
 
-    if [ "$dontDisableStatic" -ne "1" ]; then
+    if [ "''${dontDisableStatic:-1}" -ne "1" ]; then
       rm libE57Format.a
     fi
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Library for reading & writing the E57 file format";

--- a/pkgs/by-name/pd/pdal/package.nix
+++ b/pkgs/by-name/pd/pdal/package.nix
@@ -24,7 +24,6 @@
   proj,
   sqlite,
   tiledb,
-  xercesc,
   zlib,
   zstd,
 }:
@@ -59,7 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
     proj
     sqlite
     tiledb
-    xercesc
     zlib
     zstd
   ]


### PR DESCRIPTION
- update to v3.3.0: https://github.com/asmaloney/libE57Format/releases/tag/v3.3.0
- add nix-update-script
- remove CXXFLAGS override, shouldn't be necessary anymore (at least in my testing)
- instead of fetching submodules, manually link in our gtest sources in prePatch (reduces source archive size)
- fix bash error if `dontDisableStatic` is undefined
- move xercesc to propagatedBuildInputs (see below)

Note: I am a bit puzzled by the postInstall script. I'm not quite sure retaining hybrid static-and-shared builds is worth the effort, especially since the installed CMake target definition only knows about the static library, so the shared library will be ignored by CMake consumers. I'd be in favor of removing it and only building shared libraries, but perhaps there's something I'm missing. The installed target file for reference:
```cmake
#----------------------------------------------------------------
# Generated CMake target import file for configuration "Release".
#----------------------------------------------------------------

# Commands may need to know the format version.
set(CMAKE_IMPORT_FILE_VERSION 1)

# Import target "E57Format" for configuration "Release"
set_property(TARGET E57Format APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
set_target_properties(E57Format PROPERTIES
  IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "CXX"
  IMPORTED_LOCATION_RELEASE "/nix/store/x6wwf4x4c5fcbirnmkvlpgkam93ilr96-libe57format-3.3.0/lib/libE57Format.a"
  )

list(APPEND _cmake_import_check_targets E57Format )
list(APPEND _cmake_import_check_files_for_E57Format "/nix/store/x6wwf4x4c5fcbirnmkvlpgkam93ilr96-libe57format-3.3.0/lib/libE57Format.a" )

# Commands beyond this point should not need to know the version.
set(CMAKE_IMPORT_FILE_VERSION)
```


### Move xercesc to propagatedBuildInputs
libe57format refers to xercesc in its exported CMake package configuration file, which in turn means it is required by every package which has libe57format in its buildInputs (only pdal at the moment). Therefore, xercesc should be part of propagatedBuildInputs.

This also simplifies the new AliceVision PR I put together, see #496867.

#### Reference
In the generated package config file (`/nix/store/.../lib/cmake/E57Format/e57format-config.cmake`), XercesC is required via `find_dependency`.
```
include(CMakeFindDependencyMacro)

find_dependency(XercesC REQUIRED)
include(${CMAKE_CURRENT_LIST_DIR}/E57Format-export.cmake)

set_target_properties(E57Format PROPERTIES
    MAP_IMPORTED_CONFIG_MINSIZEREL "MinSizeRel;Release"
    MAP_IMPORTED_CONFIG_RELWITHDEBINFO "RelWithDebInfo;Release"
)
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
