### PR TITLE
nixos/p2pool: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -10,6 +10,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [p2pool](https://p2pool.io/), a decentralized pool for Monero mining. Available as [services.p2pool](#opt-services.p2pool.enable).
+
 - [Meshtastic](https://meshtastic.org), an open-source, off-grid, decentralised mesh network
   designed to run on affordable, low-power devices. Available as [services.meshtasticd]
   (#opt-services.meshtasticd.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -919,6 +919,7 @@
   ./services/misc/osrm.nix
   ./services/misc/overseerr.nix
   ./services/misc/owncast.nix
+  ./services/misc/p2pool.nix
   ./services/misc/packagekit.nix
   ./services/misc/paisa.nix
   ./services/misc/paperless.nix

--- a/nixos/modules/services/misc/p2pool.nix
+++ b/nixos/modules/services/misc/p2pool.nix
@@ -1,0 +1,253 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.p2pool;
+
+  # Generate the params file content.
+  # Format: "param-name = value" or "param-name = 1" for booleans.
+  # Strings with spaces need quotes.
+  configLines = lib.concatStringsSep "\n" (
+    lib.filter (x: x != "") [
+      "wallet = ${cfg.wallet}"
+      "host = ${cfg.host}"
+      "rpc-port = ${toString cfg.rpcPort}"
+      "zmq-port = ${toString cfg.zmqPort}"
+      "data-dir = /var/lib/p2pool"
+      "no-color = 1"
+      (lib.optionalString (cfg.stratum != [ ]) "stratum = ${lib.concatStringsSep "," cfg.stratum}")
+      (lib.optionalString (cfg.p2p != [ ]) "p2p = ${lib.concatStringsSep "," cfg.p2p}")
+      (lib.optionalString (cfg.addPeers != [ ]) "addpeers = ${lib.concatStringsSep "," cfg.addPeers}")
+      (lib.optionalString cfg.lightMode "light-mode = 1")
+      (lib.optionalString cfg.mini "mini = 1")
+      (lib.optionalString cfg.nano "nano = 1")
+      (lib.optionalString cfg.noDns "no-dns = 1")
+      (lib.optionalString (cfg.loglevel != null) "loglevel = ${toString cfg.loglevel}")
+      (lib.optionalString (cfg.outPeers != null) "out-peers = ${toString cfg.outPeers}")
+      (lib.optionalString (cfg.inPeers != null) "in-peers = ${toString cfg.inPeers}")
+      (lib.optionalString (cfg.dataApi != null) "data-api = \"${cfg.dataApi}\"")
+      (lib.optionalString cfg.localApi "local-api = 1")
+    ]
+    ++ cfg.extraConfig
+  );
+
+  # Write the base config file (without secrets) to the Nix store.
+  configFile = pkgs.writeText "p2pool.conf" configLines;
+in
+{
+  options = {
+    services.p2pool = {
+      enable = lib.mkEnableOption "p2pool, a decentralized pool for Monero mining";
+
+      package = lib.mkPackageOption pkgs "p2pool" { };
+
+      wallet = lib.mkOption {
+        type = lib.types.strMatching "^[48][1-9A-HJ-NP-Za-km-z]{94}$";
+        description = "Monero wallet address for receiving mining rewards.";
+        example = "44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A";
+      };
+
+      host = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        description = "IP address of the Monero node (monerod).";
+      };
+
+      rpcPort = lib.mkOption {
+        type = lib.types.port;
+        default = 18081;
+        description = "monerod RPC API port number.";
+      };
+
+      zmqPort = lib.mkOption {
+        type = lib.types.port;
+        default = 18083;
+        description = "monerod ZMQ pub port number.";
+      };
+
+      stratum = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [ "0.0.0.0:3333" ];
+        description = "List of IP:port for the stratum server to listen on.";
+      };
+
+      p2p = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [ "0.0.0.0:37889" ];
+        description = "List of IP:port for the p2p server to listen on.";
+      };
+
+      addPeers = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "List of IP:port of other p2pool nodes to connect to.";
+        example = [
+          "node.example.com:37889"
+        ];
+      };
+
+      lightMode = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Don't allocate RandomX dataset, saves 2 GiB of RAM.";
+      };
+
+      mini = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Connect to p2pool-mini sidechain. Note that it will also change default p2p port from 37889 to 37888.";
+      };
+
+      nano = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Connect to p2pool-nano sidechain. Note that it will also change default p2p port from 37889 to 37890.";
+      };
+
+      noDns = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Disable DNS queries, use only IP addresses to connect to peers.";
+      };
+
+      loglevel = lib.mkOption {
+        type = lib.types.nullOr (lib.types.ints.between 0 6);
+        default = null;
+        description = "Verbosity of the log, integer number between 0 and 6.";
+      };
+
+      outPeers = lib.mkOption {
+        type = lib.types.nullOr (lib.types.ints.between 10 450);
+        default = null;
+        description = "Maximum number of outgoing connections for the p2p server.";
+      };
+
+      inPeers = lib.mkOption {
+        type = lib.types.nullOr (lib.types.ints.between 10 450);
+        default = null;
+        description = "Maximum number of incoming connections for the p2p server.";
+      };
+
+      dataApi = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "/var/lib/p2pool/api";
+        description = ''
+          Path to the p2pool JSON data for use with an external web server.
+          When using the default DynamicUser, this path must be under
+          `/var/lib/p2pool/` to be writable by the service.
+        '';
+      };
+
+      localApi = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Enable /local/ path in the API for stratum server and built-in miner statistics.";
+      };
+
+      rpcLoginFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/run/secrets/p2pool-rpc-login";
+        description = ''
+          Path to a file containing the RPC login credentials in
+          `username:password` format for authenticating with monerod.
+
+          The file contents are securely loaded via systemd's
+          `LoadCredential` and never appear in the process command line
+          or Nix store.
+
+          Example file contents:
+          ```
+          user:secretpassword
+          ```
+        '';
+      };
+
+      extraConfig = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [ "no-upnp = 1" ];
+        description = ''
+          Additional lines to append to the p2pool configuration file.
+          Each string should be in `param = value` format.
+
+          See [p2pool documentation](https://github.com/SChernykh/p2pool/blob/master/docs/COMMAND_LINE.MD)
+          for available options.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.mini && cfg.nano);
+        message = "services.p2pool.mini and services.p2pool.nano are mutually exclusive";
+      }
+    ];
+
+    systemd.services.p2pool = {
+      description = "P2Pool Monero Mining";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      preStart = ''
+        # Copy base config to runtime directory
+        install -m 600 ${configFile} "$RUNTIME_DIRECTORY/p2pool.conf"
+
+        # Append RPC login from credential if provided
+        ${lib.optionalString (cfg.rpcLoginFile != null) ''
+          echo "rpc-login = $(cat "$CREDENTIALS_DIRECTORY/rpc-login")" >> "$RUNTIME_DIRECTORY/p2pool.conf"
+        ''}
+      '';
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} --params-file \${RUNTIME_DIRECTORY}/p2pool.conf";
+        DynamicUser = true;
+        StateDirectory = "p2pool";
+        RuntimeDirectory = "p2pool";
+        Restart = "always";
+        RestartSec = 10;
+
+        LoadCredential = lib.optional (cfg.rpcLoginFile != null) "rpc-login:${cfg.rpcLoginFile}";
+
+        # Hardening
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ];
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ titaniumtown ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1224,6 +1224,7 @@ in
   owncast = runTest ./owncast.nix;
   oxidized = handleTest ./oxidized.nix { };
   oxwm = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./oxwm.nix;
+  p2pool = runTest ./p2pool.nix;
   pacemaker = runTest ./pacemaker.nix;
   packagekit = runTest ./packagekit.nix;
   pairdrop = runTest ./web-apps/pairdrop.nix;

--- a/nixos/tests/p2pool.nix
+++ b/nixos/tests/p2pool.nix
@@ -1,0 +1,40 @@
+{ lib, ... }:
+{
+  name = "p2pool";
+  meta.maintainers = with lib.maintainers; [ titaniumtown ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.p2pool = {
+        enable = true;
+        # Monero project donation wallet for testing purposes
+        wallet = "44AFFq5kSiGBoZ4NMDwYtN18obc8AemS33DBLWs3H7otXft3XjrpDtQGv7SqSsaBYBb98uNbr2VBBEt7f2wfn3RVGQBEP3A";
+        mini = true;
+      };
+
+      environment.systemPackages = [ pkgs.p2pool ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    # Verify p2pool binary works
+    machine.succeed("p2pool --version")
+
+    # The service will start and print its banner before attempting to connect to monerod.
+    # Check that the service was activated and p2pool started.
+    machine.wait_until_succeeds(
+        "journalctl -u p2pool.service | grep -q 'P2Pool'",
+        timeout=30,
+    )
+
+    # Verify the service is still active (not crash-looping)
+    machine.succeed("systemctl is-active p2pool.service")
+
+    # Verify the config file was generated correctly
+    machine.succeed("test -f /run/p2pool/p2pool.conf")
+    machine.succeed("grep -q 'wallet = 44AFFq5' /run/p2pool/p2pool.conf")
+    machine.succeed("grep -q 'mini = 1' /run/p2pool/p2pool.conf")
+  '';
+}

--- a/pkgs/by-name/p2/p2pool/package.nix
+++ b/pkgs/by-name/p2/p2pool/package.nix
@@ -9,6 +9,7 @@
   libsodium,
   libuv,
   nix-update-script,
+  nixosTests,
   openssl,
   pkg-config,
   zeromq,
@@ -51,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    tests = { inherit (nixosTests) p2pool; };
     updateScript = nix-update-script { };
   };
 


### PR DESCRIPTION
Creates a module for the pre-existing p2pool package. This is used for decentralized Monero mining.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
