### PR TITLE
octavePackages.statistics: 1.8.0 -> 1.8.2

### DIFF
--- a/pkgs/development/octave-modules/datatypes/default.nix
+++ b/pkgs/development/octave-modules/datatypes/default.nix
@@ -1,0 +1,27 @@
+{
+  buildOctavePackage,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildOctavePackage rec {
+  pname = "datatypes";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "pr0m1th3as";
+    repo = "datatypes";
+    tag = "release-${version}";
+    sha256 = "sha256-0RhZm/UzICbAAn1uCSQSgq8+6GnOuTB6TD9NoIEdvXA=";
+  };
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=release-(.*)" ]; };
+
+  meta = {
+    homepage = "https://gnu-octave.github.io/packages/datatypes/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ KarlJoad ];
+    description = "Extra data types for GNU Octave";
+  };
+}

--- a/pkgs/development/octave-modules/statistics/default.nix
+++ b/pkgs/development/octave-modules/statistics/default.nix
@@ -3,21 +3,23 @@
   lib,
   fetchFromGitHub,
   io,
+  datatypes,
 }:
 
 buildOctavePackage rec {
   pname = "statistics";
-  version = "1.8.0";
+  version = "1.8.2";
 
   src = fetchFromGitHub {
     owner = "gnu-octave";
     repo = "statistics";
     tag = "release-${version}";
-    hash = "sha256-4nwkrnYaFdBkLLbIUJX0U4tytHrSIKltWu7Srx43K5g=";
+    hash = "sha256-5wUQLIMr1X07Yi4AANBFjd0izDzGNsI5ccY7IherB3I=";
   };
 
   requiredOctavePackages = [
     io
+    datatypes
   ];
 
   meta = {

--- a/pkgs/top-level/octave-packages.nix
+++ b/pkgs/top-level/octave-packages.nix
@@ -84,6 +84,8 @@ makeScope newScope (
 
     dataframe = callPackage ../development/octave-modules/dataframe { };
 
+    datatypes = callPackage ../development/octave-modules/datatypes { };
+
     dicom = callPackage ../development/octave-modules/dicom { };
 
     divand = callPackage ../development/octave-modules/divand { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add `octavePackages.datatypes` and update `octavePackages.statistics`, which uses `datatypes` to access functions that Octave does not ship yet.

Supersedes #490110.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
