### PR TITLE
nixoscope: 0-unstable-2026-03-05 -> 0-unstable-2026-03-09

### DIFF
--- a/pkgs/by-name/ni/nixoscope/package.nix
+++ b/pkgs/by-name/ni/nixoscope/package.nix
@@ -5,14 +5,14 @@
 }:
 python3Packages.buildPythonPackage {
   pname = "nixoscope";
-  version = "0-unstable-2026-03-05";
+  version = "0-unstable-2026-03-09";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "giomf";
     repo = "nixoscope";
-    rev = "71de2ff0b4c9376db759a05ad58ace87d2b52ccb";
-    hash = "sha256-5yNGtEWlSAfJcy4X8C3dHQ+4Xaawi6aX20C82bfZxG4=";
+    rev = "cd55aeb660deb823b17e6946e417fa14d966f8f7";
+    hash = "sha256-cyEzO2UJaCWfecWZAVke2u/1guUO6Hl+YAbVL9pSgqU=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/ni/nixoscope/package.nix
+++ b/pkgs/by-name/ni/nixoscope/package.nix
@@ -23,6 +23,16 @@ python3Packages.buildPythonPackage {
     graphviz
   ];
 
+  nativeCheckInputs = with python3Packages; [
+    unittestCheckHook
+  ];
+
+  unittestFlags = [
+    "-s"
+    "tests"
+    "-v"
+  ];
+
   meta = {
     description = "Visualize dependencies between NixOS modules";
     homepage = "https://github.com/giomf/NixoScope";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updated to new version of NixoScope and add checks.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
