### PR TITLE
gpg-tui: init at 0.11.1

### DIFF
--- a/pkgs/by-name/gp/gpg-tui/package.nix
+++ b/pkgs/by-name/gp/gpg-tui/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  pkg-config,
+  gpgme,
+  libgpg-error,
+  libxcb,
+  libxkbcommon,
+  stdenv,
+  darwin,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gpg-tui";
+  version = "0.11.1";
+
+  src = fetchFromGitHub {
+    owner = "orhun";
+    repo = "gpg-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qGm0eHpVFGn8tNdEnmQ4oIfjCxyixMFYdxih7pHvGH0=";
+  };
+
+  cargoHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      gpgme
+      libgpg-error
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libxcb
+      libxkbcommon
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.apple_sdk.frameworks.AppKit
+    ];
+
+  # tests require gpg-agent with a running keyring
+  doCheck = false;
+
+  postInstall = ''
+    installManPage man/gpg-tui.1 man/gpg-tui.toml.5
+
+    mkdir -p completions
+    OUT_DIR=completions $out/bin/gpg-tui-completions
+    installShellCompletion \
+      completions/gpg-tui.{bash,fish} \
+      --zsh completions/_gpg-tui
+
+    rm -f $out/bin/gpg-tui-completions
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Manage your GnuPG keys with ease!";
+    homepage = "https://github.com/orhun/gpg-tui";
+    changelog = "https://github.com/orhun/gpg-tui/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "gpg-tui";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description

Add [gpg-tui](https://github.com/orhun/gpg-tui), a Terminal User Interface for GnuPG.

It aims to ease key management operations such as listing, exporting, and signing GPG keys by providing a rich TUI interface, with command-line fallback for more complex operations.

- **Version:** 0.11.1
- **License:** MIT
- **Homepage:** https://github.com/orhun/gpg-tui

### Features
- List/export/sign/edit/trust GPG keys from a TUI
- Shell completions (bash, fish, zsh)
- Man pages included
- Automated update via `nix-update-script`

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside nixos/tests)
- [ ] Tested compilation of all pkgs that depend on this change using `nixpkgs-review`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

> **Note:** `cargoHash` is a placeholder pending build completion. Will update shortly.