### PR TITLE
 home-assistant-custom-components.openplantbook: ini at 1.3.2;  home-assistant-custom-components.plant: init at 2026.2.1;  home-assistant-custom-lovelace-modules.flower-card: init at 2026.2.0 

### DIFF
--- a/pkgs/development/python-modules/json-timeseries/default.nix
+++ b/pkgs/development/python-modules/json-timeseries/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  python-dateutil,
+  setuptools,
+  setuptools-scm,
+}:
+
+buildPythonPackage {
+  pname = "json-timeseries";
+  version = "0.1.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "slaxor505";
+    repo = "json-timeseries-py";
+    # asked upstream for tags
+    # https://github.com/slaxor505/json-timeseries-py/issues/2
+    rev = "d5a4f6307ce38f790c2594c3eae0f64bbc7c353e";
+    hash = "sha256-5+eS+e6d61CBIqBXFaIQta95nenF5XK2mA9pQ+Rj0vQ=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [ python-dateutil ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "json_timeseries" ];
+
+  meta = {
+    description = "JSON Time Series (JTS) spec Python library";
+    homepage = "https://github.com/slaxor505/json-timeseries-py";
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/openplantbook-sdk/default.nix
+++ b/pkgs/development/python-modules/openplantbook-sdk/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  json-timeseries,
+  numpy,
+  pandas,
+  pytestCheckHook,
+  pyyaml,
+  setuptools,
+  setuptools-scm,
+}:
+
+buildPythonPackage {
+  pname = "openplantbook-sdk";
+  version = "0.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "slaxor505";
+    repo = "openplantbook-sdk-py";
+    rev = "097ccfbd5cee6a271c79c923f1761249eca4bda1";
+    hash = "sha256-udzm8Efl3QX2jrvfzA/oCvk2kjQEFFOZCOFqKNzUUu8=";
+  };
+
+  patches = [
+    # https://github.com/slaxor505/openplantbook-sdk-py/pull/2
+    ./update-test.patch
+  ];
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    aiohttp
+    json-timeseries
+  ];
+
+  nativeBuildInputs = [
+    numpy
+    pandas
+    pyyaml
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "tests/offline"
+  ];
+
+  meta = {
+    description = "SDK to integrate with Open Plantbook API";
+    homepage = "https://github.com/slaxor505/openplantbook-sdk-py";
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/openplantbook-sdk/update-test.patch
+++ b/pkgs/development/python-modules/openplantbook-sdk/update-test.patch
@@ -1,0 +1,32 @@
+commit b5c20736ca6270b6ac20ee24e4788cfc656815cb
+Author: Sandro Jäckel <sandro.jaeckel@gmail.com>
+Date:   Tue, 10 Mar 2026 02:42:27 +0100
+
+    Update tests
+
+diff --git a/tests/offline/test_async_plant_detail_lang.py b/tests/offline/test_async_plant_detail_lang.py
+index 3d460fb..75e4018 100644
+--- a/tests/offline/test_async_plant_detail_lang.py
++++ b/tests/offline/test_async_plant_detail_lang.py
+@@ -75,7 +75,7 @@ def test_forwards_lang_param_when_provided(self):
+         self.assertIn("Authorization", sess.headers)
+         self.assertTrue(sess.headers["Authorization"].startswith("Bearer "))
+         # Assert that the request URL targets the expected endpoint
+-        self.assertTrue(sess.last_get_url.endswith("/plant/detail/abelia chinensis"))
++        self.assertTrue(sess.last_get_url.endswith("/plant/detail/abelia chinensis/"))
+         # Critical assertion: 'lang' param is forwarded
+         self.assertEqual(sess.last_get_params, {"lang": "de"})
+ 
+diff --git a/tests/offline/test_pass_through_params.py b/tests/offline/test_pass_through_params.py
+index 62c2443..0ea36a9 100644
+--- a/tests/offline/test_pass_through_params.py
++++ b/tests/offline/test_pass_through_params.py
+@@ -118,7 +118,7 @@ def test_detail_merges_and_overrides_lang_and_kwargs(self):
+         self.assertIn("Authorization", sess.headers)
+         self.assertTrue(sess.headers["Authorization"].startswith("Bearer "))
+         # Request URL targets the expected endpoint
+-        self.assertTrue(sess.last_get_url.endswith("/plant/detail/abelia chinensis"))
++        self.assertTrue(sess.last_get_url.endswith("/plant/detail/abelia chinensis/"))
+         # 'lang' from explicit arg overrides value in params; other params are preserved
+         self.assertEqual(sess.last_get_params, {"lang": "de", "page": "2"})
+         # request_kwargs forwarded to session.get

--- a/pkgs/servers/home-assistant/custom-components/openplantbook/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/openplantbook/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  json-timeseries,
+  openplantbook-sdk,
+  pytest-homeassistant-custom-component,
+  pytestCheckHook,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "olen";
+  domain = "openplantbook";
+  version = "1.3.3";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "home-assistant-openplantbook";
+    tag = "v${version}";
+    hash = "sha256-t4ZyY6zodCRJZTIqu7Rcfr7sRUmo5QarZU8y0lCKmWE=";
+  };
+
+  postPatch = ''
+    substituteInPlace custom_components/openplantbook/manifest.json \
+      --replace-fail "==" ">="
+  '';
+
+  dependencies = [
+    json-timeseries
+    openplantbook-sdk
+  ];
+
+  nativeCheckInputs = [
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Integration to search and fetch data from Openplantbook.io";
+    homepage = "https://github.com/Olen/home-assistant-openplantbook";
+    changelog = "https://github.com/Olen/home-assistant-openplantbook/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    license = lib.licenses.gpl3Only;
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/plant/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/plant/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  async-timeout,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  pytest-homeassistant-custom-component,
+  pytestCheckHook,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "olen";
+  domain = "plant";
+  version = "2026.2.1";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "homeassistant-plant";
+    tag = "v${version}";
+    hash = "sha256-nWZFywMTw3seEAERekzMeLRPceqMl1s7VXujNz0+6zI=";
+  };
+
+  dependencies = [
+    async-timeout
+  ];
+
+  nativeCheckInputs = [
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Alternative Plant component of home assistant";
+    homepage = "https://github.com/Olen/homeassistant-plant";
+    changelog = "https://github.com/Olen/homeassistant-plant/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/flower-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/flower-card/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "flower-card";
+  version = "2026.2.0";
+
+  src = fetchFromGitHub {
+    owner = "olen";
+    repo = "lovelace-flower-card";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EPahVDglhKjtPwIdu5HfUZ6KhMtTu/9YfY4VdsN+vyc=";
+  };
+
+  npmDepsHash = "sha256-XGKGoFdbeUIx12ZGP8o2oSTJHVa+PZ6jwYSWiqjtSuM=";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp flower-card.js $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Lovelace Flower Card to match the custom plant integration";
+    homepage = "https://github.com/Olen/lovelace-flower-card";
+    changelog = "https://github.com/Olen/lovelace-flower-card/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7919,6 +7919,8 @@ self: super: with self; {
 
   json-stream-rs-tokenizer = callPackage ../development/python-modules/json-stream-rs-tokenizer { };
 
+  json-timeseries = callPackage ../development/python-modules/json-timeseries { };
+
   json-tricks = callPackage ../development/python-modules/json-tricks { };
 
   json2html = callPackage ../development/python-modules/json2html { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11574,6 +11574,8 @@ self: super: with self; {
 
   openpaperwork-gtk = callPackage ../applications/office/paperwork/openpaperwork-gtk.nix { };
 
+  openplantbook-sdk = callPackage ../development/python-modules/openplantbook-sdk { };
+
   openpyxl = callPackage ../development/python-modules/openpyxl { };
 
   openrazer = callPackage ../development/python-modules/openrazer/pylib.nix { };


### PR DESCRIPTION
Those 2 custom components and one custom lovelace module work together, so it made sense to combine them in one PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
