### PR TITLE
olivetin: add known vulnerabilities

### DIFF
--- a/pkgs/by-name/ol/olivetin/package.nix
+++ b/pkgs/by-name/ol/olivetin/package.nix
@@ -142,6 +142,16 @@ buildGoModule (
       license = lib.licenses.agpl3Only;
       maintainers = with lib.maintainers; [ defelo ];
       mainProgram = "OliveTin";
+      knownVulnerabilities = [
+        "CVE-2026-27626: OS Command Injection via password argument type and webhook JSON extraction bypasses shell safety checks"
+        "CVE-2026-28342: Unauthenticated Denial of Service via Memory Exhaustion in PasswordHash API Endpoint"
+        "CVE-2026-30223: JWT Audience Validation Bypass in Local Key and HMAC Modes"
+        "CVE-2026-28789: Unauthenticated DoS via concurrent map writes in OAuth2 state handling"
+        "CVE-2026-30224: Session Fixation - Logout Fails to Invalidate Server-Side Session"
+        "CVE-2026-28790: Unauthenticated Action Termination via KillAction When Guests Must Login"
+        "CVE-2026-30233: View permission not being checked when returning dashboards"
+        "CVE-2026-30225: RestartAction always runs actions as guest"
+      ];
     };
   }
 )


### PR DESCRIPTION
Currently there seem to be no patches available for the 2k release series.

https://github.com/NixOS/nixpkgs/issues/494731
https://github.com/NixOS/nixpkgs/issues/497636
https://github.com/NixOS/nixpkgs/issues/497571
https://github.com/NixOS/nixpkgs/issues/497634
https://github.com/NixOS/nixpkgs/issues/497596
https://github.com/NixOS/nixpkgs/issues/497640
https://github.com/NixOS/nixpkgs/issues/497609
https://github.com/NixOS/nixpkgs/issues/497574

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
