### PR TITLE
nix-run: fix url

### DIFF
--- a/pkgs/by-name/ni/nix-run/nix-run.nix
+++ b/pkgs/by-name/ni/nix-run/nix-run.nix
@@ -16,7 +16,7 @@ mkDerivation rec {
   pname = "nix-run";
   version = "0.1.0.0-alpha.2";
   src = fetchgit {
-    url = "https://tangled.org/weethet.bsky.social/nix-run";
+    url = "https://tangled.org/did:plc:mojgntlezho4qt7uvcfkdndg/nix-run";
     tag = version;
     hash = "sha256-vnYD3N32H6eEPLis8eNlglXVY+guP5DDKCf2z7CLzwA=";
   };
@@ -34,7 +34,7 @@ mkDerivation rec {
     unix
   ];
   prePatch = "hpack";
-  homepage = "https://tangled.org/@weethet.bsky.social/nix-run";
+  homepage = "https://tangled.org/weethet.eurosky.social/nix-run";
   license = lib.licenses.bsd3;
   mainProgram = "nix-run";
 }


### PR DESCRIPTION
Due to me moving from bsky.social to eurosky.social my bsky handle changed, which caused the cloned to start to fail. I'm gonna use the permanent link this time instead which would hopefully also prevent this from happening in the future

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
