### PR TITLE
karlyriceditor: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/ka/karlyriceditor/package.nix
+++ b/pkgs/by-name/ka/karlyriceditor/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "gyunaev";
     repo = "karlyriceditor";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-eW5sO1gjuwIighnlylJQd9QC+07s1MZX/oPyaHIi/Qs=";
   };
 
@@ -34,7 +34,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     install -Dm755 bin/karlyriceditor $out/bin/karlyriceditor
     install -Dm644 packages/karlyriceditor.desktop $out/share/applications/karlyriceditor.desktop
-    install -Dm644 packages/karlyriceditor.png $out/share/pixmaps/karlyriceditor.png
+    install -Dm644 packages/karlyriceditor.png $out/share/icons/hicolor/24x24/apps/karlyriceditor.png
+    install -Dm644 src/images/application_icon.png $out/share/icons/hicolor/128x128/apps/karlyriceditor.png
 
     substituteInPlace $out/share/applications/karlyriceditor.desktop \
       --replace-fail 'Icon=/usr/share/pixmaps/karlyriceditor.png' 'Icon=karlyriceditor'


### PR DESCRIPTION
Part of #428824 
(this was built also including the patch in #479489 to fix the build and see what the sizes should be, but not included in this PR so that rebasing isn't as annoying)
Doesn't make sense to merge this before the build is sorted, so leaving this as draft until then.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
