### PR TITLE
home-assistant-custom-components.gtfs-realtime: init at 0.3.2

### DIFF
--- a/pkgs/development/python-modules/gtfs-station-stop/default.nix
+++ b/pkgs/development/python-modules/gtfs-station-stop/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  aiofiles,
+  aiohttp,
+  gtfs-realtime-bindings,
+  requests,
+  freezegun,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytest-httpserver,
+  pytestCheckHook,
+  python-dotenv,
+  syrupy,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "gtfs-station-stop";
+  version = "0.11.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bcpearce";
+    repo = "gtfs-station-stop";
+    tag = finalAttrs.version;
+    hash = "sha256-Z9pOdLXcNGK1ng7qhzg2J7CvSoDIOczN4P5Es5F2cLs=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    aiofiles
+    aiohttp
+    gtfs-realtime-bindings
+    requests
+  ];
+
+  # both are added to deps but not used
+  pythonRemoveDeps = [
+    "asyncio-atexit"
+    "coverage-badge"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  nativeCheckInputs = [
+    freezegun
+    pytest-asyncio
+    pytest-cov-stub
+    pytest-httpserver
+    pytestCheckHook
+    python-dotenv
+    syrupy
+  ];
+
+  pythonImportsCheck = [ "gtfs_station_stop" ];
+
+  meta = {
+    description = "Python library for Reformatting GTFS data for Station Arrivals";
+    homepage = "https://github.com/bcpearce/gtfs-station-stop";
+    changelog = "https://github.com/bcpearce/gtfs-station-stop/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.stepbrobd ];
+  };
+})

--- a/pkgs/servers/home-assistant/custom-components/gtfs-realtime/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/gtfs-realtime/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  gtfs-station-stop,
+  pytest-cov-stub,
+  pytest-freezer,
+  pytest-homeassistant-custom-component,
+  pytestCheckHook,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "bcpearce";
+  domain = "gtfs_realtime";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "bcpearce";
+    repo = "homeassistant-gtfs-realtime";
+    tag = version;
+    hash = "sha256-G3OtDoF+td7IC+zVXJ+c/chdtYMoq6cStZ3dV8eyUZI=";
+  };
+
+  dependencies = [ gtfs-station-stop ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytest-freezer
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # upstream snapshot is stale
+    "test_diagnostics"
+  ];
+
+  ignoreVersionRequirement = [ "gtfs_station_stop" ];
+
+  meta = {
+    changelog = "https://github.com/bcpearce/homeassistant-gtfs-realtime/releases/tag/${src.tag}";
+    description = "GTFS Realtime transit arrivals for Home Assistant";
+    homepage = "https://github.com/bcpearce/homeassistant-gtfs-realtime";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.stepbrobd ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6757,6 +6757,8 @@ self: super: with self; {
 
   gtfs-realtime-bindings = callPackage ../development/python-modules/gtfs-realtime-bindings { };
 
+  gtfs-station-stop = callPackage ../development/python-modules/gtfs-station-stop { };
+
   gto = callPackage ../development/python-modules/gto { };
 
   gtts = callPackage ../development/python-modules/gtts { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

get public transit data on ha dashboard

https://github.com/bcpearce/gtfs-station-stop

https://github.com/bcpearce/homeassistant-gtfs-realtime

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
