### PR TITLE
guile-zlib: fix path to zlib

### DIFF
--- a/pkgs/by-name/gu/guile-zlib/guile-zlib-change-zlib-path-from-libdir-to-sharedlibdir.diff
+++ b/pkgs/by-name/gu/guile-zlib/guile-zlib-change-zlib-path-from-libdir-to-sharedlibdir.diff
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -30,7 +30,7 @@ fi
+ 
+ PKG_CHECK_MODULES([LIBZ], [zlib])
+ AC_MSG_CHECKING([libz library directory])
+-PKG_CHECK_VAR([LIBZ_LIBDIR], [zlib], [libdir])
++PKG_CHECK_VAR([LIBZ_LIBDIR], [zlib], [sharedlibdir])
+ AC_MSG_RESULT([$LIBZ_LIBDIR])
+ AS_IF([test "x$LIBZ_LIBDIR" = "x"], [
+   AC_MSG_FAILURE([Unable to identify libz lib path.])

--- a/pkgs/by-name/gu/guile-zlib/package.nix
+++ b/pkgs/by-name/gu/guile-zlib/package.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-aaZhwHimQq408DNtHy442kh/EYdRdxP0Z1tQGDKmkmc=";
   };
 
+  patches = [
+    # fix path to libz.so to sharedlibdir from zlib.pc
+    ./guile-zlib-change-zlib-path-from-libdir-to-sharedlibdir.diff
+  ];
+
   strictDeps = true;
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
- add patch changing path to `libz.so` from `libdir` to `sharedlibdir`
variable from `zlib.pc`

In `guile-zlib` default way of finding `libz.so` is to load `zlib.pc`
with `PKG_CHECK_MODULES` macro and take path from `libdir` variable
inside.

After change in:
https://github.com/NixOS/nixpkgs/pull/476830
https://github.com/NixOS/nixpkgs/commit/ff59162e8205c085455b4863d8b871515cbf1bfd
`libdir` variable in `zlib.pc` points to `zlib.static`, so only `libz.a`
is there.
Add patch fixing `configure.ac` to load path from `sharedlibdir` instead.

Fixes build failure of `guile-zlib`:
```
make  check-TESTS
make[1]: Entering directory '/build/source'
make[2]: Entering directory '/build/source'
make[2]: *** [Makefile:873: tests/zlib.log] Error 1
make[2]: Leaving directory '/build/source'
make[1]: *** [Makefile:856: check-TESTS] Error 2
make[1]: Leaving directory '/build/source'
make: *** [Makefile:1059: check-am] Error 2
```

zlib.log:
```
Backtrace:
          19 (primitive-load-path "tests/zlib.scm")
...
In unknown file:
           2 (primitive-load-path "zlib" #<procedure 7fffeee418c0 at
ice-9/boot-9.scm:3603:37 ()>)
In zlib.scm:
   486:25  1 (_)
   486:25  0 (_)

zlib.scm:486:25: Wrong type to apply: #f
```

---

See comments in https://github.com/NixOS/nixpkgs/pull/494567 for extra context.

Fixes #493503

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
