### PR TITLE
vlang: 0.4.11 -> 0.5

### DIFF
--- a/pkgs/by-name/vl/vlang/package.nix
+++ b/pkgs/by-name/vl/vlang/package.nix
@@ -16,7 +16,7 @@
 }:
 
 let
-  version = "0.4.11";
+  version = "0.5";
   ptraceSubstitution = ''
     #include <sys/types.h>
     #include <sys/ptrace.h>
@@ -25,12 +25,12 @@ let
   # So we fix its rev to correspond to the V version.
   vc = stdenv.mkDerivation {
     pname = "v.c";
-    version = "0.4.11";
+    version = "0.5";
     src = fetchFromGitHub {
       owner = "vlang";
       repo = "vc";
-      rev = "a17f1105aa18b604ed8dac8fa5ca9424362c6e15";
-      hash = "sha256-DAsVr1wtRfGbKO74Vfq7ejci+zQabSWeir8njbHYV3o=";
+      rev = "294bff4ef87427743d0b35c0f7eb1b34a6dd061b";
+      hash = "sha256-NZR9Sxa9+iI0hGjB7Hwxl24K0Ra6ZJiUTk9yHp1J7kw=";
     };
 
     # patch the ptrace reference for darwin
@@ -63,7 +63,7 @@ stdenv.mkDerivation {
     owner = "vlang";
     repo = "v";
     rev = version;
-    hash = "sha256-K5B/fjdCYLE14LPg3ccS+sGC8CS7jZiuuxYkHvljGFA=";
+    hash = "sha256-iS9tXeEsEjxEpgJNjz/08MQfZkSfFZWHy0CMurITr+E=";
   };
 
   propagatedBuildInputs = [
@@ -107,6 +107,11 @@ stdenv.mkDerivation {
     ln -s $out/lib/v $out/bin/v
     wrapProgram $out/bin/v --prefix PATH : ${lib.makeBinPath [ stdenv.cc ]}
 
+    # gen_vc is a V-maintainer tool for pushing bootstrap C files to the vc
+    # repo; it requires network/SSH access and a v.mod root that doesn't exist
+    # in the installed layout, so it cannot be built in the Nix sandbox.
+    rm $out/lib/cmd/tools/gen_vc.v
+
     mkdir -p $HOME/.vmodules;
     ln -sf ${markdown} $HOME/.vmodules/markdown
     $out/lib/v -v build-tools
@@ -120,6 +125,7 @@ stdenv.mkDerivation {
 
   meta = {
     homepage = "https://vlang.io/";
+    changelog = "https://github.com/vlang/v/releases/tag/${version}";
     description = "Simple, fast, safe, compiled language for developing maintainable software";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
