### PR TITLE
rawtherapee: move to by-name, refactor, fix #475835

### DIFF
--- a/pkgs/by-name/ra/rawtherapee/package.nix
+++ b/pkgs/by-name/ra/rawtherapee/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  fetchurl,
   cmake,
   pkg-config,
   util-linux,
@@ -22,7 +22,7 @@
   libxdmcp,
   lcms2,
   libiptcdata,
-  fftw,
+  fftwSinglePrec,
   expat,
   pcre2,
   libsigcxx,
@@ -39,17 +39,21 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "rawtherapee";
   version = "5.12";
 
-  src = fetchFromGitHub {
-    owner = "RawTherapee";
-    repo = "RawTherapee";
-    tag = finalAttrs.version;
-    hash = "sha256-h8eWnw9I1R0l9WAI/DylsdA241qU9NhYGEPYz+JlE18=";
+  src = fetchurl {
     # The developers ask not to use the tarball from Github releases, see
-    # https://www.rawtherapee.com/downloads/5.10/#news-relevant-to-package-maintainers
-    forceFetchGit = true;
+    # https://www.rawtherapee.com/downloads/5.12/#news-relevant-to-package-maintainers
+    url = "https://rawtherapee.com/shared/source/rawtherapee-${finalAttrs.version}.tar.xz";
+    hash = "sha256-2abBBTfWSihbxGVnX+WaqpTOMiOCPfvs8K4slZkILVc=";
   };
 
   postPatch = ''
+    # https://github.com/NixOS/nixpkgs/issues/475835
+    # https://github.com/RawTherapee/RawTherapee/issues/7443#issuecomment-3014132156
+    # remove for 5.13
+    substituteInPlace rtengine/procparams.cc --replace \
+      'outputProfile(options.rtSettings.srgb),' \
+      'outputProfile("RTv4_sRGB"),'
+
     cat <<EOF > ReleaseInfo.cmake
     set(GIT_DESCRIBE ${finalAttrs.version})
     set(GIT_BRANCH ${finalAttrs.version})
@@ -89,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxdmcp
     lcms2
     libiptcdata
-    fftw
+    fftwSinglePrec
     expat
     pcre2
     libsigcxx

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10412,10 +10412,6 @@ with pkgs;
     withXineBackend = true;
   };
 
-  rawtherapee = callPackage ../applications/graphics/rawtherapee {
-    fftw = fftwSinglePrec;
-  };
-
   reaper = callPackage ../applications/audio/reaper {
     jackLibrary = libjack2; # Another option is "pipewire.jack".
     ffmpeg = ffmpeg_4-headless;


### PR DESCRIPTION
superseeds https://github.com/NixOS/nixpkgs/pull/476711

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
