### PR TITLE
python3Packages.pytest-insta: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/pytest-insta/default.nix
+++ b/pkgs/development/python-modules/pytest-insta/default.nix
@@ -4,23 +4,30 @@
   fetchFromGitHub,
   pytest,
   pytestCheckHook,
+  uv-build,
   wrapt,
-  poetry-core,
 }:
 
 buildPythonPackage rec {
   pname = "pytest-insta";
-  version = "0.3.0";
+  version = "0.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "vberlier";
     repo = pname;
     tag = "v${version}";
-    hash = "sha256-kXsKM84yXdGE89KxUtxT2mINmS2lXkuEqB6a9oXZqGo=";
+    hash = "sha256-zOhWDaCGkE/Ke2MLRyttDH85t+I9kfBZZwVDRN1sprs=";
   };
 
-  build-system = [ poetry-core ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.9.8,<0.10.0" "uv_build"
+  '';
+
+  pythonRelaxDeps = [ "wrapt" ];
+
+  build-system = [ uv-build ];
 
   buildInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/pytest-insta/default.nix
+++ b/pkgs/development/python-modules/pytest-insta/default.nix
@@ -8,7 +8,7 @@
   wrapt,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: rec {
   pname = "pytest-insta";
   version = "0.4.1";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "vberlier";
     repo = pname;
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-zOhWDaCGkE/Ke2MLRyttDH85t+I9kfBZZwVDRN1sprs=";
   };
 
@@ -40,8 +40,8 @@ buildPythonPackage rec {
   meta = {
     description = "Pytest plugin for snapshot testing";
     homepage = "https://github.com/vberlier/pytest-insta";
-    changelog = "https://github.com/vberlier/pytest-insta/blob/v${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/vberlier/pytest-insta/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/pytest-insta/default.nix
+++ b/pkgs/development/python-modules/pytest-insta/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest,
+  pytestCheckHook,
+  wrapt,
+  poetry-core,
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-insta";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "vberlier";
+    repo = pname;
+    tag = "v${version}";
+    hash = "sha256-kXsKM84yXdGE89KxUtxT2mINmS2lXkuEqB6a9oXZqGo=";
+  };
+
+  build-system = [ poetry-core ];
+
+  buildInputs = [ pytest ];
+
+  dependencies = [ wrapt ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pytest_insta" ];
+
+  meta = {
+    description = "Pytest plugin for snapshot testing";
+    homepage = "https://github.com/vberlier/pytest-insta";
+    changelog = "https://github.com/vberlier/pytest-insta/blob/v${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15203,6 +15203,8 @@ self: super: with self; {
 
   pytest-image-diff = callPackage ../development/python-modules/pytest-image-diff { };
 
+  pytest-insta = callPackage ../development/python-modules/pytest-insta { };
+
   pytest-instafail = callPackage ../development/python-modules/pytest-instafail { };
 
   pytest-integration = callPackage ../development/python-modules/pytest-integration { };


### PR DESCRIPTION
Breakouts some commits from https://github.com/NixOS/nixpkgs/pull/487341

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
