### PR TITLE
nixos/calibre-web: make calibre package configurable

### DIFF
--- a/nixos/modules/services/web-apps/calibre-web.nix
+++ b/nixos/modules/services/web-apps/calibre-web.nix
@@ -27,6 +27,8 @@ in
 
       package = lib.mkPackageOption pkgs "calibre-web" { };
 
+      calibrePackage = lib.mkPackageOption pkgs "calibre" { };
+
       listen = {
         ip = mkOption {
           type = types.str;
@@ -149,8 +151,8 @@ in
             cfg.options.calibreLibrary != null
           ) "config_calibre_dir = '${cfg.options.calibreLibrary}'"
           ++ optionals cfg.options.enableBookConversion [
-            "config_converterpath = '${pkgs.calibre}/bin/ebook-convert'"
-            "config_binariesdir = '${pkgs.calibre}/bin/'"
+            "config_converterpath = '${cfg.calibrePackage}/bin/ebook-convert'"
+            "config_binariesdir = '${cfg.calibrePackage}/bin/'"
           ]
           ++ optional cfg.options.enableKepubify "config_kepubifypath = '${pkgs.kepubify}/bin/kepubify'"
         );


### PR DESCRIPTION
## Description

This PR makes the calibre package used by calibre-web configurable via the `services.calibre-web.calibrePackage` option, allowing users to specify which calibre package to use for ebook conversion.

## Motivation

Previously, the module hard-coded `pkgs.calibre` for the ebook-convert binary paths. This meant that users who wanted to use a different version of calibre (e.g., from a newer nixpkgs branch) could only do so via overlays, and could not configure it directly through the module options.

For example, when calibre 8.16.2 failed to build due to qtbase6-setup-hook issues (#493843), users had to resort to overlays to use a working version. With this change, users can simply set:

```nix
services.calibre-web = {
  enable = true;
  enableBookConversion = true;
  calibrePackage = pkgs.calibre-master;  # or any other calibre derivation
};
```

## Changes

- Add `services.calibre-web.calibrePackage` option (defaults to `pkgs.calibre`)
- Replace hard-coded `pkgs.calibre` with `cfg.calibrePackage`

## Testing

- [x] Nix syntax check passed
- [x] Backward compatible (default behavior unchanged)

## Related Issues

Related to #493843