### PR TITLE
protobuf_25: fix GCC 15 compatibility

### DIFF
--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -85,6 +85,10 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail \
           '#define UPB_LINKARR_SENTINEL UPB_RETAIN __attribute__((weak, used))' \
           '#define UPB_LINKARR_SENTINEL            __attribute__((weak, used))'
+    ''
+    # Fix gcc15 build failures due to missing <cstring>
+    + lib.optionalString ((lib.versions.major version) == "25") ''
+      sed -i '1i #include <cstring>' third_party/utf8_range/utf8_validity.cc
     '';
 
   preHook = ''

--- a/pkgs/development/python-modules/protobuf/4.nix
+++ b/pkgs/development/python-modules/protobuf/4.nix
@@ -51,23 +51,24 @@ buildPythonPackage {
     fi
   '';
 
-  # Remove the line in setup.py that forces compiling with C++14. Upstream's
-  # CMake build has been updated to support compiling with other versions of
-  # C++, but the Python build has not. Without this, we observe compile-time
-  # errors using GCC.
-  #
-  # Fedora appears to do the same, per this comment:
-  #
-  #   https://github.com/protocolbuffers/protobuf/issues/12104#issuecomment-1542543967
-  #
-  postPatch = ''
-    sed -i "/extra_compile_args.append('-std=c++14')/d" setup.py
-
+  postPatch =
+    # Remove the line in setup.py that forces compiling with C++14. Upstream's
+    # CMake build has been updated to support compiling with other versions of
+    # C++, but the Python build has not. Without this, we observe compile-time
+    # errors using GCC.
+    #
+    # Fedora appears to do the same, per this comment:
+    #
+    #   https://github.com/protocolbuffers/protobuf/issues/12104#issuecomment-1542543967
+    ''
+      sed -i "/extra_compile_args.append('-std=c++14')/d" setup.py
+    ''
     # The former function has been renamed into the latter in Python 3.12.
     # Does not apply to all protobuf versions, hence --replace-warn.
-    substituteInPlace google/protobuf/internal/json_format_test.py \
-      --replace-warn assertRaisesRegexp assertRaisesRegex
-  '';
+    + ''
+      substituteInPlace google/protobuf/internal/json_format_test.py \
+        --replace-warn assertRaisesRegexp assertRaisesRegex
+    '';
 
   nativeBuildInputs = lib.optional isPyPy tzdata;
 
@@ -85,21 +86,29 @@ buildPythonPackage {
   ]
   ++ lib.optionals (lib.versionAtLeast protobuf.version "22") [ numpy ];
 
-  disabledTests =
-    lib.optionals isPyPy [
-      # error message differs
-      "testInvalidTimestamp"
-      # requires tracemalloc which pypy does not implement
-      # https://foss.heptapod.net/pypy/pypy/-/issues/3048
-      "testUnknownFieldsNoMemoryLeak"
-      # assertion is not raised for some reason
-      "testStrictUtf8Check"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.is32bit [
-      # OverflowError: timestamp out of range for platform time_t
-      "testTimezoneAwareDatetimeConversionWhereTimestampLosesPrecision"
-      "testTimezoneNaiveDatetimeConversionWhereTimestampLosesPrecision"
-    ];
+  disabledTests = [
+    # TypeError: np.False_ has type <class 'numpy.bool'>,
+    # but expected one of: (<class 'bool'>, <class 'int'>)
+    "NumpyBoolProtoTest"
+  ]
+  ++ lib.optionals isPyPy [
+    # error message differs
+    "testInvalidTimestamp"
+    # requires tracemalloc which pypy does not implement
+    # https://foss.heptapod.net/pypy/pypy/-/issues/3048
+    "testUnknownFieldsNoMemoryLeak"
+    # assertion is not raised for some reason
+    "testStrictUtf8Check"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.is32bit [
+    # OverflowError: timestamp out of range for platform time_t
+    "testTimezoneAwareDatetimeConversionWhereTimestampLosesPrecision"
+    "testTimezoneNaiveDatetimeConversionWhereTimestampLosesPrecision"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # AssertionError: "year (0 )?is out of range" does not match "year must be in 1..9999, not 0"
+    "testInvalidTimestamp"
+  ];
 
   disabledTestPaths =
     lib.optionals (lib.versionAtLeast protobuf.version "23") [
@@ -115,6 +124,9 @@ buildPythonPackage {
     ]
     ++ lib.optionals (lib.versionAtLeast protobuf.version "25") [
       "minimal_test.py" # ModuleNotFoundError: No module named 'google3'
+
+      # ImportError: cannot import name 'self_recursive_pb2' from 'google.protobuf.internal'
+      "google/protobuf/internal/message_test.py"
     ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
## Things done

Tracking: https://github.com/NixOS/nixpkgs/issues/475479

Fixes #495748

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
