### PR TITLE
haskellPackages: fix a few packages with high reverse dependencies

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -42,12 +42,12 @@ with haskellLib;
     ])
 
     (overrideCabal (drv: {
-      version = "1.3.0.0-unstable-2025-04-25";
+      version = "1.3.0.0-unstable-2026-01-30";
       src = pkgs.fetchFromGitHub {
         owner = "AccelerateHS";
         repo = "accelerate";
-        rev = "3f681a5091eddf5a3b97f4cd0de32adc830e1117";
-        sha256 = "sha256-tCcl7wAls+5cBSrqbxfEAJngbV43OJcLJdaC4qqkBxc=";
+        rev = "c22387ed2e00b00a6c79dcec5d22b53874da91fc";
+        sha256 = "sha256-AtKdxeCytRbmOIFe7OPbSMlhFhJnrgMuIqLFIeqnBGU";
       };
     }))
   ];

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1962,7 +1962,7 @@ with haskellLib;
   util = appendConfigureFlags [
     "--ghc-option=-fno-safe-haskell"
     "--haddock-option=--optghc=-fno-safe-haskell"
-  ] super.util;
+  ] (doJailbreak super.util); # unmaintained
   category = appendConfigureFlags [
     "--ghc-option=-fno-safe-haskell"
     "--haddock-option=--optghc=-fno-safe-haskell"

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2493,6 +2493,12 @@ with haskellLib;
 
   # Unmaintained
   records-sop = doJailbreak super.records-sop;
+  failure = appendPatch (fetchpatch {
+    # https://github.com/snoyberg/failure/pull/5
+    name = "switch-error-to-except";
+    url = "https://github.com/snoyberg/failure/commit/d46bebb5afdc17a0feb268bc86adb00b7edc4cc3.patch";
+    sha256 = "sha256-CDd/vvlRq1cldyH+qsJVNMiwViqKVSosr9A0ilv2gLM";
+  }) (doJailbreak super.failure);
 
   # Fix build failures for ghc 9 (https://github.com/mokus0/polynomial/pull/20)
   polynomial =

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -20,7 +20,6 @@ broken-packages:
   - AC-MiniTest # failure in job https://hydra.nixos.org/build/233216015 at 2023-09-02
   - AC-Terminal # failure in job https://hydra.nixos.org/build/233192747 at 2023-09-02
   - AC-VanillaArray # failure in job https://hydra.nixos.org/build/233216801 at 2023-09-02
-  - accelerate # failure in job https://hydra.nixos.org/build/307516269 at 2025-09-19
   - accelerate-fftw # failure in job https://hydra.nixos.org/build/296049868 at 2025-05-02
   - accelerate-random # failure in job https://hydra.nixos.org/build/296049869 at 2025-05-02
   - accelerate-utility # failure in job https://hydra.nixos.org/build/296049871 at 2025-05-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -6977,7 +6977,6 @@ broken-packages:
   - utf8-conversions # failure in job https://hydra.nixos.org/build/233245725 at 2023-09-02
   - utf8-prelude # failure in job https://hydra.nixos.org/build/233240100 at 2023-09-02
   - utf8-validator # failure in job https://hydra.nixos.org/build/233211712 at 2023-09-02
-  - util # failure in job https://hydra.nixos.org/build/233234741 at 2023-09-02
   - util-logict # failure in job https://hydra.nixos.org/build/233215338 at 2023-09-02
   - util-plus # failure in job https://hydra.nixos.org/build/233231591 at 2023-09-02
   - util-primitive # failure in job https://hydra.nixos.org/build/233258861 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1774,7 +1774,6 @@ broken-packages:
   - fadno-xml # failure in job https://hydra.nixos.org/build/307518209 at 2025-09-19
   - failable # failure in job https://hydra.nixos.org/build/252731566 at 2024-03-16
   - failable-list # failure in job https://hydra.nixos.org/build/233198924 at 2023-09-02
-  - failure # failure in job https://hydra.nixos.org/build/252738855 at 2024-03-16
   - failure-detector # failure in job https://hydra.nixos.org/build/233244451 at 2023-09-02
   - fake # failure in job https://hydra.nixos.org/build/233199052 at 2023-09-02
   - fake-type # failure in job https://hydra.nixos.org/build/233197081 at 2023-09-02


### PR DESCRIPTION
Some low-hanging fruit in the top 10 of https://github.com/cdepillabout/nix-haskell-updates-status?tab=readme-ov-file#top-50-broken-packages-sorted-by-number-of-reverse-dependencies

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
