### PR TITLE
python3Packages.sphinx-markdown-builder: fix build

### DIFF
--- a/pkgs/development/python-modules/sphinx-markdown-builder/default.nix
+++ b/pkgs/development/python-modules/sphinx-markdown-builder/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   nix-update-script,
-  fetchpatch2,
 
   # build system
   setuptools,
@@ -42,15 +41,6 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-DTc+yVFOGLXFyrgkwfgY3X60chyU3UDs0GwuPCzff28=";
   };
-
-  patches = [
-    # FIX: tests (remove with the next release)
-    # https://github.com/liran-funaro/sphinx-markdown-builder/issues/32
-    (fetchpatch2 {
-      url = "https://github.com/liran-funaro/sphinx-markdown-builder/commit/967edca036a73f7644251abd52a5da8451a10dd4.patch";
-      hash = "sha256-FGMYzd5k3Q0UvOccCvUSW3y6gor+AUncj2qv38xyOp4=";
-    })
-  ];
 
   build-system = [
     setuptools


### PR DESCRIPTION
Fixes failing Hydra build: https://hydra.nixos.org/build/322433840

The patch linked to liran-funaro/sphinx-markdown-builder#32 was added to fix the tests.
Patch is now included in the upstream 0.6.9 release, and can be removed.

Issue introduced with commit f2c2da87dcd812ca7d59219e5b097f9508e63db7 (#482364)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
