### PR TITLE
uefitool: a72 -> a73

### DIFF
--- a/pkgs/tools/system/uefitool/new-engine.nix
+++ b/pkgs/tools/system/uefitool/new-engine.nix
@@ -2,30 +2,39 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  qtbase,
+  qt6,
+  wrapGAppsHook3,
   cmake,
-  wrapQtAppsHook,
   zip,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "uefitool";
-  version = "A72";
+  version = "A73";
 
   src = fetchFromGitHub {
-    hash = "sha256-sVosxqUUvkZwJIY9FZ9N6xoDyBpSgTLFUmD4B9ymTHs=";
     owner = "LongSoft";
     repo = "uefitool";
     tag = finalAttrs.version;
+    hash = "sha256-XZGddj0i/r1rqntEcqU2AK6ihvqwN031TR12qmEmKLk=";
   };
 
-  buildInputs = [ qtbase ];
+  buildInputs = [ qt6.qtbase ];
+
   nativeBuildInputs = [
     cmake
     zip
-    wrapQtAppsHook
+    qt6.wrapQtAppsHook
+    wrapGAppsHook3
   ];
+
   patches = lib.optionals stdenv.hostPlatform.isDarwin [ ./bundle-destination.patch ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
 
   meta = {
     description = "UEFI firmware image viewer and editor";


### PR DESCRIPTION
https://github.com/LongSoft/UEFITool/releases/tag/A73

Also fixed it running under GNOME (not sure if other DEs are affected as well)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
