### PR TITLE
[staging-next] google-cloud-cpp: fix build by adding missing `#include <algorithm>`

### DIFF
--- a/pkgs/by-name/go/google-cloud-cpp/package.nix
+++ b/pkgs/by-name/go/google-cloud-cpp/package.nix
@@ -54,11 +54,16 @@ stdenv.mkDerivation (finalAttrs: {
   # but the target was not found.
   #
   # So, we explicitly add `universe_domain` to the list of default features
+  #
+  # Also, we add the missing `<algorithm>` header to fix
+  # "error: 'transform' is not a member of 'std'"
   postPatch = ''
     substituteInPlace cmake/GoogleCloudCppFeatures.cmake \
       --replace-fail \
         "bigtable;bigquery;iam;logging;pubsub;spanner;storage" \
         "bigtable;bigquery;iam;logging;pubsub;spanner;storage;universe_domain" \
+
+    sed -e '1i #include <algorithm>' -i google/cloud/testing_util/command_line_parsing.cc
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
Closes #495726. Hydra build failure: https://hydra.nixos.org/build/323365915

I'm not quire sure why this particular header has led to a presumably GCC 15-related failure now, long after we've gotten GCC 15. It does, however, succeed after this change, so /shrug.

I've tested picking #492506 onto staging-next, and the build still fails with the same error that it does right now, so this fix will still be needed even if that update is merged.

Upstream PR: googleapis/google-cloud-cpp#16044

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
