### PR TITLE
json-schema-catalog-rs: use toFile instead of passAsFile

### DIFF
--- a/pkgs/by-name/js/json-schema-catalog-rs/test-run.nix
+++ b/pkgs/by-name/js/json-schema-catalog-rs/test-run.nix
@@ -12,6 +12,23 @@ let
     }
   );
 
+  expectedOutput = builtins.toFile "expected-output" ''
+    {
+      "groups": [
+        {
+          "baseLocation": "/nix/store",
+          "name": "Example Schema",
+          "schemas": [
+            {
+              "id": "https://example.com/example-2.9.json",
+              "location": "${baseNameOf sample}"
+            }
+          ]
+        }
+      ],
+      "name": "Catalog"
+    }
+  '';
 in
 runCommand "json-schema-catalog-rs-test-run"
   {
@@ -19,26 +36,6 @@ runCommand "json-schema-catalog-rs-test-run"
       json-schema-catalog-rs
     ];
     inherit sample;
-    expectedOutput = ''
-      {
-        "groups": [
-          {
-            "baseLocation": "/nix/store",
-            "name": "Example Schema",
-            "schemas": [
-              {
-                "id": "https://example.com/example-2.9.json",
-                "location": "${baseNameOf sample}"
-              }
-            ]
-          }
-        ],
-        "name": "Catalog"
-      }
-    '';
-    passAsFile = [
-      "expectedOutput"
-    ];
   }
   ''
     set -u
@@ -48,7 +45,7 @@ runCommand "json-schema-catalog-rs-test-run"
 
     # Test a simple command
     json-schema-catalog new "$sample" > out.json
-    diff -U3 "$expectedOutputPath" out.json
+    diff -U3 "${expectedOutput}" out.json
 
     touch $out
   ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
