### PR TITLE
minimal-bootstrap.musl-*: Fix locale bugs

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/musl/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/musl/default.nix
@@ -8,6 +8,7 @@
   binutils,
   gnumake,
   gnugrep,
+  gnupatch,
   gnused,
   gnutar,
   gzip,
@@ -20,6 +21,19 @@ let
     url = "https://musl.libc.org/releases/musl-${version}.tar.gz";
     hash = "sha256-qaEYu+hNh2TaDqDSizqz+uhHf8fkCF2QECuFlvx8deQ=";
   };
+
+  patches = [
+    (fetchurl {
+      name = "locale-fix-1.patch";
+      url = "https://www.openwall.com/lists/musl/2025/02/13/1/1";
+      hash = "sha256-CJb821El2dByP04WXxPCCYMOcEWnXLpOhYBgg3y3KS4=";
+    })
+    (fetchurl {
+      name = "locale-fix-2.patch";
+      url = "https://www.openwall.com/lists/musl/2025/02/13/1/2";
+      hash = "sha256-BiD87k6KTlLr4ep14rUdIZfr2iQkicBYaSTq+p6WBqE=";
+    })
+  ];
 in
 bash.runCommand "${pname}-${version}"
   {
@@ -31,6 +45,7 @@ bash.runCommand "${pname}-${version}"
       gnumake
       gnused
       gnugrep
+      gnupatch
       gnutar
       gzip
     ];
@@ -64,6 +79,7 @@ bash.runCommand "${pname}-${version}"
     cd musl-${version}
 
     # Patch
+    ${lib.concatMapStringsSep "\n" (f: "patch -Np1 -i ${f}") patches}
     # https://github.com/ZilchOS/bootstrap-from-tcc/blob/2e0c68c36b3437386f786d619bc9a16177f2e149/using-nix/2a3-intermediate-musl.nix
     sed -i 's|/bin/sh|${bash}/bin/bash|' \
       tools/*.sh

--- a/pkgs/os-specific/linux/minimal-bootstrap/musl/static.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/musl/static.nix
@@ -9,6 +9,7 @@
   findutils,
   gnumake,
   gnugrep,
+  gnupatch,
   gnused,
   gnutar,
   gzip,
@@ -22,6 +23,19 @@ let
     url = "https://musl.libc.org/releases/musl-${version}.tar.gz";
     hash = "sha256-qaEYu+hNh2TaDqDSizqz+uhHf8fkCF2QECuFlvx8deQ=";
   };
+
+  patches = [
+    (fetchurl {
+      name = "locale-fix-1.patch";
+      url = "https://www.openwall.com/lists/musl/2025/02/13/1/1";
+      hash = "sha256-CJb821El2dByP04WXxPCCYMOcEWnXLpOhYBgg3y3KS4=";
+    })
+    (fetchurl {
+      name = "locale-fix-2.patch";
+      url = "https://www.openwall.com/lists/musl/2025/02/13/1/2";
+      hash = "sha256-BiD87k6KTlLr4ep14rUdIZfr2iQkicBYaSTq+p6WBqE=";
+    })
+  ];
 in
 bash.runCommand "${pname}-${version}"
   {
@@ -32,6 +46,7 @@ bash.runCommand "${pname}-${version}"
       binutils
       findutils
       gnumake
+      gnupatch
       gnused
       gnugrep
       gnutar
@@ -67,6 +82,7 @@ bash.runCommand "${pname}-${version}"
     cd musl-${version}
 
     # Patch
+    ${lib.concatMapStringsSep "\n" (f: "patch -Np1 -i ${f}") patches}
     # https://github.com/ZilchOS/bootstrap-from-tcc/blob/2e0c68c36b3437386f786d619bc9a16177f2e149/using-nix/2a3-intermediate-musl.nix
     sed -i 's|/bin/sh|${lib.getExe bash}|' \
       tools/*.sh

--- a/pkgs/os-specific/linux/minimal-bootstrap/musl/tcc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/musl/tcc.nix
@@ -32,6 +32,18 @@ let
       hash = "sha256-wd2Aev1zPJXy3q933aiup5p1IMKzVJBquAyl3gbK4PU=";
     })
   ];
+  patchesPath1 = [
+    (fetchurl {
+      name = "locale-fix-1.patch";
+      url = "https://www.openwall.com/lists/musl/2025/02/13/1/1";
+      hash = "sha256-CJb821El2dByP04WXxPCCYMOcEWnXLpOhYBgg3y3KS4=";
+    })
+    (fetchurl {
+      name = "locale-fix-2.patch";
+      url = "https://www.openwall.com/lists/musl/2025/02/13/1/2";
+      hash = "sha256-BiD87k6KTlLr4ep14rUdIZfr2iQkicBYaSTq+p6WBqE=";
+    })
+  ];
 in
 bash.runCommand "${pname}-${version}"
   {
@@ -54,6 +66,7 @@ bash.runCommand "${pname}-${version}"
 
     # Patch
     ${lib.concatMapStringsSep "\n" (f: "patch -Np0 -i ${f}") patches}
+    ${lib.concatMapStringsSep "\n" (f: "patch -Np1 -i ${f}") patchesPath1}
     # tcc does not support complex types
     rm -rf src/complex
     # Configure fails without this


### PR DESCRIPTION
Locale-related text processing bugs patched by upstream: CVE-2025-26519

Impact appears to be low, as these musls are internal to minimal-bootstrap. Specifically, stdenv tests ensure that these packages are not present in the runtime closure of stdenv.

However, these patches are still useful, because the unpatched musl-static caused gnulib test errors in diffutils in my other PR.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] i686-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
