### PR TITLE
cuda_nvcc: fix host_defines.h `__noinline__` conflict under clang

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
@@ -213,6 +213,19 @@ buildRedist (finalAttrs: {
             "__func__(float cospif(const float a))" \
             "__func__(float cospif(const float a) throw())"
       ''
+      # Fix clang CUDA compilation: host_defines.h redefines __noinline__ as
+      # __attribute__((noinline)), which conflicts with libstdc++ >=12 using
+      # __attribute__((__noinline__)) — the macro expands to
+      # __attribute__((__attribute__((noinline)))) which is invalid.
+      # Clang natively understands __noinline__ as an attribute so the macro
+      # is unnecessary. Skip it when clang is the compiler.
+      + lib.optionalString (cudaOlder "13.0") ''
+        nixLog "Patching host_defines.h to skip __noinline__ macro under clang"
+        substituteInPlace "''${!outputInclude:?}/include/crt/host_defines.h" \
+          --replace-fail \
+            '#if defined(__CUDACC__) || defined(__CUDA_ARCH__) || defined(__CUDA_LIBDEVICE__)' \
+            '#if (defined(__CUDACC__) || defined(__CUDA_ARCH__) || defined(__CUDA_LIBDEVICE__)) && !defined(__clang__)'
+      ''
     );
 
   brokenAssertions = [


### PR DESCRIPTION
## Description

`host_defines.h` redefines `__noinline__` as `__attribute__((noinline))`. When clang compiles CUDA code against libstdc++ >=12, which uses `__attribute__((__noinline__))`, the macro causes the invalid expansion `__attribute__((__attribute__((noinline))))`. Clang natively understands `__noinline__` as an attribute, so the macro is unnecessary — this patch skips it when clang is the compiler.

This is relevant when using clang as the CUDA device compiler (e.g. XLA's hermetic build configuration). It may not affect the default nvcc-based compilation paths.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
