### PR TITLE
python3Packages.mdformat-toc: remove broken attribute

### DIFF
--- a/pkgs/development/python-modules/mdformat-toc/default.nix
+++ b/pkgs/development/python-modules/mdformat-toc/default.nix
@@ -35,6 +35,5 @@ buildPythonPackage rec {
       aldoborrero
       polarmutex
     ];
-    broken = true; # broken test due to changes in mdformat; compare https://github.com/KyleKing/mdformat-admon/issues/25
   };
 }


### PR DESCRIPTION
This was set as broken due to a test failure in an mdformat plugin [0],
which has now been fixed.

[0]: https://github.com/KyleKing/mdformat-admon/issues/25

