### PR TITLE
shira: 1.7.1-unstable-2025-08-31 -> 1.8.2

### DIFF
--- a/pkgs/by-name/sh/shira/package.nix
+++ b/pkgs/by-name/sh/shira/package.nix
@@ -5,20 +5,20 @@
   ffmpeg,
 }:
 
-python3Packages.buildPythonApplication {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "shira";
-  version = "1.7.1-unstable-2025-08-31";
+  version = "1.8.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "KraXen72";
     repo = "shira";
-    rev = "a7478efa434597324458441f328c1b2f84c04dbc";
-    hash = "sha256-k15GaOmS0rlQBQldnLo1SzIyCkNQux6P5b7ZG2BIa90=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SgxEvIpjRfc0saoarqw8KySwhbk1UYCGjMcbhhWMhZg=";
   };
 
   build-system = [
-    python3Packages.flit-core
+    python3Packages.hatchling
   ];
 
   dependencies = with python3Packages; [
@@ -46,4 +46,4 @@ python3Packages.buildPythonApplication {
     maintainers = with lib.maintainers; [ thegu5 ];
     mainProgram = "shiradl";
   };
-}
+})


### PR DESCRIPTION
like #497087, but switched the build system from flit to hatchling
also `rev` -> `tag`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
