### PR TITLE
python3: propagate overrides of spliced pythons

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -173,13 +173,19 @@ let
           };
         in
         python;
-    in
-    passthruFun rec {
-      inherit self sourceVersion packageOverrides;
-      implementation = "cpython";
-      libPrefix = "python${pythonVersion}${lib.optionalString (!enableGIL) "t"}";
-      executable = libPrefix;
       pythonVersion = with sourceVersion; "${major}.${minor}";
+      libPrefix = "python${pythonVersion}${lib.optionalString (!enableGIL) "t"}";
+    in
+    passthruFun {
+      inherit
+        self
+        sourceVersion
+        packageOverrides
+        libPrefix
+        pythonVersion
+        ;
+      implementation = "cpython";
+      executable = libPrefix;
       sitePackages = "lib/${libPrefix}/site-packages";
       inherit hasDistutilsCxxPatch pythonAttr;
       inherit (splices)

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -165,12 +165,40 @@ let
         );
       }
       // __splices;
+      # When we override the interpreter we also need to override the spliced
+      # versions of the interpreter. NOTE: In lua-5/interpreter.nix, this
+      # filter is different - we take every attribute from @inputs, besides
+      # derivations. That filter causes cross compilations issues for Python
+      # See e.g:
+      #
+      # pkgsCross.armv7l-hf-multiplatform.buildPackages.python3Packages.bcrypt
+      #
+      # And the following Nixpkgs issues/PRs:
+      #
+      # - https://github.com/NixOS/nixpkgs/issues/48046
+      # - https://github.com/NixOS/nixpkgs/pull/480005 (Wrong PR)
+      # - https://github.com/NixOS/nixpkgs/pull/482866 (Correct fix)
+      # - https://github.com/NixOS/nixpkgs/pull/498251 (Re-adds this @inputs filter)
+      inputs' = lib.filterAttrs (
+        n: v:
+        (builtins.elem (builtins.typeOf v) [
+          "int"
+          "bool"
+          "string"
+          "path"
+          "null"
+        ])
+        || n == "packageOverrides"
+      ) inputs;
       override =
         attr:
         let
-          python = attr.override {
-            self = python;
-          };
+          python = attr.override (
+            inputs'
+            // {
+              self = python;
+            }
+          );
         in
         python;
       pythonVersion = with sourceVersion; "${major}.${minor}";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test