### PR TITLE
various: take maintenance over more figsoda's Rust packages

### DIFF
--- a/pkgs/by-name/cs/csv2svg/package.nix
+++ b/pkgs/by-name/cs/csv2svg/package.nix
@@ -9,7 +9,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.1.9";
 
   src = fetchCrate {
-    inherit (finalAttrs) pname version;
+    pname = "csv2svg";
+    inherit (finalAttrs) version;
     hash = "sha256-3VebLFkeJLK97jqoPXt4Wt6QTR0Zyu+eQV9oaLBSeHE=";
   };
 

--- a/pkgs/by-name/cs/csv2svg/package.nix
+++ b/pkgs/by-name/cs/csv2svg/package.nix
@@ -2,6 +2,8 @@
   lib,
   rustPlatform,
   fetchCrate,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -15,6 +17,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-RwpRxSD/oRAYD1udrHt3fy/SrrNUTVdGf+CdzQnJZ2U=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Take a csv as input and outputs svg";

--- a/pkgs/by-name/cs/csv2svg/package.nix
+++ b/pkgs/by-name/cs/csv2svg/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Take a csv as input and outputs svg";
     homepage = "https://github.com/Canop/csv2svg";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "csv2svg";
   };
 })

--- a/pkgs/by-name/cs/csv2svg/package.nix
+++ b/pkgs/by-name/cs/csv2svg/package.nix
@@ -8,15 +8,15 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "csv2svg";
-  version = "0.1.9";
+  version = "0.2.3";
 
   src = fetchCrate {
     pname = "csv2svg";
     inherit (finalAttrs) version;
-    hash = "sha256-3VebLFkeJLK97jqoPXt4Wt6QTR0Zyu+eQV9oaLBSeHE=";
+    hash = "sha256-DNnMYpzQTzGVsAp0YScqiO260mwShVTE/cwXkU/Q5IE=";
   };
 
-  cargoHash = "sha256-RwpRxSD/oRAYD1udrHt3fy/SrrNUTVdGf+CdzQnJZ2U=";
+  cargoHash = "sha256-f6ZMCkMVkPi4XfzRUZq7JDhCBz57K58UqY69T9mNzrU=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/fw/fw/package.nix
+++ b/pkgs/by-name/fw/fw/package.nix
@@ -6,6 +6,8 @@
   libgit2,
   openssl,
   zlib,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -15,7 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "brocode";
     repo = "fw";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-tqtiAw4+bnCJMF37SluAE9NM55MAjBGkJTvGLcmYFnA=";
   };
 
@@ -34,6 +36,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env = {
     OPENSSL_NO_VENDOR = true;
   };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Workspace productivity booster";

--- a/pkgs/by-name/fw/fw/package.nix
+++ b/pkgs/by-name/fw/fw/package.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Workspace productivity booster";
     homepage = "https://github.com/brocode/fw";
     license = lib.licenses.wtfpl;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "fw";
   };
 })

--- a/pkgs/by-name/ri/ripdrag/package.nix
+++ b/pkgs/by-name/ri/ripdrag/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/nik012003/ripdrag";
     changelog = "https://github.com/nik012003/ripdrag/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "ripdrag";
   };
 })

--- a/pkgs/by-name/ri/ripdrag/package.nix
+++ b/pkgs/by-name/ri/ripdrag/package.nix
@@ -5,6 +5,8 @@
   pkg-config,
   wrapGAppsHook4,
   gtk4,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -14,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "nik012003";
     repo = "ripdrag";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-1IUS0PNzIoSrlBXQrUmw/lXUD8auVVKhu/irSoYoK6w=";
   };
 
@@ -27,10 +29,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [ gtk4 ];
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Application that lets you drag and drop files from and to the terminal";
     homepage = "https://github.com/nik012003/ripdrag";
-    changelog = "https://github.com/nik012003/ripdrag/releases/tag/${finalAttrs.src.rev}";
+    changelog = "https://github.com/nik012003/ripdrag/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "ripdrag";

--- a/pkgs/by-name/ru/rune-languageserver/package.nix
+++ b/pkgs/by-name/ru/rune-languageserver/package.nix
@@ -11,7 +11,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.14.1";
 
   src = fetchCrate {
-    inherit (finalAttrs) pname version;
+    pname = "rune-languageserver";
+    inherit (finalAttrs) version;
     hash = "sha256-0b8XGbMQqMolOdQEMjpwHAVI3A4fXemyCowN39qY16A=";
   };
 
@@ -39,7 +40,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
       mit
     ];
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "rune-languageserver";
   };
 })

--- a/pkgs/by-name/ru/rust-audit-info/package.nix
+++ b/pkgs/by-name/ru/rust-audit-info/package.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit # or
       asl20
     ];
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
 })

--- a/pkgs/by-name/ru/rust-audit-info/package.nix
+++ b/pkgs/by-name/ru/rust-audit-info/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchCrate,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -15,6 +16,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-ygz9uYwuDI892kwYwJPTsTAkBfsnRN2unOgqv8VHXSA=";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Command-line tool to extract the dependency trees embedded in binaries by cargo-auditable";

--- a/pkgs/by-name/ru/rust-audit-info/package.nix
+++ b/pkgs/by-name/ru/rust-audit-info/package.nix
@@ -9,7 +9,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.5.4";
 
   src = fetchCrate {
-    inherit (finalAttrs) pname version;
+    pname = "rust-audit-info";
+    inherit (finalAttrs) version;
     hash = "sha256-zxdF65/9cgdDLM7HA30NCEZj1S5SogH+oM3aq55K0os=";
   };
 

--- a/pkgs/by-name/ru/rust-code-analysis/package.nix
+++ b/pkgs/by-name/ru/rust-code-analysis/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit # grammars
       mpl20 # code
     ];
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "rust-code-analysis-cli";
   };
 })

--- a/pkgs/by-name/ru/rust-code-analysis/package.nix
+++ b/pkgs/by-name/ru/rust-code-analysis/package.nix
@@ -2,6 +2,8 @@
   lib,
   rustPlatform,
   fetchCrate,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -16,9 +18,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-HirLjKkfZfc9UmUcUF5WW7xAJuCu7ftJDH8+zTSYlxs=";
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Analyze and collect metrics on source code";
     homepage = "https://github.com/mozilla/rust-code-analysis";
+    changelog = "https://github.com/mozilla/rust-code-analysis/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       mit # grammars
       mpl20 # code

--- a/pkgs/by-name/ru/rust-script/package.nix
+++ b/pkgs/by-name/ru/rust-script/package.nix
@@ -29,6 +29,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit # or
       asl20
     ];
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
 })

--- a/pkgs/by-name/ru/rust-script/package.nix
+++ b/pkgs/by-name/ru/rust-script/package.nix
@@ -2,6 +2,8 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -19,6 +21,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # tests require network access
   doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Run Rust files and expressions as scripts without any setup or compilation step";

--- a/pkgs/by-name/ru/rust-traverse/package.nix
+++ b/pkgs/by-name/ru/rust-traverse/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/dmcg310/Rust-Traverse";
     changelog = "https://github.com/dmcg310/Rust-Traverse/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "rt";
   };
 })

--- a/pkgs/by-name/ru/rust-traverse/package.nix
+++ b/pkgs/by-name/ru/rust-traverse/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   bzip2,
   zstd,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -14,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "dmcg310";
     repo = "Rust-Traverse";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-OcCWmBNDo4AA5Pk5TQqb8hen9LlHaY09Wrm4BkrU7qA=";
   };
 
@@ -32,6 +33,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env = {
     ZSTD_SYS_USE_PKG_CONFIG = true;
   };
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Terminal based file explorer";

--- a/pkgs/by-name/ru/rustywind/package.nix
+++ b/pkgs/by-name/ru/rustywind/package.nix
@@ -2,6 +2,8 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -11,17 +13,22 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "avencera";
     repo = "rustywind";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-qbOlU7kqVbB/sQg4b78CohOwQbraulZ8dRxeT+39rFk=";
   };
 
   cargoHash = "sha256-eXTdPtcsWhsABZU6kRzZ6eF1VaabouZwLAFI9KpAx98=";
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "CLI for organizing Tailwind CSS classes";
     mainProgram = "rustywind";
     homepage = "https://github.com/avencera/rustywind";
-    changelog = "https://github.com/avencera/rustywind/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/avencera/rustywind/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.progrm_jarvis ];
   };

--- a/pkgs/by-name/ru/rustywind/package.nix
+++ b/pkgs/by-name/ru/rustywind/package.nix
@@ -23,6 +23,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/avencera/rustywind";
     changelog = "https://github.com/avencera/rustywind/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
 })

--- a/pkgs/by-name/sa/safecloset/package.nix
+++ b/pkgs/by-name/sa/safecloset/package.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/Canop/safecloset";
     changelog = "https://github.com/Canop/safecloset/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "safecloset";
   };
 })

--- a/pkgs/by-name/sa/safecloset/package.nix
+++ b/pkgs/by-name/sa/safecloset/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   stdenv,
   libxcb,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -13,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Canop";
     repo = "safecloset";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ZLAgSD03Qfoz+uGjVJF7vCkV1pUWqw6yG/9+redbQQ8=";
   };
 
@@ -28,10 +30,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=timer::timer_tests::test_timer_reset"
   ];
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Cross-platform secure TUI secret locker";
     homepage = "https://github.com/Canop/safecloset";
-    changelog = "https://github.com/Canop/safecloset/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/Canop/safecloset/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
     maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "safecloset";

--- a/pkgs/by-name/si/simple-http-server/package.nix
+++ b/pkgs/by-name/si/simple-http-server/package.nix
@@ -33,6 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       mephistophiles
+      progrm_jarvis
     ];
     mainProgram = "simple-http-server";
   };

--- a/pkgs/by-name/si/simple-http-server/package.nix
+++ b/pkgs/by-name/si/simple-http-server/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   pkg-config,
   openssl,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -25,6 +27,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # Currently no tests are implemented, so we avoid building the package twice
   doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Simple HTTP server in Rust";

--- a/pkgs/by-name/si/simple-http-server/package.nix
+++ b/pkgs/by-name/si/simple-http-server/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "simple-http-server";
-  version = "0.6.13";
+  version = "0.6.14";
 
   src = fetchFromGitHub {
     owner = "TheWaWaR";
     repo = "simple-http-server";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-uTzzQg1UJ+PG2poIKd+LO0T0y7z48ZK0f196zIgeZhs=";
+    sha256 = "sha256-Ka6PU2Mbu7wIyj5hbAhUa8ncK61wcM+huSKYh/kiH7M=";
   };
 
-  cargoHash = "sha256-y+pNDg73fAHs9m0uZr6z0HTA/vB3fFM5qukJycuIxnY=";
+  cargoHash = "sha256-0dODUHXeIVltwMn4U9Y4/NCOTuxkfVxpRYzXIHSTfQQ=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
Took maintenance and updated packages:

- `fw`;
- `rust-audit-info`;
- `rust-code-analysis`;
- `rust-script`;
- `rustywind`;
- `safecloset`;
- `simple-http-server`;
- `ripdrag`;
- `rune-languageserver`;
- `csv2svg`.

Where applicable:
- migrated to `finalAttrs`;
- added `nix-update-script`;
- added version check;
- bumped version.

This is part of #458096

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
