### PR TITLE
qiec104: init at 1.1.1

### DIFF
--- a/pkgs/by-name/qi/qiec104/package.nix
+++ b/pkgs/by-name/qi/qiec104/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  copyDesktopItems,
+  makeDesktopItem,
+  qt5,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qiec104";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "MicroKoder";
+    repo = "QIEC104";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/kIAWxeJATKSEqXfRA3/6+TbHVeaIWZqsMYumvj2OuU=";
+  };
+
+  nativeBuildInputs = [
+    qt5.qmake
+    qt5.wrapQtAppsHook
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux copyDesktopItems;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "qiec104";
+      desktopName = "Q104";
+      comment = finalAttrs.meta.description;
+      exec = finalAttrs.meta.mainProgram;
+      icon = "Q104";
+      terminal = false;
+      categories = [ "Utility" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      install -Dm755 Q104 -t $out/bin
+      install -Dm644 icons/Q104.png -t $out/share/icons/hicolor/128x128/apps
+    ''}
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/{Applications,bin}
+      mv Q104.app $out/Applications
+      ln -s $out/Applications/Q104.app/Contents/MacOS/Q104 $out/bin/Q104
+    ''}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Small IEC104 client";
+    homepage = "https://github.com/MicroKoder/QIEC104";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sikmir ];
+    platforms = lib.platforms.unix;
+    mainProgram = "Q104";
+  };
+})


### PR DESCRIPTION
https://github.com/MicroKoder/QIEC104
> QIEC104 is a modern client for the IEC 60870-5-104 protocol, specifically designed for specialists in Supervisory Control and Data Acquisition (SCADA) systems.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
