### PR TITLE
nixos/litellm: warn when stateDir is outside /var/lib

### DIFF
--- a/nixos/modules/services/misc/litellm.nix
+++ b/nixos/modules/services/misc/litellm.nix
@@ -20,7 +20,15 @@ in
         type = types.path;
         default = "/var/lib/litellm";
         example = "/home/foo";
-        description = "State directory of LiteLLM.";
+        description = ''
+          State directory of LiteLLM.
+
+          This module runs with `DynamicUser = true` and provisions state via
+          systemd `StateDirectory=...`, which places state under `/var/lib`.
+          Setting this to a location outside `/var/lib` is therefore generally
+          unsupported unless the module is extended to run as a persistent user
+          and to provision/chown the directory accordingly.
+        '';
       };
 
       host = lib.mkOption {
@@ -132,6 +140,9 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    warnings = lib.optional (!lib.hasPrefix "/var/lib/" (toString cfg.stateDir))
+      "services.litellm.stateDir is set to '${toString cfg.stateDir}', but the module provisions state under /var/lib via systemd StateDirectory while using DynamicUser. Paths outside /var/lib may not be writable for the service.";
+
     systemd.services.litellm = {
       description = "LLM Gateway to provide model access, fallbacks and spend tracking across 100+ LLMs.";
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/misc/litellm.nix
+++ b/nixos/modules/services/misc/litellm.nix
@@ -140,8 +140,9 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    warnings = lib.optional (!lib.hasPrefix "/var/lib/" (toString cfg.stateDir))
-      "services.litellm.stateDir is set to '${toString cfg.stateDir}', but the module provisions state under /var/lib via systemd StateDirectory while using DynamicUser. Paths outside /var/lib may not be writable for the service.";
+    warnings =
+      lib.optional (!lib.hasPrefix "/var/lib/" (toString cfg.stateDir))
+        "services.litellm.stateDir is set to '${toString cfg.stateDir}', but the module provisions state under /var/lib via systemd StateDirectory while using DynamicUser. Paths outside /var/lib may not be writable for the service.";
 
     systemd.services.litellm = {
       description = "LLM Gateway to provide model access, fallbacks and spend tracking across 100+ LLMs.";


### PR DESCRIPTION
## Summary
The `services.litellm` module provisions state via systemd `StateDirectory`, which places state under `/var/lib`, while the module also exposes `services.litellm.stateDir`.

To reduce confusion and avoid common misconfigurations with `DynamicUser = true`, this adds:
- clarification to the `stateDir` option documentation
- a warning when `stateDir` is set outside `/var/lib`

## Notes / follow-ups
Supporting arbitrary state paths would likely require a larger change (e.g. an option to disable `DynamicUser` and run as a persistent user, plus directory provisioning/ownership management).

## Test plan
- [ ] Evaluate a config with `services.litellm.stateDir = /home/foo;` and confirm a warning is emitted

🤖 Generated with [eca](https://eca.dev)