### PR TITLE
gh-enhance: init at 0.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22641,6 +22641,12 @@
     githubId = 3302;
     name = "Renzo Carbonara";
   };
+  replicapra = {
+    name = "replicapra";
+    github = "replicapra";
+    githubId = 154707993;
+    email = "nixpkgs@replicapra.dev";
+  };
   repparw = {
     email = "ubritos@gmail.com";
     github = "repparw";

--- a/pkgs/by-name/gh/gh-enhance/package.nix
+++ b/pkgs/by-name/gh/gh-enhance/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  installShellFiles,
+  stdenv,
+  writableTmpDirAsHomeHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "gh-enhance";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "dlvhdr";
+    repo = "gh-enhance";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-IHtI8wnPLMkqxdBFXqkt6inYMOIqKjdTKdZbTxIhPzo=";
+  };
+
+  vendorHash = "sha256-rgql0vsHAzWeubw4EYBu/yPmm2QeADsIeACWsbcWtSk=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/dlvhdr/gh-enhance/cmd.Version=${finalAttrs.version}"
+  ];
+
+  checkFlags = [
+    # requires network
+    "-skip=TestFullOutput"
+  ];
+
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+  doInstallCheck = true;
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd gh-enhance \
+      --bash <($out/bin/gh-enhance completion bash) \
+      --fish <($out/bin/gh-enhance completion fish) \
+      --zsh <($out/bin/gh-enhance completion zsh)
+  '';
+  meta = {
+    changelog = "https://github.com/dlvhdr/gh-enhance/releases/tag/${finalAttrs.src.rev}";
+    description = "Terminal UI for GitHub Actions";
+    homepage = "https://www.gh-dash.dev/enhance";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ replicapra ];
+    mainProgram = "gh-enhance";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

## add new package gh-enhance
A new gh cli extesion by the same dev as 'gh-dash', described as 'A Blazingly Fast Terminal UI for GitHub Actions'
[homepage](https://www.gh-dash.dev/enhance)
[github repo](https://github.com/dlvhdr/gh-enhance)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
