### PR TITLE
surfshark: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8469,6 +8469,12 @@
     name = "A Frederick Christensen";
     keys = [ { fingerprint = "5A49 F4F9 3EDC 21E9 B7CC  4E94 9EEF 4142 5355 8AC4"; } ];
   };
+  FazalAAli = {
+    email = "nix@fazali.dev";
+    github = "FazalAAli";
+    githubId = 37760883;
+    name = "Fazal Ali";
+  };
   fazzi = {
     email = "faaris.ansari@proton.me";
     github = "fxzzi";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -74,6 +74,7 @@
   ./hardware/gpgsmartcards.nix
   ./hardware/graphics.nix
   ./hardware/hackrf.nix
+  ./hardware/hid-fanatecff.nix
   ./hardware/i2c.nix
   ./hardware/infiniband.nix
   ./hardware/inputmodule.nix
@@ -202,7 +203,6 @@
   ./programs/droidcam.nix
   ./programs/dsearch.nix
   ./programs/dublin-traceroute.nix
-  ./programs/ecryptfs.nix
   ./programs/ente-auth.nix
   ./programs/environment.nix
   ./programs/envision.nix
@@ -238,6 +238,7 @@
   ./programs/htop.nix
   ./programs/i3lock.nix
   ./programs/iay.nix
+  ./programs/idescriptor.nix
   ./programs/iftop.nix
   ./programs/iio-hyprland.nix
   ./programs/immersed.nix
@@ -255,7 +256,6 @@
   ./programs/lazygit.nix
   ./programs/less.nix
   ./programs/liboping.nix
-  ./programs/light.nix
   ./programs/lix.nix
   ./programs/localsend.nix
   ./programs/mdevctl.nix
@@ -316,12 +316,12 @@
   ./programs/slock.nix
   ./programs/sniffnet.nix
   ./programs/soundmodem.nix
-  ./programs/spacefm.nix
   ./programs/ssh.nix
   ./programs/starship.nix
   ./programs/steam.nix
   ./programs/streamcontroller.nix
   ./programs/streamdeck-ui.nix
+
   ./programs/sysdig.nix
   ./programs/system-config-printer.nix
   ./programs/systemtap.nix
@@ -348,6 +348,7 @@
   ./programs/wayland/hyprland.nix
   ./programs/wayland/hyprlock.nix
   ./programs/wayland/labwc.nix
+  ./programs/wayland/mangowc.nix
   ./programs/wayland/miracle-wm.nix
   ./programs/wayland/niri.nix
   ./programs/wayland/river.nix
@@ -557,7 +558,9 @@
   ./services/desktops/blueman.nix
   ./services/desktops/bonsaid.nix
   ./services/desktops/cpupower-gui.nix
+  ./services/desktops/crossmacro.nix
   ./services/desktops/dleyna.nix
+  ./services/desktops/dunst.nix
   ./services/desktops/espanso.nix
   ./services/desktops/flatpak.nix
   ./services/desktops/geoclue2.nix
@@ -602,19 +605,23 @@
   ./services/development/hoogle.nix
   ./services/development/jupyter/default.nix
   ./services/development/jupyterhub/default.nix
+  ./services/development/labgrid/coordinator.nix
   ./services/development/livebook.nix
   ./services/development/lorri.nix
   ./services/development/nixseparatedebuginfod2.nix
   ./services/development/rstudio-server/default.nix
+  ./services/development/turborepo-remote-cache.nix
   ./services/development/vsmartcard-vpcd.nix
   ./services/development/zammad.nix
   ./services/display-managers/cosmic-greeter.nix
   ./services/display-managers/default.nix
   ./services/display-managers/dms-greeter.nix
   ./services/display-managers/gdm.nix
+  ./services/display-managers/generic.nix
   ./services/display-managers/greetd.nix
   ./services/display-managers/lemurs.nix
   ./services/display-managers/ly.nix
+  ./services/display-managers/plasma-login-manager.nix
   ./services/display-managers/sddm.nix
   ./services/editors/emacs.nix
   ./services/editors/haste.nix
@@ -777,7 +784,7 @@
   ./services/mail/rss2email.nix
   ./services/mail/schleuder.nix
   ./services/mail/spamassassin.nix
-  ./services/mail/stalwart-mail.nix
+  ./services/mail/stalwart.nix
   ./services/mail/sympa.nix
   ./services/mail/tlsrpt.nix
   ./services/mail/zeyple.nix
@@ -841,6 +848,7 @@
   ./services/misc/dump1090-fa.nix
   ./services/misc/dwm-status.nix
   ./services/misc/dysnomia.nix
+  ./services/misc/elephant.nix
   ./services/misc/errbot.nix
   ./services/misc/ersatztv.nix
   ./services/misc/etebase-server.nix
@@ -867,6 +875,7 @@
   ./services/misc/headphones.nix
   ./services/misc/heisenbridge.nix
   ./services/misc/homepage-dashboard.nix
+  ./services/misc/hyprwhspr-rs.nix
   ./services/misc/ihaskell.nix
   ./services/misc/iio-niri.nix
   ./services/misc/input-remapper.nix
@@ -875,10 +884,12 @@
   ./services/misc/jackett.nix
   ./services/misc/jellyfin.nix
   ./services/misc/jellyseerr.nix
+  ./services/misc/kiwix-serve.nix
   ./services/misc/klipper.nix
   ./services/misc/languagetool.nix
   ./services/misc/leaps.nix
   ./services/misc/lifecycled.nix
+  ./services/misc/linux-enable-ir-emitter.nix
   ./services/misc/litellm.nix
   ./services/misc/llama-cpp.nix
   ./services/misc/local-content-share.nix
@@ -1030,6 +1041,7 @@
   ./services/monitoring/opentelemetry-collector.nix
   ./services/monitoring/osquery.nix
   ./services/monitoring/parsedmarc.nix
+  ./services/monitoring/perses.nix
   ./services/monitoring/pgscv.nix
   ./services/monitoring/prometheus/alertmanager-gotify-bridge.nix
   ./services/monitoring/prometheus/alertmanager-irc-relay.nix
@@ -1041,6 +1053,7 @@
   ./services/monitoring/prometheus/pushgateway.nix
   ./services/monitoring/prometheus/sachet.nix
   ./services/monitoring/prometheus/xmpp-alerts.nix
+  ./services/monitoring/pyroscope.nix
   ./services/monitoring/riemann-dash.nix
   ./services/monitoring/riemann-tools.nix
   ./services/monitoring/riemann.nix
@@ -1049,7 +1062,6 @@
   ./services/monitoring/scrutiny.nix
   ./services/monitoring/smartd.nix
   ./services/monitoring/snmpd.nix
-  ./services/monitoring/statsd.nix
   ./services/monitoring/sysstat.nix
   ./services/monitoring/teamviewer.nix
   ./services/monitoring/telegraf.nix
@@ -1061,7 +1073,6 @@
   ./services/monitoring/unpoller.nix
   ./services/monitoring/ups.nix
   ./services/monitoring/uptime-kuma.nix
-  ./services/monitoring/uptime.nix
   ./services/monitoring/vlagent.nix
   ./services/monitoring/vmagent.nix
   ./services/monitoring/vmalert.nix
@@ -1109,6 +1120,7 @@
   ./services/networking/atalkd.nix
   ./services/networking/atftpd.nix
   ./services/networking/atticd.nix
+  ./services/networking/autossh-ng.nix
   ./services/networking/autossh.nix
   ./services/networking/avahi-daemon.nix
   ./services/networking/ax25/axlisten.nix
@@ -1128,7 +1140,6 @@
   ./services/networking/cato-client.nix
   ./services/networking/centrifugo.nix
   ./services/networking/cgit.nix
-  ./services/networking/charybdis.nix
   ./services/networking/chisel-server.nix
   ./services/networking/cjdns.nix
   ./services/networking/clatd.nix
@@ -1387,12 +1398,14 @@
   ./services/networking/sunshine.nix
   ./services/networking/supplicant.nix
   ./services/networking/supybot.nix
+  ./services/networking/surfshark.nix
   ./services/networking/suricata/default.nix
   ./services/networking/syncplay.nix
   ./services/networking/syncthing-relay.nix
   ./services/networking/syncthing.nix
   ./services/networking/tailscale-auth.nix
   ./services/networking/tailscale-derper.nix
+  ./services/networking/tailscale-serve.nix
   ./services/networking/tailscale.nix
   ./services/networking/tayga.nix
   ./services/networking/tcpcrypt.nix
@@ -1490,6 +1503,7 @@
   ./services/security/hockeypuck.nix
   ./services/security/hologram-agent.nix
   ./services/security/hologram-server.nix
+  ./services/security/howdy
   ./services/security/infnoise.nix
   ./services/security/intune.nix
   ./services/security/jitterentropy-rngd.nix
@@ -1507,11 +1521,15 @@
   ./services/security/reaction.nix
   ./services/security/shibboleth-sp.nix
   ./services/security/sks.nix
+  ./services/security/spire/agent.nix
+  ./services/security/spire/server.nix
+  ./services/security/ssh-agent-switcher.nix
   ./services/security/sshguard.nix
   ./services/security/sslmate-agent.nix
   ./services/security/step-ca.nix
   ./services/security/tang.nix
   ./services/security/timekpr.nix
+  ./services/security/tinyauth.nix
   ./services/security/tor.nix
   ./services/security/torify.nix
   ./services/security/torsocks.nix
@@ -1553,6 +1571,8 @@
   ./services/torrent/opentracker.nix
   ./services/torrent/peerflix.nix
   ./services/torrent/qbittorrent.nix
+  ./services/torrent/qui.nix
+  ./services/torrent/rqbit.nix
   ./services/torrent/rtorrent.nix
   ./services/torrent/torrentstream.nix
   ./services/torrent/transmission.nix
@@ -1580,6 +1600,7 @@
   ./services/web-apps/artalk.nix
   ./services/web-apps/audiobookshelf.nix
   ./services/web-apps/baikal.nix
+  ./services/web-apps/bentopdf.nix
   ./services/web-apps/bluemap.nix
   ./services/web-apps/bluesky-pds.nix
   ./services/web-apps/bookstack.nix
@@ -1589,6 +1610,7 @@
   ./services/web-apps/changedetection-io.nix
   ./services/web-apps/chhoto-url.nix
   ./services/web-apps/cloudlog.nix
+  ./services/web-apps/cocoon.nix
   ./services/web-apps/code-server.nix
   ./services/web-apps/coder.nix
   ./services/web-apps/collabora-online.nix
@@ -1598,6 +1620,7 @@
   ./services/web-apps/cryptpad.nix
   ./services/web-apps/dashy.nix
   ./services/web-apps/davis.nix
+  ./services/web-apps/dawarich.nix
   ./services/web-apps/dependency-track.nix
   ./services/web-apps/dex.nix
   ./services/web-apps/discourse.nix
@@ -1605,9 +1628,9 @@
   ./services/web-apps/docuseal.nix
   ./services/web-apps/dokuwiki.nix
   ./services/web-apps/dolibarr.nix
+  ./services/web-apps/drasl.nix
   ./services/web-apps/drupal.nix
   ./services/web-apps/echoip.nix
-  ./services/web-apps/eintopf.nix
   ./services/web-apps/engelsystem.nix
   ./services/web-apps/ente.nix
   ./services/web-apps/fediwall.nix
@@ -1648,6 +1671,7 @@
   ./services/web-apps/immich.nix
   ./services/web-apps/immichframe.nix
   ./services/web-apps/invidious.nix
+  ./services/web-apps/invoiceplane.nix
   ./services/web-apps/isso.nix
   ./services/web-apps/jirafeau.nix
   ./services/web-apps/jitsi-meet.nix
@@ -1661,6 +1685,7 @@
   ./services/web-apps/lanraragi.nix
   ./services/web-apps/lasuite-docs.nix
   ./services/web-apps/lasuite-meet.nix
+  ./services/web-apps/lauti.nix
   ./services/web-apps/lemmy.nix
   ./services/web-apps/librechat.nix
   ./services/web-apps/librespeed.nix
@@ -1704,11 +1729,13 @@
   ./services/web-apps/outline.nix
   ./services/web-apps/pairdrop.nix
   ./services/web-apps/part-db.nix
+  ./services/web-apps/pdfding.nix
   ./services/web-apps/peering-manager.nix
   ./services/web-apps/peertube-runner.nix
   ./services/web-apps/peertube.nix
   ./services/web-apps/pgpkeyserver-lite.nix
   ./services/web-apps/photoprism.nix
+  ./services/web-apps/photoview.nix
   ./services/web-apps/phylactery.nix
   ./services/web-apps/pict-rs.nix
   ./services/web-apps/pihole-web.nix
@@ -1722,6 +1749,7 @@
   ./services/web-apps/privatebin.nix
   ./services/web-apps/prosody-filer.nix
   ./services/web-apps/readeck.nix
+  ./services/web-apps/remark42.nix
   ./services/web-apps/reposilite.nix
   ./services/web-apps/rimgo.nix
   ./services/web-apps/rss-bridge.nix
@@ -1737,6 +1765,7 @@
   ./services/web-apps/snipe-it.nix
   ./services/web-apps/snips-sh.nix
   ./services/web-apps/sogo.nix
+  ./services/web-apps/speedtest-tracker.nix
   ./services/web-apps/sshwifty.nix
   ./services/web-apps/stash.nix
   ./services/web-apps/stirling-pdf.nix
@@ -1919,7 +1948,6 @@
   ./tasks/filesystems/bindfs.nix
   ./tasks/filesystems/btrfs.nix
   ./tasks/filesystems/cifs.nix
-  ./tasks/filesystems/ecryptfs.nix
   ./tasks/filesystems/envfs.nix
   ./tasks/filesystems/erofs.nix
   ./tasks/filesystems/exfat.nix
@@ -1929,7 +1957,6 @@
   ./tasks/filesystems/nfs.nix
   ./tasks/filesystems/ntfs.nix
   ./tasks/filesystems/overlayfs.nix
-  ./tasks/filesystems/reiserfs.nix
   ./tasks/filesystems/squashfs.nix
   ./tasks/filesystems/sshfs.nix
   ./tasks/filesystems/unionfs-fuse.nix

--- a/nixos/modules/services/networking/surfshark.nix
+++ b/nixos/modules/services/networking/surfshark.nix
@@ -1,0 +1,44 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.surfshark;
+in
+{
+  options.services.surfshark = {
+    enable = lib.mkEnableOption "Surfshark VPN client";
+    package = lib.mkPackageOption pkgs "surfshark" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    # Install the systemd units shipped inside the package
+    systemd.packages = [ cfg.package ];
+
+    # surfsharkd2 — system daemon (manages VPN tunnels via openvpn/wireguard)
+    systemd.services.surfsharkd2 = {
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [
+        coreutils
+        procps
+        which
+        iputils
+      ];
+    };
+
+    # surfsharkd — per-user daemon (IPC bridge between GUI and system daemon)
+    systemd.user.services.surfsharkd = {
+      wantedBy = [ "default.target" ];
+      environment = {
+        # Required by the GJS daemon to import the NetworkManager typelib
+        GI_TYPELIB_PATH = "${pkgs.networkmanager}/lib/girepository-1.0";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ FazalAAli ];
+}

--- a/pkgs/by-name/su/surfshark/package.nix
+++ b/pkgs/by-name/su/surfshark/package.nix
@@ -1,0 +1,152 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeBinaryWrapper,
+  dpkg,
+  gjs,
+  glib,
+  nss,
+  nspr,
+  at-spi2-atk,
+  cups,
+  libdrm,
+  gtk3,
+  pango,
+  cairo,
+  libgbm,
+  expat,
+  libxkbcommon,
+  alsa-lib,
+  libnotify,
+  mesa,
+  vulkan-loader,
+  systemd,
+  coreutils,
+  procps,
+  which,
+  iputils,
+  xorg,
+}:
+let
+  xorgDeps = with xorg; [
+    libX11
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libXrandr
+    libxcb
+    libXtst
+  ];
+
+  deps = [
+    glib
+    nss
+    nspr
+    at-spi2-atk
+    cups
+    libdrm
+    gtk3
+    pango
+    cairo
+    libgbm
+    expat
+    libxkbcommon
+    alsa-lib
+    libnotify
+    mesa
+    vulkan-loader
+  ] ++ xorgDeps;
+
+  libPath = lib.makeLibraryPath (deps ++ [ (lib.getLib systemd) ]);
+  binPath = lib.makeBinPath [
+    coreutils
+    procps
+    which
+    iputils
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "surfshark";
+  version = "3.9.0";
+
+  src = fetchurl {
+    url = "https://ocean.surfshark.com/debian/pool/main/s/surfshark_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-1GdtzTQt4wIg+8rABNHq1kyGE2rf2cZTqxfQqRIIkao=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeBinaryWrapper
+  ];
+
+  buildInputs = deps;
+
+  runtimeDependencies = [ (lib.getLib systemd) ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/surfshark,lib/systemd/system,lib/systemd/user}
+
+    # App bundle
+    cp -r opt/Surfshark/. $out/share/surfshark/
+
+    # Desktop entry, icons, docs
+    cp -r usr/share/. $out/share/
+
+    # OpenVPN certs
+    mkdir -p $out/etc/openvpn/client/surfshark
+    cp -r etc/openvpn/client/surfshark/. $out/etc/openvpn/client/surfshark/
+
+    # systemd service units — patch hardcoded /opt/Surfshark paths
+    substitute usr/lib/systemd/system/surfsharkd2.service $out/lib/systemd/system/surfsharkd2.service \
+      --replace-fail "/opt/Surfshark" "$out/share/surfshark"
+    substitute usr/lib/systemd/user/surfsharkd.service $out/lib/systemd/user/surfsharkd.service \
+      --replace-fail "/opt/Surfshark" "$out/share/surfshark"
+
+    # Patch GJS shebang and make daemon scripts executable
+    for js in surfsharkd.js surfsharkd2.js; do
+      daemon="$out/share/surfshark/resources/dist/resources/$js"
+      substituteInPlace "$daemon" \
+        --replace-fail "#!/usr/bin/gjs" "#!${gjs}/bin/gjs"
+      chmod +x "$daemon"
+    done
+
+    # Fix .desktop Exec path
+    sed -i "s|Exec=/opt/Surfshark/surfshark|Exec=$out/bin/surfshark|" \
+      $out/share/applications/surfshark.desktop
+
+    # Vulkan loader symlink (so bundled ANGLE finds libvulkan)
+    ln -sf ${lib.getLib vulkan-loader}/lib/libvulkan.so.1 \
+      $out/share/surfshark/libvulkan.so.1
+
+    # Patch bundled GL libs rpath
+    patchelf $out/share/surfshark/lib*GL* --set-rpath ${libPath} || true
+
+    makeBinaryWrapper $out/share/surfshark/surfshark $out/bin/surfshark \
+      --add-flags "--no-sandbox" \
+      --prefix PATH : ${binPath} \
+      --prefix LD_LIBRARY_PATH : ${libPath}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Surfshark VPN client";
+    homepage = "https://surfshark.com";
+    downloadPage = "https://surfshark.com/download/linux";
+    mainProgram = "surfshark";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ FazalAAli ];
+  };
+})


### PR DESCRIPTION
## Description

Adds the [Surfshark VPN client](https://surfshark.com) for Linux.

Surfshark is a proprietary VPN client distributed as a Debian package. It consists of an Electron-based GUI app and two GJS (GNOME JavaScript) daemons that manage VPN tunnels via OpenVPN/WireGuard.

## Structure

- `pkgs/by-name/su/surfshark/package.nix` — unpacks the upstream `.deb`, patches GJS daemon shebangs, installs systemd units with corrected store paths, and wraps the Electron binary
- `nixos/modules/programs/surfshark.nix` — NixOS module that wires up the system and user daemons, including the `GI_TYPELIB_PATH` needed by the GJS daemon to import NetworkManager typelibs

## Testing

Tested on x86_64-linux (NixOS 25.11):
- `nix build .#surfshark` builds successfully
- `services.surfshark.enable = true` activates both `surfsharkd2.service` (system) and `surfsharkd.service` (user)
- GUI launches and connects successfully
- Upon connection, external IP changes as expected
