### PR TITLE
scrobblex: init at 1.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18192,6 +18192,12 @@
     githubId = 58110325;
     keys = [ { fingerprint = "3CAC 1D21 3D97 88FF 149A  E116 BB8B 30F5 A024 C31C"; } ];
   };
+  msaxena = {
+    email = "me@mayursaxena.com";
+    github = "MayurSaxena";
+    githubId = 7620384;
+    name = "Mayur Saxena";
+  };
   mschristiansen = {
     email = "mikkel@rheosystems.com";
     github = "mschristiansen";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -947,6 +947,7 @@
   ./services/misc/rsync.nix
   ./services/misc/rumno.nix
   ./services/misc/safeeyes.nix
+  ./services/misc/scrobblex.nix
   ./services/misc/sdrplay.nix
   ./services/misc/servarr/lidarr.nix
   ./services/misc/servarr/prowlarr.nix

--- a/nixos/modules/services/misc/scrobblex.nix
+++ b/nixos/modules/services/misc/scrobblex.nix
@@ -1,0 +1,152 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.scrobblex;
+  pkg = cfg.package;
+  stateDir = "/var/lib/scrobblex";
+in
+{
+  meta.maintainers = with lib.maintainers; [ msaxena ];
+
+  options.services.scrobblex = {
+    enable = lib.mkEnableOption "Scrobblex, a self-hosted Plex-to-Trakt scrobbler";
+
+    package = lib.mkPackageOption pkgs "scrobblex" { };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 3090;
+      description = "TCP port scrobblex listens on.";
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.enum [
+        "error"
+        "warn"
+        "info"
+        "http"
+        "verbose"
+        "debug"
+        "silly"
+      ];
+      default = "info";
+      description = "Log level (Winston).";
+    };
+
+    plexUser = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "alice"
+        "bob"
+      ];
+      description = ''
+        Plex usernames whose webhook events are accepted.
+        An empty list (the default) allows all users through.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/scrobblex";
+      description = ''
+        Path to a file containing secret environment variables, loaded by
+        systemd before the service starts. Must define at minimum:
+
+        ```
+        TRAKT_ID=your-trakt-client-id
+        TRAKT_SECRET=your-trakt-client-secret
+        ```
+
+        Use [agenix](https://github.com/ryantm/agenix) or
+        [sops-nix](https://github.com/Mic92/sops-nix) to keep secrets out
+        of the Nix store.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open {option}`services.scrobblex.port` in the firewall.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.scrobblex = {
+      description = "Scrobblex Plex-to-Trakt scrobbler";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        PORT = toString cfg.port;
+        LOG_LEVEL = cfg.logLevel;
+      }
+      // lib.optionalAttrs (cfg.plexUser != [ ]) {
+        PLEX_USER = lib.concatStringsSep "," cfg.plexUser;
+      };
+
+      serviceConfig = {
+        Type = "simple";
+
+        DynamicUser = true;
+
+        # Creates and owns /var/lib/scrobblex.
+        StateDirectory = "scrobblex";
+        StateDirectoryMode = "0700";
+
+        # The app resolves all paths (./data, ./static, ./views, ./favicon.ico)
+        # relative to process.cwd(). Set CWD to the writable state directory
+        # and symlink the read-only store assets in on startup.
+        WorkingDirectory = stateDir;
+
+        ExecStartPre = pkgs.writeShellScript "scrobblex-prestart" ''
+          ln -sfn ${pkg}/lib/scrobblex/static    ${stateDir}/static
+          ln -sfn ${pkg}/lib/scrobblex/views     ${stateDir}/views
+          ln -sfn ${pkg}/lib/scrobblex/favicon.ico ${stateDir}/favicon.ico
+        '';
+
+        # Run node directly so WorkingDirectory is respected rather than
+        # the CWD baked into the package wrapper.
+        ExecStart = "${lib.getExe pkgs.nodejs} ${pkg}/lib/scrobblex/src/index.js";
+
+        EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        # Hardening
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+          # libuv uses AF_NETLINK (NETLINK_ROUTE) to query network interfaces
+          # for Node.js os.networkInterfaces(); without it the process crashes.
+          "AF_NETLINK"
+        ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        # Node.js JIT requires writable+executable memory mappings.
+        MemoryDenyWriteExecute = false;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RemoveIPC = true;
+        ReadWritePaths = [ stateDir ];
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.optional cfg.openFirewall cfg.port;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1456,6 +1456,7 @@ in
   scaphandre = runTest ./scaphandre.nix;
   schleuder = runTest ./schleuder.nix;
   scion-freestanding-deployment = runTest ./scion/freestanding-deployment;
+  scrobblex = runTest ./scrobblex.nix;
   scrutiny = runTest ./scrutiny.nix;
   scx = runTest ./scx/default.nix;
   sddm = import ./sddm.nix { inherit runTest; };

--- a/nixos/tests/scrobblex.nix
+++ b/nixos/tests/scrobblex.nix
@@ -1,0 +1,30 @@
+{ lib, ... }:
+{
+  name = "scrobblex";
+  meta.maintainers = with lib.maintainers; [ msaxena ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.scrobblex = {
+        enable = true;
+        port = 3090;
+        # Provide dummy credentials via an environment file so the service
+        # starts without network access.  The OAuth flow will not work with
+        # these values, but the /healthcheck endpoint does not require it.
+        environmentFile = pkgs.writeText "scrobblex-env" ''
+          TRAKT_ID=test-client-id
+          TRAKT_SECRET=test-client-secret
+        '';
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("scrobblex.service")
+    machine.wait_for_open_port(3090)
+    response = machine.succeed("curl -sf http://localhost:3090/healthcheck")
+    import json
+    data = json.loads(response)
+    assert data["message"] == "OK", f"unexpected healthcheck response: {data}"
+  '';
+}

--- a/pkgs/by-name/sc/scrobblex/package.nix
+++ b/pkgs/by-name/sc/scrobblex/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeWrapper,
+  nodejs,
+}:
+
+buildNpmPackage rec {
+  pname = "scrobblex";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "ryck";
+    repo = "scrobblex";
+    tag = "v${version}";
+    hash = "sha256-rNtuditjzCdpBUnheM/Y+88cB8b/PZKF5U2Bczo1vdw=";
+  };
+
+  npmDepsHash = "sha256-2kgqQr0oiCIcUEkvnqDsmlKK9UdDKYxtLYDJ9+gMkNA=";
+
+  dontNpmBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/scrobblex
+    cp -r src views static favicon.ico package.json node_modules $out/lib/scrobblex/
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/scrobblex \
+      --add-flags "$out/lib/scrobblex/src/index.js" \
+      --chdir "$out/lib/scrobblex"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Self-hosted Plex scrobbling integration with Trakt via webhooks";
+    longDescription = ''
+      Scrobblex is a self-hosted Node.js application that listens for Plex (or
+      Tautulli) webhooks and scrobbles your watched media to Trakt. It also
+      supports pushing Plex ratings back to Trakt.
+    '';
+    homepage = "https://github.com/ryck/scrobblex";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ msaxena ];
+    mainProgram = "scrobblex";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [scrobblex](https://github.com/ryck/scrobblex) — a self-hosted Node.js application that listens for Plex (or Tautulli) webhooks and scrobbles watched media to Trakt. Also supports pushing Plex ratings back to Trakt.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
