### PR TITLE
nixos/systemd: support soft-reboot

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -1190,6 +1190,15 @@ class Machine:
         self.send_key("ctrl-alt-delete")
         self.connected = False
 
+    def disconnect(self) -> None:
+        """Reset connection but don't send reboot key.
+        This is used in soft-reboot test to prevent EOF from polluting
+        the command output byte stream, resulting in errors like
+        "Invalid base64-encoded string: number of data characters (25)
+        cannot be 1 more than a multiple of 4"
+        """
+        self.connected = False
+
     def wait_for_x(self, timeout: int = 900) -> None:
         """
         Wait until it is possible to connect to the X server.

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -144,6 +144,8 @@ let
     "final.target"
     "kexec.target"
     "systemd-kexec.service"
+    "systemd-soft-reboot.service"
+    "soft-reboot.target"
   ]
   ++ lib.optional cfg.package.withUtmp "systemd-update-utmp.service"
   ++ [
@@ -850,6 +852,20 @@ in
         create = "0664 root ${config.users.groups.utmp.name}";
         minsize = "1M";
       };
+    };
+
+    # make sure /run/next-system isn't garbage collected before the next boot
+    systemd.tmpfiles.rules = [ "L+ /nix/var/nix/gcroots/next-system - - - - /run/next-system" ];
+
+    # if /run/next-system exists, activate it before  rebooting
+    systemd.services.systemd-soft-reboot-activate-next-system = {
+      wantedBy = [ "soft-reboot.target" ];
+      before = [ "systemd-soft-reboot.service" ];
+      unitConfig = {
+        DefaultDependencies = false;
+        ConditionPathExists = "/run/next-system/activate";
+      };
+      serviceConfig.ExecStart = "/run/next-system/activate";
     };
 
     # run0 is supposed to authenticate the user via polkit and then run a command. Without this next

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -1408,6 +1408,8 @@ in
             "version=9p2000.L"
             "msize=${toString cfg.msize}"
             "x-systemd.requires=modprobe@9pnet_virtio.service"
+            # TODO: REMOVE THIS BEFORE MERGING
+            "nofail"
           ]
           ++ lib.optional (tag == "nix-store") "cache=${cfg.nixStore9pCache}";
         };

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -663,6 +663,10 @@ in
             foo = "bar";
             qux = "baz";
           };
+
+          dbusBroker.configuration = {
+            services.dbus.implementation = "broker";
+          };
         };
       };
 
@@ -757,6 +761,30 @@ in
       )
 
       boot_loader_text = "Warning: do not know how to make this configuration bootable; please enable a boot loader."
+
+
+      # TODO: REMOVE THIS BEFORE MERGING
+      with subtest("soft-reboot"):
+          switch_to_specialisation("${machine}", "")
+          # To prove soft-reboot works and is more powerful than switch,
+          # we try to change the dbus implementation, and perform soft-reboot
+          # Initially we have classic dbus instead of broker
+          machine.succeed("systemctl show -p Id dbus.service | grep dbus.service")
+          machine.fail("systemctl show -p Id dbus.service | grep dbus-broker.service")
+          # TODO
+          machine.log(machine.execute("cat /proc/self/mountinfo | grep '/nix/.ro-store'")[1])
+          # Prepare next-system to be dbus-broker
+          out = switch_to_specialisation("${machine}", "dbusBroker", action="boot")
+          assert_contains(out, boot_loader_text)
+          machine.execute("systemctl soft-reboot &")
+          # Reset connection before actual soft-reboot to avoid EOF
+          # polluting output byte stream
+          machine.disconnect()
+          machine.wait_for_unit("multi-user.target")
+          # Should now be dbus-broker
+          machine.log(machine.execute("cat /proc/self/mountinfo | grep '/nix/.ro-store'")[1])
+          machine.succeed("systemctl show -p Id dbus.service | grep dbus-broker.service")
+
 
       with subtest("pre-switch checks"):
           machine.succeed("${stderrRunner} ${otherSystem}/bin/switch-to-configuration check")
@@ -1612,5 +1640,23 @@ in
           out = switch_to_specialisation("${machine}", "")
           # Assert switching to a different generation doesn't touch units created by generators
           machine.succeed("systemctl is-active simple-generated.service")
+
+      with subtest("soft-reboot"):
+          switch_to_specialisation("${machine}", "")
+          # To prove soft-reboot works and is more powerful than switch,
+          # we try to change the dbus implementation, and perform soft-reboot
+          # Initially we have classic dbus instead of broker
+          machine.succeed("systemctl show -p Id dbus.service | grep dbus.service")
+          machine.fail("systemctl show -p Id dbus.service | grep dbus-broker.service")
+          # Prepare next-system to be dbus-broker
+          out = switch_to_specialisation("${machine}", "dbusBroker", action="boot")
+          assert_contains(out, boot_loader_text)
+          machine.execute("systemctl soft-reboot &")
+          # Reset connection before actual soft-reboot to avoid EOF
+          # polluting output byte stream
+          machine.disconnect()
+          machine.wait_for_unit("multi-user.target")
+          # Should now be dbus-broker
+          machine.succeed("systemctl show -p Id dbus.service | grep dbus-broker.service")
     '';
 }

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -6,7 +6,7 @@ use std::{
     cell::RefCell,
     collections::HashMap,
     io::{BufRead, Read, Write},
-    os::unix::{fs::PermissionsExt, process::CommandExt},
+    os::unix::{fs::{self, PermissionsExt}, process::CommandExt},
     path::{Path, PathBuf},
     rc::Rc,
     str::FromStr,
@@ -1094,6 +1094,12 @@ fn do_system_switch(action: Action) -> anyhow::Result<()> {
     }
 
     if *action == Action::Boot {
+        let next_system = Path::new("/run/next-system");
+        if next_system.exists() || next_system.is_symlink() {
+            std::fs::remove_file(next_system).context("Failed to remove old /run/next-system")?;
+        }
+        fs::symlink(&toplevel, next_system).context("Failed to link /run/next-system to toplevel")?;
+
         std::process::exit(0);
     }
 


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/309911
Closes https://github.com/NixOS/nixpkgs/issues/341564

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
