### PR TITLE
hunspellDicts.en*: 2020.12.07 -> 2026.02.25

### DIFF
--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -194,7 +194,7 @@ let
     }:
     mkDict rec {
       inherit src srcFileName dictFileName;
-      version = "2020.12.07";
+      version = "2026.02.25";
       pname = "hunspell-dict-${shortName}-wordlist";
       srcReadmeFile = "README_" + srcFileName + ".txt";
       readmeFile = "README_" + dictFileName + ".txt";
@@ -376,8 +376,8 @@ rec {
     srcFileName = "en_US";
     dictFileName = "en_US";
     src = fetchurl {
-      url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_US-2020.12.07.zip";
-      hash = "sha256-YWNIrWRacW2RyKZkUGXnEPFendo//vYM337IpOJ5da8=";
+      url = "mirror://sourceforge/wordlist/speller/2026.02.25/hunspell-en_US-2026.02.25.zip";
+      hash = "sha256-rI5zMQ6VHYjFLCzyulTOrKNPhIaoFjCsinXcX5MRefk=";
     };
   };
 
@@ -388,8 +388,8 @@ rec {
     srcFileName = "en_US-large";
     dictFileName = "en_US";
     src = fetchurl {
-      url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_US-large-2020.12.07.zip";
-      hash = "sha256-WpNhcxL/t8zMVMj9ij5nEusOnNSmnx01i4LrTTUgcrc=";
+      url = "mirror://sourceforge/wordlist/speller/2026.02.25/hunspell-en_US-large-2026.02.25.zip";
+      hash = "sha256-BqtaKhLCkDPxAJiNOwpeU9ytQL8kc8y3gnBhnR2pkyE=";
     };
   };
 
@@ -400,8 +400,8 @@ rec {
     srcFileName = "en_CA";
     dictFileName = "en_CA";
     src = fetchurl {
-      url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_CA-2020.12.07.zip";
-      hash = "sha256-/2uR5O12g0jGGufDJuhIBZgQ+kOl1gHfaz9FrZwO9b8=";
+      url = "mirror://sourceforge/wordlist/speller/2026.02.25/hunspell-en_CA-2026.02.25.zip";
+      hash = "sha256-Kf4AUECMNWFPIr6oQzi0JWliyJ9e8l2sUDgyW8uG9CQ=";
     };
   };
 
@@ -412,8 +412,8 @@ rec {
     srcFileName = "en_CA-large";
     dictFileName = "en_CA";
     src = fetchurl {
-      url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_CA-large-2020.12.07.zip";
-      hash = "sha256-RjRIkIb2QDeveqpLyo1s4X90QrZiYylW5d1MCU+Hvuo=";
+      url = "mirror://sourceforge/wordlist/speller/2026.02.25/hunspell-en_CA-large-2026.02.25.zip";
+      hash = "sha256-tLe/SniF3hw1+hs6poMXIJr6WPBNYOigfhJGk0hcWeM=";
     };
   };
 
@@ -424,8 +424,8 @@ rec {
     srcFileName = "en_AU";
     dictFileName = "en_AU";
     src = fetchurl {
-      url = "mirror://sourceforge/wordlist/speller/2020.12.07/hunspell-en_AU-2020.12.07.zip";
-      hash = "sha256-3CBVfEiuGXl4Tnn65vll6ZnI2y6aD4RjSOcAV/znglQ=";
+      url = "mirror://sourceforge/wordlist/speller/2026.02.25/hunspell-en_AU-2026.02.25.zip";
+      hash = "sha256-+FRxWTuXRPZCmMAtB/ti1Ykmv4H7XkVS4rrGRb+kAeA=";
     };
   };
 
@@ -436,8 +436,8 @@ rec {
     srcFileName = "en_AU-large";
     dictFileName = "en_AU";
     src = fetchurl {
-      url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_AU-large-2020.12.07.zip";
-      hash = "sha256-SW5HeuewGMe+Ng5gqqL5jn8cl8eJLfk7JFcRJCTGHjE=";
+      url = "mirror://sourceforge/wordlist/speller/2026.02.25/hunspell-en_AU-large-2026.02.25.zip";
+      hash = "sha256-RqJliD0dAciJtxc7ocq64MqRWqQD1qL5PO5MxmEIfbQ=";
     };
   };
 
@@ -448,8 +448,8 @@ rec {
     srcFileName = "en_GB-ise";
     dictFileName = "en_GB";
     src = fetchurl {
-      url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_GB-ise-2020.12.07.zip";
-      hash = "sha256-LO1LLsnRiMO1QNu3W1FD9luZDa8XQ3dYcm/x+rXwGtM=";
+      url = "mirror://sourceforge/wordlist/speller/2026.02.25/hunspell-en_GB-ise-2026.02.25.zip";
+      hash = "sha256-1vu5GueCTFL7AvdNe8LNkJLxMPrsYPQjJqWUN/pyR6M=";
     };
   };
 
@@ -460,8 +460,8 @@ rec {
     srcFileName = "en_GB-ize";
     dictFileName = "en_GB";
     src = fetchurl {
-      url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_GB-ize-2020.12.07.zip";
-      hash = "sha256-hpt0nsmAW4fNBfQzB/IJmGUTMbWqWwRQZBOvDC3y8jE=";
+      url = "mirror://sourceforge/wordlist/speller/2026.02.25/hunspell-en_GB-ize-2026.02.25.zip";
+      hash = "sha256-xb3ZL8HiHadQOTn+QTnzbyjwHBisNeL8kLUmobe/sJk=";
     };
   };
 
@@ -472,8 +472,8 @@ rec {
     srcFileName = "en_GB-large";
     dictFileName = "en_GB";
     src = fetchurl {
-      url = "mirror://sourceforge/wordlist/speller/2018.04.16/hunspell-en_GB-large-2020.12.07.zip";
-      hash = "sha256-+GvrdyKMc3yMaUaP/E6gZ1EocieIabmKXT7BjxJRB70=";
+      url = "mirror://sourceforge/wordlist/speller/2026.02.25/hunspell-en_GB-large-2026.02.25.zip";
+      hash = "sha256-cEpJQ4o6nU8RzXbbQzprIwuc6HcO4T+ihwAFLEUX3cE=";
     };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

hunspellDicts.en* - Update from 2020.12.07 -> 2026.02.25
Update the English language word lists from version 2020.12.07 to 2026.02.25.

Closes: #497862


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
