### PR TITLE
neovim: set provider configuration to initrc

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -242,6 +242,8 @@
 - `openrgb` was updated to 1.0rc2, which now uses Plugin API version 4.
   Some existing OpenRGB plugins may be incompatible or require updates.
 
+- the `neovim` wrapper sets provider-related configuration in its generated config rather than as wrapper arguments. It should not affect configuration unless you set `wrapRc` to false.
+
 - We now use the upstream wrapper script for Gradle, supporting both the `JAVA_HOME` and `GRADLE_OPTS` environment variables.
 
 - the `autossh-ng` NixOS module was introduced as a simpler alternative to the existing `autossh` module.

--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -242,7 +242,7 @@
 - `openrgb` was updated to 1.0rc2, which now uses Plugin API version 4.
   Some existing OpenRGB plugins may be incompatible or require updates.
 
-- the `neovim` wrapper sets provider-related configuration in its generated config rather than as wrapper arguments. It should not affect configuration unless you set `wrapRc` to false.
+- `wrapNeovimUnstable` now sets provider-related configuration in its generated config rather than as wrapper arguments. It should not affect configuration unless you set `wrapRc` to false or are using the `legacyWrapper`.
 
 - We now use the upstream wrapper script for Gradle, supporting both the `JAVA_HOME` and `GRADLE_OPTS` environment variables.
 

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -223,7 +223,8 @@ let
       res
       // {
         wrapperArgs = lib.escapeShellArgs res.wrapperArgs + " " + extraMakeWrapperArgs;
-        wrapRc = (configure != { });
+        wrapRc = configure != { };
+        legacyWrapper = true;
       }
     );
 

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -105,13 +105,16 @@ let
         packpathDirs.myNeovimPackages = vimPackageInfo.vimPackage;
         finalPackdir = neovimUtils.packDir packpathDirs;
 
-        rcContent = ''
-          ${luaRcContent}
-        ''
-        + lib.optionalString (neovimRcContent' != "") ''
-          vim.cmd.source "${writeText "init.vim" neovimRcContent'}"
-        ''
-        + lib.optionalString autoconfigure (lib.concatStringsSep "\n" vimPackageInfo.pluginAdvisedLua);
+        rcContent = lib.concatStringsSep "\n" (
+          [
+            providerLuaRc
+          ]
+          ++ lib.optional (luaRcContent != "") luaRcContent
+          ++ lib.optional (neovimRcContent' != "") ''
+            vim.cmd.source "${writeText "init.vim" neovimRcContent'}"
+          ''
+          ++ lib.optionals autoconfigure vimPackageInfo.pluginAdvisedLua
+        );
 
         python3Env =
           lib.warnIf (attrs ? python3Env)
@@ -126,12 +129,7 @@ let
 
         wrapperArgsStr = if lib.isString wrapperArgs then wrapperArgs else lib.escapeShellArgs wrapperArgs;
 
-        generatedWrapperArgs = [
-          # vim accepts a limited number of commands so we join all the provider ones
-          "--add-flags"
-          ''--cmd "lua ${providerLuaRc}"''
-        ]
-        ++
+        generatedWrapperArgs =
           lib.optionals
             (
               finalAttrs.packpathDirs.myNeovimPackages.start != [ ]
@@ -143,17 +141,17 @@ let
               "--add-flags"
               ''--cmd "set rtp^=${finalPackdir}"''
             ]
-        ++ lib.optionals finalAttrs.withRuby [
-          "--set"
-          "GEM_HOME"
-          "${rubyEnv}/${rubyEnv.ruby.gemPath}"
-        ]
-        ++ lib.optionals (finalAttrs.runtimeDeps != [ ]) [
-          "--suffix"
-          "PATH"
-          ":"
-          (lib.makeBinPath finalAttrs.runtimeDeps)
-        ];
+          ++ lib.optionals finalAttrs.withRuby [
+            "--set"
+            "GEM_HOME"
+            "${rubyEnv}/${rubyEnv.ruby.gemPath}"
+          ]
+          ++ lib.optionals (finalAttrs.runtimeDeps != [ ]) [
+            "--suffix"
+            "PATH"
+            ":"
+            (lib.makeBinPath finalAttrs.runtimeDeps)
+          ];
 
         providerLuaRc =
           let
@@ -201,7 +199,7 @@ let
         ++ lib.optionals finalAttrs.wrapRc [
           "--set-default"
           "VIMINIT"
-          "lua dofile('${writeText "init.lua" rcContent}')"
+          "lua dofile('${writeText "init.lua" finalAttrs.luaRcContent}')"
         ]
         ++ finalAttrs.generatedWrapperArgs;
 

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -130,17 +130,25 @@ let
         wrapperArgsStr = if lib.isString wrapperArgs then wrapperArgs else lib.escapeShellArgs wrapperArgs;
 
         generatedWrapperArgs =
-          lib.optionals
-            (
-              finalAttrs.packpathDirs.myNeovimPackages.start != [ ]
-              || finalAttrs.packpathDirs.myNeovimPackages.opt != [ ]
-            )
-            [
-              "--add-flags"
-              ''--cmd "set packpath^=${finalPackdir}"''
-              "--add-flags"
-              ''--cmd "set rtp^=${finalPackdir}"''
-            ]
+
+          # neovimUtils.legacyWrapper adds a `legacyWrapper` attribute to let us know we run in "legacy" mode
+          lib.optionals (attrs ? legacyWrapper) [
+            # vim accepts a limited number of commands so we join all the provider ones
+            "--add-flags"
+            ''--cmd "lua ${providerLuaRc}"''
+          ]
+          ++
+            lib.optionals
+              (
+                finalAttrs.packpathDirs.myNeovimPackages.start != [ ]
+                || finalAttrs.packpathDirs.myNeovimPackages.opt != [ ]
+              )
+              [
+                "--add-flags"
+                ''--cmd "set packpath^=${finalPackdir}"''
+                "--add-flags"
+                ''--cmd "set rtp^=${finalPackdir}"''
+              ]
           ++ lib.optionals finalAttrs.withRuby [
             "--set"
             "GEM_HOME"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
resubmission of https://github.com/NixOS/nixpkgs/pull/487390
with https://github.com/NixOS/nixpkgs/pull/492159/  already applied

if you are using home-manager, you will need https://github.com/nix-community/home-manager/pull/8734 once this hits unstable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
