### PR TITLE
mealie: 3.9.2 -> 3.11.0

### DIFF
--- a/pkgs/by-name/me/mealie/mealie-frontend.nix
+++ b/pkgs/by-name/me/mealie/mealie-frontend.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${src}/frontend/yarn.lock";
-    hash = "sha256-sZk7OEkJdBZRU9ysRDCetzv09XrK5GhPaxxEBD8k5rw=";
+    hash = "sha256-aYgTdHrorLNBYVNwVyYSTfAqtvn1JB0FBAkoem0vNSU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/me/mealie/package.nix
+++ b/pkgs/by-name/me/mealie/package.nix
@@ -4,24 +4,24 @@
   fetchFromGitHub,
   makeWrapper,
   nixosTests,
-  python3Packages,
+  python312Packages,
   nltk-data,
   writeShellScript,
   nix-update-script,
 }:
 
 let
-  version = "3.9.2";
+  version = "3.11.0";
   src = fetchFromGitHub {
     owner = "mealie-recipes";
     repo = "mealie";
     tag = "v${version}";
-    hash = "sha256-jR9NGguxobUenjnvh6vhZztntxNM2rkwkWcq/DeB4JY=";
+    hash = "sha256-JZ1NGhL/cDj4EOIPttmh0o1oipaL3mcMUNdj8SlTQAA=";
   };
 
   frontend = callPackage (import ./mealie-frontend.nix src version) { };
 
-  pythonpkgs = python3Packages;
+  pythonpkgs = python312Packages;
   python = pythonpkgs.python;
 in
 pythonpkgs.buildPythonApplication rec {
@@ -62,7 +62,7 @@ pythonpkgs.buildPythonApplication rec {
       paho-mqtt
       pillow
       pillow-heif
-      psycopg2 # pgsql optional-dependencies
+      psycopg2
       pydantic
       pydantic-settings
       pyhumps
@@ -81,6 +81,7 @@ pythonpkgs.buildPythonApplication rec {
       typing-extensions
       tzdata
       uvicorn
+      freezegun
     ]
     ++ uvicorn.optional-dependencies.standard;
 
@@ -88,7 +89,7 @@ pythonpkgs.buildPythonApplication rec {
     rm -rf dev # Do not need dev scripts & code
 
     substituteInPlace pyproject.toml \
-     --replace-fail '"setuptools==80.9.0"' '"setuptools"'
+     --replace-fail '"setuptools==82.0.0"' '"setuptools"'
 
     substituteInPlace mealie/__init__.py \
       --replace-fail '__version__ = ' '__version__ = "v${version}" #'


### PR DESCRIPTION
Updates mealie from 3.9.2 to 3.11.0. Changelog: https://github.com/mealie-recipes/mealie/releases/tag/v3.11.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## Summary of changes

- 3.9.2 → 3.11.0 (skips 3.10.x patch releases)
- Switched from python3Packages to python312Packages. Mealie enforces requires-python = ">=3.12,<3.13"
- Added freezegun as a new dependency (pinned upstream in 3.10.0: mealie-recipes/mealie#6991)
- Removed stale # pgsql optional-dependencies comment on psycopg2
- Updated setuptools minimum version constraint to >=82.0.0
- Updated frontend yarn offline cache hash