### PR TITLE
tlsanalyzer: init at 0.2.2

### DIFF
--- a/pkgs/by-name/tl/tlsanalyzer/package.nix
+++ b/pkgs/by-name/tl/tlsanalyzer/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "tlsanalyzer";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "csnp";
+    repo = "tls-analyzer";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JrQqsDeucekAIc4gXGF5F2iq5UlHG3o6b43zwMdkzTs=";
+  };
+
+  vendorHash = "sha256-CPdAinTb3Yd7dPvDiTHrKk/xeJnO0aAYETWMkf34yWI=";
+
+  ldflags = [
+    "-s"
+    "-X=main.version=${finalAttrs.version}"
+    "-X=main.commit=${finalAttrs.src.rev}"
+    "-X=main.date=1970-01-01T00:00:00Z"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  subPackages = [ "cmd/tlsanalyzer/" ];
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = [ "version" ];
+
+  meta = {
+    description = "TLS/SSL security analyzer for quantum readiness assessment and CNSA 2.0 compliance";
+    homepage = "https://github.com/csnp/tls-analyzer";
+    changelog = "https://github.com/csnp/tls-analyzer/releases/tag/${finalAttrs.src.rev}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "tlsanalyzer";
+  };
+})


### PR DESCRIPTION
TLS/SSL security analyzer for quantum readiness assessment and CNSA 2.0 compliance

https://github.com/csnp/tls-analyzer

Related https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
