### PR TITLE
gotenberg: 8.25.1 -> 8.27.0; Migrate to finalAttrs

### DIFF
--- a/pkgs/by-name/go/gotenberg/package.nix
+++ b/pkgs/by-name/go/gotenberg/package.nix
@@ -22,7 +22,7 @@ let
   libreoffice' = "${libreoffice}/lib/libreoffice/program/soffice.bin";
   inherit (lib) getExe;
 in
-buildGo126Module rec {
+buildGo126Module (finalAttrs: {
   pname = "gotenberg";
   version = "8.27.0";
 
@@ -34,14 +34,14 @@ buildGo126Module rec {
   src = fetchFromGitHub {
     owner = "gotenberg";
     repo = "gotenberg";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-TLfIsvxKrlqNTJtdnASlGCA1XrOx7huMJ11aohVyuKI=";
   };
 
   vendorHash = "sha256-AzaN0xpQWw+Nfw22G7xgww8UsgpTIHpTPK3Bicf6gMY=";
 
   postPatch = ''
-    find ./pkg -name '*_test.go' -exec sed -i -e 's#/tests#${src}#g' {} \;
+    find ./pkg -name '*_test.go' -exec sed -i -e 's#/tests#${finalAttrs.src}#g' {} \;
   '';
 
   nativeBuildInputs = [ makeBinaryWrapper ];
@@ -49,7 +49,7 @@ buildGo126Module rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/gotenberg/gotenberg/v8/cmd.Version=${version}"
+    "-X github.com/gotenberg/gotenberg/v8/cmd.Version=${finalAttrs.version}"
   ];
 
   checkInputs = [
@@ -114,8 +114,8 @@ buildGo126Module rec {
     description = "Converts numerous document formats into PDF files";
     mainProgram = "gotenberg";
     homepage = "https://gotenberg.dev";
-    changelog = "https://github.com/gotenberg/gotenberg/releases/tag/v${version}";
+    changelog = "https://github.com/gotenberg/gotenberg/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/go/gotenberg/package.nix
+++ b/pkgs/by-name/go/gotenberg/package.nix
@@ -116,6 +116,6 @@ buildGo126Module (finalAttrs: {
     homepage = "https://gotenberg.dev";
     changelog = "https://github.com/gotenberg/gotenberg/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 })

--- a/pkgs/by-name/go/gotenberg/package.nix
+++ b/pkgs/by-name/go/gotenberg/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGo125Module,
+  buildGo126Module,
   chromium,
   fetchFromGitHub,
   libreoffice,
@@ -22,9 +22,9 @@ let
   libreoffice' = "${libreoffice}/lib/libreoffice/program/soffice.bin";
   inherit (lib) getExe;
 in
-buildGo125Module rec {
+buildGo126Module rec {
   pname = "gotenberg";
-  version = "8.25.1";
+  version = "8.27.0";
 
   outputs = [
     "out"
@@ -35,10 +35,10 @@ buildGo125Module rec {
     owner = "gotenberg";
     repo = "gotenberg";
     tag = "v${version}";
-    hash = "sha256-qQuK7ylwKeBI+ijScFB2jTd0nmb+tGuk09AOFroDIG0=";
+    hash = "sha256-TLfIsvxKrlqNTJtdnASlGCA1XrOx7huMJ11aohVyuKI=";
   };
 
-  vendorHash = "sha256-uQDRo5TbT+9s0YZxcUqOESHU9hTvXAMrIiaz/6ZZEAY=";
+  vendorHash = "sha256-AzaN0xpQWw+Nfw22G7xgww8UsgpTIHpTPK3Bicf6gMY=";
 
   postPatch = ''
     find ./pkg -name '*_test.go' -exec sed -i -e 's#/tests#${src}#g' {} \;
@@ -100,7 +100,9 @@ buildGo125Module rec {
       --set PDFCPU_BIN_PATH "${getExe pdfcpu}" \
       --set PDFTK_BIN_PATH "${getExe pdftk}" \
       --set QPDF_BIN_PATH "${getExe qpdf}" \
-      --set UNOCONVERTER_BIN_PATH "${getExe unoconv}"
+      --set UNOCONVERTER_BIN_PATH "${getExe unoconv}" \
+      --set CHROMIUM_BIN_PATH "${getExe chromium}" \
+      --set LIBREOFFICE_BIN_PATH "${libreoffice'}"
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/gotenberg/gotenberg/releases/tag/v8.27.0
Diff: https://github.com/gotenberg/gotenberg/compare/v8.25.1...v8.27.0

Additional changes: Migrate to `finalAttrs`, Add myself as a maintainer✌️
(I saw that #484969 is not up to date, and the package also needed to be moved to `buildGo126Module` anyway.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
