### PR TITLE
pnpm_10: 10.29.2 -> 10.30.3

### DIFF
--- a/pkgs/build-support/teleport/default.nix
+++ b/pkgs/build-support/teleport/default.nix
@@ -10,7 +10,7 @@
   nodejs,
   openssl,
   pkg-config,
-  pnpm_10,
+  pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
   rustc,
@@ -81,7 +81,7 @@ let
         pname
         version
         ;
-      pnpm = pnpm_10;
+      pnpm = pnpm_10_29_2;
       fetcherVersion = 2;
       hash = pnpmHash;
     };
@@ -91,7 +91,7 @@ let
       cargo
       nodejs
       pnpmConfigHook
-      pnpm_10
+      pnpm_10_29_2
       rustc
       rustc.llvmPackages.lld
       rustPlatform.cargoSetupHook

--- a/pkgs/by-name/e-/e-search/package.nix
+++ b/pkgs/by-name/e-/e-search/package.nix
@@ -9,7 +9,7 @@
   gobject-introspection,
   makeWrapper,
   nodejs_20,
-  pnpm_10,
+  pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
   electron,
@@ -37,7 +37,7 @@
 }:
 
 let
-  pnpm' = pnpm_10.override { nodejs = nodejs_20; };
+  pnpm' = pnpm_10_29_2.override { nodejs = nodejs_20; };
   eSearch-OCR-ch = fetchzip {
     url = "https://github.com/xushengfeng/eSearch-OCR/releases/download/4.0.0/ch.zip";
     hash = "sha256-0NCXuy8k9/AdpK4ie49S8032u37gNhX6Jc6bOGufrV4=";

--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -8,7 +8,7 @@
   mpv-unwrapped,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm,
+  pnpm_10_29_2,
   darwin,
   copyDesktopItems,
   makeDesktopItem,
@@ -41,6 +41,7 @@ buildNpmPackage {
       version
       src
       ;
+    pnpm = pnpm_10_29_2;
     fetcherVersion = 3;
     hash = "sha256-K9mwEJA0fZXI2OnVo5y4Zmox3mwO8qLvgLiBaoyYAkg=";
   };
@@ -48,7 +49,7 @@ buildNpmPackage {
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
   nativeBuildInputs = [
-    pnpm
+    pnpm_10_29_2
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux) [ copyDesktopItems ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.autoSignDarwinBinariesHook ];

--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -6,7 +6,7 @@
   makeDesktopItem,
   makeWrapper,
   nodejs,
-  pnpm_10,
+  pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
   stdenv,
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_10
+    pnpm_10_29_2
     makeWrapper
     imagemagick
   ];
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
       version
       src
       ;
-    pnpm = pnpm_10;
+    pnpm = pnpm_10_29_2;
     fetcherVersion = 3;
     hash = "sha256-EP7bpbJUcKmHm7KMlKc0Fz2u0niQ3jC7YN/9pp7vucE=";
   };

--- a/pkgs/by-name/gi/gitify/package.nix
+++ b/pkgs/by-name/gi/gitify/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pnpm_10,
+  pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_10
+    pnpm_10_29_2
     copyDesktopItems
     imagemagick
     makeWrapper
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10;
+    pnpm = pnpm_10_29_2;
     fetcherVersion = 2;
     hash = "sha256-uK3CNyPewUVAmqBJq1WMCrNeMP5I18BEBkZIBP0qPsI=";
   };

--- a/pkgs/by-name/he/heroic-unwrapped/package.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/package.nix
@@ -4,7 +4,7 @@
   stdenv,
   fetchFromGitHub,
   # Pinned, because our FODs are not guaranteed to be stable between major versions.
-  pnpm_10,
+  pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -21,7 +21,7 @@
 }:
 
 let
-  pnpm = pnpm_10;
+  pnpm = pnpm_10_29_2;
   electron = electron_39;
 
   legendary = callPackage ./legendary.nix { };

--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm,
+  pnpm_10_29_2,
   nodejs,
   electron,
   makeWrapper,
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm
+    pnpm_10_29_2
     nodejs
     # we use a script wrapper here for environment variable expansion at runtime
     # https://github.com/NixOS/nixpkgs/issues/172583
@@ -47,6 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10_29_2;
     fetcherVersion = 3;
     hash = "sha256-MgUOOr188t+t/4sTXVpbr+xYT/1qf7/B0ZG0w+QkVxc=";
   };

--- a/pkgs/by-name/pe/pear-desktop/package.nix
+++ b/pkgs/by-name/pe/pear-desktop/package.nix
@@ -7,7 +7,7 @@
   python3,
   copyDesktopItems,
   nodejs,
-  pnpm_10,
+  pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
   makeDesktopItem,
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10;
+    pnpm = pnpm_10_29_2;
     fetcherVersion = 2;
     hash = "sha256-xZQ8rnLGD0ZxxUUPLHmNJ6mA+lnUHCTBvtJTiIPxaZU=";
   };
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     nodejs
     pnpmConfigHook
-    pnpm_10
+    pnpm_10_29_2
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ copyDesktopItems ];
 

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -6,7 +6,7 @@
   copyDesktopItems,
   electron_39,
   nodejs,
-  pnpm_10,
+  pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
   makeDesktopItem,
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10;
+    pnpm = pnpm_10_29_2;
     fetcherVersion = 2;
     hash = "sha256-nBjAmXzjR0qGCM91UAonQKP0NG7+DXImueSbhbnMK/k=";
   };
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeBinaryWrapper
     nodejs
     pnpmConfigHook
-    pnpm_10
+    pnpm_10_29_2
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     copyDesktopItems

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   nodejs_24,
-  pnpm_10,
+  pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
   electron_40,
@@ -25,7 +25,7 @@
 }:
 let
   nodejs = nodejs_24;
-  pnpm = pnpm_10;
+  pnpm = pnpm_10_29_2;
   electron = electron_40;
 
   libsignal-node = callPackage ./libsignal-node.nix { inherit nodejs; };

--- a/pkgs/by-name/sp/splayer/package.nix
+++ b/pkgs/by-name/sp/splayer/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pnpm_10,
+  pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
       version
       src
       ;
-    pnpm = pnpm_10;
+    pnpm = pnpm_10_29_2;
     fetcherVersion = 2;
     hash = "sha256-PTfZopse+9RS7qh0miLu3duYlWDfifZS254tZKqgxKk=";
   };
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm_10
+    pnpm_10_29_2
     nodejs
     rustPlatform.cargoSetupHook
     cargo

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -13,7 +13,7 @@
   pipewire,
   libpulseaudio,
   autoPatchelfHook,
-  pnpm_10,
+  pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
       src
       patches
       ;
-    pnpm = pnpm_10;
+    pnpm = pnpm_10_29_2;
     fetcherVersion = 2;
     hash = "sha256-o9dxtqXfCKTQpvNrbD/h0F3Hh39TEEA1qqYA9tN3j5I=";
   };
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_10
+    pnpm_10_29_2
     jq
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [

--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   makeWrapper,
   makeDesktopItem,
-  pnpm,
+  pnpm_10_29_2,
   pnpmConfigHook,
   nodejs,
   electron,
@@ -39,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
       sourceRoot
       pnpmInstallFlags
       ;
+    pnpm = pnpm_10_29_2;
     fetcherVersion = 1;
     hash = "sha256-yiVlEr1gi2g3m+hkYfDv6qd/wRlwwknM6lAaIeR58Ok=";
   };
@@ -50,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     nodejs
-    pnpm
+    pnpm_10_29_2
     pnpmConfigHook
     vikunja.passthru.frontend
   ];

--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   stdenv,
   nodejs_24,
-  pnpm_10,
+  pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
   buildGoModule,
@@ -35,7 +35,7 @@ let
         src
         sourceRoot
         ;
-      pnpm = pnpm_10;
+      pnpm = pnpm_10_29_2;
       fetcherVersion = 1;
       hash = "sha256-oY8DXJFFwLBjUno3EithLhmnA8hTksq4xgMSSOGtwuo=";
     };
@@ -44,7 +44,7 @@ let
       nodejs_24
       dart-sass
       pnpmConfigHook
-      pnpm_10
+      pnpm_10_29_2
     ];
 
     doCheck = true;

--- a/pkgs/by-name/vo/voicevox/package.nix
+++ b/pkgs/by-name/vo/voicevox/package.nix
@@ -13,7 +13,7 @@
   nodejs,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm,
+  pnpm_10_29_2,
 
   _7zz,
   electron,
@@ -58,6 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
       postPatch
       ;
 
+    pnpm = pnpm_10_29_2;
+
     # let's just be safe and add these explicitly to nativeBuildInputs
     # even though the fetcher already uses them in its implementation
     nativeBuildInputs = [
@@ -76,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     moreutils
     nodejs
     pnpmConfigHook
-    pnpm
+    pnpm_10_29_2
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     copyDesktopItems

--- a/pkgs/by-name/zu/zulip/package.nix
+++ b/pkgs/by-name/zu/zulip/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   nodejs,
-  pnpm_10,
+  pnpm_10_29_2,
   pnpmConfigHook,
   python3,
   electron_39,
@@ -26,14 +26,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10;
+    pnpm = pnpm_10_29_2;
     fetcherVersion = 3;
     hash = "sha256-s/KllzT46L2o4SWS3z3Z7FDQD6FEEEAnPdM6tsfGRUo=";
   };
 
   nativeBuildInputs = [
     nodejs
-    pnpm_10
+    pnpm_10_29_2
     pnpmConfigHook
     makeBinaryWrapper
     copyDesktopItems

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -14,6 +14,13 @@ let
       version = "9.15.9";
       hash = "sha256-z4anrXZEBjldQoam0J1zBxFyCsxtk+nc6ax6xNxKKKc=";
     };
+    # 10.29.3 made a breaking change: https://github.com/pnpm/pnpm/issues/10601.
+    # Pnpm packages that depend on electron builder must be upgraded to 26.8.2 or newer
+    # otherwise a runtime error will occur when launching the application.
+    "10_29_2" = {
+      version = "10.29.2";
+      hash = "sha256-hAL2daH0zJ1PJ7v6s1wtSi4dfrATHfA9rQlhnoZnTQw=";
+    };
     "10" = {
       version = "10.29.2";
       hash = "sha256-hAL2daH0zJ1PJ7v6s1wtSi4dfrATHfA9rQlhnoZnTQw=";

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -22,8 +22,8 @@ let
       hash = "sha256-hAL2daH0zJ1PJ7v6s1wtSi4dfrATHfA9rQlhnoZnTQw=";
     };
     "10" = {
-      version = "10.29.2";
-      hash = "sha256-hAL2daH0zJ1PJ7v6s1wtSi4dfrATHfA9rQlhnoZnTQw=";
+      version = "10.30.3";
+      hash = "sha256-/wpyFA9qbWbAsoT2yVYK/2BVGOKMKa6sJfsmK3QzFYg=";
     };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3249,6 +3249,7 @@ with pkgs;
   inherit (callPackage ../development/tools/pnpm { })
     pnpm_8
     pnpm_9
+    pnpm_10_29_2
     pnpm_10
     ;
   pnpm = pnpm_10;


### PR DESCRIPTION
~~Release: https://github.com/pnpm/pnpm/releases/tag/v10.31.0~~ reverted as it fails to install for a reverse dependency, `cdxgen`.

Release: https://github.com/pnpm/pnpm/releases/tag/v10.30.3

See https://github.com/NixOS/nixpkgs/pull/488068 for more context, pnpm 10.29.3 causes runtime errors for electron packages.

Closes https://github.com/NixOS/nixpkgs/pull/492822.

----

Updating bumping `electron-builder` dependency of `signal-desktop`, works, but there are many other packages. Let's leave it to a future PR or wait for upstreams to bump it.

~~I tried bumping electron-builder dependency of the signal package, but it fails with the same error at runtime. @diogotcorreia do you have any idea about why this doesn't work, perhaps we need to use a patched nix-build electron or bump other electron related node packages?~~
Oops, the electron-builder is only patched on 26.8.2, and I tried updating it to 26.8.1. On npmjs.org the latest is .1, .2 is marked as next.
After bumping to the correct .2 version, signal desktop works :)

Probably we should first find all the packages that use electron builder first, pin them to pnpm 10.29.2 and later either wait for upstream patch or patch it ourselves (patches can be kinda big which, for many packages it would bloat the nixpkgs tarball).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
