### PR TITLE
remmina: remove Plasma 5 kwallet

### DIFF
--- a/pkgs/by-name/re/remmina/package.nix
+++ b/pkgs/by-name/re/remmina/package.nix
@@ -40,8 +40,6 @@
   wayland,
   # The themes here are soft dependencies; only icons are missing without them.
   adwaita-icon-theme,
-  withKf5Wallet ? stdenv.hostPlatform.isLinux,
-  libsForQt5,
   withLibsecret ? stdenv.hostPlatform.isLinux,
   withWebkitGtk ? false,
   webkitgtk_4_1,
@@ -104,7 +102,6 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
   ]
   ++ lib.optionals withLibsecret [ libsecret ]
-  ++ lib.optionals withKf5Wallet [ libsForQt5.kwallet ]
   ++ lib.optionals withWebkitGtk [ webkitgtk_4_1 ]
   ++ lib.optionals withVte [ vte ];
 
@@ -115,7 +112,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DWITH_VTE=${if withVte then "ON" else "OFF"}"
     "-DWITH_TELEPATHY=OFF"
     "-DWITH_AVAHI=OFF"
-    "-DWITH_KF5WALLET=${if withKf5Wallet then "ON" else "OFF"}"
     "-DWITH_LIBSECRET=${if withLibsecret then "ON" else "OFF"}"
     "-DWITH_WEBKIT2GTK=${if withWebkitGtk then "ON" else "OFF"}"
   ]


### PR DESCRIPTION
Plasma 6 uses secret service anyhow.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
