### PR TITLE
rocmPackages.rpp-opencl: drop as OpenCL variant is broken and unmaintained

### DIFF
--- a/pkgs/development/rocm-modules/default.nix
+++ b/pkgs/development/rocm-modules/default.nix
@@ -175,20 +175,9 @@ let
 
       rpp = self.callPackage ./rpp { };
 
-      rpp-hip = self.rpp.override {
-        useOpenCL = false;
-        useCPU = false;
-      };
+      rpp-hip = self.rpp.override { useCPU = false; };
 
-      rpp-opencl = self.rpp.override {
-        useOpenCL = true;
-        useCPU = false;
-      };
-
-      rpp-cpu = self.rpp.override {
-        useOpenCL = false;
-        useCPU = true;
-      };
+      rpp-cpu = self.rpp.override { useCPU = true; };
 
       mivisionx = self.callPackage ./mivisionx {
         stdenv = origStdenv;
@@ -256,6 +245,11 @@ let
       };
     }
     // lib.optionalAttrs config.allowAliases {
+      rpp-opencl = throw ''
+        'rpp-opencl' has been removed as it has been broken for a year and has no consuming packages.
+        Use 'rpp' or 'rpp-cpu' instead.
+      ''; # Added 2026-03-08
+
       rocmPath = throw ''
         'rocm-path' has been removed. If a ROCM_PATH value is required in nixpkgs please
         construct one with the minimal set of required deps.

--- a/pkgs/development/rocm-modules/rpp/default.nix
+++ b/pkgs/development/rocm-modules/rpp/default.nix
@@ -12,22 +12,12 @@
   boost,
   python3Packages,
   buildDocs ? false, # Needs internet
-  useOpenCL ? false,
   useCPU ? false,
   gpuTargets ? clr.localGpuTargets or [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname =
-    "rpp-"
-    + (
-      if (!useOpenCL && !useCPU) then
-        "hip"
-      else if (!useOpenCL && !useCPU) then
-        "opencl"
-      else
-        "cpu"
-    );
+  pname = "rpp-${if useCPU then "cpu" else "hip"}";
 
   version = "7.2.0";
 
@@ -59,21 +49,13 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_INSTALL_BINDIR=bin"
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DBACKEND=${if useCPU then "CPU" else "HIP"}"
   ]
   ++ lib.optionals (gpuTargets != [ ]) [
     "-DAMDGPU_TARGETS=${lib.concatStringsSep ";" gpuTargets}"
-  ]
-  ++ lib.optionals (!useOpenCL && !useCPU) [
-    "-DBACKEND=HIP"
-  ]
-  ++ lib.optionals (useOpenCL && !useCPU) [
-    "-DBACKEND=OCL"
-  ]
-  ++ lib.optionals useCPU [
-    "-DBACKEND=CPU"
   ];
 
-  postPatch = lib.optionalString (!useOpenCL && !useCPU) ''
+  postPatch = lib.optionalString (!useCPU) ''
     # Bad path
     substituteInPlace CMakeLists.txt \
       --replace "COMPILER_FOR_HIP \''${ROCM_PATH}/llvm/bin/clang++" "COMPILER_FOR_HIP ${clr}/bin/hipcc"
@@ -95,6 +77,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;
-    broken = useOpenCL;
   };
 })


### PR DESCRIPTION
Fixes #481463

Upstream don't seem to be doing new feature development for OpenCL, eg https://github.com/ROCm/rpp/pull/673 is CPU/HIP only. rpp-opencl is a leaf package and has been broken for a long time.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
