### PR TITLE
python3Packages.starlette-admin: unbreak by patching pyproject

### DIFF
--- a/pkgs/development/python-modules/starlette-admin/0001-fix-pytest-pyproject-collision.patch
+++ b/pkgs/development/python-modules/starlette-admin/0001-fix-pytest-pyproject-collision.patch
@@ -1,0 +1,14 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 3e170b4..e2c6c77 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -183,9 +183,6 @@ parallel = true
+ concurrency = ["thread", "greenlet"]
+ source = ["starlette_admin", "tests"]
+ 
+-[tool.pytest]
+-asyncio_mode = "auto"
+-
+ [tool.pytest.ini_options]
+ asyncio_mode="auto"
+ asyncio_default_fixture_loop_scope="function"

--- a/pkgs/development/python-modules/starlette-admin/default.nix
+++ b/pkgs/development/python-modules/starlette-admin/default.nix
@@ -51,6 +51,11 @@ buildPythonPackage rec {
     hash = "sha256-JVvrfbyKillkx6fOx4DEbHZoHIPxF1Gn3HzkxyJc66o=";
   };
 
+  patches = [
+    # "Cannot use both [tool.pytest] (native TOML types) and [tool.pytest.ini_options] (string-based INI format) simultaneously"
+    ./0001-fix-pytest-pyproject-collision.patch
+  ];
+
   build-system = [ hatchling ];
 
   dependencies = [


### PR DESCRIPTION
They'll discover this in CI soon

fixes https://hydra.nixos.org/build/322192501


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
