### PR TITLE
postgresqlPackages.vectorchord: 1.1.0 -> 1.1.1

### DIFF
--- a/nixos/tests/web-apps/immich-vectorchord-reindex.nix
+++ b/nixos/tests/web-apps/immich-vectorchord-reindex.nix
@@ -17,24 +17,38 @@
         environment.IMMICH_LOG_LEVEL = "verbose";
       };
 
-      services.postgresql.extensions = lib.mkForce (ps: [
-        ps.pgvector
-        # pin vectorchord to an older version simulate version bump
-        (ps.vectorchord.overrideAttrs (prevAttrs': rec {
-          version = "0.5.2";
-          src = pkgs.fetchFromGitHub {
-            owner = "tensorchord";
-            repo = "vectorchord";
-            tag = version;
-            hash = "sha256-KGwiY5t1ivFiYex3D20y3sdiu3CT9LCDd2fPnRE56jM=";
-          };
+      services.postgresql.extensions = lib.mkForce (
+        ps:
+        let
+          # Pin vectorchord to an older version simulate version bump.
+          # This version must have a different "schema" version than the latest version in nixpkgs.
+          # See version number at https://github.com/tensorchord/VectorChord/blob/1.1.0/crates/vchordrq/src/tuples.rs#L23
+          vectorchord =
+            (ps.vectorchord.override {
+              cargo-pgrx_0_17_0 = pkgs.cargo-pgrx_0_16_0;
+            }).overrideAttrs
+              (
+                finalAttrs: _: {
+                  version = "1.0.0";
+                  src = pkgs.fetchFromGitHub {
+                    owner = "tensorchord";
+                    repo = "vectorchord";
+                    tag = finalAttrs.version;
+                    hash = "sha256-+BOuiinbKPZZaDl9aYsIoZPgvLZ4FA6Rb4/W+lAz4so=";
+                  };
 
-          cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
-            inherit src;
-            hash = "sha256-Vn3c/xuUpQzERJ74I0qbvufTZtW3goefPa5B/nOUO48=";
-          };
-        }))
-      ]);
+                  cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+                    inherit (finalAttrs) src;
+                    hash = "sha256-kwe2x7OTjpdPonZsvnR1C/89D5W/R5JswYF79YcSFEA=";
+                  };
+                }
+              );
+        in
+        [
+          ps.pgvector
+          vectorchord
+        ]
+      );
 
       specialisation."immich-vectorchord-upgraded".configuration = {
         # needs to be lower than mkForce, otherwise it does not get rid of the previous version

--- a/pkgs/development/tools/rust/cargo-pgrx/pinned.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/pinned.nix
@@ -23,4 +23,9 @@
     hash = "sha256-AjoBr+/sEPdzbD0wLUNVm2syCySkGaFOFQ70TST1U9w=";
     cargoHash = "sha256-95DHq5GLnAqb3bbKwwaeBeKEmkfRh81ZTRaJ7L59DAg=";
   };
+  cargo-pgrx_0_17_0 = {
+    version = "0.17.0";
+    hash = "sha256-Ld7m7ggxlf8FufpeiAE9qcu49X0SgX6XXHS6KIewGyA=";
+    cargoHash = "sha256-hNj39YzJna8iZxnlrLz+uLduxaD+uvggQRM7ng3MN1k=";
+  };
 }

--- a/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/vectorchord/package.nix
@@ -1,6 +1,6 @@
 {
   buildPgrxExtension,
-  cargo-pgrx_0_16_0,
+  cargo-pgrx_0_17_0,
   fetchFromGitHub,
   lib,
   nix-update-script,
@@ -9,19 +9,19 @@
 }:
 buildPgrxExtension (finalAttrs: {
   inherit postgresql;
-  cargo-pgrx = cargo-pgrx_0_16_0;
+  cargo-pgrx = cargo-pgrx_0_17_0;
 
   pname = "vectorchord";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "tensorchord";
     repo = "vectorchord";
     tag = finalAttrs.version;
-    hash = "sha256-8Gk5/wIGu5/t8EKeG9Wna7yUWKiuCOC9yjJFo2euF/I=";
+    hash = "sha256-QL9XGSQFOcrpww03Y5F0JuDbpo0v8oidUqucLxggkqE=";
   };
 
-  cargoHash = "sha256-o7NZEH3NCf/T81kL7jDa4HHGWsyTkLXXhq4KQR2/PGM=";
+  cargoHash = "sha256-IXOCzKJArNOcb/2TcJbLz1XdCquUpyF/cLHYU5vmlko=";
 
   # Include upgrade scripts in the final package
   # https://github.com/tensorchord/VectorChord/blob/0.5.0/crates/make/src/main.rs#L366

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4687,6 +4687,7 @@ with pkgs;
     cargo-pgrx_0_12_6
     cargo-pgrx_0_16_0
     cargo-pgrx_0_16_1
+    cargo-pgrx_0_17_0
     cargo-pgrx
     ;
 


### PR DESCRIPTION
https://github.com/tensorchord/VectorChord/releases/tag/1.1.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
