### PR TITLE
nixos/btrbk: add setting for CLI options

### DIFF
--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -11,7 +11,6 @@ let
     concatMapStringsSep
     concatStringsSep
     filterAttrs
-    flatten
     getAttr
     isAttrs
     literalExpression
@@ -184,6 +183,24 @@ in
                   How often this btrbk instance is started. See {manpage}`systemd.time(7)` for more information about the format.
                   Setting it to null disables the timer, thus this instance can only be started manually.
                 '';
+              };
+              options = mkOption {
+                description = ''
+                  Command line options to pass to {command}`btrbk`. See {manpage}`btrbk(1)` for the available
+                  options.
+                '';
+                example = {
+                  format = "table";
+                  preserve = true;
+                };
+                default = { };
+                type =
+                  with types;
+                  attrsOf (oneOf [
+                    bool
+                    int
+                    str
+                  ]);
               };
               snapshotOnly = mkOption {
                 type = types.bool;
@@ -365,9 +382,13 @@ in
           User = "btrbk";
           Group = "btrbk";
           Type = "oneshot";
-          ExecStart = "${pkgs.btrbk}/bin/btrbk -c /etc/btrbk/${name}.conf ${
-            if instance.snapshotOnly then "snapshot" else "run"
-          }";
+          ExecStart = lib.concatStringsSep " " (
+            [
+              "${pkgs.btrbk}/bin/btrbk -c /etc/btrbk/${name}.conf"
+              (if instance.snapshotOnly then "snapshot" else "run")
+            ]
+            ++ lib.optional (instance.options != { }) (lib.cli.toCommandLineShellGNU { } instance.options)
+          );
           Nice = cfg.niceness;
           IOSchedulingClass = cfg.ioSchedulingClass;
           StateDirectory = "btrbk";


### PR DESCRIPTION

Currently, the CLI options that are passed to `btrbk` are fixed. This commit adds the `services.btrbk.instances.<name>.options` option to specify additional CLI options.

This is e.g. important if your target disk is offline, in which case you want to set not only `snapshotOnly = true` but also `options.preserve-snapshots = true`. Otherwise, the service fails in the snapshot deletion phase.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
