### PR TITLE
nixosTests.calibre-web: fix test failure

### DIFF
--- a/nixos/tests/calibre-web.nix
+++ b/nixos/tests/calibre-web.nix
@@ -3,6 +3,7 @@
 let
   port = 3142;
   defaultPort = 8083;
+  libraryPath = "/var/lib/test-books";
 in
 {
   name = "calibre-web";
@@ -16,7 +17,7 @@ in
           enable = true;
           listen.port = port;
           options = {
-            calibreLibrary = "/tmp/books";
+            calibreLibrary = libraryPath;
             reverseProxyAuth = {
               enable = true;
               header = "X-User";
@@ -30,7 +31,7 @@ in
     start_all()
 
     customized.succeed(
-        "mkdir /tmp/books && calibredb --library-path /tmp/books add -e --title test-book"
+        "mkdir -p ${libraryPath} && calibredb --library-path ${libraryPath} add -e --title test-book"
     )
     customized.succeed("systemctl restart calibre-web")
     customized.wait_for_unit("calibre-web.service")


### PR DESCRIPTION
## Things done

The service was hardened by adding PrivateTmp=true in a previous commit 048661b. This broke the test that relied on using a /tmp path created by another process.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
