### PR TITLE
ipxe: 1.21.1-unstable-2025-11-19 -> 2.0.0

### DIFF
--- a/pkgs/by-name/ip/ipxe/package.nix
+++ b/pkgs/by-name/ip/ipxe/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  unstableGitUpdater,
+  nix-update-script,
   buildPackages,
   mtools,
   openssl,
@@ -10,45 +10,103 @@
   xorriso,
   xz,
   syslinux,
+
   embedScript ? null,
+  enableDefaultPlatformTargets ? true,
   additionalTargets ? { },
+  enableDefaultOptions ? true,
   additionalOptions ? [ ],
   firmwareBinary ? "ipxe.efirom",
 }:
 
 let
+  inherit (lib)
+    assertOneOf
+    attrNames
+    concatStringsSep
+    escapeShellArgs
+    flip
+    last
+    licenses
+    maintainers
+    mapAttrsToList
+    optional
+    optionalAttrs
+    optionalString
+    optionals
+    platforms
+    splitString
+    uniqueStrings
+    ;
+
+  inherit (stdenv.hostPlatform)
+    isAarch32
+    isAarch64
+    isx86
+    isx86_64
+    ;
+
+  platformTarget = platform: optionalAttrs (enableDefaultPlatformTargets && platform);
+
   targets =
-    additionalTargets
-    // lib.optionalAttrs stdenv.hostPlatform.isx86_64 {
+    platformTarget isx86_64 {
       "bin-x86_64-efi/ipxe.efi" = null;
       "bin-x86_64-efi/ipxe.efirom" = null;
       "bin-x86_64-efi/ipxe.usb" = "ipxe-efi.usb";
       "bin-x86_64-efi/snp.efi" = null;
     }
-    // lib.optionalAttrs stdenv.hostPlatform.isx86 {
+    // platformTarget isx86 {
       "bin/ipxe.dsk" = null;
       "bin/ipxe.usb" = null;
       "bin/ipxe.iso" = null;
       "bin/ipxe.lkrn" = null;
       "bin/undionly.kpxe" = null;
     }
-    // lib.optionalAttrs stdenv.hostPlatform.isAarch32 {
+    // platformTarget isAarch32 {
       "bin-arm32-efi/ipxe.efi" = null;
       "bin-arm32-efi/ipxe.efirom" = null;
       "bin-arm32-efi/ipxe.usb" = "ipxe-efi.usb";
       "bin-arm32-efi/snp.efi" = null;
     }
-    // lib.optionalAttrs stdenv.hostPlatform.isAarch64 {
+    // platformTarget isAarch64 {
       "bin-arm64-efi/ipxe.efi" = null;
       "bin-arm64-efi/ipxe.efirom" = null;
       "bin-arm64-efi/ipxe.usb" = "ipxe-efi.usb";
       "bin-arm64-efi/snp.efi" = null;
-    };
+    }
+    // additionalTargets;
+
+  getTargets = flip mapAttrsToList targets;
+
+  binaries = uniqueStrings (
+    getTargets (from: to: if (isNull to) then last (splitString "/" from) else to)
+  );
+
+  options =
+    optionals enableDefaultOptions [
+      "PING_CMD"
+      "IMAGE_TRUST_CMD"
+      "DOWNLOAD_PROTO_HTTP"
+      "DOWNLOAD_PROTO_HTTPS"
+    ]
+    ++ additionalOptions;
 in
+
+assert assertOneOf "When building iPXE, the 'firmwareBinary' parameter" firmwareBinary binaries;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ipxe";
-  version = "1.21.1-unstable-2026-01-30";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "ipxe";
+    repo = "ipxe";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-O7jUpnP+wa9zBIEqYa7FQ9Zo1Ii1oVH10nlk+c4iHwg=";
+  };
+
+  enableParallelBuilding = true;
+  strictDeps = true;
 
   nativeBuildInputs = [
     mtools
@@ -57,23 +115,9 @@ stdenv.mkDerivation (finalAttrs: {
     xorriso
     xz
   ]
-  ++ lib.optional stdenv.hostPlatform.isx86 syslinux;
+  ++ optional isx86 syslinux;
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-
-  strictDeps = true;
-
-  src = fetchFromGitHub {
-    owner = "ipxe";
-    repo = "ipxe";
-    rev = "74e0551ac2f66760430e69407a4f7ed0dfe9feab";
-    hash = "sha256-7Guts4js1pM/Vse58XCjr7K8qHbJU5oiFFuqojwXTC4=";
-  };
-
-  # Calling syslinux on a FAT image isn't going to work on Aarch64.
-  postPatch = lib.optionalString stdenv.hostPlatform.isAarch64 ''
-    substituteInPlace src/util/genfsimg --replace "	syslinux " "	true "
-  '';
 
   # Hardening is not possible due to assembler code.
   hardeningDisable = [
@@ -86,23 +130,22 @@ stdenv.mkDerivation (finalAttrs: {
     "ECHO_E_BIN_ECHO_E=echo" # No /bin/echo here.
     "CROSS=${stdenv.cc.targetPrefix}"
   ]
-  ++ lib.optional (embedScript != null) "EMBED=${embedScript}";
+  ++ optional (embedScript != null) "EMBED=${embedScript}";
 
-  enabledOptions = [
-    "PING_CMD"
-    "IMAGE_TRUST_CMD"
-    "DOWNLOAD_PROTO_HTTP"
-    "DOWNLOAD_PROTO_HTTPS"
-  ]
-  ++ additionalOptions;
+  buildFlags = attrNames targets;
+
+  # Calling syslinux on a FAT image isn't going to work on Aarch64.
+  postPatch = optionalString isAarch64 ''
+    substituteInPlace src/util/genfsimg --replace-fail "	syslinux " "	true "
+  '';
 
   configurePhase = ''
     runHook preConfigure
-    for opt in ${lib.escapeShellArgs finalAttrs.enabledOptions}; do echo "#define $opt" >> src/config/general.h; done
-    substituteInPlace src/Makefile.housekeeping --replace '/bin/echo' echo
+    for opt in ${escapeShellArgs options}; do echo "#define $opt" >> src/config/general.h; done
+    substituteInPlace src/Makefile.housekeeping --replace-fail '/bin/echo' echo
   ''
-  + lib.optionalString stdenv.hostPlatform.isx86 ''
-    substituteInPlace src/util/genfsimg --replace /usr/lib/syslinux ${syslinux}/share/syslinux
+  + optionalString isx86 ''
+    substituteInPlace src/util/genfsimg --replace-fail /usr/lib/syslinux ${syslinux}/share/syslinux
   ''
   + ''
     runHook postConfigure
@@ -110,19 +153,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   preBuild = "cd src";
 
-  buildFlags = lib.attrNames targets;
-
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out
-    ${lib.concatStringsSep "\n" (
-      lib.mapAttrsToList (
-        from: to: if to == null then "cp -v ${from} $out" else "cp -v ${from} $out/${to}"
-      ) targets
+    ${concatStringsSep "\n" (
+      getTargets (from: to: if (isNull to) then "cp -v ${from} $out" else "cp -v ${from} $out/${to}")
     )}
   ''
-  + lib.optionalString stdenv.hostPlatform.isx86 ''
+  + optionalString isx86 ''
     # Some PXE constellations especially with dnsmasq are looking for the file with .0 ending
     # let's provide it as a symlink to be compatible in this case.
     ln -s undionly.kpxe $out/undionly.kpxe.0
@@ -131,19 +170,16 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  enableParallelBuilding = true;
-
   passthru = {
     firmware = "${finalAttrs.finalPackage}/${firmwareBinary}";
-    updateScript = unstableGitUpdater {
-      tagPrefix = "v";
-    };
+    updateScript = nix-update-script { };
   };
 
   meta = {
     description = "Network boot firmware";
     homepage = "https://ipxe.org/";
-    license = with lib.licenses; [
+    changelog = "https://github.com/ipxe/ipxe/releases/tag/v${finalAttrs.version}";
+    license = with licenses; [
       bsd2
       bsd3
       gpl2Only
@@ -152,7 +188,7 @@ stdenv.mkDerivation (finalAttrs: {
       mit
       mpl11
     ];
-    platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ sigmasquadron ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sigmasquadron ];
   };
 })


### PR DESCRIPTION
Also refactors the derivation a bit. This was long overdue.

Needs testing as to whether it still works on real hardware. I tested QEMU (KVM) and Xen, and both booted their respective binaries fine. Cross and ARM testing would also be nice.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of <del>all</del> (*some) binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
