### PR TITLE
python3Packages.jsonargparse: cleanup, skip failing tests

### DIFF
--- a/pkgs/development/python-modules/jsonargparse/default.nix
+++ b/pkgs/development/python-modules/jsonargparse/default.nix
@@ -1,19 +1,29 @@
 {
   lib,
-  argcomplete,
   buildPythonPackage,
-  docstring-parser,
   fetchFromGitHub,
+  pythonAtLeast,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  pyyaml,
+
+  # optional-dependencies
+
+  # tests
+
+  argcomplete,
+  docstring-parser,
   fsspec,
   jsonnet,
   jsonschema,
   omegaconf,
   pytestCheckHook,
-  pyyaml,
   reconplogger,
   requests,
   ruyaml,
-  setuptools,
   toml,
   types-pyyaml,
   types-requests,
@@ -36,18 +46,18 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [ pyyaml ];
 
-  optional-dependencies = {
-    all = [
-      argcomplete
-      fsspec
-      jsonnet
-      jsonschema
-      omegaconf
-      ruyaml
-      docstring-parser
-      typeshed-client
-      requests
-    ];
+  optional-dependencies = lib.fix (self: {
+    all =
+      self.argcomplete
+      ++ self.fsspec
+      ++ self.jsonnet
+      ++ self.jsonschema
+      ++ self.omegaconf
+      ++ self.reconplogger
+      ++ self.ruyaml
+      ++ self.signatures
+      ++ self.toml
+      ++ self.urls;
     argcomplete = [ argcomplete ];
     fsspec = [ fsspec ];
     jsonnet = [
@@ -64,12 +74,18 @@ buildPythonPackage (finalAttrs: {
     ];
     toml = [ toml ];
     urls = [ requests ];
-  };
+  });
 
   nativeCheckInputs = [
     pytestCheckHook
     types-pyyaml
     types-requests
+  ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.14") [
+    # _pickle.PicklingError: Can't pickle local object ...
+    "test_get_argument_group_class_underscores_to_dashes"
+    "test_pickle_parser"
   ];
 
   pythonImportsCheck = [ "jsonargparse" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
