### PR TITLE
tclPackages.mkTclDerivation: enable stubs by default

### DIFF
--- a/doc/languages-frameworks/tcl.section.md
+++ b/doc/languages-frameworks/tcl.section.md
@@ -13,7 +13,8 @@ Tcl packages are typically built with `tclPackages.mkTclDerivation`.
 Tcl dependencies go in `buildInputs`/`nativeBuildInputs`/... like other packages.
 For more complex package definitions, such as packages with mixed languages, use `tcl.tclPackageHook`.
 
-Where possible, make sure to enable stubs for maximum compatibility, usually with the `--enable-stubs` configure flag.
+Where possible, make sure to enable stubs for maximum compatibility.
+If you are using `mkTclDerivation`, `--enable-stubs` will be automatically added to `configureFlags`.
 
 Here is a simple package example to be called with `tclPackages.callPackage`.
 
@@ -33,7 +34,6 @@ mkTclDerivation rec {
 
   configureFlags = [
     "--with-ssl-dir=${openssl.dev}"
-    "--enable-stubs"
   ];
 
   meta = {

--- a/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
+++ b/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
@@ -37,6 +37,8 @@ let
     "--with-tcl=${tcl}/lib"
     "--with-tclinclude=${tcl}/include"
     "--exec-prefix=${placeholder "out"}"
+    # Enable stubs by default for compatibility across minor versions
+    "--enable-stubs"
   ];
 
   self = (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (also built tclPackages.*, no new broken packages)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
