### PR TITLE
bbot: add websockets to pythonRelaxDeps and add maintainer

### DIFF
--- a/pkgs/by-name/bb/bbot/package.nix
+++ b/pkgs/by-name/bb/bbot/package.nix
@@ -19,6 +19,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "radixtarget"
     "regex"
     "tabulate"
+    "websockets"
   ];
 
   build-system = with python3.pkgs; [

--- a/pkgs/by-name/bb/bbot/package.nix
+++ b/pkgs/by-name/bb/bbot/package.nix
@@ -70,7 +70,10 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     description = "OSINT automation for hackers";
     homepage = "https://pypi.org/project/bbot/";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ fab ];
+    maintainers = with lib.maintainers; [
+      fab
+      robsliwi
+    ];
     mainProgram = "bbot";
   };
 })


### PR DESCRIPTION
Adding myself as a maintainer and making the build of bbot green on hydra again. Failed the first time with https://hydra.nixos.org/build/322100868

After relaxing websockets it builds and can be used fine, as far as I could test.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
