### PR TITLE
buildHomeAssistantComponent: fix ignoreVersionRequirement

### DIFF
--- a/pkgs/servers/home-assistant/build-custom-component/manifest-requirements-check-hook.sh
+++ b/pkgs/servers/home-assistant/build-custom-component/manifest-requirements-check-hook.sh
@@ -7,9 +7,12 @@ function manifestCheckPhase() {
     echo "Executing manifestCheckPhase"
     runHook preCheck
 
+    local -a ignoreVersionRequirementArray
+    concatTo ignoreVersionRequirementArray ignoreVersionRequirement
+
     args=""
     # shellcheck disable=SC2154
-    for package in "${ignoreVersionRequirement[@]}"; do
+    for package in "${ignoreVersionRequirementArray[@]}"; do
         args+=" --ignore-version-requirement ${package}"
     done
 


### PR DESCRIPTION
This fix is meant to help with a package I was building that had multiple dependencies that were outside of the scoped version. There was an issue with that though. I saw that the pattern to use here is to initialize a separate array and use the `concatTo` function to get the variable working properly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
