### PR TITLE
azure-cli-extensions.application-insights: relax isodate dependency

### DIFF
--- a/pkgs/by-name/az/azure-cli/extensions-manual.nix
+++ b/pkgs/by-name/az/azure-cli/extensions-manual.nix
@@ -73,6 +73,7 @@
     url = "https://azcliprod.blob.core.windows.net/cli-extensions/application_insights-${version}-py2.py3-none-any.whl";
     hash = "sha256-4akS+zbaKxFrs0x0uKP/xX28WyK5KLduOkgZaBYeANM=";
     description = "Support for managing Application Insights components and querying metrics, events, and logs from such components";
+    pythonRelaxDeps = [ "isodate" ];
     propagatedBuildInputs = with python3Packages; [ isodate ];
     meta.maintainers = with lib.maintainers; [ andreasvoss ];
   };


### PR DESCRIPTION
## Description

The `application-insights` extension for `azure-cli` requires `isodate~=0.6.0` but nixpkgs now has `isodate 0.7.2` since commit ed0818973867f0870d1bbf71289fb8675b7d981d.

This causes build failures:
```
Checking runtime dependencies for application_insights-2.0.0b1-py2.py3-none-any.whl
  - isodate~=0.6.0 not satisfied by version 0.7.2
```

All upstream versions (0.1.x through 2.0.0b1) have this strict constraint, and upstream hasn't updated it.

## Solution

Add `pythonRelaxDeps = [ "isodate" ];` to relax the version constraint, similar to the fix applied for `pysolcast` in commit fd08a22f9f94ca2a259a876bc63acfbda0c35090.

## Testing

- [x] Verified that the extension definition follows existing patterns in `extensions-manual.nix`
- [x] `pythonRelaxDeps` is already used by other extensions in this file (`confcom`, `ssh`)

Fixes #497475

---
*Investigation and fix assisted by Claude Opus 4.5*