### PR TITLE
rocmPackages.llvm: fix infinite loop in llvm legalize for AVX512 targets between v64i8 <-> v32i16

### DIFF
--- a/pkgs/development/rocm-modules/llvm/default.nix
+++ b/pkgs/development/rocm-modules/llvm/default.nix
@@ -306,6 +306,29 @@ overrideLlvmPackagesRocm (s: {
         stripLen = 1;
       })
       ./perf-increase-namestring-size.patch
+      # v64i8 shuffle lowering inf loop on VBMI targets, hangs whisper-cpp etc
+      # https://github.com/NixOS/nixpkgs/issues/497745
+      (fetchpatch {
+        # https://github.com/llvm/llvm-project/pull/182832
+        name = "llvm-x86-v64i8-add-test-coverage.patch";
+        url = "https://github.com/llvm/llvm-project/commit/0e3a96d0ec01e3575674d72c4e23bf98affdca28.patch";
+        relative = "llvm";
+        hash = "sha256-qhRkB8Fjz/fNacuGv1OFkiTNOQ0/QQ9p4pLFudwrTzM=";
+      })
+      (fetchpatch {
+        # https://github.com/llvm/llvm-project/pull/182852
+        name = "llvm-x86-v64i8-prefer-vpermv3-on-vbmi.patch";
+        url = "https://github.com/llvm/llvm-project/commit/8f5880d3ae4e5dfc748985d90e5413671028aa3e.patch";
+        relative = "llvm";
+        hash = "sha256-4DU6gu/1+iQpzvVYBlTTUKtw77QSRyTja4hdel4D5Cw=";
+      })
+      (fetchpatch {
+        # https://github.com/llvm/llvm-project/pull/183109
+        name = "llvm-x86-v64i8-skip-repeated-mask-lane-permute-on-vbmi.patch";
+        url = "https://github.com/llvm/llvm-project/commit/1b9fea021840f17c41ea980300d0fc45e7285909.patch";
+        relative = "llvm";
+        hash = "sha256-9Akm78QQr8BIMrVWwDG3poWS1HuQ0hpIQWfke3oADgg=";
+      })
       # TODO: consider reapplying "Don't include aliases in RegisterClassInfo::IgnoreCSRForAllocOrder"
       # it was reverted as it's a pessimization for non-GPU archs, but this compiler
       # is used mostly for amdgpu


### PR DESCRIPTION
Fixes #497745

clang could get stuck looping between different ways of doing a vector shuffle.

```
Breakpoint 1, 0x00007ffff197c974 in llvm::SelectionDAG::getVectorShuffle(llvm::EVT, llvm::SDLoc const&, llvm::SDValue, llvm::SDValue, llvm::ArrayRef<int>) () from target:/nix/store/ix8xdgl8c048jfmhpkava354fx3zd5y8-llvm-22.0.0-rocm-lib/lib/libLLVM.so.22.0
#0  0x00007ffff197c974 in llvm::SelectionDAG::getVectorShuffle(llvm::EVT, llvm::SDLoc const&, llvm::SDValue, llvm::SDValue, llvm::ArrayRef<int>) () from target:/nix/store/ix8xdgl8c048jfmhpkava354fx3zd5y8-llvm-22.0.0-rocm-lib/lib/libLLVM.so.22.0
#1  0x00007ffff3b36689 in lowerShuffleAsLanePermuteAndPermute(llvm::SDLoc const&, llvm::MVT, llvm::SDValue, llvm::SDValue, llvm::ArrayRef<int>, llvm::SelectionDAG&, llvm::X86Subtarget const&)::$_0::operator()(int) const () from
target:/nix/store/ix8xdgl8c048jfmhpkava354fx3zd5y8-llvm-22.0.0-rocm-lib/lib/libLLVM.so.22.0
#2  0x00007ffff3b329bd in lowerShuffleAsLanePermuteAndPermute(llvm::SDLoc const&, llvm::MVT, llvm::SDValue, llvm::SDValue, llvm::ArrayRef<int>, llvm::SelectionDAG&, llvm::X86Subtarget const&) () from target:/nix/store/ix8xdgl8c048jfmhpkava354fx3zd5y8-llvm-22.0.0-rocm-lib/lib/libLLVM.so.22.0
#3  0x00007ffff3b3b014 in lowerV64I8Shuffle(llvm::SDLoc const&, llvm::ArrayRef<int>, llvm::APInt const&, llvm::SDValue, llvm::SDValue, llvm::X86Subtarget const&, llvm::SelectionDAG&) () from target:/nix/store/ix8xdgl8c048jfmhpkava354fx3zd5y8-llvm-22.0.0-rocm-lib/lib/libLLVM.so.22.0
#4  0x00007ffff3b0aa01 in lower512BitShuffle(llvm::SDLoc const&, llvm::ArrayRef<int>, llvm::MVT, llvm::SDValue, llvm::SDValue, llvm::APInt const&, llvm::X86Subtarget const&, llvm::SelectionDAG&) () from target:/nix/store/ix8xdgl8c048jfmhpkava354fx3zd5y8-llvm-22.0.0-rocm-lib/lib/libLLVM.so.22.0
#5  0x00007ffff3a724a3 in lowerVECTOR_SHUFFLE(llvm::SDValue, llvm::X86Subtarget const&, llvm::SelectionDAG&) () from target:/nix/store/ix8xdgl8c048jfmhpkava354fx3zd5y8-llvm-22.0.0-rocm-lib/lib/libLLVM.so.22.0
#6  0x00007ffff1843d3a in (anonymous namespace)::SelectionDAGLegalize::LegalizeOp(llvm::SDNode*) () from target:/nix/store/ix8xdgl8c048jfmhpkava354fx3zd5y8-llvm-22.0.0-rocm-lib/lib/libLLVM.so.22.0
#7  0x00007ffff1843393 in llvm::SelectionDAG::Legalize() () from target:/nix/store/ix8xdgl8c048jfmhpkava354fx3zd5y8-llvm-22.0.0-rocm-lib/lib/libLLVM.so.22.0
#8  0x00007ffff19ce86b in llvm::SelectionDAGISel::CodeGenAndEmitDAG() () from target:/nix/store/ix8xdgl8c048jfmhpkava354fx3zd5y8-llvm-22.0.0-rocm-lib/lib/libLLVM.so.22.0
```

Backporting the following set of patches to resolve the hang:

- llvm/llvm-project@0e3a96d0ec01e3575674d72c4e23bf98affdca28
- llvm/llvm-project@8f5880d3ae4e5dfc748985d90e5413671028aa3e
- llvm/llvm-project@1b9fea021840f17c41ea980300d0fc45e7285909

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
