### PR TITLE
wails: do not overwrite user provided tools

### DIFF
--- a/pkgs/by-name/wa/wails/package.nix
+++ b/pkgs/by-name/wa/wails/package.nix
@@ -64,7 +64,7 @@ buildGoModule (finalAttrs: {
   # As Wails calls a compiler, certain apps and libraries need to be made available.
   postFixup = ''
     wrapProgram $out/bin/wails \
-      --prefix PATH : ${
+      --suffix PATH : ${
         lib.makeBinPath [
           pkg-config
           go
@@ -72,7 +72,7 @@ buildGoModule (finalAttrs: {
           nodejs
         ]
       } \
-      --prefix LD_LIBRARY_PATH : "${
+      --suffix LD_LIBRARY_PATH : "${
         lib.makeLibraryPath (
           lib.optionals stdenv.hostPlatform.isLinux [
             gtk3


### PR DESCRIPTION
For example when building a project with golang 1.26 we want to use the user provoided compiler and not have to run wailts like:
  GOTOOLCHAIN=go1.26.0 wails build -compiler '${go_1_26}/bin/go'

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
