### PR TITLE
python3Packages.python-aodhclient: fix package build

### DIFF
--- a/pkgs/development/python-modules/python-aodhclient/default.nix
+++ b/pkgs/development/python-modules/python-aodhclient/default.nix
@@ -1,24 +1,35 @@
 {
   lib,
   buildPythonPackage,
-  cliff,
   fetchFromGitHub,
-  keystoneauth1,
-  openstackdocstheme,
+  pbr,
+  setuptools,
+
+  # direct
+  cliff,
   osc-lib,
   oslo-i18n,
   oslo-serialization,
   oslo-utils,
-  oslotest,
   osprofiler,
-  pbr,
+  keystoneauth1,
   pyparsing,
-  setuptools,
+
+  # tests
+  stestrCheckHook,
+  versionCheckHook,
+  openstacksdk,
+  oslotest,
+  tempest,
+  testtools,
+  pifpaf,
+
+  # docs
   sphinxHook,
-  stestr,
+  openstackdocstheme,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "python-aodhclient";
   version = "3.10.1";
   pyproject = true;
@@ -26,11 +37,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "openstack";
     repo = "python-aodhclient";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-xm42ZicdBxxm4LTDHPhEIeNU6evBZtp2PGvGy6V2t8c=";
   };
 
-  env.PBR_VERSION = version;
+  env.PBR_VERSION = finalAttrs.version;
 
   build-system = [
     pbr
@@ -43,6 +54,10 @@ buildPythonPackage rec {
   ];
 
   sphinxBuilders = [ "man" ];
+
+  patches = [
+    ./fix-pyproject.patch
+  ];
 
   dependencies = [
     cliff
@@ -57,23 +72,31 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    stestrCheckHook
+    openstacksdk
     oslotest
-    stestr
+    tempest
+    testtools
+    pifpaf
   ];
 
-  checkPhase = ''
-    runHook preCheck
-    stestr run
-    runHook postCheck
-  '';
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
-  pythonImportsCheck = [ "aodhclient" ];
+  pythonImportsCheck = [
+    "aodhclient"
+    "aodhclient.v2"
+    "aodhclient.tests"
+    "aodhclient.tests.functional"
+    "aodhclient.tests.unit"
+  ];
 
   meta = {
-    homepage = "https://github.com/openstack/python-aodhclient";
-    description = "Client library for OpenStack Aodh API";
+    description = "Client library for OpenStack AOodh API";
+    homepage = "https://docs.openstack.org/python-aodhclient/latest/";
+    downloadPage = "https://github.com/openstack/python-aodhclientz /releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     mainProgram = "aodh";
     teams = [ lib.teams.openstack ];
   };
-}
+})

--- a/pkgs/development/python-modules/python-aodhclient/fix-pyproject.patch
+++ b/pkgs/development/python-modules/python-aodhclient/fix-pyproject.patch
@@ -1,0 +1,18 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 877242f..b5707c0 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -33,10 +33,9 @@ classifiers = [
+ Homepage = "https://docs.openstack.org/python-aodhclient"
+ Repository = "https://opendev.org/openstack/python-aodhclient"
+ 
+-[tool.setuptools]
+-packages = [
+-    "aodhclient"
+-]
++[tool.setuptools.packages.find]
++where = ["."]
++include = ["aodhclient*"]
+ 
+ [project.scripts]
+ aodh = "aodhclient.shell:main"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

AODH client was broken with openstackclient since a few time :
```
openstack server list
Could not load 'alarm-history_search': No module named 'aodhclient.v2'
Could not load 'alarm-history_show': No module named 'aodhclient.v2'
Could not load 'alarm_create': No module named 'aodhclient.v2'
Could not load 'alarm_delete': No module named 'aodhclient.v2'
Could not load 'alarm_list': No module named 'aodhclient.v2'
Could not load 'alarm_metrics': No module named 'aodhclient.v2'
Could not load 'alarm_quota_set': No module named 'aodhclient.v2'
Could not load 'alarm_quota_show': No module named 'aodhclient.v2'
Could not load 'alarm_show': No module named 'aodhclient.v2'
Could not load 'alarm_state_get': No module named 'aodhclient.v2'
Could not load 'alarm_state_set': No module named 'aodhclient.v2'
Could not load 'alarm_update': No module named 'aodhclient.v2'
Could not load 'alarming_capabilities_list': No module named 'aodhclient.v2'
+--------------------------------------+------------------+-------------------+----------------------------------------------+--------------------------+----------------------+
| ID                                   | Name             | Status            | Networks                                     | Image                    | Flavor               |
+--------------------------------------+------------------+-------------------+----------------------------------------------+--------------------------+----------------------+
| 25cd347a-7c11-4479-88fa-d2796de903be | vinetos-l3-tools | SHELVED_OFFLOADED | ext-net1=2001:1600:16:10::54c, 37.156.47.144 | N/A (booted from volume) | a1-ram2-disk20-perf1 |
+--------------------------------------+------------------+-------------------+----------------------------------------------+--------------------------+----------------------+

openstack alarm list
Could not load 'alarm-history_search': No module named 'aodhclient.v2'
Could not load 'alarm-history_show': No module named 'aodhclient.v2'
Could not load 'alarm_create': No module named 'aodhclient.v2'
Could not load 'alarm_delete': No module named 'aodhclient.v2'
Could not load 'alarm_list': No module named 'aodhclient.v2'
Could not load 'alarm_metrics': No module named 'aodhclient.v2'
Could not load 'alarm_quota_set': No module named 'aodhclient.v2'
Could not load 'alarm_quota_show': No module named 'aodhclient.v2'
Could not load 'alarm_show': No module named 'aodhclient.v2'
Could not load 'alarm_state_get': No module named 'aodhclient.v2'
Could not load 'alarm_state_set': No module named 'aodhclient.v2'
Could not load 'alarm_update': No module named 'aodhclient.v2'
Could not load 'alarming_capabilities_list': No module named 'aodhclient.v2'
openstack: 'alarm list' is not an openstack command. See 'openstack --help'.
Did you mean one of these?
[...]
```

This MR fixes the build of aodhclient : 
```
openstack alarm list


openstack server list
+------------------------+------------------+-------------------+------------------------+--------------------------+----------------------+
| ID                     | Name             | Status            | Networks               | Image                    | Flavor               |
+------------------------+------------------+-------------------+------------------------+--------------------------+----------------------+
| 25cd347a-7c11-4479-    | vinetos-l3-tools | SHELVED_OFFLOADED | ext-net1=2001:1600:16: | N/A (booted from volume) | a1-ram2-disk20-perf1 |
| 88fa-d2796de903be      |                  |                   | 10::54c, 37.156.47.144 |                          |                      |
+------------------------+------------------+-------------------+------------------------+--------------------------+----------------------+
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
