### PR TITLE
splint: Build with gnu99

### DIFF
--- a/pkgs/development/tools/analysis/splint/default.nix
+++ b/pkgs/development/tools/analysis/splint/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ flex ];
 
+  buildFlags = [
+    "CFLAGS=-std=gnu99"
+  ];
+
   doCheck = true;
 
   meta = {


### PR DESCRIPTION
Otherwise it fails to build with
```
mtgrammar.c:139:37: error: too many arguments to function 'yyprint'; expected 0, have 3
```
since gcc was updated to version 15.

See https://github.com/splintchecker/splint/issues/41 for the upstream issue.

I wasn't entirely sure what the best practice method of setting this is, so went with `buildFlags`. A quick search through nixpkgs seems to indicate that `NIX_CFLAGS_COMPILE` is most common but it may not be preferred? In any case let me know if there's a preferred way.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
