### PR TITLE
cargo-msrv: fix update script and 0.18.4 -> 0.19.2

### DIFF
--- a/pkgs/by-name/ca/cargo-msrv/package.nix
+++ b/pkgs/by-name/ca/cargo-msrv/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-msrv";
-  version = "0.18.4";
+  version = "0.19.2";
 
   src = fetchFromGitHub {
     owner = "foresterre";
     repo = "cargo-msrv";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-dvCKi40c9PmM05MK+0VGWxny0ZA+9YO/M3zmv5Qv6b0=";
+    sha256 = "sha256-GsreJpQ+WsiKIRbQx4gXyH24JnoMUgJSVLFvljWxJq8=";
   };
 
-  cargoHash = "sha256-cIyoGFIxtX4/Dn4RbtMB75WQj+UO44V182u6C5smgSw=";
+  cargoHash = "sha256-+7O+9wS72QCHNYcXJUFyc4I9PFH5B8OvisVKf5bBDdY=";
 
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version-regex=^v([0-9.]+)$" ];

--- a/pkgs/by-name/ca/cargo-msrv/package.nix
+++ b/pkgs/by-name/ca/cargo-msrv/package.nix
@@ -7,7 +7,7 @@
   openssl,
   stdenv,
   makeWrapper,
-  gitUpdater,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -23,11 +23,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-cIyoGFIxtX4/Dn4RbtMB75WQj+UO44V182u6C5smgSw=";
 
-  passthru = {
-    updateScript = gitUpdater {
-      rev-prefix = "v";
-      ignoredVersions = ".(rc|beta).*";
-    };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=^v([0-9.]+)$" ];
   };
 
   # Integration tests fail


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Migrate from `gitUpdater` (which doesn't update `cargoHash`) to `nix-update-script`(while still catching only stable updates).

Update from 0.18.4 to 0.19.2 (generated with the new update script).
[Changelog](https://github.com/foresterre/cargo-msrv/blob/main/CHANGELOG.md).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
