### PR TITLE
snpguest, snphost, uplosi, envoy-bin: add charludo as maintainer

### DIFF
--- a/pkgs/by-name/en/envoy-bin/package.nix
+++ b/pkgs/by-name/en/envoy-bin/package.nix
@@ -66,7 +66,10 @@ stdenvNoCC.mkDerivation {
     description = "Cloud-native edge and service proxy";
     license = lib.licenses.asl20;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
-    maintainers = with lib.maintainers; [ katexochen ];
+    maintainers = with lib.maintainers; [
+      katexochen
+      charludo
+    ];
     mainProgram = "envoy";
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/sn/snpguest/package.nix
+++ b/pkgs/by-name/sn/snpguest/package.nix
@@ -33,7 +33,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/virtee/snpguest";
     changelog = "https://github.com/virtee/snpguest/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ katexochen ];
+    maintainers = with lib.maintainers; [
+      katexochen
+      charludo
+    ];
     mainProgram = "snpguest";
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/by-name/sn/snphost/package.nix
+++ b/pkgs/by-name/sn/snphost/package.nix
@@ -57,7 +57,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/virtee/snphost/";
     changelog = "https://github.com/virtee/snphost/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ katexochen ];
+    maintainers = with lib.maintainers; [
+      katexochen
+      charludo
+    ];
     mainProgram = "snphost";
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/by-name/up/uplosi/package.nix
+++ b/pkgs/by-name/up/uplosi/package.nix
@@ -46,6 +46,7 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [
       katexochen
       malt3
+      charludo
     ];
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
