### PR TITLE
Add future cursors

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7946,6 +7946,13 @@
     matrix = "@epiceric:nixos.dev";
     name = "Eric Rodrigues Pires";
   };
+  epic9491 = {
+    email = "epic9491@tutamail.com";
+    github = "epic9491";
+    githubId = 213664452;
+    matrix = "@gumbo:gaialabs.me";
+    name = "gumbo";
+  }
   epireyn = {
     github = "epireyn";
     githubId = 48213068;

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7939,6 +7939,13 @@
     githubId = 5085029;
     name = "Emanuele Peruffo";
   };
+  epic9491 = {
+    email = "epic9491@tutamail.com";
+    github = "epic9491";
+    githubId = 213664452;
+    matrix = "@gumbo:gaialabs.me";
+    name = "gumbo";
+  };
   EpicEric = {
     email = "eric@eric.dev.br";
     github = "EpicEric";
@@ -7946,13 +7953,6 @@
     matrix = "@epiceric:nixos.dev";
     name = "Eric Rodrigues Pires";
   };
-  epic9491 = {
-    email = "epic9491@tutamail.com";
-    github = "epic9491";
-    githubId = 213664452;
-    matrix = "@gumbo:gaialabs.me";
-    name = "gumbo";
-  }
   epireyn = {
     github = "epireyn";
     githubId = 48213068;

--- a/pkgs/by-name/fu/future-cursors/package.nix
+++ b/pkgs/by-name/fu/future-cursors/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "future-cursors";
+  version = "0-unstable-2021-07-16";
+
+  src = fetchFromGitHub {
+    owner = "yeyushengfan258";
+    repo = "Future-cursors";
+    rev = "587c14d2f5bd2dc34095a4efbb1a729eb72a1d36";
+    hash = "sha256-ziEgMasNVhfzqeURjYJK1l5BeIHk8GK6C4ONHQR7FyY=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -dm 755 $out/share/icons/Future-cursors
+    cp -r dist/* $out/share/icons/Future-cursors/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Future cursor theme";
+    homepage = "https://github.com/yeyushengfan258/Future-cursors";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ epic9491 ];
+  };
+})


### PR DESCRIPTION
Adds the Future cursor theme for Linux desktops.

https://github.com/yeyushengfan258/Future-cursors

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.