### PR TITLE
pika-backup: 0.7.5 -> 0.7.6

### DIFF
--- a/pkgs/by-name/pi/pika-backup/package.nix
+++ b/pkgs/by-name/pi/pika-backup/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  fetchpatch,
   rustPlatform,
   replaceVars,
   cargo,
@@ -24,27 +23,22 @@
 
 stdenv.mkDerivation rec {
   pname = "pika-backup";
-  version = "0.7.5";
+  version = "0.7.6";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "pika-backup";
-    tag = "v${version}";
-    hash = "sha256-J5EsCanKEczPXw8QsNlp3mxh0MyJyJ+WulaZJ+c6hBA=";
+    tag = version;
+    hash = "sha256-tWTINRYCAhPV2srZWIYJeH4NAQIv/ED0bBdeKKgkC78=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-JjqtThxjMb+HDdPt50X7yXDxqouQliSlNvT14roZLYk=";
+    hash = "sha256-Ut7dFhm67tcpELZzQPwyIs9/3YNHofi2VF9RxQCD7qo=";
   };
 
   patches = [
-    # https://gitlab.gnome.org/World/pika-backup/-/issues/643
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/World/pika-backup/-/commit/842d93d65a342985bf6d7d8cacd5b38ea508df2e.patch";
-      hash = "sha256-HtGuEi8ghiMwzBEsvo/DTfVAExgmHpd0xp5bpWRn9Fs=";
-    })
     (replaceVars ./borg-path.patch {
       borg = lib.getExe borgbackup;
     })


### PR DESCRIPTION
Diff: https://gitlab.gnome.org/World/pika-backup/-/compare/v0.7.5...0.7.6

Changelog: https://gitlab.gnome.org/World/pika-backup/-/blob/0.7.6/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
