### PR TITLE
python3Packages.meshcore-cli: init at 1.4.1

### DIFF
--- a/pkgs/development/python-modules/meshcore-cli/default.nix
+++ b/pkgs/development/python-modules/meshcore-cli/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  # dependencies
+  bleak,
+  prompt-toolkit,
+  pycryptodome,
+  requests,
+  meshcore,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "meshcore-cli";
+  version = "1.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "meshcore-dev";
+    repo = "meshcore-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-z8k8m6exl5+Fiz7QncN/isG3cQZt17Vb/ruXzPZAMoo=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    bleak
+    prompt-toolkit
+    pycryptodome
+    requests
+    meshcore
+  ];
+
+  pythonImportsCheck = [ "meshcore_cli" ];
+
+  meta = {
+    description = "Command line interface to meshcore companion radios and repeaters";
+    homepage = "https://github.com/meshcore-dev/meshcore-cli";
+    changelog = "https://github.com/meshcore-dev/meshcore-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "meshcore-cli";
+    maintainers = with lib.maintainers; [ robertjakub ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9690,6 +9690,8 @@ self: super: with self; {
 
   meshcore = callPackage ../development/python-modules/meshcore { };
 
+  meshcore-cli = callPackage ../development/python-modules/meshcore-cli { };
+
   meshio = callPackage ../development/python-modules/meshio { };
 
   meshlabxml = callPackage ../development/python-modules/meshlabxml { };


### PR DESCRIPTION
meshcore-cli is a tool that connects to your companion radio node (meshcore client) over BLE, TCP or Serial and lets you interact with it from a terminal using a command line interface. 

homepage: https://github.com/meshcore-dev/meshcore-cli

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
