### PR TITLE
gnome-manuals: init at 49.0

### DIFF
--- a/pkgs/by-name/gn/gnome-manuals/package.nix
+++ b/pkgs/by-name/gn/gnome-manuals/package.nix
@@ -1,0 +1,70 @@
+{
+  stdenv,
+  lib,
+  desktop-file-utils,
+  fetchurl,
+  flatpak,
+  glib,
+  gnome,
+  gom,
+  gtk4,
+  libadwaita,
+  libdex,
+  libfoundry,
+  libpanel,
+  meson,
+  ninja,
+  pkg-config,
+  webkitgtk_6_0,
+  wrapGAppsHook4,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gnome-manuals";
+  version = "49.0";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/manuals/${lib.versions.major finalAttrs.version}/manuals-${finalAttrs.version}.tar.xz";
+    hash = "sha256-7WRGxMLSnCuQYrKoynJxzbrPx4z9tP3NDzvEjYyefwg=";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    flatpak
+    glib
+    gom
+    gtk4
+    libadwaita
+    libdex
+    libfoundry
+    libpanel
+    webkitgtk_6_0
+  ];
+
+  strictDeps = true;
+
+  preFixup = ''
+    gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${libpanel}/share")
+  '';
+
+  passthru.updateScript = gnome.updateScript {
+    packageName = "manuals";
+  };
+
+  meta = {
+    description = "Tool for browsing documentation";
+    mainProgram = "manuals";
+    homepage = "https://apps.gnome.org/Manuals/";
+    changelog = "https://gitlab.gnome.org/GNOME/manuals/-/blob/${finalAttrs.version}/NEWS?ref_type=tags";
+    license = lib.licenses.gpl3Plus;
+    teams = [ lib.teams.gnome ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/li/libfoundry/host_sdk_filename_nixos.patch
+++ b/pkgs/by-name/li/libfoundry/host_sdk_filename_nixos.patch
@@ -1,0 +1,16 @@
+diff --git a/plugins/fallbacks/host-sdk/plugin-host-sdk.c b/plugins/fallbacks/host-sdk/plugin-host-sdk.c
+index d3deb4fd..98ea0875 100644
+--- a/plugins/fallbacks/host-sdk/plugin-host-sdk.c
++++ b/plugins/fallbacks/host-sdk/plugin-host-sdk.c
+@@ -111,5 +111,11 @@ plugin_host_sdk_build_filename (PluginHostSdk  *self,
+   if (g_path_is_absolute (joined))
+     return g_steal_pointer (&joined);
+ 
++  if (g_strcmp0(g_get_os_info(G_OS_INFO_KEY_NAME), "NixOS") == 0) {
++    GString *str = g_string_new(joined);
++    g_string_replace(str, "usr/share", "run/current-system/sw/share", 0);
++    joined = g_string_free(str, FALSE);
++  }
++
+   return g_build_filename ("/", joined, NULL);
+ }

--- a/pkgs/by-name/li/libfoundry/package.nix
+++ b/pkgs/by-name/li/libfoundry/package.nix
@@ -1,0 +1,117 @@
+{
+  stdenv,
+  lib,
+  cmark,
+  editorconfig-core-c,
+  fetchurl,
+  flatpak,
+  gi-docgen,
+  glib,
+  gnome,
+  gobject-introspection,
+  gom,
+  gtk4,
+  gtksourceview5,
+  json-glib,
+  libdex,
+  libgit2,
+  libpeas2,
+  libsoup_3,
+  libspelling,
+  libssh2,
+  libsysprof-capture,
+  libxml2,
+  libyaml,
+  meson,
+  ninja,
+  pkg-config,
+  template-glib,
+  vte-gtk4,
+  webkitgtk_6_0,
+  wrapGAppsNoGuiHook,
+  withGtk ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libfoundry${lib.optionalString withGtk "-gtk"}";
+  version = "1.0.1";
+
+  outputs = [
+    "out"
+    "dev"
+    "devdoc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/foundry/${lib.versions.majorMinor finalAttrs.version}/foundry-${finalAttrs.version}.tar.xz";
+    hash = "sha256-wHaJBv6zTdWBmeKFRHOeohe714g+WPJPEjIphryJkzk=";
+  };
+
+  patches = [
+    ./host_sdk_filename_nixos.patch
+  ];
+
+  nativeBuildInputs = [
+    gi-docgen
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+    wrapGAppsNoGuiHook
+  ];
+
+  buildInputs = [
+    editorconfig-core-c
+    flatpak
+    gom
+    libgit2
+    libsoup_3
+    libssh2
+    libsysprof-capture
+    libxml2
+    libyaml
+    template-glib
+  ]
+  ++ lib.optionals withGtk [
+    cmark
+    gtk4
+    gtksourceview5
+    libspelling
+    vte-gtk4
+    webkitgtk_6_0
+  ];
+
+  propagatedBuildInputs = [
+    glib
+    json-glib
+    libdex
+    libpeas2
+  ];
+
+  strictDeps = true;
+
+  mesonFlags = [
+    (lib.mesonBool "docs" true)
+    (lib.mesonBool "gtk" withGtk)
+  ];
+
+  postFixup = ''
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
+  '';
+
+  passthru.updateScript = gnome.updateScript {
+    packageName = "foundry";
+    attrPath = "libfoundry";
+  };
+
+  meta = {
+    description = "Command line tool and library that can be used to build developer tools";
+    mainProgram = "foundry";
+    homepage = "https://gitlab.gnome.org/GNOME/foundry";
+    changelog = "https://gitlab.gnome.org/GNOME/foundry/-/blob/${finalAttrs.version}/NEWS?ref_type=tags";
+    license = lib.licenses.lgpl21Plus;
+    teams = [ lib.teams.gnome ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Picked from #448659, `libfoundry` is patched so that NixOS outputs for doc/gtk doc/devhelp work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
