### PR TITLE
home-assistant-custom-lovelace-modules.battery-state-card: init at 3.3.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/battery-state-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/battery-state-card/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "battery-state-card";
+  version = "3.3.0";
+
+  src = fetchFromGitHub {
+    owner = "maxwroc";
+    repo = "battery-state-card";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/oFW80zCp4vnRc3ZKVJtvNH11UPrdustFDktZdnFiQM=";
+  };
+
+  npmDepsHash = "sha256-TYiUTzNsaEwy9Y5O0UyFXCGFJ/jdjTek3B5CVvac+p8=";
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install ./dist/battery-state-card.js -Dt $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Battery state card for Home Assistant";
+    homepage = "https://github.com/maxwroc/battery-state-card";
+    changelog = "https://github.com/maxwroc/battery-state-card/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION

<img width="393" height="145" alt="image" src="https://github.com/user-attachments/assets/78f195a1-00cd-452e-b119-f69914cf1503" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
