### PR TITLE
smoked-salmon: 0.9.7.4 -> 0.10.1

### DIFF
--- a/pkgs/by-name/sm/smoked-salmon/package.nix
+++ b/pkgs/by-name/sm/smoked-salmon/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  ffmpeg-headless,
+  curl,
   flac,
   lame,
   mp3val,
@@ -10,7 +10,7 @@
 }:
 let
   runtimeDeps = [
-    ffmpeg-headless
+    curl
     flac
     lame
     mp3val
@@ -19,56 +19,61 @@ let
 in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "smoked-salmon";
-  version = "0.9.7.4";
+  version = "0.10.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "smokin-salmon";
     repo = "smoked-salmon";
     tag = finalAttrs.version;
-    hash = "sha256-JOwqu/Hu7BjYLo3DdL6o+9TI/OQvlgj5Xu8WQ0cujwo=";
+    hash = "sha256-kgBTdQTWzGmKWsHjtazaVvQoTulyF5WNFPEUuoanCo4=";
   };
 
   # Upstream tends to use very narrow version constraints
   pythonRelaxDeps = true;
 
-  build-system = with python3Packages; [
-    setuptools
-    setuptools-scm
-  ];
+  # `build-system` requirements are seemingly not covered by pythonRelaxDeps
+  postPatch = ''
+    sed -i 's/requires = \["uv_build.*"\]/requires = ["uv_build"]/' pyproject.toml
+  '';
 
-  dependencies = with python3Packages; [
-    aiohttp
-    aiohttp-jinja2
-    beautifulsoup4
-    bitstring
-    click
-    deluge-client
-    ffmpeg-python
-    filetype
-    httpx
-    humanfriendly
-    jinja2
-    msgspec
-    musicbrainzngs
-    mutagen
-    pillow
-    platformdirs
-    pycambia
-    pyoxipng
-    pyperclip
-    qbittorrent-api
-    ratelimit
-    requests
-    rich
-    send2trash
-    setuptools
-    torf
-    tqdm
-    transmission-rpc
-    unidecode
-    wheel
-  ];
+  build-system = with python3Packages; [ uv-build ];
+
+  dependencies =
+    with python3Packages;
+    [
+      aiohttp
+      aiohttp-jinja2
+      aiolimiter
+      anyio
+      asyncclick
+      av
+      beautifulsoup4
+      deluge-client
+      humanfriendly
+      jinja2
+      msgspec
+      musicbrainzngs
+      mutagen
+      numpy
+      pillow
+      platformdirs
+      pycambia
+      pyimgbox
+      pyoxipng
+      pyperclip
+      qbittorrent-api
+      requests
+      send2trash
+      tenacity
+      torf
+      tqdm
+      transmission-rpc
+      unidecode
+    ]
+    ++ aiohttp.optional-dependencies.speedups
+    ++ beautifulsoup4.optional-dependencies.lxml
+    ++ msgspec.optional-dependencies.toml;
 
   makeWrapperArgs = [
     "--suffix"
@@ -82,7 +87,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   };
 
   meta = {
-    description = "Toolkit for checking, editing and uploading music to Gazelle-based trackers";
+    description = "Toolkit for checking, editing and uploading music. Catered to Gazelle-based trackers";
     homepage = "https://github.com/smokin-salmon/smoked-salmon";
     license = with lib.licenses; [ asl20 ];
     mainProgram = "salmon";

--- a/pkgs/development/python-modules/pycambia/default.nix
+++ b/pkgs/development/python-modules/pycambia/default.nix
@@ -2,39 +2,26 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   openssl,
   pkg-config,
   pytestCheckHook,
   rustPlatform,
 }:
-let
-  cargoLockPatch = (
-    fetchpatch {
-      name = "cargo.lock.patch";
-      url = "https://github.com/KyokoMiki/pycambia/commit/00446e13c20a461c323b119e16f3f57489ba662d.patch";
-      hash = "sha256-N7F67VRxfndoN8NllmGKEePOh3mgbjlNaToUvxh+IrE=";
-    }
-  );
-in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pycambia";
-  version = "0.1.0";
+  version = "0.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "KyokoMiki";
     repo = "pycambia";
-    tag = version;
-    hash = "sha256-ZflLy6Qa4tBlPZkTya3ELu463qcnRcMS57a6FfHpSNE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5UHWAIR+qo16UUsi9D0e6W8UmQ4HUujNWLfJpyIrCUI=";
   };
 
-  patches = [ cargoLockPatch ];
-
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    hash = "sha256-jmdf+Idg9PR4jgZ7bexPsAyGj86vGxLseTWXnhzP7+E=";
-    patches = [ cargoLockPatch ];
+    inherit (finalAttrs) src;
+    hash = "sha256-w7n/W7PDC3+DPCb//X462mowhEPw0k3HA1raAeu4t/c=";
   };
 
   buildInputs = [ openssl ];
@@ -55,4 +42,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ undefined-landmark ];
   };
-}
+})


### PR DESCRIPTION
The new version of smoked-salmon has quite a big change in used dependencies. As can be seen in the [diff](https://github.com/smokin-salmon/smoked-salmon/compare/0.9.7.4...0.10.0). It also requires version 0.2.0 of pycambia, therefore this dependency is also updated.

The new version of `pycambia` means that the cargo lock patch is not necessary anymore. Also switch to `finalAttrs` pattern.

Although there is no new major version, both package contain breaking changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
