### PR TITLE
rust-addr2line: 0.25.0 -> 0.26.0

### DIFF
--- a/pkgs/by-name/ru/rust-addr2line/package.nix
+++ b/pkgs/by-name/ru/rust-addr2line/package.nix
@@ -8,18 +8,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rust-addr2line";
-  version = "0.25.0";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = "gimli-rs";
     repo = "addr2line";
     tag = version;
-    hash = "sha256-1kjFrDHfvGdU5FfSaLE+EFN83XjF0iSpydwsucjV7NQ=";
+    hash = "sha256-+GrX5/AgKlU0rNIKkt4XAQFab6G6F4DN4Qkol8Jd5DQ=";
   };
 
   cargoBuildFlags = "--bin addr2line --features bin";
 
-  cargoHash = "sha256-IJ+hZ36QL5Awq4vI+ajTTHwbRU4paG+bnB/TZU9bCCk=";
+  cargoHash = "sha256-aC69kyyMNwifIsjRPCgKxqguKtU7zSN8Mn9tChXykNo=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/ru/rust-addr2line/package.nix
+++ b/pkgs/by-name/ru/rust-addr2line/package.nix
@@ -33,7 +33,10 @@ rustPlatform.buildRustPackage rec {
       mit
       asl20
     ];
-    maintainers = [ lib.maintainers.axka ];
+    maintainers = [
+      lib.maintainers.axka
+      lib.maintainers.flokli
+    ];
     mainProgram = "addr2line";
   };
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
