### PR TITLE
systemd: set kexec-path meson option

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -560,6 +560,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "loadkeys-path" "${kbd}/bin/loadkeys")
     (lib.mesonOption "setfont-path" "${kbd}/bin/setfont")
   ]
+  ++ lib.optionals withKexectools [
+    (lib.mesonOption "kexec-path" "${kexec-tools}/bin/kexec")
+  ]
   ++ lib.optionals withKmod [
     (lib.mesonOption "kmod-path" "${kmod}/bin/kmod")
   ]


### PR DESCRIPTION
## Summary
- Set the `kexec-path` meson option when building systemd with kexec support, pointing it to the `kexec-tools` package binary

## Context
Since systemd/systemd@c3f32b9, meson no longer probes `$PATH` with `find_program()` to locate binaries like `kexec`. Instead it hardcodes `/usr/bin/kexec` unless `-Dkexec-path` is explicitly set. Previously the build would pick up the correct path from `nativeBuildInputs`, but now it needs to be set through the meson option — as the commit itself notes: "on Nix the paths will be totally different and need to be set through the option anyway."

kexec has probably only ever worked on NixOS because of the fallback codepath in `shutdown.c` that reboots via `RB_KEXEC` when the kexec binary isn't found. This also explains why `nixosTests.kexec` passes — the test loads a kernel beforehand, and the actual reboot goes through the fallback path.

This follows the same pattern already used for `kmod-path`, `loadkeys-path`, `setfont-path`, etc.

## Test plan
- [ ] Build the systemd package with this change
- [ ] Verify `systemctl kexec` works without falling back to `reboot(RB_KEXEC)`

Fixes #498149