### PR TITLE
nestix: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ne/nestix/package.nix
+++ b/pkgs/by-name/ne/nestix/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nestix";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Noah765";
+    repo = "nestix";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Y5eYqyTgsrtEVf+Ypszt5x0qo1NHSv5YIhGuIIie7ec=";
+  };
+
+  cargoHash = "sha256-k4Ew8ezkmC2ThWcRCH2shkWrj1chdxNbHOrzguO6lTw=";
+
+  meta = {
+    description = "Structural Nix code formatter";
+    homepage = "https://github.com/Noah765/nestix";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Noah765 ];
+    mainProgram = "nestix";
+  };
+})


### PR DESCRIPTION
[Nestix](https://github.com/Noah765/nestix) is a structural Nix code formatter, which currently mainly formats nested attribute sets.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
