### PR TITLE
mfcl8690cdw: 1.3.0-0 -> 1.5.0-3

### DIFF
--- a/pkgs/by-name/mf/mfcl8690cdwcupswrapper/package.nix
+++ b/pkgs/by-name/mf/mfcl8690cdwcupswrapper/package.nix
@@ -13,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mfcl8690cdwcupswrapper";
-  version = "1.4.0-0";
+  version = "1.5.0-3";
 
   src = fetchurl {
-    url = "http://download.brother.com/welcome/dlf103250/${pname}-${version}.i386.deb";
-    sha256 = "1bl9r8mmj4vnanwpfjqgq3c9lf2v46wp5k6r2n9iqprf7ldd1kb2";
+    url = "https://download.brother.com/welcome/dlf103250/mfcl8690cdwcupswrapper-${version}.i386.deb";
+    hash = "sha256-CREQRr4nhw1pD+8AfD5p/EHpx3R6vQIO8h6VtnHxXls=";
   };
 
   nativeBuildInputs = [
@@ -56,9 +56,11 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Brother MFC-L8690CDW CUPS wrapper driver";
-    homepage = "http://www.brother.com/";
+    homepage = "https://www.brother.com/";
     license = lib.licenses.unfree;
     platforms = lib.platforms.linux;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
   };
 }

--- a/pkgs/by-name/mf/mfcl8690cdwlpr/package.nix
+++ b/pkgs/by-name/mf/mfcl8690cdwlpr/package.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mfcl8690cdwlpr";
-  version = "1.3.0-0";
+  version = "1.5.0-3";
 
   src = fetchurl {
-    url = "http://download.brother.com/welcome/dlf103241/${pname}-${version}.i386.deb";
-    sha256 = "0x8zd4b1psmw1znp2ibncs37xm5mljcy9yza2rx8jm8lp0a3l85v";
+    url = "https://download.brother.com/welcome/dlf103241/mfcl8690cdwlpr-${version}.i386.deb";
+    hash = "sha256-CXYo6ISUr0hFiHRVRnXbJ/21dK/2NUrCt2bnzQuHOXI=";
   };
 
   nativeBuildInputs = [
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   ];
 
   dontUnpack = true;
+  dontPatchELF = true;
 
   installPhase = ''
     dpkg-deb -x $src $out
@@ -37,9 +38,9 @@ stdenv.mkDerivation rec {
     filter=$dir/lpd/filter_mfcl8690cdw
 
     substituteInPlace $filter \
-      --replace /usr/bin/perl ${perl}/bin/perl \
-      --replace "BR_PRT_PATH =~" "BR_PRT_PATH = \"$dir/\"; #" \
-      --replace "PRINTER =~" "PRINTER = \"mfcl8690cdw\"; #"
+      --replace-fail /usr/bin/perl ${perl}/bin/perl \
+      --replace-fail "BR_PRT_PATH =~" "BR_PRT_PATH = \"$dir/\"; #" \
+      --replace-fail "PRINTER =~" "PRINTER = \"mfcl8690cdw\"; #"
 
     wrapProgram $filter \
       --prefix PATH : ${
@@ -53,17 +54,22 @@ stdenv.mkDerivation rec {
         ]
       }
 
-    # need to use i686 glibc here, these are 32bit proprietary binaries
-    interpreter=${pkgs.pkgsi686Linux.glibc}/lib/ld-linux.so.2
-    patchelf --set-interpreter "$interpreter" $dir/lpd/brmfcl8690cdwfilter
+    # Adding x86_64 binaries
+    for file in $dir/lpd/x86_64/brmfcl8690cdwfilter $dir/lpd/x86_64/brprintconf_mfcl8690cdw; do
+      patchelf --set-interpreter \
+        ${pkgs.pkgsi686Linux.glibc}/lib/ld-linux.so.2 \
+        $file
+    done
   '';
 
   meta = {
     description = "Brother MFC-L8690CDW LPR printer driver";
-    homepage = "http://www.brother.com/";
+    homepage = "https://www.brother.com/";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
     platforms = [
       "x86_64-linux"
       "i686-linux"


### PR DESCRIPTION
This PR updates the Brother MFC-L8690CDW printer driver stack to the latest upstream version.

^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.

**Changes:**

    Version Bump: Updated mfcl8690cdwlpr and mfcl8690cdwcupswrapper from 1.3.0-0 / 1.4.0-0 to 1.5.0-3.

    Fix 404: Resolved the dead download link by updating to the new Brother directory structure.

    Refactor: Modernized package.nix using the myPatchElf helper pattern and updated substituteInPlace to use --replace-fail to resolve deprecation warnings.

    Architecture Support: Identified and patched the x86_64 binaries now included in the upstream .deb.

    Formatting: Ran nixfmt on all modified files.

**Testing:**

    Successfully built both packages locally with nix build.

    Verified binary interpreter paths with patchelf.

## Things done

Addresses Issue #498351
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
