### PR TITLE
shairport-sync: use new names of pipewire and pulseaudio backends

### DIFF
--- a/nixos/modules/services/networking/shairport-sync.nix
+++ b/nixos/modules/services/networking/shairport-sync.nix
@@ -38,13 +38,13 @@ in
       settings = mkOption {
         type = configFormat.type;
         default = {
-          general.output_backend = "pa";
+          general.output_backend = "pulseaudio";
           diagnostics.log_verbosity = 1;
         };
         example = {
           general = {
             name = "NixOS Shairport";
-            output_backend = "pw";
+            output_backend = "pipewire";
           };
           metadata = {
             enabled = "yes";
@@ -112,13 +112,23 @@ in
   ###### implementation
 
   config = mkIf config.services.shairport-sync.enable {
+    assertions = [
+      {
+        assertion = config.services.shairport-sync.settings.general.output_backend or null != "pw";
+        message = "shairport-sync 5.0 renamed the pipewire backend from 'pw' to 'pipewire'";
+      }
+      {
+        assertion = config.services.shairport-sync.settings.general.output_backend or null != "pa";
+        message = "shairport-sync 5.0 renamed the pulseaudio backend from 'pa' to 'pulseaudio'";
+      }
+    ];
 
     services.avahi.enable = true;
     services.avahi.publish.enable = true;
     services.avahi.publish.userServices = true;
 
     services.shairport-sync.settings = {
-      general.output_backend = lib.mkDefault "pa";
+      general.output_backend = lib.mkDefault "pulseaudio";
       diagnostics.log_verbosity = lib.mkDefault 1;
     };
 

--- a/pkgs/by-name/sh/shairport-sync/package.nix
+++ b/pkgs/by-name/sh/shairport-sync/package.nix
@@ -119,8 +119,8 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-ssl=openssl"
   ]
   ++ optional enableAvahi "--with-avahi"
-  ++ optional enablePulse "--with-pa"
-  ++ optional enablePipewire "--with-pw"
+  ++ optional enablePulse "--with-pulseaudio"
+  ++ optional enablePipewire "--with-pipewire"
   ++ optional enableAlsa "--with-alsa"
   ++ optional enableSndio "--with-sndio"
   ++ optional enableAo "--with-ao"


### PR DESCRIPTION
The pipewire and pulseaudio backends where renamed from `pw` to `pipewire` and from `pa` to `pulseaudio` in shairport-sync 5.0.

See https://github.com/mikebrady/shairport-sync/commit/b405c0b89651aaa276cfa1fabb36e2b2ba38fb7a#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810

I also added assertions to the module to check for the old backend names.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
