### PR TITLE
maintainers: remove aborsu

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -470,12 +470,6 @@
     githubId = 908758;
     name = "Abigail Bunyan";
   };
-  aborsu = {
-    email = "a.borsu@gmail.com";
-    github = "aborsu";
-    githubId = 5033617;
-    name = "Augustin Borsu";
-  };
   aboseley = {
     email = "adam.boseley@gmail.com";
     github = "aboseley";

--- a/nixos/modules/services/development/jupyter/default.nix
+++ b/nixos/modules/services/development/jupyter/default.nix
@@ -31,7 +31,6 @@ let
 in
 {
   meta.maintainers = with lib.maintainers; [
-    aborsu
     b-m-f
   ];
 

--- a/pkgs/applications/editors/jupyter/kernel.nix
+++ b/pkgs/applications/editors/jupyter/kernel.nix
@@ -93,7 +93,7 @@ in
       meta = {
         description = "Wrapper to create jupyter notebook kernel definitions";
         homepage = "https://jupyter.org/";
-        maintainers = with lib.maintainers; [ aborsu ];
+        maintainers = [ ];
       };
     };
 }

--- a/pkgs/development/python-modules/ftfy/default.nix
+++ b/pkgs/development/python-modules/ftfy/default.nix
@@ -52,6 +52,6 @@ buildPythonPackage rec {
     mainProgram = "ftfy";
     homepage = "https://github.com/LuminosoInsight/python-ftfy";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ aborsu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/msgpack-numpy/default.nix
+++ b/pkgs/development/python-modules/msgpack-numpy/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "Numpy data type serialization using msgpack";
     homepage = "https://github.com/lebedov/msgpack-numpy";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ aborsu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/murmurhash/default.nix
+++ b/pkgs/development/python-modules/murmurhash/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/explosion/murmurhash";
     changelog = "https://github.com/explosion/murmurhash/releases/tag/release-v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ aborsu ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/thinc/default.nix
+++ b/pkgs/development/python-modules/thinc/default.nix
@@ -76,6 +76,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/explosion/thinc";
     changelog = "https://github.com/explosion/thinc/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ aborsu ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION

## Reasons

- Last commented in [August 2020](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aaborsu)
- Hasn't created any PRs / Issues since [October 2020](https://github.com/NixOS/nixpkgs/issues?q=author%3Aaborsu)
- About 80 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aaborsu%20-commenter%3Aaborsu%20-author%3Aaborsu%20-reviewed-by%3Aaborsu) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.