### PR TITLE
maintainers: add duvallj

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7298,6 +7298,12 @@
     githubId = 60694691;
     keys = [ { fingerprint = "A7C9 3DC7 E891 046A 980F  2063 F222 A13B 2053 27A5"; } ];
   };
+  duvallj = {
+    name = "Jack Duvall";
+    email = "theduvallj@gmail.com";
+    github = "duvallj";
+    githubId = 10897431;
+  };
   dvaerum = {
     email = "nixpkgs-maintainer@varum.dk";
     github = "dvaerum";


### PR DESCRIPTION
I intend to contribute a package for https://github.com/vlabo/cspell-lsp; even though it's "deprecated" it's still the only language server for cspell outside of the vscode one.