### PR TITLE
turingdb: init at 1.22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5697,6 +5697,12 @@
     githubId = 217899;
     name = "Cyryl Płotnicki";
   };
+  cyrusknopf = {
+    email = "cyrus.knopf@gmail.com";
+    github = "cyrusknopf";
+    githubId = 26168196;
+    name = "Cyrus Knopf";
+  };
   cything = {
     name = "cy";
     email = "nix@cything.io";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23214,6 +23214,12 @@
     githubId = 55679162;
     keys = [ { fingerprint = "1401 1B63 393D 16C1 AA9C  C521 8526 B757 4A53 6236"; } ];
   };
+  roquess = {
+    name = "Steve Roques";
+    email = "steve.roques@gmail.com";
+    github = "roquess";
+    githubId = 8398054;
+  };
   rorosen = {
     email = "robert.rose@mailbox.org";
     github = "rorosen";

--- a/pkgs/by-name/mi/minio-cpp/package.nix
+++ b/pkgs/by-name/mi/minio-cpp/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  curl,
+  curlpp,
+  inih,
+  openssl,
+  pugixml,
+  nlohmann_json,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "minio-cpp";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "minio";
+    repo = "minio-cpp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JKC9SYgb5+nQ3M5C6j6QLfltM+U18oaFrep4gOKPlCI=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        'find_package(unofficial-curlpp CONFIG REQUIRED)' \
+        'find_package(PkgConfig REQUIRED)
+    pkg_check_modules(CURLPP REQUIRED IMPORTED_TARGET curlpp)' \
+      --replace-fail \
+        'unofficial::curlpp::curlpp' \
+        'PkgConfig::CURLPP' \
+      --replace-fail \
+        'find_package(unofficial-inih CONFIG REQUIRED)' \
+        'pkg_check_modules(INIH REQUIRED IMPORTED_TARGET INIReader)' \
+      --replace-fail \
+        'unofficial::inih::inireader' \
+        'PkgConfig::INIH'
+
+    substituteInPlace miniocpp-config.cmake.in \
+      --replace-fail \
+        'find_package(unofficial-curlpp CONFIG REQUIRED)' \
+        'find_package(PkgConfig REQUIRED)
+    pkg_check_modules(CURLPP REQUIRED IMPORTED_TARGET curlpp)' \
+      --replace-fail \
+        'find_package(unofficial-inih CONFIG REQUIRED)' \
+        'pkg_check_modules(INIH REQUIRED IMPORTED_TARGET INIReader)'
+
+    substituteInPlace miniocpp.pc.in \
+      --replace-fail \
+        'libdir=''${exec_prefix}/@CMAKE_INSTALL_LIBDIR@' \
+        'libdir=@CMAKE_INSTALL_FULL_LIBDIR@' \
+      --replace-fail \
+        'includedir=''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@' \
+        'includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@'
+  '';
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  buildInputs = [
+    curl
+    curlpp
+    inih
+    nlohmann_json
+    openssl
+    pugixml
+    zlib
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "MINIO_CPP_TEST" false)
+    (lib.cmakeBool "MINIO_CPP_MAKE_DOC" false)
+  ];
+
+  meta = {
+    description = "MinIO C++ Client SDK for Amazon S3 Compatible Cloud Storage";
+    homepage = "https://github.com/minio/minio-cpp";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      cyrusknopf
+      drupol
+      roquess
+    ];
+  };
+})

--- a/pkgs/by-name/tu/turingdb/package.nix
+++ b/pkgs/by-name/tu/turingdb/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  gitMinimal,
+  bison,
+  flex,
+  inih,
+  minio-cpp,
+  curl,
+  curlpp,
+  nlohmann_json,
+  openssl,
+  openblas,
+  pugixml,
+  faiss,
+  zlib,
+  llvmPackages_20,
+  versionCheckHook,
+}:
+
+let
+  turingstdenv = if stdenv.isDarwin then llvmPackages_20.stdenv else stdenv;
+in
+turingstdenv.mkDerivation (finalAttrs: {
+  pname = "turingdb";
+  version = "1.22";
+
+  src = fetchFromGitHub {
+    owner = "turing-db";
+    repo = "turingdb";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gG3KzEC90nLbIisBt4xnHXtz6LesqJxaviIkTrcTMG0=";
+
+    fetchSubmodules = true;
+
+    leaveDotGit = true;
+    postFetch = ''
+      git -C $out log -1 --format=%ct > $out/HEAD_COMMIT_TIMESTAMP
+      rm -rf $out/.git
+    '';
+  };
+
+  postPatch = ''
+    substituteInPlace storage/dump/DumpConfig.h \
+      --replace-fail HEAD_COMMIT_TIMESTAMP "$(cat $src/HEAD_COMMIT_TIMESTAMP)"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    bison
+    cmake
+    flex
+    gitMinimal
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    curlpp
+    faiss
+    inih
+    minio-cpp
+    nlohmann_json
+    openblas
+    openssl
+    pugixml
+    zlib
+  ]
+  ++ lib.optionals turingstdenv.isDarwin [ llvmPackages_20.openmp ]
+  ++ lib.optionals stdenv.isLinux [ stdenv.cc.cc.lib ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "NIX_BUILD" true)
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-fopenmp")
+    (lib.cmakeFeature "CMAKE_EXE_LINKER_FLAGS" "-lgomp")
+    (lib.cmakeFeature "FLEX_INCLUDE_DIR" "${lib.getDev flex}/include")
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    (lib.cmakeFeature "OpenMP_CXX_FLAGS" "-fopenmp")
+    (lib.cmakeFeature "OpenMP_CXX_LIB_NAMES" "omp")
+    (lib.cmakeFeature "OpenMP_omp_LIBRARY" "${lib.getLib llvmPackages_20.openmp}/lib/libomp.dylib")
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  # Upstream tests require running a TuringDB server and performing
+  # network operations, which are incompatible with the Nix build sandbox.
+  doCheck = false;
+
+  meta = {
+    description = "High performance in-memory column-oriented graph database engine";
+    longDescription = ''
+      TuringDB is a high-performance in-memory column-oriented graph
+      database engine designed for analytical and read-intensive workloads.
+    '';
+    homepage = "https://turingdb.ai";
+    changelog = "https://github.com/turing-db/turingdb/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsl11;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-darwin"
+    ];
+    mainProgram = "turingdb";
+    maintainers = with lib.maintainers; [
+      cyrusknopf
+      drupol
+      roquess
+    ];
+  };
+})


### PR DESCRIPTION
### turingdb: init at 1.22

This PR packages **TuringDB 1.22**, a high-performance in-memory column-oriented graph database written in C++.
It builds the database against system libraries in nixpkgs and enables the upstream `NIX_BUILD` CMake option intended for Nix-based builds.

#### Background

This work follows the investigation and packaging discussion in the earlier nixpkgs PRs:

* https://github.com/NixOS/nixpkgs/pull/485369
* https://github.com/NixOS/nixpkgs/pull/485413

Those PRs clarified several upstream build requirements and dependency changes for recent TuringDB versions.
In particular:

* **`boost` and `aws-sdk-cpp` are no longer required** (confirmed upstream by the TuringDB maintainers).
* TuringDB provides a `NIX_BUILD=true` flag that disables vendored dependency builds and allows using system libraries.
* The project vendors several dependencies via git submodules; these are fetched but system libraries are preferred.

This PR implements a clean Nix-native build based on those findings.

#### minio-cpp dependency

TuringDB provides S3 functionality (`CONNECT`, `PUSH`, `PULL`) through a **fork of `minio-cpp`** included as a git submodule (`external/minio-cpp`).

For packaging purposes, this PR builds **upstream `minio-cpp` (0.3.0)** as a separate derivation and links TuringDB against it.

Some small adjustments were required because upstream `minio-cpp` expects the vcpkg-style CMake targets:

* `unofficial-curlpp`
* `unofficial-inih`

These were replaced with `pkg-config` lookups for the nixpkgs-provided `curlpp` and `inih` packages.

If upstream TuringDB later requires the exact forked submodule revision instead of the upstream SDK, the `minio-cpp` derivation can easily be retargeted to that commit.

#### Build notes

Key build details:

* Uses the upstream `NIX_BUILD=true` flag to prevent vendored dependency builds.
* Links against system libraries (`curl`, `curlpp`, `faiss`, `openblas`, `openssl`, `pugixml`, `inih`, `zlib`, `nlohmann_json`).
* Extracts the git commit timestamp during fetch to satisfy `DumpConfig.h` version stamping.
* Tests are disabled because they require a running server and network access (not compatible with the Nix sandbox).

#### Platform notes

Currently enabled platforms:

* `x86_64-linux`
* `aarch64-darwin`

On Darwin, LLVM 20 is used because Apple Clang's OpenMP implementation is insufficient for the features used by TuringDB.

#### License (unfree)

TuringDB is distributed under the **Business Source License 1.1 (BSL-1.1)**.

Although the source code is publicly available, BSL is **not considered a free software license under nixpkgs policy** because it imposes usage restrictions until a future change date. For that reason the package must be marked **unfree** in nixpkgs.

Users will need to enable unfree packages in their Nix configuration to install it.

#### Maintainers

Added maintainers:

* @cyrusknopf (upstream developer)
* @drupol
* @roquess
