### PR TITLE
home-assistant: fix tests with PyJWT 2.11.0

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -306,6 +306,9 @@ python.pkgs.buildPythonApplication rec {
 
   # leave this in, so users don't have to constantly update their downstream patch handling
   patches = [
+    # https://github.com/home-assistant/core/pull/165143
+    ./pyjwt-2.11.patch
+
     # Follow symlinks in /var/lib/hass/www
     ./patches/static-follow-symlinks.patch
 

--- a/pkgs/servers/home-assistant/pyjwt-2.11.patch
+++ b/pkgs/servers/home-assistant/pyjwt-2.11.patch
@@ -1,0 +1,54 @@
+diff --git a/homeassistant/auth/jwt_wrapper.py b/homeassistant/auth/jwt_wrapper.py
+index 464df006f5f..0a9c7c4a2ec 100644
+--- a/homeassistant/auth/jwt_wrapper.py
++++ b/homeassistant/auth/jwt_wrapper.py
+@@ -21,7 +21,9 @@ MAX_TOKEN_SIZE = 8192
+ _VERIFY_KEYS = ("signature", "exp", "nbf", "iat", "aud", "iss", "sub", "jti")
+ 
+ _VERIFY_OPTIONS: dict[str, Any] = {f"verify_{key}": True for key in _VERIFY_KEYS} | {
+-    "require": []
++    "require": [],
++    "strict_aud": False,
++    "enforce_minimum_key_length": False,
+ }
+ _NO_VERIFY_OPTIONS = {f"verify_{key}": False for key in _VERIFY_KEYS}
+ 
+diff --git a/homeassistant/package_constraints.txt b/homeassistant/package_constraints.txt
+index b0ebcfd61d0..e4b36f04637 100644
+--- a/homeassistant/package_constraints.txt
++++ b/homeassistant/package_constraints.txt
+@@ -54,7 +54,7 @@ paho-mqtt==2.1.0
+ Pillow==12.1.1
+ propcache==0.4.1
+ psutil-home-assistant==0.0.1
+-PyJWT==2.10.1
++PyJWT==2.11.0
+ pymicro-vad==1.0.1
+ PyNaCl==1.6.2
+ pyOpenSSL==25.3.0
+diff --git a/pyproject.toml b/pyproject.toml
+index 86aeed2fb1e..239780d1dd7 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -59,7 +59,7 @@ dependencies = [
+   "ifaddr==0.2.0",
+   "Jinja2==3.1.6",
+   "lru-dict==1.3.0",
+-  "PyJWT==2.10.1",
++  "PyJWT==2.11.0",
+   # PyJWT has loose dependency. We want the latest one.
+   "cryptography==46.0.5",
+   "Pillow==12.1.1",
+diff --git a/requirements.txt b/requirements.txt
+index bde0cd69e87..637ec0a9933 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -40,7 +40,7 @@ packaging>=23.1
+ Pillow==12.1.1
+ propcache==0.4.1
+ psutil-home-assistant==0.0.1
+-PyJWT==2.10.1
++PyJWT==2.11.0
+ pymicro-vad==1.0.1
+ pyOpenSSL==25.3.0
+ pyspeex-noise==1.0.2


### PR DESCRIPTION
depends on #497944 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
