### PR TITLE
microclaw: init at 0.0.163

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8286,6 +8286,11 @@
     githubId = 2512008;
     name = "Even Brenden";
   };
+  everettjf = {
+    github = "everettjf";
+    githubId = 1665109;
+    name = "Everett Jia";
+  };
   evey = {
     email = "nix@lubdub.nl";
     github = "lub-dub";

--- a/pkgs/by-name/mi/microclaw/package.nix
+++ b/pkgs/by-name/mi/microclaw/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  sqlite,
+  libsodium,
+  udev,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "microclaw";
+  version = "0.0.163";
+
+  src = fetchFromGitHub {
+    owner = "microclaw";
+    repo = "microclaw";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-iXKAIvMVvr9CbHRwZpJViirxuid9wCMdmQP5eXh+wm4=";
+  };
+
+  cargoHash = "sha256-aC6e0EqfCKABdXjXHfwhWcFKMxrNp1UXU4s+543nAP8=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs =
+    [
+      openssl
+      sqlite
+      libsodium
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Multi-channel agent runtime for Telegram, Discord, and Web";
+    homepage = "https://github.com/microclaw/microclaw";
+    changelog = "https://github.com/microclaw/microclaw/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "microclaw";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ everettjf ];
+  };
+})


### PR DESCRIPTION
## Summary
- add `microclaw` package at `0.0.163`
- package location: `pkgs/by-name/mi/microclaw/package.nix`
- add maintainer entry `everettjf`

## Build / test
- `nix-build -A microclaw` (aarch64-darwin)
- `result/bin/microclaw --help`

## Notes
- Uses `rustPlatform.buildRustPackage`
- Includes Linux-only `udev` dependency guard via `stdenv.hostPlatform.isLinux`
- Upstream release: https://github.com/microclaw/microclaw/releases/tag/v0.0.163
