### PR TITLE
nchat: 5.12.21 → 5.13.17

### DIFF
--- a/pkgs/by-name/nc/nchat/fix-darwin.patch
+++ b/pkgs/by-name/nc/nchat/fix-darwin.patch
@@ -1,0 +1,35 @@
+diff --git i/CMakeLists.txt w/CMakeLists.txt
+index ceff715b..143659fb 100644
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -31,30 +31,6 @@ endif()
+ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+   add_definitions(-D_XOPEN_SOURCE_EXTENDED)
+ 
+-  # ncurses
+-  execute_process(COMMAND sh "-c"
+-                  "command -v brew &> /dev/null && brew --prefix ncurses 2> /dev/null | tr -d '\n'"
+-                  OUTPUT_VARIABLE NCURSES_ROOT_DIR)
+-  if (EXISTS "${NCURSES_ROOT_DIR}")
+-    message(STATUS "Ncurses cmake prefix '${NCURSES_ROOT_DIR}' (detected).")
+-  else()
+-    set(NCURSES_ROOT_DIR /opt/local)
+-    message(STATUS "Ncurses cmake prefix '${NCURSES_ROOT_DIR}' (default).")
+-  endif()
+-  list(APPEND CMAKE_PREFIX_PATH ${NCURSES_ROOT_DIR})
+-
+-  # openssl
+-  execute_process(COMMAND sh "-c"
+-                  "command -v brew &> /dev/null && brew --prefix openssl 2> /dev/null | tr -d '\n'"
+-                  OUTPUT_VARIABLE OPENSSL_ROOT_DIR)
+-  if (EXISTS "${OPENSSL_ROOT_DIR}")
+-    message(STATUS "OpenSSL cmake prefix '${OPENSSL_ROOT_DIR}' (detected).")
+-  else()
+-    set(OPENSSL_ROOT_DIR /opt/local)
+-    message(STATUS "OpenSSL cmake prefix '${OPENSSL_ROOT_DIR}' (default).")
+-  endif()
+-  list(APPEND CMAKE_PREFIX_PATH ${OPENSSL_ROOT_DIR})
+-
+ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Android")
+   add_compile_definitions(_XOPEN_SOURCE_EXTENDED)
+   if (DEFINED ENV{PREFIX} AND "$ENV{PREFIX}" MATCHES "^/data/data/com\\.termux/files/usr$")

--- a/pkgs/by-name/nc/nchat/go-libs-build.patch
+++ b/pkgs/by-name/nc/nchat/go-libs-build.patch
@@ -1,0 +1,48 @@
+diff --git i/CMakeLists.txt w/CMakeLists.txt
+index a1928ee3..26157e56 100644
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -126,10 +126,6 @@ message(STATUS "Static Go: ${HAS_STATICGOLIB}")
+ 
+ # Check Golang version for whatsmeow minimum requirement
+ set(GO_VERSION_MIN 1.23)
+-execute_process(COMMAND bash "-c" "go version 2> /dev/null | cut -c14- | cut -d' ' -f1 | tr -d '\n'" OUTPUT_VARIABLE GO_VERSION)
+-if((HAS_WHATSAPP OR HAS_SIGNAL) AND (NOT GO_VERSION VERSION_GREATER_EQUAL GO_VERSION_MIN))
+-  message(FATAL_ERROR "Go version ${GO_VERSION} (need >= ${GO_VERSION_MIN} to build WhatsApp or Signal).")
+-endif()
+ 
+ # Check Little/Big Endian for tdlib requirement
+ test_big_endian(IS_BIG_ENDIAN)
+diff --git i/lib/tgchat/ext/td/CMakeLists.txt w/lib/tgchat/ext/td/CMakeLists.txt
+index 795f1f4b..7e41549c 100644
+--- i/lib/tgchat/ext/td/CMakeLists.txt
++++ w/lib/tgchat/ext/td/CMakeLists.txt
+@@ -140,7 +140,6 @@ if (CLANG OR GCC)
+ endif()
+ 
+ include(GetGitRevisionDescription)
+-get_git_head_revision(TD_GIT_REFSPEC TD_GIT_COMMIT_HASH)
+ message(STATUS "Git state: ${TD_GIT_COMMIT_HASH}")
+ 
+ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/td/telegram/GitCommitHash.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/td/telegram/GitCommitHash.cpp" @ONLY)
+diff --git i/lib/wmchat/CMakeLists.txt w/lib/wmchat/CMakeLists.txt
+index 84a42ef9..556df050 100644
+--- i/lib/wmchat/CMakeLists.txt
++++ w/lib/wmchat/CMakeLists.txt
+@@ -20,8 +20,8 @@ install(TARGETS wmchat DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ target_common_config(wmchat)
+ 
+ # Dependency libraries
+-add_subdirectory(go)
+-add_dependencies(wmchat ref-cgowm)
++set(GO_LIBRARIES @libcgowm@/libcgowm.a)
++target_include_directories(wmchat PRIVATE @libcgowm@)
+ 
+ # Platform specifics
+ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+@@ -44,4 +44,4 @@ set_target_properties(wmchat PROPERTIES COMPILE_FLAGS
+ 
+ # Linking
+ message(STATUS "Go libraries: ${GO_LIBRARIES}")
+-target_link_libraries(wmchat PUBLIC ref-cgowm ncutil ${GO_LIBRARIES})
++target_link_libraries(wmchat PUBLIC @libcgowm@/libcgowm.a ncutil ${GO_LIBRARIES})

--- a/pkgs/by-name/nc/nchat/package.nix
+++ b/pkgs/by-name/nc/nchat/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildGoModule,
   fetchFromGitHub,
+  replaceVars,
   file, # for libmagic
   ncurses,
   openssl,
@@ -16,13 +17,13 @@
 }:
 
 let
-  version = "5.12.21";
+  version = "5.13.17";
 
   src = fetchFromGitHub {
     owner = "d99kris";
     repo = "nchat";
     tag = "v${version}";
-    hash = "sha256-WofBqdUX88USnCA4iyDVMDXyx4Bxz/ZV0FqDUeAOe4Q=";
+    hash = "sha256-VSya6s3/+vII/M76tHmeJEZh7/gv9L5tYdILuthdO5s=";
   };
 
   libcgowm = buildGoModule {
@@ -30,7 +31,7 @@ let
     inherit version src;
 
     sourceRoot = "${src.name}/lib/wmchat/go";
-    vendorHash = "sha256-4jn2CDWqg0GqZ7QTTaZh+9GDUH7L6WllfTONkxnfKEU=";
+    vendorHash = "sha256-lfy7uHH3rLYx6kzIy72ftEiO1CkJkEr7rRXHhuFU/ac=";
 
     buildPhase = ''
       runHook preBuild
@@ -45,34 +46,17 @@ let
     '';
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "nchat";
   inherit version src;
 
-  nl = "\n";
-  postPatch = ''
-    substituteInPlace lib/tgchat/ext/td/CMakeLists.txt \
-      --replace "get_git_head_revision" "#get_git_head_revision"
-    substituteInPlace lib/tgchat/CMakeLists.txt \
-      --replace-fail "list(APPEND OPENSSL_ROOT_DIR" "#list(APPEND OPENSSL_ROOT_DIR"
-
-    # specific mangling to handle whatsapp go module:
-
-    substituteInPlace CMakeLists.txt \
-      --replace "if(HAS_WHATSAPP AND (NOT GO_VERSION VERSION_GREATER_EQUAL GO_VERSION_MIN))" \
-      "if(FALSE AND (NOT GO_VERSION VERSION_GREATER_EQUAL GO_VERSION_MIN))"
-
-    substituteInPlace lib/wmchat/CMakeLists.txt \
-      --replace-fail "add_subdirectory(go)" \
-    "set(GO_LIBRARIES ${libcgowm}/libcgowm.a)${nl}target_include_directories(wmchat PRIVATE ${libcgowm})"
-
-    substituteInPlace lib/wmchat/CMakeLists.txt \
-      --replace-fail "target_link_libraries(wmchat PUBLIC ref-cgowm ncutil \''${GO_LIBRARIES})" \
-      "target_link_libraries(wmchat PUBLIC ${libcgowm}/libcgowm.a ncutil \''${GO_LIBRARIES})"
-
-    substituteInPlace lib/wmchat/CMakeLists.txt \
-      --replace-fail "add_dependencies(wmchat ref-cgowm)" "#add_dependencies(wmchat ref-cgowm)"
-  '';
+  patches = [
+    (replaceVars ./go-libs-build.patch {
+      inherit libcgowm;
+    })
+    # Don't use brew
+    ./fix-darwin.patch
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Changelog: https://github.com/d99kris/nchat/releases/tag/v5.13.17
Diff: https://github.com/d99kris/nchat/compare/v5.12.21...v5.13.17

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
