### PR TITLE
dstask: add shell completion support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22975,6 +22975,13 @@
     githubId = 4196789;
     name = "Nathan Ringo";
   };
+  remidupre = {
+    email = "remi+nixpkgs@dupre.io";
+    github = "remi-dupre";
+    githubId = 1173464;
+    name = "Rémi Dupré";
+    keys = [ { fingerprint = "4762 C65B F8D8 6A33 65C1  D10A 4613 02CD 1249 4653"; } ];
+  };
   remix7531 = {
     email = "remix7531@mailbox.org";
     github = "remix7531";

--- a/pkgs/by-name/ds/dstask/package.nix
+++ b/pkgs/by-name/ds/dstask/package.nix
@@ -52,6 +52,9 @@ buildGoModule (finalAttrs: {
     description = "Command line todo list with super-reliable git sync";
     homepage = finalAttrs.src.meta.homepage;
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ stianlagstad ];
+    maintainers = with lib.maintainers; [
+      remidupre
+      stianlagstad
+    ];
   };
 })

--- a/pkgs/by-name/ds/dstask/package.nix
+++ b/pkgs/by-name/ds/dstask/package.nix
@@ -1,12 +1,18 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
+  installShellFiles,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "dstask";
   version = "1.0.1";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
 
   src = fetchFromGitHub {
     owner = "naggie";
@@ -23,6 +29,13 @@ buildGoModule (finalAttrs: {
   vendorHash = "sha256-HSqAbxkkjuMulFymeqApWr/JZ+a7OUTu5EYLGPL/j2U=";
 
   doCheck = false;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd dstask \
+      --bash <($out/bin/dstask bash-completion) \
+      --fish <($out/bin/dstask fish-completion) \
+      --zsh <($out/bin/dstask zsh-completion)
+  '';
 
   # The ldflags reduce the executable size by stripping some debug stuff.
   # The other variables are set so that the output of dstask version shows the


### PR DESCRIPTION
Add shell completions for dstask.

nixpkgs-review doesn't seem to integrate with shell completion scripts, but the completion works fine when I build my configuration over this merge request (fish + darwin).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
