### PR TITLE
nixos/home-assistant: open sonos component specific ports when in use and openFirewall is true

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -35,6 +35,7 @@ let
     mkOption
     mkRemovedOptionModule
     mkRenamedOptionModule
+    optional
     optionals
     optionalString
     recursiveUpdate
@@ -569,7 +570,13 @@ in
     openFirewall = mkOption {
       default = false;
       type = types.bool;
-      description = "Whether to open the firewall for the specified port.";
+      description = "Whether to open the firewall for the specified frontend port. For components specific ports see openFirewallForComponents.";
+    };
+
+    openFirewallForComponents = mkOption {
+      default = false;
+      type = types.bool;
+      description = "Whether to open required firewall ports for enabled components. For the frontend see openFirewall.";
     };
 
     blueprints = mergeAttrsList (
@@ -620,7 +627,13 @@ in
       }
     ];
 
-    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.config.http.server_port ];
+    networking.firewall.allowedTCPPorts = mkMerge [
+      (mkIf cfg.openFirewall [ cfg.config.http.server_port ])
+      (lib.mkIf cfg.openFirewallForComponents
+        # https://www.home-assistant.io/integrations/sonos/#network-requirements
+        (optional (useComponent "sonos") 1400)
+      )
+    ];
 
     # symlink the configuration to /etc/home-assistant
     environment.etc = mkMerge [

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -569,7 +569,25 @@ in
     openFirewall = mkOption {
       default = false;
       type = types.bool;
-      description = "Whether to open the firewall for the specified port.";
+      description = ''
+        Whether to open the firewall for the specified frontend port
+
+        :::{.note}
+        For components specific ports see {option}`services.home-assistant.openFirewallForComponents`.
+        :::
+      '';
+    };
+
+    openFirewallForComponents = mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Whether to open required firewall ports for enabled components.
+
+        :::{.note}
+        For the frontend see {option}`services.home-assistant.openFirewall`.
+        :::
+      '';
     };
 
     blueprints = mergeAttrsList (
@@ -620,7 +638,13 @@ in
       }
     ];
 
-    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.config.http.server_port ];
+    networking.firewall.allowedTCPPorts = mkMerge [
+      (mkIf cfg.openFirewall [ cfg.config.http.server_port ])
+      (mkIf cfg.openFirewallForComponents
+        # https://www.home-assistant.io/integrations/sonos/#network-requirements
+        (optionals (useComponent "sonos") [ 1400 ])
+      )
+    ];
 
     # symlink the configuration to /etc/home-assistant
     environment.etc = mkMerge [


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
