### PR TITLE
nvfancontrol: migrate to by-name

### DIFF
--- a/pkgs/by-name/nv/nvfancontrol/package.nix
+++ b/pkgs/by-name/nv/nvfancontrol/package.nix
@@ -2,11 +2,13 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  libXNVCtrl,
+  linuxPackages,
   libx11,
   libxext,
 }:
-
+let
+  libXNVCtrl = linuxPackages.nvidia_x11.settings.libXNVCtrl;
+in
 rustPlatform.buildRustPackage rec {
   pname = "nvfancontrol";
   version = "0.5.1";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3082,10 +3082,6 @@ with pkgs;
   # ntfsprogs are merged into ntfs-3g
   ntfsprogs = pkgs.ntfs3g;
 
-  nvfancontrol = callPackage ../tools/misc/nvfancontrol {
-    libXNVCtrl = linuxPackages.nvidia_x11.settings.libXNVCtrl;
-  };
-
   nwdiag = with python3Packages; toPythonApplication nwdiag;
 
   ofono-phonesim = libsForQt5.callPackage ../development/tools/ofono-phonesim { };


### PR DESCRIPTION
This pull request reorganizes the packaging of `nvfancontrol` to better align with Nixpkgs conventions and improve maintainability. The main change is moving the package definition to a new location and updating how its dependencies are handled.

**Package reorganization and dependency management:**

* Moved the `nvfancontrol` package definition from `pkgs/tools/misc/nvfancontrol/default.nix` to `pkgs/by-name/nv/nvfancontrol/package.nix` to follow the new directory structure for package organization.
* Updated the way `libXNVCtrl` is referenced by deriving it from `linuxPackages.nvidia_x11.settings.libXNVCtrl` within the package definition, instead of passing it explicitly from the top-level package list.
* Removed the explicit definition of `nvfancontrol` from `pkgs/top-level/all-packages.nix`, as it is now handled by the new package structure.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
