### PR TITLE
lixPackageSets.git.lix: 2.95.0-pre-20260103 -> 2.96.0-pre-20260317

### DIFF
--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -21,6 +21,8 @@ assert lib.assertMsg (
 
 {
   stdenv,
+  closureInfo,
+  runCommand,
   meson,
   bison,
   boehmgc,
@@ -55,6 +57,7 @@ assert lib.assertMsg (
   openssl,
   pkgsStatic,
   rustc,
+  rust-cbindgen,
   toml11,
   pegtl,
   buildPackages,
@@ -94,6 +97,7 @@ assert lib.assertMsg (
   libseccomp,
   pastaFod ? lib.meta.availableOn stdenv.hostPlatform passt,
   passt,
+  withPlugins ? lib.versionAtLeast version "2.95" && !enableStatic,
 
   confDir,
   stateDir,
@@ -106,6 +110,20 @@ let
   hasDtraceSupport = lib.versionAtLeast version "2.93";
   parseToYAML = lib.versionAtLeast version "2.93";
   usesCapnp = lib.versionAtLeast version "2.94";
+
+  mesonCrossFile =
+    deps:
+    runCommand "lix-cross-file.conf"
+      {
+        input = ''
+          [project options]
+          builtin-dep-closure = @deps@
+        '';
+        passAsFile = [ "input" ];
+      }
+      ''
+        substitute $inputPath $out --replace-fail @deps@ "$(cat ${deps})"
+      '';
 in
 # gcc miscompiles coroutines at least until 13.2, possibly longer
 # do not remove this check unless you are sure you (or your users) will not report bugs to Lix upstream about GCC miscompilations.
@@ -138,6 +156,37 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   __structuredAttrs = true;
 
+  # dep closure for builtin builders in meson array form for immediate use
+  builtinDeps =
+    if stdenv.hostPlatform.isStatic then
+      builtins.toFile "lix-static-dep-closure" "[]"
+    else
+      runCommand "lix-builtin-dep-closure"
+        {
+          closure = closureInfo {
+            # closureInfo does not work all that well for things like lowdown,
+            # where it finds only -out but not -lib. we'll take -out and -lib,
+            # ignoring -bin, -man, -dev, etc. and hope that'll be good enough.
+            rootPaths = lib.flatten (
+              map
+                (drv: [
+                  (drv.out or [ ])
+                  (drv.lib or [ ])
+                ])
+                (
+                  lib.subtractLists finalAttrs.disallowedReferences (
+                    finalAttrs.buildInputs ++ finalAttrs.propagatedBuildInputs
+                  )
+                )
+            );
+          };
+        }
+        ''
+          closure=($(cat $closure/store-paths))
+          closure="$(printf ", '%s'" "''${closure[@]}")"
+          printf "[%s]" "''${closure:2}" >$out
+        '';
+
   # We only include CMake so that Meson can locate toml11, which only ships CMake dependency metadata.
   dontUseCmakeConfigure = true;
 
@@ -150,7 +199,11 @@ stdenv.mkDerivation (finalAttrs: {
       ++ lib.optionals finalAttrs.doInstallCheck [
         p.aiohttp
         p.pytest
+        p.pytest-timeout
         p.pytest-xdist
+        p.pyxattr
+        p.tappy
+        p.ruff
       ]
       ++ lib.optionals usesCapnp [ p.pycapnp ]
     ))
@@ -171,6 +224,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals isLLVMOnly [
     rustc
+    rust-cbindgen
     cargo
     rustPlatform.cargoSetupHook
   ]
@@ -185,7 +239,10 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals parseToYAML [ yq ]
   ++ lib.optionals usesCapnp [ capnproto ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ util-linuxMinimal ]
-  ++ lib.optionals (lib.versionAtLeast version "2.94") [ zstd ];
+  ++ lib.optionals (lib.versionAtLeast version "2.94") [ zstd ]
+  ++ lib.optionals (withPlugins && finalAttrs.doInstallCheck) [
+    curl
+  ];
 
   buildInputs = [
     boost
@@ -278,6 +335,11 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonBool "enable-embedded-sandbox-shell" (
       stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isStatic
     ))
+  ]
+  ++ lib.optionals (lib.versionAtLeast version "2.95") [
+    (lib.mesonBool "enable-contrib-plugins" withPlugins)
+  ]
+  ++ [
     (lib.mesonEnable "seccomp-sandboxing" withLibseccomp)
 
     (lib.mesonOption "store-dir" storeDir)
@@ -307,7 +369,12 @@ stdenv.mkDerivation (finalAttrs: {
       [
         (lib.mesonOption "build-test-env" "${pkgsStatic.busybox}/bin")
         (lib.mesonOption "build-test-shell" "${pkgsStatic.bash}/bin")
-      ];
+      ]
+  ++ lib.optionals (lib.versionAtLeast version "2.95") [
+    "--${
+      if stdenv.hostPlatform != stdenv.buildPlatform then "cross" else "native"
+    }-file=${mesonCrossFile finalAttrs.builtinDeps}"
+  ];
 
   ninjaFlags = [ "-v" ];
 

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -257,20 +257,20 @@ lib.makeExtensible (
       attrName = "git";
 
       lix-args = rec {
-        version = "2.95.0-pre-20260103_${builtins.substring 0 12 src.rev}";
+        version = "2.96.0-pre-20260317_${builtins.substring 0 12 src.rev}";
 
         src = fetchFromGitea {
           domain = "git.lix.systems";
           owner = "lix-project";
           repo = "lix";
-          rev = "d387c9113c73f04bed46dbdd59b6c36de2253d73";
-          hash = "sha256-jYUcmXA4FNwoJtxRgH+Be96wQv8h9Y9dByYf+KmcgK4=";
+          rev = "96db7c79cf2a9a06725360b0d12e5de583bef07d";
+          hash = "sha256-Ixwk38HArs7MZXxdWRkSZFzUhUdlCro+8+M/sO+fE/Y=";
         };
 
         cargoDeps = rustPlatform.fetchCargoVendor {
           name = "lix-${version}";
           inherit src;
-          hash = "sha256-APm8m6SVEAO17BBCka13u85/87Bj+LePP7Y3zHA3Mpg=";
+          hash = "sha256-a5XtutX+NS4wOqxeqbscWZMs99teKick5+cQfbCRGxQ=";
         };
       };
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
