### PR TITLE
ubootPinephonePro: init

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -670,6 +670,27 @@ in
     ];
   };
 
+  ubootPinephonePro = buildUBoot {
+    defconfig = "pinephone-pro-rk3399_defconfig";
+    env.BL31 = "${armTrustedFirmwareRK3399}/bl31.elf";
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+    ];
+    extraMeta = {
+      platforms = [ "aarch64-linux" ];
+      longDescription = ''
+        Boot loader for the Pine64 PinePhone Pro.
+
+        Flashing instructions:
+        ```sh
+        dd if=idbloader.img of=<sdcard> conv=notrunc bs=512 seek=64
+        dd if=u-boot.itb of=<sdcard> conv=notrunc bs=512 seek=16384
+        ```
+      '';
+    };
+  };
+
   ubootQemuAarch64 = buildUBoot {
     defconfig = "qemu_arm64_defconfig";
     extraMeta.platforms = [ "aarch64-linux" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8946,6 +8946,7 @@ with pkgs;
     ubootPine64LTS
     ubootPinebook
     ubootPinebookPro
+    ubootPinephonePro
     ubootQemuAarch64
     ubootQemuArm
     ubootQemuRiscv64Smode


### PR DESCRIPTION
flashing instructions taken from:
<https://wiki.pine64.org/wiki/RK3399_boot_sequence#U-Boot_boot_sequence>

after flashing, the Pinephone Pro boots with stock NixOS kernel, but lacks support for e.g. modem, camera/torch, sound, battery gauge.

the Pinephone Pro is aarch64 so build with e.g. `nix-build -A pkgsCross.aarch64-multiplatform.ubootPinephonePro`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
