### PR TITLE
Update brother printer drivers

### DIFF
--- a/pkgs/by-name/mf/mfcl8690cdwcupswrapper/package.nix
+++ b/pkgs/by-name/mf/mfcl8690cdwcupswrapper/package.nix
@@ -13,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mfcl8690cdwcupswrapper";
-  version = "1.4.0-0";
+  version = "1.5.0-3";
 
   src = fetchurl {
     url = "http://download.brother.com/welcome/dlf103250/${pname}-${version}.i386.deb";
-    sha256 = "1bl9r8mmj4vnanwpfjqgq3c9lf2v46wp5k6r2n9iqprf7ldd1kb2";
+    sha256 = "CREQRr4nhw1pD+8AfD5p/EHpx3R6vQIO8h6VtnHxXls=";
   };
 
   nativeBuildInputs = [
@@ -34,9 +34,9 @@ stdenv.mkDerivation rec {
     dir=$out/opt/brother/Printers/mfcl8690cdw
 
     substituteInPlace $dir/cupswrapper/brother_lpdwrapper_mfcl8690cdw \
-      --replace /usr/bin/perl ${perl}/bin/perl \
-      --replace "basedir =~" "basedir = \"$basedir/\"; #" \
-      --replace "PRINTER =~" "PRINTER = \"mfcl8690cdw\"; #"
+      --replace-fail /usr/bin/perl ${perl}/bin/perl \
+      --replace-fail "basedir =~" "basedir = \"$basedir/\"; #" \
+      --replace-fail "PRINTER =~" "PRINTER = \"mfcl8690cdw\"; #"
 
     wrapProgram $dir/cupswrapper/brother_lpdwrapper_mfcl8690cdw \
       --prefix PATH : ${

--- a/pkgs/by-name/mf/mfcl8690cdwlpr/package.nix
+++ b/pkgs/by-name/mf/mfcl8690cdwlpr/package.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mfcl8690cdwlpr";
-  version = "1.3.0-0";
+  version = "1.5.0-3";
 
   src = fetchurl {
     url = "http://download.brother.com/welcome/dlf103241/${pname}-${version}.i386.deb";
-    sha256 = "0x8zd4b1psmw1znp2ibncs37xm5mljcy9yza2rx8jm8lp0a3l85v";
+    sha256 = "CXYo6ISUr0hFiHRVRnXbJ/21dK/2NUrCt2bnzQuHOXI=";
   };
 
   nativeBuildInputs = [
@@ -37,9 +37,9 @@ stdenv.mkDerivation rec {
     filter=$dir/lpd/filter_mfcl8690cdw
 
     substituteInPlace $filter \
-      --replace /usr/bin/perl ${perl}/bin/perl \
-      --replace "BR_PRT_PATH =~" "BR_PRT_PATH = \"$dir/\"; #" \
-      --replace "PRINTER =~" "PRINTER = \"mfcl8690cdw\"; #"
+      --replace-fail /usr/bin/perl ${perl}/bin/perl \
+      --replace-fail "BR_PRT_PATH =~" "BR_PRT_PATH = \"$dir/\"; #" \
+      --replace-fail "PRINTER =~" "PRINTER = \"mfcl8690cdw\"; #"
 
     wrapProgram $filter \
       --prefix PATH : ${
@@ -55,7 +55,8 @@ stdenv.mkDerivation rec {
 
     # need to use i686 glibc here, these are 32bit proprietary binaries
     interpreter=${pkgs.pkgsi686Linux.glibc}/lib/ld-linux.so.2
-    patchelf --set-interpreter "$interpreter" $dir/lpd/brmfcl8690cdwfilter
+    patchelf --set-interpreter "$interpreter" $dir/lpd/x86_64/brmfcl8690cdwfilter
+    patchelf --set-interpreter "$interpreter" $dir/lpd/i686/brmfcl8690cdwfilter
   '';
 
   meta = {


### PR DESCRIPTION
The previous versions of these packages don't compile anymore because the .deb files don't exist anymore on Brother's servers:

```
       > error: cannot download mfcl8690cdwlpr-1.3.0-0.i386.deb from any mirror
       > error: cannot download mfcl8690cdwlpr-1.3.0-0.i386.deb from any mirror
```

This PR fixes it by upgrading to the latest version.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
