### PR TITLE
maintainers: remove p-rintz

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20324,13 +20324,6 @@
     githubId = 645664;
     name = "Philippe Hürlimann";
   };
-  p-rintz = {
-    email = "nix@rintz.net";
-    github = "p-rintz";
-    githubId = 13933258;
-    name = "Philipp Rintz";
-    matrix = "@philipp:srv.icu";
-  };
   p0lyw0lf = {
     email = "p0lyw0lf@protonmail.com";
     name = "PolyWolf";

--- a/pkgs/by-name/pu/pupdate/package.nix
+++ b/pkgs/by-name/pu/pupdate/package.nix
@@ -57,7 +57,7 @@ buildDotnetModule rec {
     description = "Update utility for the openFPGA cores, firmware, and other stuff on your Analogue Pocket";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ p-rintz ];
+    maintainers = [ ];
     mainProgram = "pupdate";
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [November 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ap-rintz)
- Hasn't created any PRs / Issues since [November 2024](https://github.com/NixOS/nixpkgs/issues?q=author%3Ap-rintz)
- About 9 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ap-rintz%20-commenter%3Ap-rintz%20-author%3Ap-rintz%20-reviewed-by%3Ap-rintz) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.
## Packages 

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] pupdate