### PR TITLE
neuwld: init at 0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22765,6 +22765,13 @@
     githubId = 61013287;
     name = "Ricardo Steijn";
   };
+  ricardomaps = {
+    email = "ricardomapurungajunior@gmail.com";
+    github = "ricardomaps";
+    githubId = 49507078;
+    name = "Ricardo Mapurunga Junior";
+    matrix = "@ricmaps:matrix.org";
+  };
   richar = {
     github = "ri-char";
     githubId = 17962023;

--- a/pkgs/by-name/ne/neuwld/package.nix
+++ b/pkgs/by-name/ne/neuwld/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  bmake,
+  pkg-config,
+  wayland-scanner,
+  fontconfig,
+  pixman,
+  freetype,
+  libdrm,
+  wayland,
+  stdenv,
+  fetchFromSourcehut,
+}:
+stdenv.mkDerivation {
+  pname = "neuwld";
+  version = "0.0";
+
+  src = fetchFromSourcehut {
+    owner = "~shrub900";
+    repo = "neuwld";
+    rev = "235b7b62be7d7c9eefa011eac4a5b78ba7390f1c";
+    hash = "sha256-0+rgWrefh19bBEmcqw0Lal1PHkendtCkQ2EIg+LHb74=";
+  };
+
+  nativeBuildInputs = [
+    bmake
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    fontconfig
+    pixman
+    freetype
+    libdrm
+    wayland
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  meta = {
+    description = "Drawing library that targets Wayland";
+    homepage = "https://git.sr.ht/~shrub900/neuwld";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ricardomaps ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
This PR adds the neuwld library used extensively by packages such as neuswc, hevel, shko and many others like the ones listed here [https://wayland.fyi/](https://wayland.fyi/)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
