### PR TITLE
nextcloud: direct pre-signed download link

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -214,6 +214,7 @@ let
               'use_ssl' => ${lib.boolToString s3.useSsl},
               ${lib.optionalString (s3.region != null) "'region' => '${s3.region}',"}
               'use_path_style' => ${lib.boolToString s3.usePathStyle},
+              'use_presigned_url' => ${lib.boolToString s3.usePresignedUrl},
               ${lib.optionalString (s3.sseCKeyFile != null) "'sse_c_key' => nix_read_secret('s3_sse_c_key'),"}
             ],
           ]
@@ -765,6 +766,15 @@ in
               `http://hostname.domain/bucket` instead.
             '';
           };
+          usePresignedUrl = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              Allow bypassing nextcloud instance and serve files
+              directly from the S3 server. Such a download is protected
+              with a presigned download link.
+            '';
+          };
           sseCKeyFile = lib.mkOption {
             type = lib.types.nullOr lib.types.path;
             default = null;
@@ -1312,6 +1322,14 @@ in
             message = ''
               The option `services.nextcloud.settings.mail_smtppassword` must not be used, as it puts the password into the world-readable nix store.
               Use `services.nextcloud.secrets.mail_smtppassword` instead and set it to a file containing the password.
+            '';
+          }
+          {
+            assertion =
+              lib.versionAtLeast cfg.package.version "33.0.0"
+              || cfg.config.objectstore.s3.use_presigned_url == null;
+            message = ''
+              Presigned URLs are only available on Nextcloud >= 33.0.0.
             '';
           }
         ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR extends S3 configuration with a `use_presigned_url` introduced in Nextcloud 33 with https://github.com/nextcloud/server/pull/54436

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
