### PR TITLE
python3Packages.gradio: 6.8.0 -> 6.9.0

### DIFF
--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -2,8 +2,8 @@
   lib,
   stdenv,
   buildPythonPackage,
-  fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
+  jq,
 
   # build-system
   hatchling,
@@ -36,20 +36,8 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   # no tests on pypi
-  src = fetchFromGitHub {
-    owner = "gradio-app";
-    repo = "gradio";
-    # not to be confused with @gradio/client@${version}
-    # tag = "gradio_client@${finalAttrs.version}";
-    # TODO: switch back to a tag next release, if they tag it.
-    rev = "8b03393a51e1e03fb04cb0a41b9a5dc3266a58aa"; # 2.2.0
-    sparseCheckout = [
-      "client/python"
-      "gradio/media_assets"
-    ];
-    hash = "sha256-LkTZwPyHe1w8D5unEMW7dBGKNHxM7gWJ7I+4HwiexKk=";
-  };
-
+  # they've stopped tagging "gradio_client@.*" and "@gradio/client@.*" tags on github
+  inherit (gradio) src;
   sourceRoot = "${finalAttrs.src.name}/client/python";
 
   # Because we set sourceRoot above, the folders "client/python"
@@ -58,6 +46,20 @@ buildPythonPackage (finalAttrs: {
     substituteInPlace test/conftest.py \
       --replace-fail 'from client.python.test import media_data' 'import media_data'
   '';
+
+  preConfigure = ''
+    # sanity check
+    if [[ "$(jq <gradio_client/package.json .version -r)" != "$version" ]]; then
+      echo >&2 "ERROR: version mismatch with package.json:"
+      echo >&2 "version = $version"
+      (set -x; cat >&2 gradio_client/package.json)
+      false
+    fi
+  '';
+
+  nativeBuildInputs = [
+    jq
+  ];
 
   build-system = [
     hatchling
@@ -118,16 +120,15 @@ buildPythonPackage (finalAttrs: {
 
   __darwinAllowLocalNetworking = true;
 
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "gradio_client@";
-    ignoredVersions = ".*-(beta|dev).*";
+  passthru = {
+    inherit (gradio) updateScript;
   };
 
   meta = {
     description = "Lightweight library to use any Gradio app as an API";
     homepage = "https://www.gradio.app/";
     downloadPage = "https://github.com/gradio-app/gradio/tree/main/client/python";
-    # changelog = "https://github.com/gradio-app/gradio/releases/tag/${finalAttrs.src.tag}"; TODO: uncomment if the tag exists
+    changelog = "https://github.com/gradio-app/gradio/blob/${finalAttrs.src.tag}/client/python/gradio_client/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ pbsds ];
   };

--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "gradio-client";
-  version = "2.2.0";
+  version = "2.3.0";
   pyproject = true;
 
   # no tests on pypi

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -422,7 +422,9 @@ buildPythonPackage (finalAttrs: {
     # enough tags for the ones we're looking for to show up.
     updateScript = writeScript "update-python3Packages.gradio" ''
       #! /usr/bin/env nix-shell
-      #! nix-shell -i bash -p common-updater-scripts coreutils gnugrep gnused nix-update
+      #! nix-shell -i bash -p common-updater-scripts coreutils gnugrep gnused nix-update jq curl
+      set -euo pipefail
+      set -x
 
       tag=$(list-git-tags \
             | grep "^gradio@" \
@@ -432,7 +434,10 @@ buildPythonPackage (finalAttrs: {
             | head -n 1 \
             | tr -d '\n' \
            )
-      nix-update --version="$tag"
+      nix-update python3Packages.gradio --version="$tag"
+
+      gradio_client_version="$(curl https://raw.githubusercontent.com/gradio-app/gradio/gradio@"$tag"/client/python/gradio_client/package.json | jq ".version" -r)"
+      nix-update python3Packages.gradio-client --version="$gradio_client_version" --no-src
     '';
   };
 

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -56,6 +56,7 @@
 
   # tests
   pytestCheckHook,
+  build,
   hypothesis,
   altair,
   boto3,
@@ -81,14 +82,14 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "gradio";
-  version = "6.8.0";
+  version = "6.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gradio-app";
     repo = "gradio";
     tag = "gradio@${finalAttrs.version}";
-    hash = "sha256-ZHglnRs0AXCu9HlVoSO0h5p6SE4al/OLPn0jwZgKVR8=";
+    hash = "sha256-iGaUiJto/tquCSa6D/wbkNyVtK/2kZB/hz62STfwLOY=";
   };
 
   patches = [
@@ -103,7 +104,7 @@ buildPythonPackage (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-6Cx0hdVd0srhArvck2Kn9U2fT7aKtTZjgV5b/Usrnoo=";
+    hash = "sha256-pZCYtWFNlrcRFomx6HbO0zySOyifO3n/ffzx59pS/A8=";
   };
 
   nativeBuildInputs = [
@@ -167,6 +168,7 @@ buildPythonPackage (finalAttrs: {
     boto3
     brotli
     diffusers
+    build
     docker
     ffmpeg
     gradio-pdf
@@ -214,6 +216,9 @@ buildPythonPackage (finalAttrs: {
     "test_error_analytics_successful"
     "TestSnippetExecution"
 
+    # requires network, via subprocess.run
+    "test_endpoint_status"
+
     # Flaky, tries to pin dependency behaviour. Sensitive to dep versions
     # These error only affect downstream use of the check dependencies.
     "test_no_color"
@@ -254,6 +259,8 @@ buildPythonPackage (finalAttrs: {
 
     # tests if pip and other tools are installed
     "test_get_executable_path"
+    "test_api_response"
+    "test_load_assets"
 
     # Flaky test (AssertionError when comparing to a fixed array)
     # https://github.com/gradio-app/gradio/issues/11620
@@ -356,6 +363,7 @@ buildPythonPackage (finalAttrs: {
     # 100% touches network
     "test/test_networking.py"
     "client/python/test/test_client.py"
+
     # makes pytest freeze 50% of the time
     "test/test_interfaces.py"
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6615,7 +6615,9 @@ self: super: with self; {
 
   gradio = callPackage ../development/python-modules/gradio { };
 
-  gradio-client = callPackage ../development/python-modules/gradio/client.nix { };
+  gradio-client = callPackage ../development/python-modules/gradio/client.nix {
+    inherit (pkgs) jq;
+  };
 
   gradio-pdf = callPackage ../development/python-modules/gradio-pdf { };
 


### PR DESCRIPTION
- **python3Packages.gradio-client: tether version to gradio**
- **python3Packages.gradio: 6.8.0 -> 6.9.0**

in preparation for backporting to release-25.11, due to https://github.com/NixOS/nixpkgs/issues/496131 https://github.com/NixOS/nixpkgs/issues/496130 https://github.com/NixOS/nixpkgs/issues/496125

Changelog:
https://github.com/gradio-app/gradio/blob/main/CHANGELOG.md
https://github.com/gradio-app/gradio/blob/main/client/python/gradio_client/CHANGELOG.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
