### PR TITLE
python3Packages.langgraph*: fixes

### DIFF
--- a/pkgs/development/python-modules/langgraph-checkpoint/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint/default.nix
@@ -15,6 +15,7 @@
   dataclasses-json,
   numpy,
   pandas,
+  pycryptodome,
   pytest-asyncio,
   pytest-mock,
   pytestCheckHook,
@@ -24,19 +25,19 @@
   gitUpdater,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "langgraph-checkpoint";
-  version = "4.0.0";
+  version = "4.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    tag = "checkpoint==${version}";
-    hash = "sha256-IE9Y+kFkDN49SuwvTNwa2kK+Hig18sJPZmZCqHUP3DM=";
+    tag = "checkpoint==${finalAttrs.version}";
+    hash = "sha256-NJSmpVshj/x6ws+jFYXGarNKNztbk5OIIMA1neFOyIY=";
   };
 
-  sourceRoot = "${src.name}/libs/checkpoint";
+  sourceRoot = "${finalAttrs.src.name}/libs/checkpoint";
 
   build-system = [ hatchling ];
 
@@ -53,6 +54,7 @@ buildPythonPackage rec {
     dataclasses-json
     numpy
     pandas
+    pycryptodome
     pytest-asyncio
     pytest-mock
     pytestCheckHook
@@ -68,7 +70,7 @@ buildPythonPackage rec {
   };
 
   meta = {
-    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/${src.tag}";
+    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/${finalAttrs.src.tag}";
     description = "Library with base interfaces for LangGraph checkpoint savers";
     homepage = "https://github.com/langchain-ai/langgraph/tree/main/libs/checkpoint";
     license = lib.licenses.mit;
@@ -76,4 +78,4 @@ buildPythonPackage rec {
       sarahec
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/langgraph-cli/default.nix
+++ b/pkgs/development/python-modules/langgraph-cli/default.nix
@@ -22,19 +22,19 @@
   gitUpdater,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "langgraph-cli";
-  version = "0.4.11";
+  version = "0.4.14";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    tag = "cli==${version}";
-    hash = "sha256-sr3AtcrG9V0c5UBdSXyaX3bCxzrSONpY28L5jlomZuM=";
+    tag = "cli==${finalAttrs.version}";
+    hash = "sha256-DtIIGNcpgcYMvvihH9GwgCn2PRWq+LEcHVtitA71T04=";
   };
 
-  sourceRoot = "${src.name}/libs/cli";
+  sourceRoot = "${finalAttrs.src.name}/libs/cli";
 
   build-system = [ hatchling ];
 
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     pytestCheckHook
     docker-compose
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   enabledTestPaths = [ "tests/unit_tests" ];
 
@@ -91,9 +91,9 @@ buildPythonPackage rec {
   meta = {
     description = "Official CLI for LangGraph API";
     homepage = "https://github.com/langchain-ai/langgraph/tree/main/libs/cli";
-    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/${src.tag}";
+    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "langgraph";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sarahec ];
   };
-}
+})

--- a/pkgs/development/python-modules/langgraph-prebuilt/default.nix
+++ b/pkgs/development/python-modules/langgraph-prebuilt/default.nix
@@ -29,19 +29,19 @@
 }:
 # langgraph-prebuilt isn't meant to be a standalone package but is bundled into langgraph at build time.
 # It exists so the langgraph team can iterate on it without having to rebuild langgraph.
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "langgraph-prebuilt";
-  version = "1.0.7";
+  version = "1.0.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    tag = "prebuilt==${version}";
-    hash = "sha256-gwug+eVzFa0mL+dvASHQ/cLq4/nIzl6CvigPIep7v1E=";
+    tag = "prebuilt==${finalAttrs.version}";
+    hash = "sha256-Gsh2bCcity0zf9A+FENxwktK5j3WhQOG/jZmhJ18KVE=";
   };
 
-  sourceRoot = "${src.name}/libs/prebuilt";
+  sourceRoot = "${finalAttrs.src.name}/libs/prebuilt";
 
   build-system = [ hatchling ];
 
@@ -72,7 +72,7 @@ buildPythonPackage rec {
   ];
 
   preCheck = ''
-    export PYTHONPATH=${src}/libs/langgraph:$PYTHONPATH
+    export PYTHONPATH=${finalAttrs.src}/libs/langgraph:$PYTHONPATH
   '';
 
   pytestFlags = [
@@ -100,8 +100,8 @@ buildPythonPackage rec {
   meta = {
     description = "Prebuilt agents add-on for Langgraph. Should always be bundled with langgraph";
     homepage = "https://github.com/langchain-ai/langgraph/tree/main/libs/prebuilt";
-    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/${src.tag}";
+    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sarahec ];
   };
-}
+})

--- a/pkgs/development/python-modules/langgraph-runtime-inmem/default.nix
+++ b/pkgs/development/python-modules/langgraph-runtime-inmem/default.nix
@@ -4,6 +4,7 @@
   fetchPypi,
   hatchling,
   blockbuster,
+  croniter,
   langgraph,
   langgraph-checkpoint,
   sse-starlette,
@@ -13,20 +14,21 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langgraph-runtime-inmem";
-  version = "0.23.2";
+  version = "0.26.0";
   pyproject = true;
 
   # Not available in any repository
   src = fetchPypi {
     pname = "langgraph_runtime_inmem";
     inherit (finalAttrs) version;
-    hash = "sha256-HrmkC6llvww1FBSbQRpo4KfWdU16XxcSY2tmRsUg/Ns=";
+    hash = "sha256-ucWH0TOTIKKlSlcKIa7K9Z7rxL4HzvHYpbA18/LGHWo=";
   };
 
   build-system = [ hatchling ];
 
   dependencies = [
     blockbuster
+    croniter
     langgraph
     langgraph-checkpoint
     sse-starlette

--- a/pkgs/development/python-modules/langgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/langgraph-sdk/default.nix
@@ -16,19 +16,19 @@
   gitUpdater,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "langgraph-sdk";
-  version = "0.3.6";
+  version = "0.3.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    tag = "sdk==${version}";
-    hash = "sha256-8Cnftu0uFzyBa3IBN9ktUoXZ1FRaDVaCuFxjVnqfDNU=";
+    tag = "sdk==${finalAttrs.version}";
+    hash = "sha256-E/GM0p9x2/hNfL2u4TsG9UxnnMX42f5PjeIo9KfRY0k=";
   };
 
-  sourceRoot = "${src.name}/libs/sdk-py";
+  sourceRoot = "${finalAttrs.src.name}/libs/sdk-py";
 
   build-system = [ hatchling ];
 
@@ -54,8 +54,8 @@ buildPythonPackage rec {
   meta = {
     description = "SDK for interacting with the LangGraph Cloud REST API";
     homepage = "https://github.com/langchain-ai/langgraph/tree/main/libs/sdk-py";
-    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/${src.tag}";
+    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sarahec ];
   };
-}
+})

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -25,6 +25,7 @@
   langgraph-checkpoint-sqlite,
   langsmith,
   psycopg,
+  pycryptodome,
   pytest-asyncio,
   pytest-mock,
   pytest-repeat,
@@ -38,16 +39,16 @@
   # passthru
   nix-update-script,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "langgraph";
-  version = "1.0.8";
+  version = "1.0.10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    tag = version;
-    hash = "sha256-VuvO2s6ttS3ZBs0Zz5CHOOkUSdJkfY3AnhIoCgnQOhs=";
+    tag = finalAttrs.version;
+    hash = "sha256-NJSmpVshj/x6ws+jFYXGarNKNztbk5OIIMA1neFOyIY=";
   };
 
   postgresqlTestSetupPost = ''
@@ -57,7 +58,7 @@ buildPythonPackage rec {
       --replace-fail "DEFAULT_POSTGRES_URI = \"postgres://postgres:postgres@localhost:5442/\"" "DEFAULT_POSTGRES_URI = \"postgres:///$PGDATABASE\""
   '';
 
-  sourceRoot = "${src.name}/libs/langgraph";
+  sourceRoot = "${finalAttrs.src.name}/libs/langgraph";
 
   build-system = [ hatchling ];
 
@@ -95,6 +96,7 @@ buildPythonPackage rec {
     langsmith
     psycopg
     psycopg.pool
+    pycryptodome
     pydantic
     pytest-asyncio
     pytest-mock
@@ -121,6 +123,7 @@ buildPythonPackage rec {
     "test_no_modifier"
     "test_pending_writes_resume"
     "test_remove_message_via_state_update"
+    "test_interrupt_functional_pydantic"
   ];
 
   disabledTestPaths = [
@@ -130,6 +133,8 @@ buildPythonPackage rec {
     "tests/test_large_cases_async.py"
     "tests/test_pregel.py"
     "tests/test_pregel_async.py"
+    "tests/test_subgraph_persistence.py"
+    "tests/test_subgraph_persistence_async.py"
   ];
 
   # Since `langgraph` is the only unprefixed package, we have to use an explicit match
@@ -147,8 +152,8 @@ buildPythonPackage rec {
   meta = {
     description = "Build resilient language agents as graphs";
     homepage = "https://github.com/langchain-ai/langgraph";
-    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/${src.tag}";
+    changelog = "https://github.com/langchain-ai/langgraph/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sarahec ];
   };
-}
+})


### PR DESCRIPTION
Automated version updates and (manual) finalAttrs migration.

Fixes [CVE-2026-28277](https://nvd.nist.gov/vuln/detail/CVE-2026-28277)

1. python3Packages.langgraph-cli: 0.4.11 -> 0.4.14
2. python3Packages.langgraph-sdk: 0.3.6 -> 0.3.9
3. python3Packages.langgraph: 1.0.8 -> 1.0.10
4. python3Packages.langgraph-checkpoint: 4.0.0 -> 4.0.1
5. python3Packages.langgraph-runtime-inmem: 0.23.2 -> 0.26.0
6. python3Packages.langgraph-prebuilt: 1.0.7 -> 1.0.8```

Closes #497642

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
