### PR TITLE
nixos/power-management: ensure that the power management scripts are never empty

### DIFF
--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -104,7 +104,12 @@ in
         description = "Pre-Sleep Actions";
         wantedBy = [ "sleep.target" ];
         before = [ "sleep.target" ];
-        script = cfg.powerDownCommands;
+        script = ''
+          # NixOS pre-sleep script
+
+          # config.powerManagement.powerDownCommands
+          ${cfg.powerDownCommands}
+        '';
         serviceConfig.Type = "oneshot";
       };
 
@@ -114,8 +119,14 @@ in
         # Pulled in by post-resume.service above
         after = [ "sleep.target" ];
         script = ''
+          # NixOS pre-resume script
+
           /run/current-system/systemd/bin/systemctl try-restart --no-block post-resume.target
+
+          # config.powerManagement.resumeCommands
           ${cfg.resumeCommands}
+
+          # config.powerManagement.powerUpCommands
           ${cfg.powerUpCommands}
         '';
         serviceConfig.Type = "oneshot";
@@ -130,7 +141,12 @@ in
         before = [
           "shutdown.target"
         ];
-        script = cfg.powerDownCommands;
+        script = ''
+          # NixOS pre-shutdown script
+
+          # config.powerManagement.powerDownCommands
+          ${cfg.powerDownCommands}
+        '';
         serviceConfig.Type = "oneshot";
         unitConfig.DefaultDependencies = false;
       };
@@ -143,7 +159,12 @@ in
         wantedBy = [ "multi-user.target" ];
         restartIfChanged = false;
         script = ''
+          # NixOS post-boot script
+
+          # config.powerManagement.bootCommands
           ${cfg.bootCommands}
+
+          # config.powerManagement.powerUpCommands
           ${cfg.powerUpCommands}
         '';
         serviceConfig = {


### PR DESCRIPTION
When a service's `script` attribute is the empty string, the systemd module treats it as "unset". This leads to services without `ExecStart` directives, which fail to validate.

We fix this by ensuring that we always have something in these scripts, even if that's only whitespace and comments.

Alternatives considered:

1. Removing the respective systemd units (with mkIf) when there's nothing to do can lead to recursive evaluation errors if a config modifies any of these power-management commands based on the presence of a systemd unit.

2. Setting `enabled = false` on units with empty scripts works, but enabled is primarily designed for masking systemd units which isn't what we're trying to do here.

3. We could, e.g., set ExecStart to the `true` command instead of an empty script, but that adds complexity for a negligible performance gain.

fixes #498310

Alternative to https://github.com/NixOS/nixpkgs/pull/498320

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test