### PR TITLE
chunk-cli: new package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10236,6 +10236,11 @@
     githubId = 33062605;
     name = "Hannes Hattenbach";
   };
+  hanabelmengistu = {
+    name = "hanabel.mengistu@circleci.com";
+    github = "hanabel1";
+    githubId = 224660613;
+  };
   hansjoergschurr = {
     email = "commits@schurr.at";
     github = "hansjoergschurr";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10218,6 +10218,11 @@
     githubId = 56235032;
     name = "Hamza Remmal";
   };
+  hanabelmengistu = {
+    name = "hanabel.mengistu@circleci.com";
+    github = "hanabel1";
+    githubId = 224660613;
+  };
   hanemile = {
     email = "mail@emile.space";
     github = "HanEmile";
@@ -10235,11 +10240,6 @@
     github = "HannesGitH";
     githubId = 33062605;
     name = "Hannes Hattenbach";
-  };
-  hanabelmengistu = {
-    name = "hanabel.mengistu@circleci.com";
-    github = "hanabel1";
-    githubId = 224660613;
   };
   hansjoergschurr = {
     email = "commits@schurr.at";

--- a/pkgs/by-name/ch/chunk-cli/package.nix
+++ b/pkgs/by-name/ch/chunk-cli/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "chunk-cli";
+  version = "0.6.1";
+
+  src =
+    let
+      inherit (stdenv.hostPlatform) system;
+      baseUrl = "https://github.com/CircleCI-Public/chunk-cli/releases/download/v${finalAttrs.version}";
+      platform =
+        {
+          x86_64-linux = {
+            asset = "chunk-cli_Linux_x86_64.tar.gz";
+            hash = "sha256-c2shfzy/DVMty1bAlCfi2xH3BGNL9i3SaQeaOJVu9i8=";
+          };
+          aarch64-linux = {
+            asset = "chunk-cli_Linux_arm64.tar.gz";
+            hash = "sha256-wOFJpZTg9qb/Ci3YPKek6Ek8QKMV4gBVSXzl8W4qcog=";
+          };
+          x86_64-darwin = {
+            asset = "chunk-cli_Darwin_x86_64.tar.gz";
+            hash = "sha256-4rES26zi94eI0+cv9Q+fBx77zJB3NKHUASvwbzqZu0Q==";
+          };
+          aarch64-darwin = {
+            asset = "chunk-cli_Darwin_arm64.tar.gz";
+            hash = "sha256-lkjjraD3GVEllXdz1J1Pza+XYm6YQaJw3tbOFH0eofo=";
+          };
+        }
+        .${system} or (throw "Unsupported system: ${system}");
+    in
+    fetchurl {
+      url = "${baseUrl}/${platform.asset}";
+      hash = platform.hash;
+    };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    binary=$(find . -type f -executable \( -name 'chunk' -o -name 'chunk-cli' \) 2>/dev/null | head -1)
+    if [ -z "$binary" ]; then
+      binary=$(find . -type f -executable 2>/dev/null | head -1)
+    fi
+    install -m755 "$binary" $out/bin/chunk
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Chunk CLI by CircleCI - context generation from PR review comments for AI coding guidance";
+    homepage = "https://github.com/CircleCI-Public/chunk-cli";
+    changelog = "https://github.com/CircleCI-Public/chunk-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "chunk";
+    maintainers = with lib.maintainers; [ hanabelmengistu ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/ch/chunk-cli/package.nix
+++ b/pkgs/by-name/ch/chunk-cli/package.nix
@@ -41,6 +41,10 @@ stdenv.mkDerivation (finalAttrs: {
   dontConfigure = true;
   dontBuild = true;
 
+  # Tarball has no top-level directory (single binary), so extract into one
+  unpackCmd = "mkdir -p chunk-cli && tar xf $curSrc -C chunk-cli";
+  sourceRoot = "chunk-cli";
+
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin


### PR DESCRIPTION
## Summary

- **chunk-cli: new package (init at 0.6.1)**  
  Adds the [Chunk CLI](https://github.com/CircleCI-Public/chunk-cli) by CircleCI: a CLI that uses PR review comments (via GitHub + Anthropic) to generate AI coding guidance (e.g. markdown prompts for tools like Cursor).  
  Packaged as pre-built binaries from the [GitHub releases](https://github.com/CircleCI-Public/chunk-cli/releases) for Linux (x86_64, aarch64) and Darwin (x86_64, aarch64).  
  Unpack step is customized because the release tarballs have no top-level directory.

- **maintainers: add hanabelmengistu**  
  Add myself as maintainer for the new package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
