### PR TITLE
nixos/coredump: migrate to RFC 42-style settings

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -160,6 +160,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `systemd.coredump.extraConfig` has been removed in favor of the structured [](#opt-systemd.coredump.settings.Coredump) option. Use `systemd.coredump.settings.Coredump` to set any `coredump.conf(5)` option directly. For example, replace `systemd.coredump.extraConfig = "Storage=journal";` with `systemd.coredump.settings.Coredump.Storage = "journal";`.
+
 - `opentrack`, `slushload`, `synthesia`, `vtfedit`, `winbox`, `wineasio`, and `yabridge` use wineWow64Packages instead of wineWowPackages as wine versions >= 11.0 have deprecated wineWowPackages. As such, the prefixes for these packages are NOT backwards compatible and need to be regenerated with potential for data loss.
 
 - []{#sec-release-26.05-incompatibilities-profiles-hardened-removed} `profiles/hardened` has been removed, because:

--- a/nixos/modules/system/boot/systemd/coredump.nix
+++ b/nixos/modules/system/boot/systemd/coredump.nix
@@ -11,6 +11,14 @@ let
   systemd = config.systemd.package;
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [
+      "systemd"
+      "coredump"
+      "extraConfig"
+    ] "Use systemd.coredump.settings.Coredump instead.")
+  ];
+
   options = {
     systemd.coredump.enable = lib.mkOption {
       default = true;
@@ -22,13 +30,17 @@ in
       '';
     };
 
-    systemd.coredump.extraConfig = lib.mkOption {
-      default = "";
-      type = lib.types.lines;
-      example = "Storage=journal";
+    systemd.coredump.settings.Coredump = lib.mkOption {
+      default = { };
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf utils.systemdUtils.unitOptions.unitOption;
+      };
+      example = {
+        Storage = "journal";
+      };
       description = ''
-        Extra config options for systemd-coredump. See {manpage}`coredump.conf(5)` man page
-        for available options.
+        Settings for systemd-coredump. See {manpage}`coredump.conf(5)` for
+        available options.
       '';
     };
   };
@@ -42,10 +54,7 @@ in
       ];
 
       environment.etc = {
-        "systemd/coredump.conf".text = ''
-          [Coredump]
-          ${cfg.extraConfig}
-        '';
+        "systemd/coredump.conf".text = utils.systemdUtils.lib.settingsToSections cfg.settings;
 
         # install provided sysctl snippets
         "sysctl.d/50-coredump.conf".source =

--- a/nixos/modules/system/boot/systemd/coredump.nix
+++ b/nixos/modules/system/boot/systemd/coredump.nix
@@ -6,17 +6,15 @@
   ...
 }:
 
-with lib;
-
 let
   cfg = config.systemd.coredump;
   systemd = config.systemd.package;
 in
 {
   options = {
-    systemd.coredump.enable = mkOption {
+    systemd.coredump.enable = lib.mkOption {
       default = true;
-      type = types.bool;
+      type = lib.types.bool;
       description = ''
         Whether core dumps should be processed by
         {command}`systemd-coredump`. If disabled, core dumps
@@ -24,9 +22,9 @@ in
       '';
     };
 
-    systemd.coredump.extraConfig = mkOption {
+    systemd.coredump.extraConfig = lib.mkOption {
       default = "";
-      type = types.lines;
+      type = lib.types.lines;
       example = "Storage=journal";
       description = ''
         Extra config options for systemd-coredump. See {manpage}`coredump.conf(5)` man page
@@ -35,9 +33,9 @@ in
     };
   };
 
-  config = mkMerge [
+  config = lib.mkMerge [
 
-    (mkIf cfg.enable {
+    (lib.mkIf cfg.enable {
       systemd.additionalUpstreamSystemUnits = [
         "systemd-coredump.socket"
         "systemd-coredump@.service"
@@ -76,8 +74,8 @@ in
       users.groups.systemd-coredump = { };
     })
 
-    (mkIf (!cfg.enable) {
-      boot.kernel.sysctl."kernel.core_pattern" = mkDefault "core";
+    (lib.mkIf (!cfg.enable) {
+      boot.kernel.sysctl."kernel.core_pattern" = lib.mkDefault "core";
     })
 
   ];

--- a/nixos/tests/systemd-coredump.nix
+++ b/nixos/tests/systemd-coredump.nix
@@ -21,10 +21,19 @@ in
     maintainers = [ ];
   };
 
-  nodes.machine1 = { pkgs, lib, ... }: commonConfig;
+  nodes.machine1 =
+    { pkgs, lib, ... }:
+    {
+      imports = [ commonConfig ];
+      systemd.coredump.settings.Coredump = {
+        Storage = "journal";
+        ProcessSizeMax = "0";
+      };
+    };
   nodes.machine2 =
     { pkgs, lib, ... }:
-    lib.recursiveUpdate commonConfig {
+    {
+      imports = [ commonConfig ];
       systemd.coredump.enable = false;
       systemd.package = pkgs.systemd.override {
         withCoredump = false;
@@ -38,6 +47,11 @@ in
       machine1.systemctl("start crasher");
       machine1.wait_until_succeeds("coredumpctl list | grep crasher", timeout=10)
       machine1.fail("stat /var/lib/crasher/core*")
+
+    with subtest("settings.Coredump renders coredump.conf"):
+      machine1.succeed("grep -F '[Coredump]' /etc/systemd/coredump.conf")
+      machine1.succeed("grep -F 'Storage=journal' /etc/systemd/coredump.conf")
+      machine1.succeed("grep -F 'ProcessSizeMax=0' /etc/systemd/coredump.conf")
 
     with subtest("systemd-coredump disabled"):
       machine2.systemctl("start crasher");


### PR DESCRIPTION
Replace the stringly-typed `systemd.coredump.extraConfig` option with a freeform `systemd.coredump.settings.Coredump` submodule, per RFC 42.

Users can now set any coredump.conf(5) option directly:

```nix
systemd.coredump.settings.Coredump = {
  Storage = "journal";
  ProcessSizeMax = "2G";
};
```

The old `extraConfig` option is removed via `mkRemovedOptionModule` with a message pointing to the new path.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
