### PR TITLE
facter: Add missing gems

### DIFF
--- a/pkgs/by-name/fa/facter/Gemfile
+++ b/pkgs/by-name/fa/facter/Gemfile
@@ -5,3 +5,5 @@ source "https://rubygems.org"
 gem "facter"
 
 gem "base64", "~> 0.2.0"
+gem "benchmark", "~> 0.5.0"
+gem "logger", "~> 1.7.0"

--- a/pkgs/by-name/fa/facter/Gemfile.lock
+++ b/pkgs/by-name/fa/facter/Gemfile.lock
@@ -2,10 +2,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.2.0)
+    benchmark (0.5.0)
     facter (4.10.0)
       hocon (~> 1.3)
       thor (>= 1.0.1, < 1.3)
     hocon (1.4.0)
+    logger (1.7.0)
     thor (1.2.2)
 
 PLATFORMS
@@ -13,7 +15,9 @@ PLATFORMS
 
 DEPENDENCIES
   base64 (~> 0.2.0)
+  benchmark (~> 0.5.0)
   facter
+  logger (~> 1.7.0)
 
 BUNDLED WITH
-   2.6.6
+   2.7.2

--- a/pkgs/by-name/fa/facter/gemset.nix
+++ b/pkgs/by-name/fa/facter/gemset.nix
@@ -9,6 +9,16 @@
     };
     version = "0.2.0";
   };
+  benchmark = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0v1337j39w1z7x9zs4q7ag0nfv4vs4xlsjx2la0wpv8s6hig2pa6";
+      type = "gem";
+    };
+    version = "0.5.0";
+  };
   facter = {
     dependencies = [
       "hocon"
@@ -32,6 +42,16 @@
       type = "gem";
     };
     version = "1.4.0";
+  };
+  logger = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "00q2zznygpbls8asz5knjvvj2brr3ghmqxgr83xnrdj4rk3xwvhr";
+      type = "gem";
+    };
+    version = "1.7.0";
   };
   thor = {
     groups = [ "default" ];


### PR DESCRIPTION
This resolves the warnings about the gems `benchmark` and `logger` no longer being part of the default gems from Ruby 4.0.0.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
