### PR TITLE
beamPackages.elixir_1_20: 1.20.0-rc.1 -> 1.20.0-rc.2

### DIFF
--- a/pkgs/development/interpreters/elixir/1.20.nix
+++ b/pkgs/development/interpreters/elixir/1.20.nix
@@ -1,7 +1,7 @@
 import ./generic-builder.nix {
-  version = "1.20.0-rc.1";
-  hash = "sha256-FuTZHDI8ZNe6SHjiaPDZh21Ah7ek4kHqlYVvx0ybqI4=";
-  # https://hexdocs.pm/elixir/1.20.0-rc.1/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
+  version = "1.20.0-rc.2";
+  hash = "sha256-un0F3EIwFJn/aeIHxlnlOWn41y1JCPtl+Xm+HSk03OE=";
+  # https://hexdocs.pm/elixir/1.20.0-rc.2/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
   minimumOTPVersion = "26";
   maximumOTPVersion = "28";
 }


### PR DESCRIPTION
Changelog: https://github.com/elixir-lang/elixir/releases/tag/v1.20.0-rc.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
