### PR TITLE
nixos/stub-ld: shrink build closure and re-enable i686 version on x86_64

### DIFF
--- a/nixos/modules/config/stub-ld.nix
+++ b/nixos/modules/config/stub-ld.nix
@@ -12,37 +12,90 @@ let
     types
     mkIf
     mkDefault
+    elem
+    replaceStrings
     ;
 
   cfg = config.environment.stub-ld;
 
-  message = ''
+  messagePre = "Could not start dynamically linked executable: ";
+  messagePost = "\n" + ''
     NixOS cannot run dynamically linked executables intended for generic
     linux environments out of the box. For more information, see:
     https://nix.dev/permalink/stub-ld
   '';
 
+  escapeCString = s: "\"" + replaceStrings [ "\\" "\"" "\n" ] [ "\\\\" "\\\"" "\\n" ] s + "\"";
+
+  src = builtins.toFile "stub-ld.c" ''
+    #include <stdio.h>
+
+    int main(int argc, char **argv) {
+      fputs(${escapeCString messagePre}, stderr);
+      fputs(argv[0], stderr);
+      fputs(${escapeCString messagePost}, stderr);
+      return 127; // matches behavior of bash and zsh without a loader. fish uses 139
+    }
+  '';
+
+  inherit (pkgs.minimal-bootstrap) stage0-posix;
   stub-ld-for =
-    pkgsArg: messageArg:
-    pkgsArg.pkgsStatic.runCommandCC "stub-ld"
+    system:
+    let
+      platform = lib.systems.elaborate system;
+    in
+    pkgs.runCommandCC "stub-ld"
       {
-        nativeBuildInputs = [ pkgsArg.unixtools.xxd ];
-        inherit messageArg;
+        inherit (stage0-posix)
+          M2
+          M1
+          hex2
+          m2libc
+          ;
+        inherit
+          (pkgs.minimal-bootstrap.stage0-posix.overrideScope (self: super: { hostPlatform = platform; }))
+          m2libcArch
+          baseAddress
+          ;
+        endianFlag = if platform.isLittleEndian then "--little-endian" else "--big-endian";
+        archDefine =
+          {
+            x86_64-linux = "__x86_64__";
+            i686-linux = "__i386__";
+            aarch64-linux = "__aarch64__";
+          }
+          .${system};
       }
       ''
-        printf "%s" "$messageArg" | xxd -i -n message >main.c
-        cat <<EOF >>main.c
-        #include <stdio.h>
-        int main(int argc, char * argv[]) {
-          fprintf(stderr, "Could not start dynamically linked executable: %s\n", argv[0]);
-          fwrite(message, sizeof(unsigned char), message_len, stderr);
-          return 127; // matches behavior of bash and zsh without a loader. fish uses 139
-        }
-        EOF
-        $CC -Os main.c -o $out
+        cpp -P -undef -nostdinc \
+          -isystem $m2libc \
+          -D __M2__ \
+          -D $archDefine \
+          ${src} \
+          -o stub-ld.c
+
+        $M2 --architecture $m2libcArch \
+          -f stub-ld.c \
+          -o stub-ld.M1
+
+        $M1 --architecture $m2libcArch $endianFlag \
+          -f $m2libc/$m2libcArch/''${m2libcArch}_defs.M1 \
+          -f $m2libc/$m2libcArch/libc-full.M1 \
+          -f stub-ld.M1 \
+          -o stub-ld.hex2
+
+        $hex2 --architecture $m2libcArch $endianFlag --base-address $baseAddress \
+          -f $m2libc/$m2libcArch/ELF-$m2libcArch.hex2 \
+          -f stub-ld.hex2 \
+          -o $out
       '';
 
-  stub-ld = stub-ld-for pkgs message;
+  stub-ld =
+    if elem pkgs.stdenv.hostPlatform.system stage0-posix.platforms then
+      stub-ld-for pkgs.stdenv.hostPlatform.system
+    else
+      pkgs.pkgsStatic.runCommandCC "stub-ld" { } "$CC ${src} -o $out";
+  stub-ld32 = stub-ld-for "i686-linux";
 in
 {
   options = {
@@ -62,6 +115,7 @@ in
 
   config = mkIf cfg.enable {
     environment.ldso = mkDefault stub-ld;
+    environment.ldso32 = mkIf pkgs.stdenv.hostPlatform.isx86_64 (mkDefault stub-ld32);
   };
 
   meta.maintainers = with lib.maintainers; [ tejing ];

--- a/nixos/tests/stub-ld.nix
+++ b/nixos/tests/stub-ld.nix
@@ -24,6 +24,9 @@ import ./make-test-python.nix (
         libDir = pkgs.stdenv.hostPlatform.libDir;
         ldsoBasename = lib.last (lib.splitString "/" pkgs.stdenv.cc.bintools.dynamicLinker);
 
+        libDir32 = "lib"; # pkgs.pkgsi686Linux.stdenv.hostPlatform.libDir
+        ldsoBasename32 = "ld-linux.so.2"; # last (splitString "/" pkgs.pkgsi686Linux.stdenv.cc.bintools.dynamicLinker)
+
         test-exec =
           builtins.mapAttrs
             (
@@ -39,6 +42,8 @@ import ./make-test-python.nix (
               aarch64-linux.hash = "sha256-hnldbd2cctQIAhIKoEZLIWY8H3jiFBClkNy2UlyyvAs=";
             };
         exec-name = "rustic";
+
+        if32 = pythonStatement: if pkgs.stdenv.hostPlatform.isx86_64 then pythonStatement else "pass";
       in
       ''
         machine.start()
@@ -46,26 +51,33 @@ import ./make-test-python.nix (
 
         with subtest("Check for stub (enabled, initial)"):
             machine.succeed('test -L /${libDir}/${ldsoBasename}')
+            ${if32 "machine.succeed('test -L /${libDir32}/${ldsoBasename32}')"}
 
         with subtest("Try FHS executable"):
             machine.copy_from_host('${test-exec.${pkgs.stdenv.hostPlatform.system}}','test-exec')
             machine.succeed('if test-exec/${exec-name} 2>outfile; then false; else [ $? -eq 127 ];fi')
             machine.succeed('grep -qi nixos outfile')
+            ${if32 "machine.copy_from_host('${test-exec."i686-linux"}','test-exec32')"}
+            ${if32 "machine.succeed('if test-exec32/${exec-name} 2>outfile32; then false; else [ $? -eq 127 ];fi')"}
+            ${if32 "machine.succeed('grep -qi nixos outfile32')"}
 
         with subtest("Disable stub"):
             machine.succeed("/run/booted-system/specialisation/nostub/bin/switch-to-configuration test")
 
         with subtest("Check for stub (disabled)"):
             machine.fail('test -e /${libDir}/${ldsoBasename}')
+            ${if32 "machine.fail('test -e /${libDir32}/${ldsoBasename32}')"}
 
         with subtest("Create file in stub location (to be overwritten)"):
             machine.succeed('mkdir -p /${libDir};touch /${libDir}/${ldsoBasename}')
+            ${if32 "machine.succeed('mkdir -p /${libDir32};touch /${libDir32}/${ldsoBasename32}')"}
 
         with subtest("Re-enable stub"):
             machine.succeed("/run/booted-system/bin/switch-to-configuration test")
 
         with subtest("Check for stub (enabled, final)"):
             machine.succeed('test -L /${libDir}/${ldsoBasename}')
+            ${if32 "machine.succeed('test -L /${libDir32}/${ldsoBasename32}')"}
       '';
   }
 )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
When stub-ld was first merged, there were some significant issues caused by the build closure size, which were ultimately mostly solved by #398449, though this was obviously a sub-optimal solution.

While studying the newly-hooked-up minimal bootstrap chain, I realized the `M2` compiler from `stage0-posix` had everything I actually needed to make the stub-ld executables, including for i686 binaries on x86_64 systems, with zero additional build closure beyond what was already needed for stdenv.

Effectively reverts:
- #398449
- #457909

On the systems supported by `stage0-posix` (which includes everything built by hydra):
- Makes no use of secondary nixpkgs instantiations, keeping eval costs small.
- Shares its build closure completely with `stdenv` (even if it didn't, it could be bootstrapped in a few seconds). This is the case even when building the i686 binary on x86_64 systems.

On other systems:
- Uses `pkgsStatic`, as it did before this PR.

Closes #373776

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
