### PR TITLE
obliteratus: init at 0.1.2-unstable-2026-03-05

### DIFF
--- a/pkgs/by-name/ob/obliteratus/package.nix
+++ b/pkgs/by-name/ob/obliteratus/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "obliteratus";
+  version = "0.1.2-unstable-2026-03-05";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "elder-plinius";
+    repo = "OBLITERATUS";
+    rev = "984ce140592a9385347934f9ca647413ba9fac76";
+    hash = "sha256-U5DcRC1/IEQRlBGLIfsCX48ZCxPkpzEhg8qIw3ytJps=";
+  };
+
+  __structuredAttrs = true;
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
+    accelerate
+    bitsandbytes
+    datasets
+    matplotlib
+    numpy
+    pandas
+    pyyaml
+    rich
+    safetensors
+    scikit-learn
+    seaborn
+    torch
+    tqdm
+    transformers
+  ];
+
+  optional-dependencies = with python3.pkgs; {
+    spaces = [ gradio ];
+  };
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+  # This increases the build time significantly
+  # ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
+
+  pythonImportsCheck = [ "obliteratus" ];
+
+  meta = {
+    description = "Ablation Suite for HuggingFace transformers";
+    homepage = "https://github.com/elder-plinius/OBLITERATUS";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "obliteratus";
+  };
+})


### PR DESCRIPTION
Ablation Suite for HuggingFace transformers

https://github.com/elder-plinius/OBLITERATUS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
