### PR TITLE
term39: init at 1.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1131,6 +1131,11 @@
     githubId = 2545644;
     name = "Alessandro Di Federico";
   };
+  alejandroqh = {
+    github = "alejandroqh";
+    githubId = 40313108;
+    name = "Alejandro Quintanar";
+  };
   alejandrosame = {
     email = "alejandrosanchzmedina@gmail.com";
     matrix = "@alejandrosame:matrix.org";

--- a/pkgs/by-name/te/term39/package.nix
+++ b/pkgs/by-name/te/term39/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  pam,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "term39";
+  version = "1.5.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "alejandroqh";
+    repo = "term39";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IFJXBTjGedDl+FY7HDE5p+jYqA3c5EHHxQfn8hPY/es=";
+  };
+
+  cargoHash = "sha256-RguJr5xtuLcn4OO/8hmg06AmUT6WPzGtCpB0J+xw8+I=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    pam
+  ];
+
+  meta = {
+    description = "Modern, retro-styled terminal multiplexer with a classic MS-DOS aesthetic";
+    homepage = "https://github.com/alejandroqh/term39";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ alejandroqh ];
+    mainProgram = "term39";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description

Add [term39](https://github.com/alejandroqh/term39), a modern, retro-styled terminal multiplexer with a classic MS-DOS aesthetic.

Features a full-screen text-based interface with authentic DOS-style rendering, supporting both Unicode and ASCII rendering modes. Includes optional framebuffer backend for direct Linux console rendering with pixel-perfect DOS text modes, PAM-based lockscreen, clipboard support, and battery status.