### PR TITLE
nixos/modules/profiles/nix-builder-vm: remove suffix from system version

### DIFF
--- a/nixos/modules/profiles/nix-builder-vm.nix
+++ b/nixos/modules/profiles/nix-builder-vm.nix
@@ -138,10 +138,6 @@ in
     #
     # TODO(winter): Move to qemu-vm? Trying it here for now as a
     # low impact change that'll probably improve people's experience.
-    #
-    # (I have no clue what is going on in https://github.com/nix-darwin/nix-darwin/issues/1081
-    # though, as this fix would only apply to one person in that thread... hopefully someone
-    # comes across with a reproducer if this doesn't do it.)
     system.systemBuilderArgs.allowSubstitutes = true;
 
     nix.settings = {
@@ -243,6 +239,9 @@ in
     system = {
       # To prevent gratuitous rebuilds on each change to Nixpkgs
       nixos.revision = null;
+
+      # To prevent channels and Git checkouts resulting in different system drvs
+      nixos.versionSuffix = "";
 
       # to be updated by module maintainers, see nixpkgs#325610
       stateVersion = "24.05";


### PR DESCRIPTION
The version suffix (`lib.trivial.versionSuffix`) differs between channel trees and Git trees, which results in users using channels not getting the cached builds of the system derivation, as Hydra uses a Git checkout.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
