### PR TITLE
haskellPackages.mkDerivation: let c2hs use GNU17 standard with gcc 15

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -263,6 +263,19 @@ in
     isCross && crossSupport.canProxyTH && crossSupport.needsExternalInterpreterSetup,
   # iserv-proxy needs local network access
   __darwinAllowLocalNetworking ? stdenv.hostPlatform.isDarwin && enableExternalInterpreter,
+  # Set the C standard for the C pre-processor output c2hs takes as its input. Use
+  # $CC's default if `null`.
+  #
+  # c2hs does not support relatively common elements of C23 syntax (e.g. the bool keyword),
+  # so we need to force the use of an older C standard if we're using GCC 15. Unfortunately,
+  # fixing c2hs without upstream involvement is hard since it probably requires a breaking
+  # change to language-c.
+  # This option will likely be removed after the upstream issue is solved.
+  # See https://github.com/haskell/c2hs/issues/300,
+  # https://github.com/visq/language-c/pull/104,
+  # https://github.com/NixOS/nixpkgs/issues/478368 (krank:ignore-line),
+  # https://github.com/NixOS/nixpkgs/issues/475479 (krank:ignore-line).
+  __c2hsCppStandard ? if stdenv.hasCC && stdenv.cc.isGNU then "gnu17" else null,
 }@args:
 
 assert editedCabalFile != null -> revision != null;
@@ -388,6 +401,9 @@ let
   ]
   ++ optionals stdenv.hasCC [
     "--with-gcc=$CC" # Clang won't work without that extra information.
+  ]
+  ++ optionals (stdenv.hasCC && __c2hsCppStandard != null) [
+    "--c2hs-option=--cppopts=-std=${__c2hsCppStandard}"
   ]
   ++ [
     "--package-db=$packageConfDir"


### PR DESCRIPTION
Unfortunately, upstream has not responded at all w.r.t. the incompatibility between GCC 15's pre processor output and language-c/c2hs. Also it looks like a fix would require a breaking change to language-c which makes patching this in Nixpkgs hard.

I've opted to instead work around this by instructing c2hs to pass --std=gnu17 to the C pre-processor if we're using GCC (judging by the darwin builds, clang is fine at the moment). We can do this globally using the --c2hs-option configure flag which does not cause issues even if the package doesn't use c2hs.

The standard downgrade should not cause trouble since there is no way for c2hs users to actually use C23, but we offer a way to disable the flag being passed just to be safe.

Resolves #478368 (though we should look for a better solution).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
