### PR TITLE
python3Packages.opentelemetry-semantic-conventions-ai: init at 0.4.15

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-semantic-conventions-ai/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-semantic-conventions-ai/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  opentelemetry-sdk,
+  opentelemetry-semantic-conventions,
+}:
+let
+  version = "0.4.15";
+in
+buildPythonPackage {
+  pname = "opentelemetry-semantic-conventions-ai";
+  inherit version;
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "opentelemetry_semantic_conventions_ai";
+    inherit version;
+    hash = "sha256-Et4XLR4R0hxugrv1eMfopxNYmn/adq+e14VjJWSii4E=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    opentelemetry-sdk
+    opentelemetry-semantic-conventions
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.semconv_ai" ];
+
+  meta = {
+    description = "Open-source observability for your GenAI or LLM application, based on OpenTelemetry";
+    homepage = "https://github.com/traceloop/openllmetry";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lach ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11949,6 +11949,10 @@ self: super: with self; {
     callPackage ../development/python-modules/opentelemetry-semantic-conventions
       { };
 
+  opentelemetry-semantic-conventions-ai =
+    callPackage ../development/python-modules/opentelemetry-semantic-conventions-ai
+      { };
+
   opentelemetry-test-utils = callPackage ../development/python-modules/opentelemetry-test-utils { };
 
   opentelemetry-util-http = callPackage ../development/python-modules/opentelemetry-util-http { };


### PR DESCRIPTION
Based on https://github.com/NixOS/nixpkgs/pull/498050

<!--
^ Please summarise the changes you have done and explain whythey are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
