### PR TITLE
nixos/nfs: fixup NFS tests

### DIFF
--- a/nixos/tests/nfs/simple.nix
+++ b/nixos/tests/nfs/simple.nix
@@ -18,7 +18,21 @@ import ../make-test-python.nix (
             options = [ "vers=${toString version}" ];
           };
         };
-        networking.firewall.enable = false; # FIXME: only open statd
+        services.nfs.settings = {
+          statd.port = 4000;
+          lockd.port = 4001;
+          lockd.udp-port = 4001;
+        };
+        networking.firewall.allowedTCPPorts = [
+          111
+          4000
+          4001
+        ];
+        networking.firewall.allowedUDPPorts = [
+          111
+          4000
+          4001
+        ];
       };
 
   in
@@ -41,7 +55,23 @@ import ../make-test-python.nix (
             /data 192.168.1.0/255.255.255.0(rw,no_root_squash,no_subtree_check,fsid=0)
           '';
           services.nfs.server.createMountPoints = true;
-          networking.firewall.enable = false; # FIXME: figure out what ports need to be allowed
+          services.nfs.server.mountdPort = 4002;
+          services.nfs.server.statdPort = 4000;
+          services.nfs.server.lockdPort = 4001;
+          networking.firewall.allowedTCPPorts = [
+            111
+            2049
+            4000
+            4001
+            4002
+          ];
+          networking.firewall.allowedUDPPorts = [
+            111
+            2049
+            4000
+            4001
+            4002
+          ];
         };
     };
 

--- a/nixos/tests/nfs/simple.nix
+++ b/nixos/tests/nfs/simple.nix
@@ -85,7 +85,7 @@ import ../make-test-python.nix (
 
       with subtest("locks survive server reboot"):
           client1.wait_for_unit("data.mount")
-          server.shutdown()
+          server.crash()
           server.start()
           client1.succeed("touch /data/xyzzy")
           client1.fail("time flock -n -s /data/lock true")


### PR DESCRIPTION
## Things done

The tests were overall broken due to some semantics of lock recovery being tested, during a clean shutdown locks are dropped so this test should be crashing the server. In addition, I fixed a FIXME around firewall ports used in the test.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
