### PR TITLE
better-screenshots: init at 0.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25180,6 +25180,12 @@
     githubId = 8686360;
     name = "Illia Shestakov";
   };
+  snhsish = {
+    email = "mail@snehasish.xyz";
+    github = "snhsish";
+    githubId = 113252136;
+    name = "Snehasish";
+  };
   snicket2100 = {
     github = "snicket2100";
     githubId = 57048005;

--- a/pkgs/by-name/be/better-screenshots/package.nix
+++ b/pkgs/by-name/be/better-screenshots/package.nix
@@ -16,13 +16,14 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-bms9+RuzuEh6kBV7S4yjwXWBLUSPuu0ucD/riFm07E4=";
   };
 
-  dependencies = [
-    python3Packages.setuptools
-    python3Packages.click
-    python3Packages.pillow
-    python3Packages.toml
-    python3Packages.pyyaml
-    python3Packages.requests
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    click
+    pillow
+    toml
+    pyyaml
+    requests
   ];
 
   doCheck = false;

--- a/pkgs/by-name/be/better-screenshots/package.nix
+++ b/pkgs/by-name/be/better-screenshots/package.nix
@@ -27,7 +27,10 @@ python3Packages.buildPythonApplication rec {
   ];
 
   doCheck = false;
-
+  postInstall = ''
+    wrapProgram $out/bin/better-screenshots \
+      --prefix PATH : "${lib.makeBinPath [ grim slurp wl-clipboard ]}"
+  '';
   meta = {
     description = "Screenshot tool with image and background customizations plus configurable cloud uploads.";
     mainProgram = "better-screenshots";

--- a/pkgs/by-name/be/better-screenshots/package.nix
+++ b/pkgs/by-name/be/better-screenshots/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "better-screenshots";
+  version = "0.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "snhsish";
+    repo = "better-screenshots";
+    tag = "v${version}";
+    hash = "sha256-bms9+RuzuEh6kBV7S4yjwXWBLUSPuu0ucD/riFm07E4=";
+  };
+
+  dependencies = [
+    python3Packages.setuptools
+    python3Packages.click
+    python3Packages.pillow
+    python3Packages.toml
+    python3Packages.pyyaml
+    python3Packages.requests
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Screenshot tool with image and background customizations plus configurable cloud uploads.";
+    mainProgram = "better-screenshots";
+    homepage = "https://github.com/snhsish/better-screenshots";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ snhsish ];
+  };
+}


### PR DESCRIPTION
Screenshot tool with image and background customizations plus configurable cloud uploads.

## Things done
- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
