### PR TITLE
[release-25.11]: python3Packages.authlib: 1.6.3 -> 1.6.7

### DIFF
--- a/pkgs/development/python-modules/authlib/default.nix
+++ b/pkgs/development/python-modules/authlib/default.nix
@@ -11,6 +11,7 @@
   mock,
   pytest-asyncio,
   pytestCheckHook,
+  python-multipart,
   pythonOlder,
   requests,
   setuptools,
@@ -20,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "authlib";
-  version = "1.6.3";
+  version = "1.6.5";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -29,7 +30,7 @@ buildPythonPackage rec {
     owner = "lepture";
     repo = "authlib";
     tag = "v${version}";
-    hash = "sha256-AzIjfUH89tYZwVnOpdSwEzaGNpedfQ50k9diKUfH+Fg=";
+    hash = "sha256-lz2cPqag6lZ9PXb3O/SV4buIPDDzhI71/teqWHLG+vE=";
   };
 
   build-system = [ setuptools ];
@@ -46,6 +47,7 @@ buildPythonPackage rec {
     mock
     pytest-asyncio
     pytestCheckHook
+    python-multipart
     requests
     starlette
     werkzeug

--- a/pkgs/development/python-modules/authlib/default.nix
+++ b/pkgs/development/python-modules/authlib/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "authlib";
-  version = "1.6.6";
+  version = "1.6.7";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "lepture";
     repo = "authlib";
     tag = "v${version}";
-    hash = "sha256-ma1YGsp9AhQowGhyk445le7hoZOEnWtHKo9nD9db950=";
+    hash = "sha256-Socbm6jZW5sywU7TRiSELnkWSDZ/94g3+XLRTO1ln48=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/authlib/default.nix
+++ b/pkgs/development/python-modules/authlib/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "authlib";
-  version = "1.6.5";
+  version = "1.6.6";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     owner = "lepture";
     repo = "authlib";
     tag = "v${version}";
-    hash = "sha256-lz2cPqag6lZ9PXb3O/SV4buIPDDzhI71/teqWHLG+vE=";
+    hash = "sha256-ma1YGsp9AhQowGhyk445le7hoZOEnWtHKo9nD9db950=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/authlib/default.nix
+++ b/pkgs/development/python-modules/authlib/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  cacert,
   cachelib,
   cryptography,
   fetchFromGitHub,


### PR DESCRIPTION
25.11 backport of https://github.com/NixOS/nixpkgs/pull/497852

Fixes #497599

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
