### PR TITLE
fluxer-desktop: init at 0.0.8-unstable-2026-04-09

### DIFF
--- a/pkgs/by-name/fl/fluxer-desktop/electron-builder-config.patch
+++ b/pkgs/by-name/fl/fluxer-desktop/electron-builder-config.patch
@@ -1,0 +1,21 @@
+diff --git a/electron-builder.config.cjs b/electron-builder.config.cjs
+index f8f8328c..129d9251 100644
+--- a/electron-builder.config.cjs
++++ b/electron-builder.config.cjs
+@@ -146,10 +146,12 @@ module.exports = {
+ 			},
+ 		],
+ 		desktop: {
+-			Name: productName,
+-			Comment: 'Instant messaging and VoIP application',
+-			Categories: 'Network;InstantMessaging;',
+-			StartupWMClass: isCanary ? 'fluxer-canary' : 'fluxer',
++			entry: {
++				Name: productName,
++				Comment: 'Instant messaging and VoIP application',
++				Categories: 'Network;InstantMessaging;',
++				StartupWMClass: isCanary ? 'fluxer-canary' : 'fluxer',
++			},
+ 		},
+ 	},
+ 

--- a/pkgs/by-name/fl/fluxer-desktop/package.nix
+++ b/pkgs/by-name/fl/fluxer-desktop/package.nix
@@ -1,0 +1,151 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  nodejs,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_10,
+  electron_40,
+  python3,
+  autoPatchelfHook,
+  cctools,
+  libx11,
+  libxrandr,
+  libxtst,
+  libxt,
+}:
+
+let
+  pnpm = pnpm_10;
+  electron = electron_40;
+  distSuffix = lib.optionalString stdenv.hostPlatform.isAarch64 "-arm64";
+  # must match between Electron metadata name, desktop file and icons
+  appId = "app.fluxer.Fluxer";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fluxer-desktop";
+  version = "0.0.8-unstable-2026-04-09";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "fluxerapp";
+    repo = "fluxer";
+    rootDir = "fluxer_desktop";
+    # There are no tagged releases yet, and the version info must be read from the <release> element in
+    # fluxer_desktop/packaging/linux/app.fluxer.Fluxer.metainfo.xml
+    rev = "ee1f27fe1a372b5291aead8042944afd706bf5db";
+    hash = "sha256-Wel9lIlcczQqi0MpxvJO95qowTU7WiiD9gkZwEeM8K0=";
+  };
+
+  patches = [
+    # The config seems to target an older version of electron-builder than
+    # listed in its dependencies.
+    # See this issue for the incompatibility the patch addresses:
+    # https://github.com/electron-userland/electron-builder/issues/9214
+    ./electron-builder-config.patch
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-Rh84JplYrd9k4fslofQli4fRNKmFhosftUfYXKBKU4g=";
+  };
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    nodejs
+    pnpmConfigHook
+    pnpm
+    python3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    # required by uiohook-napi
+    (lib.getLib stdenv.cc.cc) # libgcc_s.so.1, libstdc++.so.6
+    libx11
+    libxrandr
+    libxtst
+    libxt
+  ];
+
+  env.NODE_ENV = "production";
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    # Needs to be writable
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    export npm_config_nodedir=${electron.headers}
+    pnpm exec electron-builder \
+      --config electron-builder.config.cjs \
+      --dir \
+      -c.electronDist=electron-dist \
+      -c.electronVersion=${electron.version} \
+      -c.extraMetadata.name=${appId} \
+      -c.extraMetadata.version=${finalAttrs.version} \
+      -c.mac.identity=null
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    mkdir -p $out/share/{applications,metainfo,${appId}}
+    mkdir -p $out/bin
+
+    cp -r ./dist-electron/linux${distSuffix}-unpacked/resources/* $out/share/${appId}
+
+    makeWrapper ${lib.getExe electron} $out/bin/fluxer-desktop \
+      --add-flags "$out/share/${appId}/app.asar"
+
+    substitute {packaging/linux,$out/share/applications}/${appId}.desktop \
+      --replace-fail "Exec=${appId}" "Exec=$out/bin/fluxer-desktop"
+
+    install -Dm444 packaging/linux/${appId}.metainfo.xml $out/share/metainfo/
+
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    install -Dm444 packaging/linux/${appId}.svg $out/share/icons/hicolor/scalable/apps/
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/{bin,Applications}
+    mv dist-electron/mac${distSuffix}/Fluxer.app $out/Applications/
+
+    # Allow launching the app through a shell (e.g., with `nix run`)
+    cat << EOF > "$out/bin/fluxer-desktop"
+    #!${stdenv.shell}
+    open -na "$out/Applications/Fluxer.app" --args "\$@"
+    EOF
+    chmod +x "$out/bin/fluxer-desktop"
+  ''
+  + ''
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Free and open source instant messaging and VoIP platform built for friends, groups, and communities";
+    homepage = "https://fluxer.app/";
+    mainProgram = "fluxer-desktop";
+    license = lib.licenses.agpl3Plus;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [
+      niklaskorz
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Base package by @roufpup (who is listed as co-author), which I improved to meet nixpkgs standards and added darwin support. PR submitted with his consent.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
