### PR TITLE
xfr: init at 0.9.6

### DIFF
--- a/pkgs/by-name/xf/xfr/package.nix
+++ b/pkgs/by-name/xf/xfr/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "xfr";
+  version = "0.9.6";
+
+  src = fetchFromGitHub {
+    owner = "lance0";
+    repo = "xfr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wYhwDSL9C4rtWgkhaXimk3u03c9UHj2O9eEe8pRlj6c=";
+  };
+
+  cargoHash = "sha256-f8m5vFNk62iXyK1Sh3Dda0pV6rUNErymS6QxiCuZ8DA=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  postInstall = ''
+    installShellCompletion --cmd xfr \
+      --bash <($out/bin/xfr --completions bash) \
+      --fish <($out/bin/xfr --completions fish) \
+      --zsh <($out/bin/xfr --completions zsh)
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Modern iperf3 alternative with a live TUI, multi-client server, and QUIC support.";
+    mainProgram = "xfr";
+    homepage = "https://github.com/lance0/xfs";
+    changelog = "https://github.com/lance0/xfr/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [
+      _0x4A6F
+      herbetom
+    ];
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
iperf3 alternative with a live TUI, multi-client server, and QUIC support

Project Repo: https://github.com/lance0/xfr

I've reused the package.nix from the [ttl](https://github.com/NixOS/nixpkgs/blob/1f0603d571329b2ed20ac2e7afce98f0318d203b/pkgs/by-name/tt/ttl/package.nix) package of the same developer which i discovered by pure chance :)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
