### PR TITLE
performous: fix build

### DIFF
--- a/pkgs/by-name/pe/performous/package.nix
+++ b/pkgs/by-name/pe/performous/package.nix
@@ -7,7 +7,7 @@
   aubio,
   boost,
   cmake,
-  ffmpeg_7,
+  ffmpeg,
   fmt,
   gettext,
   glew,
@@ -62,6 +62,12 @@ stdenv.mkDerivation rec {
       extraPrefix = "ced-src/";
       hash = "sha256-23VD/4X4BOtcX5k+koSlRMowlbo2jAXbp3XKTXP7VrM=";
     })
+    (fetchpatch {
+      name = "performous-ffmpeg_8.patch";
+      url = "https://github.com/performous/performous/commit/783befe576051458da7ea0d915d2b4cb986eaf86.patch";
+      excludes = [ "osx-utils/macos-bundler.py" ];
+      hash = "sha256-Srkjr8BI98N8Ws853goonvjOrEyWvzjHAIhypgEydns=";
+    })
   ];
 
   prePatch = ''
@@ -72,6 +78,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace data/CMakeLists.txt \
       --replace "/usr" "$out"
+    substituteInPlace {game,testing}/CMakeLists.txt \
+      --replace-fail "system locale" "locale"
   '';
 
   nativeBuildInputs = [
@@ -84,7 +92,7 @@ stdenv.mkDerivation rec {
     SDL2
     aubio
     boost
-    ffmpeg_7
+    ffmpeg
     fmt
     glew
     glibmm


### PR DESCRIPTION
https://hydra.nixos.org/job/nixos/unstable/nixpkgs.performous.x86_64-linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
