### PR TITLE
fex: 2601 -> 2603

### DIFF
--- a/pkgs/by-name/fe/fex/package.nix
+++ b/pkgs/by-name/fe/fex/package.nix
@@ -7,6 +7,7 @@
   pkg-config,
   python3,
   nix-update-script,
+  jemalloc,
   xxHash,
   fmt,
   libxml2,
@@ -99,13 +100,13 @@ let
 in
 llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "fex";
-  version = "2601";
+  version = "2603";
 
   src = fetchFromGitHub {
     owner = "FEX-Emu";
     repo = "FEX";
     tag = "FEX-${finalAttrs.version}";
-    hash = "sha256-AfHOD3S3zDwe85Zr8XEMmI+LrdVEZdXJ9FWQQ+oUNik=";
+    hash = "sha256-rQOqziJ7IizJV3VmAWGo5s2xn2/xnp0sx3VfBtH1JK4=";
 
     leaveDotGit = true;
     postFetch = ''
@@ -116,10 +117,10 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
       git submodule update --init --depth 1 \
         External/Vulkan-Headers \
         External/drm-headers \
-        External/jemalloc \
+        External/rpmalloc \
         External/jemalloc_glibc \
-        External/robin-map \
         External/vixl \
+        External/unordered_dense \
         Source/Common/cpp-optparse
 
       find . -name .git -print0 | xargs -0 rm -rf
@@ -132,6 +133,10 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
+    substituteInPlace FEXCore/include/git_version.h.in \
+      --replace-fail "@GIT_HASH_ARRAY@" "" \
+      --replace-fail "@GIT_DESCRIBE_STRING@" "FEX-${finalAttrs.version}"
+
     substituteInPlace ThunkLibs/GuestLibs/CMakeLists.txt ThunkLibs/HostLibs/CMakeLists.txt \
       --replace-fail "/usr/include/libdrm" "${devRootFS}/include/libdrm" \
       --replace-fail "/usr/include/wayland" "${devRootFS}/include/wayland"
@@ -183,6 +188,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional withQt qt6.wrapQtAppsHook;
 
   buildInputs = [
+    jemalloc
     xxHash
     fmt
     libxml2

--- a/pkgs/by-name/fe/fex/package.nix
+++ b/pkgs/by-name/fe/fex/package.nix
@@ -149,6 +149,11 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     substituteInPlace ThunkLibs/GuestLibs/CMakeLists.txt \
       --replace-fail "-- " "-- $(cat ${llvmPackages.stdenv.cc}/nix-support/libcxx-cxxflags) "
 
+    # Disable including current date in manpages
+    substituteInPlace FEXCore/Scripts/config_generator.py \
+      --replace-fail ".Dd {0}" ".Dd" \
+      --replace-fail "output_man.write(header.format(" "output_man.write(header) #"
+
     # Patch any references to library wrapper paths
     substituteInPlace FEXCore/Source/Interface/Config/Config.json.in \
       --replace-fail "ThunkGuestLibs" "UnusedThunkGuestLibs" \


### PR DESCRIPTION
Upstream release notes:

- [Website blog post](https://fex-emu.com/FEX-2603/)
- [GitHub](https://github.com/FEX-Emu/FEX/releases/tag/FEX-2603)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
