### PR TITLE
tamarin-prover: 1.10.0 → 1.12.0

### DIFF
--- a/pkgs/applications/science/logic/tamarin-prover/default.nix
+++ b/pkgs/applications/science/logic/tamarin-prover/default.nix
@@ -6,21 +6,21 @@
   # the following are non-haskell dependencies
   makeWrapper,
   which,
+  buildNpmPackage,
   maude,
   graphviz,
   glibcLocales,
-  fetchpatch,
 }:
 
 let
   inherit (haskellPackages) mkDerivation;
 
-  version = "1.10.0";
+  version = "1.12.0";
   src = fetchFromGitHub {
     owner = "tamarin-prover";
     repo = "tamarin-prover";
-    rev = version;
-    hash = "sha256-v1BruU2p/Sg/g7b9a+QRza46bD7PkMtsGq82qFaNhpI=";
+    tag = version;
+    hash = "sha256-yXJIJENygr/lmkrVap4ohb8Pua4kri+yaD/Dy0Hpwn4=";
   };
 
   # tamarin has its own dependencies, but they're kept inside the repo,
@@ -141,6 +141,20 @@ let
     }
   );
 
+  tamarin-frontend = buildNpmPackage {
+    pname = "tamarin-frontend";
+    inherit version src;
+
+    sourceRoot = "source/frontend";
+
+    npmDepsHash = "sha256-GJiOCyTUfseZXd5WU018MKjxvrc+UOr7l7ZZSpzCS54=";
+
+    installPhase = ''
+      mkdir -p $out
+      cp dist/* $out/
+    '';
+  };
+
 in
 mkDerivation (
   common "tamarin-prover" src
@@ -148,20 +162,15 @@ mkDerivation (
     isLibrary = false;
     isExecutable = true;
 
-    patches = [
-      # Allows tamarin-prover to run with Maude 3.5.1
-      # This should be removed on the next release
-      (fetchpatch {
-        url = "https://github.com/tamarin-prover/tamarin-prover/commit/1a41b507e7f60d081d8c91cd465386d57f814f11.patch";
-        includes = [ "src/Main/Console.hs" ];
-        hash = "sha256-X8qhscwy+efATrl3rLtn0Xi9M5a2CsFrjBbiqvVRtSE=";
-      })
-    ];
-
     # strip out unneeded deps manually
     doHaddock = false;
     enableSharedExecutables = false;
     postFixup = "rm -rf $out/lib $out/nix-support $out/share/doc";
+
+    preBuild = ''
+      cp ${tamarin-frontend}/*.js data/js/
+      cp ${tamarin-frontend}/*.css data/css/
+    '';
 
     # wrap the prover to be sure it can find maude, sapic, etc
     executableToolDepends = [


### PR DESCRIPTION
Fixes & improvement: https://github.com/tamarin-prover/tamarin-prover/releases/tag/1.12.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
