### PR TITLE
pixiv-multiplatform-bin: init at 1.8.4

### DIFF
--- a/pkgs/by-name/pi/pixiv-multiplatform-bin/package.nix
+++ b/pkgs/by-name/pi/pixiv-multiplatform-bin/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  makeDesktopItem,
+  copyDesktopItems,
+  autoPatchelfHook,
+  makeWrapper,
+  libGL,
+  libx11,
+  libxext,
+  libxrender,
+  libxtst,
+  libxi,
+  fontconfig,
+  alsa-lib,
+  webkitgtk_4_1,
+  gtk3,
+  libsoup_3,
+  sqlite,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pixiv-multiplatform";
+  version = "1.8.4";
+
+  src = fetchzip {
+    url = "https://github.com/magic-cucumber/Pixiv-MultiPlatform/releases/download/v${finalAttrs.version}/linux.tar.gz";
+    hash = "sha256-HrshexFChp5ZurSNXq4qFT3GdLuMz64nIrzPMKSbobU=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libGL
+    libx11
+    libxext
+    libxrender
+    libxtst
+    libxi
+    fontconfig
+    alsa-lib
+    stdenv.cc.cc
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{opt,share/icons/hicolor/256x256/apps}
+    cp -r . $out/opt/Pixiv-MultiPlatform
+    ln -s $out/opt/Pixiv-MultiPlatform/lib/Pixiv-MultiPlatform.png $out/share/icons/hicolor/256x256/apps/pixiv-multiplatform.png
+    makeWrapper $out/opt/Pixiv-MultiPlatform/bin/Pixiv-MultiPlatform $out/bin/Pixiv-MultiPlatform \
+      --suffix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          webkitgtk_4_1
+          gtk3
+          libsoup_3
+          sqlite
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      comment = finalAttrs.meta.description;
+      name = "pixiv-multiplatform";
+      desktopName = "Pixiv-MultiPlatform";
+      exec = "Pixiv-MultiPlatform %U";
+      icon = "pixiv-multiplatform";
+      categories = [ "Network" ];
+    })
+  ];
+
+  meta = {
+    description = "Cross-platform third-party Pixiv client based on Kotlin technology stack";
+    homepage = "https://pmf.kagg886.top";
+    changelog = "https://github.com/magic-cucumber/Pixiv-MultiPlatform/releases";
+    downloadPage = "https://github.com/magic-cucumber/Pixiv-MultiPlatform/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+      binaryBytecode
+    ];
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    mainProgram = "Pixiv-MultiPlatform";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Currently it crashes at a lot of places...

Building from source is WIP at #497448. It seems to be unnecessarily difficult, so I choose to package the bin variant first.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
