### PR TITLE
[Backport release-25.11] python3Packages.pyiceberg: disable timing-sensitive test

### DIFF
--- a/pkgs/development/python-modules/pyiceberg/default.nix
+++ b/pkgs/development/python-modules/pyiceberg/default.nix
@@ -289,6 +289,10 @@ buildPythonPackage rec {
 
     # Hangs forever (from tests/io/test_pyarrow.py)
     "test_getting_length_of_file_gcs"
+
+    # Timing sensitive
+    # AssertionError: assert 8 == 5
+    "test_hive_wait_for_lock"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # ImportError: The pyarrow installation is not built with support for 'GcsFileSystem'


### PR DESCRIPTION
(cherry picked from commit 578c8b789554c6eaf2c15c06fca88b2822567445)

This is a manual backport of https://github.com/NixOS/nixpkgs/pull/493534

Currently failing on 25.11, e.g. https://hydra.nixos.org/build/323244258/nixlog/2

The deprecation warning part of the fix must be dropped, as 25.11 is on older pydantic v2.11 where that deprecation does not exist yet:

```
> ERROR: while parsing the following warning configuration:
>
>   ignore::pydantic.warnings.PydanticDeprecatedSince212
>
> This error occurred:
>
> Traceback (most recent call last):
>   File "/nix/store/18jfhi7vfsl0rizx120yqyrak4yf1c2p-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/config/__init__.py", line 1967, in parse_warning_filter
>     category: type[Warning] = _resolve_warning_category(category_)
>                               ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
>   File "/nix/store/18jfhi7vfsl0rizx120yqyrak4yf1c2p-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/config/__init__.py", line 2013, in _resolve_warning_category
>     cat = getattr(m, klass)
> AttributeError: module 'pydantic.warnings' has no attribute 'PydanticDeprecatedSince212'. Did you mean: 'PydanticDeprecatedSince210'?
```

cc @sarahec @GaetanLepage 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
