### PR TITLE
cspell-lsp: init at 1.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7298,6 +7298,12 @@
     githubId = 60694691;
     keys = [ { fingerprint = "A7C9 3DC7 E891 046A 980F  2063 F222 A13B 2053 27A5"; } ];
   };
+  duvallj = {
+    name = "Jack Duvall";
+    email = "theduvallj@gmail.com";
+    github = "duvallj";
+    githubId = 10897431;
+  };
   dvaerum = {
     email = "nixpkgs-maintainer@varum.dk";
     github = "dvaerum";

--- a/pkgs/by-name/cs/cspell-lsp/package.nix
+++ b/pkgs/by-name/cs/cspell-lsp/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  bun,
+  nodejs,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "cspell-lsp";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = "vlabo";
+    repo = "cspell-lsp";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ZLZMVw0uvr4rQ9SKMVj1Sjoj+QeK2UL3RWsnzNRdPwI=";
+  };
+
+  npmDepsHash = "sha256-XYgtV3XMEriMjC06QfudL0fyoTY1PobnpUf4PQGOA2U=";
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeBuildInputs = [
+    bun
+  ];
+
+  buildInputs = [ nodejs ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/cspell-lsp
+    mkdir -p $out/bin
+
+    # Re-install only production dependencies
+    rm -rf node_modules
+    bun install --production --frozen-lockfile
+
+    mv ./package.json ./node_modules ./dist/cspell-lsp.js $out/lib/cspell-lsp
+    # Clean up unneeded files
+    pushd $out/lib/cspell-lsp
+    shopt -s globstar
+    rm -rf **/*.md  **/*.map **/*.d.ts **/src
+    popd
+
+    cat > $out/bin/${finalAttrs.meta.mainProgram} <<EOF
+    #!/bin/sh
+    exec ${nodejs}/bin/node $out/lib/cspell-lsp/cspell-lsp.js "\$@"
+    EOF
+    chmod +x $out/bin/${finalAttrs.meta.mainProgram}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Spell checker language server using cspell";
+    longDescription = ''
+      A language server for spell checking in source code using the cspell library.
+      Works with editors that support LSP such as Helix & Neovim.
+    '';
+    homepage = "https://github.com/vlabo/cspell-lsp";
+    changelog = "https://github.com/vlabo/cspell-lsp/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ duvallj ];
+    mainProgram = "cspell-lsp";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[cspell-lsp](https://github.com/vlabo/cspell-lsp) is a third-party language server for the [cspell](https://cspell.org/) spell checker. The other language server is [only available for vscode](https://github.com/streetsidesoftware/vscode-spell-checker), so this package helps non-VSCode users work on the same codebase as VSCode users, using the same configuration.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
