### PR TITLE
numaplayer: init at 2.1.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23650,6 +23650,13 @@
     github = "saadndm";
     githubId = 88615188;
   };
+  sabrinaishere = {
+    name = "Sabrina Myers";
+    email = "SabrinaTheBitch@protonmail.com";
+    matrix = "@sabrina_the_bitch:matrix.org";
+    github = "SabrinaIsHere";
+    githubId = 74331139;
+  };
   sagikazarmark = {
     name = "Mark Sagi-Kazar";
     email = "mark.sagikazar@gmail.com";

--- a/pkgs/by-name/nu/numaplayer/package.nix
+++ b/pkgs/by-name/nu/numaplayer/package.nix
@@ -1,0 +1,116 @@
+# Thank god for the zoom-us repo, lots of this is based on that
+# I tried to patch the binary but it hard depends on /usr/bin/gsettings and almost certainly some other stuff
+{
+  stdenv,
+  wrapGAppsHook3,
+  fetchurl,
+  pkgs,
+  buildFHSEnvBubblewrap,
+  lib,
+}:
+# Fairly self explanatory, fetch the .deb, unpack it, set up the output for the fhsenv and wrap
+# gapp stuff
+let
+  pname = "numaplayer";
+  version = "2.1.8";
+  numaplayer = stdenv.mkDerivation {
+    inherit pname version;
+
+    src = fetchurl {
+      url = "https://www.studiologic-music.com/api/get-files/NumaPlayer_${version}.deb";
+      sha256 = "sha256-6GVQ4KiX9y4odDr85kqN+3kZP7+Ac/W+lnbmLiJ/rv0=";
+    };
+
+    buildInputs = with pkgs; [
+      dpkg
+    ];
+
+    nativeBuildInputs = [
+      wrapGAppsHook3
+    ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    unpackPhase = ''
+      dpkg -x $src .
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r usr/* $out
+
+      runHook postInstall
+    '';
+  };
+in
+buildFHSEnvBubblewrap {
+  inherit numaplayer;
+  name = pname;
+
+  targetPkgs =
+    with pkgs;
+    pkgs: [
+      # Dependencies found via autoPatchelfHook
+      # It seems typical to have this declared at the top of the file but it didn't seem to like
+      # glib.dev or stdenv.cc.cc so I left it here; lmk if it needs changing
+      numaplayer
+      freetype
+      fontconfig
+      curl
+      glib
+      glib.dev
+      pipewire
+      stdenv.cc.cc
+      alsa-lib
+      dconf
+      # I'm not entirely sure that these are all necessary, but I don't want to risk something not
+      # working in a different environment. These are all from the zoom-us dependencies.
+      libx11
+      libxcomposite
+      libxdamage
+      libxext
+      libxfixes
+      libxrandr
+      libxrender
+      libxtst
+      libxcb
+      libxshmfence
+      libxcb-cursor
+      libxcb-image
+      libxcb-keysyms
+      libxcb-render-util
+      libxcb-wm
+    ];
+
+  # Numa player wants to do a lot of config work in home
+  extraBwrapArgs = [
+    "--bind $HOME $HOME"
+  ];
+
+  # Vst3 plugin in /usr/lib, .desktop file in /usr/share/applications
+  # I wanted to link the plugin to ~/.vst3 or something but I wasn't sure how or what the convention was
+  # and the aur package leaves it in /usr/lib
+  extraInstallCommands = ''
+    cp -r ${numaplayer}/lib $out/lib
+
+    cp -r ${numaplayer}/share $out/share
+    substituteInPlace \
+      $out/share/applications/Numa\ Player.desktop \
+      --replace-fail \"/usr/bin/Numa\ Player\" numaplayer
+  '';
+
+  runScript = "'/bin/Numa Player'";
+
+  meta = {
+    homepage = "https://www.studiologic-music.com/products/numaplayer/";
+    description = "Virtual instrument and DAW plugin";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ sabrinaishere ];
+    mainProgram = "numaplayer";
+    license = lib.licenses.unfree;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Packaged the .deb binary of [Numa Player](https://www.studiologic-music.com/products/numaplayer/), which is a standalone virtual instrument and vst plugin. Unfree license, needs FHSEnv. Added myself as a maintainer.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
