### PR TITLE
cctag: use boost186 to fix build error

### DIFF
--- a/pkgs/by-name/cc/cctag/package.nix
+++ b/pkgs/by-name/cc/cctag/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 
   cmake,
-  boost,
+  boost186,
   eigen,
   opencv,
   onetbb,
@@ -14,7 +14,7 @@
 let
   stdenv = clangStdenv;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cctag";
   version = "1.0.4";
 
@@ -26,18 +26,18 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "alicevision";
     repo = "CCTag";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-M35KGTTmwGwXefsFWB2UKAKveUQyZBW7V8ejgOAJpXk=";
   };
 
   cmakeFlags = [
     # Feel free to create a PR to add CUDA support
-    "-DCCTAG_WITH_CUDA=OFF"
+    (lib.cmakeBool "CCTAG_WITH_CUDA" false)
 
-    "-DCCTAG_ENABLE_SIMD_AVX2=${if avx2Support then "ON" else "OFF"}"
+    (lib.cmakeBool "CCTAG_ENABLE_SIMD_AVX2" avx2Support)
 
-    "-DCCTAG_BUILD_TESTS=${if doCheck then "ON" else "OFF"}"
-    "-DCCTAG_BUILD_APPS=OFF"
+    (lib.cmakeBool "CCTAG_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "CCTAG_BUILD_APPS" false)
   ];
 
   patches = [
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    boost
+    boost186
     eigen
     opencv.cxxdev
   ];
@@ -75,4 +75,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ tmarkus ];
   };
-}
+})


### PR DESCRIPTION
cctag is incompatible with Boost 1.89 at the moment due to the dropped Boost.System find_package component and boost::system meta library.
Also includes some random cleanups (finalAttrs pattern, use of lib.cmakeBool).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
