### PR TITLE
binaryen: remove asppsa from maintainer list

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -97,7 +97,6 @@ stdenv.mkDerivation rec {
     description = "Compiler infrastructure and toolchain library for WebAssembly, in C++";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
-      asppsa
       willcohen
     ];
     license = lib.licenses.asl20;


### PR DESCRIPTION
This is myself.  I'm unfortunately not able to contribute to this maintenance anymore.

I'm still listed as the maintainer of [epstool](https://github.com/NixOS/nixpkgs/blob/943ba5b1a58e68eb9a2c284ba6e3b30ebfe45abe/pkgs/by-name/ep/epstool/package.nix#L30) as well, and there's no one else listed on that one, so I haven't removed myself from the maintainers list.