### PR TITLE
egl-wayland2: init at 1.0.1

### DIFF
--- a/pkgs/by-name/eg/egl-wayland2/package.nix
+++ b/pkgs/by-name/eg/egl-wayland2/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  eglexternalplatform,
+  pkg-config,
+  meson,
+  ninja,
+  wayland-scanner,
+  libGL,
+  libgbm,
+  libdrm,
+  wayland,
+  wayland-protocols,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "egl-wayland2";
+  version = "1.0.1";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "egl-wayland2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Udr+tihx/Si2ynFyM1FW2CIUgTg9SQn7AgrOPpGTxpY=";
+  };
+
+  depsBuildBuild = [
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    libGL
+    libgbm
+    libdrm
+    wayland
+    wayland-protocols
+  ];
+
+  propagatedBuildInputs = [
+    eglexternalplatform
+  ];
+
+  postInstall = ''
+    substituteInPlace $out/share/egl/egl_external_platform.d/09_nvidia_wayland2.json \
+      --replace-fail "libnvidia-egl-wayland2.so.1" "$out/lib/libnvidia-egl-wayland2.so.1"
+  '';
+
+  meta = {
+    description = "Dma-buf-based Wayland external platform library";
+    homepage = "https://github.com/NVIDIA/egl-wayland2/";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ vancluever ];
+  };
+})


### PR DESCRIPTION
This adds egl-wayland2 (https://github.com/NVIDIA/egl-wayland2, the dmabuf-based EGL driver) as an independent package.

While the 590 driver appears to currently be bundling it, this makes it available for eligible driver versions outside of this (i.e., 580).

This package is based on the egl-wayland one, with a few minor changes and the removal of X11 as it does not seem to be needed for the build, and nothing in the logs indicates that it is an optional feature.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
