### PR TITLE
home-assistant-custom-lovelace-modules.horizon-card: init at 1.4.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/horizon-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/horizon-card/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  yarn-berry,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "horizon-card";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "rejuvenate";
+    repo = "lovelace-horizon-card";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-z2cJ6BIhNnzUo9nIFxVyrPBVWSKf35fyLXK72pE8TJw=";
+  };
+
+  nativeBuildInputs = [
+    yarn-berry
+    yarn-berry.yarnBerryConfigHook
+  ];
+
+  offlineCache = yarn-berry.fetchYarnBerryDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-LYPHBnDRcGeXo2btx1A4/e7fr7MYg/2G5GkuG/xDG+I=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install dist/lovelace-horizon-card.js -Dt $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Sun Card successor: Visualize the position of the Sun over the horizon";
+    homepage = "https://github.com/rejuvenate/lovelace-horizon-card";
+    changelog = "https://github.com/rejuvenate/lovelace-horizon-card/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
