### PR TITLE
dispatcharr: init at 0.20.2

### DIFF
--- a/pkgs/by-name/di/dispatcharr/package.nix
+++ b/pkgs/by-name/di/dispatcharr/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  writeText,
+  fetchFromGitHub,
+  nixosTests,
+  python3,
+  streamlink,
+}:
+let
+  py = python3.override {
+    self = py;
+    packageOverrides = final: prev: {
+      django = prev.django_5;
+    };
+  };
+in
+py.pkgs.buildPythonApplication rec {
+  pname = "dispatcharr";
+  version = "0.20.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Dispatcharr";
+    repo = "Dispatcharr";
+    tag = "v${version}";
+    sha256 = "sha256-ZK65rJYgAyzS1lQdzlxrw31qfsjxcDi8xuDr+JWVlhw=";
+  };
+
+  build-system = with py.pkgs; [ hatchling ];
+
+  dependencies = with py.pkgs; [
+    celery
+    channels
+    channels-redis
+    daphne
+    django-celery-beat
+    django-cors-headers
+    django-filter
+    django
+    djangorestframework-simplejwt
+    djangorestframework
+    drf-spectacular
+    gevent
+    lxml
+    m3u8
+    pillow
+    psutil
+    psycopg2-binary
+    python-vlc
+    pytz
+    rapidfuzz
+    regex
+    requests
+    sentence-transformers
+    streamlink
+    torch
+    tzlocal
+    yt-dlp
+  ];
+
+  pythonRelaxDeps = [
+    "psutil"
+    "torch"
+  ];
+  pythonRemoveDeps = [
+    "uwsgi" # only needed to launch app
+  ];
+
+  passthru = {
+    tests = {
+      inherit (nixosTests) dispatcharr; # TODO
+    };
+  };
+
+  meta = {
+    homepage = "https://github.com/Dispatcharr/Dispatcharr";
+    description = "Your Ultimate IPTV & Stream Management Companion";
+    license = lib.licenses.cc-by-nc-sa-40;
+    maintainers = with lib.maintainers; [
+      diogotcorreia
+    ];
+    platforms = py.meta.platforms;
+  };
+}


### PR DESCRIPTION
Homepage: https://github.com/Dispatcharr/Dispatcharr
Description: Your Ultimate IPTV & Stream Management Companion
License: cc-by-nc-sa-40

## TODO

While the package builds, this is not usable in its current state.

- [ ] Build frontend
- [ ] Wrap package with uwsgi
- [ ] NixOS module
- [ ] Tests

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
