### PR TITLE
nixos/hardware/facter: better defaults for Intel graphics

### DIFF
--- a/nixos/modules/hardware/facter/graphics/default.nix
+++ b/nixos/modules/hardware/facter/graphics/default.nix
@@ -6,6 +6,7 @@ in
 {
   imports = [
     ./amd.nix
+    ./intel.nix
   ];
   options.hardware.facter.detected = {
     graphics.enable = lib.mkEnableOption "Enable the Graphics module" // {

--- a/nixos/modules/hardware/facter/graphics/intel.nix
+++ b/nixos/modules/hardware/facter/graphics/intel.nix
@@ -1,0 +1,121 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  facterLib = import ../lib.nix lib;
+  cfg = config.hardware.facter.detected.graphics.intel;
+  report = config.hardware.facter.report;
+
+  # Filter graphics cards by Intel vendor ID (0x8086)
+  intelGpus = builtins.filter (
+    entry:
+    let
+      vendor = entry.vendor.value or 0;
+    in
+    vendor == 32902 # 0x8086 - Intel vendor ID
+  ) (report.hardware.graphics_card or [ ]);
+
+  hasIntelGpu = builtins.length intelGpus > 0;
+
+  # CPU model thresholds based on Intel CPUID
+  # https://en.wikichip.org/wiki/intel/cpuid
+  #
+  # Model 42 = Sandy Bridge, first generation to use i915 kernel module
+  # Older GPUs (Ironlake, GMA) use different modules (i965, gma-*)
+  needsI915 = facterLib.hasIntelCpuModelAtLeast 42 report;
+
+  # Model 61 = Broadwell, minimum for intel-media-driver
+  # Pre-Broadwell GPUs should use intel-vaapi-driver instead
+  isBroadwellOrNewer = facterLib.hasIntelCpuModelAtLeast 61 report;
+
+  # Model 78 = Skylake, first generation supporting GuC/HuC firmware submission
+  hasGuC = facterLib.hasIntelCpuModelAtLeast 78 report;
+
+  # Model 126 = Ice Lake (Gen11), supports HuC firmware loading reliably
+  # Gen9-10 (Skylake to Comet Lake) only support GuC submission (enable_guc=2)
+  # Gen11+ (Ice Lake+) supports both GuC and HuC (enable_guc=3)
+  hasHuC = facterLib.hasIntelCpuModelAtLeast 126 report;
+
+  # Model 140 = Tiger Lake (Xe), supports QSV/VPL and newer OpenCL runtime
+  isXeGraphics = facterLib.hasIntelCpuModelAtLeast 140 report;
+
+  # Resolve the effective GuC value based on the option and hardware
+  gucValue = if cfg.guc == "auto" then if hasHuC then "3" else "2" else cfg.guc;
+in
+{
+  options.hardware.facter.detected.graphics.intel = {
+    enable = lib.mkEnableOption "Enable the Intel Graphics module" // {
+      default = hasIntelGpu;
+      defaultText = "hardware dependent";
+    };
+
+    driver = lib.mkOption {
+      type = lib.types.enum [
+        "auto"
+        "i965"
+        "iHD"
+      ];
+      default = "auto";
+      description = ''
+        VA-API driver to use. `auto` selects based on GPU generation
+        (iHD for Broadwell+, i965 otherwise). Use this to override
+        detection or force a specific driver for debugging.
+      '';
+    };
+
+    guc = lib.mkOption {
+      type = lib.types.enum [
+        "auto"
+        "2"
+        "3"
+        "disable"
+      ];
+      default = "auto";
+      description = ''
+        i915 GuC/HuC firmware loading mode:
+        - `auto`: selects based on GPU generation (2 for Skylake+, 3 for Ice Lake+)
+        - `2`: enable GuC submission only
+        - `3`: enable GuC submission and HuC loading
+        - `disable`: do not set the kernel parameter
+      '';
+    };
+  };
+
+  config = lib.mkIf (config.hardware.facter.reportPath != null && cfg.enable) {
+    services.xserver.videoDrivers = [ "modesetting" ];
+
+    # Select VA-API driver based on GPU generation:
+    # - Broadwell+: intel-media-driver (iHD)
+    # - Older: intel-vaapi-driver (i965)
+    hardware.graphics.extraPackages =
+      with pkgs;
+      if isBroadwellOrNewer then
+        [ intel-media-driver ]
+        ++ lib.optionals isXeGraphics [
+          vpl-gpu-rt
+          intel-compute-runtime
+        ]
+        ++ lib.optionals (isBroadwellOrNewer && !isXeGraphics) [
+          intel-compute-runtime-legacy1
+        ]
+      else
+        [ intel-vaapi-driver ];
+
+    # Tell libva which driver to use
+    environment.sessionVariables = {
+      LIBVA_DRIVER_NAME =
+        if cfg.driver == "auto" then if isBroadwellOrNewer then "iHD" else "i965" else cfg.driver;
+    };
+
+    # Enable GuC/HuC firmware submission for Skylake+ GPUs
+    boot.kernelParams = lib.optionals (cfg.guc != "disable" && hasGuC) [
+      "i915.enable_guc=${gucValue}"
+    ];
+
+    # Intel GPU firmware (GuC/HuC) is part of linux-firmware
+    hardware.firmware = [ pkgs.linux-firmware ];
+  };
+}

--- a/nixos/modules/hardware/facter/lib.nix
+++ b/nixos/modules/hardware/facter/lib.nix
@@ -7,6 +7,7 @@ let
   inherit (lib) assertMsg;
 
   # Query if a facter report contains a CPU with the given vendor name
+  # Asserts if hardware/cpu data is missing (use only when data is guaranteed)
   hasCpu =
     name:
     {
@@ -25,6 +26,26 @@ let
       }:
       assert assertMsg (vendor_name != null) "detail.vendor_name not found in cpu entry";
       vendor_name == name
+    ) cpus;
+
+  # Query if a facter report contains an Intel CPU with model >= threshold
+  # Returns false if no CPU info available (graceful degradation)
+  hasIntelCpuModelAtLeast =
+    minModel:
+    {
+      hardware ? { },
+      ...
+    }:
+    let
+      cpus = hardware.cpu or [ ];
+    in
+    builtins.any (
+      {
+        vendor_name ? null,
+        model ? 0,
+        ...
+      }:
+      vendor_name == "GenuineIntel" && model >= minModel
     ) cpus;
 
   # Extract all driver_modules from a list of hardware entries
@@ -49,6 +70,7 @@ in
 {
   inherit
     hasCpu
+    hasIntelCpuModelAtLeast
     collectDrivers
     toZeroPaddedHex
     ;


### PR DESCRIPTION
Basically this implements out-of-the-box what the wiki says in:
- https://wiki.nixos.org/wiki/Intel_Graphics
- https://wiki.nixos.org/wiki/Accelerated_Video_Playback

@moduon MT-13030


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

AI-assisted with OpenCode + Deepseek V4 Flash