### PR TITLE
nixos/calibre-server: fix service argument escaping

### DIFF
--- a/nixos/modules/services/misc/calibre-server.nix
+++ b/nixos/modules/services/misc/calibre-server.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  utils,
   ...
 }:
 let
@@ -11,20 +12,17 @@ let
   documentationLink = "https://manual.calibre-ebook.com";
   generatedDocumentationLink = documentationLink + "/generated/en/calibre-server.html";
 
-  execFlags = (
-    lib.concatStringsSep " " (
-      lib.mapAttrsToList (k: v: "${k} ${toString v}") (
-        lib.filterAttrs (name: value: value != null) {
-          "--listen-on" = cfg.host;
-          "--port" = cfg.port;
-          "--auth-mode" = cfg.auth.mode;
-          "--userdb" = cfg.auth.userDb;
-        }
-      )
-      ++ [ (lib.optionalString (cfg.auth.enable == true) "--enable-auth") ]
-      ++ cfg.extraFlags
+  execFlags =
+    lib.mapAttrsToList (k: v: "--${k}=${toString v}") (
+      lib.filterAttrs (name: value: value != null) {
+        listen-on = cfg.host;
+        port = cfg.port;
+        auth-mode = cfg.auth.mode;
+        userdb = cfg.auth.userDb;
+      }
     )
-  );
+    ++ lib.optional cfg.auth.enable "--enable-auth"
+    ++ cfg.extraFlags;
 in
 
 {
@@ -150,7 +148,9 @@ in
       serviceConfig = {
         User = cfg.user;
         Restart = "always";
-        ExecStart = "${cfg.package}/bin/calibre-server ${lib.concatStringsSep " " cfg.libraries} ${execFlags}";
+        ExecStart = utils.escapeSystemdExecArgs (
+          [ "${cfg.package}/bin/calibre-server" ] ++ execFlags ++ [ "--" ] ++ cfg.libraries
+        );
       };
 
     };


### PR DESCRIPTION
Fix calibre-server's argument escaping, and make sure library paths don't get treated as flags.

Fixes #493041

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test