### PR TITLE
boost18{7,9}: move cygwin patch to generic.nix

### DIFF
--- a/pkgs/development/libraries/boost/1.87.nix
+++ b/pkgs/development/libraries/boost/1.87.nix
@@ -1,10 +1,4 @@
-{
-  lib,
-  stdenv,
-  callPackage,
-  fetchurl,
-  ...
-}@args:
+{ callPackage, fetchurl, ... }@args:
 
 callPackage ./generic.nix (
   args
@@ -21,7 +15,5 @@ callPackage ./generic.nix (
       # SHA256 from http://www.boost.org/users/history/version_1_87_0.html
       sha256 = "af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89";
     };
-
-    patches = lib.optional stdenv.hostPlatform.isCygwin ./Fix-cygwin-build-187.patch;
   }
 )

--- a/pkgs/development/libraries/boost/1.89.nix
+++ b/pkgs/development/libraries/boost/1.89.nix
@@ -1,10 +1,4 @@
-{
-  lib,
-  stdenv,
-  callPackage,
-  fetchurl,
-  ...
-}@args:
+{ callPackage, fetchurl, ... }@args:
 
 callPackage ./generic.nix (
   args
@@ -21,7 +15,5 @@ callPackage ./generic.nix (
       # SHA256 from http://www.boost.org/users/history/version_1_89_0.html
       sha256 = "85a33fa22621b4f314f8e85e1a5e2a9363d22e4f4992925d4bb3bc631b5a0c7a";
     };
-
-    patches = lib.optional stdenv.hostPlatform.isCygwin ./Fix-cygwin-build-189.patch;
   }
 )

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -258,7 +258,10 @@ stdenv.mkDerivation {
     ]
     ++ lib.optional (
       stdenv.hostPlatform.isCygwin && lib.versionAtLeast version "1.87" && lib.versionOlder version "1.88"
-    ) ./Fix-cygwin-build-187.patch;
+    ) ./Fix-cygwin-build-187.patch
+    ++ lib.optional (
+      stdenv.hostPlatform.isCygwin && lib.versionAtLeast version "1.89" && lib.versionOlder version "1.90"
+    ) ./Fix-cygwin-build-189.patch;
 
   meta = {
     homepage = "http://boost.org/";

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -255,7 +255,10 @@ stdenv.mkDerivation {
         extraPrefix = "libs/context/";
         hash = "sha256-Z8uw2+4IEybqVcU25i/0XJKS16hi/+3MXUxs53ghjL0=";
       })
-    ];
+    ]
+    ++ lib.optional (
+      stdenv.hostPlatform.isCygwin && lib.versionAtLeast version "1.87" && lib.versionOlder version "1.88"
+    ) ./Fix-cygwin-build-187.patch;
 
   meta = {
     homepage = "http://boost.org/";


### PR DESCRIPTION
`boost187` and `boost189` currently pin the parameter `patches` directly in `1.87.nix` and `1.89.nix`, which makes it impossible to override that parameter downstream.

fixes https://hydra.nixos.org/build/323065524

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 497889`
Commit: `7161a38c256aede0e3438a39014b539ef1e4dfce`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>python313Packages.graph-tool</li>
    <li>python314Packages.graph-tool</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>python313Packages.graph-tool</li>
    <li>python314Packages.graph-tool</li>
  </ul>
</details>

---
### `x86_64-darwin`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>python313Packages.graph-tool</li>
    <li>python314Packages.graph-tool</li>
  </ul>
</details>

---
### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>python313Packages.graph-tool</li>
    <li>python314Packages.graph-tool</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test