### PR TITLE
multiviewer-for-f1: fix updateScript

### DIFF
--- a/pkgs/by-name/mu/multiviewer-for-f1/package.nix
+++ b/pkgs/by-name/mu/multiviewer-for-f1/package.nix
@@ -100,7 +100,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   passthru.updateScript = writeScript "update-multiviewer-for-f1" ''
     #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl common-updater-scripts
+    #!nix-shell -i bash -p curl jq common-updater-scripts
     set -eu -o pipefail
 
     # Get latest API for packages, store so we only make one request
@@ -114,10 +114,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     if [ "$version" != "${finalAttrs.version}" ]
     then
       # Pre-calculate package hash
-      hash=$(nix-prefetch-url --type sha256 $link)
+      hash=$(nix-hash --type sha256 --to-sri $(nix-prefetch-url --type sha256 $link))
 
       # Update ID and version in source
-      update-source-version ${finalAttrs.pname} "$id" --version-key=id
+      sed -i "s/id = \"[0-9]*\"/id = \"$id\"/" ${__curPos.file}
       update-source-version ${finalAttrs.pname} "$version" "$hash" --system=x86_64-linux
     fi
   '';


### PR DESCRIPTION
A number of mistakes in the updateScript [made it fail](https://nixpkgs-update-logs.nix-community.org/multiviewer-for-f1/2026-03-05.log).

This is related to #497318. Normally such a PR would have been generated automatically. We only realise now, as the first weekend of the season is entering Free Practice 3. With a bit of luck we can get things fixed before the first race day ;-)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I tested `nixpkgs-update` locally. Standard options do not really apply.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
