### PR TITLE
hatsune-miku-cursors: init at 1.2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4070,6 +4070,12 @@
     name = "Builditluc";
     keys = [ { fingerprint = "FF16E475723B8C1E57A6B2569374074AE2D6F20E"; } ];
   };
+  bunbun = {
+    email = "bunbun@bunbun.dev";
+    github = "brainlessbitch";
+    githubId = 102400503;
+    name = "Winter Hille";
+  };
   burdzwastaken = {
     email = "burdz@burdz.net";
     github = "burdzwastaken";

--- a/pkgs/by-name/ha/hatsune-miku-cursors/package.nix
+++ b/pkgs/by-name/ha/hatsune-miku-cursors/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "hatsune-miku-cursors";
+  version = "1.2.6";
+
+  src = fetchFromGitHub {
+    owner = "supermariofps";
+    repo = "hatsune-miku-windows-linux-cursors";
+    tag = finalAttrs.version;
+    hash = "sha256-OQjjOc9VnxJ7tWNmpHIMzNWX6WsavAOkgPwK1XAMwtE=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/icons
+    mv ./miku-cursor-linux $out/share/icons/"Hatsune Miku Cursors"
+  '';
+
+  meta = {
+    description = "Hatsune Miku Cursors for Linux";
+    homepage = "https://github.com/supermariofps/hatsune-miku-windows-linux-cursors";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ bunbun ];
+  };
+})


### PR DESCRIPTION
added the hatsune miku cursors

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
