### PR TITLE
rl-2605: clarify `nodejs` breaking changes

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -203,8 +203,6 @@
 
 - `services.openssh.settings.AcceptEnv` now explicitly defined as an option that takes a list of strings, to facilitate option merging. Setting it to a string value is no longer supported.
 
-- `nodejs-slim` has a `npm` and a `corepack` outputs, and `nodejs` no longer has a `libv8` output.
-
 - All Xfce packages have been moved to top level (e.g. if you previously added `pkgs.xfce.xfce4-whiskermenu-plugin` to `environment.systemPackages`, you will need to change it to `pkgs.xfce4-whiskermenu-plugin`). The `xfce` scope will be removed in NixOS 26.11.
 
 - `spacefm` was removed because it appeared to be unmaintained upstream.
@@ -263,6 +261,10 @@ gnuradioMinimal.override {
 ### Breaking changes {#sec-nixpkgs-release-26.05-lib-breaking}
 
 - The `nodejs_latest` alias now points to `nodejs_25` instead of `nodejs_24`.
+
+- `nodejs-slim` no longer exposes a `corepack` executable, it has been moved to an ad-hoc output; to restore the previous behavior, `nodejs-slim.corepack` must be explicitely included.
+
+- `nodejs` is now a simple wrapper for `nodejs-slim`+`nodejs-slim.npm`+`nodejs-slim.corepack`, meaning it is no longer possible to reference or override its attributes or outputs (e.g. `nodejs.libv8` must be replaced with `nodejs-slim.libv8`, `nodejs.nativeBuildInputs` with `nodejs-slim.nativeBuildInputs`, etc.).
 
 - `mold` is now wrapped by default.
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I've received feedback in https://github.com/NixOS/nixpkgs/pull/496015#issuecomment-3989767763 that the changelog for the recent Node.js changes in https://github.com/NixOS/nixpkgs/pull/481461 and https://github.com/NixOS/nixpkgs/pull/487796 was confusing, this PR is aiming to fix that.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
