### PR TITLE
linuxPackages_6_19.virtualbox: fix build

### DIFF
--- a/pkgs/os-specific/linux/virtualbox/default.nix
+++ b/pkgs/os-specific/linux/virtualbox/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   virtualbox,
   kernel,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation {
@@ -12,6 +13,17 @@ stdenv.mkDerivation {
     "fortify"
     "pic"
     "stackprotector"
+  ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/rpmfusion/VirtualBox-kmod/ec4795b376212b9361c2554c249886c62008c3f8/kernel-6.19.patch";
+      sha256 = "sha256-HhJ/2dnJQIXGv86Avlb42+gRzAgNx3eq81gfDwmqjeU=";
+      excludes = [
+        "vboxsf/**/*"
+        "vboxguest/**/*"
+      ];
+    })
   ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
Fixes #491434.

The fix is based on the discussion in https://github.com/VirtualBox/virtualbox/issues/467.
Specifically, this patch is also used in RPMFusion (https://github.com/rpmfusion/VirtualBox-kmod/blob/master/kernel-6.19.patch) and in Gentoo (https://bugs.gentoo.org/970012#c6).

The patch is based on the commits https://github.com/VirtualBox/virtualbox/compare/d52f0680a4e4509236797be39c2957f31ea423bd...33992f0e56b8a9bb565e0beecad91e87362ab390.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
