### PR TITLE
vitejs: init at 7.3.1

### DIFF
--- a/pkgs/by-name/vi/vitejs/package.nix
+++ b/pkgs/by-name/vi/vitejs/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pnpm_10,
+  nodejs_24,
+  makeWrapper,
+  pnpmConfigHook,
+  fetchPnpmDeps,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vitejs";
+  version = "7.3.1";
+
+  src = fetchFromGitHub {
+    owner = "vitejs";
+    repo = "vite";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ewtFvWeNFb6LowvA83p53+ilsMDugLzXK1I63lhZUAU=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs_24
+    pnpmConfigHook
+    pnpm_10
+  ];
+
+  pnpmWorkspaces = [ "vite" ];
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    fetcherVersion = 3;
+    hash = "sha256-02s37dcEvxFlaGO+RNxTMPuTV0/sx7hiX1Nzc3A/qro=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter=vite build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/vite}
+    cp -r {packages,node_modules} $out/lib/vite
+
+    makeWrapper ${lib.getExe nodejs_24} $out/bin/vite \
+      --inherit-argv0 \
+      --add-flags $out/lib/vite/packages/vite/bin/vite.js
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Frontend tooling for NodeJS";
+    homepage = "https://github.com/vitejs/vite";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    mainProgram = "vite";
+  };
+})


### PR DESCRIPTION
Packaging vite for web app development with NodeJS https://github.com/vitejs/vite

Calling it "vitejs" to avoid name conflict with existing "vite" package.

Fixes https://github.com/NixOS/nixpkgs/issues/245799
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
