### PR TITLE
python3Packages.latexify-py: disable for python 3.14+

### DIFF
--- a/pkgs/development/python-modules/latexify-py/default.nix
+++ b/pkgs/development/python-modules/latexify-py/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  pythonAtLeast,
   dill,
   fetchFromGitHub,
   hatchling,
@@ -11,6 +12,10 @@ buildPythonPackage rec {
   pname = "latexify-py";
   version = "0.4.4";
   pyproject = true;
+
+  # AttributeError: module 'ast' has no attribute 'Num'
+  # https://docs.python.org/3/whatsnew/3.14.html#id9
+  disabled = pythonAtLeast "3.14";
 
   src = fetchFromGitHub {
     owner = "google";


### PR DESCRIPTION
No upstream movement for ~1 year, but package still builds with Python 3.13.

Build with Python 3.14 fails with `AttributeError: module 'ast' has no attribute 'Num'` due to the [removal of `ast.Num`](https://docs.python.org/3/whatsnew/3.14.html#id9) in Python 3.14.

Hydra: https://hydra.nixos.org/build/322203467/nixlog/3
Tracking: #475732

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13}Packages.latexify-py`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
