### PR TITLE
qss-m: init at 1.6.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27716,7 +27716,7 @@
     email = "twicefoldampersands@tutamail.com";
     github = "twicefoldampersands";
     githubId = 265906589;
-    keys = [ { fingerprint = "2607 5DDB 15E8 2415 1B89  4B0C 13E6 8B8C 55F6 850F" } ];
+    keys = [ { fingerprint = "2607 5DDB 15E8 2415 1B89  4B0C 13E6 8B8C 55F6 850F"; } ];
   };
   twitchy0 = {
     email = "code@nitinpassa.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27711,6 +27711,13 @@
     githubId = 787843;
     keys = [ { fingerprint = "E631 8869 586F 99B4 F6E6  D785 5942 58F0 389D 2802"; } ];
   };
+  twicefoldampersands = {
+    name = "&&";
+    email = "twicefoldampersands@tutamail.com";
+    github = "twicefoldampersands";
+    githubId = 265906589;
+    keys = [ { fingerprint = "2607 5DDB 15E8 2415 1B89  4B0C 13E6 8B8C 55F6 850F" } ];
+  };
   twitchy0 = {
     email = "code@nitinpassa.com";
     github = "twitchy0";

--- a/pkgs/by-name/qs/qss-m/package.nix
+++ b/pkgs/by-name/qs/qss-m/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  SDL2,
+  fetchFromGitHub,
+  gzip,
+  libGL,
+  libGLU,
+  libvorbis,
+  libmad,
+  flac,
+  libogg,
+  libxmp,
+  curlMinimal,
+  zlib,
+  gnutls,
+  libx11,
+  copyDesktopItems,
+  makeDesktopItem,
+  pkg-config,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qss-m";
+  version = "1.6.5";
+
+  src = fetchFromGitHub {
+    owner = "timbergeron";
+    repo = "QSS-M";
+    tag = finalAttrs.version;
+    hash = "sha256-Dm9NsSe6+V1bBgtANl1R9Rvir4QkiQUCi0jdYBqevPA=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/Quake";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    pkg-config
+  ];
+
+  buildInputs = [
+    gzip
+    libGL
+    libGLU
+    libvorbis
+    libmad
+    flac
+    libogg
+    libxmp
+    SDL2
+    curlMinimal
+    zlib
+    gnutls
+    libx11
+  ];
+
+  buildFlags = [
+    "DO_USERDIRS=1"
+    "USE_CODEC_OPUS=0"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 quakespasm $out/bin/qss-m
+    install -Dm644 ../Misc/QuakeSpasm_512.png $out/share/icons/hicolor/512x512/apps/qss-m.png
+    runHook postInstall
+  '';
+
+  enableParallelBuilding = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "qss-m";
+      exec = finalAttrs.meta.mainProgram;
+      icon = "qss-m";
+      comment = finalAttrs.meta.description;
+      desktopName = "QSS-M";
+      categories = [ "Game" ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Multiplayer-focused engine for iD software's Quake";
+    homepage = "https://qssm.quakeone.com/";
+    longDescription = ''
+      QSS-M is an open source port of the original ID Software Quake.
+      Over 30 years Quake 1.09 became Fitzquake to Quakespasm that led to Quakespasm
+      Spiked and now Quakespasm Spiked Multiplayer (QSS-M). NetQuake competitive
+      multiplayer clients started with ProQuake, transitioned to Qrack or Mark V,
+      and now QSS-M made possible by all those voluntary efforts.
+    '';
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ twicefoldampersands ];
+    mainProgram = "qss-m";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add QSS-M (Quakespasm Spiked Multiplayer), a source port for id Software's Quake that is, as is suggested in the name, focused on multiplayer, providing unique client-side and server-side features that make it the preferred client for NetQuake multiplayer (content downloading from the server, native map rotation configuration, simpler graphics options for high visibility, etc...).

The package provided follows the features enabled by default in the `Makefile`, as well as creating a desktop entry with the included 512x512 icon for easy usage with an application launcher.

I have added myself as a maintainer in the `maintainer-list.nix`, and have also defined myself as the maintainer of the package in `qss-m/package.nix`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test