### PR TITLE
agent-browser: init at 0.23.3

### DIFF
--- a/pkgs/by-name/ag/agent-browser/package.nix
+++ b/pkgs/by-name/ag/agent-browser/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+  writableTmpDirAsHomeHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "agent-browser";
+  version = "0.23.3";
+
+  src = fetchFromGitHub {
+    owner = "vercel-labs";
+    repo = "agent-browser";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Q02sJr14zRrVrRJ0M30AD0EG7DGkYtafCH6/kI15/xk=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/cli";
+
+  cargoHash = "sha256-smJ+ODr88moz+16G9fXSz/NNiGngWeoTuQtBn21qu1s=";
+
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  __darwinAllowLocalNetworking = true;
+
+  # skills/ contains SKILL.md for tools like Claude Code
+  postInstall = ''
+    mkdir -p $out/share/agent-browser
+    cp -r ../skills $out/share/agent-browser/
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Headless browser automation CLI for AI agents";
+    homepage = "https://github.com/vercel-labs/agent-browser";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ codgician ];
+    mainProgram = "agent-browser";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Init agent-browser (https://github.com/vercel-labs/agent-browser) at 0.23.3, a browser automation CLI for AI agents.
 
P.S. I have been selfhosting this for a while in my NUR repo on both Linux and macOS: https://github.com/codgician/nur-packages

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
