### PR TITLE
jemalloc: default to 64KB page size on ppc64 and add overridable `pageSizeKiB`

### DIFF
--- a/pkgs/by-name/je/jemalloc/package.nix
+++ b/pkgs/by-name/je/jemalloc/package.nix
@@ -55,7 +55,11 @@ stdenv.mkDerivation (finalAttrs: {
   # https://sources.debian.org/src/jemalloc/5.3.0-3/debian/rules/
   ++ [
     (
-      if (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isLoongArch64) then
+      if
+        (
+          stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isLoongArch64 || stdenv.hostPlatform.isPower64
+        )
+      then
         "--with-lg-page=16"
       else
         "--with-lg-page=12"

--- a/pkgs/by-name/je/jemalloc/package.nix
+++ b/pkgs/by-name/je/jemalloc/package.nix
@@ -13,7 +13,30 @@
   # compatibility.
   stripPrefix ? stdenv.hostPlatform.isDarwin,
   disableInitExecTls ? false,
+  # Page size in KiB to configure jemalloc for.
+  # Defaults to 64 on architectures where 64KB pages are common, 4 otherwise.
+  # Note that a higher value is compatible with lower page sizes but may waste memory.
+  pageSizeKiB ?
+    if
+      (
+        stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isLoongArch64 || stdenv.hostPlatform.isPower64
+      )
+    then
+      64
+    else
+      4,
 }:
+
+let
+  pageSizeMap = {
+    "4" = 12;
+    "16" = 14;
+    "64" = 16;
+  };
+in
+assert lib.asserts.assertOneOf "pageSizeKiB" (toString pageSizeKiB) (
+  builtins.attrNames pageSizeMap
+);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jemalloc";
@@ -54,16 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
   # https://github.com/jemalloc/jemalloc/issues/467
   # https://sources.debian.org/src/jemalloc/5.3.0-3/debian/rules/
   ++ [
-    (
-      if
-        (
-          stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isLoongArch64 || stdenv.hostPlatform.isPower64
-        )
-      then
-        "--with-lg-page=16"
-      else
-        "--with-lg-page=12"
-    )
+    "--with-lg-page=${toString pageSizeMap."${toString pageSizeKiB}"}"
   ]
   # See https://github.com/jemalloc/jemalloc/issues/1997
   # Using a value of 48 should work on both emulated and native x86_64-darwin.


### PR DESCRIPTION
POWER often defaults to 64KB pages, causing jemalloc to fail with "Unsupported system page size" at check time when built with `--with-lg-page=12`. This PR adds `isPower64` to the 64KB page size conditional, which matches the upstream kernel default for Book3S (POWER4+) as well as Fedora, SUSE, and Arch POWER which all ship `CONFIG_PPC_64K_PAGES=y`.

Additionally, the page size is now exposed as an overridable `pageSizeKiB` argument so users on systems with non-default page sizes can tune it via an overlay, e.g. `jemalloc.override { pageSizeKiB = 4; }`.

I've tested this on a POWER8 machine running Arch POWER (which has 64KB pages).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] ppc64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test