### PR TITLE
ngn-k: update package and allow usage on all architectures on linux and freebsd

### DIFF
--- a/pkgs/by-name/ng/ngn-k/package.nix
+++ b/pkgs/by-name/ng/ngn-k/package.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation {
     "libk.so"
   ];
   checkTarget = "t";
+  doCheck = true;
 
   outputs = [
     "out"

--- a/pkgs/by-name/ng/ngn-k/package.nix
+++ b/pkgs/by-name/ng/ngn-k/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation {
   pname = "ngn-k";
-  version = "0-unstable-2025-01-04";
+  version = "0-unstable-2025-11-17";
 
   src = fetchFromCodeberg {
     owner = "ngn";
     repo = "k";
-    rev = "feb51a61443dac03213c4e97edd8df679a4a3aaa";
-    sha256 = "14v2bwbgaxi1rsq5xabp5dmv0bl0vga3lhzwdxyvsyl9q7qybf55";
+    rev = "717063f24921d5aff405a39cf7643efedb5bb365";
+    hash = "sha256-rUMi+VetQc139PjbFJXlSkmYEuK5wtM6LpQ/f1tcB1s=";
   };
 
   patches = [

--- a/pkgs/by-name/ng/ngn-k/package.nix
+++ b/pkgs/by-name/ng/ngn-k/package.nix
@@ -58,9 +58,6 @@ stdenv.mkDerivation {
     homepage = "https://codeberg.org/ngn/k";
     license = lib.licenses.agpl3Only;
     maintainers = [ lib.maintainers.sternenseemann ];
-    platforms = [
-      "x86_64-linux"
-      "x86_64-freebsd"
-    ];
+    platforms = lib.platforms.linux ++ lib.platforms.freebsd;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
