### PR TITLE
sendspin-cli: init at 5.3.0

### DIFF
--- a/nixos/tests/music-assistant.nix
+++ b/nixos/tests/music-assistant.nix
@@ -10,12 +10,55 @@
   nodes.machine = {
     services.music-assistant = {
       enable = true;
+      providers = [
+        "sendspin"
+      ];
     };
   };
 
-  testScript = ''
-    machine.wait_for_unit("music-assistant.service")
-    machine.wait_until_succeeds("curl --fail http://localhost:8095")
-    machine.log(machine.succeed("systemd-analyze security music-assistant.service | grep -v ✓"))
-  '';
+  testScript = # python
+    ''
+      import json
+
+      machine.wait_for_unit("music-assistant.service")
+      machine.wait_for_open_port(8095)
+      machine.wait_until_succeeds("curl --fail http://localhost:8095/info")
+
+      machine.log(machine.succeed("systemd-analyze security music-assistant.service | grep -v ✓"))
+
+      machine.succeed("""curl --fail http://localhost:8095/setup \
+        -H 'Accept: application/json' \
+        -H 'Content-Type: application/json' \
+        -d '{
+          "username": "hotblack_desiato",
+          "password": "disaster_area",
+          "display_name": "NixOS ♡ Music"
+        }'""")
+
+      login = json.loads(machine.succeed("""curl --fail http://localhost:8095/auth/login \
+        -X POST \
+        -H 'Accept: application/json' \
+        -H 'Content-Type: application/json' \
+        -d '{
+          "provider_id": "builtin",
+          "credentials": {
+            "username": "hotblack_desiato",
+            "password": "disaster_area"
+          }
+        }'"""))
+
+      providers = json.loads(machine.succeed(f"""curl --fail http://localhost:8095/api \
+        -H 'Accept: application/json' \
+        -H 'Content-Type: application/json' \
+        -H 'Authorization: Bearer {login["token"]}' \
+        -d '{{
+          "command": "providers/manifests",
+          "args": {{}}
+        }}'"""))
+
+      assert any(
+        provider["type"] == "player" and provider["domain"] == "sendspin"
+        for provider in providers
+      )
+    '';
 }

--- a/pkgs/by-name/se/sendspin-cli/package.nix
+++ b/pkgs/by-name/se/sendspin-cli/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+  ...
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "sendspin-cli";
+  version = "5.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Sendspin";
+    repo = "sendspin-cli";
+    tag = finalAttrs.version;
+    hash = "sha256-CTX2q85Ka5CV6YaKIA02Jiu5LKR7UsH7pxSnybos5k0=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools-scm
+  ];
+
+  dependencies = with python3Packages; [
+    aiosendspin
+    aiosendspin-mpris
+    numpy
+    pychromecast
+    pulsectl-asyncio
+    qrcode
+    readchar
+    rich
+    sounddevice
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Synchronized audio player for Sendspin servers";
+    homepage = "https://github.com/Sendspin/sendspin-cli";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fooker ];
+    mainProgram = "sendspin-cli";
+  };
+})

--- a/pkgs/development/python-modules/aiosendspin-mpris/default.nix
+++ b/pkgs/development/python-modules/aiosendspin-mpris/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  aiosendspin,
+  mpris-api,
+
+  # meta
+  music-assistant,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "aiosendspin-mpris";
+  version = "2.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "abmantis";
+    repo = "aiosendspin-mpris";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hOF6rTm0pppk+J7tTVaLDK5C1ofGXz1YU6RVGm92geQ=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    aiosendspin
+    mpris-api
+  ];
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [
+    "aiosendspin"
+  ];
+
+  meta = {
+    changelog = "https://github.com/abmantis/aiosendspin-mpris/releases/tag/${finalAttrs.src.tag}";
+    description = "MPRIS integration for aiosendspin";
+    homepage = "https://github.com/abmantis/aiosendspin-mpris";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fooker ];
+  };
+})

--- a/pkgs/development/python-modules/aiosendspin/default.nix
+++ b/pkgs/development/python-modules/aiosendspin/default.nix
@@ -16,18 +16,20 @@
 
   # meta
   music-assistant,
+
+  nixosTests,
 }:
 
 buildPythonPackage rec {
   pname = "aiosendspin";
-  version = "2.1.0";
+  version = "4.3.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Sendspin";
     repo = "aiosendspin";
     tag = version;
-    hash = "sha256-9VhNtfXH2r/cGkscz51PIK2/66pPOGv0S0IpO0wFvO4=";
+    hash = "sha256-XIrDQbM0UR7YPf00MlEcR5Wq1Cj1niVOF8fudSfd2to=";
   };
 
   # https://github.com/Sendspin/aiosendspin/blob/1.2.0/pyproject.toml#L7
@@ -56,7 +58,9 @@ buildPythonPackage rec {
   ];
 
   # needs manual compat testing with music-assistant (sendspin provider)
-  passthru.skipBulkUpdate = true; # nixpkgs-update: no auto update
+  passthru = {
+    tests = nixosTests.music-assistant;
+  };
 
   meta = {
     changelog = "https://github.com/Sendspin/aiosendspin/releases/tag/${src.tag}";

--- a/pkgs/development/python-modules/mpris-api/default.nix
+++ b/pkgs/development/python-modules/mpris-api/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  dbus-next,
+  unidecode,
+  tunit,
+
+  # meta
+  music-assistant,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "mpris-api";
+  version = "1.3.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "mpris-api";
+    inherit (finalAttrs) version;
+    hash = "sha256-Xss74nrPlJh0Ik8tkZ5nG7GLYQd/vWl+nu/uYZ0Cyuc=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    dbus-next
+    unidecode
+    tunit
+  ];
+
+  pythonImportsCheck = [
+    "mpris_api"
+  ];
+
+  meta = {
+    description = "Make your multimedia app discoverable by linux desktop.";
+    homepage = "https://bitbucket.org/massultidev/mpris-api";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fooker ];
+  };
+})

--- a/pkgs/development/python-modules/tunit/default.nix
+++ b/pkgs/development/python-modules/tunit/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+
+  # meta
+  music-assistant,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "tunit";
+  version = "1.7.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "tunit";
+    inherit (finalAttrs) version;
+    hash = "sha256-59UBnHlZBweJ675XrZ0EU9yO/k2Re2oDq2DU76aYR/Y=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+  ];
+
+  pythonImportsCheck = [
+    "tunit"
+  ];
+
+  meta = {
+    description = "Time unit types. For transparency safety and readability.";
+    homepage = "https://bitbucket.org/massultidev/tunit";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fooker ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -504,6 +504,8 @@ self: super: with self; {
 
   aiosendspin = callPackage ../development/python-modules/aiosendspin { };
 
+  aiosendspin-mpris = callPackage ../development/python-modules/aiosendspin-mpris { };
+
   aioserial = callPackage ../development/python-modules/aioserial { };
 
   aioshelly = callPackage ../development/python-modules/aioshelly { };
@@ -10214,6 +10216,8 @@ self: super: with self; {
 
   mpmath = callPackage ../development/python-modules/mpmath { };
 
+  mpris-api = callPackage ../development/python-modules/mpris-api { };
+
   mprisify = callPackage ../development/python-modules/mprisify { };
 
   mpv = callPackage ../development/python-modules/mpv { inherit (pkgs) mpv; };
@@ -19658,6 +19662,8 @@ self: super: with self; {
   tuf = callPackage ../development/python-modules/tuf { };
 
   tunigo = callPackage ../development/python-modules/tunigo { };
+
+  tunit = callPackage ../development/python-modules/tunit { };
 
   turnt = callPackage ../development/python-modules/turnt { };
 


### PR DESCRIPTION
python3Packages.aiosendspin-mpris: init at 2.1.1
python3Packages.aiosendspin: 2.1.0 -> 4.3.2
python3Packages.mpris-api: init at 1.3.0
python3Packages.tunit: init at 1.7.2
nixos/tests/music-assistant: Add provider check for sendspin



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
