### PR TITLE
nixos/hardware/facter: better NVIDIA defaults

### DIFF
--- a/nixos/modules/hardware/facter/graphics/default.nix
+++ b/nixos/modules/hardware/facter/graphics/default.nix
@@ -6,6 +6,7 @@ in
 {
   imports = [
     ./amd.nix
+    ./nvidia.nix
   ];
   options.hardware.facter.detected = {
     graphics.enable = lib.mkEnableOption "Enable the Graphics module" // {

--- a/nixos/modules/hardware/facter/graphics/nvidia.nix
+++ b/nixos/modules/hardware/facter/graphics/nvidia.nix
@@ -1,0 +1,24 @@
+{ lib, config, ... }:
+let
+  cfg = config.hardware.facter.detected.graphics.nvidia;
+in
+{
+  options.hardware.facter.detected.graphics = {
+    nvidia.enable = lib.mkEnableOption "Enable the NVIDIA Graphics module" // {
+      default = builtins.elem "nvidia" config.hardware.facter.detected.boot.graphics.kernelModules;
+      defaultText = "hardware dependent";
+    };
+  };
+  config = lib.mkIf (config.hardware.facter.reportPath != null && cfg.enable) {
+    services.xserver.videoDrivers = [ "nvidia" ];
+
+    # Companion modules that make all work smoothly
+    boot.initrd.kernelModules = [
+      "nvidia_drm"
+      "nvidia_modeset"
+      "nvidia_uvm"
+    ];
+
+    hardware.nvidia.open = lib.versionAtLeast config.hardware.nvidia.package.version "560";
+  };
+}


### PR DESCRIPTION
When NVIDIA was detected, it was not added as a video driver, like it happens with AMD cards.

With this change, when a NVIDIA card is available, it will work better out of the box.

@moduon MT-13030

Diagonally  related: #498208 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
