### PR TITLE
[staging-next] onnxruntime: fix build with protobuf 34

### DIFF
--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -143,6 +143,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.alpinelinux.org/alpine/aports/-/raw/462dfe0eb4b66948fe48de44545cc22bb64fdf9f/community/onnxruntime/0001-Remove-MATH_NO_EXCEPT-macro.patch";
       hash = "sha256-BdeGYevZExWWCuJ1lSw0Roy3h+9EbJgFF8qMwVxSn1A=";
     })
+
+    # Fix build of ignored outputs after Protobuf 34 added `[[nodiscard]]` to
+    # many functions.
+    ./protobuf34-nodiscard.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -253,6 +253,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "ABSL_ENABLE_INSTALL" true)
+    # leads to failing builds, which isn't particularly useful for Nixpkgs
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-Wno-error=unused-variable")
     (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
     (lib.cmakeBool "FETCHCONTENT_QUIET" false)
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_ABSEIL_CPP" "${abseil-cpp_202407.src}")

--- a/pkgs/by-name/on/onnxruntime/protobuf34-nodiscard.patch
+++ b/pkgs/by-name/on/onnxruntime/protobuf34-nodiscard.patch
@@ -1,0 +1,101 @@
+diff --git a/onnxruntime/core/framework/graph_partitioner.cc b/onnxruntime/core/framework/graph_partitioner.cc
+index 43caf4766d..fabc2a26a0 100644
+--- a/onnxruntime/core/framework/graph_partitioner.cc
++++ b/onnxruntime/core/framework/graph_partitioner.cc
+@@ -957,7 +957,7 @@
+ 
+     AllocatorPtr allocator = output_buffer_holder->buffer_allocator;
+     IAllocatorUniquePtr<void> buffer = IAllocator::MakeUniquePtr<void>(allocator, buffer_size);
+-    model_proto.SerializeToArray(buffer.get(), static_cast<int>(buffer_size));
++    ORT_RETURN_IF_NOT(model_proto.SerializeToArray(buffer.get(), static_cast<int>(buffer_size)), "Failed to serialize to array");
+ 
+     *output_buffer_holder->buffer_size_ptr = buffer_size;
+     *output_buffer_holder->buffer_ptr = buffer.release();
+@@ -970,7 +970,7 @@
+     auto out_stream_buf = std::make_unique<epctx::OutStreamBuf>(*output_write_func_holder);
+     std::ostream out_stream(out_stream_buf.get());
+ 
+-    model_proto.SerializeToOstream(&out_stream);
++    ORT_RETURN_IF_NOT(model_proto.SerializeToOstream(&out_stream), "Failed to serialize to out stream");
+     out_stream.flush();
+     ORT_RETURN_IF_ERROR(out_stream_buf->GetStatus());
+   } else {
+diff --git a/onnxruntime/python/onnxruntime_pybind_schema.cc b/onnxruntime/python/onnxruntime_pybind_schema.cc
+index cd1d2a8da1..05da1a1447 100644
+--- a/onnxruntime/python/onnxruntime_pybind_schema.cc
++++ b/onnxruntime/python/onnxruntime_pybind_schema.cc
+@@ -169,7 +169,7 @@
+           "_default_value",
+           [](ONNX_NAMESPACE::OpSchema::Attribute* attr) -> py::bytes {
+             std::string out;
+-            attr->default_value.SerializeToString(&out);
++            (void)attr->default_value.SerializeToString(&out);
+             return out;
+           })
+       .def_readonly("required", &ONNX_NAMESPACE::OpSchema::Attribute::required);
+diff --git a/onnxruntime/test/ep_graph/test_ep_graph.cc b/onnxruntime/test/ep_graph/test_ep_graph.cc
+index 7e6d157799..f08b09990d 100644
+--- a/onnxruntime/test/ep_graph/test_ep_graph.cc
++++ b/onnxruntime/test/ep_graph/test_ep_graph.cc
+@@ -232,7 +232,7 @@
+                                                         handle_initializer_data));
+ 
+     std::ofstream ofs(serialized_model_path, std::ios::binary);
+-    model_proto.SerializeToOstream(&ofs);
++    ASSERT_TRUE(model_proto.SerializeToOstream(&ofs));
+     ofs.flush();
+ 
+     ASSERT_TRUE(std::filesystem::exists(serialized_model_path));
+@@ -357,7 +357,7 @@
+                                                         handle_initializer_data));
+ 
+     std::ofstream ofs(serialized_model_path, std::ios::binary);
+-    model_proto.SerializeToOstream(&ofs);
++    ASSERT_TRUE(model_proto.SerializeToOstream(&ofs));
+     ofs.flush();
+ 
+     ASSERT_TRUE(std::filesystem::exists(serialized_model_path));
+@@ -487,7 +487,7 @@
+                                                         handle_initializer_data));
+ 
+     std::ofstream ofs(serialized_model_path, std::ios::binary);
+-    model_proto.SerializeToOstream(&ofs);
++    ASSERT_TRUE(model_proto.SerializeToOstream(&ofs));
+     ofs.flush();
+ 
+     ASSERT_TRUE(std::filesystem::exists(serialized_model_path));
+@@ -552,7 +552,7 @@
+     ASSERT_CXX_ORTSTATUS_OK(OrtEpUtils::OrtGraphToProto(test_graph->GetOrtGraph(), model_proto));
+ 
+     std::ofstream ofs(serialized_model_path, std::ios::binary);
+-    model_proto.SerializeToOstream(&ofs);
++    ASSERT_TRUE(model_proto.SerializeToOstream(&ofs));
+     ofs.flush();
+ 
+     ASSERT_TRUE(std::filesystem::exists(serialized_model_path));
+diff --git a/onnxruntime/test/optimizer/graph_transform_test_builder.cc b/onnxruntime/test/optimizer/graph_transform_test_builder.cc
+index 756cc4159e..8323851385 100644
+--- a/onnxruntime/test/optimizer/graph_transform_test_builder.cc
++++ b/onnxruntime/test/optimizer/graph_transform_test_builder.cc
+@@ -158,7 +158,7 @@
+ 
+   // Serialize the model to a string.
+   std::string model_data;
+-  model.ToProto().SerializeToString(&model_data);
++  ASSERT_TRUE(model.ToProto().SerializeToString(&model_data));
+   std::shared_ptr<IExecutionProvider> ep_shared = ep ? std::move(ep) : nullptr;
+ 
+   auto run_model = [&](TransformerLevel level, std::vector<OrtValue>& fetches,
+diff --git a/onnxruntime/test/optimizer/nchwc_optimizer_test.cc b/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
+index 538f600404..111692d4ca 100644
+--- a/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
++++ b/onnxruntime/test/optimizer/nchwc_optimizer_test.cc
+@@ -185,7 +185,7 @@
+ 
+   // Serialize the model to a string.
+   std::string model_data;
+-  model.ToProto().SerializeToString(&model_data);
++  ASSERT_TRUE(model.ToProto().SerializeToString(&model_data));
+ 
+   auto run_model = [&](TransformerLevel level, std::vector<OrtValue>& fetches) {
+     SessionOptions session_options;


### PR DESCRIPTION
...and downgrade unused variable errors to warnings.

Protobuf 34 introduces `[[nodiscard]]` on many functions which leads to compilation errors due to `-Werror`. Accordingly, we patch in some checks to make sure the result of Protobuf serialization calls is `true` (as this signifies success). This patch isn't particularly pretty, but when I took a glance, I couldn't find changes from upstream or other distros with similar fixes. Alternatives: pass `-Wno-error` for this, downgrade to `protobuf_33`.

Additionally, several build failures have appeared as a result of `-Werror=unused-variable`, which is rather useless to Nixpkgs as a downstream of onnxruntime. We downgrade them to non-fatal warnings accordingly. Alternative: patch them out instead of just ignoring.

I'm no expert on this ecosystem, C++, or basically anything else involved; this is just my attempt at fixing these build failures I encountered. From what I can tell, an update to the latest release would still not resolve these issues. If there are better approaches, please feel free to let me know / take that alternative in another PR. :)

Failing Hydra builds (Darwin has not yet built due to OpenBLAS failures):
- x86_64-linux: https://hydra.nixos.org/build/323743839
- aarch64-linux: https://hydra.nixos.org/build/323743837

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
