### PR TITLE
[Backport release-25.11] linphonePackages: fix source fetching, linphone-sdk: 5.4.47 -> 5.4.85, linphone-desktop: 5.3.1 -> 5.3.3

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/default.nix
@@ -8,8 +8,8 @@ makeScopeWithSplicing' {
   extra = self: {
     mkLinphoneDerivation = self.mk-linphone-derivation;
 
-    linphoneSdkVersion = "5.4.48";
-    linphoneSdkHash = "sha256-sOkq73YWbhpKJOk1dVc4tkg2+RuGyRK8/t4ckMIVVG8=";
+    linphoneSdkVersion = "5.4.85";
+    linphoneSdkHash = "sha256-mdJDCuCaZlcQ92P6oMgH/8iWgm8hGz8gTVUilC+yaSU=";
   };
   f =
     self:

--- a/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop/default.nix
@@ -39,7 +39,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "linphone-desktop";
-  version = "5.3.1";
+  version = "5.3.3";
 
   src = fetchFromGitLab {
     domain = "gitlab.linphone.org";
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     group = "BC";
     repo = "linphone-desktop";
     rev = finalAttrs.version;
-    hash = "sha256-TO9JNsOnx4sTJEkai0nDKNyZWcLuGoWfuKLBM79tQvs=";
+    hash = "sha256-DZqf1iDnN1vBRLvmLqIctag4U/C7uLyb5d2qKeNdiEk=";
   };
 
   patches = [

--- a/pkgs/applications/networking/instant-messengers/linphone/mk-linphone-derivation/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/mk-linphone-derivation/default.nix
@@ -1,11 +1,38 @@
 {
   stdenv,
-  fetchFromGitLab,
+  fetchFromGitHub,
   lib,
   cmake,
   linphoneSdkVersion,
   linphoneSdkHash,
 }:
+let
+  # linphone-sdk is hosted on BC's Gitlab instance, however since it imposes
+  # a heavy rate limit / throttling when attempting to fetch submodules, we use their
+  # GitHub mirror instead.
+  src = fetchFromGitHub {
+    owner = "BelledonneCommunications";
+    repo = "linphone-sdk";
+    tag = linphoneSdkVersion;
+    hash = linphoneSdkHash;
+    leaveDotGit = true;
+    postFetch = ''
+      cd $out
+      git remote add origin https://github.com/BelledonneCommunications/linphone-sdk.git
+      git reset --hard HEAD
+      # `external` submodules are hardcoded to resolve to BC's Gitlab instance,
+      # however, since we manually package all required external modules anyway,
+      # we do not need to also fetch them here.
+      #
+      # We also use `--jobs 1` to avoid hitting BC's rate limit for the handful of
+      # hardcoded submodules that we _do_ need.
+      for submodule in $(git config --file .gitmodules --get-regexp path | awk '{print $2}' | grep -v '^external/.*$'); do
+        git submodule update --init --recursive --jobs 1 "$submodule"
+      done
+      find "$out" -name .git -type d -print0 | xargs -0 rm -rf
+    '';
+  };
+in
 lib.extendMkDerivation {
   constructDrv = stdenv.mkDerivation;
 
@@ -25,15 +52,7 @@ lib.extendMkDerivation {
     {
       version = linphoneSdkVersion;
 
-      src = fetchFromGitLab {
-        domain = "gitlab.linphone.org";
-        owner = "public";
-        group = "BC";
-        repo = "linphone-sdk";
-        tag = linphoneSdkVersion;
-        hash = linphoneSdkHash;
-        fetchSubmodules = true;
-      };
+      inherit src;
 
       nativeBuildInputs = [
         cmake


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Waited a bit to see whether the derivation breaks _again_, but looks good fortunately. Although 25.04 is basically right around the corner, I think it's still worth backporting this part to enable users to patch the derivation and/or build without having to rely on the binary 

For the original PR, see https://github.com/NixOS/nixpkgs/pull/487626

This PR also updates Linphone from 5.3.2 to 5.3.3.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
