### PR TITLE
Revert "python3Packages.batinfo: 0.4.2 -> 2.0"

### DIFF
--- a/pkgs/development/python-modules/batinfo/default.nix
+++ b/pkgs/development/python-modules/batinfo/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "batinfo";
-  version = "2.0";
+  version = "0.4.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nicolargo";
     repo = "batinfo";
     tag = "v${version}";
-    hash = "sha256-7oR8FRnl6reFHKPf49ZH3zQIjgOX1KTOxb3aCRNYOSg=";
+    hash = "sha256-GgAJJA8bzQJLAU+nxmkDa5LFTHc4NGi+nj9PfKyw8/M=";
   };
 
   postPatch = ''
@@ -35,6 +35,11 @@ buildPythonPackage rec {
     "test_batinfo_charge_now"
     "test_batinfo_name_default"
   ];
+
+  passthru = {
+    # Upstream has a broken 2.0 tag that causes this package to get downgraded to 0.2
+    skipBulkUpdate = true;
+  };
 
   meta = {
     description = "Module to retrieve battery information";


### PR DESCRIPTION
This is a broken tag. 2.0 actually refers to 0.2. The latest version is
0.4.2

Because of this bulk updates should be skipped for this package.

This reverts commit d246e946ce821f48d0dc65fe5fa9de428c98fc7f.

CC @mweinelt

See https://github.com/nicolargo/batinfo/blob/v0.4.2/NEWS
vs https://github.com/nicolargo/batinfo/blob/v2.0/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
