### PR TITLE
[Backport release-25.11] lima: mark as insecure if older than version 2.x

### DIFF
--- a/pkgs/by-name/li/lima/additional-guestagents.nix
+++ b/pkgs/by-name/li/lima/additional-guestagents.nix
@@ -5,12 +5,15 @@
   findutils,
 }:
 
+let
+  source = callPackage ./source.nix { };
+in
 buildGoModule (finalAttrs: {
   pname = "lima-additional-guestagents";
 
   # Because agents must use the same version as lima, lima's updateScript should also update the shared src.
   # nixpkgs-update: no auto update
-  inherit (callPackage ./source.nix { }) version src vendorHash;
+  inherit (source) version src vendorHash;
 
   env.CGO_ENABLED = "0";
 
@@ -51,8 +54,7 @@ buildGoModule (finalAttrs: {
     runHook postInstallCheck
   '';
 
-  meta = {
-    homepage = "https://github.com/lima-vm/lima";
+  meta = source.meta // {
     description = "Lima Guest Agents for emulating non-native architectures";
     longDescription = ''
       This package should only be used when your guest's architecture differs from the host's.
@@ -66,8 +68,5 @@ buildGoModule (finalAttrs: {
 
       Typically, you won't need to directly add this package to your *.nix files.
     '';
-    changelog = "https://github.com/lima-vm/lima/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.asl20;
-    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -21,10 +21,13 @@
   jq,
 }:
 
+let
+  source = callPackage ./source.nix { };
+in
 buildGoModule (finalAttrs: {
   pname = "lima";
 
-  inherit (callPackage ./source.nix { }) version src vendorHash;
+  inherit (source) version src vendorHash;
 
   nativeBuildInputs = [
     makeWrapper
@@ -165,13 +168,7 @@ buildGoModule (finalAttrs: {
     };
   };
 
-  meta = {
-    homepage = "https://github.com/lima-vm/lima";
+  meta = source.meta // {
     description = "Linux virtual machines with automatic file sharing and port forwarding";
-    changelog = "https://github.com/lima-vm/lima/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      anhduy
-    ];
   };
 })

--- a/pkgs/by-name/li/lima/source.nix
+++ b/pkgs/by-name/li/lima/source.nix
@@ -21,6 +21,7 @@ in
   meta = {
     homepage = "https://github.com/lima-vm/lima";
     changelog = "https://github.com/lima-vm/lima/releases/tag/v${version}";
+    knownVulnerabilities = lib.optional (lib.versionOlder version "2") "Lima version ${version} is EOL. See https://lima-vm.io/docs/releases/.";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       anhduy

--- a/pkgs/by-name/li/lima/source.nix
+++ b/pkgs/by-name/li/lima/source.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   fetchFromGitHub,
 }:
 
@@ -16,4 +17,13 @@ in
   };
 
   vendorHash = "sha256-8S5tAL7GY7dxNdyC+WOrOZ+GfTKTSX84sG8WcSec2Os=";
+
+  meta = {
+    homepage = "https://github.com/lima-vm/lima";
+    changelog = "https://github.com/lima-vm/lima/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      anhduy
+    ];
+  };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Manually resolved the conflict: https://github.com/NixOS/nixpkgs/pull/486606#issuecomment-4012958837

```console
> nix build .#lima
error:
       … in the condition of the assert statement
         at /nix/store/wrxhr4gcg685495kxqim6m2a33ncdmsp-source/lib/customisation.nix:430:9:
          429|       drvPath =
          430|         assert condition;
             |         ^
          431|         drv.drvPath;

       … while evaluating the attribute 'handled'
         at /nix/store/wrxhr4gcg685495kxqim6m2a33ncdmsp-source/pkgs/stdenv/generic/check-meta.nix:756:9:
          755|         # or, alternatively, just output a warning message.
          756|         handled = (
             |         ^
          757|           if valid == "yes" then

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: Package ‘lima-1.2.2’ in /nix/store/wrxhr4gcg685495kxqim6m2a33ncdmsp-source/pkgs/by-name/li/lima/package.nix:172 is marked as insecure, refusing to evaluate.


       Known issues:
        - Lima version 1.2.2 is EOL. See https://lima-vm.io/docs/releases/.

       You can install it anyway by allowing this package, using the
       following methods:

       a) To temporarily allow all insecure packages, you can use an environment
          variable for a single invocation of the nix tools:

            $ export NIXPKGS_ALLOW_INSECURE=1

          Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
                then pass `--impure` in order to allow use of environment variables.

       b) for `nixos-rebuild` you can add ‘lima-1.2.2’ to
          `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
          like so:

            {
              nixpkgs.config.permittedInsecurePackages = [
                "lima-1.2.2"
              ];
            }

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
          ‘lima-1.2.2’ to `permittedInsecurePackages` in
          ~/.config/nixpkgs/config.nix, like so:

            {
              permittedInsecurePackages = [
                "lima-1.2.2"
              ];
            }
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. # No rebuilds
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

cc: @voanhduy1512, @msgilligan, @philiptaron