### PR TITLE
keepass: use writeText instead of passAsFile

### DIFF
--- a/pkgs/by-name/ke/keepass/package.nix
+++ b/pkgs/by-name/ke/keepass/package.nix
@@ -5,6 +5,7 @@
   unzip,
   mono,
   makeWrapper,
+  writeText,
   icoutils,
   replaceVars,
   xsel,
@@ -17,7 +18,38 @@
   makeDesktopItem,
   plugins ? [ ],
 }:
+let
+  # KeePass looks for plugins in under directory in which KeePass.exe is
+  # located. It follows symlinks where looking for that directory, so
+  # buildEnv is not enough to bring KeePass and plugins together.
+  #
+  # This derivation patches KeePass to search for plugins in specified
+  # plugin derivations in the Nix store and nowhere else.
+  pluginLoadPathsPatch =
+    let
+      inherit (builtins) toString;
+      inherit (lib.strings)
+        readFile
+        concatStrings
+        replaceStrings
+        unsafeDiscardStringContext
+        ;
+      inherit (lib.lists) map length;
+      inherit (lib) add;
 
+      outputLc = toString (add 7 (length plugins));
+      patchTemplate = readFile ./keepass-plugins.patch;
+      loadTemplate = readFile ./keepass-plugins-load.patch;
+      loads = concatStrings (
+        map (
+          p: replaceStrings [ "$PATH$" ] [ (unsafeDiscardStringContext (toString p)) ] loadTemplate
+        ) plugins
+      );
+    in
+    writeText "load-paths.patch" (
+      replaceStrings [ "$OUTPUT_LC$" "$DO_LOADS$" ] [ outputLc loads ] patchTemplate
+    );
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "keepass";
   version = "2.60";
@@ -47,39 +79,9 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  # KeePass looks for plugins in under directory in which KeePass.exe is
-  # located. It follows symlinks where looking for that directory, so
-  # buildEnv is not enough to bring KeePass and plugins together.
-  #
-  # This derivation patches KeePass to search for plugins in specified
-  # plugin derivations in the Nix store and nowhere else.
-  pluginLoadPathsPatch =
-    let
-      inherit (builtins) toString;
-      inherit (lib.strings)
-        readFile
-        concatStrings
-        replaceStrings
-        unsafeDiscardStringContext
-        ;
-      inherit (lib.lists) map length;
-      inherit (lib) add;
-
-      outputLc = toString (add 7 (length plugins));
-      patchTemplate = readFile ./keepass-plugins.patch;
-      loadTemplate = readFile ./keepass-plugins-load.patch;
-      loads = concatStrings (
-        map (
-          p: replaceStrings [ "$PATH$" ] [ (unsafeDiscardStringContext (toString p)) ] loadTemplate
-        ) plugins
-      );
-    in
-    replaceStrings [ "$OUTPUT_LC$" "$DO_LOADS$" ] [ outputLc loads ] patchTemplate;
-
-  passAsFile = [ "pluginLoadPathsPatch" ];
   postPatch = ''
     sed -i 's/\r*$//' KeePass/Forms/MainForm.cs
-    patch -p1 <$pluginLoadPathsPatchPath
+    patch -p1 <${pluginLoadPathsPatch}
   '';
 
   configurePhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
