### PR TITLE
rocmPackages.hipblaslt.src: compress yaml in postFetch to meet output limit

### DIFF
--- a/pkgs/development/rocm-modules/hipblaslt/default.nix
+++ b/pkgs/development/rocm-modules/hipblaslt/default.nix
@@ -76,11 +76,15 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ROCm";
     repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-I2dGn4Ld5lZeML8GePcLPssplBZ+4weNR6uBEqFdZVg=";
+    hash = "sha256-+yaOUA8hzRPnz14Cmp2BbfIS5811PgMcHQLY2+FatMU=";
     sparseCheckout = [
       "projects/hipblaslt"
       "shared"
     ];
+    # Compress the 5ish GiB of yaml files so this .src is under output size limit
+    postFetch = ''
+      find $out -name '*.yaml' -path '*/Tensile/Logic/*' -exec ${lib.getExe zstd} --rm {} \;
+    '';
   };
   sourceRoot = "${finalAttrs.src.name}/projects/hipblaslt";
   env.CXX = compiler;
@@ -121,6 +125,10 @@ stdenv.mkDerivation (finalAttrs: {
     ./TensileCreateLibrary-refactor.patch
     ./Tensile-interning.patch
   ];
+
+  preConfigure = ''
+    find . -name '*.yaml.zst' -path '*/Tensile/Logic/*' -exec zstd -d --rm {} \;
+  '';
 
   postPatch = ''
     # git isn't needed and we have no .git


### PR DESCRIPTION
Before: /nix/store/b1gvdqxccy2i377fg0cr83jkir2b8ngf-source   5.0 GiB
After: /nix/store/fnh40id9mxm58x2wkf81mr594cv5rzms-source 657.9 MiB

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
