### PR TITLE
mcelog: migrate to by-name

### DIFF
--- a/pkgs/by-name/mc/mcelog/package.nix
+++ b/pkgs/by-name/mc/mcelog/package.nix
@@ -2,8 +2,12 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  util-linux,
+  util-linuxMinimal,
 }:
+
+let
+  util-linux = util-linuxMinimal;
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mcelog";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1909,10 +1909,6 @@ with pkgs;
 
   xmlsort = perlPackages.XMLFilterSort;
 
-  mcelog = callPackage ../os-specific/linux/mcelog {
-    util-linux = util-linuxMinimal;
-  };
-
   apc-temp-fetch = with python3.pkgs; callPackage ../tools/networking/apc-temp-fetch { };
 
   asciidoc-full = asciidoc.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1705,10 +1705,6 @@ with pkgs;
 
   xmlsort = perlPackages.XMLFilterSort;
 
-  mcelog = callPackage ../os-specific/linux/mcelog {
-    util-linux = util-linuxMinimal;
-  };
-
   asciidoc-full = asciidoc.override {
     enableStandardFeatures = true;
   };


### PR DESCRIPTION
This pull request refactors the packaging of `mcelog` by relocating and simplifying its package definition. The main focus is to streamline how `mcelog` is referenced and remove redundant overrides.

**Package refactoring and simplification:**

* Moved the `mcelog` package definition from `pkgs/os-specific/linux/mcelog/default.nix` to `pkgs/by-name/mc/mcelog/package.nix`, and updated it to use `util-linuxMinimal` by default, removing the need for an explicit override.
* Removed the custom `util-linux` override for `mcelog` from `pkgs/top-level/all-packages.nix`, as it is now handled directly in the package definition.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
