### PR TITLE
python3Packages.schwifty: fix GitHub release tag for changelog

### DIFF
--- a/pkgs/development/python-modules/schwifty/default.nix
+++ b/pkgs/development/python-modules/schwifty/default.nix
@@ -21,6 +21,22 @@
   pythonOlder,
 }:
 
+let
+  inherit (lib.versions) major minor patch;
+  inherit (lib.strings) concatStringsSep replicate;
+  inherit (builtins) stringLength;
+
+  pad = char: length: input:
+    (replicate (lib.max 0 (length - stringLength input)) char) + input;
+
+  toCalVer = version:
+    concatStringsSep "." [
+      (major version)
+      (pad "0" 2 (minor version))
+      (patch version)
+    ];
+
+in
 buildPythonPackage rec {
   pname = "schwifty";
   version = "2026.1.0";
@@ -55,7 +71,8 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "schwifty" ];
 
   meta = {
-    changelog = "https://github.com/mdomke/schwifty/blob/${version}/CHANGELOG.rst";
+    # The version here must be converted as release tags on PyPI and GitHub have different zero-padding
+    changelog = "https://github.com/mdomke/schwifty/blob/${toCalVer version}/CHANGELOG.rst";
     description = "Validate/generate IBANs and BICs";
     homepage = "https://github.com/mdomke/schwifty";
     license = lib.licenses.mit;


### PR DESCRIPTION
Release tags for schwifty are different between PyPI (e.g. `2026.1.0`) and GitHub (e.g. `2026.01.0`). This fix zero-pads the minor version in the changelog URL.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
