### PR TITLE
nixos/syncthing: fix ignorePatterns error

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -286,11 +286,11 @@ let
               stale_${conf_type}_ids="$(curl -X GET ${s.baseAddress} | ${jq} \
                 --argjson new_ids ${lib.escapeShellArg (builtins.toJSON s.new_conf_IDs)} \
                 --raw-output \
-                '[.[].${s.GET_IdAttrName}] - $new_ids | .[]'
+                '[.[].${s.GET_IdAttrName}] - $new_ids | .[]|@uri'
               )"
               for id in ''${stale_${conf_type}_ids}; do
                 >&2 echo "Deleting stale device: $id"
-                curl -X DELETE ${s.baseAddress}/$id
+                curl -X DELETE "${s.baseAddress}/$id"
               done
             ''
           ))

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -272,7 +272,7 @@ let
                   If it does, write the ignore patterns to the rest API.
                 */
                 + lib.optionalString ((conf_type == "dirs") && (new_cfg.ignorePatterns != null)) ''
-                  curl -d '{"ignore": ${builtins.toJSON new_cfg.ignorePatterns}}' -X POST ${s.ignoreAddress}?folder=${new_cfg.id}
+                  curl -d '{"ignore": ${builtins.toJSON new_cfg.ignorePatterns}}' -X POST ${s.ignoreAddress}?folder=${lib.strings.escapeURL new_cfg.id}
                 ''
               ))
               (lib.concatStringsSep "\n")

--- a/nixos/tests/syncthing/folders.nix
+++ b/nixos/tests/syncthing/folders.nix
@@ -50,6 +50,12 @@ in
               ];
               ignorePatterns = [ ];
             };
+            folders."foo bar" = {
+              path = "/var/lib/syncthing/foo-bar";
+              devices = [
+                "b"
+              ];
+            };
           };
         };
       };
@@ -83,6 +89,16 @@ in
               devices = [
                 "a"
                 "c"
+              ];
+              ignorePatterns = [
+                "notB"
+              ];
+            };
+            # Test how we handle white spaces in folder IDs
+            folders."foo bar" = {
+              path = "/var/lib/syncthing/foo-bar";
+              devices = [
+                "a"
               ];
               ignorePatterns = [
                 "notB"
@@ -183,5 +199,20 @@ in
     # Check that files have been correctly ignored
     b.fail("cat /var/lib/syncthing/baz/notB")
     c.fail("cat /var/lib/syncthing/baz/notC")
+
+    # Test foo bar
+
+    a.wait_for_file("/var/lib/syncthing/foo-bar")
+    b.wait_for_file("/var/lib/syncthing/foo-bar")
+
+    a.succeed("echo a2b > /var/lib/syncthing/foo-bar/a2b")
+    a.succeed("echo a2b > /var/lib/syncthing/foo-bar/notB")
+    b.succeed("echo b2a > /var/lib/syncthing/foo-bar/b2a")
+
+    a.wait_for_file("/var/lib/syncthing/foo-bar/b2a")
+    b.wait_for_file("/var/lib/syncthing/foo-bar/a2b")
+
+    # Check that file has been correctly ignored
+    b.fail("cat /var/lib/syncthing/foo-bar/notB")
   '';
 }

--- a/nixos/tests/syncthing/many-devices.nix
+++ b/nixos/tests/syncthing/many-devices.nix
@@ -126,6 +126,10 @@ let
       t = "folder";
       id = "DeleteMe";
     }
+    {
+      t = "folder";
+      id = "Delete Me";
+    }
   ];
   addDeviceToDeleteScript = pkgs.writers.writeBash "syncthing-add-device-to-delete.sh" ''
     set -euo pipefail

--- a/nixos/tests/syncthing/many-devices.nix
+++ b/nixos/tests/syncthing/many-devices.nix
@@ -102,10 +102,10 @@ let
       not,
     }:
     lib.pipe IDsToDelete [
-      (lib.mapAttrsToList (
-        t: id:
+      (map (
+        obj:
         checkSettingWithId {
-          inherit t id;
+          inherit (obj) t id;
           inherit not;
         }
       ))
@@ -114,13 +114,19 @@ let
   # These IDs are added to syncthing using the API, similarly to how the
   # generated systemd unit's bash script does it. Only we add it and expect the
   # systemd unit bash script to remove them when executed.
-  IDsToDelete = {
-    # Also created using the syncthing generate command above
-    device = "LZ2CTHT-3W2M7BC-CMKDFZL-DLUQJFS-WJR73PA-NZGODWG-DZBHCHI-OXTQXAK";
-    # Intentionally this is a substring of the IDs of the 'test_folder's, as
-    # explained in: https://github.com/NixOS/nixpkgs/issues/259256
-    folder = "DeleteMe";
-  };
+  IDsToDelete = [
+    {
+      t = "device";
+      id = "LZ2CTHT-3W2M7BC-CMKDFZL-DLUQJFS-WJR73PA-NZGODWG-DZBHCHI-OXTQXAK";
+      # Arbitrary, doesn't really matter
+      name = "DeleteThisDevice";
+    }
+    # Folders' id strings also use for their path when created.
+    {
+      t = "folder";
+      id = "DeleteMe";
+    }
+  ];
   addDeviceToDeleteScript = pkgs.writers.writeBash "syncthing-add-device-to-delete.sh" ''
     set -euo pipefail
 
@@ -141,24 +147,27 @@ let
             --retry 5 --retry-delay 1 --retry-all-errors \
             "$@"
     }
-    curl -d ${
-      lib.escapeShellArg (
-        builtins.toJSON {
-          deviceID = IDsToDelete.device;
-          name = "DeleteMe";
-        }
-      )
-    } \
-        -X POST 127.0.0.1:8384/rest/config/devices
-    curl -d ${
-      lib.escapeShellArg (
-        builtins.toJSON {
-          id = IDsToDelete.folder;
-          path = "/var/lib/syncthing/DeleteMe";
-        }
-      )
-    } \
-        -X POST 127.0.0.1:8384/rest/config/folders
+    ${lib.concatMapStringsSep "\n" (obj: ''
+      curl -d ${
+        lib.escapeShellArg (
+          builtins.toJSON (
+            if obj.t == "device" then
+              {
+                deviceID = obj.id;
+                inherit (obj) name;
+              }
+            else if obj.t == "folder" then
+              {
+                inherit (obj) id;
+                path = "/var/lib/syncthing/${obj.id}";
+              }
+            else
+              throw "unsupported object type ${obj.t}"
+          )
+        )
+      } \
+        -X POST 127.0.0.1:8384/rest/config/${obj.t}s
+    '') IDsToDelete}
   '';
 in
 {


### PR DESCRIPTION
Escapes whitespaces of the folder id in the url. See #496052


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
