### PR TITLE
clevis: add missing dependency, remove unnecessary global dep

### DIFF
--- a/nixos/modules/system/boot/clevis.nix
+++ b/nixos/modules/system/boot/clevis.nix
@@ -106,7 +106,6 @@ in
       systemd = {
         extraBin = lib.mkIf systemd.enable {
           clevis = "${cfg.package}/bin/clevis";
-          curl = "${pkgs.curl}/bin/curl";
         };
 
         storePaths = lib.mkIf systemd.enable [

--- a/pkgs/by-name/cl/clevis/package.nix
+++ b/pkgs/by-name/cl/clevis/package.nix
@@ -87,6 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
       includeIntoPath = [
         coreutils
         cryptsetup
+        curl
         gnugrep
         gnused
         jose


### PR DESCRIPTION
`clevis` depends on `curl`. In practice, this worked in initrd because we added `curl` as a "global" dependency. While that worked, it feels less "correct" to me than the approach here.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
