### PR TITLE
kdePackages.libplasma: Install generated headers

### DIFF
--- a/pkgs/kde/plasma/libplasma/default.nix
+++ b/pkgs/kde/plasma/libplasma/default.nix
@@ -11,6 +11,7 @@ mkKdeDerivation {
   patches = [
     # https://invent.kde.org/plasma/libplasma/-/merge_requests/1406
     ./rb-extracomponents.patch
+    ./install-wayland-headers.patch
   ];
 
   extraNativeBuildInputs = [ pkg-config ];

--- a/pkgs/kde/plasma/libplasma/install-wayland-headers.patch
+++ b/pkgs/kde/plasma/libplasma/install-wayland-headers.patch
@@ -1,0 +1,13 @@
+diff --git a/src/plasmaquick/CMakeLists.txt b/src/plasmaquick/CMakeLists.txt
+index 1f1ad3172..19bd8a713 100644
+--- a/src/plasmaquick/CMakeLists.txt
++++ b/src/plasmaquick/CMakeLists.txt
+@@ -157,6 +157,8 @@ ecm_generate_export_header(PlasmaQuick
+ 
+ set(plasmaquick_LIB_INCLUDES
+     ${CMAKE_CURRENT_BINARY_DIR}/plasmaquick_export.h
++    ${CMAKE_CURRENT_BINARY_DIR}/qwayland-plasma-shell.h
++    ${CMAKE_CURRENT_BINARY_DIR}/wayland-plasma-shell-client-protocol.h
+ )
+ 
+ ecm_generate_headers(PlasmaQuick_CamelCase_HEADERS


### PR DESCRIPTION
`plasmashellwaylandintegration.h` includes generated headers and thus, these generated headers "leak" into downstream dependencies e.g. plasma-workspace. To fix this, the headers are put into the dev output.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
