### PR TITLE
python3Packages.litellm: 1.80.0 -> 1.81.14

### DIFF
--- a/pkgs/development/python-modules/litellm/default.nix
+++ b/pkgs/development/python-modules/litellm/default.nix
@@ -50,14 +50,14 @@
 
 buildPythonPackage rec {
   pname = "litellm";
-  version = "1.80.0";
+  version = "1.81.14";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "BerriAI";
     repo = "litellm";
-    tag = "v${version}-stable.1";
-    hash = "sha256-W1tckXXQ9PlqTW5S4ml0X5rcPXSCioubDaSkQxHQrMY=";
+    tag = "v${version}-stable";
+    hash = "sha256-1QYqTsTOynLrLmjzYL4TPxwKagFKFXIQbQ1rfw8TXjc=";
   };
 
   build-system = [ poetry-core ];


### PR DESCRIPTION
Updated litellm from 1.80.0 to 1.81.14.

https://github.com/BerriAI/litellm/releases/tag/v1.81.14-stable

Also updated the tag format from `v${version}-stable.1` to `v${version}-stable`

```sh
$ ./result/bin/litellm --help
  Usage: litellm [OPTIONS]
  ...

  $ ./result/bin/litellm --version
  LiteLLM: Current Version = 1.81.14
```

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.