### PR TITLE
freebsd.iwlwifi-firmware: init

### DIFF
--- a/pkgs/by-name/li/linux-firmware/package.nix
+++ b/pkgs/by-name/li/linux-firmware/package.nix
@@ -65,7 +65,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Binary firmware collection packaged by kernel.org";
     homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git";
     license = lib.licenses.unfreeRedistributableFirmware;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ fpletz ];
     priority = 6; # give precedence to kernel firmware
     sourceProvenance = with lib.sourceTypes; [ binaryFirmware ];

--- a/pkgs/os-specific/bsd/freebsd/pkgs/iwlwifi-firmware/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/iwlwifi-firmware/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  mkDerivation,
+  sys,
+  buildFreebsd,
+  linux-firmware,
+}:
+mkDerivation rec {
+  # out-of-tree, but we still want to use freebsd.mkDerivation, which wants an in-tree path
+  path = "...";
+
+  pname = "iwlwifi-firmware";
+  version = linux-firmware.version;
+
+  # Upstream FreeBSD doesn't wrap wifi firmware, only gpu firmware.
+  # We have to write our own build scripts for this.
+  src = ./src;
+
+  outputs = [
+    "out"
+    "debug"
+  ];
+
+  extraNativeBuildInputs = [ buildFreebsd.xargs-j ];
+
+  env = sys.passthru.env;
+  SYSDIR = "${sys.src}/sys";
+  KERN_DEBUGDIR = "${builtins.placeholder "debug"}/lib/debug";
+  KERN_DEBUGDIR_KODIR = "${KERN_DEBUGDIR}/kernel";
+  KERN_DEBUGDIR_KMODDIR = "${KERN_DEBUGDIR}/kernel";
+  KMODDIR = "${placeholder "out"}/kernel";
+
+  LINUX_FIRMWARE = "${linux-firmware}/lib/firmware";
+
+  # generates relocations the linker can't handle
+  hardeningDisable = [
+    "pic"
+  ];
+
+  makeFlags = [
+    "DEBUG_FLAGS=-g"
+    "XARGS_J=xargs-j"
+    "NO_XREF=1"
+  ];
+
+  preConfigure = ''
+    bash gen-makefiles
+  '';
+
+  meta = {
+    description = "Intel Wifi Firmware for FreeBSD";
+    platforms = lib.platforms.freebsd;
+    license = linux-firmware.meta.license;
+  };
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/iwlwifi-firmware/src/Makefile.inc
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/iwlwifi-firmware/src/Makefile.inc
@@ -1,0 +1,8 @@
+KMOD=	${NAME}
+
+FIRMWS=	${NAME}:${NAME}
+
+CLEANFILES+=	${NAME} ${NAME}.fwo ${NAME}.ko.debug ${NAME}.ko.full
+
+${NAME}: ${LINUX_FIRMWARE}/intel/iwlwifi/${NAME}
+	cp $? ${.TARGET}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/iwlwifi-firmware/src/gen-makefiles
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/iwlwifi-firmware/src/gen-makefiles
@@ -1,0 +1,26 @@
+set -e
+
+scriptdir=$(cd $(dirname $0) && pwd)
+fwdir=$LINUX_FIRMWARE/intel/iwlwifi
+
+for dir in $scriptdir/*; do
+	if [ ! -d "$dir" ]; then
+		continue
+	fi
+	rm -rf "$dir"
+done
+
+for file in $fwdir/*.*; do
+	base=$(basename $file)
+
+	echo "SUBDIR += $base" >> Makefile
+
+	mkdir -p "$scriptdir/$base"
+	cat > "$scriptdir/$base/Makefile" <<EOF
+NAME=		$base
+
+.include <bsd.kmod.mk>
+EOF
+done
+
+echo ".include <bsd.subdir.mk>" >> Makefile


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add a new `freebsd.iwlwifi-firmware` package. This takes iwlwifi firmware files from `linux-firmware` and wraps them in kernel modules.

This works on the upstream FreeBSD kernel with no changes, and a similar approach is done for `drm-kmod`. Upstream FreeBSD puts the firmware files in `/boot/firmware` instead of wrapping, but this won't work for NixBSD as the path is hardcoded and cannot be changed.

As part of this we need a platform list change for linux-firmware, but it should not change any derivations.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (cross for x86_64-freebsd)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
