### PR TITLE
python3Packages.torchcodec: 0.9.1 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/torchcodec/default.nix
+++ b/pkgs/development/python-modules/torchcodec/default.nix
@@ -24,16 +24,16 @@
   cudaSupport ? config.cudaSupport,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "torchcodec";
-  version = "0.9.1";
+  version = "0.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "meta-pytorch";
     repo = "torchcodec";
-    tag = "v${version}";
-    hash = "sha256-HyEv3WVCnFSl+hpF2Kj/5yb5zkvI3ToyD4/oSkD47LQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2uo2HtA5hh8s7F1Z8SS78bMwyOvw2H2j4p0Znan552I=";
   };
 
   postPatch = ''
@@ -48,6 +48,11 @@ buildPythonPackage rec {
       --replace-fail \
         '"ffmpeg"' \
         '"${lib.getExe ffmpeg}"'
+
+    substituteInPlace test/test_transform_ops.py \
+      --replace-fail \
+        'ffmpeg_cli = "ffmpeg"' \
+        'ffmpeg_cli = "${lib.getExe ffmpeg}"'
   '';
 
   nativeBuildInputs = [
@@ -146,6 +151,7 @@ buildPythonPackage rec {
       "test_contiguit"
       "test_crf_valid_value"
       "test_encode_to_tensor_long_outpu"
+      "test_num_channels"
       "test_round_trip"
       "test_video_encoder_against_ffmpeg_cli"
       "test_video_encoder_round_trip"
@@ -159,8 +165,8 @@ buildPythonPackage rec {
   meta = {
     description = "PyTorch media decoding and encoding";
     homepage = "https://github.com/meta-pytorch/torchcodec";
-    changelog = "https://github.com/meta-pytorch/torchcodec/releases/tag/${src.tag}";
+    changelog = "https://github.com/meta-pytorch/torchcodec/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/meta-pytorch/torchcodec/compare/v0.9.1...v0.10.0
Changelog: https://github.com/meta-pytorch/torchcodec/releases/tag/v0.10.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test