### PR TITLE
{openssl_3_5,openssl_3_6}: Fix ELF ABI mismatch on powerpc64

### DIFF
--- a/pkgs/development/libraries/openssl/3.5/openssl-aes-gcm-ppc-remove-localentry-directive.patch
+++ b/pkgs/development/libraries/openssl/3.5/openssl-aes-gcm-ppc-remove-localentry-directive.patch
@@ -1,0 +1,65 @@
+From 5aaa7e5fdc59e88a13d2911cb86d814d4e2669da Mon Sep 17 00:00:00 2001
+From: Danny Tsen <dtsen@us.ibm.com>
+Date: Wed, 28 Jan 2026 07:23:13 -0500
+Subject: [PATCH] aes-gcm-ppc.pl: Removed .localentry directive
+
+Otherwise there is mixing of  ELFv1 ABI and ELFv2 ABI directives
+and PPC64 big endian builds fail.
+
+Fixes #29815
+
+Signed-off-by: Danny Tsen <dtsen@us.ibm.com>
+
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+Reviewed-by: Shane Lontis <shane.lontis@oracle.com>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+MergeDate: Tue Feb  3 08:39:50 2026
+(Merged from https://github.com/openssl/openssl/pull/29827)
+---
+ crypto/modes/asm/aes-gcm-ppc.pl | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/crypto/modes/asm/aes-gcm-ppc.pl b/crypto/modes/asm/aes-gcm-ppc.pl
+index 68918a9305a2b..fd5dcc22a6117 100644
+--- a/crypto/modes/asm/aes-gcm-ppc.pl
++++ b/crypto/modes/asm/aes-gcm-ppc.pl
+@@ -409,7 +409,6 @@
+ ################################################################################
+ .align 4
+ aes_gcm_crypt_1x:
+-.localentry	aes_gcm_crypt_1x,0
+ 
+ 	cmpdi	5, 16
+ 	bge	__More_1x
+@@ -492,7 +491,6 @@
+ ################################################################################
+ .align 4
+ __Process_partial:
+-.localentry	__Process_partial,0
+ 
+ 	# create partial mask
+ 	vspltisb 16, -1
+@@ -564,7 +562,6 @@
+ .global ppc_aes_gcm_encrypt
+ .align 5
+ ppc_aes_gcm_encrypt:
+-.localentry     ppc_aes_gcm_encrypt,0
+ 
+ 	SAVE_REGS
+ 	LOAD_HASH_TABLE
+@@ -752,7 +749,6 @@
+ .global ppc_aes_gcm_decrypt
+ .align 5
+ ppc_aes_gcm_decrypt:
+-.localentry	ppc_aes_gcm_decrypt, 0
+ 
+ 	SAVE_REGS
+ 	LOAD_HASH_TABLE
+@@ -1032,7 +1028,6 @@
+ .size   ppc_aes_gcm_decrypt,.-ppc_aes_gcm_decrypt
+ 
+ aes_gcm_out:
+-.localentry	aes_gcm_out,0
+ 
+ 	mr	3, 11			# return count
+ 

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -482,6 +482,10 @@ in
         else
           ./3.5/use-etc-ssl-certs.patch
       )
+
+      # Don't cause ELF ABI mismatch on powerpc64
+      # https://github.com/openssl/openssl/issues/29815
+      ./3.5/openssl-aes-gcm-ppc-remove-localentry-directive.patch
     ]
     ++ lib.optionals stdenv.hostPlatform.isMinGW [
       ./3.5/fix-mingw-linking.patch
@@ -518,6 +522,10 @@ in
         else
           ./3.5/use-etc-ssl-certs.patch
       )
+
+      # Don't cause ELF ABI mismatch on powerpc64
+      # https://github.com/openssl/openssl/issues/29815
+      ./3.5/openssl-aes-gcm-ppc-remove-localentry-directive.patch
     ]
     ++ lib.optionals stdenv.hostPlatform.isMinGW [
       ./3.5/fix-mingw-linking.patch


### PR DESCRIPTION
https://github.com/openssl/openssl/issues/29815

https://hydra.nixos.org/build/322814546/nixlog/13

```
/nix/store/a1w3nk4d22gccnfijcjljvf8s2hak0w2-powerpc64-unknown-linux-gnuabielfv1-binutils-2.44/bin/powerpc64-unknown-linux-gnuabielfv1-ld: crypto/modes/libcrypto-shlib-aes-gcm-ppc.o: ABI version 2 is not compatible with ABI version 1 output
/nix/store/a1w3nk4d22gccnfijcjljvf8s2hak0w2-powerpc64-unknown-linux-gnuabielfv1-binutils-2.44/bin/powerpc64-unknown-linux-gnuabielfv1-ld: failed to merge target specific data of file crypto/modes/libcrypto-shlib-aes-gcm-ppc.o
```

Fixes `openssl_3_5` and `openssl_3_6` for `ppc64-elfv1`, both cross & native.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux (native & cross))
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
