### PR TITLE
wxmaxima: migrate to by-name

### DIFF
--- a/pkgs/by-name/wx/wxmaxima/package.nix
+++ b/pkgs/by-name/wx/wxmaxima/package.nix
@@ -6,7 +6,7 @@
   cmake,
   gettext,
   maxima,
-  wxGTK,
+  wxwidgets_3_2,
   adwaita-icon-theme,
   glib,
 }:
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   buildInputs = [
-    wxGTK
+    wxwidgets_3_2
     maxima
     # So it won't embed svg files into headers.
     adwaita-icon-theme
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DwxWidgets_LIBRARIES=${wxGTK}/lib"
+    "-DwxWidgets_LIBRARIES=${wxwidgets_3_2}/lib"
   ];
 
   preConfigure = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11941,12 +11941,6 @@ with pkgs;
     lisp-compiler = ecl;
   };
 
-  wxmaxima = callPackage ../applications/science/math/wxmaxima {
-    wxGTK = wxwidgets_3_2.override {
-      withWebKit = true;
-    };
-  };
-
   yacas-gui = yacas.override {
     enableGui = true;
     enableJupyter = false;


### PR DESCRIPTION
The renaming of `wxGTK` follows #489736.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
