### PR TITLE
python3Packages.pyghidra: init at 3.0.2

### DIFF
--- a/pkgs/development/python-modules/pyghidra/default.nix
+++ b/pkgs/development/python-modules/pyghidra/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  jpype1,
+  packaging,
+  pytest-datadir,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyghidra";
+  version = "3.0.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-ea1P1XHjLzQ88/zb2E/G4zPvGiZHWjqPcrYpqfPIedo=";
+  };
+
+  pythonRelaxDeps = [ "jpype1" ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    jpype1
+    packaging
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-datadir
+  ];
+
+  pythonImportsCheck = [ "pyghidra" ];
+
+  disabledTests = [
+    # Tests require a Ghidra instance
+    "test_import_ghidra_base_java_packages"
+    "test_import_script"
+    "test_invalid_jpype_keyword_arg"
+    "test_invalid_loader_type"
+    "test_invalid_vm_arg_succeed"
+    "test_loader"
+    "test_no_compiler"
+    "test_no_language_with_compiler"
+    "test_no_program"
+    "test_no_project"
+    "test_open_program"
+    "test_run_script"
+  ];
+
+  meta = {
+    description = "Native CPython for Ghidra";
+    homepage = "https://pypi.org/project/pyghidra";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13722,6 +13722,8 @@ self: super: with self; {
 
   pygetwindow = callPackage ../development/python-modules/pygetwindow { };
 
+  pyghidra = callPackage ../development/python-modules/pyghidra { };
+
   pyghmi = callPackage ../development/python-modules/pyghmi { };
 
   pygit2 = callPackage ../development/python-modules/pygit2 { };


### PR DESCRIPTION
Native CPython for Ghidra

https://pypi.org/project/pyghidra

Will be needed to fix the python3Packages.libbs failure

Related #487341
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
