### PR TITLE
rawst: init at 0.8.1

### DIFF
--- a/pkgs/by-name/ra/rawst/package.nix
+++ b/pkgs/by-name/ra/rawst/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "rawst";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "Jupiee";
+    repo = "rawst";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-+uhE80XoZyMBV+nmlP+C5DfoB+z4tyK69XGsuALxROs=";
+  };
+
+  cargoHash = "sha256-wS1dR6r3/4sg4DCMR8QZjbHgiSEhuu/v4MqJ6LxEKtY=";
+  env.RUSTC_BOOTSTRAP = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cli downloader, written in rust";
+    homepage = "https://github.com/Jupiee/rawst";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ Inarizxc ];
+    platforms = lib.platforms.linux;
+    mainProgram = "rawst";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Rawst](https://github.com/Jupiee/rawst) is cli downloader, written in rust 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
