### PR TITLE
pgadmin4: 9.11 -> 9.13

### DIFF
--- a/pkgs/by-name/pg/pgadmin4/package.nix
+++ b/pkgs/by-name/pg/pgadmin4/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3,
   fetchFromGitHub,
+  fetchpatch2,
   zlib,
   nixosTests,
   postgresqlTestHook,
@@ -20,14 +21,14 @@
 
 let
   pname = "pgadmin";
-  version = "9.11";
-  yarnHash = "sha256-x8EbZPQxCRBfeBXJGHW1tyN3tWzTqlMGvftizspfBRw=";
+  version = "9.13";
+  yarnHash = "sha256-ViqjZ40M78EZ4ZOMuiAGJqx6Xyv4dqY9X7jMDbohaY8=";
 
   src = fetchFromGitHub {
     owner = "pgadmin-org";
     repo = "pgadmin4";
     rev = "REL-${lib.versions.major version}_${lib.versions.minor version}";
-    hash = "sha256-t+TdudbCq68fXJrcAzyESZTiA4qVkQgwF4efc4IJrl0=";
+    hash = "sha256-dG8oxE9g30Dz3K3PveoMjPa1/eY9RWEV2QBdx2Dz+Rg=";
   };
 
   # keep the scope, as it is used throughout the derivation and tests
@@ -67,6 +68,12 @@ pythonPackages.buildPythonApplication rec {
     ./expose-setup.py.patch
     # check for permission of /etc/pgadmin/config_system and don't fail
     ./check-system-config-dir.patch
+    # fix session.py See https://github.com/pgadmin-org/pgadmin4/pull/9706
+    (fetchpatch2 {
+      name = "session.patch";
+      url = "https://github.com/pgadmin-org/pgadmin4/commit/7043587387c17635f62bab8414546bb8c0dbadf4.patch?full_index=1";
+      hash = "sha256-gZrO0dBy5EklZf/dKr9j3RJ54rtzFrw53v91vqkRboY=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
Superseeds #487994

Diff: https://github.com/pgadmin-org/pgadmin4/compare/REL-9_11...REL-9_13
Release Notes: https://www.pgadmin.org/docs/pgadmin4/latest/release_notes_9_13.html and https://www.pgadmin.org/docs/pgadmin4/latest/release_notes_9_12.html

(Version 9.12): Fixes: https://github.com/advisories/GHSA-3p7x-94q9-jq9x

Also includes ~~unmerged~~ merged PR to fix regression in a new feature (See https://github.com/pgadmin-org/pgadmin4/pull/9706)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
