### PR TITLE
python3Packages.tesserocr: revert 2.8.0 -> 2.9.2, fix build

### DIFF
--- a/pkgs/development/python-modules/tesserocr/default.nix
+++ b/pkgs/development/python-modules/tesserocr/default.nix
@@ -31,12 +31,9 @@ buildPythonPackage rec {
   };
 
   patches = [
-    # Fix a broken test. The issue has been reported upstream at
-    # https://github.com/sirfz/tesserocr/issues/363
-    # Check the status of the issue before removing this patch at the next
-    # update.
+    # Backport https://github.com/sirfz/tesserocr/pull/364 to fix tests
     (fetchpatch {
-      url = "https://github.com/sirfz/tesserocr/commit/78d9e8187bd4d282d572bd5221db2c69e560e017.patch";
+      url = "https://github.com/sirfz/tesserocr/commit/853a885d0154a0345e1ea7db80febe04893a3da8.patch";
       hash = "sha256-s51s9EIV9AZT6UoqwTuQ8lOjToqwIIUkDLjsvCsyYFU=";
     })
   ];

--- a/pkgs/development/python-modules/tesserocr/default.nix
+++ b/pkgs/development/python-modules/tesserocr/default.nix
@@ -22,12 +22,12 @@
 
 buildPythonPackage rec {
   pname = "tesserocr";
-  version = "2.9.2";
+  version = "2.8.0";
   format = "setuptools";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-L6H+PHlXXW/VtSd4Xnc/oZsFXwf5Iv6yrJ1sHmIjNSI=";
+    hash = "sha256-vlGNGxtf9UwRqtoeD9EpQlCepwWB4KizmipHOgstvTY=";
   };
 
   patches = [


### PR DESCRIPTION
48f7e2c73016d61a69be37c726db85c004c77285 [broke tesserocr](https://hydra.nixos.org/job/nixos/unstable/nixpkgs.python313Packages.tesserocr.x86_64-linux).

I failed at bumping to the most recent version and https://github.com/NixOS/nixpkgs/pull/488827 doesn't seem to show success soon either, so I'd propose to just revert the change for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
