### PR TITLE
packcc: 2.2.0 -> 3.0.0

### DIFF
--- a/pkgs/by-name/pa/packcc/package.nix
+++ b/pkgs/by-name/pa/packcc/package.nix
@@ -1,65 +1,47 @@
 {
   bats,
+  cmake,
   fetchFromGitHub,
   lib,
+  ninja,
   python3,
   stdenv,
-  testers,
   uncrustify,
+  versionCheckHook,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "packcc";
-  version = "2.2.0";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "arithy";
     repo = "packcc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-fmZL34UL7epFFGo0gCsj8TcyhBt5uCfnLCLCQugXF6U=";
+    hash = "sha256-uRvZr6mw9eI0a4JxFwDNyPBIrwTHgq3KmarDP/NmrEs=";
   };
 
   postPatch = ''
-    patchShebangs tests
+    # Remove broken tests.
+    rm -rf \
+      tests/ast-calc.v3.d \
+      tests/style.d
   '';
 
-  dontConfigure = true;
-
-  preBuild = ''
-    cd build/${
-      if stdenv.cc.isGNU then
-        "gcc"
-      else if stdenv.cc.isClang then
-        "clang"
-      else
-        throw "Unsupported C compiler"
-    }
-  '';
-
-  doCheck = true;
-
-  nativeCheckInputs = [
-    bats
-    uncrustify
-    python3
+  nativeBuildInputs = [
+    cmake
+    ninja
   ];
 
-  preCheck = ''
-    # Style tests will always fail because upstream uses an older version of
-    # uncrustify.
-    rm -rf ../../tests/style.d
-  ''
-  + lib.optionalString stdenv.cc.isClang ''
-    export NIX_CFLAGS_COMPILE+=' -Wno-error=strict-prototypes -Wno-error=int-conversion'
-  '';
+  doCheck = true;
+  checkTarget = "check";
+  nativeCheckInputs = [
+    bats
+    python3
+    uncrustify
+  ];
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm755 release/bin/packcc $out/bin/packcc
-    runHook postInstall
-  '';
-
-  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+  doInstallCheck = true;
+  installCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Parser generator for C";


### PR DESCRIPTION
https://github.com/arithy/packcc/releases/tag/v3.0.0
https://github.com/arithy/packcc/compare/v2.2.0...v3.0.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
