### PR TITLE
python3Packages.nlpo3: 1.4.0-unstable-2024-11-11 -> 1.4.0

### DIFF
--- a/pkgs/development/python-modules/nlpo3/default.nix
+++ b/pkgs/development/python-modules/nlpo3/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   buildPythonPackage,
-  pythonAtLeast,
   unittestCheckHook,
   rustPlatform,
   fetchFromGitHub,
@@ -15,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "nlpo3";
-  version = "1.4.0-unstable-2024-11-11";
+  version = "1.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "PyThaiNLP";
     repo = "nlpo3";
-    rev = "280c47b7f98e88319c1a4ac2c7a2e5f273c00621";
-    hash = "sha256-bEN2SaINfqvTIPSROXApR3zoLdjZY0h6bdAzbMHrJdM=";
+    tag = "nlpo3-python-v${version}";
+    hash = "sha256-GQwUKc6VXF1mDzvB2HBwHlaC0Eu3sZvlTuGe0CDrP4k=";
   };
 
   postPatch = ''
@@ -34,7 +33,7 @@ buildPythonPackage rec {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src sourceRoot;
-    hash = "sha256-S5nDOz/3ZenvMs8ruybEu5ULefeYGPIKO8kCW3dTa+E=";
+    hash = "sha256-Kp2FL6GXb5g5jqvFWZxZUy7OuGaavN9DZkp9kdI4d/4=";
   };
 
   preCheck = ''
@@ -67,7 +66,7 @@ buildPythonPackage rec {
   meta = {
     description = "Thai Natural Language Processing library in Rust, with Python and Node bindings";
     homepage = "https://github.com/PyThaiNLP/nlpo3";
-    changelog = "https://github.com/PyThaiNLP/nlpo3/releases/tag/nlpo3-python-v${version}";
+    changelog = "https://github.com/PyThaiNLP/nlpo3/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ vizid ];
   };


### PR DESCRIPTION
Changelog: https://github.com/PyThaiNLP/nlpo3/releases/nlpo3-python-v1.4.0
Diff: https://github.com/PyThaiNLP/nlpo3/compare/280c47b7f98e88319c1a4ac2c7a2e5f273c00621...nlpo3-python-v1.4.0

This fixes the build of `python314Packages.nlpo3`.

Hydra: https://hydra.nixos.org/build/322205927/nixlog/3
Tracking: #475732
Closes https://github.com/NixOS/nixpkgs/pull/436260

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.nlpo3`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
