### PR TITLE
gokapi: 2.1.0 -> 2.2.3

### DIFF
--- a/pkgs/by-name/go/gokapi/package.nix
+++ b/pkgs/by-name/go/gokapi/package.nix
@@ -9,16 +9,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "gokapi";
-  version = "2.1.0";
+  version = "2.2.3";
 
   src = fetchFromGitHub {
     owner = "Forceu";
     repo = "Gokapi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GEdg79Rl4MqaVIJz9fAVs02hN270SIStq54fvxzL7UU=";
+    hash = "sha256-v4MgpnKFrxDUOerc7+3N6PjhlZZgGcOHOGwbZi6zpds=";
   };
 
-  vendorHash = "sha256-gP9bCnRN40y7NWwh3V8dv1yOBqpmzlcp8Bf6IkdjoWU=";
+  vendorHash = "sha256-oZyZD4kPqgSIaphXRyXVzY+8gYd7kpWAAo1cfiE1ln8=";
+
+  proxyVendor = true;
 
   patches = [ ];
 


### PR DESCRIPTION
## Things done

`proxyVendor = true;` was added because otherwise the `go-modules` derivation was failing with `go: inconsistent vendoring in /build/source`. See the [nixpkgs-update logs](https://nixpkgs-update-logs.nix-community.org/gokapi/2026-03-05.log). 
I don't know Go well enough to understand how this works, but I saw other Go packages do this when faced with the same issue. For example: https://github.com/NixOS/nixpkgs/pull/474420, https://github.com/NixOS/nixpkgs/pull/482927, https://github.com/NixOS/nixpkgs/pull/492383 

<details>
  <summary>Extra info</summary>


Build info

```bash
❯ result/bin/gokapi --version 
Gokapi v2.2.3

Builder: Manual Build
Build Date: Dev Build
Is Docker Version: false
Go Version: go1.25.7
Architecture: amd64
Operating System: linux
Build Tags: None
Git Commit: None
Git Commit Timestamp: None
```

Relevant test logs:

```
machine: (finished: waiting for unit gokapi.service, in 24.80 seconds)
machine: waiting for TCP port 6000 on localhost
machine # [   22.775473] gokapi[941]: ██████   ██████   ██   ██  █████  ██████  ██
machine # [   22.787737] gokapi[941]: ██       ██    ██ ██  ██  ██   ██ ██   ██ ██
machine # [   22.801930] gokapi[941]: ██   ███ ██    ██ █████   ███████ ██████  ██
machine # [   22.815831] gokapi[941]: ██    ██ ██    ██ ██  ██  ██   ██ ██      ██
machine # [   22.829723] gokapi[941]:  ██████   ██████  ██   ██ ██   ██ ██      ██
machine # [   22.841486] gokapi[941]:
machine # [   22.853675] gokapi[941]: Gokapi v2.2.3 starting
machine # [   22.883472] gokapi[941]: Please open http://10.0.2.15:6000/setup to setup Gokapi.
machine # Connection to localhost (::1) 6000 port [tcp/x11] succeeded!
machine: (finished: waiting for TCP port 6000 on localhost, in 1.40 seconds)
machine: must succeed: curl --fail http://localhost:6000/
machine #   % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
machine #                                  Dload  Upload  Total   Spent   Left   Speed
machine #   0      0   0      0   0      0      0      0                              0100     65 100     65   0      0    541      0                              0100     65 100     65   0      0    441      0                              0100     65 100     65   0      0    373      0                              0
machine: (finished: must succeed: curl --fail http://localhost:6000/, in 0.38 seconds)
(finished: run the VM test script, in 26.59 seconds)
```

</details>

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
