### PR TITLE
nixos/esphome: add environment options and fix permission denied error

### DIFF
--- a/nixos/modules/services/home-automation/esphome.nix
+++ b/nixos/modules/services/home-automation/esphome.nix
@@ -131,6 +131,8 @@ in
         RuntimeDirectory = mkIf cfg.enableUnixSocket "esphome";
         RuntimeDirectoryMode = "0750";
         EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+        ExecPaths = "%S/${stateDir}";
+        ReadWritePaths = "%S/${stateDir}";
 
         # Hardening
         CapabilityBoundingSet = "";

--- a/nixos/modules/services/home-automation/esphome.nix
+++ b/nixos/modules/services/home-automation/esphome.nix
@@ -17,7 +17,7 @@ let
 
   cfg = config.services.esphome;
 
-  stateDir = "/var/lib/esphome";
+  stateDir = "esphome";
 
   esphomeParams =
     if cfg.enableUnixSocket then
@@ -114,17 +114,17 @@ in
 
       environment = {
         # platformio fails to determine the home directory when using DynamicUser
-        PLATFORMIO_CORE_DIR = "${stateDir}/.platformio";
+        PLATFORMIO_CORE_DIR = "%S/${stateDir}/.platformio";
       }
       // lib.optionalAttrs cfg.usePing { ESPHOME_DASHBOARD_USE_PING = "true"; }
       // cfg.environment;
 
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/esphome dashboard ${esphomeParams} ${stateDir}";
+        ExecStart = "${cfg.package}/bin/esphome dashboard ${esphomeParams} %S/${stateDir}";
         DynamicUser = true;
         User = "esphome";
         Group = "esphome";
-        WorkingDirectory = stateDir;
+        WorkingDirectory = "%S/${stateDir}";
         StateDirectory = "esphome";
         StateDirectoryMode = "0750";
         Restart = "on-failure";

--- a/nixos/modules/services/home-automation/esphome.nix
+++ b/nixos/modules/services/home-automation/esphome.nix
@@ -79,6 +79,28 @@ in
       type = types.bool;
       description = "Use ping to check online status of devices instead of mDNS";
     };
+
+    environment = mkOption {
+      default = { };
+      type = types.attrsOf types.str;
+      description = ''
+        Extra environment variables to pass to ESPHome. Secrets should be passed
+        using the {option}`services.esphome.environmentFile` option.
+      '';
+      example = {
+        USERNAME = "reimu";
+        PASSWORD = "gensokyo9";
+      };
+    };
+
+    environmentFile = mkOption {
+      default = null;
+      type = types.nullOr types.path;
+      description = ''
+        Path to an environment file.
+        Use this option for setting the dashboard password.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -94,7 +116,8 @@ in
         # platformio fails to determine the home directory when using DynamicUser
         PLATFORMIO_CORE_DIR = "${stateDir}/.platformio";
       }
-      // lib.optionalAttrs cfg.usePing { ESPHOME_DASHBOARD_USE_PING = "true"; };
+      // lib.optionalAttrs cfg.usePing { ESPHOME_DASHBOARD_USE_PING = "true"; }
+      // cfg.environment;
 
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/esphome dashboard ${esphomeParams} ${stateDir}";
@@ -107,6 +130,7 @@ in
         Restart = "on-failure";
         RuntimeDirectory = mkIf cfg.enableUnixSocket "esphome";
         RuntimeDirectoryMode = "0750";
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
 
         # Hardening
         CapabilityBoundingSet = "";


### PR DESCRIPTION
These commits introduce two new options:
 - `services.esphome.environment`
 - `services.esphome.environmentFile`

These options can be used to set a password for the dashboard.

This change also fixes a permission denied error during firmware compilation by setting ExecPaths= and ReadWritePaths= to the state directory. (https://github.com/NixOS/nixpkgs/issues/339557#issuecomment-3619059612)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
