### PR TITLE
nemorosa: 0.4.1 -> 0.4.3

### DIFF
--- a/pkgs/by-name/ne/nemorosa/package.nix
+++ b/pkgs/by-name/ne/nemorosa/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "nemorosa";
-  version = "0.4.1";
+  version = "0.4.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "KyokoMiki";
     repo = "nemorosa";
     tag = finalAttrs.version;
-    hash = "sha256-AqFjpEakEZ21iXmIIxhX+ez2aI/RMsLaUoECipQcaM4=";
+    hash = "sha256-1mP+sdAScXAFp4wjPiSCez6BvzCDgOt/MtGWQv0PD0E=";
   };
 
   # Upstream uses overly strict, fresh version specifiers
@@ -29,24 +29,29 @@ python3Packages.buildPythonApplication (finalAttrs: {
   dependencies =
     with python3Packages;
     [
+      aiohttp
       aiolimiter
+      anyio
+      apprise
       apscheduler
+      asyncer
       beautifulsoup4
       defusedxml
       deluge-client
       fastapi
-      httpx
       humanfriendly
       msgspec
       platformdirs
       qbittorrent-api
       reflink-copy
       sqlalchemy
+      tenacity
       torf
       transmission-rpc
       uvicorn
       uvloop
     ]
+    ++ aiohttp.optional-dependencies.speedups
     ++ beautifulsoup4.optional-dependencies.lxml
     ++ msgspec.optional-dependencies.yaml
     ++ sqlalchemy.optional-dependencies.aiosqlite


### PR DESCRIPTION
The version bump of nemorosa included some changes in dependencies. That caused the ryantm automatic update not to build. In this PR the dependencies are updated and the version is bumped.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
