### PR TITLE
texlive.withPackages: add withDocs, withSources and expose texliveFullWithDocs at top level

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -327,6 +327,20 @@ lib.fix (
           appliedArgs = if builtins.isFunction newArgs then newArgs args else newArgs;
         in
         self (args // { __fromCombineWrapper = false; } // appliedArgs);
+      withDocs = self (
+        args
+        // {
+          __fromCombineWrapper = false;
+          withDocs = true;
+        }
+      );
+      withSources = self (
+        args
+        // {
+          __fromCombineWrapper = false;
+          withSources = true;
+        }
+      );
       withPackages =
         reqs:
         self (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1745,6 +1745,8 @@ with pkgs;
     texliveSmall
     texliveTeTeX
     ;
+  # alias to trigger a build of all texdoc containers
+  texliveFullWithDocs = texliveFull.withDocs;
   texlivePackages = recurseIntoAttrs (lib.mapAttrs (_: v: v.build) texlive.pkgs);
 
   futhark = haskell.lib.compose.justStaticExecutables haskellPackages.futhark;


### PR DESCRIPTION
Expose new attributes `withDocs`, `withSources` that evaluate to the same `texlive.withPackages` derivation, but with `withDocs = true`. I have added `texliveFullWithDocs` at the top level to have Hydra add all texdoc containers to the binary cache.

If this gets merged, I think we can finally deprecate `texlive.combine` for good, and start updating the documentation.

There's a bit of history around these changes.

I tried to implement `.overrideAttrs { withDocs = true; }` quite some time ago (#312945), but it died out, it's just too cumbersome to implement (see also #432957) and it doesn't look like people were clamoring for it. `.overrideAttrs` is also tricky to get right, because some overrides require rebuilding the formats, some don't. It's hard to come up with an overriding mechanism that captures this nicely. Instead, `.withDocs` is embarrassingly simple to add (and suggests adding `.withPaper` for switching defaults between A4 and letter). At any rate, if we manage to implement a version `.overrideAttrs { withDocs = true; }`, leaving the `.withDocs` alias is very cheap.

The top level `texliveFullWithDocs` is odd, but when I tried to have Hydra build all texdoc containers via `texlivePackages`, I was told that in fact building each TeX Live package separately causes scheduling issues. I forgot where that conversation was!

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
