### PR TITLE
xencelabs: init at 1.3.4-26

### DIFF
--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -194,6 +194,7 @@ async function handleMerge({
         }`,
         { node_id: pull_request.node_id, sha: pull_request.head.sha },
       )
+      log('merge', 'Queued for merge')
       return [
         `:heavy_check_mark: [Queued](${resp.enqueuePullRequest.mergeQueueEntry.mergeQueue.url}) for merge (#306934)`,
       ]
@@ -215,6 +216,7 @@ async function handleMerge({
         }`,
         { node_id: pull_request.node_id, sha: pull_request.head.sha },
       )
+      log('merge', 'Auto-merge enabled')
       return [
         `:heavy_check_mark: Enabled Auto Merge (#306934)`,
         '',

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18646,6 +18646,11 @@
     name = "Noah Pierre Biewesch";
     keys = [ { fingerprint = "5FC6 088A FB1A 609D 4532  F919 0C1C 177B 3B64 68E0"; } ];
   };
+  naitrate = {
+    name = "Naitrate";
+    github = "Naitrate";
+    githubId = 64479044;
+  };
   nalbyuites = {
     email = "ashijit007@gmail.com";
     github = "nalbyuites";

--- a/nixos/modules/hardware/xencelabs.nix
+++ b/nixos/modules/hardware/xencelabs.nix
@@ -1,0 +1,43 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.hardware.xencelabs;
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    naitrate
+  ];
+
+  options = {
+    hardware.xencelabs = {
+    enable = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+        description = ''
+          Enable Xencelabs hardware udev rules, and service.
+        '';
+    };
+    package = lib.mkPackageOption pkgs "xencelabs" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    services.udev.packages = [ cfg.package ];
+
+    systemd.services.xencelabs = lib.mkIf cfg.enable {
+      description = "Xencelabs Multi-User Service";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "chmod 777 /tmp/qtsingleapp-Xencel-fb8d-lockfile";
+        Restart = "on-failure";
+      };
+    };
+  };
+}

--- a/nixos/modules/hardware/xencelabs.nix
+++ b/nixos/modules/hardware/xencelabs.nix
@@ -1,0 +1,44 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.hardware.xencelabs;
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    naitrate
+  ];
+
+  options = {
+    hardware.xencelabs = {
+      enable = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+        description = ''
+          Enable Xencelabs hardware udev rules, and service.
+        '';
+      };
+      package = lib.mkPackageOption pkgs "xencelabs" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    services.udev.packages = [ cfg.package ];
+
+    systemd.services.xencelabs = lib.mkIf cfg.enable {
+      description = "Xencelabs Multi-User Service";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "chmod 777 /tmp/qtsingleapp-Xencel-fb8d-lockfile";
+        Restart = "on-failure";
+      };
+    };
+  };
+}

--- a/nixos/modules/hardware/xencelabs.nix
+++ b/nixos/modules/hardware/xencelabs.nix
@@ -14,14 +14,15 @@ in
 
   options = {
     hardware.xencelabs = {
-    enable = lib.mkOption {
+      enable = lib.mkOption {
         default = false;
         type = lib.types.bool;
         description = ''
           Enable Xencelabs hardware udev rules, and service.
         '';
+      };
+      package = lib.mkPackageOption pkgs "xencelabs" { };
     };
-    package = lib.mkPackageOption pkgs "xencelabs" { };
   };
 
   config = lib.mkIf cfg.enable {

--- a/pkgs/by-name/co/comrak/package.nix
+++ b/pkgs/by-name/co/comrak/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "comrak";
-  version = "0.50.0";
+  version = "0.51.0";
 
   src = fetchFromGitHub {
     owner = "kivikakk";
     repo = "comrak";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-OWfNg66ZLorN+PW26v2n695f8vfqT76jO6Bl+M/FNdc=";
+    sha256 = "sha256-Klux0l0onlkpRIeQPHKZZhLhYB5On2R8CivpByGSgEA=";
   };
 
-  cargoHash = "sha256-d4krWEvupTniVka4f7OPvWbJx6YoT0tfzxr7SU46jME=";
+  cargoHash = "sha256-AB4XcGERw9PmYpwMVV1mTjpEJmL4pV7iyZUhn5GWflc=";
 
   meta = {
     description = "CommonMark-compatible GitHub Flavored Markdown parser and formatter";

--- a/pkgs/by-name/el/elephant/package.nix
+++ b/pkgs/by-name/el/elephant/package.nix
@@ -74,13 +74,13 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "elephant";
-  version = "2.20.0";
+  version = "2.20.2";
 
   src = fetchFromGitHub {
     owner = "abenz1267";
     repo = "elephant";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-r2ucLztXQFRu70VrGtNcL3PONyazxDPwq/hSn7opD+I=";
+    hash = "sha256-RvCzINnVISBT3d0F1DoIcQFbQsbRJISW9qZeKTzmNaA=";
   };
 
   vendorHash = "sha256-tO+5x2FIY1UBvWl9x3ZSpHwTWUlw1VNDTi9+2uY7xdU=";

--- a/pkgs/by-name/fd/fd/package.nix
+++ b/pkgs/by-name/fd/fd/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "fd";
-  version = "10.4.1";
+  version = "10.4.2";
 
   src = fetchFromGitHub {
     owner = "sharkdp";
     repo = "fd";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-wmlnQyRWo7qxtRQFZywsr0eX7kVmcjyqyV5NG9VtUP0=";
+    hash = "sha256-D1FCry69KqXgLxU4rVmgKjkM3JqeBRQDfbp3sJtVAbU=";
   };
 
-  cargoHash = "sha256-MhSc96zkkCb+TKYr0ixDSYq44qgxjkvnwEzSdIwZNBo=";
+  cargoHash = "sha256-nsFtnt8z1qohOtHpLk3cstrVXi/yOMMPCTt/SEEB1F0=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/ip/ipget/package.nix
+++ b/pkgs/by-name/ip/ipget/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "ipget";
-  version = "0.12.2";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "ipfs";
     repo = "ipget";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-j8CRJTqZZtZMeGEq8l4YBBXAwhX+EfO2aFMXS8/6Ek4=";
+    hash = "sha256-mOZdoOl+eVMNOy5gfxeqmzOUAnc39WNJYr1l5IVId8U=";
   };
 
-  vendorHash = "sha256-vOuQVISXOpRsZLuJ89Lk3wQHtnt0l5PhnLiDcjGKbhs=";
+  vendorHash = "sha256-oB6XWs649Aj6MYIhWBWXNgJkycsx/kGw9iEVy3nG9iw=";
 
   postPatch = ''
     # main module (github.com/ipfs/ipget) does not contain package github.com/ipfs/ipget/sharness/dependencies

--- a/pkgs/by-name/js/jsonschema-cli/package.nix
+++ b/pkgs/by-name/js/jsonschema-cli/package.nix
@@ -9,15 +9,15 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "jsonschema-cli";
-  version = "0.44.0";
+  version = "0.45.0";
 
   src = fetchCrate {
     pname = "jsonschema-cli";
     inherit (finalAttrs) version;
-    hash = "sha256-rytVrWBvUMaUZvHV4emXSnTUl4eC4uR8HS/1J4j9GwA=";
+    hash = "sha256-9pz07T7i7pxNNOV/YGbneIA45VG9uBzhI+ygwknW07Q=";
   };
 
-  cargoHash = "sha256-P8o0tAcFQPu5ta8qc8basn1+XjHvyjn1aGCW16kuYug=";
+  cargoHash = "sha256-EiLXX0wZi9v8vsMxCeg8/XMfWH9FckuNjqPpLEUK5lc=";
 
   preCheck = ''
     export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt

--- a/pkgs/by-name/ke/keepassxc/package.nix
+++ b/pkgs/by-name/ke/keepassxc/package.nix
@@ -37,13 +37,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "keepassxc";
-  version = "2.7.11";
+  version = "2.7.12";
 
   src = fetchFromGitHub {
     owner = "keepassxreboot";
     repo = "keepassxc";
     tag = finalAttrs.version;
-    hash = "sha256-Hec3RBC/f0GV6ZBniy+BjMAkABlg111mShrQv0aYm6g=";
+    hash = "sha256-eg8jRaSJdRBpEOHQ8E3jXcdwRzsnyq6r4RLyltdpIB8=";
   };
 
   env =

--- a/pkgs/by-name/xe/xencelabs/package.nix
+++ b/pkgs/by-name/xe/xencelabs/package.nix
@@ -1,0 +1,134 @@
+{
+  stdenv,
+  lib,
+  fetchzip,
+  autoPatchelfHook,
+  makeBinaryWrapper,
+  libusb1,
+  libx11,
+  libxtst,
+  libxrandr,
+  xkeyboard-config,
+  libGL,
+  qt5,
+}:
+stdenv.mkDerivation rec {
+  pname = "xencelabs";
+  version = "1.3.4-26";
+
+  src = fetchzip {
+    url = "https://download01.xencelabs.com/file/20241225/Xencelabslinux_${version}.zip";
+    sha256 = "sha256-FSxR7SekHqvvRXkNMcSpGumw8TTnRWGPP/N/rya1VOk=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    libusb1
+    libx11
+    libxtst
+    libxrandr
+    xkeyboard-config
+    libGL
+    qt5.qtbase
+    qt5.qtsvg
+  ];
+
+  dontWrapQtApps = true;
+  stripRoot = true;
+
+  installPhase = ''
+        runHook preInstall
+
+        # unpack inner tarball from .zip archive.
+        tar -xzf xencelabs-${version}.tar.gz
+
+        mkdir -p $out/lib $out/bin $out/share
+
+        # Copy application files.
+        cp -r xencelabs-${version}/App/usr/lib/xencelabs $out/lib/
+        cp -r xencelabs-${version}/App/usr/share/* $out/share/
+
+        # Copy udev rules (NixOS handles linking to /etc automatically)
+        mkdir -p $out/lib/udev/rules.d
+        cp xencelabs-${version}/App/lib/udev/rules.d/10-xencelabs.rules $out/lib/udev/rules.d/
+
+        # Create a modified start.sh script that fixes missing device configs.
+        cat > $out/lib/xencelabs/start.sh <<'EOF'
+    #!/usr/bin/env bash
+    pkill xence 2>/dev/null || true
+
+    appname=xencelabs
+    dirname=$(dirname "$0")
+    export LD_LIBRARY_PATH="$dirname/lib"
+
+    USER_CONFIG="$HOME/.local/share/xencelabs"
+    if [ ! -d "$USER_CONFIG" ]; then
+        mkdir -p "$USER_CONFIG"
+        cp -r "$dirname/config/." "$USER_CONFIG/"
+    fi
+    # Set the proper permissions for the config files regardless of if they were just created or not.
+    setfacl -Rb "$USER_CONFIG"
+    chown -R "$(id -u)":"$(id -g)" "$USER_CONFIG"
+    find "$USER_CONFIG" -type d -exec chmod 755 {} +
+    find "$USER_CONFIG" -type f -exec chmod 644 {} +
+
+    lockfile="/tmp/qtsingleapp-Xencel-fb8d-lockfile"
+    touch "$lockfile"
+    chmod 777 "$lockfile"
+
+    exec "$dirname/$appname" "$@"
+    EOF
+
+        # Set start script as executable.
+        chmod +x $out/lib/xencelabs/start.sh
+
+        # Fix desktop file to point to the proper directory rather than /lib.
+        desktopFile="$out/share/applications/xencelabs.desktop"
+        substituteInPlace "$desktopFile" \
+          --replace-fail "/usr/lib/xencelabs/start.sh" "$out/bin/xencelabs" \
+          --replace-fail "/usr/share/icons/xencelabs.png" "$out/share/icons/xencelabs.png"
+
+        # Set the main binary executable.
+        chmod +x $out/lib/xencelabs/xencelabs
+
+        # Copy and modify the systemd service file.
+        mkdir -p $out/lib/systemd/system
+        cp xencelabs-${version}/App/etc/systemd/system/xencelabs.service $out/lib/systemd/system/
+        substituteInPlace $out/lib/systemd/system/xencelabs.service \
+          --replace-fail "/usr/lib/xencelabs/restar.sh" "$out/lib/xencelabs/restar.sh"
+
+        # Copy and modify the restart script, but with the proper start for a Nix script.
+        cp xencelabs-${version}/App/usr/lib/xencelabs/restar.sh $out/lib/xencelabs/restar.sh
+        substituteInPlace $out/lib/xencelabs/restar.sh \
+          --replace-fail "#!/bin/sh" "#!/usr/bin/env sh"
+        substituteInPlace $out/lib/xencelabs/restar.sh \
+          --replace-fail "sudo chmod" "chmod"
+        chmod +x $out/lib/xencelabs/restar.sh
+
+        runHook postInstall
+  '';
+
+  postInstall = ''
+    makeBinaryWrapper \
+      "$out/lib/xencelabs/start.sh" \
+      "$out/bin/xencelabs" \
+      --set LD_LIBRARY_PATH "$out/lib/xencelabs/lib" \
+      --set QT_PLUGIN_PATH "$out/lib/xencelabs/platforms" \
+      --set XDG_DATA_DIRS "$out/share" \
+      --set QT_XKB_CONFIG_ROOT "${xkeyboard-config}/share/X11/xkb"
+  '';
+
+  meta = with lib; {
+    description = "Xencelabs tablet driver and control application";
+    homepage = "https://www.xencelabs.com/us/support/download-drivers";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [
+      naitrate
+    ];
+  };
+}

--- a/pkgs/development/python-modules/rst2pdf/default.nix
+++ b/pkgs/development/python-modules/rst2pdf/default.nix
@@ -22,12 +22,12 @@
 
 buildPythonPackage rec {
   pname = "rst2pdf";
-  version = "0.104";
+  version = "0.105";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-1o6MchhB6T0eJRuNi8nnZqQnWM+7+ZRpYlEoxLsElbM=";
+    hash = "sha256-hX6HQQFOxQFfegCq+13Mu1Y3jvTB2lWoKNRLz1/zrNs=";
   };
 
   pythonRelaxDeps = [ "packaging" ];

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -662,7 +662,13 @@ let
               "Refusing to evaluate package '${getNameWithVersion attrs}' in ${pos_str meta} because it ${error.msg}"
               + lib.optionalString (!inHydra && error.remediation != "") "\n${error.remediation}";
           in
-          if config ? handleEvalIssue then config.handleEvalIssue error.reason msg else throw msg;
+          if config ? handleEvalIssue then
+            if error.reason == "problem" then
+              error.handleProblem config.handleEvalIssue
+            else
+              config.handleEvalIssue error.reason msg
+          else
+            throw msg;
 
       giveWarning =
         acc: warning:

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -485,6 +485,11 @@ rec {
           null
         else
           {
+            reason = "problem";
+            # Only there for PR CI evaluation
+            handleProblem =
+              handleEvalIssue:
+              lib.foldl' (result: problem: handleEvalIssue problem.kind (fullMessage problem)) true errorProblems;
             msg = ''
               has problems:
               ${concatMapStringsSep "\n" (x: "- ${fullMessage x}") errorProblems}

--- a/pkgs/test/problems/cases/handleEvalIssue/default.nix
+++ b/pkgs/test/problems/cases/handleEvalIssue/default.nix
@@ -1,0 +1,30 @@
+{
+  nixpkgs ? ../../../../..,
+}:
+let
+  pkgs = import nixpkgs {
+    system = "x86_64-linux";
+    overlays = [ ];
+    config = {
+      checkMeta = true;
+      handleEvalIssue = reason: errormsg: builtins.trace "reason: ${reason}, errormsg: ${errormsg}" true;
+      problems.matchers = [
+        {
+          kind = "deprecated";
+          handler = "error";
+        }
+        {
+          kind = "removal";
+          handler = "error";
+        }
+      ];
+    };
+  };
+in
+pkgs.stdenvNoCC.mkDerivation {
+  pname = "a";
+  version = "0";
+  meta.description = "Some package";
+  meta.problems.removal.message = "To be removed.";
+  meta.problems.deprecated.message = "To be deprecated.";
+}

--- a/pkgs/test/problems/cases/handleEvalIssue/expected-stderr
+++ b/pkgs/test/problems/cases/handleEvalIssue/expected-stderr
@@ -1,0 +1,3 @@
+trace: reason: deprecated, errormsg: deprecated: To be deprecated.
+trace: reason: removal, errormsg: removal: To be removed.
+warning: you did not specify '--add-root'; the result might be removed by the garbage collector


### PR DESCRIPTION
This is an initial commit for the Xencelabs drivers for Linux (x86-64), and my first time submitting a PR for a new package. It is using the Arch Linux tar.gz archive as a base, and at one point I had to reference some PKGBUILD files from the AUR to fix the device configs being missing (hence why I opted towards a custom startup script which copies the necessary files to "~/.local/share/xencelabs" if they don't already exist). I also happened to notice that config files were being copied when I attempted to install the .rpm package on a Fedora LiveUSB to see if it had the same issue with the missing devices in the menu like what happened in NixOS. I'm unsure if any further work will be necessary for the config modules, but from my testing, the package part of this commit is functional.

The Xencelabs drivers are necessary piece of software to get their devices like the Xencelabs Quick Keys functional, which currently isn't supported by software like OpenTabletDriver, hence this commit. Fortunately, there's no kernel modules or the sorts being done, it's just dependent on libusb, some udev rules, and some QT5 libraries.

I initially worked on this package on my own system dotfiles using a custom pkg to test things. 

Homepage:
[https://www.xencelabs.com/us/support/download-drivers](https://www.xencelabs.com/us/support/download-drivers)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test