### PR TITLE
x11docker: 7.6.0-unstable-2024-04-04 -> 7.8.0

### DIFF
--- a/pkgs/by-name/x1/x11docker/package.nix
+++ b/pkgs/by-name/x1/x11docker/package.nix
@@ -25,14 +25,14 @@
   weston,
   xwayland,
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "x11docker";
-  version = "7.6.0-unstable-2024-04-04";
+  version = "7.8.0";
   src = fetchFromGitHub {
     owner = "mviereck";
     repo = "x11docker";
-    rev = "cb29a996597839239e482409b895353b1097ce3b";
-    sha256 = "sha256-NYMr2XZ4m6uvuIGO+nzX2ksxtVLJL4zy/JebxeAvqD4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mOxPNT6psRBTuTrMgASBTBr3dZzCSxanSkHKF84lmO8=";
   };
   nativeBuildInputs = [ makeWrapper ];
 
@@ -77,4 +77,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
     mainProgram = "x11docker";
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/mviereck/x11docker/compare/cb29a996597839239e482409b895353b1097ce3b...cb29a996597839239e482409b895353b1097ce3b

Resolves https://github.com/NixOS/nixpkgs/issues/497258

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
