### PR TITLE
kanshi: 1.8.0 -> 1.9.0, nixos/kanshi: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16044,6 +16044,11 @@
     githubId = 401263;
     keys = [ { fingerprint = "1147 43F1 E707 6F3E 6F4B  2C96 B9A8 B592 F126 F8E8"; } ];
   };
+  macaquinyho = {
+    github = "macaquinyho";
+    githubId = 14185777;
+    name = "Arnau Valls";
+  };
   macbucheron = {
     name = "Nathan Deprat";
     github = "Macbucheron1";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -346,6 +346,7 @@
   ./programs/wayland/gtklock.nix
   ./programs/wayland/hyprland.nix
   ./programs/wayland/hyprlock.nix
+  ./programs/wayland/kanshi.nix
   ./programs/wayland/labwc.nix
   ./programs/wayland/mangowc.nix
   ./programs/wayland/miracle-wm.nix

--- a/nixos/modules/programs/wayland/kanshi.nix
+++ b/nixos/modules/programs/wayland/kanshi.nix
@@ -1,0 +1,46 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.kanshi;
+in
+{
+  options.services.kanshi = {
+    enable = lib.mkEnableOption "kanshi, a Wayland daemon that automatically configures outputs";
+    package = lib.mkPackageOption pkgs "kanshi" { };
+    systemd.target = lib.mkOption {
+      type = lib.types.str;
+      description = ''
+        The systemd target that will automatically start the Kanshi service.
+      '';
+      default = "graphical-session.target";
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.kanshi ];
+
+    systemd.user.services.kanshi = {
+      unitConfig = {
+        Description = "Dynamic output configuration";
+        Documentation = "man:kanshi(1)";
+        ConditionEnvironment = "WAYLAND_DISPLAY";
+        PartOf = cfg.systemd.target;
+        Requires = cfg.systemd.target;
+        After = cfg.systemd.target;
+      };
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${lib.getExe cfg.package}";
+        Restart = "always";
+      };
+
+      wantedBy = [ cfg.systemd.target ];
+    };
+  };
+  meta.maintainers = [ lib.maintainers.macaquinyho ];
+}

--- a/pkgs/by-name/ka/kanshi/package.nix
+++ b/pkgs/by-name/ka/kanshi/package.nix
@@ -8,20 +8,21 @@
   scdoc,
   wayland,
   wayland-scanner,
-  libvarlink,
+  vali,
   libscfg,
+  cmake,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kanshi";
-  version = "1.8.0";
+  version = "1.9.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "emersion";
     repo = "kanshi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-90FnVtiYR8AEAddIQe9sfgQDMO8OqlQ8fNy/nJsbhKs=";
+    hash = "sha256-F6wyNFygU3uPBliDPOp5EdTeCx/5ZulnC9MOqYtiVQw=";
   };
 
   strictDeps = true;
@@ -40,8 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     wayland
-    libvarlink
     libscfg
+    vali
   ];
 
   meta = {

--- a/pkgs/by-name/va/vali/package.nix
+++ b/pkgs/by-name/va/vali/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  pkg-config,
+  aml,
+  json_c,
+  ninja,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vali";
+  version = "0.1.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "emersion";
+    repo = "vali";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-u7tJi3qHT2HEMa+E9RwcvRyrLuBA5o14ID8Kl3xkzHc=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+  ];
+  propagatedBuildInputs = [
+    json_c
+    aml
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "A C library and code generator for Varlink";
+    mainProgram = "vali";
+    homepage = "https://gitlab.freedesktop.org/emersion/vali";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.macaquinyho ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
1.9.0 replaces `libvarlink` with `vali`, this PR adds the `vali` package.
Diff from 1.8.0 to 1.9.0 https://gitlab.freedesktop.org/emersion/kanshi/-/compare/v1.8.0...v1.9.0?from_project_id=24496

Also add a new module for kanshi

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
