### PR TITLE
home-assistant: pin psutil to 7.1.2 for systemmonitor

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -223,6 +223,20 @@ let
         doCheck = false;
       });
 
+      # Pinned because systemmonitor in Home Assistant 2026.2.3 still requires
+      # psutil 7.1.2 and breaks with psutil 7.2.1 (missing sbattery in
+      # psutil._common).
+      psutil = super.psutil.overridePythonAttrs (oldAttrs: rec {
+        version = "7.1.2";
+        src = fetchFromGitHub {
+          owner = "giampaolo";
+          repo = "psutil";
+          tag = "release-${version}";
+          hash = "sha256-LyGnLrq+SzCQmz8/P5DOugoNEyuH0IC7uIp8UAPwH0U=";
+        };
+        doCheck = false;
+      });
+
       wolf-comm = super.wolf-comm.overridePythonAttrs rec {
         version = "0.0.23";
         src = fetchFromGitHub {


### PR DESCRIPTION
## Description

Home Assistant `2026.2.3` still ships `systemmonitor` with a hard requirement on `psutil==7.1.2`, and it imports symbols that were removed from `psutil 7.2.1`.

On nixpkgs unstable, `pkgs.home-assistant` currently ends up with `psutil 7.2.1`, which breaks `systemmonitor` at import time with:

```console
ImportError: cannot import name 'sbattery' from 'psutil._common'
```

Pin `psutil` to `7.1.2` inside the Home Assistant Python package set so `systemmonitor` matches its upstream dependency constraint again.

Resolves #496133.

## Testing

- `nix build -L .#home-assistant --no-link`
- Verified the resulting closure contains `python3.13-psutil-7.1.2`
- Verified `homeassistant.components.systemmonitor.coordinator` imports successfully from the built package
