### PR TITLE
python3Packages.qasync: don't propagate pyqt5, use pyqt6 for checks

### DIFF
--- a/pkgs/development/python-modules/orange-canvas-core/default.nix
+++ b/pkgs/development/python-modules/orange-canvas-core/default.nix
@@ -26,6 +26,7 @@
 
   # tests
   qt5,
+  pyqt5,
   pytest-qt,
   pytestCheckHook,
 
@@ -77,6 +78,7 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [
+    pyqt5
     pytest-qt
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/qasync/default.nix
+++ b/pkgs/development/python-modules/qasync/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pyqt5,
+  pyqt6,
   pytestCheckHook,
   uv-build,
 }:
@@ -27,9 +27,10 @@ buildPythonPackage rec {
 
   build-system = [ uv-build ];
 
-  dependencies = [ pyqt5 ];
-
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pyqt6
+  ];
 
   pythonImportsCheck = [ "qasync" ];
 


### PR DESCRIPTION
`qasync` supports [PyQt5/PyQt6, PySide2/PySide](https://github.com/CabbageDevelopment/qasync/blob/0e369e4559a5e2cbf73d63eced3c682a5bc8630c/README.md?plain=1#L86). It has no mandatory Qt binding dependency. Use `pyqt6` in `nativeCheckInputs` instead.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
