### PR TITLE
lsv: init at 0.1.15

### DIFF
--- a/pkgs/by-name/ls/lsv/package.nix
+++ b/pkgs/by-name/ls/lsv/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "lsv";
+  version = "0.1.15";
+
+  src = fetchFromGitHub {
+    owner = "SecretDeveloper";
+    repo = "lsv";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Q8UCjGY1h0r61+xp8jGwDUHF/M/7lWZNw6iwZMjTiPE=";
+  };
+
+  cargoHash = "sha256-o2LLUTijzCqlyoKrO+Fv6m7DneTnm+BnA8Q943Oo37E=";
+  env.RUSTC_BOOTSTRAP = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Configurable command line file browser with preview and key bindings";
+    homepage = "https://github.com/SecretDeveloper/lsv";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Inarizxc ];
+    platforms = lib.platforms.linux;
+    mainProgram = "lsv";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


[A configurable command line file browser with preview and key bindings](https://github.com/SecretDeveloper/lsv)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
