### PR TITLE
libvirt: fix virt-secret-init-encryption shell path

### DIFF
--- a/pkgs/by-name/li/libvirt/package.nix
+++ b/pkgs/by-name/li/libvirt/package.nix
@@ -82,6 +82,19 @@
 
 let
   inherit (stdenv.hostPlatform) isDarwin isLinux isx86_64;
+  virtSecretInitEncryptionSh =
+    if isLinux then
+      writeShellApplication {
+        name = "virt-secret-init-encryption-sh";
+        runtimeInputs = [
+          coreutils
+          systemd
+        ];
+        text = ''exec ${runtimeShell} "$@"'';
+      }
+    else
+      null;
+
   binPath = lib.makeBinPath (
     [
       dnsmasq
@@ -183,22 +196,10 @@ stdenv.mkDerivation rec {
     substituteInPlace src/libxl/libxl_capabilities.h \
      --replace-fail /usr/lib/xen ${xen}/libexec/xen
   ''
-  + lib.optionalString isLinux (
-    let
-      script = writeShellApplication {
-        name = "virt-secret-init-encryption-sh";
-        runtimeInputs = [
-          coreutils
-          systemd
-        ];
-        text = ''exec ${runtimeShell} "$@"'';
-      };
-    in
-    ''
-      substituteInPlace src/secret/virt-secret-init-encryption.service.in \
-        --replace-fail /usr/bin/sh ${lib.getExe script}
-    ''
-  );
+  + lib.optionalString isLinux ''
+    substituteInPlace src/secret/virt-secret-init-encryption.service.in \
+      --replace-fail /usr/bin/sh ${lib.getExe virtSecretInitEncryptionSh}
+  '';
 
   strictDeps = true;
 
@@ -403,6 +404,8 @@ stdenv.mkDerivation rec {
     for f in $out/lib/systemd/system/*.service ; do
       substituteInPlace $f --replace /bin/kill ${coreutils}/bin/kill
     done
+    substituteInPlace $out/lib/systemd/system/virt-secret-init-encryption.service \
+      --replace-fail /usr/bin/sh ${lib.getExe virtSecretInitEncryptionSh}
     rm $out/lib/systemd/system/{virtlockd,virtlogd}.*
     wrapProgram $out/sbin/libvirtd \
       --prefix PATH : /run/libvirt/nix-emulators:${binPath}


### PR DESCRIPTION
## Problem
`virt-secret-init-encryption.service` in libvirt calls `/usr/bin/sh`, which does not exist on NixOS. This makes the unit fail with `status=203/EXEC` during `nixos-rebuild switch`.
## Fix
Use a store-path wrapper generated via `writeShellApplication` and replace `/usr/bin/sh` in both:
- `src/secret/virt-secret-init-encryption.service.in`
- the installed `virt-secret-init-encryption.service`
## Result
The unit runs on NixOS without depending on `/usr/bin/sh`.
## Repro
- Enable `virtualisation.libvirtd.enable = true;`
- Run `sudo nixos-rebuild switch`
- Observe failure before; success after
## System
- NixOS 26.05 (unstable)
- nixpkgs revision: `80bdc1e5ce51f56b19791b52b2901187931f5353`
- libvirt: 12.1.0

## Logs
```
Checking switch inhibitors... done
activating the configuration...
setting up /etc...
reloading user units for tws...
restarting sysinit-reactivation.target
the following new units were started: NetworkManager-dispatcher.service
warning: the following units failed: virt-secret-init-encryption.service
× virt-secret-init-encryption.service
     Loaded: loaded (/etc/systemd/system/virt-secret-init-encryption.service; linked; preset: ignored)
     Active: failed (Result: exit-code) since Fri 2026-03-06 16:53:44 IST; 997ms ago
 Invocation: e1d2bfdf6e5a4f3b9198a5e0baa988ef
    Process: 29319 ExecStart=/usr/bin/sh -c umask 0077 && (dd if=/dev/random status=none bs=32 count=1 | systemd-creds encrypt --name=secrets-encryption-key - /var/lib/libvirt/secrets/secrets-encryption-key) (code=exited, status=203/EXEC)
   Main PID: 29319 (code=exited, status=203/EXEC)
         IP: 0B in, 0B out
         IO: 0B read, 0B written
   Mem peak: 2M
        CPU: 6ms

Mar 06 16:53:44 nixtop systemd[1]: Starting virt-secret-init-encryption.service...
Mar 06 16:53:44 nixtop (sh)[29319]: virt-secret-init-encryption.service: Unable to locate executable '/usr/bin/sh': No such file or directory
Mar 06 16:53:44 nixtop (sh)[29319]: virt-secret-init-encryption.service: Failed at step EXEC spawning /usr/bin/sh: No such file or directory
Mar 06 16:53:44 nixtop systemd[1]: virt-secret-init-encryption.service: Main process exited, code=exited, status=203/EXEC
Mar 06 16:53:44 nixtop systemd[1]: virt-secret-init-encryption.service: Failed with result 'exit-code'.
Mar 06 16:53:44 nixtop systemd[1]: Failed to start virt-secret-init-encryption.service.
Command 'systemd-run -E LOCALE_ARCHIVE -E NIXOS_INSTALL_BOOTLOADER -E NIXOS_NO_CHECK --collect --no-ask-password --pipe --quiet --service-type=exec --unit=nixos-rebuild-switch-to-configuration /nix/store/nj3vs3w4mx5w0jp4sfzrcb0qr26rzlq0-nixos-system-nixtop-26.05.20260304.80bdc1e/bin/switch-to-configuration switch' returned non-zero exit status 4.
```