### PR TITLE
fosrl-pangolin: 1.15.3 -> 1.16.2

### DIFF
--- a/pkgs/by-name/fo/fosrl-pangolin/package.nix
+++ b/pkgs/by-name/fo/fosrl-pangolin/package.nix
@@ -29,16 +29,16 @@ in
 
 buildNpmPackage (finalAttrs: {
   pname = "pangolin";
-  version = "1.15.3";
+  version = "1.16.2";
 
   src = fetchFromGitHub {
     owner = "fosrl";
     repo = "pangolin";
     tag = finalAttrs.version;
-    hash = "sha256-UGfwbFbuQ0ljipCjnPxZ/Is2hh1vjZJb97Lo/43sWeg=";
+    hash = "sha256-pWD2VinfkCiSSP6/einXgduKQ8lzWdHlrj2eqUU/x6Y=";
   };
 
-  npmDepsHash = "sha256-kfgwU5QusUNWVcRXlYCS3ES1Av/phCHG8nFBj0yjz2Q=";
+  npmDepsHash = "sha256-CwS26eRAIuxJ2fekRRapDWYAOHXPV0mIX/by4uW2ZOM=";
 
   nativeBuildInputs = [
     esbuild
@@ -49,12 +49,16 @@ buildNpmPackage (finalAttrs: {
   # Based on pkgs.nextjs-ollama-llm-ui.
   postPatch = ''
     substituteInPlace src/app/layout.tsx --replace-fail \
-      "{ Geist, Inter, Manrope, Open_Sans } from \"next/font/google\"" \
+      "{ Inter } from \"next/font/google\"" \
       "localFont from \"next/font/local\""
 
     substituteInPlace src/app/layout.tsx --replace-fail \
-      "const font = Inter({${"\n"}    subsets: [\"latin\"]${"\n"}});" \
-      "const font = localFont({ src: './Inter.ttf' });"
+      "const inter = Inter({${"\n"}    subsets: [\"latin\"]${"\n"}});" \
+      "const inter = localFont({ src: './Inter.ttf' });"
+
+    substituteInPlace server/lib/consts.ts --replace-fail \
+      'export const APP_VERSION = "1.16.0";' \
+      'export const APP_VERSION = "${finalAttrs.version}";'
 
     cp "${inter}/share/fonts/truetype/InterVariable.ttf" src/app/Inter.ttf
   '';
@@ -62,7 +66,7 @@ buildNpmPackage (finalAttrs: {
   preBuild = ''
     npm run set:${db false}
     npm run set:oss
-    npm run db:${db false}:generate
+    npm run db:generate
   '';
 
   buildPhase = ''


### PR DESCRIPTION
Updated the package to the latest release version of 1.16.2. This also addresses https://github.com/NixOS/nixpkgs/issues/494667 along the way. 

Updated the preBuild and postPatch to match the upstream changes. 
Please note that the APP_VERSION in upstream doesn't match the upstream release version, which is why the numbers don't match. See https://github.com/fosrl/pangolin/blob/1.16.2/server/lib/consts.ts#L5 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
