### PR TITLE
python3Packages.{torch,torchaudio}: DRY shared ROCm infrastructure

### DIFF
--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -746,6 +746,8 @@ buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
       rocmSupport
       rocmPackages
       unroll-src
+      gpuTargetString
+      rocmtoolkit_joined
       ;
     cudaCapabilities = if cudaSupport then supportedCudaCapabilities else [ ];
     # At least for 1.10.2 `torch.fft` is unavailable unless BLAS provider is MKL. This attribute allows for easy detection of its availability.

--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -764,6 +764,7 @@ buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
     homepage = "https://pytorch.org/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
+      caniko
       GaetanLepage
       LunNova # esp. for ROCm
       teh

--- a/pkgs/development/python-modules/torchaudio/default.nix
+++ b/pkgs/development/python-modules/torchaudio/default.nix
@@ -94,6 +94,7 @@ buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
       lib.platforms.linux ++ lib.optionals (!cudaSupport && !rocmSupport) lib.platforms.darwin;
     maintainers = with lib.maintainers; [
       GaetanLepage
+      caniko
       junjihashimoto
     ];
   };

--- a/pkgs/development/python-modules/torchaudio/default.nix
+++ b/pkgs/development/python-modules/torchaudio/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  symlinkJoin,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -19,62 +18,9 @@
   cudaPackages,
   rocmSupport ? torch.rocmSupport,
   rocmPackages,
-
-  gpuTargets ? [ ],
 }:
 
-let
-  # TODO: Reuse one defined in torch?
-  # Some of those dependencies are probably not required,
-  # but it breaks when the store path is different between torch and torchaudio
-  rocmtoolkit_joined = symlinkJoin {
-    name = "rocm-merged";
-
-    paths = with rocmPackages; [
-      rocm-core
-      clr
-      rccl
-      miopen
-      rocrand
-      rocblas
-      rocsparse
-      hipsparse
-      rocthrust
-      rocprim
-      hipcub
-      roctracer
-      rocfft
-      rocsolver
-      hipfft
-      hipsolver
-      hipblas-common
-      hipblas
-      rocminfo
-      rocm-comgr
-      rocm-device-libs
-      rocm-runtime
-      clr.icd
-      hipify
-    ];
-
-    # Fix `setuptools` not being found
-    postBuild = ''
-      rm -rf $out/nix-support
-    '';
-  };
-  # Only used for ROCm
-  gpuTargetString = lib.strings.concatStringsSep ";" (
-    if gpuTargets != [ ] then
-      # If gpuTargets is specified, it always takes priority.
-      gpuTargets
-    else if rocmSupport then
-      rocmPackages.clr.gpuTargets
-    else
-      throw "No GPU targets specified"
-  );
-  stdenv = torch.stdenv;
-in
-buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
+buildPythonPackage.override { stdenv = torch.stdenv; } (finalAttrs: {
   pname = "torchaudio";
   version = "2.10.0";
   pyproject = true;
@@ -124,13 +70,13 @@ buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
     sox
     torch.cxxdev
   ]
-  ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
+  ++ lib.optionals torch.stdenv.cc.isClang [ llvmPackages.openmp ];
 
   dependencies = [ torch ];
 
   preConfigure = lib.optionalString rocmSupport ''
-    export ROCM_PATH=${rocmtoolkit_joined}
-    export PYTORCH_ROCM_ARCH="${gpuTargetString}"
+    export ROCM_PATH=${torch.rocmtoolkit_joined}
+    export PYTORCH_ROCM_ARCH="${torch.gpuTargetString}"
   '';
 
   dontUseCmakeConfigure = true;


### PR DESCRIPTION
Expose `rocmtoolkit_joined` and `gpuTargetString` via torch's passthru; use them in torchaudio instead of duplicated local definitions.

Resolves torchaudio's existing `# TODO: Reuse one defined in torch?` (added in #292750). Sharing the same `rocmtoolkit_joined` store path prevents runtime mismatches between torch and its ecosystem packages.

cc @GaetanLepage @LunNova @junjihashimoto @CertainLach

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test