### PR TITLE
dovecot: add mysql-config dependency

### DIFF
--- a/pkgs/by-name/do/dovecot/generic.nix
+++ b/pkgs/by-name/do/dovecot/generic.nix
@@ -6,6 +6,7 @@
 {
   stdenv,
   lib,
+  buildPackages,
   fetchzip,
   flex,
   bison,
@@ -53,7 +54,20 @@
   withLua ? false,
   lua5_3,
 }:
-
+let
+  # The `nativeBuildInputs` version of `mysql_config` emits headers and libraries for
+  # the build platform, not the host platform; `pkg-config` emits the correct versions.
+  fake_mysql_config = buildPackages.writeShellScriptBin "mysql_config" ''
+    if [ "$1" == "--include" ]; then
+      "$PKG_CONFIG" --cflags mysqlclient
+    elif [ "$1" == "--libs" ]; then
+      "$PKG_CONFIG" --libs mysqlclient
+    else
+      echo "fake_mysql_config: unsupported option: $1" >&2
+      exit 1
+    fi
+  '';
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dovecot";
   inherit version;
@@ -64,6 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     perl
     pkg-config
   ]
+  ++ lib.optional (withMySQL && lib.versionOlder version "2.4") fake_mysql_config
   ++ lib.optionals (stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isDarwin) [ rpcsvc-proto ];
 
   buildInputs = [

--- a/pkgs/by-name/do/dovecot/generic.nix
+++ b/pkgs/by-name/do/dovecot/generic.nix
@@ -7,6 +7,7 @@
   autoreconfHook,
   stdenv,
   lib,
+  buildPackages,
   fetchzip,
   flex,
   bison,
@@ -54,7 +55,20 @@
   withLua ? false,
   lua5_3,
 }:
-
+let
+  # The `nativeBuildInputs` version of `mysql_config` emits headers and libraries for
+  # the build platform, not the host platform; `pkg-config` emits the correct versions.
+  fake_mysql_config = buildPackages.writeShellScriptBin "mysql_config" ''
+    if [ "$1" == "--include" ]; then
+      "$PKG_CONFIG" --cflags mysqlclient
+    elif [ "$1" == "--libs" ]; then
+      "$PKG_CONFIG" --libs mysqlclient
+    else
+      echo "fake_mysql_config: unsupported option: $1" >&2
+      exit 1
+    fi
+  '';
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dovecot";
   inherit version;
@@ -66,7 +80,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isDarwin) [ rpcsvc-proto ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ autoreconfHook ];
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ autoreconfHook ]
+  ++ lib.optional (withMySQL && lib.versionOlder version "2.4") fake_mysql_config;
 
   buildInputs = [
     openssl


### PR DESCRIPTION
The build of `dovecot` fails if `withMySQL` is set to `true` due to the build time tool `mysql_config` being missing. Thus, this dependency has been added.

Note that the `mysql_config` script is not cross aware, thus a `fake_mysql_config` script is used that uses `pkg-config` to obtain the correct variant of libraries and headers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
