### PR TITLE
mtPaint: 3.50.12 -> 3.50.14

### DIFF
--- a/pkgs/by-name/mt/mtpaint/package.nix
+++ b/pkgs/by-name/mt/mtpaint/package.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation {
   pname = "mtPaint";
-  version = "3.50.12";
+  version = "3.50.14";
 
   src = fetchFromGitHub {
     owner = "wjaguar";
     repo = "mtPaint";
-    rev = "7cae5d663ed835a365d89a535536c39e18862a83";
-    hash = "sha256-W/MQZ1WqoVMzyEd60rbvA8yieesDc/xfKqbYGZumi2U=";
+    rev = "8304376e8861a8a603371b0f188db30f9cafdc17";
+    hash = "sha256-dyBbzEjdgMPlPnjFlJoZOh5qjx/qY94F28jEr2ihLQE=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Resolves #497068

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
