### PR TITLE
shinestacker: init at 1.16.2

### DIFF
--- a/pkgs/by-name/sh/shinestacker/package.nix
+++ b/pkgs/by-name/sh/shinestacker/package.nix
@@ -16,9 +16,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-GDX2Aotw5PmpZylACEA0PTjTNY/Hv1W+l4v6wMTe6hE=";
   };
 
-  build-system = [
-    python3.pkgs.setuptools
-    python3.pkgs.setuptools-scm
+  build-system = with python3.pkgs; [
+    setuptools
+    setuptools-scm
   ];
 
   dependencies = with python3.pkgs; [

--- a/pkgs/by-name/sh/shinestacker/package.nix
+++ b/pkgs/by-name/sh/shinestacker/package.nix
@@ -38,12 +38,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     tqdm
   ];
 
-  optional-dependencies = with python3.pkgs; {
-    dev = [
-      pytest
-    ];
-  };
-
   pythonImportsCheck = [
     "shinestacker"
   ];

--- a/pkgs/by-name/sh/shinestacker/package.nix
+++ b/pkgs/by-name/sh/shinestacker/package.nix
@@ -34,7 +34,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     pyside6
     rawpy
     scipy
-    setuptools-scm
     tifffile
     tqdm
   ];

--- a/pkgs/by-name/sh/shinestacker/package.nix
+++ b/pkgs/by-name/sh/shinestacker/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "shinestacker";
+  version = "1.14.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "lucalista";
+    repo = "shinestacker";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GDX2Aotw5PmpZylACEA0PTjTNY/Hv1W+l4v6wMTe6hE=";
+  };
+
+  build-system = [
+    python3.pkgs.setuptools
+    python3.pkgs.setuptools-scm
+  ];
+
+  dependencies = with python3.pkgs; [
+    imagecodecs
+    ipywidgets
+    jsonpickle
+    matplotlib
+    numpy
+    opencv-python-headless
+    pillow
+    psdtags
+    psutil
+    pyside6
+    rawpy
+    scipy
+    setuptools-scm
+    tifffile
+    tqdm
+  ];
+
+  optional-dependencies = with python3.pkgs; {
+    dev = [
+      pytest
+    ];
+  };
+
+  pythonImportsCheck = [
+    "shinestacker"
+  ];
+
+  meta = {
+    description = "Focus stacking code";
+    homepage = "https://github.com/lucalista/shinestacker";
+    changelog = "https://github.com/lucalista/shinestacker/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ paperdigits ];
+    mainProgram = "shinestacker";
+  };
+})

--- a/pkgs/by-name/sh/shinestacker/package.nix
+++ b/pkgs/by-name/sh/shinestacker/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  python314,
+  fetchFromGitHub,
+}:
+
+python314.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "shinestacker";
+  version = "1.16.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "lucalista";
+    repo = "shinestacker";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Rm9Mmn0k95kwtLy26iiz3mmRYs3c2ir3WUawrzr+2P4=";
+  };
+
+  build-system = with python314.pkgs; [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = with python314.pkgs; [
+    imagecodecs
+    ipywidgets
+    jsonpickle
+    matplotlib
+    numpy
+    opencv-python-headless
+    pillow
+    psdtags
+    psutil
+    pyside6
+    rawpy
+    scipy
+    tifffile
+    tqdm
+  ];
+
+  pythonImportsCheck = [
+    "shinestacker"
+  ];
+
+  nativeCheckInputs = with python314.pkgs; [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    "tests/test_1020_gui_images.py"
+    "tests/test_1030_gui_logging.py"
+    "tests/test_1040_action_config.py"
+    "tests/test_1060_gui_run.py"
+    "tests/test_0004_app_config.py"
+    "tests/test_0090_vignetting.py"
+    "tests/test_0040_balance.py"
+    "tests/test_0030_align.py"
+    "tests/test_0020_noise_detection.py"
+  ];
+
+  meta = {
+    description = "Focus stacking code";
+    homepage = "https://github.com/lucalista/shinestacker";
+    changelog = "https://github.com/lucalista/shinestacker/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ paperdigits ];
+    mainProgram = "shinestacker";
+  };
+})

--- a/pkgs/development/python-modules/pdstags
+++ b/pkgs/development/python-modules/pdstags
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  numpy,
+  imagecodecs,
+  matplotlib,
+  tifffile,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "psdtags";
+  version = "2026.1.29";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-IzEX02BICa051sUrGKpL7+/BUkd4F2sWmO8IDD3cKP4=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  optional-dependencies = {
+    all = [
+      imagecodecs
+      matplotlib
+      tifffile
+    ];
+  };
+
+  pythonImportsCheck = [
+    "psdtags"
+  ];
+
+  meta = {
+    description = "Read and write layered TIFF ImageSourceData and ImageResources tags";
+    homepage = "https://pypi.org/project/psdtags";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ];
+  };
+})

--- a/pkgs/development/python-modules/psdtags/default.nix
+++ b/pkgs/development/python-modules/psdtags/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  numpy,
+  imagecodecs,
+  matplotlib,
+  tifffile,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "psdtags";
+  version = "2026.1.29";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-IzEX02BICa051sUrGKpL7+/BUkd4F2sWmO8IDD3cKP4=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  optional-dependencies = {
+    all = [
+      imagecodecs
+      matplotlib
+      tifffile
+    ];
+  };
+
+  pythonImportsCheck = [
+    "psdtags"
+  ];
+
+  meta = {
+    description = "Read and write layered TIFF ImageSourceData and ImageResources tags";
+    homepage = "https://pypi.org/project/psdtags";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ paperdigits ];
+  };
+})

--- a/pkgs/development/python-modules/psdtags/default.nix
+++ b/pkgs/development/python-modules/psdtags/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Read and write layered TIFF ImageSourceData and ImageResources tags";
-    homepage = "https://pypi.org/project/psdtags";
+    homepage = "https://github.com/cgohlke/psdtags";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ paperdigits ];
   };

--- a/pkgs/development/python-modules/psdtags/default.nix
+++ b/pkgs/development/python-modules/psdtags/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  numpy,
+  imagecodecs,
+  matplotlib,
+  tifffile,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "psdtags";
+  version = "2026.1.29";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-IzEX02BICa051sUrGKpL7+/BUkd4F2sWmO8IDD3cKP4=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  optional-dependencies = {
+    all = [
+      imagecodecs
+      matplotlib
+      tifffile
+    ];
+  };
+
+  pythonImportsCheck = [
+    "psdtags"
+  ];
+
+  meta = {
+    description = "Read and write layered TIFF ImageSourceData and ImageResources tags";
+    homepage = "https://github.com/cgohlke/psdtags";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ paperdigits ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12949,6 +12949,8 @@ self: super: with self; {
 
   psd-tools = callPackage ../development/python-modules/psd-tools { };
 
+  psdtags = callPackage ../development/python-modules/psdtags { };
+
   psnawp = callPackage ../development/python-modules/psnawp { };
 
   psrpcore = callPackage ../development/python-modules/psrpcore { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14084,6 +14084,8 @@ self: super: with self; {
 
   psd-tools = callPackage ../development/python-modules/psd-tools { };
 
+  psdtags = callPackage ../development/python-modules/psdtags { };
+
   psnawp = callPackage ../development/python-modules/psnawp { };
 
   psrpcore = callPackage ../development/python-modules/psrpcore { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package shinestacker

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
