### PR TITLE
rocmPackages.rocprof-trace-decoder: vendor PR to fix missing test dep

### DIFF
--- a/pkgs/development/rocm-modules/rocprof-trace-decoder/default.nix
+++ b/pkgs/development/rocm-modules/rocprof-trace-decoder/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./use-system-dependencies.patch
+    # https://github.com/ROCm/rocm-systems/pull/3800
+    ./fix-test-dependency.patch
   ];
 
   strictDeps = true;
@@ -59,11 +61,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkPhase =
     let
-      # - Sanitize tests fail because the UBSan runtime (__ubsan_vptr_type_cache) is not available for
-      #   LD_PRELOAD in the sandbox.
-      # - Validate tests fail because they depend on execute tests producing output files first, but
-      #   CTest runs them concurrently without proper ordering.
-      skipPattern = "_(sanitize|validate)$";
+      # Sanitize tests fail because the UBSan runtime (__ubsan_vptr_type_cache) is not available for
+      # LD_PRELOAD in the sandbox.
+      skipPattern = "_sanitize$";
     in
     ''
       runHook preCheck

--- a/pkgs/development/rocm-modules/rocprof-trace-decoder/fix-test-dependency.patch
+++ b/pkgs/development/rocm-modules/rocprof-trace-decoder/fix-test-dependency.patch
@@ -1,0 +1,15 @@
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index a923cadce53..95a4d3a807f 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -186,7 +186,9 @@ if(BUILD_INTEGRATION_TESTS)
+                            WORKING_DIRECTORY
+                            ${TEST_BIN_DIR}
+                            FIXTURES_REQUIRED
+-                           unpack_data)
++                           unpack_data
++                           DEPENDS
++                           ${DATA}_execute)
+         endif()
+     endforeach(DATA)
+ endif()


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
