### PR TITLE
nixos/firewall: allow virtual network DHCP requests

### DIFF
--- a/nixos/modules/services/networking/firewall-iptables.nix
+++ b/nixos/modules/services/networking/firewall-iptables.nix
@@ -150,6 +150,16 @@ let
       ip46tables -A nixos-fw -i ${iface} -j nixos-fw-accept
     '')}
 
+    # Allow DHCP server requests from systemd virtual network interfaces.
+    # ve-+: nspawn --network-veth
+    ip46tables -A nixos-fw -i ve-+ -p udp --dport 67 -j nixos-fw-accept
+    # vz-+: nspawn --network-zone
+    ip46tables -A nixos-fw -i vz-+ -p udp --dport 67 -j nixos-fw-accept
+    # vt-+: vmspawn TAP
+    ip46tables -A nixos-fw -i vt-+ -p udp --dport 67 -j nixos-fw-accept
+    # ns-+: nsresourced network namespaces.
+    ip46tables -A nixos-fw -i ns-+ -p udp --dport 67 -j nixos-fw-accept
+
     # Accept packets from established or related connections.
     ip46tables -A nixos-fw -m conntrack --ctstate ESTABLISHED,RELATED -j nixos-fw-accept
 

--- a/nixos/modules/services/networking/firewall-nftables.nix
+++ b/nixos/modules/services/networking/firewall-nftables.nix
@@ -176,6 +176,16 @@ in
         icmpv6 type != { nd-redirect, 139 } accept comment "Accept all ICMPv6 messages except redirects and node information queries (type 139).  See RFC 4890, section 4.4."
         ip6 daddr fe80::/64 udp dport 546 accept comment "DHCPv6 client"
 
+        # Allow DHCP server requests from systemd virtual network interfaces.
+        # ve-*: nspawn --network-veth
+        iifname "ve-*" udp dport 67 accept comment "systemd-nspawn veth DHCP server"
+        # vz-*: nspawn --network-zone
+        iifname "vz-*" udp dport 67 accept comment "systemd-nspawn zone DHCP server"
+        # vt-*: vmspawn TAP
+        iifname "vt-*" udp dport 67 accept comment "systemd-vmspawn TAP DHCP server"
+        # ns-*: nsresourced network namespaces.
+        iifname "ns-*" udp dport 67 accept comment "systemd-nsresourced DHCP server"
+
         ${cfg.extraInputRules}
 
       }

--- a/nixos/tests/systemd-machinectl.nix
+++ b/nixos/tests/systemd-machinectl.nix
@@ -101,11 +101,6 @@ in
         ];
         overrideStrategy = "asDropin";
       };
-
-      # open DHCP for container
-      networking.firewall.extraCommands = ''
-        ${pkgs.iptables}/bin/iptables -A nixos-fw -i ve-+ -p udp -m udp --dport 67 -j nixos-fw-accept
-      '';
     };
 
   testScript = ''


### PR DESCRIPTION
systemd-networkd has a bunch of .network configs included that will make networking for containers automatically work. They depend on DHCP working however, with this change e.g. systemd-nspawn with `--network-veth` (which is the default for `systemd-nspawn@.service`) will give you a container that has a private network but is NAT-ed.

Here I'm changing the default firewall to allow these requests so it will automatically work without having to add extra firewall config.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
