### PR TITLE
ocamlPackages.htmlit: init at 0.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/htmlit/default.nix
+++ b/pkgs/development/ocaml-modules/htmlit/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchurl,
+  buildTopkgPackage,
+}:
+
+buildTopkgPackage rec {
+  pname = "htmlit";
+  version = "0.2.0";
+
+  minimalOCamlVersion = "4.14.0";
+
+  src = fetchurl {
+    url = "https://erratique.ch/software/htmlit/releases/htmlit-${version}.tbz";
+    hash = "sha256-i+7gYle8G2y78GeoAnlNY5dpdONLhltuswusCbMmB/c=";
+  };
+
+  meta = {
+    description = "HTML generation combinators for OCaml";
+    homepage = "https://erratique.ch/software/htmlit";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ redianthus ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -817,6 +817,8 @@ let
 
         hpack = callPackage ../development/ocaml-modules/hpack { };
 
+        htmlit = callPackage ../development/ocaml-modules/htmlit { };
+
         http = callPackage ../development/ocaml-modules/cohttp/http.nix { };
 
         http-mirage-client = callPackage ../development/ocaml-modules/http-mirage-client { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
