### PR TITLE
xephem: 4.2.0 -> 4.3.0, fix build, move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/xe/xephem/package.nix
+++ b/pkgs/by-name/xe/xephem/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   makeDesktopItem,
   copyDesktopItems,
   installShellFiles,
@@ -16,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xephem";
-  version = "4.2.0";
+  version = "4.3.0";
 
   src = fetchFromGitHub {
     owner = "XEphem";
     repo = "XEphem";
-    rev = finalAttrs.version;
-    hash = "sha256-TuzXrWoJOAHg31DrJObPcHBXgtqR/KWKFRsqddPzL4c=";
+    tag = finalAttrs.version;
+    hash = "sha256-zWINscuRO7k/q3u1hngcIkfOpxX75HUxxB2X41igdBg=";
   };
 
   nativeBuildInputs = [
@@ -40,11 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    # fix compile error with GCC 14
-    (fetchpatch {
-      url = "https://github.com/XEphem/XEphem/commit/30e14f685ede015fcd8985cd83ee6510f93f0073.patch";
-      hash = "sha256-wNoLjR6xEl56ZA6FLBS2xtySeDEYXTCA8j4Z5JIrF6k=";
-    })
     ./add-cross-compilation-support.patch
   ];
 
@@ -52,6 +46,10 @@ stdenv.mkDerivation (finalAttrs: {
     cd GUI/xephem
     substituteInPlace xephem.c splash.c --replace-fail '/etc/XEphem' '${placeholder "out"}/etc/XEphem'
   '';
+
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
+  enableParallelBuilding = true;
 
   doCheck = true;
 

--- a/pkgs/by-name/xe/xephem/package.nix
+++ b/pkgs/by-name/xe/xephem/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir $out/etc
     echo "XEphem.ShareDir: $out/share/xephem" > $out/etc/XEphem
     installManPage xephem.1
-    install -Dm644 XEphem.png -t $out/share/pixmaps
+    install -Dm644 XEphem.png -t $out/share/icons/hicolor/128x128/apps
     runHook postInstall
   '';
 


### PR DESCRIPTION
Fix build with compile flags
Part of #428824 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
