### PR TITLE
olivetin-3k: init at 3000.11.3, olivetin: update `gen` hash, refactor

### DIFF
--- a/nixos/modules/services/web-apps/olivetin.nix
+++ b/nixos/modules/services/web-apps/olivetin.nix
@@ -17,7 +17,17 @@ in
   options.services.olivetin = {
     enable = lib.mkEnableOption "OliveTin";
 
-    package = lib.mkPackageOption pkgs "olivetin" { };
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "The olivetin package to use.";
+      default =
+        if lib.versionAtLeast config.system.stateVersion "26.05" then pkgs.olivetin-3k else pkgs.olivetin;
+      defaultText = lib.literalExpression ''
+        if lib.versionAtLeast config.system.stateVersion "26.05"
+        then pkgs.olivetin-3k
+        else pkgs.olivetin
+      '';
+    };
 
     user = lib.mkOption {
       type = lib.types.str;

--- a/nixos/tests/olivetin.nix
+++ b/nixos/tests/olivetin.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 
 {
   name = "olivetin";
@@ -41,16 +41,26 @@
 
   testScript = ''
     import json
+    import shlex
 
     machine.wait_for_unit("olivetin.service")
     machine.wait_for_open_port(8000)
 
-    response = json.loads(machine.succeed("curl http://localhost:8000/api/StartActionByGetAndWait/hello_world"))
+    def start_action(action):
+      if "${config.nodes.machine.services.olivetin.package.releaseSeries}" == "2k":
+        cmd = f"curl http://localhost:8000/api/StartActionByGetAndWait/{action}"
+      else:
+        req = {"actionId": action}
+        cmd = f"curl -H 'Content-Type: application/json' http://localhost:8000/api/olivetin.api.v1.OliveTinApiService/StartActionAndWait -d {shlex.quote(json.dumps(req))}"
+
+      return json.loads(machine.succeed(cmd))
+
+    response = start_action("hello_world")
     assert response["logEntry"]["exitCode"] == 0
     assert response["logEntry"]["output"] == "Hello World!"
     assert machine.succeed("cat /tmp/result") == "Hello World!"
 
-    response = json.loads(machine.succeed("curl http://localhost:8000/api/StartActionByGetAndWait/secret"))
+    response = start_action("secret")
     assert response["logEntry"]["exitCode"] == 0
     assert machine.succeed("cat /tmp/result2") == "secret"
   '';

--- a/pkgs/by-name/ol/olivetin/3k.nix
+++ b/pkgs/by-name/ol/olivetin/3k.nix
@@ -16,20 +16,20 @@
 
 buildGoModule (finalAttrs: {
   pname = "olivetin";
-  version = "2025.11.25";
+  version = "3000.11.3";
 
   src = fetchFromGitHub {
     owner = "OliveTin";
     repo = "OliveTin";
     tag = finalAttrs.version;
-    hash = "sha256-HQLInEVXowWpDaSW/4bduUMdYsvQ0Rju1Rl2l9jupYA=";
+    hash = "sha256-GSCqtekFj0c2TPSygRiUAfSMQAyPbfuR0dxAGQ/Rghw=";
   };
-
-  patches = [ ./update-go-sum.patch ];
 
   modRoot = "service";
 
-  vendorHash = "sha256-xSroaS6fwHrQ0s09uD3bkBZWWxbIndiOGL2JPvKzC6E=";
+  vendorHash = "sha256-iH9tgw4KSER/xIPOIontSQLWrI4ORayRjyHsT1HU0m8=";
+
+  subPackages = [ "." ];
 
   ldflags = [
     "-s"
@@ -75,21 +75,21 @@ buildGoModule (finalAttrs: {
     '';
 
     outputHashMode = "recursive";
-    outputHash = "sha256-fTsJE9ymtJ0TU2OhXLE+XfEOckFMG7IPi0IHHAmN84s=";
+    outputHash = "sha256-SaGHxawFw55zI37psqI9kdaR8DLnx4iV2XZdomr28b8=";
   };
 
   webui = buildNpmPackage {
     pname = "olivetin-webui";
     inherit (finalAttrs) version src;
 
-    npmDepsHash = "sha256-a1BBNlGusdMlmDXgclGqkO8AywSd4DTQKkuBVzuzAfE=";
+    npmDepsHash = "sha256-vrvwy96wtXxt0JJDs8YG0Lm3kpVRoJ2Qmu8nlggH6qc=";
 
-    sourceRoot = "${finalAttrs.src.name}/webui.dev";
+    sourceRoot = "${finalAttrs.src.name}/frontend";
 
     buildPhase = ''
       runHook preBuild
 
-      npx parcel build --public-url "."
+      make build
 
       runHook postBuild
     '';
@@ -98,7 +98,6 @@ buildGoModule (finalAttrs: {
       runHook preInstall
 
       cp -r dist $out
-      cp -r *.png $out
 
       runHook postInstall
     '';
@@ -110,8 +109,6 @@ buildGoModule (finalAttrs: {
     ln -s ${finalAttrs.gen} gen
     substituteInPlace internal/config/config.go \
       --replace-fail 'config.WebUIDir = "./webui"' 'config.WebUIDir = "${finalAttrs.webui}"'
-    substituteInPlace internal/httpservers/webuiServer_test.go \
-      --replace-fail '"../webui/"' '"${finalAttrs.webui}"'
   '';
 
   postInstall = ''
@@ -128,8 +125,8 @@ buildGoModule (finalAttrs: {
         services.olivetin.package = finalAttrs.finalPackage;
       };
     };
-    releaseSeries = "2k";
-    updateScript = ./update.sh;
+    releaseSeries = "3k";
+    updateScript = ./update-3k.sh;
   };
 
   meta = {
@@ -140,16 +137,5 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ defelo ];
     mainProgram = "OliveTin";
-    knownVulnerabilities = [
-      "CVE-2026-27626: OS Command Injection via password argument type and webhook JSON extraction bypasses shell safety checks"
-      "CVE-2026-28342: Unauthenticated Denial of Service via Memory Exhaustion in PasswordHash API Endpoint"
-      "CVE-2026-28789: Unauthenticated DoS via concurrent map writes in OAuth2 state handling"
-      "CVE-2026-28790: Unauthenticated Action Termination via KillAction When Guests Must Login"
-      "CVE-2026-30223: JWT Audience Validation Bypass in Local Key and HMAC Modes"
-      "CVE-2026-30224: Session Fixation - Logout Fails to Invalidate Server-Side Session"
-      "CVE-2026-30225: RestartAction always runs actions as guest"
-      "CVE-2026-30233: View permission not being checked when returning dashboards"
-      "CVE-2026-31817: Unsafe parsing of UniqueTrackingId can be used to write files"
-    ];
   };
 })

--- a/pkgs/by-name/ol/olivetin/package.nix
+++ b/pkgs/by-name/ol/olivetin/package.nix
@@ -75,7 +75,7 @@ buildGoModule (finalAttrs: {
     '';
 
     outputHashMode = "recursive";
-    outputHash = "sha256-wHqXsSV18mF/CfLQ0S4rGtT3QRcLnneYXAa8nXZaHpQ=";
+    outputHash = "sha256-fTsJE9ymtJ0TU2OhXLE+XfEOckFMG7IPi0IHHAmN84s=";
   };
 
   webui = buildNpmPackage {

--- a/pkgs/by-name/ol/olivetin/package.nix
+++ b/pkgs/by-name/ol/olivetin/package.nix
@@ -119,7 +119,6 @@ buildGoModule (finalAttrs: {
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgram = "${placeholder "out"}/bin/OliveTin";
   versionCheckProgramArg = "-version";
   doInstallCheck = true;
 

--- a/pkgs/by-name/ol/olivetin/package.nix
+++ b/pkgs/by-name/ol/olivetin/package.nix
@@ -14,145 +14,138 @@
   nixosTests,
 }:
 
-buildGoModule (
-  finalAttrs:
+buildGoModule (finalAttrs: {
+  pname = "olivetin";
+  version = "2025.11.25";
 
-  let
-    gen = stdenvNoCC.mkDerivation {
-      pname = "olivetin-gen";
-      inherit (finalAttrs) version src;
+  src = fetchFromGitHub {
+    owner = "OliveTin";
+    repo = "OliveTin";
+    tag = finalAttrs.version;
+    hash = "sha256-HQLInEVXowWpDaSW/4bduUMdYsvQ0Rju1Rl2l9jupYA=";
+  };
 
-      nativeBuildInputs = [
-        writableTmpDirAsHomeHook
-        buf
-        protoc-gen-go
-        protoc-gen-go-grpc
-        grpc-gateway
-      ];
+  patches = [ ./update-go-sum.patch ];
 
-      buildPhase = ''
-        runHook preBuild
+  modRoot = "service";
 
-        pushd proto
-        buf generate
-        popd
+  vendorHash = "sha256-xSroaS6fwHrQ0s09uD3bkBZWWxbIndiOGL2JPvKzC6E=";
 
-        runHook postBuild
-      '';
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
 
-      installPhase = ''
-        runHook preInstall
+  __darwinAllowLocalNetworking = true;
 
-        cp -r service/gen $out
+  gen = stdenvNoCC.mkDerivation {
+    pname = "olivetin-gen";
+    inherit (finalAttrs) version src;
 
-        runHook postInstall
-      '';
-
-      postFixup = ''
-        find $out -type f -name '*.go' -exec \
-          sed -i -E 's|//.*protoc-gen-go(-grpc)? +v.*$||' {} +
-      '';
-
-      outputHashMode = "recursive";
-      outputHash = "sha256-wHqXsSV18mF/CfLQ0S4rGtT3QRcLnneYXAa8nXZaHpQ=";
-    };
-
-    webui = buildNpmPackage {
-      pname = "olivetin-webui";
-      inherit (finalAttrs) version src;
-
-      npmDepsHash = "sha256-a1BBNlGusdMlmDXgclGqkO8AywSd4DTQKkuBVzuzAfE=";
-
-      sourceRoot = "${finalAttrs.src.name}/webui.dev";
-
-      buildPhase = ''
-        runHook preBuild
-
-        npx parcel build --public-url "."
-
-        runHook postBuild
-      '';
-
-      installPhase = ''
-        runHook preInstall
-
-        cp -r dist $out
-        cp -r *.png $out
-
-        runHook postInstall
-      '';
-    };
-  in
-
-  {
-    pname = "olivetin";
-    version = "2025.11.25";
-
-    src = fetchFromGitHub {
-      owner = "OliveTin";
-      repo = "OliveTin";
-      tag = finalAttrs.version;
-      hash = "sha256-HQLInEVXowWpDaSW/4bduUMdYsvQ0Rju1Rl2l9jupYA=";
-    };
-
-    patches = [ ./update-go-sum.patch ];
-
-    modRoot = "service";
-
-    vendorHash = "sha256-xSroaS6fwHrQ0s09uD3bkBZWWxbIndiOGL2JPvKzC6E=";
-
-    ldflags = [
-      "-s"
-      "-w"
-      "-X main.version=${finalAttrs.version}"
+    nativeBuildInputs = [
+      writableTmpDirAsHomeHook
+      buf
+      protoc-gen-go
+      protoc-gen-go-grpc
+      grpc-gateway
     ];
 
-    __darwinAllowLocalNetworking = true;
+    buildPhase = ''
+      runHook preBuild
 
-    nativeBuildInputs = [ installShellFiles ];
+      pushd proto
+      buf generate
+      popd
 
-    preBuild = ''
-      ln -s ${gen} gen
-      substituteInPlace internal/config/config.go \
-        --replace-fail 'config.WebUIDir = "./webui"' 'config.WebUIDir = "${webui}"'
-      substituteInPlace internal/httpservers/webuiServer_test.go \
-        --replace-fail '"../webui/"' '"${webui}"'
+      runHook postBuild
     '';
 
-    postInstall = ''
-      installManPage ../var/manpage/OliveTin.1.gz
+    installPhase = ''
+      runHook preInstall
+
+      cp -r service/gen $out
+
+      runHook postInstall
     '';
 
-    nativeInstallCheckInputs = [ versionCheckHook ];
-    versionCheckProgram = "${placeholder "out"}/bin/OliveTin";
-    versionCheckProgramArg = "-version";
-    doInstallCheck = true;
+    postFixup = ''
+      find $out -type f -name '*.go' -exec \
+        sed -i -E 's|//.*protoc-gen-go(-grpc)? +v.*$||' {} +
+    '';
 
-    passthru = {
-      inherit gen webui;
-      tests = { inherit (nixosTests) olivetin; };
-      updateScript = ./update.sh;
-    };
+    outputHashMode = "recursive";
+    outputHash = "sha256-wHqXsSV18mF/CfLQ0S4rGtT3QRcLnneYXAa8nXZaHpQ=";
+  };
 
-    meta = {
-      description = "Gives safe and simple access to predefined shell commands from a web interface";
-      homepage = "https://www.olivetin.app/";
-      downloadPage = "https://github.com/OliveTin/OliveTin";
-      changelog = "https://github.com/OliveTin/OliveTin/releases/tag/${finalAttrs.version}";
-      license = lib.licenses.agpl3Only;
-      maintainers = with lib.maintainers; [ defelo ];
-      mainProgram = "OliveTin";
-      knownVulnerabilities = [
-        "CVE-2026-27626: OS Command Injection via password argument type and webhook JSON extraction bypasses shell safety checks"
-        "CVE-2026-28342: Unauthenticated Denial of Service via Memory Exhaustion in PasswordHash API Endpoint"
-        "CVE-2026-28789: Unauthenticated DoS via concurrent map writes in OAuth2 state handling"
-        "CVE-2026-28790: Unauthenticated Action Termination via KillAction When Guests Must Login"
-        "CVE-2026-30223: JWT Audience Validation Bypass in Local Key and HMAC Modes"
-        "CVE-2026-30224: Session Fixation - Logout Fails to Invalidate Server-Side Session"
-        "CVE-2026-30225: RestartAction always runs actions as guest"
-        "CVE-2026-30233: View permission not being checked when returning dashboards"
-        "CVE-2026-31817: Unsafe parsing of UniqueTrackingId can be used to write files"
-      ];
-    };
-  }
-)
+  webui = buildNpmPackage {
+    pname = "olivetin-webui";
+    inherit (finalAttrs) version src;
+
+    npmDepsHash = "sha256-a1BBNlGusdMlmDXgclGqkO8AywSd4DTQKkuBVzuzAfE=";
+
+    sourceRoot = "${finalAttrs.src.name}/webui.dev";
+
+    buildPhase = ''
+      runHook preBuild
+
+      npx parcel build --public-url "."
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r dist $out
+      cp -r *.png $out
+
+      runHook postInstall
+    '';
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  preBuild = ''
+    ln -s ${finalAttrs.gen} gen
+    substituteInPlace internal/config/config.go \
+      --replace-fail 'config.WebUIDir = "./webui"' 'config.WebUIDir = "${finalAttrs.webui}"'
+    substituteInPlace internal/httpservers/webuiServer_test.go \
+      --replace-fail '"../webui/"' '"${finalAttrs.webui}"'
+  '';
+
+  postInstall = ''
+    installManPage ../var/manpage/OliveTin.1.gz
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/OliveTin";
+  versionCheckProgramArg = "-version";
+  doInstallCheck = true;
+
+  passthru = {
+    tests = { inherit (nixosTests) olivetin; };
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "Gives safe and simple access to predefined shell commands from a web interface";
+    homepage = "https://www.olivetin.app/";
+    downloadPage = "https://github.com/OliveTin/OliveTin";
+    changelog = "https://github.com/OliveTin/OliveTin/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ defelo ];
+    mainProgram = "OliveTin";
+    knownVulnerabilities = [
+      "CVE-2026-27626: OS Command Injection via password argument type and webhook JSON extraction bypasses shell safety checks"
+      "CVE-2026-28342: Unauthenticated Denial of Service via Memory Exhaustion in PasswordHash API Endpoint"
+      "CVE-2026-28789: Unauthenticated DoS via concurrent map writes in OAuth2 state handling"
+      "CVE-2026-28790: Unauthenticated Action Termination via KillAction When Guests Must Login"
+      "CVE-2026-30223: JWT Audience Validation Bypass in Local Key and HMAC Modes"
+      "CVE-2026-30224: Session Fixation - Logout Fails to Invalidate Server-Side Session"
+      "CVE-2026-30225: RestartAction always runs actions as guest"
+      "CVE-2026-30233: View permission not being checked when returning dashboards"
+      "CVE-2026-31817: Unsafe parsing of UniqueTrackingId can be used to write files"
+    ];
+  };
+})

--- a/pkgs/by-name/ol/olivetin/update-3k.sh
+++ b/pkgs/by-name/ol/olivetin/update-3k.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update common-updater-scripts
+
+set -euo pipefail
+
+nix-update olivetin-3k --src-only --override-filename
+update-source-version olivetin-3k --source-key=gen --ignore-same-version
+update-source-version olivetin-3k --source-key=webui.npmDeps --ignore-same-version
+update-source-version olivetin-3k --source-key=goModules --ignore-same-version

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12437,6 +12437,8 @@ with pkgs;
 
   radicle-node-unstable = callPackage ../by-name/ra/radicle-node/unstable.nix { };
 
+  olivetin-3k = callPackage ../by-name/ol/olivetin/3k.nix { };
+
   newlib-nano = newlib.override {
     nanoizeNewlib = true;
   };


### PR DESCRIPTION
The `olivetin` package (currently on the 2k release series) contains a number of unpatched security vulnerabilities (#498593, #498868) which have only been fixed in the 3k release series. According to the [documentation](https://docs.olivetin.app/upgrade/2k3k.html) 3k contains some breaking changes, and 2k is still supposed to be supported "until at least 31st December 2028", so this PR adds a new `olivetin-3k` package and makes it the default for the olivetin module starting with NixOS 26.05, but still allows users to go back to the 2k releases series by using the `olivetin` package instead. Due to aforementioned security vulnerabilities this is not recommended at the moment, but will hopefully be possible once the fixes have been backported to 2k.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
