### PR TITLE
libation: add glib to runtimeDeps

### DIFF
--- a/pkgs/by-name/li/libation/package.nix
+++ b/pkgs/by-name/li/libation/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   dotnetCorePackages,
   wrapGAppsHook3,
+  glib,
   glew,
   gtk3,
   libxrandr,
@@ -56,6 +57,8 @@ buildDotnetModule rec {
     libxcursor
     # For file dialogs
     gtk3
+    # For web view (login dialog); loaded via P/Invoke at runtime
+    glib
   ];
 
   postInstall = ''


### PR DESCRIPTION
When I ran ``nix run nixpkgs#libation``, the app opened, but then showed an error when trying to add an account:

```
Unable to load shared library 'libglib' or one of its dependencies. In order to help diagnose loading problems, consider using a tool like strace. If you're using glibc, consider setting the LD_DEBUG environment variable: 
/nix/store/pawn3zrndzh3s4c7sya5gngi7qxc1kyr-libation-13.1.8/lib/libation/libglib.so: cannot open shared object file: No such file or directory
/nix/store/3wgrbbv53l219mc3ycckg4nhm4rm9vmg-dotnet-runtime-10.0.3/share/dotnet/shared/Microsoft.NETCore.App/10.0.3/libglib.so: cannot open shared object file: No such file or directory
/nix/store/pawn3zrndzh3s4c7sya5gngi7qxc1kyr-libation-13.1.8/lib/libation/liblibglib.so: cannot open shared object file: No such file or directory
/nix/store/3wgrbbv53l219mc3ycckg4nhm4rm9vmg-dotnet-runtime-10.0.3/share/dotnet/shared/Microsoft.NETCore.App/10.0.3/liblibglib.so: cannot open shared object file: No such file or directory
/nix/store/pawn3zrndzh3s4c7sya5gngi7qxc1kyr-libation-13.1.8/lib/libation/libglib: cannot open shared object file: No such file or directory
/nix/store/3wgrbbv53l219mc3ycckg4nhm4rm9vmg-dotnet-runtime-10.0.3/share/dotnet/shared/Microsoft.NETCore.App/10.0.3/libglib: cannot open shared object file: No such file or directory
/nix/store/pawn3zrndzh3s4c7sya5gngi7qxc1kyr-libation-13.1.8/lib/libation/liblibglib: cannot open shared object file: No such file or directory
/nix/store/3wgrbbv53l219mc3ycckg4nhm4rm9vmg-dotnet-runtime-10.0.3/share/dotnet/shared/Microsoft.NETCore.App/10.0.3/liblibglib: cannot open shared object file: No such file or directory


   at qe.s()
   at qe.s()
   at pu.a()
   at qf.a(Action`1 a)
   at Avalonia.Controls.NativeWebDialog.e()
   at Avalonia.Controls.NativeWebDialog.c()
   at Avalonia.Controls.NativeWebDialog.Show()
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__124_0(Object state)
   at Avalonia.Threading.SendOrPostCallbackDispatcherOperation.InvokeCore()
   at Avalonia.Threading.Dispatcher.ExecuteJobsCore(Boolean fromExplicitBackgroundProcessingCallback)
   at Avalonia.X11.X11PlatformThreading.RunLoop(CancellationToken cancellationToken)
   at Avalonia.Threading.DispatcherFrame.Run(IControlledDispatcherImpl impl)
   at Avalonia.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
   at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken)
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.StartCore(String[] args)
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args)
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(AppBuilder builder, String[] args, ShutdownMode shutdownMode)
   at LibationAvalonia.Program.Main(String[] args) in /build/source/Source/LibationAvalonia/Program.cs:line 58
```

Claude helped me with this and had the following to say about why it's needed explicitly:

_buildDotnetModule adds runtimeDeps to LD_LIBRARY_PATH in the wrapper script, but does not recurse into their transitive dependencies. While gtk3 depends on glib, and wrapGAppsHook3 sets up
   GSettings schemas, GIO modules, and GDK pixbuf paths, neither mechanism adds glib's lib directory to LD_LIBRARY_PATH. This is normally fine for native GTK apps that link against glib at
  build time, but Libation's Avalonia web view loads libglib via P/Invoke (dlopen) at runtime, so it needs to be explicitly listed in runtimeDeps._