### PR TITLE
claude-code: 2.1.66 -> 2.1.69

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -8,8 +8,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "claude-code";
     publisher = "anthropic";
-    version = "2.1.66";
-    hash = "sha256-+vn4qbv3SCsq8PPv3uBsDx+XfmpbfO3HYgA8f0V1FLU=";
+    version = "2.1.69";
+    hash = "sha256-SCS9CqtBzspaSliqaluoqzTXRU4GwCVrH3zYztcQbNk=";
   };
 
   postInstall = ''

--- a/pkgs/by-name/cl/claude-code-bin/manifest.json
+++ b/pkgs/by-name/cl/claude-code-bin/manifest.json
@@ -1,46 +1,46 @@
 {
-  "version": "2.1.66",
-  "buildDate": "2026-03-04T00:21:37Z",
+  "version": "2.1.69",
+  "buildDate": "2026-03-04T23:34:44Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "7ada6848516636e229eca0b5061585741c02b46d6b285f121c11a58c4c4875b8",
-      "size": 193616080
+      "checksum": "a86e14f44b167c1e8dbf764f76755b92ecf52c097d732a3461fe65b5fb60be05",
+      "size": 197100144
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "bf072c24f815f18246b7ce492c4b0a8a5ae2c0189c20aa950d602d6fd7a51126",
-      "size": 199683904
+      "checksum": "e5987b4dd502a6542bf86c3c0bcd1d533b774616fc7d49566ce0b2040e6c1374",
+      "size": 203176272
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "2fcbd25c344c56efe6a3db2c19f22575a88f24e3a129ad0f1fe59e9004094528",
-      "size": 234065035
+      "checksum": "ecc7bbf10513ff122327866eb97212945b73afd7f81e30700375cdf10f50b2a3",
+      "size": 237611685
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "23c277040f5e5125232f8689ed2698b7a09a0cd9b2863adb49220d25ea9deea4",
-      "size": 237111222
+      "checksum": "b3bdbd5a3cbf8caafe353022170df77fefa80b00003074d4d27e7da8c59e629a",
+      "size": 240662792
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "2677f8a01d29b6857e41e09476701483f35e1bc25fa4cc8fe2490b864f01d9dd",
-      "size": 224600507
+      "checksum": "0d2c7173a68c5a9b451f090938de6ece5f16923d28bcd971db16264a437b7fae",
+      "size": 228147157
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "52e7006c66553aae1fd06985a1c9c8248530adc8769ada887d40a5643fc3bd8d",
-      "size": 227712806
+      "checksum": "7e4d51b619bed03f5850e44dcd39b65aee4e7425411ffac72237bc1c14722181",
+      "size": 231260280
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "fadd391dfed8e8abadb3be8f41af792a26845e5a5fc6fc0daf72282beaa6517e",
-      "size": 243029664
+      "checksum": "68d1426abfa810b75a99d5a5f268cc9d84c6fc667dd15f145ff72024a49ec0ca",
+      "size": 246461088
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "6629d9bbce902bc984ab1d240c77668e40895bf61c9ae65b3595d5d071c3d649",
-      "size": 234732704
+      "checksum": "6298e893feb23e681de168da1ec2e73f4ae630b6be68ddf1116cdd4da85987b4",
+      "size": 238147232
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/package-lock.json
+++ b/pkgs/by-name/cl/claude-code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.1.66",
+  "version": "2.1.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthropic-ai/claude-code",
-      "version": "2.1.66",
+      "version": "2.1.69",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -15,14 +15,14 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "claude-code";
-  version = "2.1.66";
+  version = "2.1.69";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${finalAttrs.version}.tgz";
-    hash = "sha256-bZDWmtYUKL6Yrkuz70B4CgJLGn63W68G1MQa5ggivbg=";
+    hash = "sha256-P4jVq1/ZCN2NLik/cpx2qusGwv2SdUfSqKUh5LqZZK8=";
   };
 
-  npmDepsHash = "sha256-brrbatyYO2PH4EbduuEkknql4W0MQCMMKL1LvAQnx2s=";
+  npmDepsHash = "sha256-ODZt0zKNp0AF+Q0Vv1y2DEygQFY3MqIK7P53f3mwcps=";
 
   strictDeps = true;
 


### PR DESCRIPTION
Update claude-code, claude-code-bin, and vscode-extensions.anthropic.claude-code to 2.1.69.

https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
