### PR TITLE
librewolf-bin-unwrapped: 148.0-1 -> 148.0.2-2

### DIFF
--- a/pkgs/by-name/li/librewolf-bin-unwrapped/package.nix
+++ b/pkgs/by-name/li/librewolf-bin-unwrapped/package.nix
@@ -36,7 +36,7 @@ let
 
   pname = "librewolf-bin-unwrapped";
 
-  version = "148.0-1";
+  version = "148.0.2-2";
 in
 
 stdenv.mkDerivation {
@@ -46,8 +46,8 @@ stdenv.mkDerivation {
     url = "https://codeberg.org/api/packages/librewolf/generic/librewolf/${version}/librewolf-${version}-${arch}-package.tar.xz";
     hash =
       {
-        x86_64-linux = "sha256-UV9laKmAvyafNXXcCGrEr51dlyO1DaV3iHJy981OR9M=";
-        aarch64-linux = "sha256-EZFNcshCdx3xje3/RWXJVYf3IFxeNXbZSoWjoQhoa7I=";
+        x86_64-linux = "sha256-4FigAIvksbwJ46XqH225woK+inQHUnvyxvQBP/yyagU=";
+        aarch64-linux = "sha256-wp31BZLUgH+pXkaDnlUtXMNuacWEgQbnkxMYt2vhKZY=";
       }
       .${stdenv.hostPlatform.system} or throwSystem;
   };


### PR DESCRIPTION
Diff: https://codeberg.org/librewolf/source/compare/148.0-1...148.0.2-2
Security: https://www.mozilla.org/en-US/security/advisories/mfsa2026-19

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
