### PR TITLE
me3: init at 0.11.0

### DIFF
--- a/pkgs/by-name/me/me3/package.nix
+++ b/pkgs/by-name/me/me3/package.nix
@@ -1,0 +1,103 @@
+{
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  pkgsCross,
+  replaceVars,
+  rustPlatform,
+  steam,
+  symlinkJoin,
+}:
+
+let
+  version = "0.11.0";
+
+  # me3 creates a pipe under /tmp needed by the compat tool subprocess
+  steam-run =
+    (steam.override {
+      privateTmp = false;
+    }).run-free;
+
+  src = fetchFromGitHub {
+    owner = "garyttierney";
+    repo = "me3";
+    tag = "v${version}";
+    sha256 = "sha256-XyeMVPGzNF2syipLz9HPtUg7lhxcEq434FnRH3Ax+HM=";
+  };
+
+  cargoHash = "sha256-T1HeYe9FUC5oy/SDeEd6vV4D9YIGIXMkbzf43gRNyt8=";
+
+  me3-cli = rustPlatform.buildRustPackage (final: {
+    inherit cargoHash version src;
+    pname = "me3-cli";
+
+    # Wrap the compat tool subprocess to support proton's pressure vessel
+    patches = [
+      (replaceVars ./steam-run.patch {
+        steamRun = lib.getExe steam-run;
+      })
+    ];
+
+    cargoBuildFlags = [
+      "--package"
+      "me3-cli"
+    ];
+
+    cargoTestFlags = final.cargoBuildFlags;
+
+    postInstall = ''
+      install -Dm644 distribution/linux/me3-launch.desktop \
+        $out/share/applications/me3-launch.desktop
+      install -Dm644 distribution/linux/me3.xml \
+        $out/share/mime/packages/me3.xml
+      install -Dm644 distribution/assets/me3.png \
+        $out/share/icons/hicolor/128x128/apps/me3.png
+    '';
+  });
+
+  me3-windows = pkgsCross.mingwW64.rustPlatform.buildRustPackage (final: {
+    inherit cargoHash version src;
+    pname = "me3-windows";
+
+    CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-Clink-arg=-lmcfgthread";
+    RUSTC_BOOTSTRAP = 1;
+
+    cargoBuildFlags = [
+      "--package"
+      "me3-launcher"
+      "--package"
+      "me3-mod-host"
+    ];
+
+    cargoTestFlags = final.cargoBuildFlags;
+
+    # Remove useless libme3_mod_host.dll.a
+    postInstall = ''
+      rm -r $out/lib
+    '';
+  });
+in
+symlinkJoin {
+  inherit version;
+  name = "me3";
+
+  paths = [
+    me3-cli
+    me3-windows
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/me3 \
+      --set WINEPATH $out/bin \
+      --add-flags "--windows-binaries-dir $out/bin"
+  '';
+
+  meta = {
+    description = "Framework for modding and instrumenting games.";
+    homepage = "https://github.com/garyttierney/me3";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.icedborn ];
+  };
+}

--- a/pkgs/by-name/me/me3/package.nix
+++ b/pkgs/by-name/me/me3/package.nix
@@ -46,11 +46,11 @@ let
     cargoTestFlags = final.cargoBuildFlags;
 
     postInstall = ''
-      install -Dm644 distribution/linux/me3-launch.desktop \
+      install -Dm444 distribution/linux/me3-launch.desktop \
         $out/share/applications/me3-launch.desktop
-      install -Dm644 distribution/linux/me3.xml \
+      install -Dm444 distribution/linux/me3.xml \
         $out/share/mime/packages/me3.xml
-      install -Dm644 distribution/assets/me3.png \
+      install -Dm444 distribution/assets/me3.png \
         $out/share/icons/hicolor/128x128/apps/me3.png
     '';
   });

--- a/pkgs/by-name/me/me3/steam-run.patch
+++ b/pkgs/by-name/me/me3/steam-run.patch
@@ -1,0 +1,17 @@
+--- a/crates/cli/src/commands/launch/strategy/compat_tool.rs
++++ b/crates/cli/src/commands/launch/strategy/compat_tool.rs
+@@ -260,10 +260,10 @@
+             tool = parent_tool;
+         }
+ 
+-        let mut command = Command::new(
+-            args.pop_front()
+-                .ok_or_eyre("Compat Tool produced invalid command")?,
+-        );
++        let program = args.pop_front()
++            .ok_or_eyre("Compat Tool produced invalid command")?;
++        let mut command = Command::new("@steamRun@");
++        command.arg(program);
+         command.args(args);
+         command.arg(exe);
+         command.arg("--");


### PR DESCRIPTION
A framework for modding and instrumenting games.

https://github.com/garyttierney/me3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
