### PR TITLE
crystalline: 0.15.0 -> 0.17.1

### DIFF
--- a/pkgs/development/tools/language-servers/crystalline/default.nix
+++ b/pkgs/development/tools/language-servers/crystalline/default.nix
@@ -8,18 +8,17 @@
 }:
 
 let
-  version = "0.15.0";
-in
-crystal.buildCrystalPackage {
-  pname = "crystalline";
-  inherit version;
-
+  version = "0.17.1";
   src = fetchFromGitHub {
     owner = "elbywan";
     repo = "crystalline";
-    rev = "v${version}";
-    hash = "sha256-6ZAogEuOJH1QQ6NSJ+8KZUSFSgQAcvd4U9vWNAGix/M=";
+    tag = "v${version}";
+    hash = "sha256-SIfInDY6KhEwEPZckgobOrpKXBDDd0KhQt/IjdGBhWo=";
   };
+in
+crystal.buildCrystalPackage {
+  pname = "crystalline";
+  inherit version src;
 
   format = "crystal";
   shardsFile = ./shards.nix;
@@ -30,6 +29,12 @@ crystal.buildCrystalPackage {
     makeWrapper
   ];
   env.LLVM_CONFIG = lib.getExe' (lib.getDev llvmPackages.llvm) "llvm-config";
+
+  preConfigure = ''
+    substituteInPlace "./src/crystalline/main.cr" \
+      --replace-fail '`shards version #{__DIR__}`' '"${version}"' \
+      --replace-fail 'system("git rev-parse --short HEAD || echo unknown").stringify' '"${src.rev}"'
+  '';
 
   doCheck = false;
   doInstallCheck = false;

--- a/pkgs/development/tools/language-servers/crystalline/shards.nix
+++ b/pkgs/development/tools/language-servers/crystalline/shards.nix
@@ -1,27 +1,22 @@
 {
-  bisect = {
+  "bisect" = {
     url = "https://github.com/spider-gazelle/bisect.git";
     rev = "v1.2.1";
     sha256 = "1ddz7fag1l65m6g0vw6xa96yv00rdwjj2z69k26rvyz37qk9ccqg";
   };
-  lsp = {
+  "lsp" = {
     url = "https://github.com/elbywan/crystal-lsp.git";
     rev = "v0.1.2";
     sha256 = "0knw8xaq3ssyb34w77a390j79m4w6bks5hlwr8m8fci2gq9a0r6z";
   };
-  priority-queue = {
+  "priority-queue" = {
     url = "https://github.com/spider-gazelle/priority-queue.git";
     rev = "v1.0.1";
     sha256 = "1rkppd8win4yalxcvsxikqcq6sw0npdqjajqbj57m78bzlxpyjv6";
   };
-  sentry = {
+  "sentry" = {
     url = "https://github.com/samueleaton/sentry.git";
     rev = "e448ce83486f99ef016c311e10ec0cac805cded3";
     sha256 = "13yp7805xpd605jpfpb3srqb0psy25w7n6x9mpkcyvzhqmpnpfyq";
-  };
-  version_from_shard = {
-    url = "https://github.com/hugopl/version_from_shard.git";
-    rev = "v1.2.5";
-    sha256 = "0xizj0q4rd541rwjbx04cjifc2gfx4l5v6q2y7gmd0ndjmkgb8ik";
   };
 }


### PR DESCRIPTION
Tag `v0.16.0` introduced a version compiler macro. I've substituted this with the package version and the `refs/tags/v{version}` rev. Shards file updated and conforms to the new style.
Will, as before, still not build until https://github.com/NixOS/nixpkgs/pull/498486 is merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
