### PR TITLE
python313Packages.torchao: 0.15.0 -> 0.16.0; python3Packages.torchtune:: 0.6.1 -> 0.6.12-unstable-2026-02-19

### DIFF
--- a/pkgs/development/python-modules/torchao/default.nix
+++ b/pkgs/development/python-modules/torchao/default.nix
@@ -33,14 +33,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "torchao";
-  version = "0.15.0";
+  version = "0.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pytorch";
     repo = "ao";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-N5s2AzkK9HmUT+qVq2owrB/53izDlzd25fqThjA3hPQ=";
+    hash = "sha256-FyBsIVb3zdKtA8Vqjt301bRrGIoyeqiOUADVFGxiRPY=";
   };
 
   # AttributeError: 'typing.Union' object has no attribute '__module__' and no __dict__ for setting
@@ -304,6 +304,16 @@ buildPythonPackage (finalAttrs: {
     "test/quantization/pt2e/test_arm_inductor_quantizer.py"
     "test/quantization/pt2e/test_x86inductor_fusion.py"
     "test/quantization/pt2e/test_x86inductor_quantizer.py"
+
+    # TypeError: Trying to convert Float8_e4m3fn to the MPS backend but it does not have support for that dtype.
+    "test/quantization/quantize_/workflows/float8/test_float8_tensor.py"
+
+    # AssertionError: Torch not compiled with CUDA enabled
+    "test/integration/test_integration.py"
+
+    # Wants network access
+    "test/test_low_bit_optim.py::TestQuantize::test_bf16_stochastic_round_dtensor_device_mps_compile_False"
+    "test/test_low_bit_optim.py::TestQuantize::test_bf16_stochastic_round_dtensor_device_mps_compile_True"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/torchtune/default.nix
+++ b/pkgs/development/python-modules/torchtune/default.nix
@@ -37,14 +37,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "torchtune";
-  version = "0.6.1";
+  version = "0.6.2-unstable-2026-02-19";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "meta-pytorch";
     repo = "torchtune";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-evhQBpZiUXriL0PAYkEzGypH21iRs37Ix6Nl5YAyeQ0=";
+    rev = "6f2aa7254458145f99d7004cbd6ebc8e53a06404";
+    hash = "sha256-ryR5iO3IwkoLdMLSFGhHCLl0P8yD+GQdZFEE6M/EYh0=";
   };
 
   build-system = [
@@ -103,12 +103,16 @@ buildPythonPackage (finalAttrs: {
     "test_deprecated"
 
     # Flaky
-    # AssertionError: actual: -83.3048095703125, expected: -83.15229797363281
+    # AssertionError: (numbers slightly different than expected))
     "test_forward"
     "test_forward_kv_cache"
     "test_forward_with_2d_pos_ids"
     "test_forward_with_curr_pos"
     "test_forward_with_packed_pos"
+    "test_local_kv_cache"
+
+    # TypeError: exceptions must be derived from Warning, not <class 'NoneType'>
+    "test_deprecate_parameter"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64) [
     # RuntimeError: Error in dlopen:
@@ -133,12 +137,17 @@ buildPythonPackage (finalAttrs: {
     "tests/torchtune/_cli/test_download.py::TestTuneDownloadCommand::test_download_calls_snapshot"
     "tests/torchtune/_cli/test_download.py::TestTuneDownloadCommand::test_gated_repo_error_no_token"
     "tests/torchtune/_cli/test_download.py::TestTuneDownloadCommand::test_gated_repo_error_with_token"
+
+    # NameError: name 'TypeVar' is not defined
+    "tests/torchtune/rlhf/loss/test_dpo_loss.py"
+    "tests/torchtune/rlhf/loss/test_ppo_loss.py"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # fail due to floating-point precision differences
     "tests/torchtune/models/flux/test_flux_autoencoder.py::TestFluxAutoencoder::test_encode"
     "tests/torchtune/modules/peft/test_dora.py::TestDoRALinear::test_qdora_parity[True-dtype1]"
     "tests/torchtune/modules/peft/test_lora.py::TestLoRALinear::test_qlora_parity[True-dtype1]"
+    "tests/torchtune/modules/test_common_utils.py::TestLocalKVCache::test_local_kv_cache[llama_decoder_model]"
 
     # hangs
     "tests/torchtune/utils"
@@ -147,7 +156,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "PyTorch native post-training library";
     homepage = "https://github.com/meta-pytorch/torchtune";
-    changelog = "https://github.com/meta-pytorch/torchtune/releases/tag/${finalAttrs.src.tag}";
+    # changelog = "https://github.com/meta-pytorch/torchtune/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       GaetanLepage


### PR DESCRIPTION
### Torchao
1. Version bump
2. Disabled failing tests on Darwin

### Torchtune
1. Bump to unstable version as 0.6.1 was importing packages that were dropped in torchao 0.16.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
