### PR TITLE
spade: 0.16.0 -> 0.17.0

### DIFF
--- a/pkgs/by-name/sp/spade/package.nix
+++ b/pkgs/by-name/sp/spade/package.nix
@@ -16,18 +16,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "spade";
-  version = "0.16.0";
+  version = "0.17.0";
 
   src = fetchFromGitLab {
     owner = "spade-lang";
     repo = "spade";
     rev = "v${version}";
-    hash = "sha256-Q9LiyCkrHQxnTorAqPOykS4F06c01pYPW9t82xEn6DY=";
+    hash = "sha256-jdcwIn/CiibWiYhh4yICa1LWXZCI0r2w3AFDRO0ZbFw=";
     # only needed for vatch, which contains test data
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-zuj34DpQKu7uWYgL/JTq7zLTPvZKQ/eedBXrkN1Pvg0=";
+  cargoHash = "sha256-JnyICAJ+W9ZwQpJnSVkEb5dSvkrcnx6PZ/IgQMEOsag=";
 
   # TODO: somehow respect https://nixos.org/manual/nixpkgs/stable/#var-passthru-updateScript-commit
   passthru.updateScript = _experimental-update-script-combinators.sequence [

--- a/pkgs/by-name/sw/swim/package.nix
+++ b/pkgs/by-name/sw/swim/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "swim";
-  version = "0.16.0";
+  version = "0.17.0";
 
   src = fetchFromGitLab {
     owner = "spade-lang";
     repo = "swim";
     rev = "v${version}";
-    hash = "sha256-8JUy5gMZv7qzksrnoCwS4Wxk8xvy02sYGKHxwncAy7c=";
+    hash = "sha256-5GxOW5Np5CS1hO8Bd/CoKuRHMiQ9Q2Xz61NGyXXNF7Q=";
   };
 
-  cargoHash = "sha256-M4gwOAEPN3J7Ftirotbdk/UOE0hqbYpxBDO65YPXxBc=";
+  cargoHash = "sha256-TmPw/vP4/LZrBOv1/vJBv3NIn75NnRQmtS4gdmZRH2w=";
 
   preConfigure = ''
     # de-vendor spade git submodule


### PR DESCRIPTION
- **spade: 0.16.0 -> 0.17.0**
- **swim: 0.16.0 -> 0.17.0**

Blog:

* https://blog.spade-lang.org/v0-17-0/

Diff:

* https://gitlab.com/spade-lang/swim/-/compare/v0.16.0...v0.17.0
* https://gitlab.com/spade-lang/spade/-/compare/v0.16.0...0.17.0

Changelog:

* https://gitlab.com/spade-lang/swim/-/blob/v0.17.0/CHANGELOG.md
* https://gitlab.com/spade-lang/spade/-/blob/v0.17.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
