### PR TITLE
[25.11] ghostfolio: 2.218.0 -> 2.246.0

### DIFF
--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.229.0";
+  version = "2.233.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-hzweYMIn4BUuEv2fH9AofeE1GTc1J4Yrnzs8zN2nr0o=";
+    hash = "sha256-if6mx/pjRqx9++ufkTHWVnqGScr+e3uZ0a6P6Ai9zWE=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-9HdYw/OKGmqrVPFUqd0f4jW7aHBNAW2S5f2rDRbPR4c=";
+  npmDepsHash = "sha256-wMA8Q/cCTXwVnlpAEdEaA4iyfQOnYwwGRq+/k1Py+zg=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.233.0";
+  version = "2.234.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-if6mx/pjRqx9++ufkTHWVnqGScr+e3uZ0a6P6Ai9zWE=";
+    hash = "sha256-kj7KCgk4s9Ua//UPGXBh3pI91FTGC90bqMdUrvH4Bhc=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-wMA8Q/cCTXwVnlpAEdEaA4iyfQOnYwwGRq+/k1Py+zg=";
+  npmDepsHash = "sha256-FA5T95nii7pk36YwQQVMSJAvKgOWKFbGwKeyCuygDIQ=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.234.0";
+  version = "2.237.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-kj7KCgk4s9Ua//UPGXBh3pI91FTGC90bqMdUrvH4Bhc=";
+    hash = "sha256-udko0oiO5tLEDBKxkGiTRU0Qd/Yd0bvPB6iPM5wJ7Ls=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-FA5T95nii7pk36YwQQVMSJAvKgOWKFbGwKeyCuygDIQ=";
+  npmDepsHash = "sha256-2j/u++63qaOzvsgdhWeDsH+TUVmOLvgQQRNY14LZI2k=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.228.0";
+  version = "2.229.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-/SCZ/dv/yVA+0meDLO70hcjOLIdk2MA+Qjd5WbuU0nM=";
+    hash = "sha256-hzweYMIn4BUuEv2fH9AofeE1GTc1J4Yrnzs8zN2nr0o=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-IEE6HPWqzes+LiQlSr8OaGjVkKoetASCK2SRchFnnVE=";
+  npmDepsHash = "sha256-9HdYw/OKGmqrVPFUqd0f4jW7aHBNAW2S5f2rDRbPR4c=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.223.0";
+  version = "2.224.2";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-qgIwAfcDP2TDQvg5Q92RDHm7HSv4KT16hsoaz8ux7fg=";
+    hash = "sha256-IaRwBqz1A2ZkcAQ+jAL6NxyEgtjM70T+N0mf0kvpxmA=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-KSKqybqVw2BG/WKuVRyNsneLYyedVeyCvNBLIREx7MQ=";
+  npmDepsHash = "sha256-CSssn/aYWcGoQmBsJFWJG4ZIuAJcIeDO2CeAcOiUdP4=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.224.2";
+  version = "2.225.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-IaRwBqz1A2ZkcAQ+jAL6NxyEgtjM70T+N0mf0kvpxmA=";
+    hash = "sha256-nzXQfi4N7t/tm5Zub29AIYKgBYzZN8k/fPLqRK3PKwM=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-CSssn/aYWcGoQmBsJFWJG4ZIuAJcIeDO2CeAcOiUdP4=";
+  npmDepsHash = "sha256-TADFJd6kWmEsXi9+04OAGlhR2rX+++K5OraaQatLSho=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.225.0";
+  version = "2.228.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-nzXQfi4N7t/tm5Zub29AIYKgBYzZN8k/fPLqRK3PKwM=";
+    hash = "sha256-/SCZ/dv/yVA+0meDLO70hcjOLIdk2MA+Qjd5WbuU0nM=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-TADFJd6kWmEsXi9+04OAGlhR2rX+++K5OraaQatLSho=";
+  npmDepsHash = "sha256-IEE6HPWqzes+LiQlSr8OaGjVkKoetASCK2SRchFnnVE=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.237.0";
+  version = "2.239.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-udko0oiO5tLEDBKxkGiTRU0Qd/Yd0bvPB6iPM5wJ7Ls=";
+    hash = "sha256-1CJM395lApSIo5/7WVaLaBV1MwNJ7ehWukln59Ew6fg=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-2j/u++63qaOzvsgdhWeDsH+TUVmOLvgQQRNY14LZI2k=";
+  npmDepsHash = "sha256-rX/RkM2wjDFoL/BtnNa3WuUlHIIlviGGsfoobDzeD0M=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.239.0";
+  version = "2.242.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-1CJM395lApSIo5/7WVaLaBV1MwNJ7ehWukln59Ew6fg=";
+    hash = "sha256-xjY03/3sFUmwlRiNcBPoAK620VS7sgruz41BESMa5Vg=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-rX/RkM2wjDFoL/BtnNa3WuUlHIIlviGGsfoobDzeD0M=";
+  npmDepsHash = "sha256-ey34WKyCT269Sgf1Kti9ZBeZSvNBcpkM4F/X2ibJktQ=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.242.0";
+  version = "2.246.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-xjY03/3sFUmwlRiNcBPoAK620VS7sgruz41BESMa5Vg=";
+    hash = "sha256-i3ZTxGNGHmDgQ9XFTYrXDOPhqfkBCD2O/9PdXxSF9hc=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-ey34WKyCT269Sgf1Kti9ZBeZSvNBcpkM4F/X2ibJktQ=";
+  npmDepsHash = "sha256-4nLNRIBvYZuwWFqp7nfrEvvLkTzii8KAbdzRdwj9Ahg=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.219.0";
+  version = "2.221.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-WXBKUvwfllH6HQFgUBcUSaaHqhMrWU3V969ZtJ9y7KQ=";
+    hash = "sha256-hcFzcaa8SpwecyPeDbKE2/hnANUFP4EiUzJCs5Ybkyc=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-Xn+8+CHgCQ6Zh2/HUbl1xW8LkIypCfHAFzflc6vIeKQ=";
+  npmDepsHash = "sha256-fzY/gf65u5iQe/J+7p46lSp4uAEZ21nr+L0OB9GyWxk=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.222.0";
+  version = "2.223.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-pMkmjGRdJjkEDMf9k7QqYIwkUX9LaeovQYG2i+vmOtE=";
+    hash = "sha256-qgIwAfcDP2TDQvg5Q92RDHm7HSv4KT16hsoaz8ux7fg=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-7Xf3Yn4fC+Jjc/UFu+cg9cVwiYK/VMasZwPOIJu771o=";
+  npmDepsHash = "sha256-KSKqybqVw2BG/WKuVRyNsneLYyedVeyCvNBLIREx7MQ=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.221.0";
+  version = "2.222.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-hcFzcaa8SpwecyPeDbKE2/hnANUFP4EiUzJCs5Ybkyc=";
+    hash = "sha256-pMkmjGRdJjkEDMf9k7QqYIwkUX9LaeovQYG2i+vmOtE=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-fzY/gf65u5iQe/J+7p46lSp4uAEZ21nr+L0OB9GyWxk=";
+  npmDepsHash = "sha256-7Xf3Yn4fC+Jjc/UFu+cg9cVwiYK/VMasZwPOIJu771o=";
 
   nativeBuildInputs = [
     prisma_6

--- a/pkgs/by-name/gh/ghostfolio/package.nix
+++ b/pkgs/by-name/gh/ghostfolio/package.nix
@@ -11,13 +11,13 @@
 
 buildNpmPackage rec {
   pname = "ghostfolio";
-  version = "2.218.0";
+  version = "2.219.0";
 
   src = fetchFromGitHub {
     owner = "ghostfolio";
     repo = "ghostfolio";
     tag = version;
-    hash = "sha256-r/C/P+tdfaTLe0yCa5XPUg8O4NO9cHEF7EXzyfpkpD8=";
+    hash = "sha256-WXBKUvwfllH6HQFgUBcUSaaHqhMrWU3V969ZtJ9y7KQ=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,7 +27,7 @@ buildNpmPackage rec {
     '';
   };
 
-  npmDepsHash = "sha256-EMLQUZaL6u5jsOgBa67bivUHItJo8JeGZLbIq6tJdgE=";
+  npmDepsHash = "sha256-Xn+8+CHgCQ6Zh2/HUbl1xW8LkIypCfHAFzflc6vIeKQ=";
 
   nativeBuildInputs = [
     prisma_6


### PR DESCRIPTION
Resolve #497597

Fix [CVE-2026-28785](https://nvd.nist.gov/vuln/detail/CVE-2026-28785)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
