### PR TITLE
burp: 2.4.0 -> 3.2.0

### DIFF
--- a/pkgs/by-name/bu/burp/package.nix
+++ b/pkgs/by-name/bu/burp/package.nix
@@ -2,65 +2,52 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   autoreconfHook,
   pkg-config,
   acl,
   librsync,
   ncurses,
-  openssl_legacy,
+  openssl,
   zlib,
   uthash,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "burp";
-  version = "2.4.0";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "grke";
     repo = "burp";
     tag = finalAttrs.version;
-    hash = "sha256-y6kRd1jD6t+Q6d5t7W9MDuk+m2Iq1THQkP50PJwI7Nc=";
+    hash = "sha256-jZSrHq3dL9Za71E2k4UDTHe10ESAgkBy5bogY2AqtnM=";
   };
-
-  patches = [
-    # Pull upstream fix for ncurses-6.3 support
-    (fetchpatch {
-      name = "ncurses-6.3.patch";
-      url = "https://github.com/grke/burp/commit/1d6c931af7c11f164cf7ad3479781e8f03413496.patch";
-      hash = "sha256-dJn9YhFQWggoqD3hce7F1d5qHYogbPP6+NMqCpVbTpM=";
-    })
-    # Pull upstream fix for backup resuming
-    (fetchpatch {
-      name = "fix-resume.patch";
-      url = "https://github.com/grke/burp/commit/b5ed667f73805b5af9842bb0351f5af95d4d50b3.patch";
-      hash = "sha256-MT9D2thLgV4nT3LsIDHZp8sWQF2GlOENj0nkOQXZKuk=";
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
   ];
-  # use openssl_legacy due to burp-2.4.0 not supporting file encryption with openssl 3.0
-  # replace with 'openssl' once burp-3.x has been declared stable and this package upgraded
+
   buildInputs = [
     librsync
     ncurses
-    openssl_legacy
+    openssl
     zlib
     uthash
   ]
   ++ lib.optional (!stdenv.hostPlatform.isDarwin) acl;
 
-  configureFlags = [ "--localstatedir=/var" ];
+  configureFlags = [
+    "--sysconfdir=/etc/burp"
+    "--localstatedir=/var"
+  ];
 
   installFlags = [ "localstatedir=/tmp" ];
 
   meta = {
-    description = "BackUp and Restore Program";
+    description = "Backup and restore Program";
     homepage = "https://burp.grke.org";
+    changelog = "https://github.com/grke/burp/blob/${finalAttrs.version}/CHANGELOG";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [ arjan-s ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update burp to 3.2.0, which is [the newly recommended, stable version](https://github.com/grke/burp/releases/tag/3.2.0). Diff: [grke/burp@`2.4.0...3.2.0`](https://github.com/grke/burp/compare/2.4.0...3.2.0)

In the past, [previous updates were denied as it was not a recommended, stable version.](https://github.com/NixOS/nixpkgs/pull/399104#issuecomment-2809900852)

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
