### PR TITLE
mediaflow-proxy: init at 2.4.4

### DIFF
--- a/pkgs/by-name/me/mediaflow-proxy/package.nix
+++ b/pkgs/by-name/me/mediaflow-proxy/package.nix
@@ -1,0 +1,71 @@
+{
+  fetchFromGitHub,
+  lib,
+  nixosTests,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: rec {
+  pname = "mediaflow-proxy";
+  version = "2.4.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mhdzumair";
+    repo = "mediaflow-proxy";
+    tag = finalAttrs.version;
+    hash = "sha256-pY9VoHQ72NejZYmFnikjT+1LD2rzT+xKkqDEkSU2NEk=";
+  };
+
+  dontWrapPythonPrograms = true;
+
+  build-system = with python3Packages; [ hatchling ];
+
+  dependencies = with python3Packages; [
+    fastapi
+    aiohttp
+    aiohttp-socks
+    tenacity
+    xmltodict
+    pydantic-settings
+    gunicorn
+    pycryptodome
+    uvicorn
+    tqdm
+    aiofiles
+    beautifulsoup4
+    lxml
+    psutil
+    curl-cffi
+    telethon
+    cryptg
+    redis
+    av
+  ];
+
+  postInstall = ''
+    makeWrapper ${lib.getExe python3Packages.gunicorn} "''${!outputBin}"/bin/mediaflow-proxy \
+      --prefix PYTHONPATH : "$out/${python3Packages.python.sitePackages}:${python3Packages.makePythonPath dependencies}" \
+      --set-default MEDIAFLOW_PROXY_WORKERS 1 \
+      --set-default MEDIAFLOW_PROXY_WORKER_TIMEOUT 120 \
+      --set-default MEDIAFLOW_PROXY_HOST "[::1]" \
+      --set-default MEDIAFLOW_PROXY_PORT 8888 \
+      --add-flags "mediaflow_proxy.main:app -k uvicorn.workers.UvicornWorker \
+        -w \"\$MEDIAFLOW_PROXY_WORKERS\" \
+        -b \"\$MEDIAFLOW_PROXY_HOST:\$MEDIAFLOW_PROXY_PORT\" \
+        -t \"\$MEDIAFLOW_PROXY_WORKER_TIMEOUT\""
+  '';
+
+  passthru.tests = {
+    # smoke-test = nixosTests.mediaflow-proxy;
+  };
+
+  meta = {
+    description = "A high-performance proxy server for streaming media";
+    homepage = "https://github.com/mhdzumair/mediaflow-proxy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ diogotcorreia ];
+    mainProgram = "mediaflow-proxy";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/telethon/default.nix
+++ b/pkgs/development/python-modules/telethon/default.nix
@@ -24,21 +24,22 @@ buildPythonPackage rec {
     hash = "sha256-NMHJkSTGR3/tck0k97EfVN9f85PAWst+EZ6G7Tgrt5s=";
   };
 
-  patches = [
-    # https://github.com/LonamiWebs/Telethon/pull/4670
-    (fetchpatch {
-      url = "https://github.com/LonamiWebs/Telethon/commit/8e2a46568ef9193f5887aea1abf919ac4ca6d31e.patch";
-      name = "fix_async_test.patch";
-      hash = "sha256-oVpLnO4OxNam/mq945OskVEHkbS5TDSUXk/0xPHVv3I=";
-    })
-  ]
-  ++ lib.optionals (lib.versionOlder version "1.40.1") [
-    (fetchpatch {
-      url = "https://github.com/LonamiWebs/Telethon/commit/ae9c798e2c3648ff40dee1b3f371f5d66851642e.patch";
-      name = "fix_test_messages_test.patch";
-      hash = "sha256-8SJm8EE6w7zRQxt1NuTX6KP1MTYPiYO/maJ5tOA2I9w=";
-    })
-  ];
+  patches =
+    lib.optionals (lib.versionOlder version "1.42.0") [
+      # https://github.com/LonamiWebs/Telethon/pull/4670
+      (fetchpatch {
+        url = "https://github.com/LonamiWebs/Telethon/commit/8e2a46568ef9193f5887aea1abf919ac4ca6d31e.patch";
+        name = "fix_async_test.patch";
+        hash = "sha256-oVpLnO4OxNam/mq945OskVEHkbS5TDSUXk/0xPHVv3I=";
+      })
+    ]
+    ++ lib.optionals (lib.versionOlder version "1.40.1") [
+      (fetchpatch {
+        url = "https://github.com/LonamiWebs/Telethon/commit/ae9c798e2c3648ff40dee1b3f371f5d66851642e.patch";
+        name = "fix_test_messages_test.patch";
+        hash = "sha256-8SJm8EE6w7zRQxt1NuTX6KP1MTYPiYO/maJ5tOA2I9w=";
+      })
+    ];
 
   postPatch = ''
     substituteInPlace telethon/crypto/libssl.py --replace-fail \


### PR DESCRIPTION
Project name: Mediaflow Proxy
Homepage: https://github.com/mhdzumair/mediaflow-proxy
Description: A high-performance proxy server for streaming media, supporting HTTP(S), HLS, and MPEG-DASH with real-time DRM decryption, acestream, xtreamcode proxy
Licence: MIT

Blockers:
- https://github.com/NixOS/nixpkgs/pull/495032 (commit is cherry-picked here for testing)

TODO:
- [ ] Add module
- [ ] Add tests
- [ ] Use `python3` instead of `python3Packages`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
