### PR TITLE
stl: init at 0.1.0-alpha.79

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24088,6 +24088,11 @@
     github = "scvalex";
     githubId = 2588;
   };
+  sd-st = {
+    name = "sd-st";
+    github = "sd-st";
+    githubId = 208631639;
+  };
   sdaqo = {
     name = "sdaqo";
     email = "sdaqo.dev@protonmail.com";

--- a/pkgs/by-name/st/stl/package.nix
+++ b/pkgs/by-name/st/stl/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  go_1_25,
+  fetchFromGitHub,
+}:
+buildGoModule rec {
+  pname = "stl";
+  version = "0.1.0-alpha.79";
+
+  vendorHash = "sha256-OWfYAhV9jFuRTMtjjMdut2htFcYzjDl/RqgzesOBptk=";
+
+  src = fetchFromGitHub {
+    owner = "stainless-api";
+    repo = "stainless-api-cli";
+    rev = "v${version}";
+    hash = "sha256-PrN4/mJmPgDeMXI5W/pM37uCJUurpkMvYGzSlabXKho=";
+  };
+
+  nativeBuildInputs = [ go_1_25 ];
+
+  doCheck = false;
+
+  meta = {
+    description = "The official CLI for the Stainless REST API";
+    homepage = "https://github.com/stainless-api/stainless-api-cli";
+    license = lib.licenses.asl20;
+    mainProgram = "stl";
+    maintainers = [ lib.maintainers.sd-st ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds stl, the official CLI for the Stainless REST API. This can be used to manage your generated SDKs from the command-line.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
