### PR TITLE
nixos/kmonad: disable service restart

### DIFF
--- a/nixos/modules/services/hardware/kmonad.nix
+++ b/nixos/modules/services/hardware/kmonad.nix
@@ -146,11 +146,8 @@ let
           ${lib.getExe cfg.package} ${mkCfg keyboard} \
             ${utils.escapeSystemdExecArgs cfg.extraArgs}
         '';
-        Restart = "always";
-        # Restart at increasing intervals from 2s to 1m
-        RestartSec = 2;
-        RestartSteps = 30;
-        RestartMaxDelaySec = "1min";
+        # Restarts are initiated by the accompanying path unit. See systemd.path(5).
+        Restart = "no";
         Nice = -20;
         DynamicUser = true;
         User = "kmonad";


### PR DESCRIPTION
The path unit is responsible for starting the service whenever the specified path exists. Restart=always effectively does nothing while the path exists, and only restarts the service unnecessarily when it doesn't. Combined with a delay starting at 2 seconds, we never hit the configured start limit and kept indefinitely restarting the service. This in turn also makes things like `nixos-rebuild switch` fail if it believes the service needs to be restarted.

## Things done

Tested this change in my personal system config.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
