### PR TITLE
rocmPackages.rocm-comgr: fix failure to find code object when xnack any variant should match

### DIFF
--- a/pkgs/development/rocm-modules/rocm-comgr/default.nix
+++ b/pkgs/development/rocm-modules/rocm-comgr/default.nix
@@ -40,6 +40,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/GZGavinZhao/rocm-llvm-project/commit/2c1e44fc3eacadcafdd4ada3e3184a092b6f26c5.patch";
       relative = "amd/comgr";
     })
+    # Fix: CCOB compat patch used coerced (featureless) name for output filename,
+    # causing CLR's code_obj_map key to miss when looking up device ISA with features
+    ./fix-ccob-compat-output-filename.patch
   ];
 
   postPatch = ''

--- a/pkgs/development/rocm-modules/rocm-comgr/fix-ccob-compat-output-filename.patch
+++ b/pkgs/development/rocm-modules/rocm-comgr/fix-ccob-compat-output-filename.patch
@@ -1,0 +1,11 @@
+--- a/src/comgr-compiler.cpp
++++ b/src/comgr-compiler.cpp
+@@ -1425,7 +1425,7 @@
+       // Add an output file for each target
+       SmallString<128> OutputFilePath = OutputDir;
+       sys::path::append(OutputFilePath,
+-                        OutputPrefix + "-" + CompatEntry + "." + FileExtension);
++                        OutputPrefix + "-" + Entry + "." + FileExtension);
+
+       BundlerConfig.TargetNames.emplace_back(CompatEntry);
+       BundlerConfig.OutputFileNames.emplace_back(OutputFilePath);


### PR DESCRIPTION
Fixes failure to load a code object when it should be compatible due to loading an xnack any binary complaining that the bare target name doesn't match the featured name.
```
No compatible code objects found for: gfx90a:sramecc+:xnack- in /nix/store/klazf7j7i5642cyjwi125fx4fdwx82f3-python3.13-torch-2.10.0-lib/lib/libtorch_hip.so, value of HIP_FORCE_SPIRV_CODEOBJECT: 0. Available code objects: [amdgcn-amd-amdhsa--gfx90a]
Failed to load fat binary for function '_ZN2at6native29vectorized_elementwise_kernelILi4ENS0_11FillFunctorIiEESt5arrayIPcLm1EEEEviT0_T1_' (error 200)
```

If AMD_LOG_LEVEL is unset this will usually manifest as a segmentation fault without any useful logs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
