### PR TITLE
pwdsphinx: 2.0.3 -> 2.0.4

### DIFF
--- a/pkgs/by-name/pw/pwdsphinx/package.nix
+++ b/pkgs/by-name/pw/pwdsphinx/package.nix
@@ -9,14 +9,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "pwdsphinx";
-  version = "2.0.3";
+  version = "2.0.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "stef";
     repo = "pwdsphinx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-COSfA5QqIGWEnahmo5klFECK7XjyabGs1nG9vyhj/DM=";
+    hash = "sha256-wAvcXSAoaottnsnvlD2QnLP3QIithI6xplo5tN8yjVg=";
   };
 
   postPatch = ''
@@ -55,7 +55,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   preCheck = ''
     mkdir -p ~/.config/sphinx
-    cp ${finalAttrs.src}/configs/config ~/.config/sphinx/config
+    cp ${finalAttrs.src}/sphinx.cfg_sample ~/.config/sphinx/config
+    substituteInPlace ~/.config/sphinx/config \
+      --replace-fail 'pinentry=/usr/bin/pinentry' 'pinentry="/usr/bin/pinentry"' \
+      --replace-fail 'log=' 'log=""'
     # command fails without key but the command generates the key, so always pass
     $out/bin/sphinx init || true
   '';


### PR DESCRIPTION
https://github.com/stef/pwdsphinx/releases/tag/v2.0.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
