### PR TITLE
nixos/all-hardware.nix: conditionally enable module aliases removed i…

### DIFF
--- a/nixos/modules/hardware/all-hardware.nix
+++ b/nixos/modules/hardware/all-hardware.nix
@@ -60,7 +60,6 @@ in
       "pata_oldpiix"
       "pata_pcmcia"
       "pata_pdc2027x"
-      "pata_qdi"
       "pata_rz1000"
       "pata_serverworks"
       "pata_sil680"
@@ -68,7 +67,6 @@ in
       "pata_sl82c105"
       "pata_triflex"
       "pata_via"
-      "pata_winbond"
 
       # SCSI support (incomplete).
       "3w-9xxx"
@@ -106,7 +104,11 @@ in
       "vmxnet3"
       "vsock"
     ]
-    ++ lib.optional platform.isx86 "vmw_balloon"
+    ++ lib.optionals (lib.versionOlder config.boot.kernelPackages.kernel.version "7.0") [
+      "pata_qdi"
+      "pata_winbond"
+    ]
+    ++ lib.optionals platform.isx86 [ "vmw_balloon" ]
     ++ lib.optionals (pkgs.stdenv.hostPlatform.isi686 || pkgs.stdenv.hostPlatform.isx86_64) [
       "vmw_vmci"
       "vmwgfx"


### PR DESCRIPTION
…n linux v7.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
