### PR TITLE
python3Packages.pytest-ansible: cleanup, skip failing tests

### DIFF
--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -1,20 +1,29 @@
 {
   lib,
   stdenv,
-  ansible-compat,
-  ansible-core,
   buildPythonPackage,
-  coreutils,
   fetchFromGitHub,
-  packaging,
-  pytest,
-  pytest-xdist,
-  pytestCheckHook,
+  coreutils,
+
+  # build-system
   setuptools,
   setuptools-scm,
+
+  # dependencies
+  ansible-compat,
+  ansible-core,
+  packaging,
+  pytest-xdist,
+
+  # buildInputs
+  pytest,
+
+  # tests
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-ansible";
   version = "26.2.0";
   pyproject = true;
@@ -22,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ansible";
     repo = "pytest-ansible";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-3pppBAgAfkwJNPRsI6CH4UDMqyZ45+mFNejlQwX5bCg=";
   };
 
@@ -45,11 +54,10 @@ buildPythonPackage rec {
     pytest-xdist
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  preCheck = ''
-    export HOME=$TMPDIR
-  '';
+  nativeCheckInputs = [
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
 
   enabledTestPaths = [ "tests/" ];
 
@@ -72,6 +80,14 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # Test want s to execute pytest in a subprocess
     "tests/integration/test_molecule.py"
+
+    # TypeError: Cannot define type '_AnsibleLazyTemplateDict' since '_AnsibleLazyTemplateDict'
+    # already extends '_AnsibleTaggedDict'.
+    "tests/test_host_manager.py"
+
+    # assert <ExitCode.TESTS_FAILED: 1> == <ExitCode.OK: 0>
+    "tests/test_fixtures.py"
+    "tests/test_params.py"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # These tests fail in the Darwin sandbox
@@ -88,10 +104,10 @@ buildPythonPackage rec {
   meta = {
     description = "Plugin for pytest to simplify calling ansible modules from tests or fixtures";
     homepage = "https://github.com/jlaska/pytest-ansible";
-    changelog = "https://github.com/ansible-community/pytest-ansible/releases/tag/${src.tag}";
+    changelog = "https://github.com/ansible-community/pytest-ansible/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       robsliwi
     ];
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
