### PR TITLE
zabbix.web-service: init multiple versions

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13061,6 +13061,12 @@
     githubId = 45771313;
     name = "Sena";
   };
+  jnclark = {
+    email = "nixpkgs@jnclark.org";
+    github = "jnclark";
+    githubId = 1663189;
+    name = "J. Clark";
+  };
   jnsgruk = {
     email = "jon@sgrs.uk";
     github = "jnsgruk";

--- a/pkgs/servers/monitoring/zabbix/web-service.nix
+++ b/pkgs/servers/monitoring/zabbix/web-service.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildGoModule,
+  fetchurl,
+  autoreconfHook,
+  pkg-config,
+}:
+
+import ./versions.nix (
+  {
+    version,
+    hash,
+    ...
+  }:
+  buildGoModule {
+    pname = "zabbix-web-service";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://cdn.zabbix.com/zabbix/sources/stable/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
+      inherit hash;
+    };
+
+    modRoot = "src/go";
+
+    vendorHash = null;
+
+    nativeBuildInputs = [
+      autoreconfHook
+      pkg-config
+    ];
+    buildInputs = [ ];
+
+    # need to provide GO* env variables & patch for reproducibility
+    postPatch = ''
+      substituteInPlace src/go/Makefile.am \
+        --replace-fail '`go env GOOS`' "$GOOS" \
+        --replace-fail '`go env GOARCH`' "$GOARCH" \
+        --replace-fail '`date +%H:%M:%S`' "00:00:00" \
+        --replace-fail '`date +"%b %_d %Y"`' "Jan 1 1970"
+    '';
+
+    preConfigure = ''
+      ./configure \
+        --prefix=${placeholder "out"} \
+        --enable-webservice
+    '';
+
+    # as stated in agent2.nix, zabbix build process is complex to get
+    # right in nix. We again use automake to build the go project
+    # ensuring proper access to the go vendor directory
+    buildPhase = ''
+      cd ../..
+      make
+    '';
+
+    installPhase = ''
+      mkdir -p $out/sbin
+
+      install -Dm0644 src/go/conf/zabbix_web_service.conf $out/etc/zabbix_web_service.conf
+      install -Dm0755 src/go/bin/zabbix_web_service $out/bin/zabbix_web_service
+    '';
+
+    meta = {
+      description = "Enterprise-class open source distributed monitoring solution (web service for generating and sending scheduled reports)";
+      homepage = "https://www.zabbix.com/";
+      license =
+        if (lib.versions.major version >= "7") then lib.licenses.agpl3Only else lib.licenses.gpl2Plus;
+      maintainers = with lib.maintainers; [
+        aanderse
+        bstanderline
+        jnclark
+      ];
+      platforms = lib.platforms.linux;
+    };
+  }
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7751,6 +7751,7 @@ with pkgs;
       (callPackages ../servers/monitoring/zabbix/server.nix { postgresqlSupport = true; }).${version};
     web = (callPackages ../servers/monitoring/zabbix/web.nix { }).${version};
     agent2 = (callPackages ../servers/monitoring/zabbix/agent2.nix { }).${version};
+    web-service = (callPackages ../servers/monitoring/zabbix/web-service.nix { }).${version};
 
     # backwards compatibility
     server = server-pgsql;


### PR DESCRIPTION
This introduces the `zabbix-web-service` package, as `zabbix{,60,70,74}.web-service`, using the existing nixpkgs zabbix packaging structure. `zabbix-web-service` is used for generating and sending scheduled reports within zabbix.

Following the packaging structure, it introduces several versions, 

- zabbix60.web-service: 6.0.46
- zabbix70.web-service: 7.0.27
- zabbix74.web-service: 7.4.11

Importantly, this introduces just the package with an eventual goal of a module (or module option) to run the web service.

For testing, I have successfully built all the above variants, and run the zabbix70 and zabbix74 versions (with chromium in path) to generate a sample report from a zabbix70 server/web.
    
Upstream documentation:
- https://www.zabbix.com/documentation/current/en/manual/concepts/web_service
- https://www.zabbix.com/documentation/current/en/manual/appendix/install/web_service
- https://www.zabbix.com/documentation/current/en/manual/config/reports
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
