### PR TITLE
onnxslim: uses hatchling, not setuptools

### DIFF
--- a/pkgs/development/python-modules/onnxslim/default.nix
+++ b/pkgs/development/python-modules/onnxslim/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 
   # build-system
-  setuptools,
+  hatchling,
 
   # dependencies
   colorama,
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   };
 
   build-system = [
-    setuptools
+    hatchling
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/onnxslim/default.nix
+++ b/pkgs/development/python-modules/onnxslim/default.nix
@@ -13,7 +13,7 @@
   sympy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "onnxslim";
   version = "0.1.82";
   pyproject = true;
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "inisis";
     repo = "OnnxSlim";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-hrrCodLaHVo/YRq0HczxogcZQSwZKxZthyLYxz/+XJ0=";
   };
 
@@ -46,4 +46,4 @@ buildPythonPackage rec {
     homepage = "https://pypi.org/project/onnxslim/";
     license = lib.licenses.mit;
   };
-}
+})


### PR DESCRIPTION
Version on master fails to build with

```
       Output paths:
         /nix/store/4srhc1h0m70h1qkpbyy77lgwf5qq9y3j-python3.13-onnxslim-0.1.82
         /nix/store/nxpb35nzzln2z1q1gl27skramgns8jc8-python3.13-onnxslim-0.1.82-dist
       Last 25 log lines:
       > Using pythonImportsCheckPhase
       > Sourcing python-namespaces-hook
       > Sourcing python-catch-conflicts-hook.sh
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/pkl0yw41bavmd0gwd658ggi7k5win15b-source
       > source root is source
       > setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/tests/utils.py"
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing pypaBuildPhase
       > Creating a wheel...
       > pypa build flags: --no-isolation --outdir dist/ --wheel
       > * Getting build dependencies for wheel...
       >
       > Traceback (most recent call last):
       >   File "/nix/store/r4285bvfn3pdjrz2qv1s3yir5rjb3fmi-python3.13-pyproject-hooks-1.2.0/lib/python3.13/site-packages/pyproject_hooks/_impl.py", line 402, in _call_hook
       >     raise BackendUnavailable(
       >     ...<4 lines>...
       >     )
       > pyproject_hooks._impl.BackendUnavailable: Cannot import 'hatchling.build'
       >
       > ERROR Backend 'hatchling.build' is not available.
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
