### PR TITLE
xnldorker: init at 4.1

### DIFF
--- a/pkgs/by-name/xn/xnldorker/package.nix
+++ b/pkgs/by-name/xn/xnldorker/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "xnldorker";
+  version = "4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xnl-h4ck3r";
+    repo = "xnldorker";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-k0nTY3n5g7cNsVVWDcdFpCjQVJCErPp/21iz2R/TTGs=";
+  };
+
+  pythonRemoveDeps = [
+    # https://github.com/xnl-h4ck3r/xnldorker/pull/11
+    "asyncio"
+  ];
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  nativeBuildInputs = [ writableTmpDirAsHomeHook ];
+
+  dependencies = with python3.pkgs; [
+    beautifulsoup4
+    playwright
+    pyyaml
+    requests
+    termcolor
+    tldextract
+    urllib3
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "xnldorker" ];
+
+  meta = {
+    description = "Gather results of dorks across a number of search engines";
+    homepage = "https://github.com/xnl-h4ck3r/xnldorker";
+    changelog = "https://github.com/xnl-h4ck3r/xnldorker/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    # https://github.com/xnl-h4ck3r/xnldorker/issues/10
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "xnldorker";
+  };
+})


### PR DESCRIPTION
Gather results of dorks across a number of search engines

https://github.com/xnl-h4ck3r/xnldorker

Related https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
