### PR TITLE
teams/security-review: init and add as maintainer

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -719,6 +719,10 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
+  security-review = {
+    github = "security-review";
+  };
+
   stdenv = {
     enableFeatureFreezePing = true;
     github = "stdenv";

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -92,6 +92,7 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [
       ivan
     ];
+    teams = [ lib.teams.security-review ];
     platforms = lib.platforms.unix;
     identifiers.cpeParts = {
       vendor = "samba";

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -170,6 +170,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/linux-audit/audit-userspace/releases/tag/v4.1.2";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ grimmauld ];
+    teams = [ lib.teams.security-review ];
     pkgConfigModules = [
       "audit"
       "auparse"

--- a/pkgs/by-name/bo/boehmgc/package.nix
+++ b/pkgs/by-name/bo/boehmgc/package.nix
@@ -119,6 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/bdwgc/bdwgc/blob/v${finalAttrs.version}/ChangeLog";
     license = lib.licenses.boehmGC;
     maintainers = [ ];
+    teams = [ lib.teams.security-review ];
     platforms = lib.platforms.all;
     identifiers.cpeParts =
       lib.meta.cpeFullVersionWithVendor "boehm-demers-weiser" finalAttrs.version

--- a/pkgs/by-name/ca/cacert/package.nix
+++ b/pkgs/by-name/ca/cacert/package.nix
@@ -33,6 +33,7 @@ let
       fpletz
       lukegb
     ];
+    teams = [ lib.teams.security-review ];
     license = lib.licenses.mpl20;
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "mozilla" version // {
       product = "nss";

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -285,6 +285,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       Scrumplex
     ];
+    teams = [ lib.teams.security-review ];
     platforms = lib.platforms.all;
     # Fails to link against static gss
     broken = stdenv.hostPlatform.isStatic && gssSupport;

--- a/pkgs/by-name/gi/git/package.nix
+++ b/pkgs/by-name/gi/git/package.nix
@@ -617,6 +617,7 @@ stdenv.mkDerivation (finalAttrs: {
       philiptaron
       zivarah
     ];
+    teams = [ lib.teams.security-review ];
     mainProgram = "git";
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "git-scm" finalAttrs.version;
   };

--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     license = lib.licenses.lgpl21;
     maintainers = with lib.maintainers; [ grimmauld ];
+    teams = [ lib.teams.security-review ];
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "libcap-ng_project" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/li/libsodium/package.nix
+++ b/pkgs/by-name/li/libsodium/package.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
       mdaniels5757
       raskin
     ];
+    teams = [ lib.teams.security-review ];
     pkgConfigModules = [ "libsodium" ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/lo/logrotate/package.nix
+++ b/pkgs/by-name/lo/logrotate/package.nix
@@ -57,6 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Rotates and compresses system logs";
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.tobim ];
+    teams = [ lib.teams.security-review ];
     platforms = lib.platforms.all;
     mainProgram = "logrotate";
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "logrotate_project" finalAttrs.version;

--- a/pkgs/by-name/op/openresolv/package.nix
+++ b/pkgs/by-name/op/openresolv/package.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://roy.marples.name/projects/openresolv";
     license = lib.licenses.bsd2;
     maintainers = [ ];
+    teams = [ lib.teams.security-review ];
     platforms = lib.platforms.unix;
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "openresolv_project" finalAttrs.version;
   };

--- a/pkgs/by-name/sh/shadow/package.nix
+++ b/pkgs/by-name/sh/shadow/package.nix
@@ -132,6 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Suite containing authentication-related tools such as passwd and su";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ mdaniels5757 ];
+    teams = [ lib.teams.security-review ];
     platforms = lib.platforms.linux;
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "shadow_project" finalAttrs.version;
   };

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -245,6 +245,7 @@ stdenv.mkDerivation (finalAttrs: {
       publicDomain
     ];
     maintainers = with lib.maintainers; [ numinit ];
+    teams = [ lib.teams.security-review ];
     platforms = lib.platforms.unix;
     pkgConfigModules = [
       "blkid"

--- a/pkgs/development/compilers/gcc/common/meta.nix
+++ b/pkgs/development/compilers/gcc/common/meta.nix
@@ -27,7 +27,10 @@ in
   '';
 
   platforms = platforms.unix;
-  teams = [ teams.gcc ];
+  teams = [
+    teams.gcc
+    teams.security-review
+  ];
   mainProgram = "${targetPrefix}gcc";
 
   identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version;

--- a/pkgs/development/compilers/llvm/common/common-let.nix
+++ b/pkgs/development/compilers/llvm/common/common-let.nix
@@ -20,7 +20,10 @@ rec {
           asl20
           llvm-exception
         ];
-    teams = [ lib.teams.llvm ];
+    teams = [
+      lib.teams.llvm
+      lib.teams.security-review
+    ];
 
     # See llvm/cmake/config-ix.cmake.
     platforms =

--- a/pkgs/development/interpreters/perl/interpreter.nix
+++ b/pkgs/development/interpreters/perl/interpreter.nix
@@ -359,7 +359,10 @@ stdenv.mkDerivation (
       description = "Standard implementation of the Perl 5 programming language";
       license = lib.licenses.artistic1;
       maintainers = [ ];
-      teams = [ lib.teams.perl ];
+      teams = [
+        lib.teams.perl
+        lib.teams.security-review
+      ];
       platforms = lib.platforms.all;
       priority = 6; # in `buildEnv' (including the one inside `perl.withPackages') the library files will have priority over files in `perl`
       mainProgram = "perl";

--- a/pkgs/development/libraries/acl/default.nix
+++ b/pkgs/development/libraries/acl/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
     homepage = "https://savannah.nongnu.org/projects/acl";
     description = "Library and tools for manipulating access control lists";
     license = lib.licenses.gpl2Plus;
+    teams = [ lib.teams.security-review ];
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "acl_project" version;
   };
 }

--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     badPlatforms = lib.platforms.microblaze;
     license = lib.licenses.gpl2Plus;
+    teams = [ lib.teams.security-review ];
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "attr_project" version;
   };
 }

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -352,6 +352,7 @@ stdenv.mkDerivation (
             ma27
             connorbaker
           ];
+          teams = [ lib.teams.security-review ];
           platforms = lib.platforms.linux;
         }
         // (args.meta or { });

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -385,6 +385,7 @@ let
         license = lib.licenses.openssl;
         mainProgram = "openssl";
         maintainers = with lib.maintainers; [ thillux ];
+        teams = [ lib.teams.security-review ];
         pkgConfigModules = [
           "libcrypto"
           "libssl"

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -161,6 +161,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.publicDomain;
     mainProgram = "sqlite3";
     maintainers = with lib.maintainers; [ np ];
+    teams = [ lib.teams.security-review ];
     platforms = lib.platforms.unix ++ lib.platforms.windows;
     pkgConfigModules = [ "sqlite3" ];
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "sqlite" version;

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -173,6 +173,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.zlib;
     platforms = lib.platforms.all;
     pkgConfigModules = [ "zlib" ];
+    teams = [ lib.teams.security-review ];
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "zlib" finalAttrs.version;
   };
 })

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -193,6 +193,7 @@ stdenv.mkDerivation rec {
       TethysSvensson
       qyliss
     ];
+    teams = [ lib.teams.security-review ];
     platforms = lib.platforms.linux;
     priority = 15; # below systemd (halt, init, poweroff, reboot) and coreutils
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "busybox" version;

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -170,6 +170,7 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     mainProgram = "iptables";
     maintainers = with lib.maintainers; [ fpletz ];
+    teams = [ lib.teams.security-review ];
     license = lib.licenses.gpl2Plus;
     downloadPage = "https://www.netfilter.org/projects/iptables/files/";
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "netfilter" finalAttrs.version;

--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -575,7 +575,10 @@ lib.makeOverridable (
       license = lib.licenses.gpl2Only;
       homepage = "https://www.kernel.org/";
       maintainers = [ maintainers.thoughtpolice ];
-      teams = [ teams.linux-kernel ];
+      teams = [
+        teams.linux-kernel
+        teams.security-review
+      ];
       platforms = platforms.linux;
       badPlatforms =
         lib.optionals (lib.versionOlder version "4.15") [

--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -141,6 +141,7 @@ stdenv.mkDerivation rec {
     ]; # GPLv2+ for tools
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ artturin ];
+    teams = [ lib.teams.security-review ];
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "kernel" version;
   };
 }

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -995,7 +995,10 @@ stdenv.mkDerivation (finalAttrs: {
       ofl
       publicDomain
     ];
-    teams = [ lib.teams.systemd ];
+    teams = [
+      lib.teams.systemd
+      lib.teams.security-review
+    ];
     pkgConfigModules = [
       "libsystemd"
       "libudev"

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -283,6 +283,7 @@ lib.warnIf (withDocs != null)
       # https://github.com/NixOS/nixpkgs/issues/333338
       badPlatforms = [ lib.systems.inspect.patterns.isMinGW ];
       maintainers = with lib.maintainers; [ infinisil ];
+      teams = [ lib.teams.security-review ];
       mainProgram = "bash";
       identifiers.cpeParts =
         let

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -266,6 +266,7 @@ stdenv.mkDerivation (finalAttrs: {
       das_j
       mdaniels5757
     ];
+    teams = [ lib.teams.security-review ];
     platforms = with lib.platforms; unix ++ windows;
     priority = 10;
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" finalAttrs.version;

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -106,6 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     mainProgram = "find";
     maintainers = [ lib.maintainers.mdaniels5757 ];
+    teams = [ lib.teams.security-review ];
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" finalAttrs.version;
   };
 })

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -311,6 +311,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix ++ lib.platforms.windows;
     maintainers = extraMeta.maintainers or [ ];
+    teams = [ lib.teams.security-review ];
     mainProgram = "ssh";
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "openbsd" finalAttrs.version;
   }

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -120,7 +120,10 @@ let
       nixComponentsAttributeName
     ];
 
-  teams = [ lib.teams.nix ];
+  teams = [
+    lib.teams.nix
+    lib.teams.security-review
+  ];
 
   # Disables tests that have been flaky due to the darwin sandbox and fork safety
   # with missing shebangs.

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -217,6 +217,7 @@ stdenv.mkDerivation rec {
       fpletz
       sgo
     ];
+    teams = [ lib.teams.security-review ];
     platforms = lib.platforms.all;
     mainProgram = "gpg";
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnupg" version;

--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -113,6 +113,7 @@ stdenv.mkDerivation {
       lib.maintainers.das_j
       lib.maintainers.m00wl
     ];
+    teams = [ lib.teams.security-review ];
     platforms = lib.platforms.all;
     mainProgram = "grep";
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version // {


### PR DESCRIPTION
Adds the @NixOS/security-review team to the team list, and adds it as a maintainer to the list of packages we [determined to be important](https://github.com/NixOS/nixpkgs/issues/494349#issuecomment-4005099033).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
