### PR TITLE
python3Packages.pyosmium: fix build

### DIFF
--- a/pkgs/development/python-modules/pyosmium/default.nix
+++ b/pkgs/development/python-modules/pyosmium/default.nix
@@ -12,7 +12,8 @@
   pybind11,
   pytest-httpserver,
   pytestCheckHook,
-  setuptools,
+  scikit-build-core,
+  ninja,
   shapely,
   werkzeug,
   isPyPy,
@@ -34,7 +35,10 @@ buildPythonPackage rec {
     hash = "sha256-AkldgvZmn1CLa9Ze7RHBhL5wLLJ+mBnNj+yyV98nzZ8=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    scikit-build-core
+    ninja
+  ];
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
pyosmium was broken in https://github.com/NixOS/nixpkgs/pull/482364 by commit 2713b96bdb7ee19ecc626b5c0217654b2f85a841.

Version 4.1.0 replaced setuptools with scikit-build-core as the build system.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
