### PR TITLE
knot-resolver-manager_6: include `watchdog`

### DIFF
--- a/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
@@ -41,10 +41,10 @@ python3Packages.buildPythonPackage {
     aiohttp
     jinja2
     pyyaml
-    prometheus-client
+    prometheus-client # optional, for prometheus metrics
     supervisor
     typing-extensions
-    watchdog
+    watchdog # optional, watching changes in files (TLS certs, RPZs)
   ];
 
   # set up (additional) Lua dependencies

--- a/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver-manager_6/package.nix
@@ -44,6 +44,7 @@ python3Packages.buildPythonPackage {
     prometheus-client
     supervisor
     typing-extensions
+    watchdog
   ];
 
   # set up (additional) Lua dependencies


### PR DESCRIPTION
Upstream it is listed as an optional python dependency, alongside prometheus-client:
https://github.com/CZ-NIC/knot-resolver/blob/e16aea363f6d2ca39c8a3713f42f21297b72a078/pyproject.toml#L41

It is required when using `network.tls.watchdog=true` in the settings: https://www.knot-resolver.cz/documentation/latest/config-network-server-tls.html#cmdoption-arg-files-watchdog

```
[ERROR]   stderr) Configuration validation error detected:
[ERROR]   stderr)         [/network/tls] 'files-watchdog' is enabled, but the required 'watchdog' dependency (optional) is not installed
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
