### PR TITLE
bukubrow: use structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/by-name/bu/bukubrow/package.nix
+++ b/pkgs/by-name/bu/bukubrow/package.nix
@@ -21,8 +21,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "SamHH";
     repo = "bukubrow-host";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-xz5Agsm+ATQXXgpPGN4EQ00i1t8qUlrviNHauVdCu4U=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xz5Agsm+ATQXXgpPGN4EQ00i1t8qUlrviNHauVdCu4U=";
   };
 
   cargoHash = "sha256-mCPJE9WW14NtahbMnDcE+0xXl5w25dzerPy3wv78l20=";

--- a/pkgs/by-name/bu/bukubrow/package.nix
+++ b/pkgs/by-name/bu/bukubrow/package.nix
@@ -29,10 +29,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [ sqlite ];
 
-  passAsFile = [
-    "firefoxManifest"
-    "chromeManifest"
-  ];
   firefoxManifest = builtins.toJSON (
     manifest
     // {
@@ -46,13 +42,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
     }
   );
   postBuild = ''
-    substituteAll $firefoxManifestPath firefox.json
-    substituteAll $chromeManifestPath chrome.json
+    printf "%s" "$firefoxManifest" > firefox.json
+    substituteInPlace firefox.json \
+      --replace-fail "@out@" "$out"
+    printf "%s" "$chromeManifest" > chrome.json
+    substituteInPlace chrome.json \
+      --replace-fail "@out@" "$out"
   '';
   postInstall = ''
     install -Dm0644 firefox.json $out/lib/mozilla/native-messaging-hosts/com.samhh.bukubrow.json
     install -Dm0644 chrome.json $out/etc/chromium/native-messaging-hosts/com.samhh.bukubrow.json
   '';
+
+  __structuredAttrs = true;
 
   meta = {
     description = "WebExtension for Buku, a command-line bookmark manager";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
