### PR TITLE
Revert "python3Packages.pylink-square: 1.6.0 -> 2.0.0"

### DIFF
--- a/pkgs/development/python-modules/pylink-square/default.nix
+++ b/pkgs/development/python-modules/pylink-square/default.nix
@@ -13,6 +13,7 @@
   # tests
   mock,
   pytestCheckHook,
+  pyocd,
 }:
 
 buildPythonPackage rec {
@@ -52,6 +53,10 @@ buildPythonPackage rec {
     "test_jlink_restarted"
     "test_set_log_file_success"
   ];
+
+  passthru.tests = {
+    inherit pyocd;
+  };
 
   meta = {
     description = "Python interface for the SEGGER J-Link";

--- a/pkgs/development/python-modules/pylink-square/default.nix
+++ b/pkgs/development/python-modules/pylink-square/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "pylink-square";
-  version = "2.0.0";
+  version = "1.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "square";
     repo = "pylink";
     tag = "v${version}";
-    hash = "sha256-QitJGJGgXeSl5RaYW6+VtwOrV9AYDA9+kUHNtopDgVc=";
+    hash = "sha256-rkkdnpkl9UHcBDjp6lsFXR1zNn7tH1KeTQ7wV+yJ3m0=";
   };
 
   patches = [


### PR DESCRIPTION
This reverts commit 6dc073f2c927e9fbbf68ff60f8d14923b138e589.

This fixes the build of pyocd, the only consumer of pylink-square

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
