### PR TITLE
nixosTests: fix and re-enable broken aarch64 tests

### DIFF
--- a/nixos/tests/common/wayland-cage.nix
+++ b/nixos/tests/common/wayland-cage.nix
@@ -8,6 +8,6 @@
   };
 
   virtualisation = {
-    qemu.options = [ "-vga virtio" ];
+    qemu.options = [ "-vga none -device virtio-gpu-pci" ];
   };
 }

--- a/nixos/tests/drawterm.nix
+++ b/nixos/tests/drawterm.nix
@@ -27,7 +27,10 @@ let
           imports = [ ./common/wayland-cage.nix ];
           services.cage.program = "${pkgs.drawterm-wayland}/bin/drawterm";
         };
-      systems = [ "x86_64-linux" ];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
     };
   };
 

--- a/nixos/tests/dwl.nix
+++ b/nixos/tests/dwl.nix
@@ -23,9 +23,6 @@
       services.displayManager.defaultSession = lib.mkForce "dwl";
 
       programs.dwl.enable = true;
-
-      # Need to switch to a different GPU driver than the default one (-vga std) so that dwl works on aarch64-linux
-      virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
     };
 
   testScript = ''

--- a/nixos/tests/freetube.nix
+++ b/nixos/tests/freetube.nix
@@ -35,8 +35,6 @@ let
           "${name}" = machine;
         };
         meta.maintainers = with pkgs.lib.maintainers; [ kirillrdy ];
-        # time-out on ofborg
-        meta.broken = pkgs.stdenv.hostPlatform.isAarch64;
         enableOCR = true;
 
         testScript = ''

--- a/nixos/tests/initrd-secrets-changing.nix
+++ b/nixos/tests/initrd-secrets-changing.nix
@@ -18,6 +18,7 @@ testing.makeTest {
     { ... }:
     {
       virtualisation.useBootLoader = true;
+      virtualisation.useEFIBoot = true;
 
       boot.loader.grub.device = "/dev/vda";
 

--- a/nixos/tests/initrd-secrets.nix
+++ b/nixos/tests/initrd-secrets.nix
@@ -12,15 +12,11 @@ let
     testing.makeTest {
       name = "initrd-secrets-${compressor}";
 
-      meta = {
-        maintainers = [ ];
-        broken = pkgs.stdenv.hostPlatform.isAarch64;
-      };
-
       nodes.machine =
         { ... }:
         {
           virtualisation.useBootLoader = true;
+          virtualisation.useEFIBoot = true;
           boot.initrd.secrets = {
             "/test" = secretInStore;
 

--- a/nixos/tests/systemd-initrd-luks-unl0kr.nix
+++ b/nixos/tests/systemd-initrd-luks-unl0kr.nix
@@ -31,7 +31,7 @@ in
         mountHostNixStore = true;
         useEFIBoot = true;
         qemu.options = [
-          "-vga virtio"
+          "-vga none -device virtio-gpu-pci"
         ];
       };
       boot.loader.systemd-boot.enable = true;


### PR DESCRIPTION
These tests were failing and/or marked broken because:

1. `-vga virtio` doesn't work on aarch64.
2. Similarly, aarch64 requires EFI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
