### PR TITLE
raphael-xiv: init at 0.28.6

### DIFF
--- a/pkgs/by-name/ra/raphael-xiv/package.nix
+++ b/pkgs/by-name/ra/raphael-xiv/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  libGL,
+  libxkbcommon,
+  wayland,
+  libx11,
+  libxcursor,
+  libxi,
+  vulkan-loader,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "raphael-xiv";
+  version = "0.28.1";
+
+  src = fetchFromGitHub {
+    owner = "KonaeAkira";
+    repo = "raphael-rs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pHKvQmrg7mBzC88geYbRgApAtSsNT1hgFXZIPd1Thzs=";
+  };
+
+  cargoHash = "sha256-qoxSEAWn3LTDjAzZzwH9KrITKzdPo/rQItCy0ikve6w=";
+
+  buildInputs = [
+    libGL
+    libxkbcommon
+    libx11
+    libxcursor
+    libxi
+    vulkan-loader
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wayland
+  ];
+
+  cargoBuildFlags = [
+    "--package"
+    "raphael-xiv"
+    "--package"
+    "raphael-cli"
+  ];
+
+  # The GUI application needs most of the buildInputs at runtime, with the exception of libGL
+  postFixup = ''
+    patchelf --set-rpath "${lib.makeLibraryPath (lib.lists.remove libGL finalAttrs.buildInputs)}" \
+      "$out/bin/raphael-xiv"
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Crafting macro solver for Final Fantasy XIV";
+    homepage = "https://github.com/KonaeAkira/raphael-rs";
+    changelog = "https://github.com/KonaeAkira/raphael-rs/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hekazu ];
+    mainProgram = "raphael-xiv";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/ra/raphael-xiv/package.nix
+++ b/pkgs/by-name/ra/raphael-xiv/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  libGL,
+  libxkbcommon,
+  wayland,
+  libx11,
+  libxcursor,
+  libxi,
+  vulkan-loader,
+  copyDesktopItems,
+  makeDesktopItem,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "raphael-xiv";
+  version = "0.28.6";
+
+  src = fetchFromGitHub {
+    owner = "KonaeAkira";
+    repo = "raphael-rs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YsHOakC1lSwozEO3I5RqPIYuoxNFOvoOrb81dexv9qc=";
+  };
+
+  cargoHash = "sha256-CRGBPDt3fCDfmSTY6sPzBU9YocJ5G5wewQ5P6eFZlV0=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    libGL
+    libxkbcommon
+    libx11
+    libxcursor
+    libxi
+    vulkan-loader
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wayland
+  ];
+
+  cargoBuildFlags = [
+    "--package"
+    "raphael-xiv"
+    "--package"
+    "raphael-cli"
+  ];
+
+  preInstall = ''
+    mkdir -p "$out/share/icons/hicolor/64x64/apps"
+    cp assets/favicon-64x64.png "$out/share/icons/hicolor/64x64/apps/raphael-xiv.png"
+  '';
+
+  # The GUI application needs most of the buildInputs at runtime, with the exception of libGL
+  postFixup = ''
+    patchelf --set-rpath "${lib.makeLibraryPath (lib.lists.remove libGL finalAttrs.buildInputs)}" \
+      "$out/bin/raphael-xiv"
+  '';
+
+  __structuredAttrs = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = finalAttrs.pname;
+      exec = "raphael-xiv";
+      icon = "raphael-xiv";
+      desktopName = "Raphael XIV";
+      comment = finalAttrs.meta.description;
+    })
+  ];
+
+  meta = {
+    description = "Crafting macro solver for Final Fantasy XIV";
+    homepage = "https://github.com/KonaeAkira/raphael-rs";
+    changelog = "https://github.com/KonaeAkira/raphael-rs/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hekazu ];
+    mainProgram = "raphael-xiv";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Raphael XIV is a crafting macro solver for Square Enix's MMORPG Final Fantasy XIV. It includes both GUI and CLI options. https://github.com/KonaeAkira/raphael-rs 
## Things done
The package builds and the GUI is confirmed to run on Wayland and X11 with Vulkan. The solver produces results as expected. Additionally the CLI is also built as part of the package.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
