### PR TITLE
unofficial-homestuck-collection: 2.7.2 -> 2.8.0

### DIFF
--- a/pkgs/by-name/un/unofficial-homestuck-collection/package.nix
+++ b/pkgs/by-name/un/unofficial-homestuck-collection/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   electron,
   fetchFromGitHub,
-  fetchurl,
   fetchYarnDeps,
   fixup-yarn-lock,
   replaceVars,
@@ -15,13 +14,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "unofficial-homestuck-collection";
-  version = "2.7.2";
+  version = "2.8.0";
 
   src = fetchFromGitHub {
     owner = "GiovanH";
     repo = "unofficial-homestuck-collection";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-0RPZfXdcdBo1OxJU3eSRF7fEO5EYMyJCcAZLEqzDMRk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JHVyg0QIjxPGXf9HsrquV6z6iRCSnw4nHxd+zhNS8H4=";
   };
 
   patches = [


### PR DESCRIPTION
Updates unofficial-homestuck-collection from 2.7.2 to 2.8.0.
https://github.com/GiovanH/unofficial-homestuck-collection/releases/tag/v2.8.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
