### PR TITLE
python3Packages.torchtitan: init at 0.2.2

### DIFF
--- a/pkgs/development/python-modules/torchtitan/default.nix
+++ b/pkgs/development/python-modules/torchtitan/default.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  datasets,
+  einops,
+  fsspec,
+  pillow,
+  tensorboard,
+  tokenizers,
+  tomli,
+  torch,
+  torchdata,
+  transformers,
+  tyro,
+
+  # tests
+  pytestCheckHook,
+  tomli-w,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "torchtitan";
+  version = "0.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "torchtitan";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YXbbqNjmPBIFDRbvagHRIy5ph1pZmSerUxlqaF6f4cY=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    datasets
+    einops
+    fsspec
+    pillow
+    tensorboard
+    tokenizers
+    tomli
+    torch
+    torchdata
+    tyro
+  ];
+
+  pythonImportsCheck = [ "torchtitan" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    tomli-w
+    transformers
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTests = [
+    # Require internet access
+    "test_list_files"
+  ];
+
+  disabledTestPaths = [
+    # Require internet access
+    "tests/unit_tests/test_tokenizer.py"
+  ];
+
+  meta = {
+    description = "PyTorch native platform for training generative AI models";
+    homepage = "https://github.com/pytorch/torchtitan";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19385,6 +19385,8 @@ self: super: with self; {
 
   torchsummary = callPackage ../development/python-modules/torchsummary { };
 
+  torchtitan = callPackage ../development/python-modules/torchtitan { };
+
   torchtnt = callPackage ../development/python-modules/torchtnt { };
 
   torchtune = callPackage ../development/python-modules/torchtune { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [torchtitan](https://github.com/pytorch/torchtitan), a PyTorch native platform for training generative AI models.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
