### PR TITLE
libgcc: turn off executable stack

### DIFF
--- a/pkgs/development/libraries/gcc/libgcc/default.nix
+++ b/pkgs/development/libraries/gcc/libgcc/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libgcc";
   inherit (gcc.cc) src version;
 
+  env.NIX_LDFLAGS = "-z,noexecstack";
+
   outputs = [
     "out"
     "dev"


### PR DESCRIPTION
Since glibc version 2.41 loading of shared objects with executable stack is not allowed.

From glibc 2.41 release notes (https://lists.gnu.org/archive/html/info-gnu/2025-01/msg00014.html):

> dlopen and dlmopen no longer make the stack executable if a shared
> library requires it, either implicitly because of a missing GNU_STACK
> ELF header (and default ABI permission having the executable bit set)
> or explicitly because of the executable bit in GNU_STACK, and the
> stack is not already executable.  Instead, loading such objects will
> fail.

See-also: https://github.com/NixOS/nixpkgs/issues/495182

The `env.NIX_LDFLAGS = "-z,noexecstack";` workaround is described in [nixos/doc/manual/release-notes/rl-2605.section.md](https://github.com/NixOS/nixpkgs/blob/3604e3ae9d333cd7d468a8be4b277adfd9427f1b/nixos/doc/manual/release-notes/rl-2605.section.md?plain=1#L94-L130).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
