### PR TITLE
kontainer: refactor derivation

### DIFF
--- a/pkgs/by-name/ko/kontainer/package.nix
+++ b/pkgs/by-name/ko/kontainer/package.nix
@@ -4,16 +4,16 @@
   fetchFromGitHub,
   cmake,
   ninja,
-  qt6,
   kdePackages,
   nix-update-script,
   git,
   distrobox,
-  ...
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "kontainer";
   version = "1.4.1";
+
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "DenysMb";
@@ -30,35 +30,33 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     ninja
-    kdePackages.extra-cmake-modules
-    qt6.wrapQtAppsHook
-  ];
-
-  qtWrapperArgs = [
-    "--prefix PATH : ${
-      lib.makeBinPath [
-        distrobox
-      ]
-    }"
-  ];
+  ]
+  ++ (with kdePackages; [
+    extra-cmake-modules
+    wrapQtAppsHook
+  ]);
 
   buildInputs = [
-    qt6.qtbase
-    qt6.qtdeclarative
-    kdePackages.kirigami
-    kdePackages.kirigami-addons
-    kdePackages.ki18n
-    kdePackages.kcoreaddons
-    kdePackages.qqc2-desktop-style
-    kdePackages.kiconthemes
-    kdePackages.kio
     git
-  ];
+  ]
+  ++ (with kdePackages; [
+    qtbase
+    qtdeclarative
+    kirigami
+    kirigami-addons
+    ki18n
+    kcoreaddons
+    qqc2-desktop-style
+    kiconthemes
+    kio
+  ]);
+
+  qtWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ distrobox ]}" ];
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Manage Distrobox containers";
+    description = "Graphical management application for Distrobox containers";
     longDescription = ''
       Kontainer is a graphical user interface (GUI) application built with KDE Kirigami that provides a user-friendly way to manage Distrobox containers.
 
@@ -76,6 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       griffi-gh
+      sigmasquadron
     ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
Fixes some nits which were skipped during the init PR. Notably, we don't need the `...` operator for a `callPackage`'d function, nor do we need `qt6` when `kdePackages` already provides everything Qt 6-related.

Unfortunately rebuilds because `qt6.*` is technically different from `kdePackages.*`, but it should effectively be a no-op.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
