### PR TITLE
dpkg: 1.23.5 -> 1.23.6

### DIFF
--- a/pkgs/by-name/dp/dpkg/package.nix
+++ b/pkgs/by-name/dp/dpkg/package.nix
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dpkg";
-  version = "1.23.5";
+  version = "1.23.6";
 
   src = fetchgit {
     url = "https://git.launchpad.net/ubuntu/+source/dpkg";
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
       rm -rf .git
       popd
     '';
-    hash = "sha256-Ug82hdskTvWSzMZ8l+EdWhWAmt9OhS2pUpwOYa/9FLw=";
+    hash = "sha256-NwPq8tpMVE55r4RGjzW+xrAAaBe/uIrFcJjUi+ehtGg=";
   };
 
   configureFlags = [


### PR DESCRIPTION
## Summary

Fixes CVE-2026-2219: `dpkg-deb` did not properly validate the end of the data stream when decompressing a zstd-compressed `.deb` archive, which could result in denial of service (infinite CPU-spinning loop).

The fix commit [`6610297a`](https://git.dpkg.org/cgit/dpkg/dpkg.git/commit/?id=6610297a62c0780dd0e80b0e302ef64fdcc9d313) (`libdpkg: Terminate zstd decompression when we have no more data`) is included in upstream 1.23.6.

#closes #497805

## Testing

- Built locally on `aarch64-darwin` ✅
- `nixpkgs-review rev HEAD` passed (dpkg built successfully; 5 pre-existing unrelated failures) ✅
- `versionCheckHook` confirmed binary reports `1.23.6` ✅