### PR TITLE
burn-central-cli: init at 0.4.0

### DIFF
--- a/pkgs/by-name/bu/burn-central-cli/package.nix
+++ b/pkgs/by-name/bu/burn-central-cli/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  zlib,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "burn-central-cli";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "tracel-ai";
+    repo = "burn-central-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gZ92DFZPox6s4+EKPQ/uxWNV5+F7kYhSnv/Mtpur3Vo=";
+  };
+
+  buildAndTestSubdir = "crates/burn-central-cli";
+
+  cargoHash = "sha256-kUCjkkIog+xXFMTw8LAoHE/D6aBPR6S7Mtqg/Hjuw+o=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    # Pulled in by flate2
+    zlib
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command-line tool for interacting with Burn Central";
+    longDescription = ''
+      The Burn Central CLI (burn) is the command-line tool for interacting
+      with Burn Central, the centralized platform for experiment tracking,
+      model sharing, and deployment for Burn users.
+    '';
+    homepage = "https://github.com/tracel-ai/burn-central-cli";
+    changelog = "https://github.com/tracel-ai/burn-central-cli/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ kilyanni ];
+    mainProgram = "burn";
+  };
+})


### PR DESCRIPTION
`burn-central-cli` is a small CLI tool by Tracel AI for their new Cloud Offering.

It's very new so the repo is small atm. It is built to support [`burn`](https://github.com/tracel-ai/burn), which is a well established deep learning framework for Rust made by Tracel, so I believe this is worth adding to nixpkgs despite being quite niche at the moment.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
