### PR TITLE
jetbrains.jdk: add darwin support

### DIFF
--- a/pkgs/by-name/ce/cef-binary/package.nix
+++ b/pkgs/by-name/ce/cef-binary/package.nix
@@ -35,7 +35,10 @@
   buildType ? "Release",
   srcHashes ? {
     aarch64-linux = "sha256-wUCXk5Nqgzu0q0PvV8a2AKF3h4YxxTeaP2yVecrf0j8=";
+    aarch64-darwin = "sha256-7vEhqsXSQtlZN3Ky0ZYo8vAlpeXAZAP4lgdFe90/UQA=";
     x86_64-linux = "sha256-pFMHjj4MktjnX3g03sgLqgai4X/lF29Phmduf7a+KfM=";
+    #TODO: 26.11: remove the support for x86_64-darwin for more info please see: https://github.com/NixOS/nixpkgs/pull/492160
+    x86_64-darwin = "sha256-zYltcWgv56xo8PNfg17Ayp0+bdJUW18co1aze2ytry8=";
   },
 }:
 
@@ -76,7 +79,7 @@ let
     attrs:
     attrs.${stdenv.hostPlatform.system} or (throw "Unsupported system ${stdenv.hostPlatform.system}");
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cef-binary";
   inherit version;
 
@@ -84,7 +87,10 @@ stdenv.mkDerivation {
     url = "https://cef-builds.spotifycdn.com/cef_binary_${version}+g${gitRevision}+chromium-${chromiumVersion}_${
       selectSystem {
         aarch64-linux = "linuxarm64";
+        aarch64-darwin = "macosarm64";
         x86_64-linux = "linux64";
+        #TODO: 26.11: remove the support for x86_64-darwin for more info please see: https://github.com/NixOS/nixpkgs/pull/492160
+        x86_64-darwin = "macosx64";
       }
     }_minimal.tar.bz2";
     hash = selectSystem srcHashes;
@@ -94,16 +100,24 @@ stdenv.mkDerivation {
 
   dontPatchELF = true;
 
+  patchLibs =
+    if stdenv.hostPlatform.isLinux then
+      ''
+        patchelf --set-rpath "${rpath}" --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" ${buildType}/chrome-sandbox
+        patchelf --add-needed libudev.so --set-rpath "${rpath}" ${buildType}/libcef.so
+        patchelf --set-rpath "${gl_rpath}" ${buildType}/libEGL.so
+        patchelf --add-needed libGL.so.1 --set-rpath "${gl_rpath}" ${buildType}/libGLESv2.so
+        patchelf --set-rpath "${gl_rpath}" ${buildType}/libvk_swiftshader.so
+        patchelf --set-rpath "${gl_rpath}" ${buildType}/libvulkan.so.1
+      ''
+    else
+      "";
+
   installPhase = ''
     runHook preInstall
 
     sed 's/-O0/-O2/' -i cmake/cef_variables.cmake
-    patchelf --set-rpath "${rpath}" --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" ${buildType}/chrome-sandbox
-    patchelf --add-needed libudev.so --set-rpath "${rpath}" ${buildType}/libcef.so
-    patchelf --set-rpath "${gl_rpath}" ${buildType}/libEGL.so
-    patchelf --add-needed libGL.so.1 --set-rpath "${gl_rpath}" ${buildType}/libGLESv2.so
-    patchelf --set-rpath "${gl_rpath}" ${buildType}/libvk_swiftshader.so
-    patchelf --set-rpath "${gl_rpath}" ${buildType}/libvulkan.so.1
+    ${finalAttrs.patchLibs}
     cp --recursive . $out
 
     runHook postInstall
@@ -117,9 +131,12 @@ stdenv.mkDerivation {
   meta = {
     description = "Simple framework for embedding Chromium-based browsers in other applications";
     homepage = "https://cef-builds.spotifycdn.com/index.html";
-    maintainers = with lib.maintainers; [ puffnfresh ];
+    maintainers = with lib.maintainers; [
+      puffnfresh
+      eveeifyeve # Darwin
+    ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.bsd3;
     platforms = builtins.attrNames srcHashes;
   };
-}
+})

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -30,6 +30,7 @@
   fontconfig,
   shaderc,
   vulkan-headers,
+  darwin,
 }:
 
 assert debugBuild -> withJcef;
@@ -39,9 +40,13 @@ let
     {
       "aarch64-linux" = "aarch64";
       "x86_64-linux" = "x64";
+      "aarch64-darwin" = "aarch64";
+      #TODO: 26.11: remove the support for x86_64-darwin for more info please see: https://github.com/NixOS/nixpkgs/pull/492160
+      "x86_64-darwin" = "x64";
     }
     .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   cpu = stdenv.hostPlatform.parsed.cpu.name;
+  os = if stdenv.isDarwin then "macosx" else "linux";
 in
 jdk.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk" + lib.optionalString withJcef "-jcef";
@@ -71,11 +76,31 @@ jdk.overrideAttrs (oldAttrs: rec {
   patches = [ ];
 
   dontConfigure = true;
+  jcefDestName = if stdenv.isDarwin then "jcef_mac" else "jcef_linux_${arch}";
+  mkimagesSh =
+    if stdenv.isDarwin then
+      "./jb/project/tools/mac/scripts/mkimages.sh"
+    else
+      "./jb/project/tools/linux/scripts/mkimages_${arch}.sh";
+
+  osSpecificPatch =
+    if stdenv.isDarwin then
+      ''
+        sed -i '40i\--with-xcode-path="${darwin.xcode_16_1}" \\' ./jb/project/tools/mac/scripts/mkimages.sh
+        # See https://github.com/JetBrains/JetBrainsRuntime/issues/461
+        sed \
+          -e 's/C_O_FLAG_HIGHEST_JVM="-O3"/C_O_FLAG_HIGHEST_JVM="-O1"/g' \
+          -e 's/C_O_FLAG_HIGHEST="-O3"/C_O_FLAG_HIGHEST="-O1"/g' \
+          -e 's/C_O_FLAG_HI="-O3"/C_O_FLAG_HI="-O1"/g' \
+          -i make/autoconf/flags-cflags.m4
+      ''
+    else
+      "";
 
   buildPhase = ''
     runHook preBuild
 
-    ${lib.optionalString withJcef "cp -r ${jetbrains.jcef} jcef_linux_${arch}"}
+    ${lib.optionalString withJcef "cp -r ${jetbrains.jcef} ${jcefDestName}"}
 
     sed \
         -e "s/OPENJDK_TAG=.*/OPENJDK_TAG=${openjdkTag}/" \
@@ -94,16 +119,14 @@ jdk.overrideAttrs (oldAttrs: rec {
       esac
     done
     echo "computed configure flags: ''${realConfigureFlags[*]}"
-    substituteInPlace jb/project/tools/linux/scripts/mkimages_${arch}.sh --replace-fail "STATIC_CONF_ARGS" "STATIC_CONF_ARGS ''${realConfigureFlags[*]}"
+    substituteInPlace ${mkimagesSh} --replace-fail "STATIC_CONF_ARGS" "STATIC_CONF_ARGS ''${realConfigureFlags[*]}"
     sed \
         -e "s/create_image_bundle \"jb/#/" \
         -e "s/echo Creating /exit 0 #/" \
-        -i jb/project/tools/linux/scripts/mkimages_${arch}.sh
+        -i ${mkimagesSh}
 
     patchShebangs .
-    ./jb/project/tools/linux/scripts/mkimages_${arch}.sh ${build} ${
-      if debugBuild then "fd" else (if withJcef then "jcef" else "nomod")
-    }
+    ${mkimagesSh} ${build} ${if debugBuild then "fd" else (if withJcef then "jcef" else "nomod")}
 
     runHook postBuild
   '';
@@ -115,17 +138,39 @@ jdk.overrideAttrs (oldAttrs: rec {
       jcefSuffix = if debugBuild || !withJcef then "" else "_jcef";
       jbrsdkDir = "jbrsdk${jcefSuffix}-${javaVersion}-linux-${arch}${debugSuffix}-b${build}";
     in
-    ''
-      runHook preInstall
+    (
+      if stdenv.hostPlatform.isLinux then
+        ''
+          runHook preInstall
 
-      mv build/linux-${cpu}-server-${buildType}/images/jdk/man build/linux-${cpu}-server-${buildType}/images/${jbrsdkDir}
-      rm -rf build/linux-${cpu}-server-${buildType}/images/jdk
-      mv build/linux-${cpu}-server-${buildType}/images/${jbrsdkDir} build/linux-${cpu}-server-${buildType}/images/jdk
-    ''
-    + oldAttrs.installPhase
+          mv build/${os}-${cpu}-server-${buildType}/images/jdk/man build/${os}-${cpu}-server-${buildType}/images/${jbrsdkDir}
+          rm -rf build/${os}-${cpu}-server-${buildType}/images/jdk
+          mv build/${os}-${cpu}-server-${buildType}/images/${jbrsdkDir} build/${os}-${cpu}-server-${buildType}/images/jdk
+        ''
+        + oldAttrs.installPhase
+      else
+        ''
+          # We need to implement the install phase manually because the default jdk is zulu instead of OpenJDK.
+          mkdir -p $out/lib
+
+          cp -r build/${os}-${cpu}-server-${buildType}/images/jdk $out/lib/openjdk
+
+          # Remove some broken manpages.
+          rm -rf $out/lib/openjdk/man/ja*
+
+          # Mirror some stuff in top-level.
+          mkdir -p $out/share
+          ln -s $out/lib/openjdk/include $out/include
+          ln -s $out/lib/openjdk/man $out/share/man
+          ln -s $out/lib/openjdk/lib/src.zip $out/lib/src.zip
+          ln -s $out/include/linux/*_md.h $out/include/
+          ln -s $out/lib/openjdk/bin $out/bin
+        ''
+    )
     + "runHook postInstall";
 
-  postInstall = lib.optionalString withJcef ''
+  # This is only available on Linux https://github.com/JetBrains/JetBrainsRuntime/releases/tag/jbr-release-21.0.6b631.42
+  postInstall = lib.optionalString (withJcef && stdenv.hostPlatform.isLinux) ''
     chmod +x $out/lib/openjdk/lib/chrome-sandbox
   '';
 
@@ -134,25 +179,29 @@ jdk.overrideAttrs (oldAttrs: rec {
   postFixup = ''
     # Build the set of output library directories to rpath against
     LIBDIRS="${
-      lib.makeLibraryPath [
-        libxdamage
-        libxxf86vm
-        libxrandr
-        libxi
-        libxcursor
-        libxrender
-        libx11
-        libxext
-        libxkbcommon
-        libxcb
-        nss
-        nspr
-        libdrm
-        libgbm
-        wayland
-        udev
-        fontconfig
-      ]
+      lib.makeLibraryPath (
+        [
+          libxdamage
+          libxxf86vm
+          libxrandr
+          libxi
+          libxcursor
+          libxrender
+          libx11
+          libxext
+          libxkbcommon
+          libxcb
+          nss
+          nspr
+          fontconfig
+        ]
+        ++ lib.optionals stdenv.isLinux [
+          wayland
+          libgbm
+          libdrm
+          udev
+        ]
+      )
     }"
     for output in ${lib.concatStringsSep " " oldAttrs.outputs}; do
       if [ "$output" = debug ]; then continue; fi
@@ -176,12 +225,22 @@ jdk.overrideAttrs (oldAttrs: rec {
     rsync
     shaderc # glslc
   ]
-  ++ oldAttrs.nativeBuildInputs;
+  ++ oldAttrs.nativeBuildInputs
+  ++ lib.optionals stdenv.isDarwin [
+    darwin.bootstrap_cmds
+    darwin.xcode_16_1
+    darwin.xattr
+  ];
 
   buildInputs = [
     vulkan-headers
   ]
-  ++ oldAttrs.buildInputs or [ ];
+  ++ oldAttrs.buildInputs or [ ]
+  ++ lib.optionals stdenv.isDarwin [
+    darwin.bootstrap_cmds
+    darwin.xattr
+    darwin.xcode_16_1
+  ];
 
   meta = {
     description = "OpenJDK fork to better support Jetbrains's products";
@@ -199,9 +258,8 @@ jdk.overrideAttrs (oldAttrs: rec {
     inherit (jdk.meta) license platforms mainProgram;
     maintainers = with lib.maintainers; [
       aoli-al
+      eveeifyeve # Darwin
     ];
-
-    broken = stdenv.hostPlatform.isDarwin;
   };
 
   passthru = oldAttrs.passthru // {

--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -25,6 +25,8 @@
   boost,
   thrift,
   cef-binary,
+  darwin,
+  apple-sdk,
 }:
 
 let
@@ -33,6 +35,9 @@ let
     {
       "aarch64-linux" = "linuxarm64";
       "x86_64-linux" = "linux64";
+      "aarch64-darwin" = "macosarm64";
+      #TODO: 26.11: remove the support for x86_64-darwin for more info please see: https://github.com/NixOS/nixpkgs/pull/492160
+      "x86_64-darwin" = "macosx64";
     }
     .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   arches =
@@ -42,8 +47,19 @@ let
         projectArch = "arm64";
         targetArch = "arm64";
       };
+      "macosarm64" = {
+        depsArch = "universal";
+        projectArch = "arm64";
+        targetArch = "arm64";
+      };
       "linux64" = {
         depsArch = "amd64";
+        projectArch = "x86_64";
+        targetArch = "x86_64";
+      };
+      #TODO: 26.11: remove the support for x86_64-darwin for more info please see: https://github.com/NixOS/nixpkgs/pull/492160
+      "macosx64" = {
+        depsArch = "universal";
         projectArch = "x86_64";
         targetArch = "x86_64";
       };
@@ -60,7 +76,10 @@ let
     chromiumVersion = "137.0.7151.104";
     srcHashes = {
       aarch64-linux = "sha256-C9P4+TpzjyMD5z2qLbzubbrIr66usFjRx7QqiAxI2D8=";
+      aarch64-darwin = "sha256-rKXorqz0KxpwRjq2rf6eJiCzkgJe+9+Vfa0eG2dDSQQ=";
       x86_64-linux = "sha256-iDC3a/YN0NqjX/b2waKvUAZCaR0lkLmUPqBJphE037Q=";
+      #TODO: 26.11: remove the support for x86_64-darwin for more info please see: https://github.com/NixOS/nixpkgs/pull/492160
+      x86_64-darwin = "sha256-BkG/duc49skqOLSgkKSNlsm4H6egUgNqBt8snJrc7MU=";
     };
   };
 
@@ -107,7 +126,12 @@ stdenv.mkDerivation rec {
     ninja
     strip-nondeterminism
     stripJavaArchivesHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     autoPatchelfHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.xcode_16_1
   ];
   buildInputs = [
     boost
@@ -117,6 +141,9 @@ stdenv.mkDerivation rec {
     nss
     nspr
     thrift20
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk
   ];
 
   src = fetchFromGitHub {
@@ -126,11 +153,38 @@ stdenv.mkDerivation rec {
     hash = "sha256-w5t1M66KW5cUbNTpAc4ksGd+414EJsXwbq1UP1COFsw=";
   };
 
-  # Find the hash in tools/buildtools/linux64/clang-format.sha1
-  clang-fmt = fetchurl {
-    url = "https://storage.googleapis.com/chromium-clang-format/dd736afb28430c9782750fc0fd5f0ed497399263";
-    hash = "sha256-4H6FVO9jdZtxH40CSfS+4VESAHgYgYxfCBFSMHdT0hE=";
-  };
+  clang-fmt =
+    let
+      platformInfo =
+        {
+          "linuxarm64" = {
+            key = "dd736afb28430c9782750fc0fd5f0ed497399263";
+            hash = "sha256-4H6FVO9jdZtxH40CSfS+4VESAHgYgYxfCBFSMHdT0hE=";
+          };
+          "linux64" = {
+            key = "dd736afb28430c9782750fc0fd5f0ed497399263";
+            hash = "sha256-4H6FVO9jdZtxH40CSfS+4VESAHgYgYxfCBFSMHdT0hE=";
+          };
+          #TODO: 26.11: remove the support for x86_64-darwin for more info please see: https://github.com/NixOS/nixpkgs/pull/492160
+          "macosx64" = {
+            key = "a1b33be85faf2578f3101d7806e443e1c0949498";
+            hash = "sha256-RscqWe309rwQe1vEoefAP+fHxx5KAtvQA0Zh3lj62pc=";
+          };
+          "macosarm64" = {
+            key = "f1424c44ee758922823d6b37de43705955c99d7e";
+            hash = "sha256-m+qCYEZUmCgU37JTlEVdyYml4T/rA3Lt/vJh7/ToSlo=";
+          };
+        }
+        .${platform};
+    in
+    fetchurl {
+      url = "https://storage.googleapis.com/chromium-clang-format/${platformInfo.key}";
+      hash = platformInfo.hash;
+    };
+
+  clangFmtFolder = if stdenv.isDarwin then "mac" else "linux64";
+  os = if stdenv.isDarwin then "macosx" else "linux";
+  toolFolder = if stdenv.isDarwin then "mac" else "linux";
 
   configurePhase = ''
     runHook preConfigure
@@ -147,8 +201,8 @@ stdenv.mkDerivation rec {
       -e 's|"%s rev-list --count %s" % (git_exe, branch)|"echo '${version}'"|' \
       -i tools/git_util.py
 
-    cp ${clang-fmt} tools/buildtools/linux64/clang-format
-    chmod +w tools/buildtools/linux64/clang-format
+    cp ${clang-fmt} tools/buildtools/${clangFmtFolder}/clang-format
+    chmod +w tools/buildtools/${clangFmtFolder}/clang-format
 
     sed \
       -e 's|include(cmake/vcpkg.cmake)||' \
@@ -157,6 +211,10 @@ stdenv.mkDerivation rec {
       -i CMakeLists.txt
 
     sed -e 's|vcpkg_bring_host_thrift()|set(THRIFT_COMPILER_HOST ${lib.getExe thrift20})|' -i remote/CMakeLists.txt
+
+    # Remove runtime for appbundler because it only recognizes MacOS style Java home paths
+    # https://github.com/ome/appbundler/blob/6f153a3706960e3568a6815c27f5cd02cb36f654/appbundler/src/com/oracle/appbundler/AppBundlerTask.java#L629
+    sed -e 's|<runtime dir="''${env.JAVA_HOME}"/>||' -i build.xml
 
     mkdir jcef_build
     cd jcef_build
@@ -182,10 +240,10 @@ stdenv.mkDerivation rec {
     export OUT_NATIVE_DIR=$JCEF_ROOT_DIR/jcef_build/native/${buildType}
     export OUT_REMOTE_DIR=$JCEF_ROOT_DIR/jcef_build/remote/${buildType}
     export JB_TOOLS_DIR=$(realpath ../jb/tools)
-    export JB_TOOLS_OS_DIR=$JB_TOOLS_DIR/linux
+    export JB_TOOLS_OS_DIR=$JB_TOOLS_DIR/${toolFolder}
     export OUT_CLS_DIR=$(realpath ../out/${platform})
     export TARGET_ARCH=${targetArch} DEPS_ARCH=${depsArch}
-    export OS=linux
+    export OS=${os}
     export JOGAMP_DIR="$JCEF_ROOT_DIR"/third_party/jogamp/jar
 
     bash "$JB_TOOLS_DIR"/common/create_modules.sh
@@ -195,7 +253,7 @@ stdenv.mkDerivation rec {
     bash "$JB_TOOLS_DIR"/common/create_version_file.sh $out
 
     cp -r $JCEF_ROOT_DIR/jmods/ $out
-    cp -r $JCEF_ROOT_DIR/cef_server/ $out
+    ${if stdenv.isLinux then "cp -r $JCEF_ROOT_DIR/cef_server/ $out" else ""}
 
     runHook postInstall
   '';
@@ -212,12 +270,13 @@ stdenv.mkDerivation rec {
     description = "Jetbrains' fork of JCEF";
     license = lib.licenses.bsd3;
     homepage = "https://github.com/JetBrains/JCEF";
-    platforms = [
+    platforms = lib.platforms.darwin ++ [
       "aarch64-linux"
       "x86_64-linux"
     ];
     maintainers = with lib.maintainers; [
       aoli-al
+      eveeifyeve # Darwin
     ];
   };
 }

--- a/pkgs/development/compilers/zulu/common.nix
+++ b/pkgs/development/compilers/zulu/common.nix
@@ -81,6 +81,13 @@ let
     pname = "zulu-${javaPackage}";
     version = dist.jdkVersion;
 
+    outputs = [
+      "out"
+    ]
+    ++ lib.optionals (lib.versionOlder dist.jdkVersion "11") [
+      "jre"
+    ];
+
     src = fetchurl {
       url = "https://cdn.azul.com/zulu/bin/zulu${dist.zuluVersion}-${javaPackage}${dist.jdkVersion}-${platform}_${arch}.tar.gz";
       inherit (dist) hash;


### PR DESCRIPTION
This adds darwin support to jetbrains.jdk.

This is currently marked broken due to it not building on darwin due to fixup issue at jcef.

Closes: https://github.com/NixOS/nixpkgs/pull/398564

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
