### PR TITLE
demucs-rs: init at 0.3.4

### DIFF
--- a/pkgs/by-name/de/demucs-rs/package.nix
+++ b/pkgs/by-name/de/demucs-rs/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  vulkan-loader,
+  makeWrapper,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "demucs-rs";
+  version = "0.3.4";
+
+  src = fetchFromGitHub {
+    owner = "nikhilunni";
+    repo = "demucs-rs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IidfPS+/T8aJoW30gdnKhhsgluMt+h9RllAXH9Yrq1g=";
+  };
+
+  cargoHash = "sha256-xngHyenlB3sMqzJHNk9utk4TNhdt+awutDuP1JzhhBA=";
+
+  # Only build the CLI crate, not the DAW plugin or WASM targets
+  buildAndTestSubdir = "demucs-cli";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  # wgpu dlopen()s libvulkan at runtime, so LD_LIBRARY_PATH is needed (RPATH has no effect).
+  # this is Linux-only: on Darwin wgpu uses Metal and should need no runtime patching.
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram $out/bin/demucs \
+      --prefix LD_LIBRARY_PATH : "${vulkan-loader}/lib"
+  '';
+
+  meta = {
+    description = "Native Rust implementation of HTDemucs v4 music source separation CLI";
+    longDescription = ''
+      A native Rust implementation of HTDemucs v4 — state-of-the-art music
+      source separation. Splits any song into individual stems (drums, bass,
+      vocals, etc.) using GPU-accelerated inference via Burn.
+
+      Model weights are downloaded automatically from Hugging Face on first
+      use and cached for future runs.
+    '';
+    homepage = "https://github.com/nikhilunni/demucs-rs";
+    license = lib.licenses.asl20;
+    mainProgram = "demucs";
+    maintainers = with lib.maintainers; [ eymeric ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
  - [x] pkgsCross.aarch64-multiplatform
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
