### PR TITLE
bats: use writeText instead of passAsFile 

### DIFF
--- a/pkgs/by-name/ba/bats/package.nix
+++ b/pkgs/by-name/ba/bats/package.nix
@@ -18,6 +18,7 @@
   symlinkJoin,
   makeWrapper,
   runCommand,
+  writeText,
   doInstallCheck ? true,
   # packages that use bats (for update testing)
   bash-preexec,
@@ -157,7 +158,7 @@ resholve.mkDerivation rec {
     libraries =
       runCommand "${bats.name}-with-libraries-test"
         {
-          testScript = ''
+          testScript = writeText "bats-libraries-test-script" ''
             setup() {
               bats_load_library bats-support
               bats_load_library bats-assert
@@ -191,7 +192,6 @@ resholve.mkDerivation rec {
               assert_output "hi"
             }
           '';
-          passAsFile = [ "testScript" ];
         }
         ''
           ${
@@ -201,7 +201,7 @@ resholve.mkDerivation rec {
               p.bats-file
               p.bats-detik
             ])
-          }/bin/bats "$testScriptPath"
+          }/bin/bats "$testScript"
           touch "$out"
         '';
 

--- a/pkgs/by-name/ba/bats/package.nix
+++ b/pkgs/by-name/ba/bats/package.nix
@@ -152,6 +152,8 @@ resholve.mkDerivation rec {
         wrapProgram "$out/bin/bats" \
           --suffix BATS_LIB_PATH : "$out/share/bats"
       '';
+
+      inherit meta;
     };
 
   passthru.tests = {

--- a/pkgs/by-name/ba/bats/package.nix
+++ b/pkgs/by-name/ba/bats/package.nix
@@ -156,54 +156,52 @@ resholve.mkDerivation rec {
 
   passthru.tests = {
     libraries =
-      runCommand "${bats.name}-with-libraries-test"
-        {
-          testScript = writeText "bats-libraries-test-script" ''
-            setup() {
-              bats_load_library bats-support
-              bats_load_library bats-assert
-              bats_load_library bats-file
-              bats_load_library bats-detik/detik.bash
+      let
+        testScript = writeText "bats-libraries-test-script" ''
+          setup() {
+            bats_load_library bats-support
+            bats_load_library bats-assert
+            bats_load_library bats-file
+            bats_load_library bats-detik/detik.bash
 
-              bats_require_minimum_version 1.5.0
+            bats_require_minimum_version 1.5.0
 
-              TEST_TEMP_DIR="$(temp_make --prefix 'nixpkgs-bats-test')"
-            }
+            TEST_TEMP_DIR="$(temp_make --prefix 'nixpkgs-bats-test')"
+          }
 
-            teardown() {
-              temp_del "$TEST_TEMP_DIR"
-            }
+          teardown() {
+            temp_del "$TEST_TEMP_DIR"
+          }
 
-            @test echo_hi {
-              run -0 echo hi
-              assert_output "hi"
-            }
+          @test echo_hi {
+            run -0 echo hi
+            assert_output "hi"
+          }
 
-            @test cp_failure {
-              run ! cp
-              assert_line --index 0 "cp: missing file operand"
-              assert_line --index 1 "Try 'cp --help' for more information."
-            }
+          @test cp_failure {
+            run ! cp
+            assert_line --index 0 "cp: missing file operand"
+            assert_line --index 1 "Try 'cp --help' for more information."
+          }
 
-            @test file_exists {
-              echo "hi" > "$TEST_TEMP_DIR/hello.txt"
-              assert_file_exist "$TEST_TEMP_DIR/hello.txt"
-              run cat "$TEST_TEMP_DIR/hello.txt"
-              assert_output "hi"
-            }
-          '';
-        }
-        ''
-          ${
-            bats.withLibraries (p: [
-              p.bats-support
-              p.bats-assert
-              p.bats-file
-              p.bats-detik
-            ])
-          }/bin/bats "$testScript"
-          touch "$out"
+          @test file_exists {
+            echo "hi" > "$TEST_TEMP_DIR/hello.txt"
+            assert_file_exist "$TEST_TEMP_DIR/hello.txt"
+            run cat "$TEST_TEMP_DIR/hello.txt"
+            assert_output "hi"
+          }
         '';
+        batsWithLibraries = bats.withLibraries (p: [
+          p.bats-support
+          p.bats-assert
+          p.bats-file
+          p.bats-detik
+        ]);
+      in
+      runCommand "${bats.name}-with-libraries-test" { } ''
+        ${lib.getExe batsWithLibraries} "${testScript}"
+        touch "$out"
+      '';
 
     upstream = bats.unresholved.overrideAttrs (old: {
       name = "${bats.name}-tests";


### PR DESCRIPTION
This fixes compatibility with `__structuredAttrs`.

Tested with `nix-build -A bats.tests.libraries`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
