### PR TITLE
linuxPackages.digimend: fix build

### DIFF
--- a/pkgs/os-specific/linux/digimend/default.nix
+++ b/pkgs/os-specific/linux/digimend/default.nix
@@ -17,6 +17,13 @@ stdenv.mkDerivation {
     hash = "sha256-5kJj3SJfzrQ3n9r1YOn5xt0KO9WcEf0YpNMjiZEYMEo=";
   };
 
+  patches = [
+    # `del_timer_sync` was renamed to `timer_delete_sync` in Linux 6.2.
+    # The `del_timer_sync` compatibility wrapper was removed in Linux 6.15.
+    # Upstream PR: https://github.com/DIGImend/digimend-kernel-drivers/pull/729
+    ./linux-6.15.patch
+  ];
+
   postPatch = ''
     sed 's/udevadm /true /' -i Makefile
     sed 's/depmod /true /' -i Makefile

--- a/pkgs/os-specific/linux/digimend/linux-6.15.patch
+++ b/pkgs/os-specific/linux/digimend/linux-6.15.patch
@@ -1,0 +1,34 @@
+From 011686d1018e18c7c5cf5c2468ac43f275ecec82 Mon Sep 17 00:00:00 2001
+From: Dominik Kummer <devel@arkades.org>
+Date: Sat, 14 Feb 2026 10:13:46 +0100
+Subject: [PATCH] add conditional function definition based on kernel version
+ for backwards compability
+
+---
+ hid-uclogic-core.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/hid-uclogic-core.c b/hid-uclogic-core.c
+index 72680dd..75e7882 100644
+--- a/hid-uclogic-core.c
++++ b/hid-uclogic-core.c
+@@ -25,6 +25,10 @@
+ #include "compat.h"
+ #include <linux/version.h>
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 84)
++#define timer_delete_sync del_timer_sync
++#endif
++
+ /**
+  * uclogic_inrange_timeout - handle pen in-range state timeout.
+  * Emulate input events normally generated when pen goes out of range for
+@@ -491,7 +495,7 @@ static void uclogic_remove(struct hid_device *hdev)
+ {
+ 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
+ 
+-	del_timer_sync(&drvdata->inrange_timer);
++	timer_delete_sync(&drvdata->inrange_timer);
+ 	hid_hw_stop(hdev);
+ 	kfree(drvdata->desc_ptr);
+ 	uclogic_params_cleanup(&drvdata->params);


### PR DESCRIPTION
`del_timer_sync` [was renamed to `timer_delete_sync` in Linux 6.2](https://github.com/torvalds/linux/commit/9b13df3fb64ee95e2397585404e442afee2c7d4f). The `del_timer_sync` compatibility wrapper [was removed in Linux 6.15](https://github.com/torvalds/linux/commit/8fa7292fee5c5240402371ea89ab285ec856c916).

Hydra: https://hydra.nixos.org/build/323061357/nixlog/2
Upstream PR: https://github.com/DIGImend/digimend-kernel-drivers/pull/729

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
