### PR TITLE
python313Packages.compressed-tensors: 0.13.0 -> 0.14.0

### DIFF
--- a/pkgs/development/python-modules/compressed-tensors/default.nix
+++ b/pkgs/development/python-modules/compressed-tensors/default.nix
@@ -25,7 +25,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "compressed-tensors";
-  version = "0.13.0";
+  version = "0.14.0";
   pyproject = true;
 
   # Release on PyPI is missing the `utils` directory, which `setup.py` wants to import
@@ -33,11 +33,8 @@ buildPythonPackage (finalAttrs: {
     owner = "neuralmagic";
     repo = "compressed-tensors";
     tag = finalAttrs.version;
-    hash = "sha256-XsQRP186ISarMMES3P+ov4t/1KKJdl0tXBrfpjyM3XA=";
+    hash = "sha256-auiVCTL4WpfaD2cwdG3kt08+nW77T/txWZP4SAW00mk=";
   };
-
-  #  RuntimeError("torch.compile is not supported on Python 3.14+")
-  disabled = pythonAtLeast "3.14";
 
   postPatch = ''
     substituteInPlace pyproject.toml \
@@ -58,6 +55,8 @@ buildPythonPackage (finalAttrs: {
     torch
     transformers
   ];
+
+  pythonRelaxDeps = [ "transformers" ];
 
   doCheck = true;
 
@@ -83,6 +82,13 @@ buildPythonPackage (finalAttrs: {
     "test_save_compressed_model"
     "test_target_prioritization"
     "test_expand_targets_with_llama_stories"
+
+    # AssertionError: Torch not compiled with CUDA enabled
+    "test_register_parameter"
+    "test_register_parameter_invalidates"
+    "test_set_item"
+    "test_set_item_buffers"
+    "test_update_offload_parameter_with_grad"
   ];
 
   disabledTestPaths = [
@@ -93,6 +99,16 @@ buildPythonPackage (finalAttrs: {
     "tests/test_transform/factory/test_serialization.py::test_serialization[True-random-hadamard]"
     "tests/test_transform/factory/test_serialization.py::test_serialization[False-hadamard]"
     "tests/test_transform/factory/test_serialization.py::test_serialization[False-random-hadamard]"
+    "tests/test_transform/factory/test_serialization.py::test_serialization[False-True-hadamard]"
+    "tests/test_transform/factory/test_serialization.py::test_serialization[False-True-random-hadamard]"
+    "tests/test_transform/factory/test_serialization.py::test_serialization[False-False-hadamard]"
+    "tests/test_transform/factory/test_serialization.py::test_serialization[False-False-random-hadamard]"
+
+    # AssertionError: Torch not compiled with CUDA enabled
+    "tests/test_transform/factory/test_serialization.py::test_serialization[True-True-hadamard]"
+    "tests/test_transform/factory/test_serialization.py::test_serialization[True-True-random-hadamard]"
+    "tests/test_transform/factory/test_serialization.py::test_serialization[True-False-hadamard]"
+    "tests/test_transform/factory/test_serialization.py::test_serialization[True-False-random-hadamard]"
   ];
 
   meta = {


### PR DESCRIPTION
https://github.com/vllm-project/compressed-tensors/releases/tag/0.14.0

Enables Python 3.14 compatibility

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
