### PR TITLE
maintainers: remove syberant

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26031,12 +26031,6 @@
     githubId = 127287939;
     name = "Syed Sumairul Hasan";
   };
-  syberant = {
-    email = "sybrand@neuralcoding.com";
-    github = "syberant";
-    githubId = 20063502;
-    name = "Sybrand Aarnoutse";
-  };
   syboxez = {
     email = "syboxez@gmail.com";
     matrix = "@syboxez:matrix.org";

--- a/pkgs/by-name/gi/gitoxide/package.nix
+++ b/pkgs/by-name/gi/gitoxide/package.nix
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit # or
       asl20
     ];
-    maintainers = with lib.maintainers; [ syberant ];
+    maintainers = [ ];
     # NB: `ein` is also provided by this package, but `nix run
     # nixpkgs#gitoxide` doesn't work at all without this set.
     mainProgram = "gix";


### PR DESCRIPTION
## Reasons

- Last commented in [February 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Asyberant)
- Hasn't created any PRs / Issues since [April 2022](https://github.com/NixOS/nixpkgs/issues?q=author%3Asyberant)
- About 37 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Asyberant%20-commenter%3Asyberant%20-author%3Asyberant%20-reviewed-by%3Asyberant) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages 

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] gitoxide