### PR TITLE
nixos/slurm: expose NVML library when NVIDIA datacenter is enabled

### DIFF
--- a/nixos/modules/services/computing/slurm/slurm.nix
+++ b/nixos/modules/services/computing/slurm/slurm.nix
@@ -453,6 +453,8 @@ in
         users.groups.slurmrestd = lib.mkIf (cfg.rest.enable) { };
 
         systemd.services.slurmd = lib.mkIf (cfg.client.enable) {
+
+          environment.LD_LIBRARY_PATH = lib.mkIf config.hardware.nvidia.datacenter.enable "/run/opengl-driver/lib";
           path =
             with pkgs;
             [


### PR DESCRIPTION
When `hardware.nvidia.datacenter.enable` is turned on we likely want the NVIDIA Management Library (NVML) at runtime so that Slurm can query GPU metrics. This adds the driver directory containing `libnvidia‑ml.so` to `slurmd` environment's `LD_LIBRARY_PATH`, making it discoverable.

Note: You might be wondering why not enable on `pkgs.config.cudaSupport`? The reason not to is because Slurm can also use regular nvidia mode, NVML mode is just for cases when the GPU resources are on an NVLink topology, which is what the datacenter driver is for.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
