### PR TITLE
stirling-pdf: remove override in all-packages.nix

### DIFF
--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -22,7 +22,7 @@
 
   nix-update-script,
 
-  isDesktopVariant, # set in all-packages.nix
+  isDesktopVariant ? false,
   buildWithFrontend ? !isDesktopVariant,
 }:
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3399,10 +3399,6 @@ with pkgs;
 
   spoof-mac = python3Packages.callPackage ../tools/networking/spoof-mac { };
 
-  stirling-pdf = callPackage ../by-name/st/stirling-pdf/package.nix {
-    isDesktopVariant = false;
-  };
-
   stirling-pdf-desktop = callPackage ../by-name/st/stirling-pdf/package.nix {
     isDesktopVariant = true;
   };


### PR DESCRIPTION
This is one of the last steps towards #483820, which will help enable checking for additional by-name directories (e.g. Python) in nixpkgs-vet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
