### PR TITLE
edk2: Fix cross-compile

### DIFF
--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -182,8 +182,6 @@ stdenv.mkDerivation (finalAttrs: {
           ++ attrs.nativeBuildInputs or [ ];
           strictDeps = true;
 
-          env.${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
-
           prePatch = ''
             rm -rf BaseTools
             ln -sv ${buildPackages.edk2}/BaseTools BaseTools
@@ -211,7 +209,14 @@ stdenv.mkDerivation (finalAttrs: {
         // removeAttrs attrs [
           "nativeBuildInputs"
           "depsBuildBuild"
+          "env"
         ]
+        // {
+          env = {
+            ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
+          }
+          // (attrs.env or { });
+        }
       );
   };
 })


### PR DESCRIPTION
  deep-merge env in mkDerivation to preserve GCC5 prefix

  The shallow `//` merge in edk2.mkDerivation allowed consumers' `env`
  attrs to completely overwrite the base `env` containing GCC5_*_PREFIX,
  causing cross-compilation failures (e.g. x86_64 -> aarch64 OVMF) with
  `gcc: error: unrecognized command-line option '-mlittle-endian'`.

  Exclude `env` from the consumer attrs spread and explicitly deep-merge
  it, ensuring GCC5_*_PREFIX is always set as a base while consumer `env`
  keys (NIX_CFLAGS_COMPILE, PYTHON_COMMAND, etc.) are merged on top.

  Fixes regression from c7b9734f4ae8 ("edk2: move env variable(s) into
  env for structuredAttrs").


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
