### PR TITLE
tracexec: 0.13.1 -> 0.17.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14605,6 +14605,13 @@
     githubId = 2422454;
     name = "Kai Wohlfahrt";
   };
+  kxxt = {
+    name = "kxxt";
+    email = "rsworktech@outlook.com";
+    matrix = "@kxxt:matrix.org";
+    github = "kxxt";
+    githubId = 18085551;
+  };
   kyehn = {
     name = "kyehn";
     github = "kyehn";

--- a/pkgs/by-name/tr/tracexec/package.nix
+++ b/pkgs/by-name/tr/tracexec/package.nix
@@ -51,9 +51,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     cargo about generate --config about.toml -o THIRD_PARTY_LICENSES.HTML about.hbs
   '';
 
-  checkFlags = [
-    "--skip=log_mode_without_args_works" # `Permission denied` (needs `CAP_SYS_PTRACE`)
-  ];
+  # tracexec uses $XDG_DATA_HOME/tracexec for storing temporary files and logs.
+  # Set this directory to $TMPDIR because integration tests needs to access it.
+  preCheck = ''
+    export TRACEXEC_DATA="$TMPDIR"
+  '';
 
   postInstall = ''
     # Remove test binaries (e.g. `empty-argv`, `corrupted-envp`) and only retain `tracexec`

--- a/pkgs/by-name/tr/tracexec/package.nix
+++ b/pkgs/by-name/tr/tracexec/package.nix
@@ -15,16 +15,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tracexec";
-  version = "0.13.1";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "kxxt";
     repo = "tracexec";
-    rev = "dbb9b733370f5200df2a0de7f007312c23431480";
-    hash = "sha256-M2ZIfWupnFxQZvr5cl8V0xtLgh+xBcaHHVsHIoio7nI=";
+    rev = "ecbda651a4006789debf565376cd6f37241dec3e";
+    hash = "sha256-wP7jAGoWgvm3/4XBHr27MD8M9qwyVpuDVR96S8+I3eo=";
   };
 
-  cargoHash = "sha256-cyzSxibLw6sb0V3ueNcp55OhFQ5jUNJWcSF8uYnzG2M=";
+  cargoHash = "sha256-kJrWAyRcU5eEfTwaAxcN6oE5KHgBdjznWeI21/3c/UE=";
 
   hardeningDisable = [ "zerocallusedregs" ];
 
@@ -56,7 +56,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   checkFlags = [
-    "--skip=cli::test::log_mode_without_args_works" # `Permission denied` (needs `CAP_SYS_PTRACE`)
+    "--skip=log_mode_without_args_works" # `Permission denied` (needs `CAP_SYS_PTRACE`)
   ];
 
   postInstall = ''

--- a/pkgs/by-name/tr/tracexec/package.nix
+++ b/pkgs/by-name/tr/tracexec/package.nix
@@ -44,11 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoBuildFlags = [
     "--no-default-features"
     "--features=recommended"
-  ]
-  # Remove RiscV64 specialisation when this is fixed:
-  # * https://github.com/NixOS/nixpkgs/pull/310158#pullrequestreview-2046944158
-  # * https://github.com/rust-vmm/seccompiler/pull/72
-  ++ lib.optional stdenv.hostPlatform.isRiscV64 "--no-default-features";
+  ];
 
   preBuild = ''
     sed -i '1ino-clearly-defined = true' about.toml  # disable network requests

--- a/pkgs/by-name/tr/tracexec/package.nix
+++ b/pkgs/by-name/tr/tracexec/package.nix
@@ -75,6 +75,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "tracexec";
     maintainers = with lib.maintainers; [
       fpletz
+      kxxt
       nh2
     ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changes: https://github.com/kxxt/tracexec/blob/main/CHANGELOG.md#v0170

This PR also contains to clean up commits:
1. drop riscv64 specialization because tracexec no longer depends on seccompiler and now uses libsecomp which supports riscv64.
2. enable skipped test by setting `TRACEXEC_DATA` to tmpdir. `TRACEXEC_DATA` defaults to `$XDG_DATA_HOME/tracexec` that causes failures during integration tests because it is not writable.

I am the upstream maintainer of tracexec. I am also adding myself to maintainers of this package because I find myself
using nix more and more during my life and thus I want to try maintaining a package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
