### PR TITLE
beads: 0.42.0 -> 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11393,6 +11393,11 @@
     githubId = 39416660;
     name = "Mladen Branković";
   };
+  imcvampire = {
+    github = "imcvampire";
+    githubId = 9426721;
+    name = "Quoc-Anh Nguyen";
+  };
   imgabe = {
     email = "gabrielpmonte@hotmail.com";
     github = "ImGabe";

--- a/pkgs/by-name/be/beads/package.nix
+++ b/pkgs/by-name/be/beads/package.nix
@@ -2,25 +2,28 @@
   lib,
   stdenv,
   buildGoModule,
+  dolt,
   fetchFromGitHub,
   gitMinimal,
+  icu,
   installShellFiles,
+  makeBinaryWrapper,
   versionCheckHook,
   writableTmpDirAsHomeHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "beads";
-  version = "0.42.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "steveyegge";
+    owner = "gastownhall";
     repo = "beads";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3t+pm7vuFj3PH1oCJ/AnwbGupqleimNQnP2bRSBHrSg=";
+    hash = "sha256-D2jShGpkOWKx9aRmRvV5bmV8t0/Y2eAE8q0m54QrRN0=";
   };
 
-  vendorHash = "sha256-ovG0EWQFtifHF5leEQTFvTjGvc+yiAjpAaqaV0OklgE=";
+  vendorHash = "sha256-7DJgqJX2HDa9gcGD8fLNHLIXvGAEivYeDYx3snCUyCE=";
 
   subPackages = [ "cmd/bd" ];
 
@@ -29,23 +32,46 @@ buildGoModule (finalAttrs: {
     "-w"
   ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  buildInputs = [
+    icu
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeBinaryWrapper
+  ];
 
   nativeCheckInputs = [
     gitMinimal
     writableTmpDirAsHomeHook
   ];
 
-  # Skip security tests on Darwin - they check for /etc/passwd which isn't available in sandbox
-  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
-    "-skip=TestCleanupMergeArtifacts_CommandInjectionPrevention"
-  ];
+  # Workaround for: panic: httptest: failed to listen on a port: listen tcp6 [::1]:0: bind: operation not permitted
+  # ref: https://github.com/NixOS/nix/pull/1646
+  __darwinAllowLocalNetworking = true;
+
+  checkFlags =
+    let
+      skippedTests = [
+        # Upstream test bug: version gap 0.55.0->1.0.0 triggers "very old" warning instead of expected "ok"
+        "TestCheckMetadataVersionTracking"
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        # Checks for /etc/passwd which isn't available in sandbox
+        "TestCleanupMergeArtifacts_CommandInjectionPrevention"
+      ];
+    in
+    [ "-skip=^(${lib.concatStringsSep "|" skippedTests})$" ];
 
   preCheck = ''
     export PATH="$out/bin:$PATH"
   '';
 
-  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+  postInstall = ''
+    wrapProgram $out/bin/bd \
+      --prefix PATH : ${lib.makeBinPath [ dolt ]}
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd bd \
       --bash <($out/bin/bd completion bash) \
       --fish <($out/bin/bd completion fish) \
@@ -61,9 +87,12 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Lightweight memory system for AI coding agents with graph-based issue tracking";
-    homepage = "https://github.com/steveyegge/beads";
+    homepage = "https://github.com/gastownhall/beads";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kedry ];
+    maintainers = with lib.maintainers; [
+      kedry
+      imcvampire
+    ];
     mainProgram = "bd";
   };
 })


### PR DESCRIPTION
https://github.com/steveyegge/beads/releases/tag/v1.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
