### PR TITLE
libamplsolver: 20211109 -> 1.0.1

### DIFF
--- a/pkgs/by-name/li/libamplsolver/package.nix
+++ b/pkgs/by-name/li/libamplsolver/package.nix
@@ -2,16 +2,19 @@
   lib,
   stdenv,
   substitute,
-  fetchurl,
+  fetchFromGitHub,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libamplsolver";
-  version = "20211109";
+  version = "1.0.1";
 
-  src = fetchurl {
-    url = "https://ampl.com/netlib/ampl/solvers.tgz";
-    sha256 = "sha256-LVmScuIvxmZzywPSBl9T9YcUBJP7UFAa3eWs9r4q3JM=";
+  src = fetchFromGitHub {
+    owner = "ampl";
+    repo = "asl";
+    rootDir = "src/solvers";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D1hB5z6r4n6+u1oWclhIst1mXDvObmOsh1j0uocairQ=";
   };
 
   patches = [
@@ -24,6 +27,10 @@ stdenv.mkDerivation {
       ];
     })
   ];
+
+  preConfigure = ''
+    chmod u+x configure configurehere
+  '';
 
   env = {
     # For non-trapping FP architectures like loongarch64 and riscv64
@@ -59,4 +66,4 @@ stdenv.mkDerivation {
     # generates header at compile time
     broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Swap upstreams from the developer's download page (does not offer versioned releases, only the latest unstable build) to the official github mirror. This lets us move to the stable release 1.0.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
