### PR TITLE
python3Packages.firebase-admin: 7.1.0 -> 7.2.0; python3Packages.google-cloud-firestore: enable on Python 3.14

### DIFF
--- a/pkgs/development/python-modules/firebase-admin/default.nix
+++ b/pkgs/development/python-modules/firebase-admin/default.nix
@@ -20,27 +20,19 @@
   pytest-mock,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "firebase-admin";
-  version = "7.1.0";
+  version = "7.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "firebase";
     repo = "firebase-admin-python";
-    tag = "v${version}";
-    hash = "sha256-xlKrtH8f9UzY9OGYrpNH0i2OAlcxTrpzPC5JEuL8plM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WXUTiJorAsXg+I6xCr2wtDFwrxkr5fsOwRpsaQu8sA4=";
   };
 
   build-system = [ setuptools ];
-
-  patches = [
-    (fetchpatch {
-      name = "remove-asyncio-default-fixture-loop-scope.patch";
-      url = "https://github.com/firebase/firebase-admin-python/commit/de713d21da83b1f50c24c5a23132ffc442700448.patch";
-      hash = "sha256-D4edbVHMejpnSmIYblrq9E5+YdbBzLe/VWbObvMNGdk=";
-    })
-  ];
 
   dependencies = [
     cachecontrol
@@ -78,11 +70,11 @@ buildPythonPackage rec {
   meta = {
     description = "Firebase Admin Python SDK";
     homepage = "https://github.com/firebase/firebase-admin-python";
-    changelog = "https://github.com/firebase/firebase-admin-python/releases/tag/${src.tag}";
+    changelog = "https://github.com/firebase/firebase-admin-python/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       jhahn
       sarahec
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/google-cloud-firestore/default.nix
+++ b/pkgs/development/python-modules/google-cloud-firestore/default.nix
@@ -12,18 +12,20 @@
   protobuf,
   pytest-asyncio,
   pytestCheckHook,
+  pythonAtLeast,
+  pythonOlder,
   pyyaml,
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "google-cloud-firestore";
   version = "2.23.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "google_cloud_firestore";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-qc/7p83GEBER1tVM3iLVIcmPnn1BXmdIaxN/oW8GqgM=";
   };
 
@@ -38,18 +40,22 @@ buildPythonPackage rec {
   ++ google-api-core.optional-dependencies.grpc;
 
   nativeCheckInputs = [
-    aiounittest
     freezegun
     google-cloud-testutils
     mock
     pytest-asyncio
     pytestCheckHook
     pyyaml
-  ];
+  ]
+  ++ lib.optionals (pythonOlder "3.14") [ aiounittest ];
 
   preCheck = ''
     # do not shadow imports
     rm -r google
+  ''
+  + lib.optionalString (pythonAtLeast "3.14") ''
+    # aiounittest is not available for Python 3.14
+    rm -r tests/unit/v1/test_bulk_writer.py
   '';
 
   disabledTestPaths = [
@@ -58,6 +64,11 @@ buildPythonPackage rec {
     "tests/system/test_system_async.py"
     # Test requires credentials
     "tests/system/test_pipeline_acceptance.py"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # RuntimeError: There is no current event loop in thread 'MainThread'
+    # due to eliding aiounittest
+    "tests/unit/v1/test_bundle.py::TestAsyncBundle::test_async_query"
   ];
 
   pythonImportsCheck = [
@@ -68,8 +79,8 @@ buildPythonPackage rec {
   meta = {
     description = "Google Cloud Firestore API client library";
     homepage = "https://github.com/googleapis/python-firestore";
-    changelog = "https://github.com/googleapis/python-firestore/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/googleapis/python-firestore/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ sarahec ];
   };
-}
+})


### PR DESCRIPTION
1. `python3Packages.firebase-admin`: 7.1.0 -> 7.2.0, including fixedAttrs. https://github.com/firebase/firebase-admin-python/releases/tag/v7.2.0
2. `python3Packages.google-cloud-firestore`: enable on Python 3.14

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
