### PR TITLE
mini-pqc: init at 0.1.5-unstable-2025-09-17

### DIFF
--- a/pkgs/by-name/mi/mini-pqc/package.nix
+++ b/pkgs/by-name/mi/mini-pqc/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mini-pqc";
+  version = "0.1.5-unstable-2025-09-17";
+
+  src = fetchFromGitHub {
+    owner = "oferzinger";
+    repo = "mini-pqc-scanner";
+    rev = "c9c730397109f8a5a73201b4ba958aa437571279";
+    hash = "sha256-l+Wu4iDjjupMY4EFRdZfy7mZ6n6eKFvv16bs89FG2o8=";
+  };
+
+  vendorHash = "sha256-UO22uxPV8fqGix/8Nx5mLIQl8Y7fWE8ze7fbtoAehJE=";
+
+  ldflags = [
+    "-s"
+    "-X=main.version=${finalAttrs.version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/$pname
+  '';
+
+  meta = {
+    description = "Command-line tool that helps to assess quantum readiness";
+    homepage = "https://github.com/oferzinger/mini-pqc-scanner";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "mini-pqc";
+  };
+})


### PR DESCRIPTION
Command-line tool that helps to assess quantum readiness

https://github.com/oferzinger/mini-pqc-scanner

Related https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
