### PR TITLE
fetchItchIo: fix SSL error and improve missing envvar message

### DIFF
--- a/pkgs/build-support/fetchitchio/default.nix
+++ b/pkgs/build-support/fetchitchio/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenvNoCC,
+  cacert,
   python3,
 }:
 
@@ -78,7 +79,11 @@ lib.extendMkDerivation {
         outputHashAlgo = if finalHashHasColon then lib.head finalHashColonMatch else null;
         outputHashMode = "flat";
 
-        nativeBuildInputs = [ python3 ] ++ nativeBuildInputs;
+        nativeBuildInputs = [
+          cacert
+          python3
+        ]
+        ++ nativeBuildInputs;
 
         inherit preferLocalBuild;
 

--- a/pkgs/build-support/fetchitchio/fetchitchio.py
+++ b/pkgs/build-support/fetchitchio/fetchitchio.py
@@ -4,7 +4,6 @@ import os
 import platform
 import shutil
 import sys
-import urllib.error
 import urllib.parse
 import urllib.request
 
@@ -24,13 +23,14 @@ def abort(message):
     print(message, file=sys.stderr)
     sys.exit(1)
 
-try:
-    API_KEY = os.environ[ENV['apiKeyVar']]
-except KeyError:
+API_KEY = os.environ.get(ENV['apiKeyVar'])
+
+if not API_KEY:
     abort(
-        f'Either set {ENV['apiKeyVar']} for the nix building process '
+        f'Error: Either set the environment variable {ENV['apiKeyVar']} '
+        '(for the nix-daemon in multi user mode) '
         f'or manually download {ENV.get('uploadName', 'the required file')} '
-        f'from {GAME_URL} and add it to nix store.'
+        f'from {GAME_URL} and add it to the nix store.'
     )
 
 def urlopen(url_or_request):


### PR DESCRIPTION
Trying to build `celestegame`, I was facing issues with missing SSL certificates and an undefined environment variable when using the fetcher with both `nix-build` and `nix build --impure`. These changes make the build succeed when the .zip file has to be fetched from Itch.io.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
