### PR TITLE
sbarlua: 5.4 -> 5.5; add new maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13709,6 +13709,12 @@
     githubId = 41012641;
     name = "Benjamin Kaylor";
   };
+  kaynetik = {
+    email = "aleksandar@nesovic.dev";
+    github = "kaynetik";
+    githubId = 48174247;
+    name = "Aleksandar Nesovic";
+  };
   kazcw = {
     email = "kaz@lambdaverse.org";
     github = "kazcw";

--- a/pkgs/by-name/sb/sbarlua/package.nix
+++ b/pkgs/by-name/sb/sbarlua/package.nix
@@ -2,31 +2,34 @@
   lib,
   fetchFromGitHub,
   gcc,
-  lua54Packages,
+  lua55Packages,
   readline,
 }:
-lua54Packages.buildLuaPackage {
+lua55Packages.buildLuaPackage {
   pname = "sbarLua";
-  version = "0-unstable-2024-08-12";
+  version = "0-unstable-2026-03-06";
 
   src = fetchFromGitHub {
     owner = "FelixKratz";
     repo = "SbarLua";
-    rev = "437bd2031da38ccda75827cb7548e7baa4aa9978";
-    hash = "sha256-F0UfNxHM389GhiPQ6/GFbeKQq5EvpiqQdvyf7ygzkPg=";
+    rev = "dba9cc421b868c918d5c23c408544a28aadf2f2f";
+    hash = "sha256-lhLTrdufA3ALJ2S5HLdgNOr5seWIWEHkVhZNPObzbvI=";
   };
 
   nativeBuildInputs = [ gcc ];
 
   buildInputs = [ readline ];
 
-  makeFlags = [ "INSTALL_DIR=$(out)/lib/lua/${lua54Packages.lua.luaversion}" ];
+  makeFlags = [ "INSTALL_DIR=$(out)/lib/lua/${lua55Packages.lua.luaversion}" ];
 
   meta = {
     description = "Lua API for SketchyBar";
     homepage = "https://github.com/FelixKratz/SbarLua/";
     license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.khaneliman ];
+    maintainers = [
+      lib.maintainers.khaneliman
+      lib.maintainers.kaynetik
+    ];
     platforms = lib.platforms.darwin;
   };
 }


### PR DESCRIPTION
Updates `sbarlua` from `lua54Packages` to `lua55Packages` to track the upstream SbarLua release that added Lua 5.5 support. Homebrew's `lua` formula recently upgraded to 5.5, causing the previously built `sketchybar.so` (targeting `lib/lua/5.4/`) to no longer be found at runtime. This update bumps the package to the latest upstream commit, rebuilds against Lua 5.5, and installs the module to the correct `lib/lua/5.5/` path.

Also adds `kaynetik` as a co-maintainer.

**Changes:**
- `lua54Packages` → `lua55Packages` throughout
- `rev` + `hash` updated to latest upstream commit (`2026-03-06`)
- `version`: `0-unstable-2024-08-12` → `0-unstable-2026-03-06`
- `maintainers`: added `kaynetik`
- `maintainers/maintainer-list.nix`: added `kaynetik` entry

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests at `passthru.tests`
  - [ ] Tests in `lib/tests` or `pkgs/test`
- [x] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files — `sketchybar.so` present and loads correctly under Lua 5.5
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking
- NixOS Release Notes
  - [ ] Module addition
  - [ ] Module update
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs
