### PR TITLE
nixos/nix-flakes: declare default for nix.registry.*.from in option

### DIFF
--- a/nixos/modules/config/nix-flakes.nix
+++ b/nixos/modules/config/nix-flakes.nix
@@ -46,6 +46,10 @@ in
               options = {
                 from = mkOption {
                   type = referenceAttrs;
+                  default = {
+                    type = "indirect";
+                    id = name;
+                  };
                   example = {
                     type = "indirect";
                     id = "nixpkgs";
@@ -88,10 +92,6 @@ in
                 };
               };
               config = {
-                from = mkDefault {
-                  type = "indirect";
-                  id = name;
-                };
                 to = mkIf (config.flake != null) (
                   mkDefault (
                     {


### PR DESCRIPTION
Declaring the default for the option `nix.registry.<name>.from` in the option declaration instead of via config, which does:

- reduce the priority of the nixpkgs provided default
  - this can be **considered a breaking change** for modules out there relying on this default to have priority 1000 (`mkDefault`) instead of 1500 (`mkOptionDefault`)
- making the default visible in generated documentations

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
