### PR TITLE
agent-of-empires: init at 1.4.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9499,6 +9499,12 @@
     githubId = 34658064;
     name = "Grace Dinh";
   };
+  gdw2 = {
+    email = "gdwarner@gmail.com";
+    github = "gdw2";
+    githubId = 665024;
+    name = "Greg Warner";
+  };
   genga898 = {
     email = "genga898@gmail.com";
     github = "genga898";

--- a/pkgs/by-name/ag/agent-of-empires/package.nix
+++ b/pkgs/by-name/ag/agent-of-empires/package.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  installShellFiles,
+  buildNpmPackage,
+  libgit2,
+  openssl,
+  zlib,
+  stdenv,
+  gitMinimal,
+  nix-update-script,
+}:
+
+let
+  version = "1.4.5";
+
+  src = fetchFromGitHub {
+    owner = "njbrake";
+    repo = "agent-of-empires";
+    tag = "v${version}";
+    hash = "sha256-4jy3ooWASCQ44q4OenBWXs4gA0MAU+uD2BmaV4k9JO4=";
+  };
+
+  # Common Rust build arguments shared between the TUI-only and web-enabled variants.
+  commonArgs = {
+    inherit version src;
+    cargoHash = "sha256-Ic0QncAIcWPMpfYAfEx3x8m41pZcbWyQJJ/2dVu/WMQ=";
+    nativeBuildInputs = [
+      pkg-config
+      installShellFiles
+    ];
+    nativeCheckInputs = [ gitMinimal ];
+    buildInputs = [
+      libgit2
+      openssl
+      zlib
+    ];
+    env.OPENSSL_NO_VENDOR = 1;
+    postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd aoe \
+        --bash <($out/bin/aoe completion bash) \
+        --fish <($out/bin/aoe completion fish) \
+        --zsh <($out/bin/aoe completion zsh)
+    '';
+  };
+
+  # Build the React/Vite web dashboard as a standalone derivation.
+  # AOE_WEB_DIST is read by build.rs to skip running npm during the Rust build.
+  # Update npmDepsHash when web/package-lock.json changes:
+  #   nix-update agent-of-empires (via passthru.npmDeps)
+  webFrontend = buildNpmPackage {
+    pname = "agent-of-empires-web";
+    inherit version src;
+    sourceRoot = "${src.name}/web";
+    npmDepsHash = "sha256-xk+Tob7yptWVaorn86xVgVtTYz2h0moPJDMe1kXt1Bs=";
+    installPhase = ''
+      mkdir $out
+      cp -r dist $out/
+    '';
+  };
+
+  sharedMeta = {
+    homepage = "https://github.com/njbrake/agent-of-empires";
+    changelog = "https://github.com/njbrake/agent-of-empires/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gdw2 ];
+    mainProgram = "aoe";
+    platforms = lib.platforms.unix;
+  };
+in
+
+rustPlatform.buildRustPackage (
+  commonArgs
+  // {
+    pname = "agent-of-empires";
+    __structuredAttrs = true;
+
+    passthru = {
+      updateScript = nix-update-script { };
+      # Build variant with the web dashboard included (--features serve).
+      # Use as: pkgs.agent-of-empires.withWeb
+      withWeb = rustPlatform.buildRustPackage (
+        commonArgs
+        // {
+          pname = "agent-of-empires-web";
+          buildFeatures = [ "serve" ];
+          env = commonArgs.env // {
+            AOE_WEB_DIST = "${webFrontend}/dist";
+          };
+          # Expose npmDeps so nix-update can recompute npmDepsHash automatically.
+          passthru.npmDeps = webFrontend.npmDeps;
+          meta = sharedMeta // {
+            description = "Terminal session manager for AI coding agents, built on tmux (with web dashboard)";
+          };
+        }
+      );
+    };
+
+    meta = sharedMeta // {
+      description = "Terminal session manager for AI coding agents, built on tmux";
+      longDescription = ''
+        Agent of Empires (AoE) is a terminal session manager for AI coding
+        agents on Linux and macOS. Built on tmux, it allows running multiple
+        AI agents in parallel across different branches of your codebase,
+        each in its own isolated session with optional Docker sandboxing.
+
+        Supports Claude Code, OpenCode, Mistral Vibe, Codex CLI, and Gemini CLI.
+      '';
+    };
+  }
+)


### PR DESCRIPTION
Adds `agent-of-empires` v1.4.5 a terminal session manager for AI coding agents built on tmux. The binary is named `aoe`.

- Upstream: https://github.com/njbrake/agent-of-empires
- License: MIT
- Platforms: `lib.platforms.unix`

**Build notes:** Uses `git2 = { features = ["vendored-openssl"] }` upstream; overridden with `OPENSSL_NO_VENDOR = 1` + system `openssl`, `libgit2`, and `zlib` via `pkg-config`. Shell completions (bash, fish, zsh) installed via `aoe completion <shell>`. Tests pass.

**AI disclosure:** This PR was created with the assistance of an AI coding agent (OpenCode / Claude). The package expression, hash derivation workflow, and PR text were produced with AI assistance and reviewed by the submitter.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - `./result/bin/aoe --version` → `aoe 1.4.5` (x86_64-linux via nixpkgs-review, aarch64-darwin locally)
  - Shell completions verified at `share/bash-completion/completions/aoe.bash`, `share/fish/vendor_completions.d/aoe.fish`, `share/zsh/site-functions/_aoe`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Web dashboard: An optional web UI variant is available via pkgs.agent-of-empires.withWeb (builds with --features serve). The React/Vite frontend is built as a separate buildNpmPackage derivation and injected via AOE_WEB_DIST (a build.rs escape hatch added upstream for Nix). passthru.npmDeps is exposed so nix-update can recompute npmDepsHash automatically.