### PR TITLE
libresprite: fix darwin by removing homebrew interference

### DIFF
--- a/pkgs/by-name/li/libresprite/no-brew.patch
+++ b/pkgs/by-name/li/libresprite/no-brew.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1234567..abcdefg 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -151,14 +151,4 @@ include_directories(${ZLIB_INCLUDE_DIRS})
+ 
+ # libArchive
+-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+-    # Homebrew ships libarchive keg only, include dirs have to be set manually
+-    execute_process(
+-        COMMAND brew --prefix libarchive
+-        OUTPUT_VARIABLE LIBARCHIVE_PREFIX
+-        OUTPUT_STRIP_TRAILING_WHITESPACE
+-        COMMAND_ERROR_IS_FATAL ANY
+-    )
+-    set(LibArchive_INCLUDE_DIR "${LIBARCHIVE_PREFIX}/include")
+-endif()
+ find_package(LibArchive REQUIRED)
+ include_directories(${LibArchive_INCLUDE_DIR})

--- a/pkgs/by-name/li/libresprite/package.nix
+++ b/pkgs/by-name/li/libresprite/package.nix
@@ -40,6 +40,9 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # From https://github.com/LibreSprite/LibreSprite/pull/565
     ./cmake4.diff
+    # Remove Homebrew-specific brew invocation for libarchive on Darwin;
+    # Nix provides libarchive directly via buildInputs.
+    ./no-brew.patch
   ];
   nativeBuildInputs = [
     cmake
@@ -110,7 +113,5 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     maintainers = with lib.maintainers; [ fgaz ];
     platforms = lib.platforms.all;
-    # https://github.com/LibreSprite/LibreSprite/issues/308
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


Thoughts? @fgaz 

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
