### PR TITLE
cwal: init at 0.41.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10079,6 +10079,12 @@
     githubId = 28863828;
     name = "guserav";
   };
+  gustlik501 = {
+    email = "sevcnikar.gregor2@gmail.com";
+    github = "Gustlik501";
+    githubId = 36334538;
+    name = "Gustlik501";
+  };
   guttermonk = {
     github = "guttermonk";
     githubId = 4753752;

--- a/pkgs/by-name/cw/cwal/package.nix
+++ b/pkgs/by-name/cw/cwal/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  imagemagick,
+  libimagequant,
+  lua,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cwal";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "nitinbhat972";
+    repo = "cwal";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-H7liUw/KUT8U0KxBbUFvfu+L1vD7CbGw0cjbwjwwKrY=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    imagemagick
+    libimagequant
+    lua
+  ];
+
+  meta = {
+    description = "Blazing-fast pywal-like color palette generator written in C";
+    homepage = "https://github.com/nitinbhat972/cwal";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "cwal";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ gustlik501 ];
+  };
+})


### PR DESCRIPTION
Add `cwal` at `0.4.1` (`pkgs/by-name/cw/cwal`), a pywal-like color palette generator written in C.

Also added myself as pkg maintainer since project is kind of niche.

Repo: https://github.com/nitinbhat972/cwal
Changelog/release: https://github.com/nitinbhat972/cwal/releases/tag/v0.4.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.