### PR TITLE
qbom: init at 0.1.0-unstable-2026-01-21

### DIFF
--- a/pkgs/by-name/qb/qbom/package.nix
+++ b/pkgs/by-name/qb/qbom/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "qbom";
+  version = "0.1.0-unstable-2026-01-21";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "csnp";
+    repo = "qbom";
+    rev = "817414c311faac8da99042be82d9449019a8e9f9";
+    hash = "sha256-qTcNoQZkcTaHQyZ0Lqbt1XlXsV15+tOcv7f+K7ydqmw=";
+  };
+
+  build-system = with python3.pkgs; [ hatchling ];
+
+  dependencies = with python3.pkgs; [
+    click
+    pydantic
+    rich
+    xxhash
+  ];
+
+  optional-dependencies = with python3.pkgs; {
+    all = [
+      cirq
+      pennylane
+      qiskit
+    ];
+    cirq = [ cirq ];
+    pennylane = [ pennylane ];
+    qiskit = [ qiskit ];
+  };
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytest-cov-stub
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  pythonImportsCheck = [ "qbom" ];
+
+  meta = {
+    description = "Quantum Bill of Materials (QBOM) tool";
+    homepage = "https://github.com/csnp/qbom";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "qbom";
+  };
+})


### PR DESCRIPTION
Quantum Bill of Materials (QBOM) tool

https://github.com/csnp/qbom

Related https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
