### PR TITLE
cuda_nvcc: also patch math_functions.hpp for glibc 2.42

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
@@ -189,6 +189,29 @@ buildRedist (finalAttrs: {
           --replace-fail \
             "rsqrtf(float x);" \
             "rsqrtf(float x) noexcept (true);"
+
+        # math_functions.hpp has the same functions wrapped in __func__() macros.
+        # These also need throw() annotations to match glibc 2.42's declarations.
+        nixLog "Patching math_functions.hpp signatures to match glibc's ones"
+        substituteInPlace "''${!outputInclude:?}/include/crt/math_functions.hpp" \
+          --replace-fail \
+            "__func__(double rsqrt(const double a))" \
+            "__func__(double rsqrt(const double a) throw())" \
+          --replace-fail \
+            "__func__(double sinpi(double a))" \
+            "__func__(double sinpi(double a) throw())" \
+          --replace-fail \
+            "__func__(double cospi(double a))" \
+            "__func__(double cospi(double a) throw())" \
+          --replace-fail \
+            "__func__(float rsqrtf(const float a))" \
+            "__func__(float rsqrtf(const float a) throw())" \
+          --replace-fail \
+            "__func__(float sinpif(const float a))" \
+            "__func__(float sinpif(const float a) throw())" \
+          --replace-fail \
+            "__func__(float cospif(const float a))" \
+            "__func__(float cospif(const float a) throw())"
       ''
     );
 


### PR DESCRIPTION
## Description

The existing glibc 2.42 compatibility patch ([added in #484031](https://github.com/NixOS/nixpkgs/pull/484031)) fixes function signatures in `math_functions.h` but misses `math_functions.hpp`, which has the same `rsqrt`/`sinpi`/`cospi` functions wrapped in `__func__()` macros. Without `throw()` annotations on these, C++ compilation against CUDA headers fails when glibc 2.42 declares the same functions with `throw()`.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
