### PR TITLE
pcre2: support cross-compiling to WASI

### DIFF
--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -17,7 +17,16 @@ stdenv.mkDerivation rec {
     hash = "sha256-FfvFq6a+7gsXrssEYCrjlDI5OroevY45t8q/fbiDKZ8=";
   };
 
+  patches = lib.optionals stdenv.hostPlatform.isWasi [
+    ./wasi-disable-rlimit.patch
+  ];
+
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
+
+  env = lib.optionalAttrs stdenv.hostPlatform.isWasi {
+    NIX_CFLAGS_COMPILE = "-D_WASI_EMULATED_PROCESS_CLOCKS";
+    NIX_LDFLAGS = "-lwasi-emulated-process-clocks";
+  };
 
   configureFlags = [
     "--enable-pcre2-16"
@@ -26,7 +35,10 @@ stdenv.mkDerivation rec {
     "--enable-jit=${if stdenv.hostPlatform.isS390x then "no" else "auto"}"
   ]
   # fix pcre jit in systemd units that set MemoryDenyWriteExecute=true like gitea
-  ++ lib.optional withJitSealloc "--enable-jit-sealloc";
+  ++ lib.optional withJitSealloc "--enable-jit-sealloc"
+  ++ lib.optionals stdenv.hostPlatform.isWasi [
+    "--disable-pcre2grep-callout-fork"
+  ];
 
   outputs = [
     "bin"

--- a/pkgs/development/libraries/pcre2/wasi-disable-rlimit.patch
+++ b/pkgs/development/libraries/pcre2/wasi-disable-rlimit.patch
@@ -1,0 +1,12 @@
+diff --git a/src/pcre2test.c b/src/pcre2test.c
+index 1234567..abcdefg 100644
+--- a/src/pcre2test.c
++++ b/src/pcre2test.c
+@@ -9620,7 +9620,7 @@ else if (strcmp(arg, "-S") == 0 && argc > 2 &&
+       ((uli = strtoul(argv[op+1], &endptr, 10)), *endptr == 0))
+     {
+-#if defined(_WIN32) || defined(WIN32) || defined(__HAIKU__) || defined(NATIVE_ZOS) || defined(__VMS)
++#if defined(_WIN32) || defined(WIN32) || defined(__HAIKU__) || defined(NATIVE_ZOS) || defined(__VMS) || defined(__wasi__)
+     fprintf(stderr, "pcre2test: -S is not supported on this OS\n");
+     exit(1);
+ #else


### PR DESCRIPTION
_My goal is to get nix-util, nix-store and nix-expr to compile to WASI. I have succeeded and I'm submitting a bunch of pull requests to finalise that effort._

This is the first of around 14 pull requests I'll make to nixpkgs. Please review with the expectation of very similar pull requests coming for other packages, though this is probably the most simple one.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
