### PR TITLE
multiviewer-for-f1: 2.1.0 -> 2.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20916,6 +20916,11 @@
     githubId = 9267430;
     name = "Philipp Mildenberger";
   };
+  philipp-tty = {
+    github = "philipp-tty";
+    githubId = 19515917;
+    name = "Philipp";
+  };
   philiptaron = {
     email = "philip.taron@gmail.com";
     github = "philiptaron";

--- a/pkgs/by-name/mu/multiviewer-for-f1/package.nix
+++ b/pkgs/by-name/mu/multiviewer-for-f1/package.nix
@@ -31,15 +31,15 @@
   writeScript,
 }:
 let
-  id = "305607196";
+  id = "367699519";
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "multiviewer-for-f1";
-  version = "2.3.0";
+  version = "2.6.0";
 
   src = fetchurl {
-    url = "https://releases.multiviewer.dev/download/${id}/multiviewer_${finalAttrs.version}_amd64.deb";
-    hash = "sha256-Uc4db2o4XBV9eRNugxS6pA9Z5YhjY5QnEkwOICXmUwc=";
+    url = "https://releases.multiviewer.app/download/${id}/multiviewer_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-tlDrPA1drM/rNtiXb1GZPzxkCwYi3I9Gkvr3tJ9YzcI=";
   };
 
   nativeBuildInputs = [
@@ -127,7 +127,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://multiviewer.app";
     downloadPage = "https://multiviewer.app/download";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ babeuh ];
+    maintainers = with lib.maintainers; [ babeuh philipp-tty];
     platforms = [ "x86_64-linux" ];
     mainProgram = "multiviewer";
   };


### PR DESCRIPTION
Update the package to the latest upstream version. The previous maintainer appears to be inactive, and the application had become broken in the meantime. This update restores functionality and brings the package in sync with the current upstream release.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
