### PR TITLE
svgo: 4.0.0 -> 4.0.1

### DIFF
--- a/pkgs/by-name/sv/svgo/package.nix
+++ b/pkgs/by-name/sv/svgo/package.nix
@@ -12,20 +12,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "svgo";
-  version = "4.0.0";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner = "svg";
     repo = "svgo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eSttRNHxcZquIxrTogk+7YS7rhp083qnOwJI71cmO20=";
+    hash = "sha256-HYI3E14MN0XhREQMYkhLB1gZOBtrpjayC1RyVEhvkOU=";
   };
 
   missingHashes = ./missing-hashes.json;
 
   offlineCache = yarn-berry.fetchYarnBerryDeps {
     inherit (finalAttrs) src missingHashes;
-    hash = "sha256-DrIbnm0TWviCfylCI/12XYsx7YOIk7JFVV18Q4dImwU=";
+    hash = "sha256-oBWUTYlMa3wi7TYAOTXSNBbSMiAZI6APXZvPyQzoPbM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/svg/svgo/releases/tag/v4.0.1
https://github.com/svg/svgo/security/advisories/GHSA-xpqw-6gx7-v673

Fixes: CVE-2026-29074
Closes: #497579 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
