### PR TITLE
python3Packages.cassandra-driver: fixes

### DIFF
--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -116,6 +116,7 @@ buildPythonPackage (finalAttrs: {
     "test_connection_initialization"
     # time-sensitive
     "test_nts_token_performance"
+    "test_empty_connections"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -28,8 +28,8 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "datastax";
-    repo = "python-driver";
+    owner = "apache";
+    repo = "cassandra-python-driver";
     tag = finalAttrs.version;
     hash = "sha256-VynrUc7gqAi061FU2ln4B1fK4NaSUcjSgH1i1JQpmvk=";
   };
@@ -120,8 +120,8 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Python client driver for Apache Cassandra";
-    homepage = "http://datastax.github.io/python-driver";
-    changelog = "https://github.com/datastax/python-driver/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
+    homepage = "https://github.com/apache/cassandra-python-driver";
+    changelog = "https://github.com/apache/cassandra-python-driver/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ris ];
   };

--- a/pkgs/development/python-modules/cassandra-driver/default.nix
+++ b/pkgs/development/python-modules/cassandra-driver/default.nix
@@ -22,7 +22,7 @@
   distutils,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cassandra-driver";
   version = "3.29.3";
   pyproject = true;
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "datastax";
     repo = "python-driver";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-VynrUc7gqAi061FU2ln4B1fK4NaSUcjSgH1i1JQpmvk=";
   };
 
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     pyyaml
     sure
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   # This is used to determine the version of cython that can be used
   env.CASS_DRIVER_ALLOWED_CYTHON_VERSION = cython.version;
@@ -121,8 +121,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python client driver for Apache Cassandra";
     homepage = "http://datastax.github.io/python-driver";
-    changelog = "https://github.com/datastax/python-driver/blob/${version}/CHANGELOG.rst";
+    changelog = "https://github.com/datastax/python-driver/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ris ];
   };
-}
+})


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/323296015

1. Disable timing-sensitive test that broke on Hydra
2. Migrate to new home at github:apache/cassandra-python-driver
3. Migrate to finalAttrs


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
