### PR TITLE
waves: 0.1.41 -> 0.1.42

### DIFF
--- a/pkgs/by-name/wa/waves/package.nix
+++ b/pkgs/by-name/wa/waves/package.nix
@@ -10,16 +10,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "waves";
-  version = "0.1.41";
+  version = "0.1.42";
 
   src = fetchFromGitHub {
     owner = "llehouerou";
     repo = "waves";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-F3ZJSaL8e8TO2J0k3p33zrqMwurw6xIA+AuloNp3Zw0=";
+    hash = "sha256-UReEoPXVGwBpWs53Dk8iWn2el2+/9PMAJ5KW4M9FjnA=";
   };
 
-  vendorHash = "sha256-jUwA7KOHceuwSUMDzex8MHCBYvMPRkfkyk5THvXsF+M=";
+  vendorHash = "sha256-mUifSJ8IalfzqQHeDpFp0jbtZDr7OWPq16st9RJVu7U=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
 


### PR DESCRIPTION
waves: 0.1.41 -> 0.1.42

[Changelog](https://github.com/llehouerou/waves/releases/tag/v0.1.42)

Fixes MPRIS metadata causing dbus errors on startup for desktop shells that query player properties (e.g. Hyprland + Noctalia Shell).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [Built, ran and tested locally](https://nixos.org/manual/nixpkgs/unstable/#sec-building-simple)
- For new packages:
  - [ ] Added to `pkgs/by-name`
- [x] Determined the impact on dependent packages (e.g. by running `nix-build -A nixosTests`)
- [x] Ensured that relevant tests pass with: `nix-build -A tests.waves` or `nix-build -A nixosTests.waves`
- [x] Verified the [code] is in good shape