### PR TITLE
python3Packages.lexilang: compile and install dictionaries

### DIFF
--- a/pkgs/development/python-modules/lexilang/default.nix
+++ b/pkgs/development/python-modules/lexilang/default.nix
@@ -6,7 +6,7 @@
   python,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "lexilang";
   version = "1.0.7";
   pyproject = true;
@@ -14,11 +14,19 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "LibreTranslate";
     repo = "LexiLang";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-5/P9u2naTTyG5l3uhrinRIAekyOYn8OKLwb/VEON2Vc=";
   };
 
   build-system = [ setuptools ];
+
+  # Upstream builds in CI:
+  # https://github.com/LibreTranslate/LexiLang/blob/ba49108a736b9c077ea45cbe61d54fa635fe25d5/.github/workflows/publish.yml#L30-L31
+  postInstall = ''
+    ${lib.getExe python} -c "from lexilang.utils import compile_data; compile_data()"
+    rm -f lexilang/data/.gitignore
+    cp -r lexilang/data $out/${python.sitePackages}/lexilang/data
+  '';
 
   pythonImportsCheck = [ "lexilang" ];
 
@@ -34,4 +42,4 @@ buildPythonPackage rec {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ izorkin ];
   };
-}
+})


### PR DESCRIPTION
This package needs some extra steps to include compile and distribute the word lists for recognizing languages. Upstream does this in [CI](https://github.com/LibreTranslate/LexiLang/blob/ba49108a736b9c077ea45cbe61d54fa635fe25d5/.github/workflows/publish.yml#L30-L31) when publishing, but we build from source.

Without this change, we get the errors seen in https://github.com/LibreTranslate/LexiLang/issues/11.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
