### PR TITLE
buildFHSEnv, appimageTools: support finalAttrs

### DIFF
--- a/doc/build-helpers/images/appimagetools.section.md
+++ b/doc/build-helpers/images/appimagetools.section.md
@@ -28,7 +28,7 @@ However, [those were unified early 2020](https://github.com/NixOS/nixpkgs/pull/8
 
 ```nix
 { appimageTools, fetchurl }:
-let
+appimageTools.wrapType2 {
   pname = "nuclear";
   version = "0.6.30";
 
@@ -36,8 +36,7 @@ let
     url = "https://github.com/nukeop/nuclear/releases/download/v${version}/nuclear-v${version}.AppImage";
     hash = "sha256-he1uGC1M/nFcKpMM9JKY4oeexJcnzV0ZRxhTjtJz6xw=";
   };
-in
-appimageTools.wrapType2 { inherit pname version src; }
+}
 ```
 
 :::
@@ -56,7 +55,7 @@ There are a few ways to learn which dependencies an application needs:
 
 ```nix
 { appimageTools, fetchurl }:
-let
+appimageTools.wrapType2 {
   pname = "irccloud";
   version = "0.16.0";
 
@@ -64,9 +63,7 @@ let
     url = "https://github.com/irccloud/irccloud-desktop/releases/download/v${version}/IRCCloud-${version}-linux-x86_64.AppImage";
     hash = "sha256-/hMPvYdnVB1XjKgU2v47HnVvW4+uC3rhRjbucqin4iI=";
   };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
+
   extraPkgs = pkgs: [ pkgs.at-spi2-core ];
 }
 ```
@@ -88,12 +85,12 @@ However, [those were unified early 2020](https://github.com/NixOS/nixpkgs/pull/8
 
 # Extracting an AppImage to install extra files
 
-This example was adapted from a real package in Nixpkgs to show how `extract` is usually used in combination with `wrapType2`.
-Note how `appimageContents` is used in `extraInstallCommands` to install additional files that were extracted from the AppImage.
+`wrapType2` automatically extracts the AppImage for you and makes it available via the `contents` attribute.
+Note how `finalAttrs.contents` is used in `extraInstallCommands` to install additional files that were extracted from the AppImage.
 
 ```nix
 { appimageTools, fetchurl }:
-let
+appimageTools.wrapType2 (finalAttrs: {
   pname = "irccloud";
   version = "0.16.0";
 
@@ -102,27 +99,24 @@ let
     hash = "sha256-/hMPvYdnVB1XjKgU2v47HnVvW4+uC3rhRjbucqin4iI=";
   };
 
-  appimageContents = appimageTools.extract { inherit pname version src; };
-in
-appimageTools.wrapType2 {
-  inherit pname version src;
-
   extraPkgs = pkgs: [ pkgs.at-spi2-core ];
 
   extraInstallCommands = ''
     mv $out/bin/irccloud-${version} $out/bin/irccloud
-    install -m 444 -D ${appimageContents}/irccloud.desktop $out/share/applications/irccloud.desktop
-    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/irccloud.png \
+    install -m 444 -D ${finalAttrs.contents}/irccloud.desktop $out/share/applications/irccloud.desktop
+    install -m 444 -D ${finalAttrs.contents}/usr/share/icons/hicolor/512x512/apps/irccloud.png \
       $out/share/icons/hicolor/512x512/apps/irccloud.png
     substituteInPlace $out/share/applications/irccloud.desktop \
       --replace-fail 'Exec=AppRun' 'Exec=irccloud'
   '';
-}
+})
 ```
 
 :::
 
-The argument passed to `extract` can also contain a `postExtract` attribute, which allows you to execute additional commands after the files are extracted from the AppImage.
+`appimageTools` also exposes the `extract` function should you need to do it manually, requiring `pname`, `version`, and `src` arguments (`src` being the AppImage file to extract).
+
+The arguments passed to `extract` can also contain a `postExtract` attribute, which allows you to execute additional commands after the files are extracted from the AppImage.
 `postExtract` must be a string with commands to run.
 
 :::{.warning}
@@ -138,7 +132,7 @@ This is a rewrite of [](#ex-extracting-appimage) to use `postExtract` and `wrapA
 
 ```nix
 { appimageTools, fetchurl }:
-let
+appimageTools.wrapAppImage (finalAttrs: {
   pname = "irccloud";
   version = "0.16.0";
 
@@ -147,30 +141,22 @@ let
     hash = "sha256-/hMPvYdnVB1XjKgU2v47HnVvW4+uC3rhRjbucqin4iI=";
   };
 
-  appimageContents = appimageTools.extract {
-    inherit pname version src;
+  contents = appimageTools.extract {
+    inherit (finalAttrs) pname version src;
     postExtract = ''
       substituteInPlace $out/irccloud.desktop --replace-fail 'Exec=AppRun' 'Exec=irccloud'
     '';
   };
-in
-appimageTools.wrapAppImage {
-  inherit pname version;
-
-  src = appimageContents;
 
   extraPkgs = pkgs: [ pkgs.at-spi2-core ];
 
   extraInstallCommands = ''
     mv $out/bin/irccloud-${version} $out/bin/irccloud
-    install -m 444 -D ${appimageContents}/irccloud.desktop $out/share/applications/irccloud.desktop
-    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/irccloud.png \
+    install -m 444 -D ${finalAttrs.contents}/irccloud.desktop $out/share/applications/irccloud.desktop
+    install -m 444 -D ${finalAttrs.contents}/usr/share/icons/hicolor/512x512/apps/irccloud.png \
       $out/share/icons/hicolor/512x512/apps/irccloud.png
   '';
-
-  # specify src archive for nix-update
-  passthru.src = src;
-}
+})
 ```
 
 :::

--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -233,6 +233,8 @@
 
 - The `services.nextcloud-spreed-signaling` NixOS module has been added to facilitate declarative management of a standalone Spreed signaling server ("High Performance Backend" for Nextcloud Talk).
 
+- `buildFHSEnv`, `appimageTools.wrapAppImage`, and `appimageTools.wrapType2` now support the `finalAttrs` pattern. When using `wrapAppImage`, it is now recommended to pass the extracted AppImage to the `contents` attribute (instead of `src`), to avoid shadowing `src`. Passing the extracted contents to `src` is now deprecated and will be removed in a future release.
+
 - `fetchPnpmDeps` and `pnpmConfigHook` were added as top-level attributes, replacing the now deprecated `pnpm.fetchDeps` and `pnpm.configHook` attributes.
 
 - `buildNpmPackage` now supports `npmDepsCacheVersion`. Set to `2` to enable packument caching, which fixes builds for projects using npm workspaces.

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -129,6 +129,8 @@
 
 - `super-productivity` has been updated. The binary has been renamed from `super-productivity` to `superproductivity`. A symlink from the old name is provided for backward compatibility.
 
+- `buildFHSEnv`, `appimageTools.wrapAppImage`, and `appimageTools.wrapType2` now support the `finalAttrs` pattern. When using `wrapAppImage`, it is now recommended to pass the extracted AppImage to the `contents` attribute (instead of `src`), to avoid shadowing `src`. Passing the extracted contents to `src` is now deprecated and will be removed in a future release.
+
 - Package-URL (PURL, https://github.com/package-url/purl-spec) metadata identifier has been added for `fetchgit`, `fetchpypi` and `fetchFromGithub` fetchers.
   `mkDerivation` has been adjusted to reuse this information.
   Package-URLs allow reliably identifying and locating software packages.

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -8,16 +8,18 @@
   pv,
   squashfsTools,
   buildFHSEnv,
-  pkgs,
+  replaceVarsWith,
+  runtimeShell,
+  runCommand,
 }:
 
 rec {
-  appimage-exec = pkgs.replaceVarsWith {
+  appimage-exec = replaceVarsWith {
     src = ./appimage-exec.sh;
     isExecutable = true;
     dir = "bin";
     replacements = {
-      inherit (pkgs) runtimeShell;
+      inherit runtimeShell;
       path = lib.makeBinPath [
         bash
         binutils-unwrapped
@@ -42,7 +44,7 @@ rec {
     assert lib.assertMsg (
       name == null
     ) "The `name` argument is deprecated. Use `pname` and `version` instead to construct the name.";
-    pkgs.runCommand "${pname}-${version}-extracted"
+    runCommand "${pname}-${version}-extracted"
       {
         nativeBuildInputs = [ appimage-exec ];
         strictDeps = true;
@@ -57,60 +59,55 @@ rec {
   extractType2 = extract;
   wrapType1 = wrapType2;
 
-  wrapAppImage =
-    args@{
-      src,
-      extraPkgs ? pkgs: [ ],
-      meta ? { },
-      ...
-    }:
-    buildFHSEnv (
+  wrapAppImage = lib.extendMkDerivation {
+    constructDrv = buildFHSEnv;
+    excludeDrvArgNames = [ "extraPkgs" ];
+    extendDrvArgs =
+      finalAttrs:
+      prev@{
+        contents ? prev.src,
+        extraPkgs ? pkgs: [ ],
+        meta ? { },
+        ...
+      }:
       defaultFhsEnvArgs
       // {
         targetPkgs = pkgs: [ appimage-exec ] ++ defaultFhsEnvArgs.targetPkgs pkgs ++ extraPkgs pkgs;
 
-        runScript = "appimage-exec.sh -w ${src} --";
+        runScript = "appimage-exec.sh -w ${contents} --";
 
         meta = {
           sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
         }
         // meta;
-      }
-      // (removeAttrs args (builtins.attrNames (builtins.functionArgs wrapAppImage)))
-    );
+      };
+  };
 
-  wrapType2 =
-    args@{
-      src,
-      extraPkgs ? pkgs: [ ],
-      ...
-    }:
-    wrapAppImage (
-      args
-      // {
-        inherit extraPkgs;
-        src = extract (
-          lib.filterAttrs (
-            key: value:
-            builtins.elem key [
-              "pname"
-              "version"
-              "src"
-            ]
-          ) args
-        );
-
-        # passthru src to make nix-update work
-        # hack to keep the origin position (unsafeGetAttrPos)
-        passthru =
-          lib.pipe args [
-            lib.attrNames
-            (lib.remove "src")
-            (removeAttrs args)
+  wrapType2 = lib.extendMkDerivation {
+    constructDrv = wrapAppImage;
+    extendDrvArgs = finalAttrs: args: {
+      contents = extract (
+        lib.filterAttrs (
+          key: value:
+          builtins.elem key [
+            "pname"
+            "version"
+            "src"
           ]
-          // args.passthru or { };
-      }
-    );
+        ) finalAttrs
+      );
+
+      # passthru src to make nix-update work
+      # hack to keep the origin position (unsafeGetAttrPos)
+      passthru =
+        lib.pipe finalAttrs [
+          lib.attrNames
+          (lib.remove "src")
+          (removeAttrs finalAttrs)
+        ]
+        // args.passthru or { };
+    };
+  };
 
   defaultFhsEnvArgs = {
     # Most of the packages were taken from the Steam chroot

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -8,16 +8,18 @@
   pv,
   squashfsTools,
   buildFHSEnv,
-  pkgs,
+  replaceVarsWith,
+  runtimeShell,
+  runCommand,
 }:
 
 rec {
-  appimage-exec = pkgs.replaceVarsWith {
+  appimage-exec = replaceVarsWith {
     src = ./appimage-exec.sh;
     isExecutable = true;
     dir = "bin";
     replacements = {
-      inherit (pkgs) runtimeShell;
+      inherit runtimeShell;
       path = lib.makeBinPath [
         bash
         binutils-unwrapped
@@ -42,7 +44,7 @@ rec {
     assert
       name == null
       || throw "The `name` argument is deprecated. Use `pname` and `version` instead to construct the name.";
-    pkgs.runCommand "${pname}-${version}-extracted"
+    runCommand "${pname}-${version}-extracted"
       {
         nativeBuildInputs = [ appimage-exec ];
         strictDeps = true;
@@ -57,60 +59,55 @@ rec {
   extractType2 = extract;
   wrapType1 = wrapType2;
 
-  wrapAppImage =
-    args@{
-      src,
-      extraPkgs ? pkgs: [ ],
-      meta ? { },
-      ...
-    }:
-    buildFHSEnv (
+  wrapAppImage = lib.extendMkDerivation {
+    constructDrv = buildFHSEnv;
+    excludeDrvArgNames = [ "extraPkgs" ];
+    extendDrvArgs =
+      finalAttrs:
+      prev@{
+        contents ? prev.src,
+        extraPkgs ? pkgs: [ ],
+        meta ? { },
+        ...
+      }:
       defaultFhsEnvArgs
       // {
         targetPkgs = pkgs: [ appimage-exec ] ++ defaultFhsEnvArgs.targetPkgs pkgs ++ extraPkgs pkgs;
 
-        runScript = "appimage-exec.sh -w ${src} --";
+        runScript = "appimage-exec.sh -w ${finalAttrs.contents or prev.src} --";
 
         meta = {
           sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
         }
         // meta;
-      }
-      // (removeAttrs args (builtins.attrNames (builtins.functionArgs wrapAppImage)))
-    );
+      };
+  };
 
-  wrapType2 =
-    args@{
-      src,
-      extraPkgs ? pkgs: [ ],
-      ...
-    }:
-    wrapAppImage (
-      args
-      // {
-        inherit extraPkgs;
-        src = extract (
-          lib.filterAttrs (
-            key: value:
-            builtins.elem key [
-              "pname"
-              "version"
-              "src"
-            ]
-          ) args
-        );
-
-        # passthru src to make nix-update work
-        # hack to keep the origin position (unsafeGetAttrPos)
-        passthru =
-          lib.pipe args [
-            lib.attrNames
-            (lib.remove "src")
-            (removeAttrs args)
+  wrapType2 = lib.extendMkDerivation {
+    constructDrv = wrapAppImage;
+    extendDrvArgs = finalAttrs: args: {
+      contents = extract (
+        lib.filterAttrs (
+          key: value:
+          builtins.elem key [
+            "pname"
+            "version"
+            "src"
           ]
-          // args.passthru or { };
-      }
-    );
+        ) finalAttrs
+      );
+
+      # passthru src to make nix-update work
+      # hack to keep the origin position (unsafeGetAttrPos)
+      passthru =
+        lib.pipe finalAttrs [
+          lib.attrNames
+          (lib.remove "src")
+          (removeAttrs finalAttrs)
+        ]
+        // args.passthru or { };
+    };
+  };
 
   defaultFhsEnvArgs = {
     # Most of the packages were taken from the Steam chroot

--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -11,30 +11,6 @@
   bubblewrap,
 }:
 
-{
-  pname ? throw "You must provide either `name` or `pname`",
-  version ? throw "You must provide either `name` or `version`",
-  name ? "${pname}-${version}",
-  runScript ? "bash",
-  nativeBuildInputs ? [ ],
-  extraInstallCommands ? "",
-  executableName ? args.pname or name,
-  meta ? { },
-  passthru ? { },
-  extraPreBwrapCmds ? "",
-  extraBwrapArgs ? [ ],
-  unshareUser ? false,
-  unshareIpc ? false,
-  unsharePid ? false,
-  unshareNet ? false,
-  unshareUts ? false,
-  unshareCgroup ? false,
-  privateTmp ? false,
-  chdirToPwd ? true,
-  dieWithParent ? true,
-  ...
-}@args:
-
 # NOTE:
 # `pname` and `version` will throw if they were not provided.
 # Use `name` instead of directly evaluating `pname` or `version`.
@@ -42,296 +18,323 @@
 # If you need `pname` or `version` specifically, use `args` instead:
 # e.g. `args.pname or ...`.
 
-let
-  inherit (lib)
-    concatLines
-    concatStringsSep
-    escapeShellArgs
-    filter
-    optionalString
-    splitString
-    ;
-
-  inherit (lib.attrsets) removeAttrs;
-
-  # The splicing code does not handle `pkgsi686Linux` well, so we have to be
-  # explicit about which package set it's coming from.
-  inherit (pkgsHostTarget) pkgsi686Linux;
-
-  # we don't know which have been supplied, and want to avoid defaulting missing attrs to null. Passed into runCommandLocal
-  nameAttrs = lib.filterAttrs (
-    key: value:
-    builtins.elem key [
-      "name"
-      "pname"
-      "version"
-    ]
-  ) args;
-
-  buildFHSEnv = callPackage ./buildFHSEnv.nix { };
-
-  fhsenv = buildFHSEnv (
-    removeAttrs args [
-      "runScript"
-      "extraInstallCommands"
-      "meta"
-      "passthru"
-      "extraPreBwrapCmds"
-      "extraBwrapArgs"
-      "dieWithParent"
-      "unshareUser"
-      "unshareCgroup"
-      "unshareUts"
-      "unshareNet"
-      "unsharePid"
-      "unshareIpc"
-      "privateTmp"
-    ]
-  );
-
-  etcBindEntries =
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+  excludeDrvArgNames = [
+    "multiPkgs"
+    "targetPkgs"
+  ];
+  extendDrvArgs =
+    finalAttrs:
+    {
+      pname ? throw "You must provide either `name` or `pname`",
+      version ? throw "You must provide either `name` or `version`",
+      name ? "${args.pname}-${args.version}",
+      runScript ? "bash",
+      extraInstallCommands ? "",
+      executableName ? args.pname or name,
+      meta ? { },
+      passthru ? { },
+      extraPreBwrapCmds ? "",
+      extraBwrapArgs ? [ ],
+      unshareUser ? false,
+      unshareIpc ? false,
+      unsharePid ? false,
+      unshareNet ? false,
+      unshareUts ? false,
+      unshareCgroup ? false,
+      privateTmp ? false,
+      chdirToPwd ? true,
+      dieWithParent ? true,
+      ...
+    }@args:
     let
-      files = [
-        # NixOS Compatibility
-        "static"
-        "nix" # mainly for nixVersions.git users, but also for access to nix/netrc
-        # Shells
-        "shells"
-        "bashrc"
-        "zshenv"
-        "zshrc"
-        "zinputrc"
-        "zprofile"
-        # Users, Groups, NSS
-        "passwd"
-        "group"
-        "shadow"
-        "hosts"
-        "resolv.conf"
-        "nsswitch.conf"
-        # User profiles
-        "profiles"
-        # Sudo & Su
-        "login.defs"
-        "sudoers"
-        "sudoers.d"
-        # Time
-        "localtime"
-        "zoneinfo"
-        # Other Core Stuff
-        "machine-id"
-        "os-release"
-        # PAM
-        "pam.d"
-        # Fonts
-        "fonts"
-        # ALSA
-        "alsa"
-        "asound.conf"
-        # SSL
-        "ssl/certs"
-        "ca-certificates"
-        "pki"
-        # Custom dconf profiles
-        "dconf"
-      ];
-    in
-    map (path: "/etc/${path}") files;
+      inherit (lib)
+        concatLines
+        concatStringsSep
+        escapeShellArgs
+        filter
+        optionalString
+        splitString
+        ;
 
-  # Here's the problem case:
-  # - we need to run bash to run the init script
-  # - LD_PRELOAD may be set to another dynamic library, requiring us to discover its dependencies
-  # - oops! ldconfig is part of the init script, and it hasn't run yet
-  # - everything explodes
-  #
-  # In particular, this happens with fhsenvs in fhsenvs, e.g. when running
-  # a wrapped game from Steam.
-  #
-  # So, instead of doing that, we build a tiny static (important!) shim
-  # that executes ldconfig in a completely clean environment to generate
-  # the initial cache, and then execs into the "real" init, which is the
-  # first time we see anything dynamically linked at all.
-  #
-  # Also, the real init is placed strategically at /init, so we don't
-  # have to recompile this every time.
-  containerInit =
-    runCommandCC "container-init"
-      {
-        buildInputs = [ stdenv.cc.libc.static or null ];
-      }
-      ''
-        $CXX -static -s -o $out ${./container-init.cc}
+      inherit (lib.attrsets) removeAttrs;
+
+      # The splicing code does not handle `pkgsi686Linux` well, so we have to be
+      # explicit about which package set it's coming from.
+      inherit (pkgsHostTarget) pkgsi686Linux;
+
+      buildFHSEnv = callPackage ./buildFHSEnv.nix { };
+
+      fhsenv = buildFHSEnv (
+        removeAttrs args [
+          "runScript"
+          "extraInstallCommands"
+          "meta"
+          "passthru"
+          "extraPreBwrapCmds"
+          "extraBwrapArgs"
+          "dieWithParent"
+          "unshareUser"
+          "unshareCgroup"
+          "unshareUts"
+          "unshareNet"
+          "unsharePid"
+          "unshareIpc"
+          "privateTmp"
+        ]
+      );
+
+      etcBindEntries =
+        let
+          files = [
+            # NixOS Compatibility
+            "static"
+            "nix" # mainly for nixVersions.git users, but also for access to nix/netrc
+            # Shells
+            "shells"
+            "bashrc"
+            "zshenv"
+            "zshrc"
+            "zinputrc"
+            "zprofile"
+            # Users, Groups, NSS
+            "passwd"
+            "group"
+            "shadow"
+            "hosts"
+            "resolv.conf"
+            "nsswitch.conf"
+            # User profiles
+            "profiles"
+            # Sudo & Su
+            "login.defs"
+            "sudoers"
+            "sudoers.d"
+            # Time
+            "localtime"
+            "zoneinfo"
+            # Other Core Stuff
+            "machine-id"
+            "os-release"
+            # PAM
+            "pam.d"
+            # Fonts
+            "fonts"
+            # ALSA
+            "alsa"
+            "asound.conf"
+            # SSL
+            "ssl/certs"
+            "ca-certificates"
+            "pki"
+            # Custom dconf profiles
+            "dconf"
+          ];
+        in
+        map (path: "/etc/${path}") files;
+
+      # Here's the problem case:
+      # - we need to run bash to run the init script
+      # - LD_PRELOAD may be set to another dynamic library, requiring us to discover its dependencies
+      # - oops! ldconfig is part of the init script, and it hasn't run yet
+      # - everything explodes
+      #
+      # In particular, this happens with fhsenvs in fhsenvs, e.g. when running
+      # a wrapped game from Steam.
+      #
+      # So, instead of doing that, we build a tiny static (important!) shim
+      # that executes ldconfig in a completely clean environment to generate
+      # the initial cache, and then execs into the "real" init, which is the
+      # first time we see anything dynamically linked at all.
+      #
+      # Also, the real init is placed strategically at /init, so we don't
+      # have to recompile this every time.
+      containerInit =
+        runCommandCC "container-init"
+          {
+            buildInputs = [ stdenv.cc.libc.static or null ];
+          }
+          ''
+            $CXX -static -s -o $out ${./container-init.cc}
+          '';
+
+      realInit =
+        run:
+        writeShellScript "${name}-init" ''
+          source /etc/profile
+          exec ${run} "$@"
+        '';
+
+      indentLines = str: concatLines (map (s: "  " + s) (filter (s: s != "") (splitString "\n" str)));
+      bwrapCmd =
+        {
+          initArgs ? "",
+        }:
+        ''
+          ignored=(/nix /dev /proc /etc ${optionalString privateTmp "/tmp"})
+          ro_mounts=()
+          symlinks=()
+          etc_ignored=()
+
+          ${extraPreBwrapCmds}
+
+          # loop through all entries of root in the fhs environment, except its /etc.
+          for i in ${fhsenv}/*; do
+            path="/''${i##*/}"
+            if [[ $path == '/etc' ]]; then
+              :
+            elif [[ -L $i ]]; then
+              symlinks+=(--symlink "$(${coreutils}/bin/readlink "$i")" "$path")
+              ignored+=("$path")
+            else
+              ro_mounts+=(--ro-bind "$i" "$path")
+              ignored+=("$path")
+            fi
+          done
+
+          # loop through the entries of /etc in the fhs environment.
+          if [[ -d ${fhsenv}/etc ]]; then
+            for i in ${fhsenv}/etc/*; do
+              path="/''${i##*/}"
+              # NOTE: we're binding /etc/fonts and /etc/ssl/certs from the host so we
+              # don't want to override it with a path from the FHS environment.
+              if [[ $path == '/fonts' || $path == '/ssl' ]]; then
+                continue
+              fi
+              if [[ -L $i ]]; then
+                symlinks+=(--symlink "$i" "/etc$path")
+              else
+                ro_mounts+=(--ro-bind "$i" "/etc$path")
+              fi
+              etc_ignored+=("/etc$path")
+            done
+          fi
+
+          # propagate /etc from the actual host if nested
+          if [[ -e /.host-etc ]]; then
+            ro_mounts+=(--ro-bind /.host-etc /.host-etc)
+          else
+            ro_mounts+=(--ro-bind /etc /.host-etc)
+          fi
+
+          # link selected etc entries from the actual root
+          for i in ${escapeShellArgs etcBindEntries}; do
+            if [[ "''${etc_ignored[@]}" =~ "$i" ]]; then
+              continue
+            fi
+            if [[ -e $i ]]; then
+              symlinks+=(--symlink "/.host-etc/''${i#/etc/}" "$i")
+            fi
+          done
+
+          declare -a auto_mounts
+          # loop through all directories in the root
+          for dir in /*; do
+            # if it is a directory and it is not ignored
+            if [[ -d "$dir" ]] && [[ ! "''${ignored[@]}" =~ "$dir" ]]; then
+              # add it to the mount list
+              auto_mounts+=(--bind "$dir" "$dir")
+            fi
+          done
+
+          declare -a x11_args
+          # Always mount a tmpfs on /tmp/.X11-unix
+          # Rationale: https://github.com/flatpak/flatpak/blob/be2de97e862e5ca223da40a895e54e7bf24dbfb9/common/flatpak-run.c#L277
+          x11_args+=(--tmpfs /tmp/.X11-unix)
+
+          # Try to guess X socket path. This doesn't cover _everything_, but it covers some things.
+          if [[ "$DISPLAY" == *:* ]]; then
+            # recover display number from $DISPLAY formatted [host]:num[.screen]
+            display_nr=''${DISPLAY/#*:} # strip host
+            display_nr=''${display_nr/%.*} # strip screen
+            local_socket=/tmp/.X11-unix/X$display_nr
+            x11_args+=(--ro-bind-try "$local_socket" "$local_socket")
+          fi
+
+          ${optionalString privateTmp ''
+            # sddm places XAUTHORITY in /tmp
+            if [[ "$XAUTHORITY" == /tmp/* ]]; then
+              x11_args+=(--ro-bind-try "$XAUTHORITY" "$XAUTHORITY")
+            fi
+
+            # dbus-run-session puts the socket in /tmp
+            IFS=";" read -ra addrs <<<"$DBUS_SESSION_BUS_ADDRESS"
+            for addr in "''${addrs[@]}"; do
+              [[ "$addr" == unix:* ]] || continue
+              IFS="," read -ra parts <<<"''${addr#unix:}"
+              for part in "''${parts[@]}"; do
+                printf -v part '%s' "''${part//\\/\\\\}"
+                printf -v part '%b' "''${part//%/\\x}"
+                [[ "$part" == path=/tmp/* ]] || continue
+                x11_args+=(--ro-bind-try "''${part#path=}" "''${part#path=}")
+              done
+            done
+          ''}
+
+          cmd=(
+            ${bubblewrap}/bin/bwrap
+            --dev-bind /dev /dev
+            --proc /proc
+            ${optionalString chdirToPwd ''--chdir "$(pwd)"''}
+            ${optionalString unshareUser "--unshare-user"}
+            ${optionalString unshareIpc "--unshare-ipc"}
+            ${optionalString unsharePid "--unshare-pid"}
+            ${optionalString unshareNet "--unshare-net"}
+            ${optionalString unshareUts "--unshare-uts"}
+            ${optionalString unshareCgroup "--unshare-cgroup"}
+            ${optionalString dieWithParent "--die-with-parent"}
+            --bind /nix /nix
+            ${optionalString privateTmp "--tmpfs /tmp"}
+            # Our glibc will look for the cache in its own path in `/nix/store`.
+            # As such, we need a cache to exist there, because pressure-vessel
+            # depends on the existence of an ld cache. However, adding one
+            # globally proved to be a bad idea (see #100655), the solution we
+            # settled on being mounting one via bwrap.
+            # Also, the cache needs to go to both 32 and 64 bit glibcs, for games
+            # of both architectures to work.
+            --tmpfs ${glibc}/etc \
+            --tmpfs /etc \
+            --symlink /etc/ld.so.conf ${glibc}/etc/ld.so.conf \
+            --symlink /etc/ld.so.cache ${glibc}/etc/ld.so.cache \
+            --ro-bind ${glibc}/etc/rpc ${glibc}/etc/rpc \
+            --remount-ro ${glibc}/etc \
+            --symlink ${realInit runScript} /init \
+        ''
+        + optionalString fhsenv.isMultiBuild (indentLines ''
+          --tmpfs ${pkgsi686Linux.glibc}/etc \
+          --symlink /etc/ld.so.conf ${pkgsi686Linux.glibc}/etc/ld.so.conf \
+          --symlink /etc/ld.so.cache ${pkgsi686Linux.glibc}/etc/ld.so.cache \
+          --ro-bind ${pkgsi686Linux.glibc}/etc/rpc ${pkgsi686Linux.glibc}/etc/rpc \
+          --remount-ro ${pkgsi686Linux.glibc}/etc \
+        '')
+        + ''
+            "''${ro_mounts[@]}"
+            "''${symlinks[@]}"
+            "''${auto_mounts[@]}"
+            "''${x11_args[@]}"
+            ${concatStringsSep "\n  " extraBwrapArgs}
+            ${containerInit} ${initArgs}
+          )
+          exec "''${cmd[@]}"
+        '';
+
+      bin = writeShellScript "${name}-bwrap" (bwrapCmd {
+        initArgs = ''"$@"'';
+      });
+    in
+    {
+      buildCommand = ''
+        mkdir -p $out/bin
+        ln -s ${bin} $out/bin/${executableName}
+
+        ${extraInstallCommands}
       '';
 
-  realInit =
-    run:
-    writeShellScript "${name}-init" ''
-      source /etc/profile
-      exec ${run} "$@"
-    '';
-
-  indentLines = str: concatLines (map (s: "  " + s) (filter (s: s != "") (splitString "\n" str)));
-  bwrapCmd =
-    {
-      initArgs ? "",
-    }:
-    ''
-      ignored=(/nix /dev /proc /etc ${optionalString privateTmp "/tmp"})
-      ro_mounts=()
-      symlinks=()
-      etc_ignored=()
-
-      ${extraPreBwrapCmds}
-
-      # loop through all entries of root in the fhs environment, except its /etc.
-      for i in ${fhsenv}/*; do
-        path="/''${i##*/}"
-        if [[ $path == '/etc' ]]; then
-          :
-        elif [[ -L $i ]]; then
-          symlinks+=(--symlink "$(${coreutils}/bin/readlink "$i")" "$path")
-          ignored+=("$path")
-        else
-          ro_mounts+=(--ro-bind "$i" "$path")
-          ignored+=("$path")
-        fi
-      done
-
-      # loop through the entries of /etc in the fhs environment.
-      if [[ -d ${fhsenv}/etc ]]; then
-        for i in ${fhsenv}/etc/*; do
-          path="/''${i##*/}"
-          # NOTE: we're binding /etc/fonts and /etc/ssl/certs from the host so we
-          # don't want to override it with a path from the FHS environment.
-          if [[ $path == '/fonts' || $path == '/ssl' ]]; then
-            continue
-          fi
-          if [[ -L $i ]]; then
-            symlinks+=(--symlink "$i" "/etc$path")
-          else
-            ro_mounts+=(--ro-bind "$i" "/etc$path")
-          fi
-          etc_ignored+=("/etc$path")
-        done
-      fi
-
-      # propagate /etc from the actual host if nested
-      if [[ -e /.host-etc ]]; then
-        ro_mounts+=(--ro-bind /.host-etc /.host-etc)
-      else
-        ro_mounts+=(--ro-bind /etc /.host-etc)
-      fi
-
-      # link selected etc entries from the actual root
-      for i in ${escapeShellArgs etcBindEntries}; do
-        if [[ "''${etc_ignored[@]}" =~ "$i" ]]; then
-          continue
-        fi
-        if [[ -e $i ]]; then
-          symlinks+=(--symlink "/.host-etc/''${i#/etc/}" "$i")
-        fi
-      done
-
-      declare -a auto_mounts
-      # loop through all directories in the root
-      for dir in /*; do
-        # if it is a directory and it is not ignored
-        if [[ -d "$dir" ]] && [[ ! "''${ignored[@]}" =~ "$dir" ]]; then
-          # add it to the mount list
-          auto_mounts+=(--bind "$dir" "$dir")
-        fi
-      done
-
-      declare -a x11_args
-      # Always mount a tmpfs on /tmp/.X11-unix
-      # Rationale: https://github.com/flatpak/flatpak/blob/be2de97e862e5ca223da40a895e54e7bf24dbfb9/common/flatpak-run.c#L277
-      x11_args+=(--tmpfs /tmp/.X11-unix)
-
-      # Try to guess X socket path. This doesn't cover _everything_, but it covers some things.
-      if [[ "$DISPLAY" == *:* ]]; then
-        # recover display number from $DISPLAY formatted [host]:num[.screen]
-        display_nr=''${DISPLAY/#*:} # strip host
-        display_nr=''${display_nr/%.*} # strip screen
-        local_socket=/tmp/.X11-unix/X$display_nr
-        x11_args+=(--ro-bind-try "$local_socket" "$local_socket")
-      fi
-
-      ${optionalString privateTmp ''
-        # sddm places XAUTHORITY in /tmp
-        if [[ "$XAUTHORITY" == /tmp/* ]]; then
-          x11_args+=(--ro-bind-try "$XAUTHORITY" "$XAUTHORITY")
-        fi
-
-        # dbus-run-session puts the socket in /tmp
-        IFS=";" read -ra addrs <<<"$DBUS_SESSION_BUS_ADDRESS"
-        for addr in "''${addrs[@]}"; do
-          [[ "$addr" == unix:* ]] || continue
-          IFS="," read -ra parts <<<"''${addr#unix:}"
-          for part in "''${parts[@]}"; do
-            printf -v part '%s' "''${part//\\/\\\\}"
-            printf -v part '%b' "''${part//%/\\x}"
-            [[ "$part" == path=/tmp/* ]] || continue
-            x11_args+=(--ro-bind-try "''${part#path=}" "''${part#path=}")
-          done
-        done
-      ''}
-
-      cmd=(
-        ${bubblewrap}/bin/bwrap
-        --dev-bind /dev /dev
-        --proc /proc
-        ${optionalString chdirToPwd ''--chdir "$(pwd)"''}
-        ${optionalString unshareUser "--unshare-user"}
-        ${optionalString unshareIpc "--unshare-ipc"}
-        ${optionalString unsharePid "--unshare-pid"}
-        ${optionalString unshareNet "--unshare-net"}
-        ${optionalString unshareUts "--unshare-uts"}
-        ${optionalString unshareCgroup "--unshare-cgroup"}
-        ${optionalString dieWithParent "--die-with-parent"}
-        --bind /nix /nix
-        ${optionalString privateTmp "--tmpfs /tmp"}
-        # Our glibc will look for the cache in its own path in `/nix/store`.
-        # As such, we need a cache to exist there, because pressure-vessel
-        # depends on the existence of an ld cache. However, adding one
-        # globally proved to be a bad idea (see #100655), the solution we
-        # settled on being mounting one via bwrap.
-        # Also, the cache needs to go to both 32 and 64 bit glibcs, for games
-        # of both architectures to work.
-        --tmpfs ${glibc}/etc \
-        --tmpfs /etc \
-        --symlink /etc/ld.so.conf ${glibc}/etc/ld.so.conf \
-        --symlink /etc/ld.so.cache ${glibc}/etc/ld.so.cache \
-        --ro-bind ${glibc}/etc/rpc ${glibc}/etc/rpc \
-        --remount-ro ${glibc}/etc \
-        --symlink ${realInit runScript} /init \
-    ''
-    + optionalString fhsenv.isMultiBuild (indentLines ''
-      --tmpfs ${pkgsi686Linux.glibc}/etc \
-      --symlink /etc/ld.so.conf ${pkgsi686Linux.glibc}/etc/ld.so.conf \
-      --symlink /etc/ld.so.cache ${pkgsi686Linux.glibc}/etc/ld.so.cache \
-      --ro-bind ${pkgsi686Linux.glibc}/etc/rpc ${pkgsi686Linux.glibc}/etc/rpc \
-      --remount-ro ${pkgsi686Linux.glibc}/etc \
-    '')
-    + ''
-        "''${ro_mounts[@]}"
-        "''${symlinks[@]}"
-        "''${auto_mounts[@]}"
-        "''${x11_args[@]}"
-        ${concatStringsSep "\n  " extraBwrapArgs}
-        ${containerInit} ${initArgs}
-      )
-      exec "''${cmd[@]}"
-    '';
-
-  bin = writeShellScript "${name}-bwrap" (bwrapCmd {
-    initArgs = ''"$@"'';
-  });
-in
-runCommandLocal name
-  (
-    nameAttrs
-    // {
-      inherit nativeBuildInputs;
+      passAsFile = [ "buildCommand" ];
+      enableParallelBuilding = true;
+      preferLocalBuild = true;
+      allowSubstitutes = false;
 
       passthru = passthru // {
         env =
@@ -352,11 +355,5 @@ runCommandLocal name
         mainProgram = executableName;
       }
       // meta;
-    }
-  )
-  ''
-    mkdir -p $out/bin
-    ln -s ${bin} $out/bin/${executableName}
-
-    ${extraInstallCommands}
-  ''
+    };
+}

--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  stdenvNoCC,
   callPackage,
   runCommandLocal,
   writeShellScript,
@@ -11,30 +12,6 @@
   bubblewrap,
 }:
 
-{
-  pname ? throw "You must provide either `name` or `pname`",
-  version ? throw "You must provide either `name` or `version`",
-  name ? "${pname}-${version}",
-  runScript ? "bash",
-  nativeBuildInputs ? [ ],
-  extraInstallCommands ? "",
-  executableName ? args.pname or name,
-  meta ? { },
-  passthru ? { },
-  extraPreBwrapCmds ? "",
-  extraBwrapArgs ? [ ],
-  unshareUser ? false,
-  unshareIpc ? false,
-  unsharePid ? false,
-  unshareNet ? false,
-  unshareUts ? false,
-  unshareCgroup ? false,
-  privateTmp ? false,
-  chdirToPwd ? true,
-  dieWithParent ? true,
-  ...
-}@args:
-
 # NOTE:
 # `pname` and `version` will throw if they were not provided.
 # Use `name` instead of directly evaluating `pname` or `version`.
@@ -42,339 +19,358 @@
 # If you need `pname` or `version` specifically, use `args` instead:
 # e.g. `args.pname or ...`.
 
-let
-  inherit (lib)
-    concatLines
-    concatStringsSep
-    escapeShellArgs
-    filter
-    optionalString
-    splitString
-    ;
-
-  inherit (lib.attrsets) removeAttrs;
-
-  # The splicing code does not handle `pkgsi686Linux` well, so we have to be
-  # explicit about which package set it's coming from.
-  inherit (pkgsHostTarget) pkgsi686Linux;
-
-  # we don't know which have been supplied, and want to avoid defaulting missing attrs to null. Passed into runCommandLocal
-  nameAttrs = lib.filterAttrs (
-    key: value:
-    builtins.elem key [
-      "name"
-      "pname"
-      "version"
-    ]
-  ) args;
-
-  buildFHSEnv = callPackage ./buildFHSEnv.nix { };
-
-  fhsenv = buildFHSEnv (
-    removeAttrs args [
+lib.makeOverridable (
+  lib.extendMkDerivation {
+    constructDrv = stdenvNoCC.mkDerivation;
+    excludeDrvArgNames = [
+      "multiPkgs"
+      "targetPkgs"
       "runScript"
-      "extraInstallCommands"
-      "meta"
-      "passthru"
-      "extraPreBwrapCmds"
-      "extraBwrapArgs"
-      "dieWithParent"
-      "unshareUser"
-      "unshareCgroup"
-      "unshareUts"
-      "unshareNet"
-      "unsharePid"
-      "unshareIpc"
-      "privateTmp"
-    ]
-  );
-
-  etcBindEntries =
-    let
-      files = [
-        # NixOS Compatibility
-        "static"
-        "nix" # mainly for nixVersions.git users, but also for access to nix/netrc
-        # Shells
-        "shells"
-        "bashrc"
-        "zshenv"
-        "zshrc"
-        "zinputrc"
-        "zprofile"
-        # Users, Groups, NSS
-        "passwd"
-        "group"
-        "shadow"
-        "hosts"
-        "resolv.conf"
-        "nsswitch.conf"
-        # User profiles
-        "profiles"
-        # Sudo & Su
-        "login.defs"
-        "sudoers"
-        "sudoers.d"
-        # Time
-        "localtime"
-        "zoneinfo"
-        # Other Core Stuff
-        "machine-id"
-        "os-release"
-        # PAM
-        "pam.d"
-        # Fonts
-        "fonts"
-        # ALSA
-        "alsa"
-        "asound.conf"
-        # SSL
-        "ssl/certs"
-        "ca-certificates"
-        "pki"
-        # Custom dconf profiles
-        "dconf"
-      ];
-    in
-    map (path: "/etc/${path}") files;
-
-  # Here's the problem case:
-  # - we need to run bash to run the init script
-  # - LD_PRELOAD may be set to another dynamic library, requiring us to discover its dependencies
-  # - oops! ldconfig is part of the init script, and it hasn't run yet
-  # - everything explodes
-  #
-  # In particular, this happens with fhsenvs in fhsenvs, e.g. when running
-  # a wrapped game from Steam.
-  #
-  # So, instead of doing that, we build a tiny static (important!) shim
-  # that executes ldconfig in a completely clean environment to generate
-  # the initial cache, and then execs into the "real" init, which is the
-  # first time we see anything dynamically linked at all.
-  #
-  # Also, the real init is placed strategically at /init, so we don't
-  # have to recompile this every time.
-  containerInit =
-    runCommandCC "container-init"
+    ];
+    extendDrvArgs =
+      finalAttrs:
       {
-        buildInputs = [ stdenv.cc.libc.static or null ];
-      }
-      ''
-        $CXX -static -s -o $out ${./container-init.cc}
-      '';
+        pname ? throw "You must provide either `name` or `pname`",
+        version ? throw "You must provide either `name` or `version`",
+        name ? "${pname}-${version}",
+        runScript ? "bash",
+        executableName ? args.pname or name,
+        meta ? { },
+        passthru ? { },
+        unshareUser ? false,
+        unshareIpc ? false,
+        unsharePid ? false,
+        unshareNet ? false,
+        unshareUts ? false,
+        unshareCgroup ? false,
+        privateTmp ? false,
+        chdirToPwd ? true,
+        dieWithParent ? true,
+        ...
+      }@args:
+      let
+        inherit (lib)
+          concatLines
+          concatStringsSep
+          escapeShellArgs
+          filter
+          optionalString
+          splitString
+          removeAttrs
+          ;
 
-  realInit =
-    run:
-    writeShellScript "${name}-init" ''
-      source /etc/profile
-      exec ${run} "$@"
-    '';
+        # The splicing code does not handle `pkgsi686Linux` well, so we have to be
+        # explicit about which package set it's coming from.
+        inherit (pkgsHostTarget) pkgsi686Linux;
 
-  indentLines = str: concatLines (map (s: "  " + s) (filter (s: s != "") (splitString "\n" str)));
-  bwrapCmd =
-    {
-      initArgs ? "",
-    }:
-    ''
-      ignored=(/nix /dev /proc /etc ${optionalString privateTmp "/tmp"})
-      ro_mounts=()
-      symlinks=()
-      etc_ignored=()
+        buildFHSEnv = callPackage ./buildFHSEnv.nix { };
 
-      ${extraPreBwrapCmds}
+        fhsenv = buildFHSEnv (
+          removeAttrs args [
+            "runScript"
+            "extraInstallCommands"
+            "meta"
+            "passthru"
+            "extraPreBwrapCmds"
+            "extraBwrapArgs"
+            "dieWithParent"
+            "unshareUser"
+            "unshareCgroup"
+            "unshareUts"
+            "unshareNet"
+            "unsharePid"
+            "unshareIpc"
+            "privateTmp"
+          ]
+        );
 
-      # loop through all entries of root in the fhs environment, except its /etc.
-      for i in ${fhsenv}/*; do
-        path="/''${i##*/}"
-        if [[ $path == '/etc' ]]; then
-          :
-        elif [[ -L $i ]]; then
-          symlinks+=(--symlink "$(${coreutils}/bin/readlink "$i")" "$path")
-          ignored+=("$path")
-        else
-          ro_mounts+=(--ro-bind "$i" "$path")
-          ignored+=("$path")
-        fi
-      done
+        etcBindEntries =
+          let
+            files = [
+              # NixOS Compatibility
+              "static"
+              "nix" # mainly for nixVersions.git users, but also for access to nix/netrc
+              # Shells
+              "shells"
+              "bashrc"
+              "zshenv"
+              "zshrc"
+              "zinputrc"
+              "zprofile"
+              # Users, Groups, NSS
+              "passwd"
+              "group"
+              "shadow"
+              "hosts"
+              "resolv.conf"
+              "nsswitch.conf"
+              # User profiles
+              "profiles"
+              # Sudo & Su
+              "login.defs"
+              "sudoers"
+              "sudoers.d"
+              # Time
+              "localtime"
+              "zoneinfo"
+              # Other Core Stuff
+              "machine-id"
+              "os-release"
+              # PAM
+              "pam.d"
+              # Fonts
+              "fonts"
+              # ALSA
+              "alsa"
+              "asound.conf"
+              # SSL
+              "ssl/certs"
+              "ca-certificates"
+              "pki"
+              # Custom dconf profiles
+              "dconf"
+            ];
+          in
+          map (path: "/etc/${path}") files;
 
-      # loop through the entries of /etc in the fhs environment.
-      if [[ -d ${fhsenv}/etc ]]; then
-        for i in ${fhsenv}/etc/*; do
-          path="/''${i##*/}"
-          # NOTE: we're binding /etc/fonts and /etc/ssl/certs from the host so we
-          # don't want to override it with a path from the FHS environment.
-          if [[ $path == '/fonts' || $path == '/ssl' ]]; then
-            continue
-          fi
-          if [[ -L $i ]]; then
-            symlinks+=(--symlink "$i" "/etc$path")
-          else
-            ro_mounts+=(--ro-bind "$i" "/etc$path")
-          fi
-          etc_ignored+=("/etc$path")
-        done
-      fi
-
-      # propagate /etc from the actual host if nested
-      if [[ -e /.host-etc ]]; then
-        ro_mounts+=(--ro-bind /.host-etc /.host-etc)
-      else
-        ro_mounts+=(--ro-bind /etc /.host-etc)
-      fi
-
-      declare -A etc_ignored_set
-      for ign in "''${etc_ignored[@]}"; do
-        etc_ignored_set[$ign]=1
-      done
-
-      # link selected etc entries from the actual root
-      for i in ${escapeShellArgs etcBindEntries}; do
-        if [[ -n "''${etc_ignored_set[$i]:-}" ]]; then
-          continue
-        fi
-        if [[ -e $i ]]; then
-          symlinks+=(--symlink "/.host-etc/''${i#/etc/}" "$i")
-        fi
-      done
-
-      declare -A ignored_set
-      for ign in "''${ignored[@]}"; do
-        ignored_set[$ign]=1
-      done
-
-      declare -a auto_mounts
-      # loop through all directories in the root
-      for dir in /*; do
-        # if it is a directory and not already provided by the FHS env or
-        # explicitly ignored, bind-mount it into the chroot. Use exact match
-        # via associative array because regex substring matching incorrectly
-        # skips prefixes (e.g. /sb would match /sbin and never get mounted,
-        # breaking --chdir when CWD is on a custom mount like /sb/project).
-        # https://github.com/NixOS/nixpkgs/issues/241151
-        if [[ -d "$dir" ]] && [[ -z "''${ignored_set[$dir]:-}" ]]; then
-          # add it to the mount list
-          auto_mounts+=(--bind "$dir" "$dir")
-        fi
-      done
-
-      declare -a x11_args
-      # Always mount a tmpfs on /tmp/.X11-unix
-      # Rationale: https://github.com/flatpak/flatpak/blob/be2de97e862e5ca223da40a895e54e7bf24dbfb9/common/flatpak-run.c#L277
-      x11_args+=(--tmpfs /tmp/.X11-unix)
-
-      # Try to guess X socket path. This doesn't cover _everything_, but it covers some things.
-      if [[ "$DISPLAY" == *:* ]]; then
-        # recover display number from $DISPLAY formatted [host]:num[.screen]
-        display_nr=''${DISPLAY/#*:} # strip host
-        display_nr=''${display_nr/%.*} # strip screen
-        local_socket=/tmp/.X11-unix/X$display_nr
-        x11_args+=(--ro-bind-try "$local_socket" "$local_socket")
-      fi
-
-      ${optionalString privateTmp ''
-        # sddm places XAUTHORITY in /tmp
-        if [[ "$XAUTHORITY" == /tmp/* ]]; then
-          x11_args+=(--ro-bind-try "$XAUTHORITY" "$XAUTHORITY")
-        fi
-
-        # dbus-run-session puts the socket in /tmp
-        IFS=";" read -ra addrs <<<"$DBUS_SESSION_BUS_ADDRESS"
-        for addr in "''${addrs[@]}"; do
-          [[ "$addr" == unix:* ]] || continue
-          IFS="," read -ra parts <<<"''${addr#unix:}"
-          for part in "''${parts[@]}"; do
-            printf -v part '%s' "''${part//\\/\\\\}"
-            printf -v part '%b' "''${part//%/\\x}"
-            [[ "$part" == path=/tmp/* ]] || continue
-            x11_args+=(--ro-bind-try "''${part#path=}" "''${part#path=}")
-          done
-        done
-      ''}
-
-      cmd=(
-        ${bubblewrap}/bin/bwrap
-        --dev-bind /dev /dev
-        --proc /proc
-        ${optionalString chdirToPwd ''--chdir "$(pwd)"''}
-        ${optionalString unshareUser "--unshare-user"}
-        ${optionalString unshareIpc "--unshare-ipc"}
-        ${optionalString unsharePid "--unshare-pid"}
-        ${optionalString unshareNet "--unshare-net"}
-        ${optionalString unshareUts "--unshare-uts"}
-        ${optionalString unshareCgroup "--unshare-cgroup"}
-        ${optionalString dieWithParent "--die-with-parent"}
-        --bind /nix /nix
-        ${optionalString privateTmp "--tmpfs /tmp"}
-        # Our glibc will look for the cache in its own path in `/nix/store`.
-        # As such, we need a cache to exist there, because pressure-vessel
-        # depends on the existence of an ld cache. However, adding one
-        # globally proved to be a bad idea (see #100655), the solution we
-        # settled on being mounting one via bwrap.
-        # Also, the cache needs to go to both 32 and 64 bit glibcs, for games
-        # of both architectures to work.
-        --tmpfs ${glibc}/etc \
-        --tmpfs /etc \
-        --symlink /etc/ld.so.conf ${glibc}/etc/ld.so.conf \
-        --symlink /etc/ld.so.cache ${glibc}/etc/ld.so.cache \
-        --ro-bind ${glibc}/etc/rpc ${glibc}/etc/rpc \
-        --remount-ro ${glibc}/etc \
-        --symlink ${realInit runScript} /init \
-    ''
-    + optionalString fhsenv.isMultiBuild (indentLines ''
-      --tmpfs ${pkgsi686Linux.glibc}/etc \
-      --symlink /etc/ld.so.conf ${pkgsi686Linux.glibc}/etc/ld.so.conf \
-      --symlink /etc/ld.so.cache ${pkgsi686Linux.glibc}/etc/ld.so.cache \
-      --ro-bind ${pkgsi686Linux.glibc}/etc/rpc ${pkgsi686Linux.glibc}/etc/rpc \
-      --remount-ro ${pkgsi686Linux.glibc}/etc \
-    '')
-    + ''
-        "''${ro_mounts[@]}"
-        "''${symlinks[@]}"
-        "''${auto_mounts[@]}"
-        "''${x11_args[@]}"
-        ${concatStringsSep "\n  " extraBwrapArgs}
-        ${containerInit} ${initArgs}
-      )
-      exec "''${cmd[@]}"
-    '';
-
-  bin = writeShellScript "${name}-bwrap" (bwrapCmd {
-    initArgs = ''"$@"'';
-  });
-in
-runCommandLocal name
-  (
-    nameAttrs
-    // {
-      inherit nativeBuildInputs;
-
-      __structuredAttrs = true;
-      strictDeps = true;
-
-      passthru = passthru // {
-        env =
-          runCommandLocal "${name}-shell-env"
+        # Here's the problem case:
+        # - we need to run bash to run the init script
+        # - LD_PRELOAD may be set to another dynamic library, requiring us to discover its dependencies
+        # - oops! ldconfig is part of the init script, and it hasn't run yet
+        # - everything explodes
+        #
+        # In particular, this happens with fhsenvs in fhsenvs, e.g. when running
+        # a wrapped game from Steam.
+        #
+        # So, instead of doing that, we build a tiny static (important!) shim
+        # that executes ldconfig in a completely clean environment to generate
+        # the initial cache, and then execs into the "real" init, which is the
+        # first time we see anything dynamically linked at all.
+        #
+        # Also, the real init is placed strategically at /init, so we don't
+        # have to recompile this every time.
+        containerInit =
+          runCommandCC "container-init"
             {
-              shellHook = bwrapCmd { };
+              buildInputs = [ stdenv.cc.libc.static or null ];
             }
             ''
-              echo >&2 ""
-              echo >&2 "*** User chroot 'env' attributes are intended for interactive nix-shell sessions, not for building! ***"
-              echo >&2 ""
-              exit 1
+              $CXX -static -s -o $out ${./container-init.cc}
             '';
-        inherit args fhsenv;
+
+        realInit =
+          run:
+          writeShellScript "${name}-init" ''
+            source /etc/profile
+            exec ${run} "$@"
+          '';
+
+        indentLines = str: concatLines (map (s: "  " + s) (filter (s: s != "") (splitString "\n" str)));
+        bwrapCmd =
+          {
+            initArgs ? "",
+          }:
+          ''
+            ignored=(/nix /dev /proc /etc ${optionalString privateTmp "/tmp"})
+            ro_mounts=()
+            symlinks=()
+            etc_ignored=()
+
+            ${finalAttrs.extraPreBwrapCmds or ""}
+
+            # loop through all entries of root in the fhs environment, except its /etc.
+            for i in ${fhsenv}/*; do
+              path="/''${i##*/}"
+              if [[ $path == '/etc' ]]; then
+                :
+              elif [[ -L $i ]]; then
+                symlinks+=(--symlink "$(${coreutils}/bin/readlink "$i")" "$path")
+                ignored+=("$path")
+              else
+                ro_mounts+=(--ro-bind "$i" "$path")
+                ignored+=("$path")
+              fi
+            done
+
+            # loop through the entries of /etc in the fhs environment.
+            if [[ -d ${fhsenv}/etc ]]; then
+              for i in ${fhsenv}/etc/*; do
+                path="/''${i##*/}"
+                # NOTE: we're binding /etc/fonts and /etc/ssl/certs from the host so we
+                # don't want to override it with a path from the FHS environment.
+                if [[ $path == '/fonts' || $path == '/ssl' ]]; then
+                  continue
+                fi
+                if [[ -L $i ]]; then
+                  symlinks+=(--symlink "$i" "/etc$path")
+                else
+                  ro_mounts+=(--ro-bind "$i" "/etc$path")
+                fi
+                etc_ignored+=("/etc$path")
+              done
+            fi
+
+            # propagate /etc from the actual host if nested
+            if [[ -e /.host-etc ]]; then
+              ro_mounts+=(--ro-bind /.host-etc /.host-etc)
+            else
+              ro_mounts+=(--ro-bind /etc /.host-etc)
+            fi
+
+            declare -A etc_ignored_set
+            for ign in "''${etc_ignored[@]}"; do
+              etc_ignored_set[$ign]=1
+            done
+
+            # link selected etc entries from the actual root
+            for i in ${escapeShellArgs etcBindEntries}; do
+              if [[ -n "''${etc_ignored_set[$i]:-}" ]]; then
+                continue
+              fi
+              if [[ -e $i ]]; then
+                symlinks+=(--symlink "/.host-etc/''${i#/etc/}" "$i")
+              fi
+            done
+
+            declare -A ignored_set
+            for ign in "''${ignored[@]}"; do
+              ignored_set[$ign]=1
+            done
+
+            declare -a auto_mounts
+            # loop through all directories in the root
+            for dir in /*; do
+              # if it is a directory and not already provided by the FHS env or
+              # explicitly ignored, bind-mount it into the chroot. Use exact match
+              # via associative array because regex substring matching incorrectly
+              # skips prefixes (e.g. /sb would match /sbin and never get mounted,
+              # breaking --chdir when CWD is on a custom mount like /sb/project).
+              # https://github.com/NixOS/nixpkgs/issues/241151
+              if [[ -d "$dir" ]] && [[ -z "''${ignored_set[$dir]:-}" ]]; then
+                # add it to the mount list
+                auto_mounts+=(--bind "$dir" "$dir")
+              fi
+            done
+
+            declare -a x11_args
+            # Always mount a tmpfs on /tmp/.X11-unix
+            # Rationale: https://github.com/flatpak/flatpak/blob/be2de97e862e5ca223da40a895e54e7bf24dbfb9/common/flatpak-run.c#L277
+            x11_args+=(--tmpfs /tmp/.X11-unix)
+
+            # Try to guess X socket path. This doesn't cover _everything_, but it covers some things.
+            if [[ "$DISPLAY" == *:* ]]; then
+              # recover display number from $DISPLAY formatted [host]:num[.screen]
+              display_nr=''${DISPLAY/#*:} # strip host
+              display_nr=''${display_nr/%.*} # strip screen
+              local_socket=/tmp/.X11-unix/X$display_nr
+              x11_args+=(--ro-bind-try "$local_socket" "$local_socket")
+            fi
+
+            ${optionalString privateTmp ''
+              # sddm places XAUTHORITY in /tmp
+              if [[ "$XAUTHORITY" == /tmp/* ]]; then
+                x11_args+=(--ro-bind-try "$XAUTHORITY" "$XAUTHORITY")
+              fi
+
+              # dbus-run-session puts the socket in /tmp
+              IFS=";" read -ra addrs <<<"$DBUS_SESSION_BUS_ADDRESS"
+              for addr in "''${addrs[@]}"; do
+                [[ "$addr" == unix:* ]] || continue
+                IFS="," read -ra parts <<<"''${addr#unix:}"
+                for part in "''${parts[@]}"; do
+                  printf -v part '%s' "''${part//\\/\\\\}"
+                  printf -v part '%b' "''${part//%/\\x}"
+                  [[ "$part" == path=/tmp/* ]] || continue
+                  x11_args+=(--ro-bind-try "''${part#path=}" "''${part#path=}")
+                done
+              done
+            ''}
+
+            cmd=(
+              ${bubblewrap}/bin/bwrap
+              --dev-bind /dev /dev
+              --proc /proc
+              ${optionalString chdirToPwd ''--chdir "$(pwd)"''}
+              ${optionalString unshareUser "--unshare-user"}
+              ${optionalString unshareIpc "--unshare-ipc"}
+              ${optionalString unsharePid "--unshare-pid"}
+              ${optionalString unshareNet "--unshare-net"}
+              ${optionalString unshareUts "--unshare-uts"}
+              ${optionalString unshareCgroup "--unshare-cgroup"}
+              ${optionalString dieWithParent "--die-with-parent"}
+              --bind /nix /nix
+              ${optionalString privateTmp "--tmpfs /tmp"}
+              # Our glibc will look for the cache in its own path in `/nix/store`.
+              # As such, we need a cache to exist there, because pressure-vessel
+              # depends on the existence of an ld cache. However, adding one
+              # globally proved to be a bad idea (see #100655), the solution we
+              # settled on being mounting one via bwrap.
+              # Also, the cache needs to go to both 32 and 64 bit glibcs, for games
+              # of both architectures to work.
+              --tmpfs ${glibc}/etc \
+              --tmpfs /etc \
+              --symlink /etc/ld.so.conf ${glibc}/etc/ld.so.conf \
+              --symlink /etc/ld.so.cache ${glibc}/etc/ld.so.cache \
+              --ro-bind ${glibc}/etc/rpc ${glibc}/etc/rpc \
+              --remount-ro ${glibc}/etc \
+              --symlink ${realInit runScript} /init \
+          ''
+          + optionalString fhsenv.isMultiBuild (indentLines ''
+            --tmpfs ${pkgsi686Linux.glibc}/etc \
+            --symlink /etc/ld.so.conf ${pkgsi686Linux.glibc}/etc/ld.so.conf \
+            --symlink /etc/ld.so.cache ${pkgsi686Linux.glibc}/etc/ld.so.cache \
+            --ro-bind ${pkgsi686Linux.glibc}/etc/rpc ${pkgsi686Linux.glibc}/etc/rpc \
+            --remount-ro ${pkgsi686Linux.glibc}/etc \
+          '')
+          + ''
+              "''${ro_mounts[@]}"
+              "''${symlinks[@]}"
+              "''${auto_mounts[@]}"
+              "''${x11_args[@]}"
+              ${concatStringsSep "\n  " (finalAttrs.extraBwrapArgs or [ ])}
+              ${containerInit} ${initArgs}
+            )
+            exec "''${cmd[@]}"
+          '';
+
+        bin = writeShellScript "${name}-bwrap" (bwrapCmd {
+          initArgs = ''"$@"'';
+        });
+      in
+      {
+        buildCommand = ''
+          mkdir -p $out/bin
+          ln -s ${bin} $out/bin/${executableName}
+
+          ${finalAttrs.extraInstallCommands or ""}
+        '';
+
+        __structuredAttrs = true;
+        strictDeps = true;
+
+        enableParallelBuilding = true;
+        preferLocalBuild = true;
+        allowSubstitutes = false;
+
+        passthru = passthru // {
+          env =
+            runCommandLocal "${name}-shell-env"
+              {
+                shellHook = bwrapCmd { };
+              }
+              ''
+                echo >&2 ""
+                echo >&2 "*** User chroot 'env' attributes are intended for interactive nix-shell sessions, not for building! ***"
+                echo >&2 ""
+                exit 1
+              '';
+          inherit args fhsenv;
+        };
+
+        meta = {
+          mainProgram = executableName;
+        }
+        // meta;
       };
-
-      meta = {
-        mainProgram = executableName;
-      }
-      // meta;
-    }
-  )
-  ''
-    mkdir -p $out/bin
-    ln -s ${bin} $out/bin/${executableName}
-
-    ${extraInstallCommands}
-  ''
+  }
+)

--- a/pkgs/by-name/pi/pixinsight/package.nix
+++ b/pkgs/by-name/pi/pixinsight/package.nix
@@ -161,13 +161,5 @@ buildFHSEnv {
     unwrapped = pixinsight;
   };
 
-  inherit (pixinsight.meta)
-    description
-    homepage
-    license
-    maintainers
-    platforms
-    sourceProvenance
-    hydraPlatforms
-    ;
+  inherit (pixinsight) meta;
 }

--- a/pkgs/by-name/pi/pixinsight/package.nix
+++ b/pkgs/by-name/pi/pixinsight/package.nix
@@ -163,13 +163,15 @@ buildFHSEnv {
     unwrapped = pixinsight;
   };
 
-  inherit (pixinsight.meta)
-    description
-    homepage
-    license
-    maintainers
-    platforms
-    sourceProvenance
-    hydraPlatforms
-    ;
+  meta = {
+    inherit (pixinsight.meta)
+      description
+      homepage
+      license
+      maintainers
+      platforms
+      sourceProvenance
+      hydraPlatforms
+      ;
+  };
 }

--- a/pkgs/by-name/si/simplenote/package.nix
+++ b/pkgs/by-name/si/simplenote/package.nix
@@ -38,6 +38,7 @@ appimageTools.wrapType2 {
   desktopItems = [
     (makeDesktopItem {
       name = pname;
+      desktopName = "Simplenote";
       exec = pname;
       icon = "simplenote";
       genericName = "Note Taking Application";


### PR DESCRIPTION
Feedback welcome. This is an attempt at making both buildFHSEnv and appimageTools.{wrapAppImage,wrapType2} support the finalAttrs pattern via lib.extendMkDerivation.

This is achieved by removing runCommand from buildFHSEnv and replace it with a "normal" mkDerivation that does the exact same thing (copied the implementation of runCommandWith), to be used in extendMkDerivation.

I have also made a somewhat breaking change to wrapAppImage: it now takes a `contents` argument instead of `src`, leaving src for the actual appimage file; overriding wouldn't work otherwise. (Potential TODO: emit a warning when contents is not specified? I don't think it would be a bad idea, I just don't really know how to do it)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (tested osu-lazer-bin)
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
