### PR TITLE
edid-generator: use structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/by-name/ed/edid-generator/package.nix
+++ b/pkgs/by-name/ed/edid-generator/package.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation {
     patchShebangs modeline2edid
   '';
 
-  passAsFile = [ "modelines" ];
   clean = false;
   modelines = "";
 
@@ -51,7 +50,7 @@ stdenv.mkDerivation {
     runHook preConfigure
 
     test "$clean" != 1 || rm *x*.S
-    ./modeline2edid - <"$modelinesPath"
+    echo "$modelines" | ./modeline2edid -
 
     for file in *.S ; do
       echo "--- generated file: $file"
@@ -77,6 +76,8 @@ stdenv.mkDerivation {
   installPhase = ''
     install -Dm 444 *.bin -t "$out/lib/firmware/edid"
   '';
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Hackerswork to generate an EDID blob from given Xorg Modelines";


### PR DESCRIPTION
I'm not sure what is going on here, I tried testing with:

```
$ nix-build --expr 'let pkgs = import ./. { }; in pkgs.edid-generator.overrideAttrs { modelines = "Modeline \"PG278Q_60\"      241.50   2560 2608 2640 2720   1440 1443 1448 1481   -hsync +vsync"; }'`
```

and on master no extra files are generated, but with this PR applied I get

```
Searching for modelines in '/dev/stdin'
-- Found modeline: Modeline "PG278Q_60" 241.50 2560 2608 2640 2720 1440 1443 1448 1481 -hsync +vsync
```

and I end up with a `PG278Q_60.bin` file.

Does that mean it was broken before?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
