### PR TITLE
sbomqs: init at 2.0.4

### DIFF
--- a/pkgs/by-name/sb/sbomqs/package.nix
+++ b/pkgs/by-name/sb/sbomqs/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "sbomqs";
+  version = "2.0.4";
+
+  src = fetchFromGitHub {
+    owner = "interlynk-io";
+    repo = "sbomqs";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-I3KxHXcAqLD94/pt2aE/V21xIN5OBVkVp5LWeIuf+iA=";
+  };
+
+  vendorHash = "sha256-yEIY5qaXiT1TNoj/t3S0CG8SR5dMr/uDEFfgdoLdSSs=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = with lib; {
+    description = "A comprehensive SBOM quality and compliance tool";
+    homepage = "https://github.com/interlynk-io/sbomqs";
+    license = licenses.asl20;
+    maintainers = [ ];
+    mainProgram = "sbomqs";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [sbomqs](https://github.com/interlynk-io/sbomqs), a tool for validating the quality and compliance of SBOMs.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
