### PR TITLE
various: fixup leftover pixmaps references

### DIFF
--- a/pkgs/applications/misc/diffpdf/default.nix
+++ b/pkgs/applications/misc/diffpdf/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
         install -Dpm755 -D diffpdf $out/bin/diffpdf
         install -Dpm644 -D diffpdf.1 $out/share/man/man1/diffpdf.1
 
-        install -dpm755 $out/share/doc/${pname}-${version} $out/share/licenses/${pname}-${version} $out/share/icons $out/share/pixmaps $out/share/applications
+        install -dpm755 $out/share/doc/${pname}-${version} $out/share/licenses/${pname}-${version} $out/share/icons $out/share/applications
         install -Dpm644 CHANGES README help.html $out/share/doc/${pname}-${version}/
         install -Dpm644 gpl-2.0.txt $out/share/licenses/${pname}-${version}/
         install -Dpm644 images/icon.png $out/share/icons/hicolor/64x64/apps/diffpdf.png
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
         Name=diffpdf
         Icon=diffpdf
         Comment=PDF diffing tool
-        Exec=$out/bin/diffpdf
+        Exec=diffpdf
         Terminal=false
         EOF
       '';

--- a/pkgs/by-name/gp/gpsprune/package.nix
+++ b/pkgs/by-name/gp/gpsprune/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm644 ${finalAttrs.src} $out/share/java/gpsprune.jar
     makeWrapper ${jre}/bin/java $out/bin/gpsprune \
       --add-flags "-jar $out/share/java/gpsprune.jar"
-    mkdir -p $out/share/pixmaps
+    mkdir -p $out/share/icons/hicolor/64x64/apps
     ${unzip}/bin/unzip -p $src tim/prune/gui/images/window_icon_64.png > $out/share/icons/hicolor/64x64/apps/gpsprune.png
 
     runHook postInstall

--- a/pkgs/tools/graphics/nifskope/default.nix
+++ b/pkgs/tools/graphics/nifskope/default.nix
@@ -70,8 +70,7 @@ stdenv.mkDerivation {
     cp ./install/linux-install/nifskope.desktop $out/share/applications
 
     substituteInPlace $out/share/applications/nifskope.desktop \
-      --replace 'Exec=nifskope' "Exec=$out/bin/NifSkope" \
-      --replace 'Icon=nifskope' "Icon=$out/share/pixmaps/nifskope.png"
+      --replace-fail 'Exec=nifskope' "Exec=NifSkope" \
 
     find $out/share -type f -exec chmod -x {} \;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes a few mistakes that slipped through review as part of #428824
I can't personally verify the darwin fix for `filen-desktop`, but you'll see that darwin was copying from the nonexistent pixmaps location, now it copies into place directly from source just like linux

Closes #513447
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
