### PR TITLE
sift-rs: add package for rupurt/sift

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23431,6 +23431,11 @@
     githubId = 6445619;
     name = "Ruben Cano Diaz";
   };
+  rupurt = {
+    name = "Alex Kwiatkowski";
+    github = "rupurt";
+    githubId = 680789;
+  };
   RudiOnTheAir = {
     name = "Rüdiger Schwoon";
     email = "wolf@schwoon.info";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23431,11 +23431,6 @@
     githubId = 6445619;
     name = "Ruben Cano Diaz";
   };
-  rupurt = {
-    name = "Alex Kwiatkowski";
-    github = "rupurt";
-    githubId = 680789;
-  };
   RudiOnTheAir = {
     name = "Rüdiger Schwoon";
     email = "wolf@schwoon.info";
@@ -23472,6 +23467,11 @@
     github = "running-grass";
     githubId = 17241154;
     keys = [ { fingerprint = "5156 0FAB FF32 83EC BC8C  EA13 9344 3660 9397 0138"; } ];
+  };
+  rupurt = {
+    name = "Alex Kwiatkowski";
+    github = "rupurt";
+    githubId = 680789;
   };
   rushmorem = {
     email = "rushmore@webenchanter.com";

--- a/pkgs/by-name/si/sift-rs/package.nix
+++ b/pkgs/by-name/si/sift-rs/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sift-rs";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "rupurt";
+    repo = "sift";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-1ngTLt5whz5NT2aklwPnx7PaR9iUfq8niHtMWUXbnSU=";
+  };
+
+  cargoHash = "sha256-/1HbCyTl6uEmzxEqLxzQKyC6zqIx7RkPbewbKBwXTqw=";
+
+  doCheck = false;
+
+  meta = {
+    description = "Standalone Rust CLI for local document retrieval in agentic coding workflows";
+    homepage = "https://github.com/rupurt/sift";
+    license = lib.licenses.mit;
+    mainProgram = "sift";
+    maintainers = with lib.maintainers; [ rupurt ];
+  };
+})


### PR DESCRIPTION
## Description

- Add `pkgs/by-name/si/sift-rs/package.nix` for https://github.com/rupurt/sift.
- Add new maintainer `rupurt` to `maintainers/maintainer-list.nix`.

## Testing

- `nix-build -A sift-rs --no-out-link`
- `nix-build lib/tests/maintainers.nix`
