### PR TITLE
cargo-oxichrome: init at 0.2.0

### DIFF
--- a/pkgs/by-name/ca/cargo-oxichrome/package.nix
+++ b/pkgs/by-name/ca/cargo-oxichrome/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  nix-update-script,
+  fetchCrate,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cargo-oxichrome";
+  version = "0.2.0";
+
+  # Use fetchCrate over fetchFromGitHub as Git repo does not contain a Cargo.lock file
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-uMKHRuyFiRNz6QST9fCvUnx/ggdYw2mAHfLi9wHz4AY=";
+  };
+
+  cargoHash = "sha256-nMDjQNkqDxTfPnmaT857xo62xYtH3qvw9SqqPwVYRNc=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Develop browser extensions entirely in Rust";
+    longDescription = ''
+      Framework to build browser extensions entirely in Rust
+      with proc macros, type-safe Chrome API bindings, and Leptos for reactive UI.
+      Compiles to WebAssembly with zero hand-written JavaScript"
+    '';
+    homepage = "https://oxichrome.dev";
+    downloadPage = "https://github.com/0xsouravm/oxichrome";
+    changelog = "https://github.com/0xsouravm/oxichrome/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    mainProgram = "cargo-oxichrome";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
