### PR TITLE
fetchtorrent: fix single-file torrents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -79,7 +79,7 @@ indent_size = unset
 trim_trailing_whitespace = true
 
 # binaries
-[*.nib]
+[*.{nib,torrent}]
 end_of_line = unset
 insert_final_newline = unset
 trim_trailing_whitespace = unset

--- a/.gitattributes
+++ b/.gitattributes
@@ -62,3 +62,6 @@ ci/OWNERS linguist-language=CODEOWNERS
 # patching CRLF line endings from an upstream source package.
 *.diff !text !eol
 *.patch !text !eol
+
+# Torrent files are binary files and should not be re-encoded.
+*.torrent !text !eol

--- a/pkgs/build-support/fetchtorrent/default.nix
+++ b/pkgs/build-support/fetchtorrent/default.nix
@@ -31,15 +31,45 @@ let
   # Default to flattening if no flatten argument was specified.
   flatten' = if flatten == null then true else flatten;
 
-  transmissionFinishScript = writeShellScript "fetch-bittorrent-done.sh" ''
+  setupScript = ''
+    export HOME=$TMP
+    mkdir -p $out
+    downloadedDirectory=${
+      if flatten' then "$(mktemp -d $out/downloadedDirectory.XXXXXXXXXX)" else "$out"
+    }
+    export downloadedDirectory # See https://www.shellcheck.net/wiki/SC2155
+    port="$(shuf -n 1 -i 49152-65535)"
+  '';
+
+  flattenScript = ''
+    (
+      shopt -s dotglob nullglob
+      downloadedFiles=($downloadedDirectory/*)
+      if [[ ''${#downloadedFiles[@]} -eq 0 ]]; then
+        echo "Failed to download any files."
+        exit 1
+      elif [[ ''${#downloadedFiles[@]} -eq 1 ]] && [[ -d "$downloadedFiles" ]]; then
+        # Flatten the directory, so that only the torrent contents are in $out,
+        # not the folder name
+        mv -v "$downloadedFiles"/* $out
+      else
+        # Either we downloaded a single (regular) file, or we downloaded
+        # multiple files/directories. We can't flatten, so we move them to
+        # $out.
+        mv -v "''${downloadedFiles[@]}" $out
+      fi
+      rm -v -rf $downloadedDirectory
+    )
+  '';
+
+  finishScript = ''
     ${postUnpack}
-    # Flatten the directory, so that only the torrent contents are in $out, not
-    # the folder name
-    shopt -s dotglob
-    mv -v $downloadedDirectory/*/* $out
-    rm -v -rf $downloadedDirectory
-    unset downloadedDirectory
+    ${lib.optionalString flatten' flattenScript}
     ${postFetch}
+  '';
+
+  transmissionFinishScript = writeShellScript "fetch-bittorrent-done.sh" ''
+    ${finishScript}
     kill $PPID
   '';
   jsonConfig = (formats.json { }).generate "jsonConfig" config;
@@ -115,12 +145,9 @@ runCommand name
   (
     if (backend == "transmission") then
       ''
-        export HOME=$TMP
-        mkdir -p $out
-        export downloadedDirectory=$(mktemp -d $out/downloadedDirectory.XXXXXXXXXX)
+        ${setupScript}
         mkdir -p $HOME/.config/transmission
         cp ${jsonConfig} $HOME/.config/transmission/settings.json
-        port="$(shuf -n 1 -i 49152-65535)"
         function handleChild {
           # This detects failures and logs the contents of the transmission fetch
           find $out
@@ -136,18 +163,7 @@ runCommand name
       ''
     else
       ''
-        export HOME=$TMP
-      ''
-      + lib.optionalString flatten' ''
-        mkdir -p $out
-        downloadedDirectory=$(mktemp -d $out/downloadedDirectory.XXXXXXXXXX)
-      ''
-      + lib.optionalString (!flatten') ''
-        downloadedDirectory=$out
-      ''
-      + ''
-        port="$(shuf -n 1 -i 49152-65535)"
-
+        ${setupScript}
         rqbit \
             --disable-dht-persistence \
             --http-api-listen-addr "127.0.0.1:$port" \
@@ -155,18 +171,6 @@ runCommand name
             -o "$downloadedDirectory" \
             --exit-on-finish \
             "$url"
-
-        ${postUnpack}
-      ''
-      + lib.optionalString flatten' ''
-        # Flatten the directory, so that only the torrent contents are in $out,
-        # not the folder name
-        shopt -s dotglob
-        mv -v $downloadedDirectory/*/* $out
-        rm -v -rf $downloadedDirectory
-        unset downloadedDirectory
-      ''
-      + ''
-        ${postFetch}
+        ${finishScript}
       ''
   )

--- a/pkgs/build-support/fetchtorrent/default.nix
+++ b/pkgs/build-support/fetchtorrent/default.nix
@@ -73,45 +73,6 @@ let
     kill $PPID
   '';
   jsonConfig = (formats.json { }).generate "jsonConfig" config;
-
-  # https://github.com/NixOS/nixpkgs/issues/432001
-  #
-  # For a while, the transmission backend would put the downloaded torrent in
-  # the output directory, but whether the rqbit backend would put the output in
-  # the output directory or a subdirectory depended on the version of rqbit.
-  # We want to standardise on a single behaviour, but give users of
-  # fetchtorrent with the rqbit backend some warning that the behaviour might
-  # be unexpected, particularly since we can't know what behaviour users might
-  # be expecting at this point, and they probably wouldn't notice a change
-  # straight away because the results are fixed-output derivations.
-  #
-  # This warning was introduced for 25.11, so we can remove handling of the
-  # `flatten` argument once that release is no longer supported.
-  warnings =
-    if backend == "rqbit" && flatten == null then
-      [
-        ''
-          `fetchtorrent` with the rqbit backend may or may not have the
-          downloaded files stored in a subdirectory of the output directory.
-          Verify which behaviour you need, and set the `flatten` argument to
-          `fetchtorrent` accordingly.
-
-          The `flatten = false` behaviour will still produce a warning, as this
-          behaviour is deprecated.  It is only available with the "rqbit" backend
-          to provide temporary support for users who are relying on the
-          previous incorrect behaviour.  For a warning-free evaluation, use
-          `flatten = true`.
-        ''
-      ]
-    else if flatten == false then
-      [
-        ''
-          `fetchtorrent` with `flatten = false` is deprecated and will be
-          removed in a future release.
-        ''
-      ]
-    else
-      [ ];
 in
 assert lib.assertMsg (config != { } -> backend == "transmission") ''
   json config for configuring fetchtorrent only works with the transmission backend
@@ -129,7 +90,41 @@ runCommand name
       if (backend == "transmission") then
         [ transmission_4 ]
       else if (backend == "rqbit") then
-        [ rqbit ]
+        lib.warnIf (flatten != true) (
+          # https://github.com/NixOS/nixpkgs/issues/432001
+          #
+          # For a while, the transmission backend would put the downloaded torrent in
+          # the output directory, but whether the rqbit backend would put the output in
+          # the output directory or a subdirectory depended on the version of rqbit.
+          # We want to standardise on a single behaviour, but give users of
+          # fetchtorrent with the rqbit backend some warning that the behaviour might
+          # be unexpected, particularly since we can't know what behaviour users might
+          # be expecting at this point, and they probably wouldn't notice a change
+          # straight away because the results are fixed-output derivations.
+          #
+          # This warning was introduced for 25.11, so we can remove handling of the
+          # `flatten` argument once that release is no longer supported.
+          if flatten == null then
+            ''
+              `fetchtorrent` with the rqbit backend may or may not have the
+              downloaded files stored in a subdirectory of the output directory.
+              Verify which behaviour you need, and set the `flatten` argument to
+              `fetchtorrent` accordingly.
+
+              The `flatten = false` behaviour will still produce a warning, as this
+              behaviour is deprecated.  It is only available with the "rqbit" backend
+              to provide temporary support for users who are relying on the
+              previous incorrect behaviour.  For a warning-free evaluation, use
+              `flatten = true`.
+            ''
+          else if flatten == false then
+            ''
+              `fetchtorrent` with `flatten = false` is deprecated and will be
+              removed in a future release.
+            ''
+          else
+            throw "invalid value for flatten: must be true, false, or null"
+        ) [ rqbit ]
       else
         throw "rqbit or transmission are the only available backends for fetchtorrent"
     );

--- a/pkgs/build-support/fetchtorrent/default.nix
+++ b/pkgs/build-support/fetchtorrent/default.nix
@@ -116,8 +116,8 @@ runCommand name
     if (backend == "transmission") then
       ''
         export HOME=$TMP
-        export downloadedDirectory=$out/downloadedDirectory
-        mkdir -p $downloadedDirectory
+        mkdir -p $out
+        export downloadedDirectory=$(mktemp -d $out/downloadedDirectory.XXXXXXXXXX)
         mkdir -p $HOME/.config/transmission
         cp ${jsonConfig} $HOME/.config/transmission/settings.json
         port="$(shuf -n 1 -i 49152-65535)"
@@ -139,8 +139,8 @@ runCommand name
         export HOME=$TMP
       ''
       + lib.optionalString flatten' ''
-        downloadedDirectory=$out/downloadedDirectory
-        mkdir -p $downloadedDirectory
+        mkdir -p $out
+        downloadedDirectory=$(mktemp -d $out/downloadedDirectory.XXXXXXXXXX)
       ''
       + lib.optionalString (!flatten') ''
         downloadedDirectory=$out

--- a/pkgs/build-support/fetchtorrent/test-single-file.torrent
+++ b/pkgs/build-support/fetchtorrent/test-single-file.torrent
@@ -1,0 +1,1 @@
+d10:created by13:mktorrent 1.113:creation datei1772926249e4:infod6:lengthi1097e4:name7:COPYING12:piece lengthi262144e6:pieces20:€åÏÊ\c™èçæÉ\Q3Ní-e8:url-list96:https://raw.githubusercontent.com/NixOS/nixpkgs/3d82431ec4b51262989559b821b83abe4a9f6dbd/COPYINGe

--- a/pkgs/build-support/fetchtorrent/tests.nix
+++ b/pkgs/build-support/fetchtorrent/tests.nix
@@ -75,7 +75,7 @@ let
     );
 in
 # Seems almost but not quite worth using lib.mapCartesianProduct...
-builtins.mapAttrs (n: v: testers.invalidateFetcherByDrvHash fetchtorrentWithHash v) {
+(builtins.mapAttrs (n: v: testers.invalidateFetcherByDrvHash fetchtorrentWithHash v) {
   http-link = {
     inherit (http) url;
     inherit (flattened) postFetch;
@@ -140,4 +140,20 @@ builtins.mapAttrs (n: v: testers.invalidateFetcherByDrvHash fetchtorrentWithHash
   #  flatten = false;
   #  inherit (unflattened) postFetch;
   #};
+})
+// {
+  # Make sure we can download and "flatten" single-file torrents.
+  # We only test with transmission because we use a web-seed and rqbit
+  # doesn't support web-seeds.
+  single-file = fetchtorrent {
+    hash = "sha256-u5c/ZN5V79Jg1aN6spbui4OdhExsXjofk1JpvUdW7Ro=";
+    backend = "transmission";
+    flatten = true;
+    url = "${./test-single-file.torrent}";
+    meta = {
+      hydraPlatforms = [ ];
+      license = lib.licenses.mit;
+      description = "The license file for the Nixpkgs repository as of 7 March 2026";
+    };
+  };
 }

--- a/pkgs/build-support/fetchtorrent/tests.nix
+++ b/pkgs/build-support/fetchtorrent/tests.nix
@@ -94,16 +94,22 @@ builtins.mapAttrs (n: v: testers.invalidateFetcherByDrvHash fetchtorrentWithHash
     backend = "transmission";
     inherit (flattened) postFetch;
   };
-  http-link-rqbit = {
-    inherit (http) url;
-    backend = "rqbit";
-    inherit (flattened) postFetch;
-  };
-  magnet-link-rqbit = {
-    inherit (magnet) url;
-    backend = "rqbit";
-    inherit (flattened) postFetch;
-  };
+  #
+  # Disabled because these warn that flatten hasn't been explicitly
+  # set to true, and warnings are treated as failures in tests.
+  #
+  # Re-enable these tests when flatten defaults to true.
+  #
+  #http-link-rqbit = {
+  #  inherit (http) url;
+  #  backend = "rqbit";
+  #  inherit (flattened) postFetch;
+  #};
+  #magnet-link-rqbit = {
+  #  inherit (magnet) url;
+  #  backend = "rqbit";
+  #  inherit (flattened) postFetch;
+  #};
   http-link-rqbit-flattened = {
     inherit (http) url;
     backend = "rqbit";
@@ -116,16 +122,22 @@ builtins.mapAttrs (n: v: testers.invalidateFetcherByDrvHash fetchtorrentWithHash
     flatten = true;
     inherit (flattened) postFetch;
   };
-  http-link-rqbit-unflattened = {
-    inherit (http) url;
-    backend = "rqbit";
-    flatten = false;
-    inherit (unflattened) postFetch;
-  };
-  magnet-link-rqbit-unflattened = {
-    inherit (magnet) url;
-    backend = "rqbit";
-    flatten = false;
-    inherit (unflattened) postFetch;
-  };
+  #
+  # Disabled because these warn that `flatten = false` is deprecated
+  # and will be removed.
+  #
+  # Remove these when support for `flatten = false` is completely removed.
+  #
+  #http-link-rqbit-unflattened = {
+  #  inherit (http) url;
+  #  backend = "rqbit";
+  #  flatten = false;
+  #  inherit (unflattened) postFetch;
+  #};
+  #magnet-link-rqbit-unflattened = {
+  #  inherit (magnet) url;
+  #  backend = "rqbit";
+  #  flatten = false;
+  #  inherit (unflattened) postFetch;
+  #};
 }

--- a/pkgs/build-support/fetchtorrent/tests.nix
+++ b/pkgs/build-support/fetchtorrent/tests.nix
@@ -47,7 +47,7 @@ let
     pushd "$out" &&
     sha512sum --check --strict ${./test-hashes.sha512sum} &&
     sed 's/.*  //' ${./test-hashes.sha512sum} | xargs rm --verbose &&
-    popd
+    popd || exit 1
   '';
   unflattened.postFetch = ''
     pushd "$out" &&
@@ -56,7 +56,7 @@ let
     sed 's/.*  //' ${./test-hashes.sha512sum} | xargs rm --verbose &&
     popd &&
     rm --dir --verbose Sintel &&
-    popd
+    popd || exit 1
   '';
 
   fetchtorrentWithHash =


### PR DESCRIPTION
Previously, the flattening logic expected transmission/rqbit to download a directory of files. However, some torrents (ISOs, etc.) download a single file, not wrapped in a directory.

This patch fixes (and tests) that and:

1. Shares logic between rqbit and transmission as much as possible so I don't have to fix this bug twice.
2. Actually emits the rqbit flatten warnings.
3. Disables the tests that now emit warnings due to (2).
4. Makes the Sintel torrent tests to actually exit with a non-zero exit code on hash mismatch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
