### PR TITLE
home-assistant-custom-components.tibber_local: init at 2026.2.2

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/tibber_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/tibber_local/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  smllib,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "marq24";
+  domain = "tibber_local";
+  version = "2026.2.2";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "ha-tibber-pulse-local";
+    tag = version;
+    sha256 = "sha256-YHvhVAGOMkPwaxdQVv1cO6H8LitoG2PChOV1b8Z/4KU=";
+  };
+
+  dependencies = [
+    smllib
+  ];
+
+  meta = {
+    changelog = "https://github.com/marq24/ha-tibber-pulse-local/releases/tag/${version}";
+    description = "Home Assistant integration framework for (garbage collection) schedules";
+    homepage = "https://github.com/marq24/ha-tibber-pulse-local";
+    maintainers = with lib.maintainers; [ hensoko ];
+    license = lib.licenses.asl20;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
home-assistant-custom-components.tibber_local: init at 2026.2.2

this PR packages https://github.com/marq24/ha-tibber-pulse-local to be used with home assistant.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
