### PR TITLE
efibootmgr: fix setting boot order with orphaned entries

### DIFF
--- a/pkgs/by-name/ef/efibootmgr/package.nix
+++ b/pkgs/by-name/ef/efibootmgr/package.nix
@@ -33,6 +33,12 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/rhboot/efibootmgr/commit/3eac27c5fccf93d2d6e634d6fe2a76d06708ec6e.diff?full_index=1";
       hash = "sha256-zXkmfW+BYv8jc/dibu0LEni06KyydVjfW/Lug0i+jUw=";
     })
+    (fetchpatch2 {
+      # https://github.com/rhboot/efibootmgr/pull/228
+      name = "efibootmgr_downgrade-missing-boot-entry-in-order-to-warning.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/rhboot/efibootmgr/pull/228.diff?full_index=1";
+      hash = "sha256-7et0GuUNBx+hcQXi2sInosfx4tvrSrtRRrU38zBuflY=";
+    })
   ];
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
## Summary
Some firmware adds entries to BootOrder that don't have corresponding Boot#### variables. This caused a fatal error when using `efibootmgr -o` to set the boot order. This applies the upstream patch from [rhboot/efibootmgr#228](https://github.com/rhboot/efibootmgr/pull/228) to downgrade the error to a warning, so users can still manage the boot order in this case.

This was needed on my system after #409409 

## Test plan
- [x] Built the package locally
- [x] Verified `efibootmgr -o` succeeds with orphaned boot entries in the boot order