### PR TITLE
linuxPackages.nvidiaPackages.beta: 590.44.01 -> 595.45.04

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -90,12 +90,12 @@ rec {
   });
 
   beta = selectHighestVersion latest (generic {
-    version = "590.44.01";
-    sha256_64bit = "sha256-VbkVaKwElaazojfxkHnz/nN/5olk13ezkw/EQjhKPms=";
-    sha256_aarch64 = "sha256-gpqz07aFx+lBBOGPMCkbl5X8KBMPwDqsS+knPHpL/5g=";
-    openSha256 = "sha256-ft8FEnBotC9Bl+o4vQA1rWFuRe7gviD/j1B8t0MRL/o=";
-    settingsSha256 = "sha256-wVf1hku1l5OACiBeIePUMeZTWDQ4ueNvIk6BsW/RmF4=";
-    persistencedSha256 = "sha256-nHzD32EN77PG75hH9W8ArjKNY/7KY6kPKSAhxAWcuS4=";
+    version = "595.45.04";
+    sha256_64bit = "sha256-zUllSSRsuio7dSkcbBTuxF+dN12d6jEPE0WgGvVOj14=";
+    sha256_aarch64 = "sha256-jl6lQWsgF6ya22sAhYPpERJ9r+wjnWzbGnINDpUMzsk=";
+    openSha256 = "sha256-uqNfImwTKhK8gncUdP1TPp0D6Gog4MSeIJMZQiJWDoE=";
+    settingsSha256 = "sha256-Y45pryyM+6ZTJyRaRF3LMKaiIWxB5gF5gGEEcQVr9nA=";
+    persistencedSha256 = "sha256-5FoeUaRRMBIPEWGy4Uo0Aho39KXmjzQsuAD9m/XkNpA=";
   });
 
   # Vulkan developer beta driver


### PR DESCRIPTION
- Added support for the VK_EXT_descriptor_heap extension.
- Fixed a bug that caused GPU hangs and Xid errors in Black Myth: Wukong.
- Added support for DRI3 version 1.2.
- Added support for the VK_EXT_present_timing extension.
- Fixed hang when NVIDIA Smooth Motion is enabled in applications that use VK_KHR_present_id2.
- Modified nvidia.ko to handle video memory preservation on its own when the open kernel modules are in use if NVreg_UseKernelSuspendNotifiers=1 is enabled. When the proprietary driver is in use, or if kernel suspend notifiers are disabled, video memory preservation requires using the /proc/driver/nvidia/suspend interface for suspend and resume notifications.
  - See the chapter titled "Configuring Power Management Support" in the README for more information.
- Enabled the nvidia-drm.ko modeset=1 parameter by default.
- Updated the driver to allow nvidia-smi to reset GPUs while nvidia-drm is loaded with the modeset=1 parameter enabled, as long as no other processes are using the GPU.
- Added a new application profile - CudaNoStablePerfLimit - that allows CUDA-using apps to reach P0 PState. See the 'Application Profiles' appendix of the driver README for details.
- Raised the minimum supported Wayland version to 1.20.
- Fixed a bug that prevented the PowerMizer preferred mode dropdown menu in the nvidia-settings control panel from functioning correctly on Wayland.
- Raised the minimum supported glibc version to 2.27.
- Improved the performance of recreating Vulkan swapchains. This helps prevent stuttering when resizing Vulkan application windows.
- Raised the minimum supported X.Org xserver version to 1.17 (video driver ABI version 19).
- Fixed a bug that caused adaptive sync displays to go blank when connected with an active USB-C-to-HDMI adapter.
- Fixed a bug that could cause Vulkan swapchains to stop presenting new frames on X11.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
