### PR TITLE
[Backport release-25.11] python3Packages.langgraph*: security fixes

### DIFF
--- a/pkgs/development/python-modules/langgraph-checkpoint-mongodb/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-mongodb/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  gitUpdater,
 
   # build-system
   hatchling,
@@ -14,20 +15,24 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint-mongodb";
-  version = "0.3.0";
+  version = "0.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-mongodb";
     tag = "libs/langgraph-checkpoint-mongodb/v${version}";
-    hash = "sha256-pfgqJ7QPtAxV86HEEaRBMAOCKC8y/iTlZmPzu1szE/o=";
+    hash = "sha256-vCiZ6Mp6aHmSEkLbeM6qTLJaxH0uoAdq80olTT5saX0=";
   };
 
   sourceRoot = "${src.name}/libs/langgraph-checkpoint-mongodb";
 
   build-system = [
     hatchling
+  ];
+
+  pythonRelaxDeps = [
+    "pymongo"
   ];
 
   dependencies = [
@@ -40,6 +45,14 @@ buildPythonPackage rec {
 
   # Connection refused (to localhost:27017) for all tests
   doCheck = false;
+
+  passthru = {
+    # python updater script sets the wrong tag
+    skipBulkUpdate = true;
+    updateScript = gitUpdater {
+      rev-prefix = "libs/langgraph-checkpoint-mongodb/v";
+    };
+  };
 
   # no pythonImportsCheck as this package does not provide any direct imports
   pythonImportsCheck = [ "langgraph.checkpoint.mongodb" ];

--- a/pkgs/development/python-modules/langgraph-checkpoint/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint/default.nix
@@ -15,6 +15,7 @@
   dataclasses-json,
   numpy,
   pandas,
+  pycryptodome,
   pytest-asyncio,
   pytest-mock,
   pytestCheckHook,
@@ -26,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint";
-  version = "3.0.0";
+  version = "4.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "checkpoint==${version}";
-    hash = "sha256-YjO8KfDx7lZOps+dG7CPsY7LOqhKIBdfCXexPsR2pB4=";
+    hash = "sha256-NJSmpVshj/x6ws+jFYXGarNKNztbk5OIIMA1neFOyIY=";
   };
 
   sourceRoot = "${src.name}/libs/checkpoint";
@@ -53,6 +54,7 @@ buildPythonPackage rec {
     dataclasses-json
     numpy
     pandas
+    pycryptodome
     pytest-asyncio
     pytest-mock
     pytestCheckHook

--- a/pkgs/development/python-modules/langgraph-cli/default.nix
+++ b/pkgs/development/python-modules/langgraph-cli/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-cli";
-  version = "0.4.7";
+  version = "0.4.14";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "cli==${version}";
-    hash = "sha256-VvxY5fXK/f1aCdIB0XPGTsWgEe/cA797kK6eLmb0vtg=";
+    hash = "sha256-DtIIGNcpgcYMvvihH9GwgCn2PRWq+LEcHVtitA71T04=";
   };
 
   sourceRoot = "${src.name}/libs/cli";
@@ -56,7 +56,7 @@ buildPythonPackage rec {
     pytestCheckHook
     docker-compose
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.concatAttrValues optional-dependencies;
 
   enabledTestPaths = [ "tests/unit_tests" ];
 

--- a/pkgs/development/python-modules/langgraph-prebuilt/default.nix
+++ b/pkgs/development/python-modules/langgraph-prebuilt/default.nix
@@ -31,14 +31,14 @@
 # It exists so the langgraph team can iterate on it without having to rebuild langgraph.
 buildPythonPackage rec {
   pname = "langgraph-prebuilt";
-  version = "1.0.5";
+  version = "1.0.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "prebuilt==${version}";
-    hash = "sha256-Vytt5c1GZyQAILs09Z40n80XDoSKXyAb+cFwjK5JySY=";
+    hash = "sha256-Gsh2bCcity0zf9A+FENxwktK5j3WhQOG/jZmhJ18KVE=";
   };
 
   sourceRoot = "${src.name}/libs/prebuilt";

--- a/pkgs/development/python-modules/langgraph-runtime-inmem/default.nix
+++ b/pkgs/development/python-modules/langgraph-runtime-inmem/default.nix
@@ -4,6 +4,7 @@
   fetchPypi,
   hatchling,
   blockbuster,
+  croniter,
   langgraph,
   langgraph-checkpoint,
   sse-starlette,
@@ -13,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-runtime-inmem";
-  version = "0.18.0";
+  version = "0.26.0";
   pyproject = true;
 
   # Not available in any repository
   src = fetchPypi {
     pname = "langgraph_runtime_inmem";
     inherit version;
-    hash = "sha256-BXdcHy3N1XXrhx/m/rGu0hqEbFbG56C9+QakV+AMF74=";
+    hash = "sha256-ucWH0TOTIKKlSlcKIa7K9Z7rxL4HzvHYpbA18/LGHWo=";
   };
 
   build-system = [
@@ -29,6 +30,7 @@ buildPythonPackage rec {
 
   dependencies = [
     blockbuster
+    croniter
     langgraph
     langgraph-checkpoint
     sse-starlette

--- a/pkgs/development/python-modules/langgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/langgraph-sdk/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-sdk";
-  version = "0.3.1";
+  version = "0.3.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "sdk==${version}";
-    hash = "sha256-pIQuvOYyjXajPxqoRDHuolxNgaBeSmJvPRskinXkkDo=";
+    hash = "sha256-E/GM0p9x2/hNfL2u4TsG9UxnnMX42f5PjeIo9KfRY0k=";
   };
 
   sourceRoot = "${src.name}/libs/sdk-py";
@@ -38,6 +38,8 @@ buildPythonPackage rec {
     orjson
     typing-extensions
   ];
+
+  pythonRelaxDeps = [ "orjson" ];
 
   disabledTests = [ "test_aevaluate_results" ]; # Compares execution time to magic number
 

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -25,6 +25,7 @@
   langgraph-checkpoint-sqlite,
   langsmith,
   psycopg,
+  pycryptodome,
   pytest-asyncio,
   pytest-mock,
   pytest-repeat,
@@ -40,14 +41,14 @@
 }:
 buildPythonPackage rec {
   pname = "langgraph";
-  version = "1.0.5";
+  version = "1.0.10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = version;
-    hash = "sha256-QvnBb69JxOVfZ/22igX+WVatJNAUrHUrh3aIpztYmmc=";
+    hash = "sha256-NJSmpVshj/x6ws+jFYXGarNKNztbk5OIIMA1neFOyIY=";
   };
 
   postgresqlTestSetupPost = ''
@@ -95,6 +96,7 @@ buildPythonPackage rec {
     langsmith
     psycopg
     psycopg.pool
+    pycryptodome
     pydantic
     pytest-asyncio
     pytest-mock
@@ -121,6 +123,7 @@ buildPythonPackage rec {
     "test_no_modifier"
     "test_pending_writes_resume"
     "test_remove_message_via_state_update"
+    "test_interrupt_functional_pydantic"
   ];
 
   disabledTestPaths = [
@@ -130,6 +133,8 @@ buildPythonPackage rec {
     "tests/test_large_cases_async.py"
     "tests/test_pregel.py"
     "tests/test_pregel_async.py"
+    "tests/test_subgraph_persistence.py"
+    "tests/test_subgraph_persistence_async.py"
   ];
 
   # Since `langgraph` is the only unprefixed package, we have to use an explicit match


### PR DESCRIPTION
Backports https://github.com/NixOS/nixpkgs/pull/493459 and https://github.com/NixOS/nixpkgs/pull/497668 to fix [CVE-2026-27794](https://nvd.nist.gov/vuln/detail/CVE-2026-27794) and [CVE-2026-28277](https://nvd.nist.gov/vuln/detail/CVE-2026-28277)

Supersedes #496007

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
