### PR TITLE
python3Packages.mkdocs-obsidian-bridge: init at 1.3.1

### DIFF
--- a/pkgs/development/python-modules/mkdocs-obsidian-bridge/default.nix
+++ b/pkgs/development/python-modules/mkdocs-obsidian-bridge/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  markdown,
+  mkdocs,
+  obsidian-callouts,
+  obsidian-media,
+  pytestCheckHook,
+  mkdocs-test,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "mkdocs-obsidian-bridge";
+  version = "1.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "GooRoo";
+    repo = "mkdocs-obsidian-bridge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-362hEIu84dpfo7L+VsK9/AordnByWZUcakO2mByhZaw=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    markdown
+    mkdocs
+    obsidian-callouts
+    obsidian-media
+  ];
+
+  pythonImportsCheck = [
+    "mkdocs_obsidian_bridge"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    mkdocs-test
+  ];
+
+  meta = {
+    description = "Use Obsidian’s syntax for your website with this MkDocs plugin";
+    homepage = "https://github.com/GooRoo/mkdocs-obsidian-bridge";
+    license = with lib.licenses; [
+      bsd3
+      cc0
+    ];
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+})

--- a/pkgs/development/python-modules/obsidian-callouts/default.nix
+++ b/pkgs/development/python-modules/obsidian-callouts/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  markdown,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "obsidian-callouts";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "GooRoo";
+    repo = "obsidian-callouts";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-inq/c5rJ8YirwfFrlfhFVe9FqOt/o2Nkv7+EFUoYBXA=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    markdown
+  ];
+
+  pythonImportsCheck = [
+    "obsidian_callouts"
+  ];
+
+  # No tests are available
+  doCheck = false;
+
+  meta = {
+    description = "A plugin for Python-Markdown that allows you to use callouts as in Obsidian";
+    homepage = "https://github.com/GooRoo/obsidian-callouts";
+    license = with lib.licenses; [
+      bsd3
+      cc0
+    ];
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "obsidian-callouts";
+  };
+})

--- a/pkgs/development/python-modules/obsidian-media/default.nix
+++ b/pkgs/development/python-modules/obsidian-media/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  markdown,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "obsidian-media";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "GooRoo";
+    repo = "obsidian-media";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+JerHkpQExP2ytYFFxNbsvAJInUqVg/483KtywP38/g=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    markdown
+  ];
+
+  pythonImportsCheck = [
+    "obsidian_media"
+  ];
+
+  # No tests are available
+  doCheck = false;
+
+  meta = {
+    description = "";
+    homepage = "https://github.com/GooRoo/obsidian-media";
+    license = with lib.licenses; [
+      bsd3
+      cc0
+    ];
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "obsidian-media";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11267,6 +11267,8 @@ self: super: with self; {
 
   obsidian-callouts = callPackage ../development/python-modules/obsidian-callouts { };
 
+  obsidian-media = callPackage ../development/python-modules/obsidian-media { };
+
   obspy = callPackage ../development/python-modules/obspy { };
 
   oca-port = callPackage ../development/python-modules/oca-port { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11265,6 +11265,8 @@ self: super: with self; {
 
   objsize = callPackage ../development/python-modules/objsize { };
 
+  obsidian-callouts = callPackage ../development/python-modules/obsidian-callouts { };
+
   obspy = callPackage ../development/python-modules/obspy { };
 
   oca-port = callPackage ../development/python-modules/oca-port { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9953,6 +9953,8 @@ self: super: with self; {
 
   mkdocs-minify-plugin = callPackage ../development/python-modules/mkdocs-minify-plugin { };
 
+  mkdocs-obsidian-bridge = callPackage ../development/python-modules/mkdocs-obsidian-bridge { };
+
   mkdocs-puml = callPackage ../development/python-modules/mkdocs-puml { };
 
   mkdocs-redirects = callPackage ../development/python-modules/mkdocs-redirects { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
