### PR TITLE
hypre: 3.0.0 -> 3.1.0; support complex scalar

### DIFF
--- a/pkgs/by-name/hy/hypre/package.nix
+++ b/pkgs/by-name/hy/hypre/package.nix
@@ -13,10 +13,16 @@
   mpiCheckPhaseHook,
   isILP64 ? false,
   mpiSupport ? true,
+  scalarType ? "real",
   precision ? "double",
   testers,
   hypre,
 }:
+
+assert lib.elem scalarType [
+  "real"
+  "complex"
+];
 
 assert lib.elem precision [
   "single"
@@ -75,6 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "HYPRE_ENABLE_HYPRE_LAPACK" false)
     (lib.cmakeBool "HYPRE_ENABLE_FORTRAN" true)
     (lib.cmakeBool "HYPRE_ENABLE_BIGINT" isILP64)
+    (lib.cmakeBool "HYPRE_ENABLE_COMPLEX" (scalarType == "complex"))
     (lib.cmakeBool "HYPRE_ENABLE_SINGLE" (precision == "single"))
     (lib.cmakeBool "HYPRE_ENABLE_LONG_DOUBLE" (precision == "long-double"))
     (lib.cmakeBool "HYPRE_ENABLE_OPENMP" true)

--- a/pkgs/by-name/hy/hypre/package.nix
+++ b/pkgs/by-name/hy/hypre/package.nix
@@ -26,13 +26,13 @@ assert lib.elem precision [
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hypre";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "hypre-space";
     repo = "hypre";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zu9YWfBT2WJxPg6JHrXjZWRM9Ai1p28EpvAx6xfdPsY=";
+    hash = "sha256-U+6PUlrTY4ewS6vOSusRerqh9Jw6TX5A+Y08pfcIvZU=";
   };
 
   outputs = [

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -83,6 +83,7 @@ let
       fortranSupport
       pythonSupport
       precision
+      scalarType
       withPtScotch
       ;
     enableMpi = self.mpiSupport;
@@ -268,6 +269,9 @@ stdenv.mkDerivation (finalAttrs: {
     tests = {
       serial = petsc.override {
         mpiSupport = false;
+      };
+      complex = petsc.override {
+        scalarType = "complex";
       };
     }
     // lib.optionalAttrs stdenv.hostPlatform.isLinux {


### PR DESCRIPTION
changelog: https://github.com/hypre-space/hypre/compare/v3.0.0...v3.1.0

~~also add option scalarType in parallel with petsc, fix build of "petsc.tests.complex"~~

hypre's complex support still broken, we can not build petsc with both complex scalar and hypre support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
