### PR TITLE
nixos/power-management: only create systemd units when used

### DIFF
--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -91,6 +91,7 @@ in
     '';
 
     systemd.targets.post-resume = {
+      enable = config.systemd.services.post-resume.enable;
       description = "Post-Resume Actions";
       requires = [ "post-resume.service" ];
       after = [ "post-resume.service" ];
@@ -101,6 +102,7 @@ in
     systemd.services = {
       # Service executed before suspending/hibernating.
       pre-sleep = {
+        enable = cfg.powerDownCommands != "";
         description = "Pre-Sleep Actions";
         wantedBy = [ "sleep.target" ];
         before = [ "sleep.target" ];
@@ -110,6 +112,7 @@ in
 
       # Service executed after resuming from suspend/hibernate
       post-resume = {
+        enable = cfg.powerUpCommands != "" || cfg.resumeCommands != "";
         description = "Post-Resume Actions";
         # Pulled in by post-resume.service above
         after = [ "sleep.target" ];
@@ -123,6 +126,7 @@ in
 
       # Service executed before shutdown
       pre-shutdown = {
+        enable = cfg.powerDownCommands != "";
         description = "Pre-Shutdown Actions";
         wantedBy = [
           "shutdown.target"
@@ -137,6 +141,7 @@ in
 
       # Service executed after boot
       post-boot = {
+        enable = cfg.bootCommands != "" || cfg.powerUpCommands != "";
         description = "Post-Boot Actions";
         # It's not well defined at what point in the bootup sequence this should run
         # we should eventually just remove this.


### PR DESCRIPTION
When a service's `script` attribute is the empty string, the systemd module treats it as "unset". This leads to services without `ExecStart` directives, which fail to validate.

We could simply write dummy values to ensure we create empty scripts, but it's cleaner (IMO) to simply not create services/targets we don't need.

fixes #498310

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

<!-- Message of single commit: -->