### PR TITLE
libid3tag: 0.16.3 -> 0.16.4

### DIFF
--- a/pkgs/by-name/li/libid3tag/package.nix
+++ b/pkgs/by-name/li/libid3tag/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromCodeberg,
-  fetchpatch,
   cmake,
   gperf,
   zlib,
@@ -10,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libid3tag";
-  version = "0.16.3";
+  version = "0.16.4";
 
   outputs = [
     "out"
@@ -21,17 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "tenacityteam";
     repo = "libid3tag";
     rev = finalAttrs.version;
-    hash = "sha256-6/49rk7pmIpJRj32WmxC171NtdIOaMNhX8RD7o6Jbzs=";
+    hash = "sha256-v3tvZmQE6G8Xsk+eluVtlou0Nyhyaisv0UclivQBi28=";
   };
-
-  patches = [
-    # Fix the build with CMake 4.
-    (fetchpatch {
-      name = "libid3tag-fix-cmake-4.patch";
-      url = "https://codeberg.org/tenacityteam/libid3tag/commit/eee94b22508a066f7b9bc1ae05d2d85982e73959.patch";
-      hash = "sha256-OAdMapNr8qpvXZqNOZ3LUHQ1H79zD1rvzrVksqmz6dU=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace packaging/id3tag.pc.in \


### PR DESCRIPTION
Changes: https://codeberg.org/tenacityteam/libid3tag/commit/fff52d4e27a6f8e3a714bd304e4258d9e1b0dad8


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
