### PR TITLE
clang-tools: Respect $CLANGD_FLAGS in wrapper

### DIFF
--- a/pkgs/development/compilers/llvm/common/clang-tools/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang-tools/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests.smokeOk =
+  passthru.tests =
     let
       src = writeText "main.cpp" ''
         #include <iostream>
@@ -61,28 +61,24 @@ stdenv.mkDerivation (finalAttrs: {
       '';
 
     in
-    runCommand "clang-tools-test-smoke-ok" { } ''
-      ${finalAttrs.finalPackage}/bin/clangd  --check=${src}
-      touch $out
-    '';
-
-  passthru.tests.smokeErr =
-    let
-      src = writeText "main.cpp" ''
-        #include <iostream>
-
-        int main() {
-           std::cout << "Hi!";
-        }
+    {
+      smokeOk = runCommand "clang-tools-test-smoke-ok" { } ''
+        ${finalAttrs.finalPackage}/bin/clangd  --check=${src}
+        touch $out
       '';
+      smokeErr = runCommand "clang-tools-test-smoke-err" { } ''
+        (${finalAttrs.finalPackage}/bin/clangd --query-driver='**' --check=${src} 2>&1 || true) \
+            | grep 'use of undeclared identifier'
 
-    in
-    runCommand "clang-tools-test-smoke-err" { } ''
-      (${finalAttrs.finalPackage}/bin/clangd --query-driver='**' --check=${src} 2>&1 || true) \
-          | grep 'use of undeclared identifier'
+        touch $out
+      '';
+      environmentErr = runCommand "clang-tools-test-environment-err" { } ''
+         (CLANGD_FLAGS="--query-driver='**'" ${finalAttrs.finalPackage}/bin/clangd --check=${src} 2>&1 || true) \
+            | grep 'use of undeclared identifier'
 
-      touch $out
-    '';
+        touch $out
+      '';
+    };
 
   meta = llvm_meta // {
     description = "Standalone command line tools for C++ development";

--- a/pkgs/development/compilers/llvm/common/clang-tools/wrapper
+++ b/pkgs/development/compilers/llvm/common/clang-tools/wrapper
@@ -40,7 +40,7 @@ buildcpluspath() {
 # don't want to infect user-specified toolchain and headers with our stuff.
 extendcpath=true
 
-for arg in "$@"; do
+for arg in "$@" $CLANGD_FLAGS; do
   if [[ "${arg}" == \-\-query\-driver* ]]; then
     extendcpath=false
   fi


### PR DESCRIPTION
`clangd` can take arguments also via environment variable CLANGD_FLAGS.
This has to be respected in the wrapper, which checks whether a `--query-driver` argument was provided.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
