### PR TITLE
ticket: init at 0.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3617,6 +3617,12 @@
     githubId = 535135;
     name = "Brennon Loveless";
   };
+  blsalin = {
+    name = "Alin Andrei Balasa";
+    email = "alin.andrei.balasa@blsalin.dev";
+    github = "blsalin";
+    githubId = 39619013;
+  };
   Blu3 = {
     name = "Blu3";
     email = "Blu3SoulsIT@gmail.com";

--- a/pkgs/by-name/ti/ticket/package.nix
+++ b/pkgs/by-name/ti/ticket/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  nix-update-script,
+  bash,
+  coreutils,
+  findutils,
+  gawk,
+  gnugrep,
+  gnused,
+  ripgrep,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ticket";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "wedow";
+    repo = "ticket";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-orxqAwJBL+LHe+I9M+djYGa/yfvH67HdR/VVy8fdg90=";
+  };
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ticket $out/bin/ticket
+    ln -s $out/bin/ticket $out/bin/tk
+
+    wrapProgram $out/bin/ticket \
+      --set PATH "${
+        lib.makeBinPath [
+          bash
+          coreutils
+          findutils
+          gawk
+          gnugrep
+          gnused
+          ripgrep
+        ]
+      }"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/tk help | grep -q "minimal ticket system"
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Git-backed issue tracker for AI agents with dependency tracking";
+    homepage = "https://github.com/wedow/ticket";
+    changelog = "https://github.com/wedow/ticket/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      blsalin
+    ];
+    mainProgram = "tk";
+  };
+})


### PR DESCRIPTION
New package: [ticket](https://github.com/wedow/ticket) — a git-backed issue tracker for AI agents. Tickets are
  markdown files with YAML frontmatter stored in `.tickets/`, designed for easy search and navigation by both AI
  agents and IDEs. Portable bash script requiring only coreutils.

  ## Things done

  <!-- Please check what applies. Note that these are not hard requirements but merely serve as information for
  reviewers. -->

  - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [x] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [x] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

  [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

  [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
  [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
  [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
  [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
