### PR TITLE
btrpa-scan: init at 0.6.0-unstable-2026-02-18

### DIFF
--- a/pkgs/by-name/bt/btrpa-scan/package.nix
+++ b/pkgs/by-name/bt/btrpa-scan/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "btrpa-scan";
+  version = "0.6.0-unstable-2026-02-18";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "HackingDave";
+    repo = "btrpa-scan";
+    rev = "aa286d8d7a5ff11926f1b9f064ec9e00eeeeb5a6";
+    hash = "sha256-Q0+seEDvBQ2s+f8djM71JV84yzODe+gBEZZV1UTKKGg=";
+  };
+
+  build-system = with python3.pkgs; [ hatchling ];
+
+  dependencies = with python3.pkgs; [
+    bleak
+    cryptography
+    flask
+    flask-socketio
+  ];
+
+  pythonImportsCheck = [ "btrpa_scan" ];
+
+  meta = {
+    description = "Bluetooth Low Energy (BLE) scanner";
+    homepage = "https://github.com/HackingDave/btrpa-scan";
+    changelog = "https://github.com/HackingDave/btrpa-scan/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "btrpa-scan";
+  };
+})


### PR DESCRIPTION
Bluetooth Low Energy (BLE) scanner

https://github.com/HackingDave/btrpa-scan

Related https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
