### PR TITLE
jwtcat: init at 0-unstable-2022-10-15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -93,6 +93,11 @@
     github = "0x120581f";
     githubId = 130835755;
   };
+  _0x2B = {
+    name = "0x2B";
+    github = "0x2B-bin";
+    githubId = 49249957;
+  };
   _0x3f = {
     name = "0x3f";
     github = "0x3fiona";

--- a/pkgs/by-name/jw/jwtcat/package.nix
+++ b/pkgs/by-name/jw/jwtcat/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "jwtcat";
+  version = "0-unstable-2022-10-15";
+  pyproject = false;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "aress31";
+    repo = "jwtcat";
+    rev = "f80f3d9352b82f0e7da504b2ee11f4a61f23c385";
+    hash = "sha256-pk0/Lzw4yUIXfLBX/0Xwaecio42MjLYUzECQ8xaH3vY=";
+  };
+
+  dependencies = with python3Packages; [
+    pyjwt
+    coloredlogs
+    tqdm
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 jwtcat.py $out/bin/jwtcat
+
+    runHook postInstall
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "CPU-based JSON Web Token cracker and scanner";
+    homepage = "https://github.com/aress31/jwtcat";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ _0x2B ];
+    mainProgram = "jwtcat";
+  };
+}


### PR DESCRIPTION
Init jwtcat at 0-unstable-2022-10-15

jwtcat is a CPU-based JSON Web Token (JWT) cracker and scanner. I am packaging the latest commit because the upstream repository does not currently use version tags.

Link: https://github.com/aress31/jwtcat

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
