### PR TITLE
[25.11] gokapi: mark vulnerable

### DIFF
--- a/pkgs/by-name/go/gokapi/package.nix
+++ b/pkgs/by-name/go/gokapi/package.nix
@@ -68,6 +68,18 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [
       delliott
     ];
+    knownVulnerabilities = [
+      (
+        "The following vulnerabilities have been fixed in gokapi 2.2.3 "
+        + "(which is in Nixpkgs unstable), but cannot be included in the stable "
+        + "release due to breaking changes:"
+      )
+      "CVE-2026-28683"
+      "CVE-2026-29060"
+      "CVE-2026-29061"
+      "CVE-2026-29084"
+      "CVE-2026-28682"
+    ];
     mainProgram = "gokapi";
   };
 }


### PR DESCRIPTION
See #497563.

Breaking changes between 2.1.0 and 2.2.3:
* https://github.com/Forceu/Gokapi/releases/tag/v2.2.0
* https://github.com/Forceu/Gokapi/releases/tag/v2.2.3

Not-cherry-picked-because: cannot backport due to breaking changes


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
