### PR TITLE
python3Packages.amd-quark: init at 0.11.1

### DIFF
--- a/pkgs/development/python-modules/amd-quark/default.nix
+++ b/pkgs/development/python-modules/amd-quark/default.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  mypy-protobuf,
+
+  # dependencies
+  evaluate,
+  joblib,
+  ninja,
+  numpy,
+  onnx,
+  onnxscript,
+  onnxslim,
+  pandas,
+  plotly,
+  protobuf,
+  pydantic,
+  rich,
+  scipy,
+  sentencepiece,
+  tqdm,
+  zstandard,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "amd-quark";
+  version = "0.11.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "amd";
+    repo = "Quark";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-x0y3NFbXAF1SnlzQSkWKEWiz0qRPYHWvQ6oTizKpyQw=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"protobuf-protoc-bin==31.1",' ""
+    substituteInPlace setup.py \
+      --replace-fail 'subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])' 'b"nix"'
+  '';
+
+  env.QUARK_RELEASE = "1";
+
+  build-system = [
+    setuptools
+    mypy-protobuf
+  ];
+
+  dependencies = [
+    evaluate
+    joblib
+    ninja
+    numpy
+    onnx
+    onnxscript
+    onnxslim
+    pandas
+    plotly
+    protobuf
+    pydantic
+    rich
+    scipy
+    sentencepiece
+    tqdm
+    zstandard
+  ];
+
+  pythonRelaxDeps = true;
+
+  pythonImportsCheck = [ "quark" ];
+
+  # Most of the tests require gpu and some other unspecified dependencies
+  doCheck = false;
+
+  meta = {
+    description = "AMD Quark Model Optimizer";
+    homepage = "https://github.com/amd/Quark";
+    changelog = "https://github.com/amd/Quark/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lach ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -714,6 +714,8 @@ self: super: with self; {
 
   amcrest = callPackage ../development/python-modules/amcrest { };
 
+  amd-quark = callPackage ../development/python-modules/amd-quark { };
+
   amdsmi = toPythonModule (
     pkgs.rocmPackages.amdsmi.override {
       inherit python;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
