### PR TITLE
nixos-rebuild-ng: fix terminal corruption from background journalctl

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -724,11 +724,11 @@ def _run_action_with_systemd(
 
     try:
         _run_action(
-            action,
-            path_to_config,
-            install_bootloader,
-            target_host,
-            sudo,
+            action=action,
+            path_to_config=path_to_config,
+            install_bootloader=install_bootloader,
+            target_host=target_host,
+            sudo=sudo,
             prefix=[*SYSTEMD_RUN_CMD_PREFIX, f"--unit={unique_unit_name}"],
         )
     except KeyboardInterrupt:
@@ -768,11 +768,11 @@ def switch_to_configuration(
 
     if _has_systemd(target_host):
         _run_action_with_systemd(
-            action,
-            path_to_config,
-            install_bootloader,
-            target_host,
-            sudo,
+            action=action,
+            path_to_config=path_to_config,
+            install_bootloader=install_bootloader,
+            target_host=target_host,
+            sudo=sudo,
         )
     else:
         logger.debug(
@@ -780,11 +780,11 @@ def switch_to_configuration(
             "not working in target host"
         )
         _run_action(
-            action,
-            path_to_config,
-            install_bootloader,
-            target_host,
-            sudo,
+            action=action,
+            path_to_config=path_to_config,
+            install_bootloader=install_bootloader,
+            target_host=target_host,
+            sudo=sudo,
         )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -740,6 +740,7 @@ def _run_action_with_systemd(
         raise
     finally:
         journalctl.terminate()
+        journalctl.wait()
 
 
 def switch_to_configuration(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -210,7 +210,7 @@ def run_wrapper_bg(
     if process_input:
         stdin = subprocess.PIPE
     else:
-        stdin = None
+        stdin = subprocess.DEVNULL
 
     r = subprocess.Popen(
         final_args,


### PR DESCRIPTION
Fix terminal corruption caused by the background `journalctl` process spawned in `_run_action_with_systemd`. Regression from #463029.

- Redirect `stdin` to `DEVNULL` in `run_wrapper_bg` — the background process doesn't need terminal input.
- Call `journalctl.wait()` after `terminate()` to let it clean up before the parent continues.
