### PR TITLE
tmaze: init at 1.18.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9244,6 +9244,12 @@
     github = "fkautz";
     githubId = 135706;
   };
+  fkomarek = {
+    name = "Filip Komárek";
+    github = "filip2cz";
+    githubId = 82812634;
+    email = "filip@fkomarek.eu";
+  };
   FKouhai = {
     name = "Fran Cirka";
     email = "frandres00@gmail.com";

--- a/pkgs/by-name/tm/tmaze/package.nix
+++ b/pkgs/by-name/tm/tmaze/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  alsa-lib,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tmaze";
+  version = "1.18.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ur-fault";
+    repo = "TMaze";
+    tag = version;
+    hash = "sha256-JB3ZFoC659TNaxoMWmzFFyvzdQZwmBDdsJHz79nRyn8=";
+  };
+
+  cargoHash = "sha256-srxk7+xAktUIkjve9aAruRdHqrglRlNjY+8S720w/M4=";
+
+  # Upstream broke examples compilation in 1.18.0 due to API changes
+  doCheck = false;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ alsa-lib ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple multiplatform maze solving game for terminal";
+    homepage = "https://github.com/ur-fault/TMaze";
+    license = lib.licenses.unfree // {
+      fullName = "Komarek's public license v1";
+      url = "https://github.com/ur-fault/TMaze/blob/master/LICENSE";
+    };
+    maintainers = with lib.maintainers; [
+      fkomarek
+    ];
+    mainProgram = "tmaze";
+  };
+}


### PR DESCRIPTION
ADD: [TMaze](https://github.com/ur-fault/tmaze), version 1.18.0
TMaze is an experience combining immensely complex maze-generation algorithms and mind-numming mazes to solve. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
