### PR TITLE
opensc: fix ill-defined escape sequence in version regex

### DIFF
--- a/pkgs/by-name/op/opensc/package.nix
+++ b/pkgs/by-name/op/opensc/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     "completiondir=$(out)/etc"
   ];
 
-  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=^([0-9\.]+)$" ]; };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=^([0-9\\.]+)$" ]; };
 
   meta = {
     description = "Set of libraries and utilities to access smart cards";


### PR DESCRIPTION
Nix warns about `\.` being an ill-defined escape in the updateScript version regex. Use `\\.` to properly escape the backslash so the regex still matches a literal dot.
