### PR TITLE
tclPackages.rl_json: 0.15.3 -> 0.15.7

### DIFF
--- a/pkgs/development/tcl-modules/by-name/rl/rl_json/package.nix
+++ b/pkgs/development/tcl-modules/by-name/rl/rl_json/package.nix
@@ -8,15 +8,32 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rl_json";
-  version = "0.15.3";
+  version = "0.15.7";
 
   src = fetchFromGitHub {
     owner = "RubyLane";
     repo = "rl_json";
-    rev = finalAttrs.version;
-    hash = "sha256-JyJBf8lMrO/P5grOMojqs1PRoMPRsPWGQYS33eB7bRI=";
+    tag = finalAttrs.version;
+    hash = "sha256-6Y6bq/Lm6KCFFV3RF6v4fVPEN1LO+jE2xZV50a8zyng=";
     fetchSubmodules = true;
   };
+
+  # The vendored libtommath conflicts with tclTomMath.
+  # Replacing it with tclTomMath fixes the issue.
+  # https://github.com/RubyLane/rl_json/issues/57
+  # The switch to a vendored libtommath was done in 0.15.4 in commit
+  # https://github.com/RubyLane/rl_json/commit/9294d533f4d81288acf53045666b1587cf7fbf92
+  # "for proper bignum handling", but the commit message doesn't explain what's wrong
+  # with tclTomMath's bignum handling and all tests pass anyway.
+  postPatch = ''
+    rm -r deps/libtommath
+    substituteInPlace Makefile.in \
+      --replace-fail 'deps: local/lib/libtommath.a' 'deps:'
+    substituteInPlace configure.ac \
+      --replace-fail -ltommath ""
+    substituteInPlace generic/rl_jsonInt.h \
+      --replace-fail '#include <tommath.h>' '#include <tclTomMath.h>'
+  '';
 
   nativeBuildInputs = [
     autoreconfHook
@@ -29,6 +46,10 @@ stdenv.mkDerivation (finalAttrs: {
     "--includedir=${placeholder "out"}/include"
     "--datarootdir=${placeholder "out"}/share"
   ];
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error";
+
+  doCheck = true;
 
   meta = {
     homepage = "https://github.com/RubyLane/rl_json";


### PR DESCRIPTION
Also unbreaks the package: #475479
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
