### PR TITLE
surfshark: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8534,6 +8534,12 @@
     github = "yaoshiu";
     githubId = 56054933;
   };
+  FazalAAli = {
+    email = "nix@fazali.dev";
+    github = "FazalAAli";
+    githubId = 37760883;
+    name = "Fazal Ali";
+  };
   fazzi = {
     email = "faaris.ansari@proton.me";
     github = "fxzzi";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1397,6 +1397,7 @@
   ./services/networking/sunshine.nix
   ./services/networking/supplicant.nix
   ./services/networking/supybot.nix
+  ./services/networking/surfshark.nix
   ./services/networking/suricata/default.nix
   ./services/networking/syncplay.nix
   ./services/networking/syncthing-relay.nix

--- a/nixos/modules/services/networking/surfshark.nix
+++ b/nixos/modules/services/networking/surfshark.nix
@@ -16,11 +16,10 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
-    # Install the systemd units shipped inside the package
     systemd.packages = [ cfg.package ];
 
-    # surfsharkd2 — system daemon (manages VPN tunnels via openvpn/wireguard)
     systemd.services.surfsharkd2 = {
+      serviceConfig.Description = "surfsharkd — per-user daemon (IPC bridge between GUI and system daemon)";
       wantedBy = [ "multi-user.target" ];
       path = with pkgs; [
         coreutils
@@ -30,14 +29,6 @@ in
       ];
     };
 
-    # surfsharkd — per-user daemon (IPC bridge between GUI and system daemon)
-    systemd.user.services.surfsharkd = {
-      wantedBy = [ "default.target" ];
-      environment = {
-        # Required by the GJS daemon to import the NetworkManager typelib
-        GI_TYPELIB_PATH = "${pkgs.networkmanager}/lib/girepository-1.0";
-      };
-    };
   };
 
   meta.maintainers = with lib.maintainers; [ FazalAAli ];

--- a/nixos/modules/services/networking/surfshark.nix
+++ b/nixos/modules/services/networking/surfshark.nix
@@ -1,0 +1,44 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.surfshark;
+in
+{
+  options.services.surfshark = {
+    enable = lib.mkEnableOption "Surfshark VPN client";
+    package = lib.mkPackageOption pkgs "surfshark" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    # Install the systemd units shipped inside the package
+    systemd.packages = [ cfg.package ];
+
+    # surfsharkd2 — system daemon (manages VPN tunnels via openvpn/wireguard)
+    systemd.services.surfsharkd2 = {
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [
+        coreutils
+        procps
+        which
+        iputils
+      ];
+    };
+
+    # surfsharkd — per-user daemon (IPC bridge between GUI and system daemon)
+    systemd.user.services.surfsharkd = {
+      wantedBy = [ "default.target" ];
+      environment = {
+        # Required by the GJS daemon to import the NetworkManager typelib
+        GI_TYPELIB_PATH = "${pkgs.networkmanager}/lib/girepository-1.0";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ FazalAAli ];
+}

--- a/pkgs/by-name/su/surfshark/package.nix
+++ b/pkgs/by-name/su/surfshark/package.nix
@@ -65,7 +65,6 @@ let
     libxtst
   ];
 
-  libPath = lib.makeLibraryPath (deps ++ [ (lib.getLib systemd) ]);
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "surfshark";
@@ -84,8 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = deps;
-
-  runtimeDependencies = [ (lib.getLib systemd) ];
 
   dontConfigure = true;
   dontBuild = true;
@@ -121,13 +118,6 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $out/share/applications/surfshark.desktop \
       --replace-fail "Exec=/opt/Surfshark/surfshark" "Exec=$out/bin/surfshark"
 
-    # Vulkan loader symlink (so bundled ANGLE finds libvulkan)
-    ln -sf ${lib.getLib vulkan-loader}/lib/libvulkan.so.1 \
-      $out/share/surfshark/libvulkan.so.1
-
-    # Patch bundled GL libs rpath
-    patchelf $out/share/surfshark/lib*GL* --set-rpath ${libPath} || true
-
     makeBinaryWrapper $out/share/surfshark/surfshark $out/bin/surfshark \
       --add-flags "--no-sandbox" \
       --prefix PATH : ${
@@ -138,7 +128,6 @@ stdenv.mkDerivation (finalAttrs: {
           iputils
         ]
       } \
-      --prefix LD_LIBRARY_PATH : ${libPath}
 
     runHook postInstall
   '';

--- a/pkgs/by-name/su/surfshark/package.nix
+++ b/pkgs/by-name/su/surfshark/package.nix
@@ -37,16 +37,6 @@
   libxtst,
 }:
 let
-  xorgDeps = [
-    libx11
-    libxcb
-    libxcomposite
-    libxdamage
-    libxext
-    libxfixes
-    libxrandr
-    libxtst
-  ];
 
   deps = [
     glib
@@ -65,8 +55,15 @@ let
     libnotify
     mesa
     vulkan-loader
-  ]
-  ++ xorgDeps;
+    libx11
+    libxcb
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrandr
+    libxtst
+  ];
 
   libPath = lib.makeLibraryPath (deps ++ [ (lib.getLib systemd) ]);
   binPath = lib.makeBinPath [
@@ -88,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     autoPatchelfHook
     dpkg
+    gjs
     makeBinaryWrapper
   ];
 
@@ -97,7 +95,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontConfigure = true;
   dontBuild = true;
-  dontStrip = true;
 
   installPhase = ''
     runHook preInstall
@@ -120,17 +117,15 @@ stdenv.mkDerivation (finalAttrs: {
     substitute usr/lib/systemd/user/surfsharkd.service $out/lib/systemd/user/surfsharkd.service \
       --replace-fail "/opt/Surfshark" "$out/share/surfshark"
 
-    # Patch GJS shebang and make daemon scripts executable
-    for js in surfsharkd.js surfsharkd2.js; do
-      daemon="$out/share/surfshark/resources/dist/resources/$js"
-      substituteInPlace "$daemon" \
-        --replace-fail "#!/usr/bin/gjs" "#!${gjs}/bin/gjs"
-      chmod +x "$daemon"
-    done
+    # Make daemon scripts executable
+    chmod +x $out/share/surfshark/resources/dist/resources/surfsharkd*.js
+
+    # Patch shebangs
+    patchShebangs $out/share/surfshark/resources/dist/resources
 
     # Fix .desktop Exec path
-    sed -i "s|Exec=/opt/Surfshark/surfshark|Exec=$out/bin/surfshark|" \
-      $out/share/applications/surfshark.desktop
+    substituteInPlace $out/share/applications/surfshark.desktop \
+      --replace-fail "Exec=/opt/Surfshark/surfshark" "Exec=$out/bin/surfshark"
 
     # Vulkan loader symlink (so bundled ANGLE finds libvulkan)
     ln -sf ${lib.getLib vulkan-loader}/lib/libvulkan.so.1 \

--- a/pkgs/by-name/su/surfshark/package.nix
+++ b/pkgs/by-name/su/surfshark/package.nix
@@ -66,12 +66,6 @@ let
   ];
 
   libPath = lib.makeLibraryPath (deps ++ [ (lib.getLib systemd) ]);
-  binPath = lib.makeBinPath [
-    coreutils
-    procps
-    which
-    iputils
-  ];
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "surfshark";
@@ -136,7 +130,14 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeBinaryWrapper $out/share/surfshark/surfshark $out/bin/surfshark \
       --add-flags "--no-sandbox" \
-      --prefix PATH : ${binPath} \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          procps
+          which
+          iputils
+        ]
+      } \
       --prefix LD_LIBRARY_PATH : ${libPath}
 
     runHook postInstall

--- a/pkgs/by-name/su/surfshark/package.nix
+++ b/pkgs/by-name/su/surfshark/package.nix
@@ -1,0 +1,160 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeBinaryWrapper,
+  dpkg,
+  gjs,
+  glib,
+  nss,
+  nspr,
+  at-spi2-atk,
+  cups,
+  libdrm,
+  gtk3,
+  pango,
+  cairo,
+  libgbm,
+  expat,
+  libxkbcommon,
+  alsa-lib,
+  libnotify,
+  mesa,
+  vulkan-loader,
+  systemd,
+  coreutils,
+  procps,
+  which,
+  iputils,
+  libx11,
+  libxcb,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrandr,
+  libxtst,
+}:
+let
+  xorgDeps = [
+    libx11
+    libxcb
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrandr
+    libxtst
+  ];
+
+  deps = [
+    glib
+    nss
+    nspr
+    at-spi2-atk
+    cups
+    libdrm
+    gtk3
+    pango
+    cairo
+    libgbm
+    expat
+    libxkbcommon
+    alsa-lib
+    libnotify
+    mesa
+    vulkan-loader
+  ]
+  ++ xorgDeps;
+
+  libPath = lib.makeLibraryPath (deps ++ [ (lib.getLib systemd) ]);
+  binPath = lib.makeBinPath [
+    coreutils
+    procps
+    which
+    iputils
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "surfshark";
+  version = "3.9.0";
+
+  src = fetchurl {
+    url = "https://ocean.surfshark.com/debian/pool/main/s/surfshark_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-1GdtzTQt4wIg+8rABNHq1kyGE2rf2cZTqxfQqRIIkao=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeBinaryWrapper
+  ];
+
+  buildInputs = deps;
+
+  runtimeDependencies = [ (lib.getLib systemd) ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/surfshark,lib/systemd/system,lib/systemd/user}
+
+    # App bundle
+    cp -r opt/Surfshark/. $out/share/surfshark/
+
+    # Desktop entry, icons, docs
+    cp -r usr/share/. $out/share/
+
+    # OpenVPN certs
+    mkdir -p $out/etc/openvpn/client/surfshark
+    cp -r etc/openvpn/client/surfshark/. $out/etc/openvpn/client/surfshark/
+
+    # systemd service units — patch hardcoded /opt/Surfshark paths
+    substitute usr/lib/systemd/system/surfsharkd2.service $out/lib/systemd/system/surfsharkd2.service \
+      --replace-fail "/opt/Surfshark" "$out/share/surfshark"
+    substitute usr/lib/systemd/user/surfsharkd.service $out/lib/systemd/user/surfsharkd.service \
+      --replace-fail "/opt/Surfshark" "$out/share/surfshark"
+
+    # Patch GJS shebang and make daemon scripts executable
+    for js in surfsharkd.js surfsharkd2.js; do
+      daemon="$out/share/surfshark/resources/dist/resources/$js"
+      substituteInPlace "$daemon" \
+        --replace-fail "#!/usr/bin/gjs" "#!${gjs}/bin/gjs"
+      chmod +x "$daemon"
+    done
+
+    # Fix .desktop Exec path
+    sed -i "s|Exec=/opt/Surfshark/surfshark|Exec=$out/bin/surfshark|" \
+      $out/share/applications/surfshark.desktop
+
+    # Vulkan loader symlink (so bundled ANGLE finds libvulkan)
+    ln -sf ${lib.getLib vulkan-loader}/lib/libvulkan.so.1 \
+      $out/share/surfshark/libvulkan.so.1
+
+    # Patch bundled GL libs rpath
+    patchelf $out/share/surfshark/lib*GL* --set-rpath ${libPath} || true
+
+    makeBinaryWrapper $out/share/surfshark/surfshark $out/bin/surfshark \
+      --add-flags "--no-sandbox" \
+      --prefix PATH : ${binPath} \
+      --prefix LD_LIBRARY_PATH : ${libPath}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Surfshark VPN client";
+    homepage = "https://surfshark.com";
+    downloadPage = "https://surfshark.com/download/linux";
+    mainProgram = "surfshark";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ FazalAAli ];
+  };
+})


### PR DESCRIPTION
## Description

Adds the [Surfshark VPN client](https://surfshark.com) for Linux.

Surfshark is a proprietary VPN client distributed as a Debian package. It consists of an Electron-based GUI and two GJS (GNOME JavaScript) daemons that manage VPN tunnels via OpenVPN/WireGuard.

## Structure

- `pkgs/by-name/su/surfshark/package.nix` — unpacks the upstream `.deb`, patches GJS daemon shebangs, installs systemd units with corrected store paths, and wraps the Electron binary
- `nixos/modules/services/networking/surfshark.nix` — NixOS module that wires up the system and user daemons, including the `GI_TYPELIB_PATH` needed by the GJS daemon to import NetworkManager typelibs

## Testing

Tested on `x86_64-linux` (NixOS 25.11):
- `nix build .#surfshark` builds successfully
- `services.surfshark.enable = true` activates both `surfsharkd2.service` (system) and `surfsharkd.service` (user)
- GUI launches and connects successfully

## Checklist

- [x] Package builds on `x86_64-linux`
- [x] `meta.license = lib.licenses.unfree`
- [x] `meta.sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ]`
- [x] Maintainer entry added in a separate commit
- [x] NixOS module added to `module-list.nix`
- [x] `dontStrip = true` (Electron binary)
- [x] Formatted with `treefmt`
- [x] IP Changes when connected to VPN