### PR TITLE
intel-oneapi.base: fix failing build

### DIFF
--- a/pkgs/development/libraries/intel-oneapi/base.nix
+++ b/pkgs/development/libraries/intel-oneapi/base.nix
@@ -27,6 +27,7 @@
   gtk3,
   pango,
   cairo,
+  libgbm,
   expat,
   libxkbcommon,
   eudev,
@@ -103,6 +104,7 @@ intel-oneapi.mkIntelOneApi (finalAttrs: {
       nss
       dbus
       cups
+      libgbm
       expat
       libxkbcommon
       eudev
@@ -154,6 +156,7 @@ intel-oneapi.mkIntelOneApi (finalAttrs: {
       gtk3
       pango
       cairo
+      libgbm
       expat
       libxkbcommon
       eudev

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1635,7 +1635,7 @@ with pkgs;
 
   coreboot-configurator = libsForQt5.callPackage ../tools/misc/coreboot-configurator { };
 
-  intel-oneapi = callPackage ../development/libraries/intel-oneapi { };
+  intel-oneapi = recurseIntoAttrs (callPackage ../development/libraries/intel-oneapi { });
 
   cambrinary = python3Packages.callPackage ../applications/misc/cambrinary { };
 


### PR DESCRIPTION
The package depended on `mesa`. This dependency got removed in treewide commit 520e2f2, breaking the package. This commit reintroduces just the specific part that mesa was pulled in for: `libgbm`.

Also changes the way its listed in `top-level/all-packages.nix` to make it properly visible to `nixpkgs-review`, NixOS search, the update bot and similar.

Closes #498190

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
