### PR TITLE
rust: 1.93.1 -> 1.94.0

### DIFF
--- a/pkgs/development/compilers/rust/1_94.nix
+++ b/pkgs/development/compilers/rust/1_94.nix
@@ -50,8 +50,8 @@ let
 in
 import ./default.nix
   {
-    rustcVersion = "1.93.1";
-    rustcSha256 = "sha256-TCMKRLPZyfPO+VCUNxn4OABY0nyR/aXjapqUfvAT4B8=";
+    rustcVersion = "1.94.0";
+    rustcSha256 = "sha256-uD+SHNPzIf9hT5wGqLhw2JKZ/AKIi0ilVJaDo2gjR0w=";
     rustcPatches = [ ./ignore-missing-docs.patch ];
 
     llvmSharedForBuild = llvmSharedFor pkgsBuildBuild;
@@ -66,30 +66,30 @@ import ./default.nix
     # Note: the version MUST be the same version that we are building. Upstream
     # ensures that each released compiler can compile itself:
     # https://github.com/NixOS/nixpkgs/pull/351028#issuecomment-2438244363
-    bootstrapVersion = "1.93.1";
+    bootstrapVersion = "1.94.0";
 
     # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
     bootstrapHashes = {
-      i686-unknown-linux-gnu = "ef2a03ba7b314c32c464f7d1f51053808b270fa46e0334c3962751e63c5a607a";
-      x86_64-unknown-linux-gnu = "fa99eb4e823fdeb8ee25e486c7973b4803013ac68c64e8f74880da788db9739c";
-      x86_64-unknown-linux-musl = "5a6c766ce05ad7229aadbb365bad2c9c809c9e378706f123c156821fe6ab2711";
-      arm-unknown-linux-gnueabihf = "a33bb432cf0ff752a628be3d73670ae053be8675f39414af1f17ada62257449a";
-      armv7-unknown-linux-gnueabihf = "0177f471c457b0a29ff81bf99d1078b676d652e6a7ebb31dfbeceb63a274e38c";
-      aarch64-unknown-linux-gnu = "bbe822f0aae2c1d31fa950a78446d4749e07ed67e974f87bf0c69146df2a9d9c";
-      aarch64-unknown-linux-musl = "859d2e973ba1b0106aaeb5df7db72673cb82b9de417339e28ae9b5074756db5b";
-      x86_64-apple-darwin = "5d4bd3705d6cb005449a22aa74ac073886a0e6a6026d2fc24d53b0acaca60255";
-      aarch64-apple-darwin = "6bafa3b5367019c576751741295e06717f8f28c9d0e6631dcb9496cd142a386a";
-      powerpc64-unknown-linux-gnu = "1b7869988be45153d86703c9ef4c970053b251745ac1571831dcd5f52d512cbf";
-      powerpc64le-unknown-linux-gnu = "59dfda4a3ba76113406ce80c802161ec669da49d5b7c0214abc5b99bff633e39";
-      powerpc64le-unknown-linux-musl = "2164eec8312e07d5e696cd46c10b5e3bcee06418d9aec47135d81bda2fa0198d";
-      riscv64gc-unknown-linux-gnu = "4c2e2697c4911d32bf16dc7361f4205a08aeb557a3843403de1c554cd09ae601";
-      s390x-unknown-linux-gnu = "1fafb56fb2d006561d8683c3943d355090bd4350b6692c7643d6f69fee301fd0";
-      loongarch64-unknown-linux-gnu = "b0ceb4393dddd0eb3567c4fc7aa4d8b46c21bdb7558289223ffd7336cbaac130";
-      loongarch64-unknown-linux-musl = "234fc65d9ae378ce2f55d273cc71841d09d38d6a4c41d873468ed017230d17df";
-      x86_64-unknown-freebsd = "61c78738716543c1e217c813bab3ac58d0524afbaeb5fbd40dfdcd3f2c3992a2";
+      i686-unknown-linux-gnu = "4c309c178f96770968ce79226af935996b1715389abf4bc08bdd4f596660201d";
+      x86_64-unknown-linux-gnu = "3bb1925a0a5ad2c17be731ee6e977e4a68490ab2182086db897bd28be21e965f";
+      x86_64-unknown-linux-musl = "57a78e193b11573da839c7177b8d29552aeb2c4751973179a384d472210f9c89";
+      arm-unknown-linux-gnueabihf = "2abf1ca017b0762f0750bcebff1c4814805a28c66935c09139d2adf3565105c6";
+      armv7-unknown-linux-gnueabihf = "338514f8c7adccb67c851ce220baceef0cec53b26291ae805094dbdbb5ceaad1";
+      aarch64-unknown-linux-gnu = "a0dc5a65ab337421347533e5be11d3fab11f119683a0dbd257ef3fe968bd2d72";
+      aarch64-unknown-linux-musl = "8ff50ffcf1da9aaea29767864abcdc4cce2eb840d3200e9a3ff585ad17f002b8";
+      x86_64-apple-darwin = "97724032da92646194a802a7991f1166c4dc9f0a63f3bb01a53860e98f31d08c";
+      aarch64-apple-darwin = "94903e93a4334d42bb6d92377a39903349c07f3709c792864bcdf7959f3c8c7d";
+      powerpc64-unknown-linux-gnu = "34dcc95d487f5a7da33ec05abf394515f80559d030e45b1c1744e2005690d720";
+      powerpc64le-unknown-linux-gnu = "fc6fa22878c5d12cb60e0ebaffdad70161965719bcc5d0b6793b132a0de8f759";
+      powerpc64le-unknown-linux-musl = "52472bac4cdecb95e7a091ad9bb328747a09b8cfe7082a90511d5250a330cdbc";
+      riscv64gc-unknown-linux-gnu = "ee71279fee2755d7f613597b24c8b168cc4e404d17e4e966c6b92aaf4d3c21ef";
+      s390x-unknown-linux-gnu = "a27d205e95d9e1ec3f14d94c2cc28b1b6d3b64dda50c1f25a787a30989782a18";
+      loongarch64-unknown-linux-gnu = "12361da66b693b848f6908d2321d03bb53ee9037bcc3d406876e6fc7b945e23d";
+      loongarch64-unknown-linux-musl = "42278996624153a2b872905be08796515e49079dfcdee5f28d4c389f18c2f0e5";
+      x86_64-unknown-freebsd = "6fba7bf41553e67b6d0f2014f7e128818b92f215b1e96a100ac5eaed06a41a04";
     };
 
-    selectRustPackage = pkgs: pkgs.rust_1_93;
+    selectRustPackage = pkgs: pkgs.rust_1_94;
   }
 
   (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4627,15 +4627,15 @@ with pkgs;
   wrapRustcWith = { rustc-unwrapped, ... }@args: callPackage ../build-support/rust/rustc-wrapper args;
   wrapRustc = rustc-unwrapped: wrapRustcWith { inherit rustc-unwrapped; };
 
-  rust_1_93 = callPackage ../development/compilers/rust/1_93.nix { };
-  rust = rust_1_93;
+  rust_1_94 = callPackage ../development/compilers/rust/1_94.nix { };
+  rust = rust_1_94;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
   mrustc-bootstrap = callPackage ../development/compilers/mrustc/bootstrap.nix { };
 
-  rustPackages_1_93 = rust_1_93.packages.stable;
-  rustPackages = rustPackages_1_93;
+  rustPackages_1_94 = rust_1_94.packages.stable;
+  rustPackages = rustPackages_1_94;
 
   inherit (rustPackages)
     cargo


### PR DESCRIPTION
Changelog: https://github.com/rust-lang/rust/releases/tag/1.94.0
Blog: https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/
Diff: https://github.com/rust-lang/rust/compare/1.93.1...1.94.0

Packages built:
- [x] fd
- [ ] firefox (I built it on the wrong branch, fails because of protobufc)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
