### PR TITLE
neothesia:0.3.1 -> 0.4.0, fix tests, modernize derivation

### DIFF
--- a/pkgs/by-name/ne/neothesia/package.nix
+++ b/pkgs/by-name/ne/neothesia/package.nix
@@ -13,17 +13,25 @@
   libxi,
   libxcursor,
   libx11,
+  fetchpatch,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "neothesia";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "PolyMeilex";
     repo = "Neothesia";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qYwBSye6RYClSlWmHwuy/rxq9w5932tR33Z+o2S1l8k=";
+    hash = "sha256-5DuyWuDJ08S12C3OWhC9mLhQvPCfWMdJCRUOWtKq/+k=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/PolyMeilex/Neothesia/commit/c450689134e5e767293ae9a4878a0396e585259b.patch";
+      hash = "sha256-A7GuaEHIfSFrvS1SCBWGCuh3rvb2gaaw8dQ970f6u2Y=";
+    })
+  ];
 
   buildInputs = [
     ffmpeg_7
@@ -36,7 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rustPlatform.bindgenHook
   ];
 
-  cargoHash = "sha256-mXeNAVYqPsBWiUZFV/atx/xjLgFNarm2HwI7k/NaAbc=";
+  cargoHash = "sha256-gX9DlgPgrM8KukX3auxbBKpJq7QG4+kRhHSUk3eQjAQ=";
 
   cargoBuildFlags = [
     "-p neothesia -p neothesia-cli"

--- a/pkgs/by-name/ne/neothesia/package.nix
+++ b/pkgs/by-name/ne/neothesia/package.nix
@@ -14,20 +14,16 @@
   libxcursor,
   libx11,
 }:
-let
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "neothesia";
   version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "PolyMeilex";
     repo = "Neothesia";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-qYwBSye6RYClSlWmHwuy/rxq9w5932tR33Z+o2S1l8k=";
   };
-in
-rustPlatform.buildRustPackage {
-  pname = "neothesia";
-
-  inherit src version;
 
   buildInputs = [
     ffmpeg_7
@@ -74,4 +70,4 @@ rustPlatform.buildRustPackage {
       lib.maintainers.naxdy
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
