### PR TITLE
nixos/wivrn: remove defaultRuntime

### DIFF
--- a/nixos/modules/services/video/wivrn.nix
+++ b/nixos/modules/services/video/wivrn.nix
@@ -80,14 +80,6 @@ in
 
       openFirewall = mkEnableOption "the default ports in the firewall for the WiVRn server";
 
-      defaultRuntime = mkEnableOption ''
-        WiVRn as the default OpenXR runtime on the system.
-        The config can be found at `/etc/xdg/openxr/1/active_runtime.json`.
-
-        Note that applications can bypass this option by setting an active
-        runtime in a writable XDG_CONFIG_DIRS location like `~/.config`
-      '';
-
       autoStart = mkEnableOption "starting the service by default";
 
       highPriority = mkEnableOption "high priority capability for asynchronous reprojection";
@@ -247,9 +239,6 @@ in
         PRESSURE_VESSEL_IMPORT_OPENXR_1_RUNTIMES = "1";
       };
       pathsToLink = [ "/share/openxr" ];
-      etc."xdg/openxr/1/active_runtime.json" = mkIf cfg.defaultRuntime {
-        source = "${cfg.package}/share/openxr/1/openxr_wivrn.json";
-      };
     };
   };
   meta.maintainers = with maintainers; [ passivelemon ];


### PR DESCRIPTION
This option shouldn't exist for WiVRn as it manages the active runtime itself. It also causes apps that attempt to initialise OpenXR while WiVRn isn't running to hang.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

@PassiveLemon

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
