### PR TITLE
updateAutotoolsGnuConfigScriptsHook: fix error: attribute 'shell'

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -288,7 +288,7 @@ with pkgs;
     name = "update-autotools-gnu-config-scripts-hook";
     substitutions = {
       gnu_config = gnu-config.override {
-        runtimeShell = targetPackages.stdenv.shell;
+        runtimeShell = if stdenv.buildPlatform == stdenv.hostPlatform then stdenv.shell else runtimeShell;
       };
     };
   } ../build-support/setup-hooks/update-autotools-gnu-config-scripts.sh;


### PR DESCRIPTION
Fix nixpkgs eval using `pkgsCross.aarch64-multiplatform` : 
`nix-env --option system x86_64-linux --nix-path nixpkgs=..../nixpkgs -f '<nixpkgs>' -qaP --out-path --no-allow-import-from-derivation -A pkgsCross.aarch64-multiplatform`

Before this PR, the output was : 
```log
       … while querying the derivation named 'update-autotools-gnu-config-scripts-hook'

       … while calling the 'getAttr' builtin
         at «nix-internal»/derivation-internal.nix:50:17:
           49|     value = commonAttrs // {
           50|       outPath = builtins.getAttr outputName strict;
             |                 ^
           51|       drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'update-autotools-gnu-config-scripts-hook'
         whose name attribute is located at /home/eymeric/code_bidouille/projet/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:536:13

       … while evaluating attribute 'gnu_config' of derivation 'update-autotools-gnu-config-scripts-hook'
         at /home/eymeric/code_bidouille/projet/nixpkgs/pkgs/top-level/all-packages.nix:290:7:
          289|     substitutions = {
          290|       gnu_config = gnu-config.override {
             |       ^
          291|         runtimeShell = targetPackages.stdenv.shell;

       … while calling the 'getAttr' builtin
         at «nix-internal»/derivation-internal.nix:50:17:
           49|     value = commonAttrs // {
           50|       outPath = builtins.getAttr outputName strict;
             |                 ^
           51|       drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'gnu-config-aarch64-unknown-linux-gnu-2024-01-01'
         whose name attribute is located at /home/eymeric/code_bidouille/projet/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:536:13

       … while evaluating attribute 'fixupPhase' of derivation 'gnu-config-aarch64-unknown-linux-gnu-2024-01-01'
         at /home/eymeric/code_bidouille/projet/nixpkgs/pkgs/by-name/gn/gnu-config/package.nix:57:3:
           56|
           57|   fixupPhase = ''
             |   ^
           58|     runHook preFixup

       … while evaluating the attribute 'stdenv.shell'
         at /home/eymeric/code_bidouille/projet/nixpkgs/pkgs/stdenv/booter.nix:144:5:
          143|     __raw = true;
          144|     stdenv.cc =
             |     ^
          145|       if buildPackages.stdenv.hasCC then

       error: attribute 'shell' missing
       at /home/eymeric/code_bidouille/projet/nixpkgs/pkgs/top-level/all-packages.nix:291:24:
          290|       gnu_config = gnu-config.override {
          291|         runtimeShell = targetPackages.stdenv.shell;
             |                        ^
          292|       };

```

This is related/inspired by : #116207 #207315 #347053

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform: (nothing to build)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
