### PR TITLE
jchempaint: update mvnHash, disable version updating

### DIFF
--- a/pkgs/by-name/jc/jchempaint/package.nix
+++ b/pkgs/by-name/jc/jchempaint/package.nix
@@ -18,11 +18,11 @@ maven.buildMavenPackage {
   src = fetchFromGitHub {
     owner = "JChemPaint";
     repo = "jchempaint";
-    rev = "de023b6ddc1a13f5af48fa2acc8a2633c36a30fa";
+    rev = "de023b6ddc1a13f5af48fa2acc8a2633c36a30fa"; # this commit was previously a "nightly" release tag
     hash = "sha256-1wcJ1qP8yZg1qe4YkpCRGidHUXc1/1eUabR3NoM6kjc=";
   };
 
-  mvnHash = "sha256-AGDyXyEEDMjPHMlbcxninkciZ7V/ALMUS/OkgBnni18=";
+  mvnHash = "sha256-goISSdlFng1PDrotnZGwLVbXpBB3w1CFYysvLW78bDE=";
 
   nativeBuildInputs = [
     makeWrapper
@@ -71,12 +71,11 @@ maven.buildMavenPackage {
     })
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=skip" ]; }; # only update hash
 
   meta = {
     description = "Chemical 2D structure editor application/applet based on the Chemistry Development Kit";
     homepage = "https://jchempaint.github.io";
-    changelog = "https://github.com/JChemPaint/jchempaint/releases/tag/nightly";
     license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ ZZBaron ];


### PR DESCRIPTION
The previous "nightly" release tag was removed by upstream. The most recent version 3.4b, has many build failures. So I am pinning the commit that was used for the nightly release. And disabling version updating for now. Come next release, it will be added back.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
