### PR TITLE
mtkclient: 2.1.2 -> 2.1.4.1 (+ udev, desktop item)

### DIFF
--- a/pkgs/by-name/mt/mtkclient/package.nix
+++ b/pkgs/by-name/mt/mtkclient/package.nix
@@ -1,7 +1,9 @@
 {
   lib,
+  copyDesktopItems,
   fetchFromGitHub,
   gcc-arm-embedded,
+  makeDesktopItem,
   python3Packages,
   udevCheckHook,
 }:
@@ -33,6 +35,7 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [
     udevCheckHook
+    copyDesktopItems
 
     # Dependencies for stage1 kamakiri payloads
     gcc-arm-embedded
@@ -50,6 +53,18 @@ python3Packages.buildPythonApplication rec {
   postInstall = ''
     install -Dm444 Setup/Linux/52-mtk.rules -t $out/lib/udev/rules.d
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "mtkclient";
+      desktopName = "MTKClient";
+      comment = "Mediatek Flash and Repair Utility";
+      exec = "mtk_gui";
+      categories = [
+        "Development"
+      ];
+    })
+  ];
 
   meta = {
     description = "MTK reverse engineering and flash tool";

--- a/pkgs/by-name/mt/mtkclient/package.nix
+++ b/pkgs/by-name/mt/mtkclient/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "mtkclient";
-  version = "2.1.2";
+  version = "2.1.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bkerler";
     repo = "mtkclient";
     rev = "v${version}";
-    hash = "sha256-mbfuOYJvwHfDvjTtAgMBLi7REIRRcJ9bhkY5oVjxCAM=";
+    hash = "sha256-PNDjIoMkd/UkP/CQxLiJbCcQvJ3u1ghp0ILJ0jHJrts=";
   };
 
   build-system = [ python3Packages.hatchling ];

--- a/pkgs/by-name/mt/mtkclient/package.nix
+++ b/pkgs/by-name/mt/mtkclient/package.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "mtkclient";
-  version = "2.1.3";
+  version = "2.1.4.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bkerler";
     repo = "mtkclient";
     rev = "v${version}";
-    hash = "sha256-PNDjIoMkd/UkP/CQxLiJbCcQvJ3u1ghp0ILJ0jHJrts=";
+    hash = "sha256-8Y9tyw+dmhhc4tFo3slr4wQIPXIrmIk/wuCK4aM6oLY=";
   };
 
   build-system = [ python3Packages.hatchling ];

--- a/pkgs/by-name/mt/mtkclient/package.nix
+++ b/pkgs/by-name/mt/mtkclient/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   python3Packages,
+  udevCheckHook,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -29,10 +30,17 @@ python3Packages.buildPythonApplication rec {
     shiboken6
   ];
 
+  nativeBuildInputs = [
+    udevCheckHook
+  ];
+
   pythonImportsCheck = [ "mtkclient" ];
 
-  # Note: No need to install mtkclient udev rules, 50-android.rules is covered by
+  # Note: No need to install other mtkclient udev rules, 50-android.rules is covered by
   #       systemd 258 or newer and 51-edl.rules only applies to Qualcomm (i.e. not MTK).
+  postInstall = ''
+    install -Dm444 Setup/Linux/52-mtk.rules -t $out/lib/udev/rules.d
+  '';
 
   meta = {
     description = "MTK reverse engineering and flash tool";

--- a/pkgs/by-name/mt/mtkclient/package.nix
+++ b/pkgs/by-name/mt/mtkclient/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  gcc-arm-embedded,
   python3Packages,
   udevCheckHook,
 }:
@@ -32,9 +33,17 @@ python3Packages.buildPythonApplication rec {
 
   nativeBuildInputs = [
     udevCheckHook
+
+    # Dependencies for stage1 kamakiri payloads
+    gcc-arm-embedded
   ];
 
   pythonImportsCheck = [ "mtkclient" ];
+
+  # Build on-device payloads from source before assembling into a python package.
+  preBuild = ''
+    make -C src/stage1
+  '';
 
   # Note: No need to install other mtkclient udev rules, 50-android.rules is covered by
   #       systemd 258 or newer and 51-edl.rules only applies to Qualcomm (i.e. not MTK).


### PR DESCRIPTION
Changelog from 2.1.2 to 2.1.3 is [here](https://github.com/bkerler/mtkclient/compare/v2.1.2...v2.1.3).
Changelog from 2.1.3 to 2.1.4.1 is [here](https://github.com/bkerler/mtkclient/compare/v2.1.3...v2.1.4.1).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
