### PR TITLE
nixos/nvidia: use kernel suspend notifiers if available

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -93,6 +93,20 @@ in
         the NVIDIA docs, on Chapter 22. PCI-Express Runtime D3 (RTD3) Power Management
       '';
 
+      powerManagement.kernelSuspendNotifier =
+        lib.mkEnableOption ''
+          NVIDIA driver support for kernel suspend notifiers, which allows the driver
+          to be notified of suspend and resume events by the kernel, rather than
+          relying on systemd services.
+          Requires NVIDIA driver version 595 or newer, and the open source kernel modules.
+        ''
+        // {
+          default = useOpenModules && lib.versionAtLeast nvidia_x11.version "595";
+          defaultText = lib.literalExpression ''
+            config.hardware.nvidia.open == true && lib.versionAtLeast config.hardware.nvidia.package.version "595"
+          '';
+        };
+
       dynamicBoost.enable = lib.mkEnableOption ''
         dynamic Boost balances power between the CPU and the GPU for improved
         performance on supported laptops using the nvidia-powerd daemon. For more
@@ -465,6 +479,13 @@ in
               assertion = cfg.dynamicBoost.enable -> lib.versionAtLeast nvidia_x11.version "510.39.01";
               message = "NVIDIA's Dynamic Boost feature only exists on versions >= 510.39.01";
             }
+
+            {
+              assertion =
+                cfg.powerManagement.kernelSuspendNotifier
+                -> (useOpenModules && lib.versionAtLeast nvidia_x11.version "595");
+              message = "NVIDIA driver support for kernel suspend notifiers requires NVIDIA driver version 595 or newer, and the open source kernel modules.";
+            }
           ];
 
           # If Optimus/PRIME is enabled, we:
@@ -576,7 +597,9 @@ in
               ''
             );
 
-          systemd.packages = lib.optional cfg.powerManagement.enable nvidia_x11.out;
+          systemd.packages = lib.optional (
+            cfg.powerManagement.enable && !cfg.powerManagement.kernelSuspendNotifier
+          ) nvidia_x11.out;
 
           systemd.services =
             let
@@ -592,7 +615,7 @@ in
               };
             in
             lib.mkMerge [
-              (lib.mkIf cfg.powerManagement.enable {
+              (lib.mkIf (cfg.powerManagement.enable && !cfg.powerManagement.kernelSuspendNotifier) {
                 nvidia-suspend = nvidiaService "suspend";
                 nvidia-hibernate = nvidiaService "hibernate";
                 nvidia-resume = (nvidiaService "resume") // {
@@ -669,6 +692,9 @@ in
               ++ lib.optional (
                 (offloadCfg.enable || cfg.modesetting.enable) && lib.versionAtLeast nvidia_x11.version "545"
               ) "nvidia-drm.fbdev=1"
+              ++ lib.optional (
+                cfg.powerManagement.enable && cfg.powerManagement.kernelSuspendNotifier
+              ) "nvidia.NVreg_UseKernelSuspendNotifiers=1"
               ++ lib.optional cfg.powerManagement.enable "nvidia.NVreg_PreserveVideoMemoryAllocations=1"
               ++ lib.optional useOpenModules "nvidia.NVreg_OpenRmEnableUnsupportedGpus=1"
               ++ lib.optional (config.boot.kernelPackages.kernel.kernelAtLeast "6.2" && !ibtSupport) "ibt=off";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Open kernel modules have been able to handle video memory preservation when using kernel suspend notifiers since beta version 595.45.04.
See: https://us.download.nvidia.com/XFree86/Linux-x86_64/595.45.04/README/powermanagement.html
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
