### PR TITLE
nixos/tlsrpt: reuse sender address as envelope sender

### DIFF
--- a/nixos/modules/services/mail/tlsrpt.nix
+++ b/nixos/modules/services/mail/tlsrpt.nix
@@ -244,12 +244,12 @@ in
               type = with types; nullOr str;
               default =
                 if config.services.postfix.enable && config.services.postfix.setSendmail then
-                  "/run/wrappers/bin/sendmail -i -t"
+                  "/run/wrappers/bin/sendmail -i -t -f ${cfg.reportd.settings.sender_address}"
                 else
                   null;
               defaultText = lib.literalExpression ''
                 if config.services.postfix.enable && config.services.postfix.setSendmail then
-                  "/run/wrappers/bin/sendmail -i -t"
+                  "/run/wrappers/bin/sendmail -i -t -f $${cfg.reportd.settings.sender_address}"
                 else
                   null
               '';


### PR DESCRIPTION
This prevents leaking the local user and hostname into the envelope, which could prevent DKIM signing due to lack of keys for the MX hostname.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
