### PR TITLE
megapixels: 2.0.0 -> 2.1.0

### DIFF
--- a/pkgs/by-name/me/megapixels/package.nix
+++ b/pkgs/by-name/me/megapixels/package.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitLab,
   glib,
+  gperf,
   meson,
   ninja,
   pkg-config,
@@ -41,17 +42,18 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "megapixels";
-  version = "2.0.0";
+  version = "2.1.0";
 
   src = fetchFromGitLab {
     owner = "megapixels-org";
     repo = "Megapixels";
     tag = finalAttrs.version;
-    hash = "sha256-tuAMp92166WZJfGIEzEWal9BExzQJoYodd2uZHhqEuQ=";
+    hash = "sha256-fnG8fei3x0UkWJWBm8rB2r9bcKOhtFxG0Zaq+qjd7dE=";
   };
 
   nativeBuildInputs = [
     glib
+    gperf
     meson
     ninja
     pkg-config


### PR DESCRIPTION
Diff: https://gitlab.com/megapixels-org/Megapixels/-/compare/2.0.0...2.1.0

Changelog: https://gitlab.com/megapixels-org/Megapixels/-/tags/2.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
