### PR TITLE
llvm/libunwind: support building for WASM targets

### DIFF
--- a/pkgs/development/compilers/llvm/common/libunwind/default.nix
+++ b/pkgs/development/compilers/llvm/common/libunwind/default.nix
@@ -11,6 +11,7 @@
   ninja,
   python3,
   libcxx,
+  fetchpatch,
   enableShared ? !stdenv.hostPlatform.isStatic,
   doFakeLibgcc ? stdenv.hostPlatform.useLLVM && !stdenv.hostPlatform.isStatic,
   devExtraCmakeFlags ? [ ],
@@ -55,7 +56,32 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "LIBUNWIND_ENABLE_SHARED" enableShared)
     (lib.cmakeFeature "LLVM_ENABLE_RUNTIMES" "libunwind")
   ]
+  ++ lib.optionals stdenv.hostPlatform.isWasm [
+    # Required otherwise CMake fails to determine platform
+    (lib.cmakeBool "UNIX" true)
+  ]
   ++ devExtraCmakeFlags;
+
+  env = lib.optionalAttrs stdenv.hostPlatform.isWasm {
+    # New EH model is needed for Unwind-wasm.c
+    NIX_CFLAGS_COMPILE = "-fwasm-exceptions -mllvm -wasm-use-legacy-eh=false";
+  };
+
+  # https://github.com/llvm/llvm-project/pull/168449
+  prePatch = lib.optionalString stdenv.hostPlatform.isWasm ''
+    chmod -R +w ../libunwind/src
+  '';
+  patches = lib.optionals stdenv.hostPlatform.isWasm [
+    (fetchpatch {
+      url = "https://gist.githubusercontent.com/yamt/b699eb2604d2598810a2876ff2ffc8d8/raw/1bc7d7d7c5cb4b37893415521528ae1c8f77b054/a.diff";
+      hash = "sha256-Z2wbPs59rFBa0ki6DeoAULQfU/V800QcIxj99jofjLs=";
+    })
+  ];
+  patchFlags = lib.optionals stdenv.hostPlatform.isWasm [
+    "-p1"
+    "-d"
+    ".."
+  ];
 
   postInstall =
     lib.optionalString (enableShared && !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isWindows)


### PR DESCRIPTION
_My goal is to get nix-util, nix-store and nix-expr to compile to WASI. I have succeeded and I'm submitting a bunch of pull requests to finalise that effort._

libunwind has a WASM backend which works with the current exception handling proposal. This PR adds nixpkgs support for native C++ exceptions to translate pretty straight forwardly to WASM.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
