### PR TITLE
nixos/errbot: Use systemd-tmpfiles instead of ExecPreStart to create directories

### DIFF
--- a/nixos/modules/services/misc/errbot.nix
+++ b/nixos/modules/services/misc/errbot.nix
@@ -91,6 +91,20 @@ in
     };
     users.groups.errbot = { };
 
+    systemd.tmpfiles.settings = {
+      "10-errbot" = lib.mapAttrs' (
+        name: instanceCfg:
+        let
+          dataDir = if instanceCfg.dataDir != null then instanceCfg.dataDir else "/var/lib/errbot/${name}";
+        in
+        lib.nameValuePair "${dataDir}".d {
+          group = "errbot";
+          user = "errbot";
+          mode = "0755";
+        }
+      ) cfg.instances;
+    };
+
     systemd.services = lib.mapAttrs' (
       name: instanceCfg:
       lib.nameValuePair "errbot-${name}" (
@@ -103,12 +117,7 @@ in
           serviceConfig = {
             User = "errbot";
             Restart = "on-failure";
-            ExecStartPre = [
-              "${lib.getExe' pkgs.coreutils "mkdir"} -p ${dataDir}"
-              "${lib.getExe' pkgs.coreutils "chown"} -R errbot:errbot ${dataDir}"
-            ];
             ExecStart = "${pkgs.errbot}/bin/errbot -c ${mkConfigDir instanceCfg dataDir}/config.py";
-            PermissionsStartOnly = true;
           };
         }
       )


### PR DESCRIPTION
This is more "correct", and also allows removing the deprecated PermissionsStartOnly declaration in serviceConfig. I believe this should match the previous behavior exactly.

See #53852 for the PermissionsStartOnly deprecation.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
