### PR TITLE
ci/github-script/merge: Add documentation links to GitHub script bot comments

### DIFF
--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -46,12 +46,15 @@ function runChecklist({
       classify(pull_request.base.ref).type.includes('development'),
     'PR touches only files of packages in `pkgs/by-name/`.': allByName,
     'PR is at least one of:': {
-      'Approved by a committer.': committers.intersection(approvals).size > 0,
+      'Approved by a [committer](https://github.com/orgs/NixOS/teams/nixpkgs-committers).':
+        committers.intersection(approvals).size > 0,
       'Backported via label.':
         pull_request.user.login === 'nixpkgs-ci[bot]' &&
         pull_request.head.ref.startsWith('backport-'),
-      'Opened by a committer.': committers.has(pull_request.user.id),
-      'Opened by r-ryantm.': pull_request.user.login === 'r-ryantm',
+      'Opened by a [committer](https://github.com/orgs/NixOS/teams/nixpkgs-committers).':
+        committers.has(pull_request.user.id),
+      'Opened by [@r-ryantm](https://nix-community.github.io/nixpkgs-update/r-ryantm/).':
+        pull_request.user.login === 'r-ryantm',
     },
   }
 


### PR DESCRIPTION
The comment the merge bot comments, upon failure of automatic merging does not match the documentation here https://github.com/NixOS/nixpkgs/blob/master/ci/README.md#merge-bot-constraints. 
Most importantly, a link / explanation to what a nixpkgs committer is, is missing. As well as a link to who r-ryantm is. Both can be confusion to newcomers.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
