### PR TITLE
nixos/borgmatic: improved repository options

### DIFF
--- a/nixos/modules/services/backup/borgmatic.nix
+++ b/nixos/modules/services/backup/borgmatic.nix
@@ -69,17 +69,12 @@ let
   repository =
     with lib.types;
     submodule {
+      freeformType = settingsFormat.type;
       options = {
         path = lib.mkOption {
           type = str;
           description = ''
             Path to the repository
-          '';
-        };
-        label = lib.mkOption {
-          type = str;
-          description = ''
-            Label to the repository
           '';
         };
       };
@@ -119,7 +114,7 @@ let
           example = [
             {
               path = "ssh://user@backupserver/./sourcehostname.borg";
-              label = "backupserver";
+              encryption = "repokey-blake2";
             }
             {
               path = "/mnt/backup";

--- a/nixos/tests/borgmatic.nix
+++ b/nixos/tests/borgmatic.nix
@@ -13,6 +13,10 @@
               label = "local";
               path = "/var/backup";
             }
+            {
+              path = "/var/backup2";
+              encryption = "repokey-blake2";
+            }
           ];
           keep_daily = 7;
         };


### PR DESCRIPTION
Fixes [#483610](https://github.com/NixOS/nixpkgs/issues/483610)

Removed the label option which is not required by borgmatic and added freeformType = settingsFormat.type to allow for more flexible repository definitions .

Tested with encryption option present and label option omitted, both locally and via NixOS tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage