### PR TITLE
python3Packages.{pymupdf,pymupdf4llm}, browsr: fix build

### DIFF
--- a/pkgs/by-name/br/browsr/package.nix
+++ b/pkgs/by-name/br/browsr/package.nix
@@ -6,7 +6,7 @@
   extras ? [ "all" ],
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "browsr";
   version = "1.22.1";
   pyproject = true;
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "juftin";
     repo = "browsr";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-eISOADs++ZF62qkWbhFZu6JkEVtTytg3q5nbwS2m+8g=";
   };
 
@@ -46,7 +46,7 @@ python3Packages.buildPythonApplication rec {
       textual
       textual-universal-directorytree
     ]
-    ++ lib.attrVals extras optional-dependencies;
+    ++ lib.attrVals extras finalAttrs.passthru.optional-dependencies;
 
   optional-dependencies = with python3Packages; {
     all = [
@@ -96,8 +96,8 @@ python3Packages.buildPythonApplication rec {
     description = "File explorer in your terminal";
     mainProgram = "browsr";
     homepage = "https://juftin.com/browsr";
-    changelog = "https://github.com/juftin/browsr/releases/tag/v${version}";
+    changelog = "https://github.com/juftin/browsr/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/br/browsr/package.nix
+++ b/pkgs/by-name/br/browsr/package.nix
@@ -77,6 +77,7 @@ python3Packages.buildPythonApplication rec {
     "rich-pixels"
     "rich"
     "textual"
+    "universal-pathlib"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pymupdf/default.nix
+++ b/pkgs/development/python-modules/pymupdf/default.nix
@@ -44,14 +44,14 @@ let
 in
 buildPythonPackage rec {
   pname = "pymupdf";
-  version = "1.26.7";
+  version = "1.27.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pymupdf";
     repo = "PyMuPDF";
     tag = version;
-    hash = "sha256-7OidTOG3KAx7EaQ3Bu4i1Fw007oXVAipBHeYNkmbIcA=";
+    hash = "sha256-Ebvdkvp0y7seG0sciMMnztflIBVRHh/Cowpw/lSLYLE=";
   };
 
   patches = [
@@ -122,6 +122,7 @@ buildPythonPackage rec {
     "test_codespell"
     "test_pylint"
     "test_flake8"
+    "test_4751"
     # Upstream recommends disabling these when not using bundled MuPDF build
     "test_color_count"
     "test_3050"
@@ -140,6 +141,9 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # mad about markdown table formatting
     "tests/test_tables.py::test_markdown"
+
+    # Do not lint code
+    "tests/test_typing.py"
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin [
     # Trace/BPT trap: 5 when getting widget options

--- a/pkgs/development/python-modules/pymupdf/default.nix
+++ b/pkgs/development/python-modules/pymupdf/default.nix
@@ -42,7 +42,7 @@ let
   mupdf-cxx-lib = toPythonModule (lib.getLib mupdf-cxx);
   mupdf-cxx-dev = lib.getDev mupdf-cxx;
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pymupdf";
   version = "1.27.1";
   pyproject = true;
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pymupdf";
     repo = "PyMuPDF";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Ebvdkvp0y7seG0sciMMnztflIBVRHh/Cowpw/lSLYLE=";
   };
 
@@ -168,9 +168,9 @@ buildPythonPackage rec {
   meta = {
     description = "Python bindings for MuPDF's rendering library";
     homepage = "https://github.com/pymupdf/PyMuPDF";
-    changelog = "https://github.com/pymupdf/PyMuPDF/releases/tag/${src.tag}";
+    changelog = "https://github.com/pymupdf/PyMuPDF/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ sarahec ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/python-modules/pymupdf4llm/default.nix
+++ b/pkgs/development/python-modules/pymupdf4llm/default.nix
@@ -7,7 +7,7 @@
   tabulate,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pymupdf4llm";
   version = "0.3.4";
   pyproject = true;
@@ -15,11 +15,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pymupdf";
     repo = "RAG";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-SgJ47jkE6GcSXVsOMOx8Hm+Ce6pCAjLEhdxGeJEu6DQ=";
   };
 
-  sourceRoot = "${src.name}/pymupdf4llm";
+  sourceRoot = "${finalAttrs.src.name}/pymupdf4llm";
 
   build-system = [ setuptools ];
 
@@ -53,8 +53,8 @@ buildPythonPackage rec {
   meta = {
     description = "PyMuPDF Utilities for LLM/RAG - converts PDF pages to Markdown format for Retrieval-Augmented Generation";
     homepage = "https://github.com/pymupdf/RAG";
-    changelog = "https://github.com/pymupdf/RAG/blob/${src.tag}/CHANGES.md";
+    changelog = "https://github.com/pymupdf/RAG/blob/${finalAttrs.src.tag}/CHANGES.md";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ ryota2357 ];
   };
-}
+})

--- a/pkgs/development/python-modules/pymupdf4llm/default.nix
+++ b/pkgs/development/python-modules/pymupdf4llm/default.nix
@@ -4,25 +4,29 @@
   fetchFromGitHub,
   setuptools,
   pymupdf,
+  tabulate,
 }:
 
 buildPythonPackage rec {
   pname = "pymupdf4llm";
-  version = "0.2.9";
+  version = "0.3.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pymupdf";
     repo = "RAG";
-    tag = version;
-    hash = "sha256-iuffv49voZLiuabwhag+YC3j3Oa2IAevZtcJtMVzX/4=";
+    tag = "v${version}";
+    hash = "sha256-SgJ47jkE6GcSXVsOMOx8Hm+Ce6pCAjLEhdxGeJEu6DQ=";
   };
 
   sourceRoot = "${src.name}/pymupdf4llm";
 
   build-system = [ setuptools ];
 
-  dependencies = [ pymupdf ];
+  dependencies = [
+    pymupdf
+    tabulate
+  ];
 
   checkPhase = ''
     runHook preCheck


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/322427188

1. python3Packages.{pymupdf,pymupdf4llm}: version update, add finalAttrs
2. browsr: relax dependency on universal-pathlib, add finalAttrs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
