### PR TITLE
iproute2mac: 1.6.0 -> 1.7.2

### DIFF
--- a/pkgs/by-name/ip/iproute2mac/package.nix
+++ b/pkgs/by-name/ip/iproute2mac/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "iproute2mac";
-  version = "1.6.0";
+  version = "1.7.2";
 
   src = fetchFromGitHub {
     owner = "brona";
     repo = "iproute2mac";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-aemeZnZlnmIKdLz5Myjn51dYTvfovFPQeytJbNxbI4E=";
+    hash = "sha256-EmuMF1hvS8wqhimBZ+Nyo+ChPG5FtbbGciquHl54j8k=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -39,8 +39,10 @@ stdenv.mkDerivation (finalAttrs: {
     install -D -m 755 src/iproute2mac.py $out/libexec/iproute2mac.py
     install -D -m 755 src/ip.py $out/libexec/ip
     install -D -m 755 src/bridge.py $out/libexec/bridge
+    install -D -m 755 src/ss.py $out/libexec/ss
     makeWrapper $out/libexec/ip $out/bin/ip
     makeWrapper $out/libexec/bridge $out/bin/bridge
+    makeWrapper $out/libexec/ss $out/bin/ss
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
