### PR TITLE
semtools: 1.2.0 -> 3.0.1

### DIFF
--- a/pkgs/by-name/se/semtools/package.nix
+++ b/pkgs/by-name/se/semtools/package.nix
@@ -1,32 +1,37 @@
 {
   lib,
-  stdenv,
   rustPlatform,
   fetchFromGitHub,
   nix-update-script,
   openssl,
   pkg-config,
+  protobuf,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "semtools";
-  version = "1.2.0";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "run-llama";
     repo = "semtools";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wpOKEESM3uG9m/EqWnF2uXITbrwIhwe2MSA0FN7Fu+w=";
+    hash = "sha256-8vQJd1/EnskcMNN2cfXOQxHeLPh61dypL51KwCLps8Q=";
   };
 
-  cargoHash = "sha256-irLhwlNnB3G63WUGV2wo+LQGQgNHYzu/vb/RM/G6Fdc=";
+  cargoHash = "sha256-spllUpCze3ajNZtWVRr9GZLDj7HMi6UIraeEp9XgfK0=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+  ];
+
   buildInputs = [ openssl ];
 
-  checkFlags = lib.optionals (stdenv.hostPlatform.system == "x86_64-darwin") [
-    # https://github.com/run-llama/semtools/issues/17
-    "--skip=tests::test_search_result_context_calculation"
+  checkFlags = [
+    # Require network
+    "--skip=search::tests"
+    "--skip=workspace::tests::test_workspace_save_and_open"
   ];
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
Changelog:
- https://github.com/run-llama/semtools/releases/tag/v3.0.0
- https://github.com/run-llama/semtools/releases/tag/v3.0.1

Diff: https://github.com/run-llama/semtools/compare/v1.2.0..v3.0.1

https://r.ryantm.com/log/semtools/2026-02-19.log

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
