### PR TITLE
litellm: 1.80.0 -> 1.81.14

### DIFF
--- a/nixos/modules/services/misc/litellm.nix
+++ b/nixos/modules/services/misc/litellm.nix
@@ -132,6 +132,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    systemd.tmpfiles.rules = [
+      "d '${cfg.stateDir}/ui' 0700 - - - -"
+    ];
+
     systemd.services.litellm = {
       description = "LLM Gateway to provide model access, fallbacks and spend tracking across 100+ LLMs.";
       wantedBy = [ "multi-user.target" ];
@@ -152,7 +156,9 @@ in
         in
         {
           ExecStartPre = [
-            "${pkgs.runtimeShell} -euc 'mkdir -p ${cfg.stateDir}/ui; chmod -R u+rwX ${cfg.stateDir}/ui'"
+            # LiteLLM may rewrite/copy UI assets with read-only permissions
+            # during previous runs; normalize writability on each start.
+            "${pkgs.runtimeShell} -euc 'chmod -R u+rwX ${cfg.stateDir}/ui'"
           ];
           ExecStart = "${lib.getExe cfg.package} --host \"${cfg.host}\" --port ${toString cfg.port} --config ${configFile}";
           EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;

--- a/nixos/modules/services/misc/litellm.nix
+++ b/nixos/modules/services/misc/litellm.nix
@@ -9,6 +9,36 @@ let
 
   cfg = config.services.litellm;
   settingsFormat = pkgs.formats.yaml { };
+
+  tiktokenEncodings = {
+    cl100k_base = {
+      url = "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken";
+      hash = "sha256-Ijkht27pm96ZW3/3OFE+7xAPtR0YyTWXoRO8/+hlsqc=";
+    };
+  };
+
+  tiktokenCacheEntries = lib.mapAttrsToList (
+    _: encoding:
+    let
+      cacheKey = builtins.hashString "sha1" encoding.url;
+      sourceFile = pkgs.fetchurl {
+        inherit (encoding) url hash;
+      };
+    in
+    {
+      inherit cacheKey sourceFile;
+    }
+  ) tiktokenEncodings;
+
+  seedTiktokenCacheScript = pkgs.writeShellScript "litellm-seed-tiktoken-cache" ''
+    set -eu
+
+    mkdir -p "$CUSTOM_TIKTOKEN_CACHE_DIR"
+
+    ${lib.concatMapStringsSep "\n" (entry: ''
+      ln -sf ${entry.sourceFile} "$CUSTOM_TIKTOKEN_CACHE_DIR/${entry.cacheKey}"
+    '') tiktokenCacheEntries}
+  '';
 in
 {
   options = {
@@ -134,6 +164,7 @@ in
   config = lib.mkIf cfg.enable {
     systemd.tmpfiles.rules = [
       "d '${cfg.stateDir}/ui' 0700 - - - -"
+      "d '${cfg.stateDir}/tiktoken-cache' 0700 - - - -"
     ];
 
     systemd.services.litellm = {
@@ -147,6 +178,9 @@ in
         # UI lives in the read-only Nix store, so point it at a writable runtime path.
         LITELLM_NON_ROOT = "true";
         LITELLM_UI_PATH = "${cfg.stateDir}/ui";
+
+        # LiteLLM sets TIKTOKEN_CACHE_DIR internally from this variable.
+        CUSTOM_TIKTOKEN_CACHE_DIR = "${cfg.stateDir}/tiktoken-cache";
       }
       // cfg.environment;
 
@@ -156,6 +190,10 @@ in
         in
         {
           ExecStartPre = [
+            # Seed tokenizer cache with fixed-output files so startup does not
+            # depend on outbound network access.
+            seedTiktokenCacheScript
+
             # LiteLLM may rewrite/copy UI assets with read-only permissions
             # during previous runs; normalize writability on each start.
             "${pkgs.runtimeShell} -euc 'chmod -R u+rwX ${cfg.stateDir}/ui'"
@@ -166,6 +204,7 @@ in
           StateDirectory = [
             "litellm"
             "litellm/ui"
+            "litellm/tiktoken-cache"
           ];
           RuntimeDirectory = "litellm";
           RuntimeDirectoryMode = "0755";

--- a/nixos/modules/services/misc/litellm.nix
+++ b/nixos/modules/services/misc/litellm.nix
@@ -151,6 +151,9 @@ in
           configFile = settingsFormat.generate "config.yaml" cfg.settings;
         in
         {
+          ExecStartPre = [
+            "${pkgs.runtimeShell} -euc 'mkdir -p ${cfg.stateDir}/ui; chmod -R u+rwX ${cfg.stateDir}/ui'"
+          ];
           ExecStart = "${lib.getExe cfg.package} --host \"${cfg.host}\" --port ${toString cfg.port} --config ${configFile}";
           EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
           WorkingDirectory = cfg.stateDir;

--- a/nixos/modules/services/misc/litellm.nix
+++ b/nixos/modules/services/misc/litellm.nix
@@ -137,7 +137,15 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
 
-      environment = cfg.environment;
+      environment =
+        {
+          # LiteLLM will try to "restructure" (rewrite) its packaged UI files on startup
+          # to support extensionless routes (e.g. `/ui/login`). In Nix builds the packaged
+          # UI lives in the read-only Nix store, so point it at a writable runtime path.
+          LITELLM_NON_ROOT = "true";
+          LITELLM_UI_PATH = "${cfg.stateDir}/ui";
+        }
+        // cfg.environment;
 
       serviceConfig =
         let
@@ -147,7 +155,7 @@ in
           ExecStart = "${lib.getExe cfg.package} --host \"${cfg.host}\" --port ${toString cfg.port} --config ${configFile}";
           EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
           WorkingDirectory = cfg.stateDir;
-          StateDirectory = "litellm";
+          StateDirectory = [ "litellm" "litellm/ui" ];
           RuntimeDirectory = "litellm";
           RuntimeDirectoryMode = "0755";
           PrivateTmp = true;

--- a/nixos/modules/services/misc/litellm.nix
+++ b/nixos/modules/services/misc/litellm.nix
@@ -137,15 +137,14 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
 
-      environment =
-        {
-          # LiteLLM will try to "restructure" (rewrite) its packaged UI files on startup
-          # to support extensionless routes (e.g. `/ui/login`). In Nix builds the packaged
-          # UI lives in the read-only Nix store, so point it at a writable runtime path.
-          LITELLM_NON_ROOT = "true";
-          LITELLM_UI_PATH = "${cfg.stateDir}/ui";
-        }
-        // cfg.environment;
+      environment = {
+        # LiteLLM will try to "restructure" (rewrite) its packaged UI files on startup
+        # to support extensionless routes (e.g. `/ui/login`). In Nix builds the packaged
+        # UI lives in the read-only Nix store, so point it at a writable runtime path.
+        LITELLM_NON_ROOT = "true";
+        LITELLM_UI_PATH = "${cfg.stateDir}/ui";
+      }
+      // cfg.environment;
 
       serviceConfig =
         let
@@ -155,7 +154,10 @@ in
           ExecStart = "${lib.getExe cfg.package} --host \"${cfg.host}\" --port ${toString cfg.port} --config ${configFile}";
           EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
           WorkingDirectory = cfg.stateDir;
-          StateDirectory = [ "litellm" "litellm/ui" ];
+          StateDirectory = [
+            "litellm"
+            "litellm/ui"
+          ];
           RuntimeDirectory = "litellm";
           RuntimeDirectoryMode = "0755";
           PrivateTmp = true;

--- a/pkgs/by-name/ai/aider-chat/package.nix
+++ b/pkgs/by-name/ai/aider-chat/package.nix
@@ -165,6 +165,13 @@ let
         url = "https://github.com/Aider-AI/aider/commit/7201abc56539ae8ee2bf4ea0926f584c9ec5558c.patch";
         hash = "sha256-bjL9nbEQGGNkFczm1hDOMP3b48eRJk17zcivXjOdVnw=";
       })
+
+      # https://github.com/Aider-AI/aider/commit/38716cc5a2621499c50454aa77ee379aa2b0c590
+      (fetchpatch {
+        name = "add-permission-denied-error-to-litellm-exceptions.patch";
+        url = "https://github.com/Aider-AI/aider/commit/38716cc5a2621499c50454aa77ee379aa2b0c590.patch";
+        hash = "sha256-uDIUHbauAmzCfaqx6aswnkUHcmgJi4X2OdMPyn4NeYU=";
+      })
     ];
 
     disabledTestPaths = [

--- a/pkgs/development/python-modules/litellm/default.nix
+++ b/pkgs/development/python-modules/litellm/default.nix
@@ -50,14 +50,14 @@
 
 buildPythonPackage rec {
   pname = "litellm";
-  version = "1.80.0";
+  version = "1.81.14";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "BerriAI";
     repo = "litellm";
-    tag = "v${version}-stable.1";
-    hash = "sha256-W1tckXXQ9PlqTW5S4ml0X5rcPXSCioubDaSkQxHQrMY=";
+    tag = "v${version}-stable";
+    hash = "sha256-1QYqTsTOynLrLmjzYL4TPxwKagFKFXIQbQ1rfw8TXjc=";
   };
 
   build-system = [ poetry-core ];


### PR DESCRIPTION
## Summary
- Bump `litellm` to `1.81.14`.
- Set `LITELLM_UI_PATH` for the NixOS `services.litellm` unit to a writable state directory, avoiding runtime attempts to rewrite UI assets in the read-only Nix store.

## Test plan
- [x] `nix build .#litellm`
- [ ] `nix build .#nixosTests.litellm`

🤖 Generated with [eca](https://eca.dev)