### PR TITLE
nvibrant: 1.1.0 -> 1.2.0-unstable-595.58.03

### DIFF
--- a/pkgs/by-name/nv/nvibrant/hatch_build.patch
+++ b/pkgs/by-name/nv/nvibrant/hatch_build.patch
@@ -1,0 +1,76 @@
+diff --git a/hatch_build.py b/hatch_build.py
+index 036079a..fa2275e 100644
+--- a/hatch_build.py
++++ b/hatch_build.py
+@@ -1,6 +1,5 @@
+ import os
+ import subprocess
+-import sys
+ from pathlib import Path
+ from tempfile import TemporaryDirectory
+ 
+@@ -58,28 +57,27 @@ class BuildHook(BuildHookInterface):
+ 
+         # Configure the project
+         subprocess.check_call((
+-            sys.executable, "-m", "mesonbuild.mesonmain",
+-            "setup", Dirs.build,
++            "meson", "setup", Dirs.build,
+             "--buildtype", "release",
+             "--reconfigure", "--wipe",
+         ), cwd=Dirs.repository)
+ 
+         # Make binaries for all known driver version
+         for driver in subprocess.check_output(
+-            ("git", "tag"), cwd=Dirs.opengpu
++            ("cat", "./SOURCE_TAGS"), cwd=Dirs.opengpu
+         ).decode().strip().splitlines():
+ 
+             # Checkout driver version
+-            subprocess.check_call(
+-                ("git", "checkout", "-f", driver),
+-                cwd=Dirs.opengpu,
+-            )
++            if driver != os.environ["OLDEST_DRIVER_VERSION"]:
++                subprocess.check_call(
++                    ("git", "apply", f"./PATCHES/{driver}.patch"),
++                    cwd=Dirs.opengpu,
++                )
+ 
+             # Compile an executable
+-            subprocess.check_call((
+-                sys.executable, "-m", "ninja",
+-                "-C", Dirs.build,
+-            ))
++            subprocess.check_call(
++                ("ninja", "-C", Dirs.build)
++            )
+ 
+             # Find and vendor the binary for this version
+             binary = Dirs.build.joinpath("nvibrant")
+@@ -90,25 +88,3 @@ class BuildHook(BuildHookInterface):
+ 
+             # Include in the wheel
+             build["force_include"][str(target)] = f"nvibrant/resources/{target.name}"
+-
+-        # Revert back main branch
+-        subprocess.check_call(
+-            ("git", "checkout", "-f", "main"),
+-            cwd=Dirs.opengpu
+-        )
+-
+-# --------------------------------------------------------------------------- #
+-
+-if __name__ == '__main__':
+-
+-    # Intended operation
+-    subprocess.check_call(
+-        ("git", "config", "advice.detachedHead", "false"),
+-        cwd=Dirs.opengpu,
+-    )
+-
+-    environ = os.environ.copy()
+-    subprocess.check_call(
+-        args=("uv", "build", "--wheel", "-o", Dirs.dist),
+-        cwd=Dirs.repository,
+-    )

--- a/pkgs/by-name/nv/nvibrant/package.nix
+++ b/pkgs/by-name/nv/nvibrant/package.nix
@@ -1,38 +1,152 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
-  meson,
-  ninja,
-  pkg-config,
+  python3Packages,
+  writeShellScript,
+  common-updater-scripts,
+  coreutils,
+  gitMinimal,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "nvibrant";
-  version = "1.1.0";
+  version = finalAttrs.passthru._version;
+  pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "Tremeschin";
-    repo = "nvibrant";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-RZIi1V3hcwZdaI84Nd0YSQOjDng9/ZDg7aqfTL7GJIU=";
-    fetchSubmodules = true;
+  passthru = {
+    nvibrantVersion = "1.2.0";
+
+    oldestDriverVersion = "515.43.04";
+    latestDriverVersion = "595.58.03";
+
+    _version = lib.concatStringsSep "-" [
+      finalAttrs.passthru.nvibrantVersion
+      "unstable"
+      finalAttrs.passthru.latestDriverVersion
+    ];
+
+    srcAttrs = {
+      nvibrant = fetchFromGitHub {
+        owner = "tremeschin";
+        repo = "nvibrant";
+        name = "nvibrant";
+        tag = "v${finalAttrs.passthru.nvibrantVersion}";
+        hash = "sha256-OQo+VGWz8LNpsCdXbJXWWCrnVE0+t4s220uJ+pTHVKs=";
+      };
+      open-gpu = fetchFromGitHub {
+        owner = "nvidia";
+        repo = "open-gpu-kernel-modules";
+        name = "open-gpu";
+        tag = finalAttrs.passthru.oldestDriverVersion;
+        hash = "sha256-pSVK5oVob4QBo18ULHnQfO3UrTcC5lDDrTR9ec9pDp8=";
+
+        # since .git isn't deterministic, we can't use it to checkout tags in
+        # the build phase, so instead we generate patches for each version
+        # upgrade before .git is removed and apply them incrementally
+        fetchTags = true;
+        postCheckout = ''
+          cd $out
+
+          while IFS= read -r tag; do
+            echo "adding $tag"
+            echo "$tag" >> SOURCE_TAGS
+
+            if [[ "$tag" == ${finalAttrs.passthru.latestDriverVersion} ]]; then
+              echo 'reached end of known tags'
+              break
+            fi
+          done < <(git tag --sort v:refname)
+
+          mkdir PATCHES
+
+          prev_tag=${finalAttrs.passthru.oldestDriverVersion}
+          while IFS= read -r tag; do
+            if [ "$prev_tag" == "$tag" ]; then continue; fi
+
+            echo "generating patch: $prev_tag -> $tag"
+            git diff --minimal --binary "$prev_tag" "$tag" \
+              > "PATCHES/$tag.patch"
+
+            prev_tag=$tag
+          done < SOURCE_TAGS
+          unset prev_tag
+
+          rm -rf .git
+        '';
+      };
+    };
+
+    updateScript = writeShellScript "update-nvibrant" ''
+      set -euo pipefail
+
+      export PATH="${
+        lib.makeBinPath [
+          common-updater-scripts
+          coreutils
+          gitMinimal
+        ]
+      }:$PATH"
+
+      list_tags() {
+        git ls-remote --tags --sort v:refname --refs "$1" |
+          cut --delimiter=/ --field=3-
+      }
+
+      readarray -t nvibrant_tags < <(list_tags \
+        'https://github.com/tremeschin/nvibrant.git')
+
+      readarray -t open_gpu_tags < <(list_tags \
+        'https://github.com/nvidia/open-gpu-kernel-modules.git')
+
+      update-source-version nvibrant "''${nvibrant_tags[-1]:1}" \
+        --version-key=nvibrantVersion --source-key=srcAttrs.nvibrant \
+        --ignore-same-hash --ignore-same-version
+
+      update-source-version nvibrant "''${open_gpu_tags[0]}" \
+        --version-key=oldestDriverVersion --source-key=srcAttrs.open-gpu \
+        --ignore-same-hash --ignore-same-version
+
+      update-source-version nvibrant "''${open_gpu_tags[-1]}" \
+        --version-key=latestDriverVersion --source-key=srcAttrs.open-gpu \
+        --ignore-same-hash --ignore-same-version
+    '';
   };
 
-  nativeBuildInputs = [
+  srcs = lib.attrValues finalAttrs.passthru.srcAttrs;
+  sourceRoot = ".";
+
+  postUnpack = ''
+    mv open-gpu nvibrant/
+    cd nvibrant
+  '';
+
+  # replaces code that depends on .git and uses of python -m {ninja,meson}
+  patches = [ ./hatch_build.patch ];
+
+  configurePhase = ''
+    export OLDEST_DRIVER_VERSION=${finalAttrs.passthru.oldestDriverVersion}
+  '';
+
+  nativeBuildInputs = [ gitMinimal ];
+
+  build-system = with python3Packages; [
+    hatchling
     meson
     ninja
-    pkg-config
   ];
 
-  mesonBuildType = "release";
+  dependencies = with python3Packages; [
+    packaging
+  ];
 
-  meta = with lib; {
+  meta = {
     description = "Configure NVIDIA's Digital Vibrance on Wayland";
     homepage = "https://github.com/Tremeschin/nvibrant";
-    license = licenses.gpl3Only;
-    maintainers = [ maintainers.mikaeladev ];
-    platforms = [ "x86_64-linux" ];
     mainProgram = "nvibrant";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      mikaeladev
+    ];
   };
 })


### PR DESCRIPTION
TL;DR: Overhauls the build script following breakage on driver `595.44.02`.

Previously nixpkgs would ship only a single binary built from the latest nvidia driver, which would cause problems if the host system was running a significantly older or newer driver version.

Upstream's solution to this is to build multiple binaries for each driver version and have a python script select which one to use at runtime. I've adapted the build script to implement this and added an update script to ensure that it's always built with the latest drivers.

However, herein lies a problem. Upstream expects distributors to rebuild when a new driver comes out, but, as long as nothing breaks, the upstream package version doesn't change. This is bad, so I've updated the versioning to include the driver version it was built up to.

Apart from all that, this also adds `aarch64-linux` as a supported platform thanks to changes with the upstream build-system.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
