### PR TITLE
ultimate-doom-builder: fix render device error by adding missing libraries

### DIFF
--- a/pkgs/by-name/ul/ultimate-doom-builder/package.nix
+++ b/pkgs/by-name/ul/ultimate-doom-builder/package.nix
@@ -94,7 +94,14 @@ stdenv.mkDerivation (finalAttrs: {
 
     # GTK, OpenGL, and other libraries are loaded dynamically by Mono at runtime
     wrapProgram $out/opt/UltimateDoomBuilder/builder \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk2-x11 libGL libpng libx11 ]}"
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          gtk2-x11
+          libGL
+          libpng
+          libx11
+        ]
+      }"
 
     ln -s $out/opt/UltimateDoomBuilder/builder $out/bin/ultimate-doom-builder
 

--- a/pkgs/by-name/ul/ultimate-doom-builder/package.nix
+++ b/pkgs/by-name/ul/ultimate-doom-builder/package.nix
@@ -92,9 +92,9 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $out/opt/UltimateDoomBuilder/builder --replace-fail mono ${mono}/bin/mono
     substituteInPlace $out/opt/UltimateDoomBuilder/builder --replace-fail Builder.exe $out/opt/UltimateDoomBuilder/Builder.exe
 
-    # GTK is loaded dynamically by Mono at runtime
+    # GTK, OpenGL, and other libraries are loaded dynamically by Mono at runtime
     wrapProgram $out/opt/UltimateDoomBuilder/builder \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk2-x11 ]}"
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk2-x11 libGL libpng libx11 ]}"
 
     ln -s $out/opt/UltimateDoomBuilder/builder $out/bin/ultimate-doom-builder
 


### PR DESCRIPTION
## Description

Fixes the "Fatal Windows Forms error: Could not create render device" error when launching ultimate-doom-builder.

## Problem

The package wrapper only included `gtk2-x11` in LD_LIBRARY_PATH, but was missing `libGL`, `libpng`, and `libx11`. These libraries are already declared in `buildInputs` but weren't being added to the runtime library path.

## Solution

Added the missing libraries to the `wrapProgram` call. These libraries need to be dynamically loaded by Mono at runtime for proper OpenGL rendering support.

## Testing

- Built and tested the package locally
- Confirmed the application launches without render device errors
- Verified all required libraries are now in LD_LIBRARY_PATH

## Checklist

- [x] Tested on Linux (x86_64)
- [x] Package builds successfully
- [x] Application runs without errors