### PR TITLE
salmon: fix broken build

### DIFF
--- a/pkgs/by-name/sa/salmon/package.nix
+++ b/pkgs/by-name/sa/salmon/package.nix
@@ -41,7 +41,12 @@ stdenv.mkDerivation (finalAttrs: {
     ./fetch-pufferfish.patch
   ];
 
-  postPatch = "patchShebangs .";
+  postPatch = ''
+    patchShebangs .
+    sed -i '1a cmake_policy(SET CMP0167 NEW)' CMakeLists.txt
+  '';
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=template-body";
 
   buildInputs = [
     (boost.override {


### PR DESCRIPTION
- find boost fix
- template-body ERR -> WARN

# More info on cmake-boost changes

Salmon is using the FindBoost module.

CMP0167
-------

.. versionadded:: 3.30

The ``FindBoost`` module is removed.

CMake 3.29 and below provide a ``FindBoost`` module, but it needs constant
updates to keep up with upstream Boost releases.  Upstream Boost 1.70
and above provide a ``BoostConfig.cmake`` package configuration file.
``find_package(Boost CONFIG)`` finds the upstream package directly,
without the find module.

CMake 3.30 and above prefer to not provide the ``FindBoost`` module
so that ``find_package(Boost)`` calls, without the ``CONFIG`` or
``NO_MODULE`` options, find the upstream ``BoostConfig.cmake`` directly.
This policy provides compatibility for projects that have not been ported
to use the upstream Boost package.

The ``OLD`` behavior of this policy is for ``find_package(Boost)`` to
load CMake's ``FindBoost`` module.  The ``NEW`` behavior is for
``find_package(Boost)`` to search for the upstream ``BoostConfig.cmake``.

This policy was introduced in CMake version 3.30.
It may be set by ``cmake_policy()`` or ``cmake_minimum_required()``.
If it is not set, CMake warns, and uses ``OLD`` behavior.

.. note::
  The ``OLD`` behavior of a policy is
  ``deprecated by definition``
  and may be removed in a future version of CMake.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
