### PR TITLE
direwolf: include darwin and BSD deps

### DIFF
--- a/pkgs/by-name/di/direwolf/package.nix
+++ b/pkgs/by-name/di/direwolf/package.nix
@@ -3,16 +3,22 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch,
-  cmake,
+  avahi,
+  avahiSupport ? true,
   alsa-lib,
+  cmake,
+  libgpiod,
+  libgpiodSupport ? false,
   gpsd,
   gpsdSupport ? false,
   hamlib_4,
   hamlib ? hamlib_4,
   hamlibSupport ? true,
+  hidapi,
   perl,
   portaudio,
   python3,
+  sndio,
   espeak,
   udev,
   udevCheckHook,
@@ -44,7 +50,13 @@ stdenv.mkDerivation (finalAttrs: {
       alsa-lib
       udev
     ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ portaudio ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      hidapi
+      portaudio
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isBSD) [ sndio ]
+    ++ lib.optionals avahiSupport [ avahi ]
+    ++ lib.optionals libgpiodSupport [ libgpiod ]
     ++ lib.optionals gpsdSupport [ gpsd ]
     ++ lib.optionals hamlibSupport [ hamlib ]
     ++ lib.optionals extraScripts [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

This fixes the build of direwolf on darwin:

```
$ nix build .#direwolf
...
       > CMake Error in src/CMakeLists.txt:
       >   Found relative path while evaluating include directories of "appserver":
       >
       >     "HIDAPI_INCLUDE_DIRS-NOTFOUND"
       >
       >
       >
       > -- Generating done (0.1s)
       > CMake Warning:
       >   Manually-specified variables were not used by the project:
       >
       >     BUILD_TESTING
       >     CMAKE_EXPORT_NO_PACKAGE_REGISTRY
       >     CMAKE_INSTALL_BINDIR
       >     CMAKE_INSTALL_DOCDIR
       >     CMAKE_INSTALL_INCLUDEDIR
       >     CMAKE_INSTALL_INFODIR
       >     CMAKE_INSTALL_LIBDIR
       >     CMAKE_INSTALL_LIBEXECDIR
       >     CMAKE_INSTALL_LOCALEDIR
       >     CMAKE_INSTALL_MANDIR
       >     CMAKE_INSTALL_SBINDIR
       >
       >
       > CMake Generate step failed.  Build files cannot be regenerated correctly.
       For full logs, run:
 ```

Supersedes: https://github.com/NixOS/nixpkgs/pull/484861

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
