### PR TITLE
rtpkcs11ecp: init at 2.18.4.0

### DIFF
--- a/pkgs/by-name/rt/rtpkcs11ecp/package.nix
+++ b/pkgs/by-name/rt/rtpkcs11ecp/package.nix
@@ -1,0 +1,53 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  pcsclite,
+  ...
+}:
+stdenv.mkDerivation rec {
+  pname = "rtpkcs11ecp";
+  version = "2.18.4.0";
+
+  src = fetchurl {
+    url = "https://download.rutoken.ru/Rutoken/PKCS11Lib/${version}/Linux/x64/librtpkcs11ecp_${version}-1_amd64.deb";
+    hash = "sha256-3alkDqC/EqUYsF5/paody64W3SvkVNVRCetYztclq98=";
+  };
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  buildInputs = [ pcsclite ];
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  unpackCmd = "dpkg -X $curSrc source";
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib"
+    install -D opt/aktivco/rutokenecp/amd64/librtpkcs11ecp.so "$out/lib/librtpkcs11ecp.so"
+
+    runHook postInstall
+  '';
+  fixupPhase = ''
+    runHook preFixup
+
+    autoPatchelf "$out"
+
+    runHook postFixup
+  '';
+
+  meta = {
+    description = "Rutoken PKCS#11 Library";
+    homepage = "https://www.rutoken.ru/";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ lib.maintainers.maxmosk ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
Rutoken (Active Co.) PKCS#11 library.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
