### PR TITLE
nixos/docker-registry: fix mkIf misuse and OCI manifest test

### DIFF
--- a/nixos/modules/services/misc/docker-registry.nix
+++ b/nixos/modules/services/misc/docker-registry.nix
@@ -28,20 +28,6 @@ let
     };
   };
 
-  registryConfig.redis = lib.mkIf cfg.enableRedisCache {
-    addr = "${cfg.redisUrl}";
-    password = "${cfg.redisPassword}";
-    db = 0;
-    dialtimeout = "10ms";
-    readtimeout = "10ms";
-    writetimeout = "10ms";
-    pool = {
-      maxidle = 16;
-      maxactive = 64;
-      idletimeout = "300s";
-    };
-  };
-
   configFile = cfg.configFile;
 in
 {
@@ -139,6 +125,22 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    services.dockerRegistry.extraConfig = lib.mkIf cfg.enableRedisCache {
+      redis = {
+        addr = "${cfg.redisUrl}";
+        password = "${cfg.redisPassword}";
+        db = 0;
+        dialtimeout = "10ms";
+        readtimeout = "10ms";
+        writetimeout = "10ms";
+        pool = {
+          maxidle = 16;
+          maxactive = 64;
+          idletimeout = "300s";
+        };
+      };
+    };
+
     systemd.services.docker-registry = {
       description = "Docker Container Registry";
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/misc/docker-registry.nix
+++ b/nixos/modules/services/misc/docker-registry.nix
@@ -28,20 +28,6 @@ let
     };
   };
 
-  registryConfig.redis = lib.mkIf cfg.enableRedisCache {
-    addr = "${cfg.redisUrl}";
-    password = "${cfg.redisPassword}";
-    db = 0;
-    dialtimeout = "10ms";
-    readtimeout = "10ms";
-    writetimeout = "10ms";
-    pool = {
-      maxidle = 16;
-      maxactive = 64;
-      idletimeout = "300s";
-    };
-  };
-
   configFile = cfg.configFile;
 in
 {
@@ -138,49 +124,69 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    systemd.services.docker-registry = {
-      description = "Docker Container Registry";
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        systemd.services.docker-registry = {
+          description = "Docker Container Registry";
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network.target" ];
 
-      serviceConfig = {
-        ExecStart = "${lib.getExe cfg.package} serve ${configFile}";
-        User = "docker-registry";
-        WorkingDirectory = cfg.storagePath;
-        AmbientCapabilities = lib.mkIf (cfg.port < 1024) "cap_net_bind_service";
-      };
-    };
+          serviceConfig = {
+            ExecStart = "${lib.getExe cfg.package} serve ${configFile}";
+            User = "docker-registry";
+            WorkingDirectory = cfg.storagePath;
+            AmbientCapabilities = lib.mkIf (cfg.port < 1024) "cap_net_bind_service";
+          };
+        };
 
-    systemd.services.docker-registry-garbage-collect = {
-      description = "Run Garbage Collection for docker registry";
+        systemd.services.docker-registry-garbage-collect = {
+          description = "Run Garbage Collection for docker registry";
 
-      restartIfChanged = false;
-      unitConfig.X-StopOnRemoval = false;
+          restartIfChanged = false;
+          unitConfig.X-StopOnRemoval = false;
 
-      serviceConfig.Type = "oneshot";
+          serviceConfig.Type = "oneshot";
 
-      script = ''
-        ${cfg.package}/bin/registry garbage-collect ${configFile}
-        /run/current-system/systemd/bin/systemctl restart docker-registry.service
-      '';
+          script = ''
+            ${cfg.package}/bin/registry garbage-collect ${configFile}
+            /run/current-system/systemd/bin/systemctl restart docker-registry.service
+          '';
 
-      startAt = lib.optional cfg.enableGarbageCollect cfg.garbageCollectDates;
-    };
+          startAt = lib.optional cfg.enableGarbageCollect cfg.garbageCollectDates;
+        };
 
-    users.users.docker-registry =
-      (lib.optionalAttrs (cfg.storagePath != null) {
-        createHome = true;
-        home = cfg.storagePath;
+        users.users.docker-registry =
+          (lib.optionalAttrs (cfg.storagePath != null) {
+            createHome = true;
+            home = cfg.storagePath;
+          })
+          // {
+            group = "docker-registry";
+            isSystemUser = true;
+          };
+        users.groups.docker-registry = { };
+
+        networking.firewall = lib.mkIf cfg.openFirewall {
+          allowedTCPPorts = [ cfg.port ];
+        };
+      }
+
+      (lib.mkIf cfg.enableRedisCache {
+        services.dockerRegistry.extraConfig.redis = {
+          addr = "${cfg.redisUrl}";
+          password = "${cfg.redisPassword}";
+          db = 0;
+          dialtimeout = "10ms";
+          readtimeout = "10ms";
+          writetimeout = "10ms";
+          pool = {
+            maxidle = 16;
+            maxactive = 64;
+            idletimeout = "300s";
+          };
+        };
       })
-      // {
-        group = "docker-registry";
-        isSystemUser = true;
-      };
-    users.groups.docker-registry = { };
-
-    networking.firewall = lib.mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.port ];
-    };
-  };
+    ]
+  );
 }

--- a/nixos/tests/docker-registry.nix
+++ b/nixos/tests/docker-registry.nix
@@ -53,7 +53,7 @@
     client2.succeed("docker images | grep scratch")
 
     client2.succeed(
-        "curl -fsS -X DELETE registry:8080/v2/scratch/manifests/$(curl -fsS -I -H\"Accept: application/vnd.docker.distribution.manifest.v2+json\" registry:8080/v2/scratch/manifests/latest | grep Docker-Content-Digest | sed -e 's/Docker-Content-Digest: //' | tr -d '\\r')"
+        "curl -fsS -X DELETE registry:8080/v2/scratch/manifests/$(curl -fsS -I -H\"Accept: application/vnd.oci.image.manifest.v1+json\" registry:8080/v2/scratch/manifests/latest | grep Docker-Content-Digest | sed -e 's/Docker-Content-Digest: //' | tr -d '\\r')"
     )
 
     registry.systemctl("start docker-registry-garbage-collect.service")


### PR DESCRIPTION
Two bugs in the docker-registry module. Both cause the NixOS test to fail.

`registryConfig.redis` was wrapped in `lib.mkIf` inside a let binding. `mkIf` only works inside module config definitions. In a plain let binding it serializes its internal structure instead of conditionally omitting the value. That got written straight into the JSON config file. docker-registry silently ignored the unknown keys, so this went unnoticed since #37871 in 2018. It also meant `enableRedisCache = true` never actually configured redis.

Fixed by switching to `lib.optionalAttrs`, same pattern already used on the line above for `storagePath`.

The test's `curl` sends `Accept: application/vnd.docker.distribution.manifest.v2+json`, but distribution v3 (#395747) defaults to OCI manifests. The `HEAD` request 404s, `Docker-Content-Digest` comes back empty, and the `DELETE` fails.

Fixed by changing the accept header to `application/vnd.oci.image.manifest.v1+json`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
