### PR TITLE
trajan: init at 1.0.0

### DIFF
--- a/pkgs/by-name/tr/trajan/package.nix
+++ b/pkgs/by-name/tr/trajan/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "trajan";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "praetorian-inc";
+    repo = "trajan";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ji4IkImpDRQr8BuJCIqRfxyEWFD3Ux99D5lP3ALt+OQ=";
+  };
+
+  vendorHash = "sha256-Vr9MkEJZOIrryhGOWrUq76J8B7+2bzf5BOV4omVDIY8=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  ldflags = [
+    "-s"
+    "-X=main.Version=${finalAttrs.version}"
+    "-X=main.GitCommit=${finalAttrs.src.rev}"
+    "-X=main.BuildDate=1970-01-01T00:00:00Z"
+  ];
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = [ "version" ];
+
+  meta = {
+    description = "Multi-platform CI/CD vulnerability detection and attack automation tool";
+    homepage = "https://github.com/praetorian-inc/trajan";
+    changelog = "https://github.com/praetorian-inc/trajan/releases/tag/v${finalAttrs.src.rev}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "trajan";
+  };
+})


### PR DESCRIPTION
Multi-platform CI/CD vulnerability detection and attack automation tool

https://github.com/praetorian-inc/trajan

Related https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
