### PR TITLE
grafanaPlugins.grafana-clickhouse-datasource: 4.8.2 -> 4.14.0

### DIFF
--- a/pkgs/servers/monitoring/grafana/plugins/grafana-clickhouse-datasource/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-clickhouse-datasource/default.nix
@@ -2,12 +2,12 @@
 
 grafanaPlugin rec {
   pname = "grafana-clickhouse-datasource";
-  version = "4.8.2";
+  version = "4.14.0";
   zipHash = {
-    x86_64-linux = "sha256-gegkpks7KIHKUG3nmNzEulbhH18eOsx8Afr0tprHFkk=";
-    aarch64-linux = "sha256-wvde2c+goezC1xFPZZ9MnHEk287E2ScyExKNXDTbcT8=";
-    x86_64-darwin = "sha256-zS9LfvSOWCKQIv5GsRS48taM31ZN4i2REY+IIQbqisk=";
-    aarch64-darwin = "sha256-0QfTdgOkfs27EW1VB+AgHPwF1GRcFBxMPBZ9nRyovrs=";
+    x86_64-linux = "sha256-+4RoyDRGLgD46FelK9zWfjokiXtgBhEU5RdsGheCEns=";
+    aarch64-linux = "sha256-9CJy8Wf/B17T64NyL4SBrmLYecdVYSXA5qnpKhcdAHs=";
+    x86_64-darwin = "sha256-ixrSa02vC/MBg29FNmBRd6YvhkL3QZnzOysLLFgjHEA=";
+    aarch64-darwin = "sha256-g7ovNQ5jJWcG82EJr6mnc2ijD/Wk6dY3cYhSchZOs5M=";
   };
   meta = {
     description = "Connects Grafana to ClickHouse";

--- a/pkgs/servers/monitoring/grafana/plugins/update-grafana-plugin.sh
+++ b/pkgs/servers/monitoring/grafana/plugins/update-grafana-plugin.sh
@@ -35,8 +35,8 @@ update() {
     update-source-version $system "grafanaPlugins.${plugin_name}" "$latest_version" "$hash"
 }
 
-if echo "$api_response" | jq -e .packages.any > /dev/null; then
-    # the package contains an "any" package, so there should be only one zipHash.
+if echo "$api_response" | jq -e '.packages | select(length == 1) | .any' > /dev/null; then
+    # the package only contains an "any" package, so there should be only one zipHash.
     update "any"
 else
     update "linux-amd64" "x86_64-linux"


### PR DESCRIPTION
## Things done

Also modify the upgrade script to handle packages that have per-platform and also 'any' packages

fyi @nagisa 

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
