### PR TITLE
python-ly: add yiyu as maintainer, cleanup

### DIFF
--- a/pkgs/development/python-modules/python-ly/default.nix
+++ b/pkgs/development/python-modules/python-ly/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage (finalAttrs: {
     '';
     homepage = "https://pypi.org/project/python-ly";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ yiyu ];
     mainProgram = "ly";
   };
 })

--- a/pkgs/development/python-modules/python-ly/default.nix
+++ b/pkgs/development/python-modules/python-ly/default.nix
@@ -1,13 +1,14 @@
 {
   buildPythonPackage,
   fetchFromGitHub,
-  lib,
   hatchling,
+  lib,
   lxml,
   pytestCheckHook,
+  versionCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "python-ly";
   version = "0.9.9";
   pyproject = true;
@@ -15,25 +16,40 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "frescobaldi";
     repo = "python-ly";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-CMMssU+qoHbhdny0sgpoYQas4ySPVHnu7GPnSthuMuE=";
   };
+
+  pythonImportsCheck = [ "ly" ];
 
   build-system = [ hatchling ];
 
   # Tests seem to be broken ATM: https://github.com/wbsoft/python-ly/issues/70
   doCheck = false;
-
   nativeCheckInputs = [
     lxml
     pytestCheckHook
   ];
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   meta = {
-    changelog = "https://github.com/frescobaldi/python-ly/releases/tag/${src.tag}";
+    changelog = "https://github.com/frescobaldi/python-ly/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Tool and library for manipulating LilyPond files";
-    homepage = "https://github.com/frescobaldi/python-ly";
-    license = lib.licenses.gpl2;
+    longDescription = ''
+      This package provides a Python library ly containing various
+      Python modules to parse, manipulate or create documents in
+      LilyPond format.  A command line program ly is also provided
+      that can be used to do various manipulations with LilyPond
+      files.
+
+      The LilyPond format is a plain text input format that is used by
+      the GNU music typesetter [LilyPond](https://lilypond.org).
+    '';
+    homepage = "https://pypi.org/project/python-ly";
+    license = lib.licenses.gpl2Plus;
     maintainers = [ ];
+    mainProgram = "ly";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
