### PR TITLE
hap-py: compile with latest nixpkgs

### DIFF
--- a/pkgs/by-name/ha/hap-py/package.nix
+++ b/pkgs/by-name/ha/hap-py/package.nix
@@ -8,6 +8,7 @@
   fetchFromGitHub,
   htslib,
   lib,
+  libdeflate,
   makeWrapper,
   perl,
   python3,
@@ -56,6 +57,16 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail \
         "cmake_minimum_required (VERSION 2.8)" \
         "cmake_minimum_required (VERSION 3.10)"
+
+
+    # Boost 1.89 no longer provides a boost_system CMake component package,
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        "filesystem system program_options" \
+        "filesystem program_options"
+
+    # Insert missing include for uint64_t
+    sed -i '/#include <vector>/a #include <cstdint>' src/c++/include/helpers/Roc.hh
   '';
 
   patches = [
@@ -64,6 +75,9 @@ stdenv.mkDerivation (finalAttrs: {
     # Update to python3
     ./python3.patch
   ];
+
+  env.NIX_LDFLAGS = toString [ "-ldeflate" ];
+
   nativeBuildInputs = [
     autoconf
     cmake
@@ -74,6 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
     bzip2
     curl
     htslib
+    libdeflate
     my-python
     rtg-tools
     xz


### PR DESCRIPTION

Avoid removal (see #490615 ) of this useful package in bioinformatics by fixing build errors

## Things done

I haven't yet the time to test the binary.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
