### PR TITLE
python3Packages.pycparser-fake-libc: init at 2.21

### DIFF
--- a/pkgs/development/python-modules/pycparser-fake-libc/default.nix
+++ b/pkgs/development/python-modules/pycparser-fake-libc/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pycparser-fake-libc";
+  version = "2.21";
+  pyproject = true;
+
+  # Fetching from GitHub causes headers to not be included
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-pG+12tpUgYLDnaNAps1zZoUTWf+3je4nzGGdZcM6Ueg=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "pycparser_fake_libc" ];
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    changelog = "https://github.com/ThomasGerstenberg/pycparser-fake-libc/releases/tag/v${version}";
+    description = "Pip-installable package which contains the fake libc headers from pycparser ";
+    homepage = "https://github.com/ThomasGerstenberg/pycparser-fake-libc";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.gigahawk ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13383,6 +13383,8 @@ self: super: with self; {
 
   pycparser = callPackage ../development/python-modules/pycparser { };
 
+  pycparser-fake-libc = callPackage ../development/python-modules/pycparser-fake-libc { };
+
   pycrashreport = callPackage ../development/python-modules/pycrashreport { };
 
   pycrdt = callPackage ../development/python-modules/pycrdt { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
