### PR TITLE
top-level/by-name-overlay: set meta.position

### DIFF
--- a/pkgs/by-name/do/docling-serve/package.nix
+++ b/pkgs/by-name/do/docling-serve/package.nix
@@ -16,9 +16,11 @@
       withCPU
       ;
   }
-))
-// {
-  passthru.tests = {
-    docling-serve = nixosTests.docling-serve;
-  };
-}
+)).overrideAttrs
+  (old: {
+    passthru = old.passthru or { } // {
+      tests = old.passthru.tests or { } // {
+        inherit (nixosTests) docling-serve;
+      };
+    };
+  })

--- a/pkgs/by-name/hc/hci/package.nix
+++ b/pkgs/by-name/hc/hci/package.nix
@@ -56,8 +56,3 @@ let
       );
 in
 pkg
-// {
-  meta = pkg.meta // {
-    position = toString ./package.nix + ":1";
-  };
-}

--- a/pkgs/by-name/im/immersed/darwin.nix
+++ b/pkgs/by-name/im/immersed/darwin.nix
@@ -4,6 +4,7 @@
   version,
   src,
   meta,
+  passthru,
   undmg,
 }:
 
@@ -13,6 +14,7 @@ stdenv.mkDerivation {
     version
     src
     meta
+    passthru
     ;
 
   nativeBuildInputs = [ undmg ];

--- a/pkgs/by-name/im/immersed/linux.nix
+++ b/pkgs/by-name/im/immersed/linux.nix
@@ -3,6 +3,7 @@
   version,
   src,
   meta,
+  passthru,
   appimageTools,
   libgpg-error,
 }:
@@ -20,7 +21,12 @@ let
 in
 
 appimageTools.wrapAppImage {
-  inherit pname version meta;
+  inherit
+    pname
+    version
+    meta
+    passthru
+    ;
   src = src';
 
   extraPkgs =

--- a/pkgs/by-name/im/immersed/package.nix
+++ b/pkgs/by-name/im/immersed/package.nix
@@ -36,30 +36,16 @@ let
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 
-in
-
-(
-  if stdenv.hostPlatform.isDarwin then
-    callPackage ./darwin.nix {
-      inherit
-        pname
-        version
-        src
-        meta
-        ;
-    }
-  else
-    callPackage ./linux.nix {
-      inherit
-        pname
-        version
-        src
-        meta
-        ;
-    }
-)
-// {
   passthru = {
     inherit sources;
   };
+in
+callPackage (if stdenv.hostPlatform.isDarwin then ./darwin.nix else ./linux.nix) {
+  inherit
+    pname
+    version
+    src
+    meta
+    passthru
+    ;
 }

--- a/pkgs/by-name/sm/sm64baserom/package.nix
+++ b/pkgs/by-name/sm/sm64baserom/package.nix
@@ -28,12 +28,10 @@ let
       }
       .${region};
   };
-  result = runCommand "baserom-${region}-safety-dir" { } ''
+  result = runCommand "baserom-${region}-safety-dir" { passthru = { inherit romPath; }; } ''
     mkdir $out
     ln -s ${file} $out/${file.name}
   '';
+  romPath = "${result.outPath}/${file.name}";
 in
 result
-// {
-  romPath = "${result.outPath}/${file.name}";
-}

--- a/pkgs/by-name/ub/ubports-click/package.nix
+++ b/pkgs/by-name/ub/ubports-click/package.nix
@@ -148,6 +148,9 @@ let
 
     passthru = {
       updateScript = gitUpdater { };
+      tests.pkg-config = testers.hasPkgConfigModules {
+        package = self;
+      };
     };
 
     meta = {
@@ -168,10 +171,3 @@ let
   };
 in
 self
-// {
-  passthru = self.passthru // {
-    tests.pkg-config = testers.hasPkgConfigModules {
-      package = self;
-    };
-  };
-}

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -88,29 +88,30 @@ let
       # NOTE: the above documentation had to be duplicated in `lib/customisation.nix`: `makeOverridable`.
       overrideAttrs =
         f0:
-        let
-          extends' =
-            overlay: f:
+        makeDerivationExtensible (
+          final:
+          let
+            prev = rattrs final;
+            thisOverlay = lib.toExtension f0 final prev;
+            warnForBadVersionOverride = (
+              thisOverlay ? version
+              && prev ? src
+              && prev ? version
+              # We could check that the version is actually distinct, but that
+              # would probably just delay the inevitable, or preserve tech debt.
+              # && prev.version != thisOverlay.version
+              && !(thisOverlay ? src)
+              && !(thisOverlay.__intentionallyOverridingVersion or false)
+            );
+          in
+          lib.warnIf warnForBadVersionOverride
             (
-              final:
               let
-                prev = f final;
-                thisOverlay = overlay final prev;
-                warnForBadVersionOverride = (
-                  prev ? src
-                  && thisOverlay ? version
-                  && prev ? version
-                  # We could check that the version is actually distinct, but that
-                  # would probably just delay the inevitable, or preserve tech debt.
-                  # && prev.version != thisOverlay.version
-                  && !(thisOverlay ? src)
-                  && !(thisOverlay.__intentionallyOverridingVersion or false)
-                );
                 pname = args.pname or "<unknown name>";
                 version = args.version or "<unknown version>";
                 pos = builtins.unsafeGetAttrPos "version" thisOverlay;
               in
-              lib.warnIf warnForBadVersionOverride ''
+              ''
                 ${
                   args.name or "${pname}-${version}"
                 } was overridden with `version` but not `src` at ${pos.file or "<unknown file>"}:${
@@ -129,10 +130,22 @@ let
                 })
 
                 (To silence this warning, set `__intentionallyOverridingVersion = true` in your `overrideAttrs` call.)
-              '' (prev // (removeAttrs thisOverlay [ "__intentionallyOverridingVersion" ]))
-            );
-        in
-        makeDerivationExtensible (extends' (lib.toExtension f0) rattrs);
+              ''
+            )
+            (
+              prev
+              // (
+                # The `if` is logically redundant with the `removeAttrs`, but
+                # this way is faster according to Nix stats, and this is a
+                # hotter path now that every pkgs/by-name package calls
+                # `overrideAttrs`.
+                if thisOverlay ? __intentionallyOverridingVersion then
+                  removeAttrs thisOverlay [ "__intentionallyOverridingVersion" ]
+                else
+                  thisOverlay
+              )
+            )
+        );
 
       finalPackage = mkDerivationSimple overrideAttrs args;
 

--- a/pkgs/top-level/by-name-overlay.nix
+++ b/pkgs/top-level/by-name-overlay.nix
@@ -49,6 +49,17 @@ self: super:
   # and whether it's defined by this file here or `all-packages.nix`.
   # TODO: This can be removed once `pkgs/by-name` can handle custom `callPackage` arguments without `all-packages.nix` (or any other way of achieving the same result).
   # Because at that point the code in ./stage.nix can be changed to not allow definitions in `all-packages.nix` to override ones from `pkgs/by-name` anymore and throw an error if that happens instead.
-  _internalCallByNamePackageFile = file: self.callPackage file { };
+  _internalCallByNamePackageFile =
+    file:
+    (self.callPackage file { })
+    # Ensure that even a package that is a simple override of another package
+    # has a position that points to its own file.
+    .overrideAttrs
+      {
+        pos = {
+          file = toString file;
+          line = 1;
+        };
+      };
 }
 // mapAttrs (name: self._internalCallByNamePackageFile) packageFiles


### PR DESCRIPTION
Inspired by #495822, which morally ought to have worked, but of course could not because all the `meta.position`s point to the same file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
