### PR TITLE
nixos/pocket-id: add delay between restarts

### DIFF
--- a/nixos/modules/services/security/pocket-id.nix
+++ b/nixos/modules/services/security/pocket-id.nix
@@ -223,6 +223,7 @@ in
             ${getExe cfg.package}
           '';
           Restart = "always";
+          RestartSec = 1;
           EnvironmentFile = [
             cfg.environmentFile
             settingsFile


### PR DESCRIPTION
Previously the service sometimes failed when it got restarted by switch-to-configuration:
```console
Mar 08 16:21:46 raspi5-doboz z5b082dy9fpn4mv84pz7wlg78nf4ms6f-pocket-id-start[3397708]: Mar  8 16:21:46 INF Pocket ID is starting app=pocket-id version=2.4.0
Mar 08 16:21:46 raspi5-doboz z5b082dy9fpn4mv84pz7wlg78nf4ms6f-pocket-id-start[3397708]: Mar  8 16:21:46 INF Connected to database app=pocket-id version=2.4.0 provider=sqlite
Mar 08 16:21:46 raspi5-doboz z5b082dy9fpn4mv84pz7wlg78nf4ms6f-pocket-id-start[3397708]: Mar  8 16:21:46 ERR Failed to run pocket-id app=pocket-id version=2.4.0 error="failed to acquire application lock: lock is already held by another p>
Mar 08 16:21:46 raspi5-doboz systemd[1]: pocket-id.service: Main process exited, code=exited, status=1/FAILURE
Mar 08 16:21:46 raspi5-doboz systemd[1]: pocket-id.service: Scheduled restart job, restart counter is at 4.
Mar 08 16:21:46 raspi5-doboz z5b082dy9fpn4mv84pz7wlg78nf4ms6f-pocket-id-start[3397748]: Mar  8 16:21:46 INF Pocket ID is starting app=pocket-id version=2.4.0
Mar 08 16:21:46 raspi5-doboz z5b082dy9fpn4mv84pz7wlg78nf4ms6f-pocket-id-start[3397748]: Mar  8 16:21:46 INF Connected to database app=pocket-id version=2.4.0 provider=sqlite
Mar 08 16:21:46 raspi5-doboz z5b082dy9fpn4mv84pz7wlg78nf4ms6f-pocket-id-start[3397748]: Mar  8 16:21:46 ERR Failed to run pocket-id app=pocket-id version=2.4.0 error="failed to acquire application lock: lock is already held by another p>
Mar 08 16:21:46 raspi5-doboz systemd[1]: pocket-id.service: Main process exited, code=exited, status=1/FAILURE
Mar 08 16:21:46 raspi5-doboz systemd[1]: pocket-id.service: Scheduled restart job, restart counter is at 5.
Mar 08 16:21:46 raspi5-doboz systemd[1]: Failed to start Pocket ID.
```

Manually restarting it worked, so waiting a second between restarts should fix this.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
