### PR TITLE
godot: add C++ modules to godot and godot-mono

### DIFF
--- a/pkgs/development/tools/godot/build-godot-module.nix
+++ b/pkgs/development/tools/godot/build-godot-module.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+}:
+
+{
+  name,
+  src,
+  version ? "unstable",
+  meta ? { },
+  passthru ? { },
+  ...
+}@args:
+
+stdenv.mkDerivation (
+  builtins.removeAttrs args [
+    "name"
+    "version"
+    "meta"
+    "passthru"
+  ]
+  // {
+    pname = "godot-module-${name}";
+    inherit version src;
+
+    dontBuild = true;
+    dontConfigure = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/share/godot/modules/${name}"
+      cp -r . "$out/share/godot/modules/${name}/"
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Godot C++ module: ${name}";
+      license = lib.licenses.mit;
+    }
+    // meta;
+
+    passthru = {
+      moduleName = name;
+    }
+    // passthru;
+  }
+)

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -82,6 +82,13 @@
   wslay,
   zip,
   zstd,
+  # List of derivations produced by buildGodotModule.
+  # Each must install its source tree to $out/share/godot/modules/<name>/.
+  # Modules are copied to a writable directory before compilation because
+  # some modules write generated files into their own source tree during the
+  # SCons build, and Nix store paths are read-only.
+  godotModules ? [ ],
+  extraSconsFlags ? [ ],
 }:
 assert lib.asserts.assertOneOf "withPrecision" withPrecision [
   "single"
@@ -419,63 +426,76 @@ let
           # darwin needs $HOME/.cache/clang/ModuleCache.
           + lib.optionalString stdenv.hostPlatform.isDarwin ''
             export HOME=$(mktemp -d)
+          ''
+          + lib.optionalString (godotModules != [ ]) ''
+            echo "Copying custom Godot modules to writable build directory..."
+            mkdir -p "$NIX_BUILD_TOP/godot-modules"
+            ${lib.concatMapStringsSep "\n" (m: ''
+              cp -r --no-preserve=mode \
+                ${m}/share/godot/modules/. \
+                "$NIX_BUILD_TOP/godot-modules/"
+            '') godotModules}
+            chmod -R u+w "$NIX_BUILD_TOP/godot-modules"
           '';
 
         # From: https://github.com/godotengine/godot/blob/4.2.2-stable/SConstruct
-        sconsFlags = mkSconsFlagsFromAttrSet (
-          {
-            # Options from 'SConstruct'
-            precision = withPrecision; # Floating-point precision level
-            production = true; # Set defaults to build Godot for use in production
-            platform = withPlatform;
-            inherit target;
-            debug_symbols = true;
+        sconsFlags =
+          mkSconsFlagsFromAttrSet (
+            {
+              # Options from 'SConstruct'
+              precision = withPrecision; # Floating-point precision level
+              production = true; # Set defaults to build Godot for use in production
+              platform = withPlatform;
+              inherit target;
+              debug_symbols = true;
 
-            # Options from 'platform/linuxbsd/detect.py'
-            alsa = withAlsa;
-            dbus = withDbus; # Use D-Bus to handle screensaver and portal desktop settings
-            fontconfig = withFontconfig; # Use fontconfig for system fonts support
-            pulseaudio = withPulseaudio; # Use PulseAudio
-            speechd = withSpeechd; # Use Speech Dispatcher for Text-to-Speech support
-            touch = withTouch; # Enable touch events
-            udev = withUdev; # Use udev for gamepad connection callbacks
-            wayland = withWayland; # Compile with Wayland support
-            x11 = withX11; # Compile with X11 support
+              # Options from 'platform/linuxbsd/detect.py'
+              alsa = withAlsa;
+              dbus = withDbus; # Use D-Bus to handle screensaver and portal desktop settings
+              fontconfig = withFontconfig; # Use fontconfig for system fonts support
+              pulseaudio = withPulseaudio; # Use PulseAudio
+              speechd = withSpeechd; # Use Speech Dispatcher for Text-to-Speech support
+              touch = withTouch; # Enable touch events
+              udev = withUdev; # Use udev for gamepad connection callbacks
+              wayland = withWayland; # Compile with Wayland support
+              x11 = withX11; # Compile with X11 support
 
-            module_mono_enabled = withMono;
+              module_mono_enabled = withMono;
 
-            # aliasing bugs exist with hardening+LTO
-            # https://github.com/godotengine/godot/pull/104501
-            ccflags = "-fno-strict-aliasing";
-            # on darwin: ld: unknown option: --build-id
-            linkflags = lib.optionalString (!stdenv.hostPlatform.isDarwin) "-Wl,--build-id";
+              # aliasing bugs exist with hardening+LTO
+              # https://github.com/godotengine/godot/pull/104501
+              ccflags = "-fno-strict-aliasing";
+              # on darwin: ld: unknown option: --build-id
+              linkflags = lib.optionalString (!stdenv.hostPlatform.isDarwin) "-Wl,--build-id";
 
-            # libraries that aren't available in nixpkgs
-            builtin_msdfgen = true;
-            builtin_rvo2_2d = true;
-            builtin_rvo2_3d = true;
-            builtin_xatlas = true;
+              # libraries that aren't available in nixpkgs
+              builtin_msdfgen = true;
+              builtin_rvo2_2d = true;
+              builtin_rvo2_3d = true;
+              builtin_xatlas = true;
 
-            # using system clipper2 is currently not implemented
-            builtin_clipper2 = true;
+              # using system clipper2 is currently not implemented
+              builtin_clipper2 = true;
 
-            use_sowrap = false;
-          }
-          // lib.optionalAttrs (lib.versionOlder version "4.4") {
-            # libraries that aren't available in nixpkgs
-            builtin_squish = true;
+              use_sowrap = false;
+            }
+            // lib.optionalAttrs (lib.versionOlder version "4.4") {
+              # libraries that aren't available in nixpkgs
+              builtin_squish = true;
 
-            # broken with system packages
-            builtin_miniupnpc = true;
-          }
-          // lib.optionalAttrs (lib.versionAtLeast version "4.5") {
-            redirect_build_objects = false; # Avoid copying build objects to output
-          }
-          # see postBuild
-          // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && !(editor && withMono)) {
-            generate_bundle = "yes";
-          }
-        );
+              # broken with system packages
+              builtin_miniupnpc = true;
+            }
+            // lib.optionalAttrs (lib.versionAtLeast version "4.5") {
+              redirect_build_objects = false; # Avoid copying build objects to output
+            }
+            # see postBuild
+            // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && !(editor && withMono)) {
+              generate_bundle = "yes";
+            }
+          )
+          ++ lib.optional (godotModules != [ ]) "custom_modules=$NIX_BUILD_TOP/godot-modules"
+          ++ extraSconsFlags;
 
         enableParallelBuilding = true;
 
@@ -626,7 +646,8 @@ let
           ++ lib.optionals stdenv.hostPlatform.isDarwin [
             apple-sdk_26
             moltenvk
-          ];
+          ]
+          ++ godotModules;
 
         nativeBuildInputs = [
           gettext

--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -46,6 +46,8 @@ let
     };
 in
 rec {
+  buildGodotModule = callPackage ./build-godot-module.nix { };
+
   godot3 = callPackage ./3 { };
   godot3-export-templates = callPackage ./3/export-templates.nix { };
   godot3-headless = callPackage ./3/headless.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2116,6 +2116,7 @@ with pkgs;
   gnused = callPackage ../tools/text/gnused { };
 
   inherit (callPackage ../development/tools/godot { })
+    buildGodotModule
     godot3
     godot3-export-templates
     godot3-headless


### PR DESCRIPTION
Allows users to declaratively compose a custom Godot build with third-party C++ modules (e.g. [LimboAI](https://github.com/limbonaut/limboai), [GodotSteam](https://codeberg.org/godotsteam/godotsteam)) without maintaining a fork of the engine. Modules are copied to a writable build directory at compile time since SCons builds them in-tree alongside the engine.

Example shell.nix
```nix

{ pkgs ? import <nixpkgs> {} }:

let
  limboai = pkgs.buildGodotModule rec {
    name    = "limboai";
    version = "1.7.0";
    src = pkgs.fetchFromGitHub {
      owner = "limbonaut";
      repo = "limboai";
      tag = "v${version}";
      sha256 = "sha256-5cMOGLY39B60ECsWtHedyTHcOHhIQaFeY80e/rKdyGk=";
    };
  };

  my-godot-mono = pkgs.godot-mono.override {
    godotModules = [ limboai ];
  };
in
  pkgs.mkShell {
    buildInputs = [ my-godot-mono];
  }

```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
