### PR TITLE
fuse3: define alias on Darwin

### DIFF
--- a/pkgs/by-name/af/afflib/package.nix
+++ b/pkgs/by-name/af/afflib/package.nix
@@ -5,7 +5,6 @@
   zlib,
   curl,
   expat,
-  fuse,
   fuse3,
   openssl,
   autoreconfHook,
@@ -30,9 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
     expat
     openssl
     python3
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ fuse3 ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ fuse ];
+    fuse3
+  ];
+
+  env.CFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-DFUSE_DARWIN_ENABLE_EXTENSIONS=0";
 
   meta = {
     homepage = "http://afflib.sourceforge.net/";

--- a/pkgs/by-name/bt/btfs/disable-macfuse-extensions.patch
+++ b/pkgs/by-name/bt/btfs/disable-macfuse-extensions.patch
@@ -1,0 +1,31 @@
+diff --git a/src/btfs.cc b/src/btfs.cc
+index eaac245..6bae7c0 100644
+--- a/src/btfs.cc
++++ b/src/btfs.cc
+@@ -19,6 +19,10 @@ along with BTFS.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ #define FUSE_USE_VERSION 31
+ 
++#ifdef __APPLE__
++#define FUSE_DARWIN_ENABLE_EXTENSIONS 0
++#endif
++
+ #include <cstdlib>
+ #include <iostream>
+ #include <fstream>
+@@ -733,15 +737,9 @@ btfs_listxattr(const char *path, char *data, size_t len) {
+ 	return xattrslen;
+ }
+ 
+-#ifdef __APPLE__
+-static int
+-btfs_getxattr(const char *path, const char *key, char *value, size_t len,
+-		uint32_t position) {
+-#else
+ static int
+ btfs_getxattr(const char *path, const char *key, char *value, size_t len) {
+ 	uint32_t position = 0;
+-#endif
+ 	char xattr[16];
+ 	int xattrlen = 0;
+ 

--- a/pkgs/by-name/bt/btfs/package.nix
+++ b/pkgs/by-name/bt/btfs/package.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-JuofC4TpbZ56qiUrHeoK607YHVbwqwLGMIdUpsTm9Ic=";
   };
 
+  patches = [
+    # https://github.com/johang/btfs/pull/103
+    ./disable-macfuse-extensions.patch
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config

--- a/pkgs/by-name/di/dislocker/package.nix
+++ b/pkgs/by-name/di/dislocker/package.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
     mbedtls
   ];
 
+  env.CFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-DFUSE_DARWIN_ENABLE_EXTENSIONS=0";
+
   meta = {
     description = "Read BitLocker encrypted partitions in Linux";
     homepage = "https://github.com/Aorimn/dislocker";

--- a/pkgs/by-name/s3/s3backer/package.nix
+++ b/pkgs/by-name/s3/s3backer/package.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
       'AC_CHECK_DECLS(fdatasync)' ""
   '';
 
+  env.CFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-DFUSE_DARWIN_ENABLE_EXTENSIONS=0";
+
   meta = {
     homepage = "https://github.com/archiecobbs/s3backer";
     description = "FUSE-based single file backing store via Amazon S3";

--- a/pkgs/by-name/ss/sshfs-fuse/common.nix
+++ b/pkgs/by-name/ss/sshfs-fuse/common.nix
@@ -15,16 +15,12 @@
   docutils,
   makeWrapper,
   fuse3,
-  macfuse-stubs,
   glib,
   which,
   python3Packages,
   openssh,
 }:
 
-let
-  fuse = if stdenv.hostPlatform.isDarwin then macfuse-stubs.override { isFuse3 = true; } else fuse3;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "sshfs-fuse";
   inherit version;
@@ -46,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
   ];
   buildInputs = [
-    fuse
+    fuse3
     glib
   ];
   nativeCheckInputs = [
@@ -75,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   checkPhase = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     # The tests need fusermount:
     mkdir bin
-    cp ${fuse}/bin/fusermount3 bin/fusermount
+    cp ${fuse3}/bin/fusermount3 bin/fusermount
     export PATH=bin:$PATH
     # Can't access /dev/fuse within the sandbox: "FUSE kernel module does not seem to be loaded"
     substituteInPlace test/util.py --replace "/dev/fuse" "/dev/null"

--- a/pkgs/by-name/ss/sshfs-fuse/common.nix
+++ b/pkgs/by-name/ss/sshfs-fuse/common.nix
@@ -15,6 +15,7 @@
   docutils,
   makeWrapper,
   fuse3,
+  macfuse-stubs,
   glib,
   which,
   python3Packages,

--- a/pkgs/development/python-modules/pyfuse3/default.nix
+++ b/pkgs/development/python-modules/pyfuse3/default.nix
@@ -62,5 +62,6 @@ buildPythonPackage rec {
       dotlambda
     ];
     changelog = "https://github.com/libfuse/pyfuse3/blob/${src.tag}/Changes.rst";
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8616,7 +8616,7 @@ with pkgs;
   );
   fuse = fuse2;
   fuse2 = lowPrio (if stdenv.hostPlatform.isDarwin then macfuse-stubs else fusePackages.fuse_2);
-  fuse3 = fusePackages.fuse_3;
+  fuse3 = lowPrio (if stdenv.hostPlatform.isDarwin then macfuse-stubs.override { isFuse3 = true; } else fusePackages.fuse_3);
 
   gpm-ncurses = gpm.override { withNcurses = true; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8616,7 +8616,12 @@ with pkgs;
   );
   fuse = fuse2;
   fuse2 = lowPrio (if stdenv.hostPlatform.isDarwin then macfuse-stubs else fusePackages.fuse_2);
-  fuse3 = lowPrio (if stdenv.hostPlatform.isDarwin then macfuse-stubs.override { isFuse3 = true; } else fusePackages.fuse_3);
+  fuse3 = lowPrio (
+    if stdenv.hostPlatform.isDarwin then
+      macfuse-stubs.override { isFuse3 = true; }
+    else
+      fusePackages.fuse_3
+  );
 
   gpm-ncurses = gpm.override { withNcurses = true; };
 


### PR DESCRIPTION
Now that macfuse-stubs supports FUSE3, update the fuse3 alias in all-package.nix to use it. This allows some additional packages (afflib, btfs, dislocker, and s3backer) to be built with fuse3 on Darwin, though most of them also need `-DFUSE_DARWIN_ENABLE_EXTENSIONS=0`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
