### PR TITLE
pqcscan: init at 0.8.0

### DIFF
--- a/pkgs/by-name/pq/pqcscan/package.nix
+++ b/pkgs/by-name/pq/pqcscan/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pqcscan";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "anvilsecure";
+    repo = "pqcscan";
+    tag = finalAttrs.version;
+    hash = "sha256-+IwUESqmxvZu53n5ORNoYVD8JiSwAjD9AudnsXfIKvc=";
+  };
+
+  cargoHash = "sha256-ZZm1I4fsw4PDCVZYuyhy4fC5ocfz1Snrv9vMltF26x8=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "Post-Quantum Cryptography Scanner";
+    homepage = "https://github.com/anvilsecure/pqcscan";
+    changelog = "https://github.com/anvilsecure/pqcscan/releases/tag/${finalAttrs.src.rev}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "pqcscan";
+  };
+})


### PR DESCRIPTION
Post-Quantum Cryptography Scanner

https://github.com/anvilsecure/pqcscan

Related https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
