### PR TITLE
treewide: Remove continuation escape at end of commands

### DIFF
--- a/nixos/modules/services/backup/restic-rest-server.nix
+++ b/nixos/modules/services/backup/restic-rest-server.nix
@@ -94,7 +94,7 @@ in
           ${lib.optionalString cfg.appendOnly "--append-only"} \
           ${lib.optionalString cfg.privateRepos "--private-repos"} \
           ${lib.optionalString cfg.prometheus "--prometheus"} \
-          ${lib.escapeShellArgs cfg.extraFlags} \
+          ${lib.escapeShellArgs cfg.extraFlags}
         '';
         Type = "simple";
         User = "restic";

--- a/nixos/modules/services/databases/dgraph.nix
+++ b/nixos/modules/services/databases/dgraph.nix
@@ -16,7 +16,7 @@ let
       ''
         mkdir -p $out/bin
         makeWrapper ${cfg.package}/bin/dgraph $out/bin/dgraph \
-          --prefix PATH : "${lib.makeBinPath [ pkgs.nodejs ]}" \
+          --prefix PATH : "${lib.makeBinPath [ pkgs.nodejs ]}"
       '';
   securityOptions = {
     NoNewPrivileges = true;

--- a/nixos/modules/services/monitoring/prometheus/exporters/collectd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/collectd.nix
@@ -86,7 +86,7 @@ in
     let
       collectSettingsArgs = optionalString (cfg.collectdBinary.enable) ''
         --collectd.listen-address ${cfg.collectdBinary.listenAddress}:${toString cfg.collectdBinary.port} \
-        --collectd.security-level ${cfg.collectdBinary.securityLevel} \
+        --collectd.security-level ${cfg.collectdBinary.securityLevel}
       '';
     in
     {

--- a/nixos/modules/services/networking/teamspeak3.nix
+++ b/nixos/modules/services/networking/teamspeak3.nix
@@ -185,7 +185,7 @@ in
             ${optionalString (cfg.fileTransferIP != null) "filetransfer_ip=${cfg.fileTransferIP}"} \
             ${optionalString (cfg.queryIP != null) "query_ip=${cfg.queryIP}"} \
             ${optionalString (cfg.queryIP != null) "query_ssh_ip=${cfg.queryIP}"} \
-            ${optionalString (cfg.queryIP != null) "query_http_ip=${cfg.queryIP}"} \
+            ${optionalString (cfg.queryIP != null) "query_http_ip=${cfg.queryIP}"}
         '';
         WorkingDirectory = cfg.dataDir;
         User = user;

--- a/nixos/modules/services/x11/unclutter-xfixes.nix
+++ b/nixos/modules/services/x11/unclutter-xfixes.nix
@@ -55,7 +55,7 @@ in
         ${cfg.package}/bin/unclutter \
           --timeout ${toString cfg.timeout} \
           --jitter ${toString (cfg.threshold - 1)} \
-          ${concatMapStrings (x: " --" + x) cfg.extraOptions} \
+          ${concatMapStrings (x: " --" + x) cfg.extraOptions}
       '';
       serviceConfig.RestartSec = 3;
       serviceConfig.Restart = "always";

--- a/nixos/modules/services/x11/unclutter.nix
+++ b/nixos/modules/services/x11/unclutter.nix
@@ -69,7 +69,7 @@ in
           -jitter ${toString (cfg.threshold - 1)} \
           ${optionalString cfg.keystroke "-keystroke"} \
           ${concatMapStrings (x: " -" + x) cfg.extraOptions} \
-          -not ${concatStringsSep " " cfg.excluded} \
+          -not ${concatStringsSep " " cfg.excluded}
       '';
       serviceConfig.PassEnvironment = "DISPLAY";
       serviceConfig.RestartSec = 3;

--- a/nixos/tests/matrix/mjolnir.nix
+++ b/nixos/tests/matrix/mjolnir.nix
@@ -17,7 +17,7 @@ let
   csr = runWithOpenSSL "matrix.csr" ''
     openssl req \
        -new -key ${key} \
-       -out $out -subj "/CN=localhost" \
+       -out $out -subj "/CN=localhost"
   '';
   cert = runWithOpenSSL "matrix_cert.pem" ''
     openssl x509 \

--- a/nixos/tests/matrix/pantalaimon.nix
+++ b/nixos/tests/matrix/pantalaimon.nix
@@ -19,7 +19,7 @@ let
   csr = runWithOpenSSL "matrix.csr" ''
     openssl req \
        -new -key ${key} \
-       -out $out -subj "/CN=localhost" \
+       -out $out -subj "/CN=localhost"
   '';
   cert = runWithOpenSSL "matrix_cert.pem" ''
     openssl x509 \

--- a/pkgs/applications/science/logic/hol_light/default.nix
+++ b/pkgs/applications/science/logic/hol_light/default.nix
@@ -24,7 +24,7 @@ let
       lib.optionalString (num != null) ''
         -I ${num}/lib/ocaml/${ocaml.version}/site-lib/num \
         -I ${num}/lib/ocaml/${ocaml.version}/site-lib/top-num \
-        -I ${num}/lib/ocaml/${ocaml.version}/site-lib/stublibs \
+        -I ${num}/lib/ocaml/${ocaml.version}/site-lib/stublibs
       '';
 
   start_script = ''

--- a/pkgs/applications/virtualization/krunvm/default.nix
+++ b/pkgs/applications/virtualization/krunvm/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     wrapProgram $out/bin/krunvm \
-      --prefix PATH : ${lib.makeBinPath [ buildah ]} \
+      --prefix PATH : ${lib.makeBinPath [ buildah ]}
   '';
 
   meta = {

--- a/pkgs/build-support/rust/lib/default.nix
+++ b/pkgs/build-support/rust/lib/default.nix
@@ -77,7 +77,7 @@
       + lib.optionalString (rustTargetPlatform != rustHostPlatform) ''
         "CC_${stdenv.targetPlatform.rust.cargoEnvVarTarget}=${ccForTarget}" \
         "CXX_${stdenv.targetPlatform.rust.cargoEnvVarTarget}=${cxxForTarget}" \
-        "CARGO_TARGET_${stdenv.targetPlatform.rust.cargoEnvVarTarget}_LINKER=${ccForTarget}" \
+        "CARGO_TARGET_${stdenv.targetPlatform.rust.cargoEnvVarTarget}_LINKER=${ccForTarget}"
       '';
     };
 }

--- a/pkgs/by-name/aw/awslogs/package.nix
+++ b/pkgs/by-name/aw/awslogs/package.nix
@@ -27,7 +27,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "boto3>=1.34.75" "boto3>=1.34.58" \
+      --replace "boto3>=1.34.75" "boto3>=1.34.58"
   '';
 
   nativeCheckInputs = with python3.pkgs; [

--- a/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
       tests/volume-control-test.cc \
       --replace-quiet 'loop(50)' 'loop(500)' \
       --replace-quiet 'loop(100)' 'loop(1000)' \
-      --replace-quiet 'loop(500)' 'loop(5000)' \
+      --replace-quiet 'loop(500)' 'loop(5000)'
   '';
 
   strictDeps = true;

--- a/pkgs/by-name/bl/bleep/package.nix
+++ b/pkgs/by-name/bl/bleep/package.nix
@@ -57,7 +57,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       export PATH=$PATH:$out/bin
       installShellCompletion --cmd bleep \
         --bash <(bleep install-tab-completions-bash --stdout) \
-        --zsh <(bleep install-tab-completions-zsh --stdout) \
+        --zsh <(bleep install-tab-completions-zsh --stdout)
     '';
 
   passthru.tests.version = testers.testVersion {

--- a/pkgs/by-name/bo/bootiso/package.nix
+++ b/pkgs/by-name/bo/bootiso/package.nix
@@ -60,7 +60,7 @@ stdenvNoCC.mkDerivation rec {
           gnugrep
           busybox
         ]
-      } \
+      }
   '';
 
   meta = {

--- a/pkgs/by-name/cb/cbmc/package.nix
+++ b/pkgs/by-name/cb/cbmc/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     mv $out/bin/ls_parse.py $out/share/cbmc/ls_parse.py
     chmod +x $out/share/cbmc/ls_parse.py
     wrapProgram $out/bin/goto-cc \
-      --prefix PATH : "$out/share/cbmc" \
+      --prefix PATH : "$out/share/cbmc"
   '';
 
   env.NIX_CFLAGS_COMPILE = toString (

--- a/pkgs/by-name/co/coost/package.nix
+++ b/pkgs/by-name/co/coost/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace cmake/coost.pc.in \
       --replace-fail '$'{exec_prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@ \
-      --replace-fail '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@ \
+      --replace-fail '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
   '';
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/cu/cubelify/package.nix
+++ b/pkgs/by-name/cu/cubelify/package.nix
@@ -25,7 +25,7 @@ appimageTools.wrapType2 rec {
       install -Dm444 ${contents}/cubelify-overlay.desktop -t $out/share/applications/
       install -Dm444 ${contents}/cubelify-overlay.png -t $out/share/pixmaps/
       substituteInPlace $out/share/applications/cubelify-overlay.desktop \
-        --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=cubelify' \
+        --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=cubelify'
     '';
 
   passthru.updateScript = ./update.sh;

--- a/pkgs/by-name/de/deckmaster/package.nix
+++ b/pkgs/by-name/de/deckmaster/package.nix
@@ -33,7 +33,7 @@ buildGoModule (finalAttrs: {
   # Let the app find Roboto-*.ttf files (hard-coded file names).
   postFixup = ''
     wrapProgram $out/bin/deckmaster \
-      --prefix XDG_DATA_DIRS : "${roboto.out}/share/" \
+      --prefix XDG_DATA_DIRS : "${roboto.out}/share/"
   '';
 
   meta = {

--- a/pkgs/by-name/fl/flyway/package.nix
+++ b/pkgs/by-name/fl/flyway/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper "${jre_headless}/bin/java" $out/bin/flyway \
       --add-flags "-Djava.security.egd=file:/dev/../dev/urandom" \
       --add-flags "-classpath '$out/share/flyway/lib/*:$out/share/flyway/lib/flyway/*:$out/share/flyway/lib/aad/*:$out/share/flyway/lib/netty/*:$out/share/flyway/drivers/*'" \
-      --add-flags "org.flywaydb.commandline.Main" \
+      --add-flags "org.flywaydb.commandline.Main"
   '';
   passthru.tests = {
     version = testers.testVersion { package = finalAttrs.finalPackage; };

--- a/pkgs/by-name/fs/fsautocomplete/package.nix
+++ b/pkgs/by-name/fs/fsautocomplete/package.nix
@@ -24,7 +24,7 @@ buildDotnetModule (finalAttrs: {
     rm global.json
 
     substituteInPlace src/FsAutoComplete/FsAutoComplete.fsproj \
-      --replace-fail TargetFrameworks TargetFramework \
+      --replace-fail TargetFrameworks TargetFramework
   '';
 
   dotnet-sdk = dotnetCorePackages.sdk_8_0;

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -310,7 +310,7 @@ stdenv.mkDerivation (finalAttrs: {
     addToSearchPath XDG_DATA_DIRS "${shared-mime-info}/share"
 
     echo "12345678901234567890123456789012" > machine-id
-    export NIX_REDIRECTS=/etc/machine-id=$(realpath machine-id) \
+    export NIX_REDIRECTS=/etc/machine-id=$(realpath machine-id)
   '';
 
   postInstall = ''

--- a/pkgs/by-name/gt/gtypist/package.nix
+++ b/pkgs/by-name/gt/gtypist/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preFixup = ''
     wrapProgram "$out/bin/typefortune" \
-      --prefix PATH : "${fortune}/bin" \
+      --prefix PATH : "${fortune}/bin"
   '';
 
   meta = {

--- a/pkgs/by-name/h5/h5utils/package.nix
+++ b/pkgs/by-name/h5/h5utils/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   # libdf is an alternative name for libhdf (hdf4)
   preConfigure = lib.optionalString (hdf4 != null) ''
     substituteInPlace configure \
-    --replace "-ldf" "-lhdf" \
+    --replace "-ldf" "-lhdf"
   '';
 
   preBuild = lib.optionalString hdf5.mpiSupport "export CC=${lib.getBin hdf5.mpi}/mpicc";

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -88,7 +88,7 @@ let
            --replace /dev/stderr stderr.log
 
         substituteInPlace ortograf/herramientas/remover_comentarios.sh \
-           --replace /bin/bash ${bash}/bin/bash \
+           --replace /bin/bash ${bash}/bin/bash
       '';
       buildPhase = ''
         cd ortograf/herramientas

--- a/pkgs/by-name/hw/hwatch/package.nix
+++ b/pkgs/by-name/hw/hwatch/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installShellCompletion --cmd hwatch \
       --bash $src/completion/bash/hwatch-completion.bash \
       --fish $src/completion/fish/hwatch.fish \
-      --zsh $src/completion/zsh/_hwatch \
+      --zsh $src/completion/zsh/_hwatch
   '';
 
   passthru.tests.version = testers.testVersion {

--- a/pkgs/by-name/hy/hyperscan/package.nix
+++ b/pkgs/by-name/hy/hyperscan/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace CMakeLists.txt \
       --replace-fail \
         "cmake_minimum_required (VERSION 2.8.11)" \
-        "cmake_minimum_required (VERSION 3.10)" \
+        "cmake_minimum_required (VERSION 3.10)"
   '';
 
   buildInputs = [ boost ];

--- a/pkgs/by-name/je/jellyfin-web/package.nix
+++ b/pkgs/by-name/je/jellyfin-web/package.nix
@@ -28,7 +28,7 @@ buildNpmPackage (finalAttrs: {
 
   postPatch = ''
     substituteInPlace webpack.common.js \
-      --replace-fail "git describe --always --dirty" "echo ${finalAttrs.src.rev}" \
+      --replace-fail "git describe --always --dirty" "echo ${finalAttrs.src.rev}"
   '';
 
   npmDepsHash = "sha256-bXZn2FOWeIN8VTNLbKe7jM7yDtE2QRmyoWNZXgE5W4Q=";

--- a/pkgs/by-name/ke/kew/package.nix
+++ b/pkgs/by-name/ke/kew/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace Makefile \
       --replace-fail '$(shell uname -s)' '${uppercaseFirst stdenv.hostPlatform.parsed.kernel.name}' \
-      --replace-fail '$(shell uname -m)' '${stdenv.hostPlatform.parsed.cpu.name}' \
+      --replace-fail '$(shell uname -m)' '${stdenv.hostPlatform.parsed.cpu.name}'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ke/keychain/package.nix
+++ b/pkgs/by-name/ke/keychain/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
           openssh
           procps
         ]
-      }" \
+      }"
   '';
 
   meta = {

--- a/pkgs/by-name/li/lib60870/package.nix
+++ b/pkgs/by-name/li/lib60870/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace src/CMakeLists.txt \
-      --replace-warn "-lrt" "" \
+      --replace-warn "-lrt" ""
   '';
 
   separateDebugInfo = true;

--- a/pkgs/by-name/li/libfprint-tod/package.nix
+++ b/pkgs/by-name/li/libfprint-tod/package.nix
@@ -39,7 +39,7 @@ libfprint.overrideAttrs (
       patchShebangs \
         ./libfprint/tod/tests/*.sh \
         ./tests/*.py \
-        ./tests/*.sh \
+        ./tests/*.sh
     '';
 
     meta = {

--- a/pkgs/by-name/lo/loupe/package.nix
+++ b/pkgs/by-name/lo/loupe/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace src/meson.build --replace-fail \
       "'src' / rust_target / meson.project_name()," \
-      "'src' / '${stdenv.hostPlatform.rust.cargoShortTarget}' / rust_target / meson.project_name()," \
+      "'src' / '${stdenv.hostPlatform.rust.cargoShortTarget}' / rust_target / meson.project_name(),"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/lu/lunar-client/package.nix
+++ b/pkgs/by-name/lu/lunar-client/package.nix
@@ -26,7 +26,7 @@ appimageTools.wrapType2 rec {
       install -Dm444 ${contents}/lunarclient.desktop -t $out/share/applications/
       install -Dm444 ${contents}/lunarclient.png -t $out/share/pixmaps/
       substituteInPlace $out/share/applications/lunarclient.desktop \
-        --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=lunarclient' \
+        --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=lunarclient'
     '';
 
   passthru.updateScript = ./update.sh;

--- a/pkgs/by-name/ma/mackup/package.nix
+++ b/pkgs/by-name/ma/mackup/package.nix
@@ -19,7 +19,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   postPatch = ''
     substituteInPlace src/mackup/utils.py \
-      --replace-fail '"/usr/bin/pgrep"' '"${lib.getExe' procps "pgrep"}"' \
+      --replace-fail '"/usr/bin/pgrep"' '"${lib.getExe' procps "pgrep"}"'
   '';
 
   build-system = with python3Packages; [ hatchling ];

--- a/pkgs/by-name/mp/mpv/scripts/convert.nix
+++ b/pkgs/by-name/mp/mpv/scripts/convert.nix
@@ -30,7 +30,7 @@ buildLua {
       --replace-fail 'yad_exe = "yad"' \
                 'yad_exe = "${lib.getExe yad}"' \
       --replace-fail 'notify_send_exe = "notify-send"' \
-                'notify_send_exe = "${lib.getExe libnotify}"' \
+                'notify_send_exe = "${lib.getExe libnotify}"'
   '';
 
   scriptPath = "convert_script.lua";

--- a/pkgs/by-name/no/notion/package.nix
+++ b/pkgs/by-name/no/notion/package.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
           xmessage
           xterm
         ]
-      }" \
+      }"
   '';
 
   meta = {

--- a/pkgs/by-name/op/open-isns/package.nix
+++ b/pkgs/by-name/op/open-isns/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   # The location of /var/lib is not made configurable in the meson.build file
   postPatch = ''
     substituteInPlace meson.build \
-        --replace-fail "/var/lib" "$out/var/lib" \
+        --replace-fail "/var/lib" "$out/var/lib"
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/po/poetry/unwrapped.nix
+++ b/pkgs/by-name/po/poetry/unwrapped.nix
@@ -86,7 +86,7 @@ buildPythonPackage rec {
     installShellCompletion --cmd poetry \
       --bash <($out/bin/poetry completions bash) \
       --fish <($out/bin/poetry completions fish) \
-      --zsh <($out/bin/poetry completions zsh) \
+      --zsh <($out/bin/poetry completions zsh)
   '';
 
   nativeCheckInputs = [

--- a/pkgs/by-name/pr/prometheus-cpp-lite/package.nix
+++ b/pkgs/by-name/pr/prometheus-cpp-lite/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace 3rdpatry/http-client-lite/CMakeLists.txt --replace-fail \
       'cmake_minimum_required(VERSION 3.3 FATAL_ERROR)' \
-      'cmake_minimum_required(VERSION 3.10)' \
+      'cmake_minimum_required(VERSION 3.10)'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ra/rascal/package.nix
+++ b/pkgs/by-name/ra/rascal/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     mkdir -p $out/bin
     makeWrapper ${jdk}/bin/java $out/bin/rascal \
-      --add-flags "-jar ${finalAttrs.src}" \
+      --add-flags "-jar ${finalAttrs.src}"
   '';
 
   meta = {

--- a/pkgs/by-name/re/renode/package.nix
+++ b/pkgs/by-name/re/renode/package.nix
@@ -171,7 +171,7 @@ buildDotnetModule rec {
       --prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules" \
       --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk3-x11 ]}" \
       --prefix PYTHONPATH : "${pythonLibs}" \
-      --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive" \
+      --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive"
   '';
 
   postFixup = ''

--- a/pkgs/by-name/sh/sharedown/package.nix
+++ b/pkgs/by-name/sh/sharedown/package.nix
@@ -59,7 +59,7 @@ buildNpmPackage (finalAttrs: {
       --add-flags $out/lib/node_modules/sharedown/app.js \
       --set PUPPETEER_EXECUTABLE_PATH ${chromium}/bin/chromium \
       --prefix PATH : ${lib.makeBinPath finalAttrs.finalPackage.passthru.wrapperPaths} \
-      --add-flags "--no-sandbox" \
+      --add-flags "--no-sandbox"
   '';
 
   desktopItems = [

--- a/pkgs/by-name/sn/snowsql/package.nix
+++ b/pkgs/by-name/sn/snowsql/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
         lib64/snowflake/snowsql/snowsql
 
     makeWrapper $out/lib64/snowflake/snowsql/snowsql $out/bin/snowsql \
-      --set LD_LIBRARY_PATH "${libPath}":"${placeholder "out"}"/lib64/snowflake/snowsql \
+      --set LD_LIBRARY_PATH "${libPath}":"${placeholder "out"}"/lib64/snowflake/snowsql
   '';
 
   meta = {

--- a/pkgs/by-name/sp/spacectl/package.nix
+++ b/pkgs/by-name/sp/spacectl/package.nix
@@ -30,7 +30,7 @@ buildGoModule (finalAttrs: {
       installShellCompletion --cmd spacectl \
         --bash <(${emulator} $out/bin/spacectl completion bash) \
         --fish <(${emulator} $out/bin/spacectl completion fish) \
-        --zsh <(${emulator} $out/bin/spacectl completion zsh) \
+        --zsh <(${emulator} $out/bin/spacectl completion zsh)
     '';
 
   meta = {

--- a/pkgs/by-name/sp/speakersafetyd/package.nix
+++ b/pkgs/by-name/sp/speakersafetyd/package.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     substituteInPlace Makefile \
       --replace-fail "target/release" \
-                     "target/${stdenv.hostPlatform.rust.cargoShortTarget}/$cargoBuildType" \
+                     "target/${stdenv.hostPlatform.rust.cargoShortTarget}/$cargoBuildType"
   '';
 
   installFlags = [

--- a/pkgs/by-name/sp/splix/package.nix
+++ b/pkgs/by-name/sp/splix/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     mv -v *.ppd ppd/
     substituteInPlace src/pstoqpdl.cpp \
       --replace "RASTERDIR \"/\" RASTERTOQPDL" "\"$out/lib/cups/filter/rastertoqpdl\"" \
-      --replace "RASTERDIR" "\"${cups-filters}/lib/cups/filter\"" \
+      --replace "RASTERDIR" "\"${cups-filters}/lib/cups/filter\""
   '';
 
   makeFlags = [

--- a/pkgs/by-name/ss/sshuttle/package.nix
+++ b/pkgs/by-name/ss/sshuttle/package.nix
@@ -58,7 +58,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
             net-tools
           ]
         )
-      }" \
+      }"
   '';
 
   meta = {

--- a/pkgs/by-name/st/steamguard-cli/package.nix
+++ b/pkgs/by-name/st/steamguard-cli/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installShellCompletion --cmd steamguard \
       --bash <($out/bin/steamguard completion --shell bash) \
       --fish <($out/bin/steamguard completion --shell fish) \
-      --zsh <($out/bin/steamguard completion --shell zsh) \
+      --zsh <($out/bin/steamguard completion --shell zsh)
   '';
 
   meta = {

--- a/pkgs/by-name/su/supertuxkart/package.nix
+++ b/pkgs/by-name/su/supertuxkart/package.nix
@@ -143,7 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
   preFixup = ''
     wrapProgram $out/bin/supertuxkart \
       --set-default SUPERTUXKART_ASSETS_DIR "${assets}" \
-      --set-default SUPERTUXKART_DATADIR "$out/share/supertuxkart" \
+      --set-default SUPERTUXKART_DATADIR "$out/share/supertuxkart"
   '';
 
   meta = {

--- a/pkgs/by-name/tl/tldr/package.nix
+++ b/pkgs/by-name/tl/tldr/package.nix
@@ -41,7 +41,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd tldr \
       --bash <($out/bin/tldr --print-completion bash | sed -E "s#\"/nix/store/[^\"]+/bin/python[^\"]*\" -m tldr#\"$out/bin/tldr\"#g") \
-      --zsh <($out/bin/tldr --print-completion zsh | sed -E "s#\"/nix/store/[^\"]+/bin/python[^\"]*\" -m tldr#\"$out/bin/tldr\"#g") \
+      --zsh <($out/bin/tldr --print-completion zsh | sed -E "s#\"/nix/store/[^\"]+/bin/python[^\"]*\" -m tldr#\"$out/bin/tldr\"#g")
   '';
 
   meta = {

--- a/pkgs/by-name/vi/victoriametrics/package.nix
+++ b/pkgs/by-name/vi/victoriametrics/package.nix
@@ -60,7 +60,7 @@ buildGo126Module (finalAttrs: {
     substituteInPlace lib/storage/storage_test.go \
       --replace-fail "time.After(10 " "time.After(120 " \
       --replace-fail "time.NewTimer(30 " "time.NewTimer(120 " \
-      --replace-fail "time.NewTimer(time.Second * 10)" "time.NewTimer(time.Second * 120)" \
+      --replace-fail "time.NewTimer(time.Second * 10)" "time.NewTimer(time.Second * 120)"
   '';
 
   ldflags = [

--- a/pkgs/by-name/zp/zps/package.nix
+++ b/pkgs/by-name/zp/zps/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     mkdir -p $out/share/applications
     substitute ../.application/zps.desktop $out/share/applications/zps.desktop \
-      --replace Exec=zps Exec=$out/zps \
+      --replace Exec=zps Exec=$out/zps
   '';
 
   meta = {

--- a/pkgs/desktops/lomiri/qml/lomiri-push-qml/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-push-qml/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # Queries QMake for QML install location, returns QtBase build path
     substituteInPlace src/*/PushNotifications/CMakeLists.txt \
-      --replace-fail 'qmake -query QT_INSTALL_QML' 'echo ''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}' \
+      --replace-fail 'qmake -query QT_INSTALL_QML' 'echo ''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}'
   '';
 
   strictDeps = true;

--- a/pkgs/desktops/lxqt/compton-conf/default.nix
+++ b/pkgs/desktops/lxqt/compton-conf/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     substituteInPlace autostart/CMakeLists.txt \
-      --replace-fail "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg" \
+      --replace-fail "DESTINATION \"\''${LXQT_ETC_XDG_DIR}" "DESTINATION \"etc/xdg"
   '';
 
   postPatch = ''

--- a/pkgs/development/compilers/opensmalltalk-vm/default.nix
+++ b/pkgs/development/compilers/opensmalltalk-vm/default.nix
@@ -60,7 +60,7 @@ let
           --replace "/bin/rm" "rm"
         substituteInPlace ./platforms/unix/config/configure \
           --replace "/usr/bin/file" "file" \
-          --replace "/usr/bin/pkg-config" "pkg-config" \
+          --replace "/usr/bin/pkg-config" "pkg-config"
       '';
 
       preConfigure = ''

--- a/pkgs/development/compilers/swift/swiftpm2nix/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm2nix/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
           jq
           nurl
         ]
-      } \
+      }
   '';
 
   preferLocalBuild = true;

--- a/pkgs/development/coq-modules/compcert/default.nix
+++ b/pkgs/development/coq-modules/compcert/default.nix
@@ -98,8 +98,8 @@ let
       -toolprefix ${tools}/bin/ \
       -use-external-Flocq \
       -use-external-MenhirLib \
-      ${target} \
-    ''; # don't remove the \ above, the command gets appended in override below
+      ${target}
+    '';
 
     installTargets = "documentation install";
     installFlags = [ ]; # trust ./configure
@@ -342,6 +342,10 @@ in
 patched_compcert.overrideAttrs (
   o:
   lib.optionalAttrs (coq.version != null && coq.version == "dev") {
-    configurePhase = "${o.configurePhase} -ignore-ocaml-version -ignore-coq-version";
+    configurePhase = ''
+      ${o.configurePhase} \
+        -ignore-ocaml-version \
+        -ignore-coq-version
+    '';
   }
 )

--- a/pkgs/development/libraries/rlottie-qml/default.nix
+++ b/pkgs/development/libraries/rlottie-qml/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix QML install path
     substituteInPlace CMakeLists.txt \
       --replace-fail 'QT_IMPORTS_DIR "/lib/''${ARCH_TRIPLET}"' 'QT_IMPORTS_DIR "''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"' \
-      --replace-fail "\''${QT_IMPORTS_DIR}/\''${PLUGIN}" "\''${QT_IMPORTS_DIR}" \
+      --replace-fail "\''${QT_IMPORTS_DIR}/\''${PLUGIN}" "\''${QT_IMPORTS_DIR}"
   '';
 
   strictDeps = true;

--- a/pkgs/development/libraries/science/math/libtorch/bin.nix
+++ b/pkgs/development/libraries/science/math/libtorch/bin.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation {
 
     substituteInPlace \
       $dev/share/cmake/Caffe2/Caffe2Targets-release.cmake \
-      --replace \''${_IMPORT_PREFIX}/lib "$out/lib" \
+      --replace \''${_IMPORT_PREFIX}/lib "$out/lib"
   '';
 
   postFixup =

--- a/pkgs/development/python-modules/devtools/default.nix
+++ b/pkgs/development/python-modules/devtools/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail 'asttokens>=2.0.0,<3.0.0' 'asttokens>=2.0.0' \
+      --replace-fail 'asttokens>=2.0.0,<3.0.0' 'asttokens>=2.0.0'
   '';
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/django-pgpubsub/default.nix
+++ b/pkgs/development/python-modules/django-pgpubsub/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace pyproject.toml \
     --replace 'poetry.masonry.api' 'poetry.core.masonry.api' \
-    --replace 'poetry>=1.1.13' 'poetry-core>=1.0.0' \
+    --replace 'poetry>=1.1.13' 'poetry-core>=1.0.0'
   '';
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/elgato/default.nix
+++ b/pkgs/development/python-modules/elgato/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set a version for the pyproject.toml
     substituteInPlace pyproject.toml \
-      --replace "0.0.0" "${version}" \
+      --replace "0.0.0" "${version}"
   '';
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/ffcv/default.nix
+++ b/pkgs/development/python-modules/ffcv/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace-fail "'assertpy'," "" \
       --replace-fail "'fastargs'," "" \
-      --replace-fail "'psutil'," "" \
+      --replace-fail "'psutil'," ""
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/green/default.nix
+++ b/pkgs/development/python-modules/green/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   checkPhase = ''
     $out/bin/green -tvvv \
       green.test.test_version \
-      green.test.test_cmdline \
+      green.test.test_cmdline
   '';
 
   pythonImportsCheck = [ "green" ];

--- a/pkgs/development/python-modules/ipycanvas/default.nix
+++ b/pkgs/development/python-modules/ipycanvas/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   #
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail '"jupyterlab>=3,<5",' "" \
+      --replace-fail '"jupyterlab>=3,<5",' ""
   '';
 
   build-system = [

--- a/pkgs/development/python-modules/open-meteo/default.nix
+++ b/pkgs/development/python-modules/open-meteo/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set a version for the pyproject.toml
     substituteInPlace pyproject.toml \
-      --replace-fail "0.0.0" "${version}" \
+      --replace-fail "0.0.0" "${version}"
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/pyppeteer-ng/default.nix
+++ b/pkgs/development/python-modules/pyppeteer-ng/default.nix
@@ -63,7 +63,7 @@ buildPythonPackage rec {
       --replace-fail '_port = get_free_port()' ""
 
     substituteInPlace tests/utils/server.py \
-      --replace-fail '_Middleware' '_Middlewares' \
+      --replace-fail '_Middleware' '_Middlewares'
   '';
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/pyvips/default.nix
+++ b/pkgs/development/python-modules/pyvips/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
       --replace 'libvips.so.42' '${lib.getLib vips}/lib/libvips${stdenv.hostPlatform.extensions.sharedLibrary}' \
       --replace 'libvips.42.dylib' '${lib.getLib vips}/lib/libvips${stdenv.hostPlatform.extensions.sharedLibrary}' \
       --replace 'libgobject-2.0.so.0' '${glib.out}/lib/libgobject-2.0${stdenv.hostPlatform.extensions.sharedLibrary}' \
-      --replace 'libgobject-2.0.dylib' '${glib.out}/lib/libgobject-2.0${stdenv.hostPlatform.extensions.sharedLibrary}' \
+      --replace 'libgobject-2.0.dylib' '${glib.out}/lib/libgobject-2.0${stdenv.hostPlatform.extensions.sharedLibrary}'
   '';
 
   disabledTests = [

--- a/pkgs/development/python-modules/rdkit/default.nix
+++ b/pkgs/development/python-modules/rdkit/default.nix
@@ -137,7 +137,7 @@ buildPythonPackage rec {
       External/pubchem_shape/Wrap/CMakeLists.txt \
       --replace-fail \
         "find_package(Python3 COMPONENTS Interpreter Development.Module NumPy" \
-        "find_package(Python3 COMPONENTS Interpreter Development NumPy" \
+        "find_package(Python3 COMPONENTS Interpreter Development NumPy"
   '';
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/python-modules/rendercv-fonts/default.nix
+++ b/pkgs/development/python-modules/rendercv-fonts/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   # pythonRelaxDeps seems not taking effect for the build-system dependencies
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail 'hatchling==1.26.3' 'hatchling' \
+      --replace-fail 'hatchling==1.26.3' 'hatchling'
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/sphinx-last-updated-by-git/default.nix
+++ b/pkgs/development/python-modules/sphinx-last-updated-by-git/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage (finalAttrs: {
     substituteInPlace src/sphinx_last_updated_by_git.py \
       --replace-fail "'git', 'ls-tree'" " '${lib.getExe gitMinimal}', 'ls-tree'" \
       --replace-fail "'git', 'log'" "'${lib.getExe gitMinimal}', 'log'" \
-      --replace-fail "'git', 'rev-parse'" "'${lib.getExe gitMinimal}', 'rev-parse'" \
+      --replace-fail "'git', 'rev-parse'" "'${lib.getExe gitMinimal}', 'rev-parse'"
   '';
 
   propagatedBuildInputs = [ gitMinimal ];

--- a/pkgs/development/python-modules/strawberry-graphql/default.nix
+++ b/pkgs/development/python-modules/strawberry-graphql/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "--emoji" "" \
+      --replace-fail "--emoji" ""
   '';
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -626,7 +626,7 @@ buildPythonPackage {
       -e "s/'gast[^']*',/'gast',/" \
       -e "/'libclang[^']*',/d" \
       -e "/'keras[^']*')\?,/d" \
-      -e "s/'protobuf[^']*',/'protobuf',/" \
+      -e "s/'protobuf[^']*',/'protobuf',/"
   '';
 
   # Upstream has a pip hack that results in bin/tensorboard being in both tensorflow

--- a/pkgs/development/python-modules/vehicle/default.nix
+++ b/pkgs/development/python-modules/vehicle/default.nix
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set a version for the pyproject.toml
     substituteInPlace pyproject.toml \
-      --replace "0.0.0" "${version}" \
+      --replace "0.0.0" "${version}"
   '';
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/wled/default.nix
+++ b/pkgs/development/python-modules/wled/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   postPatch = ''
     # Upstream doesn't set a version for the pyproject.toml
     substituteInPlace pyproject.toml \
-      --replace-fail "0.0.0" "${version}" \
+      --replace-fail "0.0.0" "${version}"
   '';
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/zstandard/default.nix
+++ b/pkgs/development/python-modules/zstandard/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "cffi~=" "cffi>=" \
+      --replace-fail "cffi~=" "cffi>="
   '';
 
   build-system = [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -2970,7 +2970,7 @@ let
       postPatch = ''
         substituteInPlace src/Makefile --replace-fail \
           "all:\$(PROG) ../inst/bwa clean" \
-          "all:\$(PROG) ../inst/bwa" \
+          "all:\$(PROG) ../inst/bwa"
       '';
     });
 

--- a/pkgs/games/fteqw/default.nix
+++ b/pkgs/games/fteqw/default.nix
@@ -79,7 +79,7 @@
 
       postFixup = ''
         patchelf $out/bin/${pname} \
-          --add-needed ${gnutls}/lib/libgnutls.so \
+          --add-needed ${gnutls}/lib/libgnutls.so
       '';
 
       description = "Dedicated server for FTEQW";

--- a/pkgs/servers/home-assistant/custom-components/systemair/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/systemair/package.nix
@@ -21,7 +21,7 @@ buildHomeAssistantComponent rec {
 
   postPatch = ''
     substituteInPlace custom_components/systemair/manifest.json \
-      --replace-fail "pymodbus==" "pymodbus>=" \
+      --replace-fail "pymodbus==" "pymodbus>="
   '';
 
   dependencies = [


### PR DESCRIPTION
To avoid confusion and spurious newlines in the output.

Found by searching for a backslash followed by a newline, some indentation, and then the end of multi-line string marker, using the following extended regex:

```regex
\\\n +'';
```

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
