### PR TITLE
python3Packages.deepwave: fix build

### DIFF
--- a/pkgs/development/python-modules/deepwave/default.nix
+++ b/pkgs/development/python-modules/deepwave/default.nix
@@ -2,21 +2,13 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  cmake,
+  scikit-build-core,
   torch,
-  ninja,
-  scipy,
-  which,
-  pybind11,
-  pytest-xdist,
   pytestCheckHook,
+  scipy,
 }:
 
-let
-  linePatch = ''
-    import os
-    os.environ['PATH'] = os.environ['PATH'] + ':${ninja}/bin'
-  '';
-in
 buildPythonPackage rec {
   pname = "deepwave";
   version = "0.0.26";
@@ -29,36 +21,26 @@ buildPythonPackage rec {
     hash = "sha256-gjFbBn7fJiLZUm+97xf6xd7C+OkEoeFe3061tFkJhFk=";
   };
 
-  # unable to find ninja although it is available, most likely because it looks for its pip version
-  postPatch = ''
-    substituteInPlace setup.cfg --replace "ninja" ""
-
-    # Adding ninja to the path forcibly
-    mv src/deepwave/__init__.py tmp
-    echo "${linePatch}" > src/deepwave/__init__.py
-    cat tmp >> src/deepwave/__init__.py
-    rm tmp
-  '';
-
-  # The source files are compiled at runtime and cached at the
-  # $HOME/.cache folder, so for the check phase it is needed to
-  # have a temporary home. This is also the reason ninja is not
-  # needed at the nativeBuildInputs, since it will only be used
-  # at runtime.
+  # Return to project root to locate `pyproject.toml` for build
   preBuild = ''
-    export HOME=$(mktemp -d)
+    cd ..
   '';
 
-  propagatedBuildInputs = [
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  build-system = [
+    scikit-build-core
+  ];
+
+  dependencies = [
     torch
-    pybind11
   ];
 
   nativeCheckInputs = [
-    which
-    scipy
-    pytest-xdist
     pytestCheckHook
+    scipy
   ];
 
   pythonImportsCheck = [ "deepwave" ];


### PR DESCRIPTION
Upstream changed its approach to building the package considerably, which wasn't accounted for in nixpkgs.

Hydra: https://hydra.nixos.org/build/323002039/nixlog/2
Tracking: #475732

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{13,14}Packages.deepwave`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
