### PR TITLE
buildBazelPackage: don't gzip deps tarball

### DIFF
--- a/pkgs/build-support/build-bazel-package/default.nix
+++ b/pkgs/build-support/build-bazel-package/default.nix
@@ -136,7 +136,7 @@ stdenv.mkDerivation (
     deps = stdenv.mkDerivation (
       fFetchAttrs
       // {
-        name = "${name}-deps.tar.gz";
+        name = "${name}-deps.tar";
 
         impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ fFetchAttrs.impureEnvVars or [ ];
 
@@ -232,7 +232,7 @@ stdenv.mkDerivation (
 
               echo '${bazel.name}' > $bazelOut/external/.nix-bazel-version
 
-              (cd $bazelOut/ && tar czf $out --sort=name --mtime='@1' --owner=0 --group=0 --numeric-owner external/)
+              (cd $bazelOut/ && tar cf $out --sort=name --mtime='@1' --owner=0 --group=0 --numeric-owner external/)
 
               runHook postInstall
             ''
@@ -261,7 +261,7 @@ stdenv.mkDerivation (
     preConfigure = ''
       mkdir -p "$bazelOut"
 
-      (cd $bazelOut && tar xfz $deps)
+      (cd $bazelOut && tar xf $deps)
 
       test "${bazel.name}" = "$(<$bazelOut/external/.nix-bazel-version)" || {
         echo "fixed output derivation was built for a different bazel version" >&2

--- a/pkgs/by-name/ba/bant/package.nix
+++ b/pkgs/by-name/ba/bant/package.nix
@@ -45,10 +45,13 @@ buildBazelPackage rec {
   removeRulesCC = false;
 
   fetchAttrs = {
+    preInstall = ''
+      rm -rf $bazelOut/external/rules_shell~~sh_configure~local_config_shell
+    '';
     hash =
       {
-        aarch64-linux = "sha256-vg2U7v68Tn6cxPakeWir8TpHL3oMxZ2AzJ68TMR1+/E=";
-        x86_64-linux = "sha256-jIffzBTO+5VMX73vV4XPlGv7/26oMLXpYdb0vzFgulc=";
+        aarch64-linux = "sha256-E70F3D7HGsyV0bPd0zbRTytx1UCHyEuNKObaG2eRy8A=";
+        x86_64-linux = "sha256-E9XAKrt16DOAne3/wY9PwWIM61YX0fWs8x1hqF3YJSU=";
       }
       .${system} or (throw "No hash for system: ${system}");
   };

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -49,8 +49,8 @@ let
       depsHash
     else
       {
-        x86_64-linux = "sha256-CMd8dIyvuYFoHg1+AdkkyBj5P367ZcklCOgih+7uQIA=";
-        aarch64-linux = "sha256-NJIkiTIJBZFPb+FpTYo6pQQQt8++VuCHHj0Y0AjqWGo=";
+        x86_64-linux = "sha256-CUWT2EIHG9vWo4aUbA18SpYn2HTa9haWNo7lGLN8ihw=";
+        aarch64-linux = "sha256-bdFQlvBi7UG2oV8h74geNZbDQCXh+4oIQxD8JNtpWf4=";
       }
       .${stdenv.system} or (throw "unsupported system ${stdenv.system}");
 

--- a/pkgs/by-name/fc/fcitx5-mozc/package.nix
+++ b/pkgs/by-name/fc/fcitx5-mozc/package.nix
@@ -69,7 +69,7 @@ buildBazelPackage {
       rm -rv "$bazelOut"/external/host_platform
     '';
 
-    hash = "sha256-nFPGhZWvzzBOSeIa35XQbK6dHgJJSYum/5X8eAA0uCY=";
+    hash = "sha256-ZjrXMQwxlaU5YGZtBZ+D2XBQHnOk+zV+a9cmkf3U5NU=";
   };
 
   preConfigure = ''

--- a/pkgs/by-name/mo/mozc/package.nix
+++ b/pkgs/by-name/mo/mozc/package.nix
@@ -46,7 +46,7 @@ buildBazelPackage rec {
   bazel = bazel_7;
 
   fetchAttrs = {
-    hash = "sha256-c+v2vWvTmwJ7MFh3VJlUh+iSINjsX66W9K0UBX5K/1s=";
+    hash = "sha256-G05vlHiOJp4rvQBUj2ffRBuWBA/lpJju8CLiopYJckE=";
 
     preInstall = ''
       # Remove zip code data. It will be replaced with jp-zip-codes from nixpkgs

--- a/pkgs/by-name/pe/perf_data_converter/package.nix
+++ b/pkgs/by-name/pe/perf_data_converter/package.nix
@@ -38,8 +38,8 @@ buildBazelPackage {
   fetchAttrs = {
     hash =
       {
-        aarch64-linux = "sha256-GvuOEQfzPF5J75TRlEc4oDiXXUN4G3fMfRhMDmg3FL0=";
-        x86_64-linux = "sha256-A47JJg+GUIhR7FhufxEsfsIuSg6dd7sPNzSWiQZXIEE=";
+        aarch64-linux = "sha256-Pm7iSGO3Ij3bbII/7oWqucTeg8cw6P/FV8/GMcTMyhQ=";
+        x86_64-linux = "sha256-4JForyvjZmD9e3myRamt2N2PD4fImci50EEWc+1WxM8=";
       }
       .${system} or (throw "No hash for system: ${system}");
   };

--- a/pkgs/by-name/pr/protoc-gen-js/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-js/package.nix
@@ -49,7 +49,7 @@ buildBazelPackage' rec {
       rm -rv "$bazelOut/external/host_platform"
     '';
 
-    hash = "sha256-CekpXINZSr6Hysa4qrVkdchBla9pgBwRtqBiuUGPNq0=";
+    hash = "sha256-znkwUs984vbinz/BLo1uxQ+PvxkpXo719lJu4TD1Vmg=";
   };
 
   buildAttrs.installPhase = ''

--- a/pkgs/by-name/ve/verible/package.nix
+++ b/pkgs/by-name/ve/verible/package.nix
@@ -55,10 +55,13 @@ buildBazelPackage {
   ];
 
   fetchAttrs = {
+    preInstall = ''
+      rm -rf $bazelOut/external/rules_shell~~sh_configure~local_config_shell
+    '';
     hash =
       {
-        aarch64-linux = "sha256-SUURIZF3mlFRFKpxdHrgYAbJQ4rkkzCeqcC/1vxmreo=";
-        x86_64-linux = "sha256-p7h2L1aLzmMeWWxXC//Qau8/F4HbnUFY6aV8u7zfjRk=";
+        aarch64-linux = "sha256-KsXrwRIiCft/WaT0uj28gOj5ahhTKxcaiosbY7Mo3JY=";
+        x86_64-linux = "sha256-X7/W2iOTXruRO2wx9J5tGYvy2IuZ6mXiRAmUI5Eq9Vc=";
         aarch64-darwin = "sha256-Zn22un/KaHdTEA/ucaentR7t/krmnZQk3A+jfbPVYnA=";
       }
       .${system} or (throw "No hash for system: ${system}");

--- a/pkgs/development/python-modules/tensorflow-probability/default.nix
+++ b/pkgs/development/python-modules/tensorflow-probability/default.nix
@@ -83,7 +83,7 @@ let
     LIBTOOL = lib.optionalString stdenv.hostPlatform.isDarwin "${cctools}/bin/libtool";
 
     fetchAttrs = {
-      sha256 = "sha256-7sPdIHWNFn13eaUanFgN988hFAwGnlU6cxmHOJUDpiQ=";
+      sha256 = "sha256-RzX8Shr8It9EahXDd3KotcZ2CjFcuzZVyK5aQutLPA4=";
     };
 
     buildAttrs = {


### PR DESCRIPTION
## Summary

- Remove gzip compression from the `buildBazelPackage` deps tarball (`.tar.gz` → `.tar`)
- The gzip compression is unnecessary since the tarball is a fixed-output derivation that is never transferred over the network, and removing it speeds up both fetch and build phases
- More importantly, gzipping circumvents the scanner that checks for `/nix/store` paths in fixed-output derivation outputs, violating that invariant (see https://github.com/NixOS/nixpkgs/pull/495323#issuecomment-4006358010)
- Update all deps hashes for packages using `buildBazelPackage`
- Fix `verible` which had a `/nix/store` reference in `rules_shell~~sh_configure~local_config_shell` that was previously hidden by gzip

## Packages updated

| Package | Hash type | Status |
|---|---|---|
| `protoc-gen-js` | single | updated |
| `mozc` | single | updated |
| `fcitx5-mozc` | single | updated |
| `bant` | x86_64-linux | updated |
| `perf_data_converter` | x86_64-linux | updated |
| `verible` | x86_64-linux | updated (+ store path fix) |
| `envoy` | x86_64-linux | updated |
| `tensorflow-probability` | single | updated |
| `tensorflow-lite` | — | skipped (broken) |
| `tensorflow` | — | skipped (broken) |
| `jaxlib` | — | skipped (broken) |

## Still needed

- aarch64-linux and aarch64-darwin hashes need to be updated on those platforms for: `bant`, `perf_data_converter`, `verible`, `envoy`