### PR TITLE
protonmail-export: 1.0.5 -> 1.0.6

### DIFF
--- a/pkgs/by-name/pr/protonmail-export/package.nix
+++ b/pkgs/by-name/pr/protonmail-export/package.nix
@@ -18,22 +18,21 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "protonmail-export";
-  version = "1.0.5";
+  version = "1.0.6";
 
   src = fetchFromGitHub {
     owner = "ProtonMail";
     repo = "proton-mail-export";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-rpfTI3vcZlEK1TrxRMMHFKutwC/YqAZrZCFiUsfMafc=";
+    hash = "sha256-ZYUqbxT9Aq3iaXdaCag4xstbrm9z9X435zm/Qz8OOyM=";
   };
 
   goModules =
     (buildGoModule {
-      pname = "protonmail-export-go-modules";
-      inherit (finalAttrs) src version;
+      inherit (finalAttrs) pname src version;
       sourceRoot = "${finalAttrs.src.name}/go-lib";
-      vendorHash = "sha256-rKi3PNsYsZA+MLcLTVrVI3T2SUBZCiq9Zxtf+1SGArk=";
+      vendorHash = "sha256-jtrfxKPFTiowllHDR7fo8GaeyhcPxAAXehBTk4bXKn8=";
 
       nativeBuildInputs = [ unzip ];
 


### PR DESCRIPTION
https://github.com/ProtonMail/proton-mail-export/releases/tag/v1.0.6
Diff: https://github.com/ProtonMail/proton-mail-export/compare/v1.0.5...v1.0.6

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
