### PR TITLE
python3Packages.colcon: 0.19.0 -> 0.20.1

### DIFF
--- a/pkgs/development/python-modules/colcon/0001-update-setuptools.patch
+++ b/pkgs/development/python-modules/colcon/0001-update-setuptools.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.cfg b/setup.cfg
+index 3f97885..3b55c34 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -38,7 +38,7 @@ install_requires =
+   pytest-cov
+   pytest-repeat
+   pytest-rerunfailures
+-  setuptools>=30.3.0,<80
++  setuptools>=30.3.0
+   # toml is also supported but deprecated
+   tomli>=1.0.0; python_version < "3.11"
+ packages = find:

--- a/pkgs/development/python-modules/colcon/default.nix
+++ b/pkgs/development/python-modules/colcon/default.nix
@@ -21,15 +21,19 @@
 
 buildPythonPackage rec {
   pname = "colcon-core";
-  version = "0.19.0";
+  version = "0.20.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "colcon";
     repo = "colcon-core";
     tag = version;
-    hash = "sha256-R/TVHPT305PwaVSisP0TtbgjCFBwCZkXOAgkYhCKpyY=";
+    hash = "sha256-FV/G2FcnBgr7mUY/Jr+bVAdEfhHL9qAnpc92hpTfy7Y=";
   };
+
+  # Upstream tracking issue: https://github.com/ros2/ros2/issues/1738
+  # This will break some functionality of building setuptools packages using colcon, other package types should work fine
+  patches = [ ./0001-update-setuptools.patch ];
 
   build-system = [ setuptools ];
 
@@ -68,7 +72,10 @@ buildPythonPackage rec {
     description = "Command line tool to build sets of software packages";
     homepage = "https://github.com/colcon/colcon-core";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ guelakais ];
+    maintainers = with lib.maintainers; [
+      amronos
+      guelakais
+    ];
     mainProgram = "colcon";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://github.com/colcon/colcon-core/compare/0.19.0...0.20.1

https://github.com/colcon/colcon-core/pull/699 broke ``colcon`` for ``nixpkgs`` by pinning ``setuptools`` to ``<80``. ``colcon`` currently relies on deprecated/removed functionalities in ``setuptools`` to support some of its features for Python packages.

Since ``nixpkgs`` has already updated ``setuptools`` to the latest versions, these features are already broken for Python packages. I have thus added a patch that allows the latest versions of ``colcon`` to build with the latest ``setuptools``.

Upstream tracking issue: https://github.com/ros2/ros2/issues/1738

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
