### PR TITLE
isa-l: 2.31.1 -> 2.32.0

### DIFF
--- a/pkgs/by-name/is/isa-l/package.nix
+++ b/pkgs/by-name/is/isa-l/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "isa-l";
-  version = "2.31.1";
+  version = "2.32.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "isa-l";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pv0Aq1Yp/NkGN7KXJ4oQMSG36k5v9YnsELuATl86Zp4=";
+    hash = "sha256-LvxAlyBUSYEVLrMGcLii7bGvN1GZY/noYRSrBqsGiMI=";
   };
 
   nativeBuildInputs = [
@@ -32,14 +32,17 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
   ];
 
+  # configure.ac has two code paths for assembler detection:
+  # 1. When AS is unset: searches for nasm and tests with correct nasm syntax
+  # 2. When AS is set: tests with yasm-style syntax that nasm rejects
+  # AM_PROG_AS sets AS=as, so we must unset it to use path 1.
   preConfigure = ''
-    export AS=nasm
+    unset AS
   '';
 
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
-  versionCheckProgram = "${placeholder "out"}/bin/igzip";
   doInstallCheck = true;
 
   passthru = {


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/intel/isa-l/compare/v2.31.1...v2.32.0
Changelog: https://github.com/intel/isa-l/releases/tag/v2.32.0

cc @jbedo

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test