### PR TITLE
python314Packages.kicost-digikey-api-v3: init at 0.1.3

### DIFF
--- a/pkgs/development/python-modules/kicost-digikey-api-v3/default.nix
+++ b/pkgs/development/python-modules/kicost-digikey-api-v3/default.nix
@@ -1,0 +1,57 @@
+{
+  buildPythonPackage,
+  certifi,
+  distutils,
+  fetchFromGitHub,
+  inflection,
+  lib,
+  pyopenssl,
+  python-dateutil,
+  setuptools,
+  six,
+  tldextract,
+  requests,
+  urllib3,
+  wheel,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "kicost-digikey-api-v3";
+  version = "0.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "set-soft";
+    repo = "kicost-digikey-api-v3";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-O4bYvf8EnAlcgJ/fqYEuo2+37Q6lTdmlSrmaD2Cl/q8=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  # Dependencies as specified in setup.py
+  dependencies = [
+    certifi
+    distutils
+    inflection
+    pyopenssl
+    python-dateutil
+    requests
+    six
+    tldextract
+    urllib3
+  ];
+
+  doCheck = true;
+  pythonImportsCheck = [ "kicost_digikey_api_v3" ];
+
+  meta = {
+    description = "KiCost plugin for the Digikey PartSearch API v3";
+    homepage = "https://github.com/set-soft/kicost-digikey-api-v3";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ guelakais ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8395,6 +8395,8 @@ self: super: with self; {
 
   kicadcliwrapper = callPackage ../development/python-modules/kicadcliwrapper { };
 
+  kicost-digikey-api-v3 = callPackage ../development/python-modules/kicost-digikey-api-v3 { };
+
   kinparse = callPackage ../development/python-modules/kinparse { };
 
   kiosker-python-api = callPackage ../development/python-modules/kiosker-python-api { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
