### PR TITLE
katifetch: init at 13.1

### DIFF
--- a/pkgs/by-name/ka/katifetch/default.nix
+++ b/pkgs/by-name/ka/katifetch/default.nix
@@ -1,1 +1,0 @@
-(import ./package.nix)

--- a/pkgs/by-name/ka/katifetch/default.nix
+++ b/pkgs/by-name/ka/katifetch/default.nix
@@ -1,0 +1,1 @@
+(import ./package.nix)

--- a/pkgs/by-name/ka/katifetch/package.nix
+++ b/pkgs/by-name/ka/katifetch/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pciutils, coreutils }:
+{ stdenv, fetchFromGitHub, bash, pciutils, coreutils, lib }:
 
 stdenv.mkDerivation {
   pname = "katifetch";
@@ -11,7 +11,8 @@ stdenv.mkDerivation {
     sha256 = "1y4arp28807z28k9p69qsm0afn71cbwrpx2s3a9g7bxcpqbrnkzy";
   };
 
-  buildInputs = [ pciutils coreutils ];
+  buildInputs = [ coreutils ];
+  propagatedBuildInputs = [ bash pciutils ];
 
   installPhase = ''
     mkdir -p $out/bin
@@ -19,11 +20,11 @@ stdenv.mkDerivation {
     chmod +x $out/bin/katifetch
   '';
 
-  meta = {
-    description = "Fast and customizable Neofetch alternative written in Bash";
-    homepage = "https://github.com/ximimoments/katifetch";
-    license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
-    maintainers = with stdenv.lib.maintainers; [ ximimoments ];
-  };
+ meta = {
+  description = "Fast and customizable Neofetch alternative written in Bash";
+  homepage = "https://github.com/ximimoments/katifetch";
+  license = lib.licenses.mit;
+  platforms = lib.platforms.all;
+  maintainers = [];
+ };
 }

--- a/pkgs/by-name/ka/katifetch/package.nix
+++ b/pkgs/by-name/ka/katifetch/package.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, pciutils, coreutils }:
 
 stdenv.mkDerivation {
   pname = "katifetch";
@@ -10,6 +10,8 @@ stdenv.mkDerivation {
     rev = "13.1";
     sha256 = "1y4arp28807z28k9p69qsm0afn71cbwrpx2s3a9g7bxcpqbrnkzy";
   };
+
+  buildInputs = [ pciutils coreutils ];
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/by-name/ka/katifetch/package.nix
+++ b/pkgs/by-name/ka/katifetch/package.nix
@@ -1,11 +1,13 @@
-{ stdenv, fetchzip }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation {
   pname = "katifetch";
   version = "13.1";
 
-  src = fetchzip {
-    url = "https://github.com/ximimoments/katifetch/archive/refs/tags/13.1.zip";
+  src = fetchFromGitHub {
+    owner = "ximimoments";
+    repo = "katifetch";
+    rev = "13.1";
     sha256 = "1y4arp28807z28k9p69qsm0afn71cbwrpx2s3a9g7bxcpqbrnkzy";
   };
 
@@ -18,5 +20,8 @@ stdenv.mkDerivation {
   meta = {
     description = "Fast and customizable Neofetch alternative written in Bash";
     homepage = "https://github.com/ximimoments/katifetch";
+    license = stdenv.lib.licenses.mit;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+    maintainers = with stdenv.lib.maintainers; [ ximimoments ];
   };
 }

--- a/pkgs/by-name/ka/katifetch/package.nix
+++ b/pkgs/by-name/ka/katifetch/package.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchzip }:
+
+stdenv.mkDerivation {
+  pname = "katifetch";
+  version = "13.1";
+
+  src = fetchzip {
+    url = "https://github.com/ximimoments/katifetch/archive/refs/tags/13.1.zip";
+    sha256 = "1y4arp28807z28k9p69qsm0afn71cbwrpx2s3a9g7bxcpqbrnkzy";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp katifetch.sh $out/bin/katifetch
+    chmod +x $out/bin/katifetch
+  '';
+
+  meta = {
+    description = "Fast and customizable Neofetch alternative written in Bash";
+    homepage = "https://github.com/ximimoments/katifetch";
+  };
+}


### PR DESCRIPTION
## Things done

Added katifetch, a customizable Neofetch alternative written in Bash.

Homepage: https://github.com/ximimoments/katifetch

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested basic functionality:
  - [x] Ran ./result/bin/katifetch successfully
- [ ] Ran nixpkgs-review on this PR.
- [x] Fits CONTRIBUTING.md, pkgs/README.md and other guidelines.