### PR TITLE
lomiri.lomiri-addressbook-app: init at 0.9.1

### DIFF
--- a/pkgs/by-name/bu/buteo-syncfw/package.nix
+++ b/pkgs/by-name/bu/buteo-syncfw/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchDebianPatch,
   gitUpdater,
   testers,
   dbus,
@@ -29,7 +30,28 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-WZ70dFrQeHO0c9MM3wS8aWMd0DDhTW9Ks4hhw7pPmu8=";
   };
 
+  patches = [
+    # Make systemd service activatable via dbus
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname;
+      version = "0.11.10";
+      debianRevision = "1";
+      patch = "2000-systemd-dbus-activation.patch";
+      hash = "sha256-zo/wOAw3rEQGrg8L0vJwDKitDQf4fi2Z2ajfdGWaBLw=";
+    })
+
+    # Add functionality needed in Lomiri
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname;
+      version = "0.11.10";
+      debianRevision = "1";
+      patch = "2004_Add-method-to-enable-disable-sync-profiles-for-a-specific-service.patch";
+      hash = "sha256-EpZb1HgiM5tM09GFeQBvkWmsYnUXjzeTE6Ima8eI9cI=";
+    })
+  ];
+
   postPatch = ''
+    # TODO Send this upstream, Debian ships a similar change but with more changes to the install location
     # Wildcard breaks file installation (tries to run ~ "install source/* target/*")
     substituteInPlace doc/doc.pri \
       --replace-fail 'htmldocs.files = $${PWD}/html/*' 'htmldocs.files = $${PWD}/html' \

--- a/pkgs/desktops/lomiri/applications/lomiri-addressbook-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-addressbook-app/default.nix
@@ -1,0 +1,171 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchpatch,
+  gitUpdater,
+  accounts-qml-module,
+  buteo-syncfw-qml,
+  cmake,
+  ctestCheckHook,
+  gsettings-qt,
+  libqofono,
+  lomiri-content-hub,
+  lomiri-telephony-service,
+  lomiri-ui-toolkit,
+  mesa,
+  pkg-config,
+  qtbase,
+  qtdeclarative,
+  qtgraphicaleffects ? null,
+  qtpim,
+  qtquickcontrols2 ? null,
+  wrapQtAppsHook,
+  writableTmpDirAsHomeHook,
+  xvfb-run,
+}:
+
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+  listToQtVar = suffix: lib.makeSearchPathOutput "bin" suffix;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-addressbook-app";
+  version = "0.9.1";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-addressbook-app";
+    tag = finalAttrs.version;
+    hash = "sha256-otdNQ8i6wgGqN5pUAub3JKDc+cfFOO/DHvQkh+xOSHs=";
+  };
+
+  patches = [
+    # Remove when version > 0.9.1
+    (fetchpatch {
+      name = "0001-lomiri-addressbook-app-Bump-cmake_minimum_required.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-addressbook-app/-/commit/2b5c633c2126758415e1aade54f11729271665c5.patch";
+      hash = "sha256-hrEykXsYpVnu5zrgAOhugTDha0O9BBufwAm6F2y+p/U=";
+    })
+
+    # Remove when version > 0.9.1
+    (fetchpatch {
+      name = "0002-lomiri-addressbook-app-Ringtone-sound-selection-rework.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-addressbook-app/-/commit/75d31bdbe86215670261626988c0671937484868.patch";
+      hash = "sha256-jYObiXr0tnr4oiZJjf1oYc7lARKPn4pUxBq5Q4f13HQ=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+      'QT_IMPORTS_DIR "''${CMAKE_INSTALL_LIBDIR}/qt5/qml"' \
+      'QT_IMPORTS_DIR "''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"'
+
+    substituteInPlace tests/qml/CMakeLists.txt \
+      --replace-fail 'NO_DEFAULT_PATH' ""
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libqofono
+    qtbase
+    qtpim
+
+    # QML
+    accounts-qml-module
+    buteo-syncfw-qml
+    gsettings-qt
+    lomiri-content-hub
+    lomiri-telephony-service
+    lomiri-ui-toolkit
+  ]
+  ++ lib.optionals (!withQt6) [
+    # Folder into qtdeclarative in Qt6
+    qtquickcontrols2
+  ];
+
+  nativeCheckInputs = [
+    ctestCheckHook
+    mesa.llvmpipeHook # LUITK sometimes needs a valid OpenGL context: https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/issues/35
+    qtdeclarative # qmltestrunner
+    writableTmpDirAsHomeHook
+    xvfb-run
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "CLICK_MODE" false)
+    (lib.cmakeBool "INSTALL_COMPONENTS" true)
+    (lib.cmakeBool "INSTALL_TESTS" false)
+    (lib.cmakeBool "USE_XVFB" finalAttrs.finalPackage.doCheck)
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # Parallelism makes xvfb upset
+  enableParallelChecking = false;
+
+  preCheck = ''
+    export QT_PLUGIN_PATH=${
+      listToQtVar qtbase.qtPluginPrefix [
+        qtbase
+        qtpim
+      ]
+    }
+    export QML2_IMPORT_PATH=${
+      listToQtVar qtbase.qtQmlPrefix (
+        [
+          buteo-syncfw-qml
+          gsettings-qt
+          libqofono
+          lomiri-content-hub
+          lomiri-telephony-service
+          lomiri-ui-toolkit
+          qtpim
+        ]
+        # using propagatedBuildInputs to get QML deps only gives dev outputs, doesn't work with lib.makeSearchPathOutput :(
+        # LUITK deps
+        ++ lib.optionals (!withQt6) [
+          # Deprecated in Qt6
+          qtgraphicaleffects
+        ]
+        ++ lib.optionals (!withQt6) [
+          # Folded into qtdeclative in Qt6
+          qtquickcontrols2
+        ]
+      )
+    }
+  '';
+
+  disabledTests = [
+    # Needs Lomiri.Keyboard
+    "contact_editor"
+  ];
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Address Book application to manager contacts";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-addressbook-app";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-addressbook-app/-/blob/${
+      if (finalAttrs.src.tag != null) then finalAttrs.src.tag else finalAttrs.src.rev
+    }/ChangeLog";
+    mainProgram = "lomiri-addressbook-app";
+    license = with lib.licenses; [
+      # code
+      gpl3Only
+
+      # assets
+      cc-by-sa-30
+    ];
+    teams = [ lib.teams.lomiri ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -51,6 +51,7 @@ let
       u1db-qt = callPackage ./development/u1db-qt { };
 
       #### QML / QML-related
+      buteo-syncfw-qml = callPackage ./qml/buteo-syncfw-qml { };
       lomiri-action-api = callPackage ./qml/lomiri-action-api { };
       lomiri-notifications = callPackage ./qml/lomiri-notifications { };
       lomiri-push-qml = callPackage ./qml/lomiri-push-qml { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -15,6 +15,7 @@ let
     {
       #### Core Apps
       lomiri = callPackage ./applications/lomiri { };
+      lomiri-addressbook-app = callPackage ./applications/lomiri-addressbook-app { };
       lomiri-calculator-app = callPackage ./applications/lomiri-calculator-app { };
       lomiri-calendar-app = callPackage ./applications/lomiri-calendar-app { };
       lomiri-camera-app = callPackage ./applications/lomiri-camera-app { };

--- a/pkgs/desktops/lomiri/qml/buteo-syncfw-qml/default.nix
+++ b/pkgs/desktops/lomiri/qml/buteo-syncfw-qml/default.nix
@@ -1,0 +1,84 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  gitUpdater,
+  cmake,
+  dbus-test-runner,
+  pkg-config,
+  python3,
+  qtbase,
+  qtdeclarative,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "buteo-syncfw-qml";
+  version = "0.3.1";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/buteo-syncfw-qml";
+    tag = finalAttrs.version;
+    hash = "sha256-1LeKV4hwaqOsEbTGkuWsfXpo7p1hxWzaEUglC3TbOY0=";
+  };
+
+  postPatch = ''
+    substituteInPlace Buteo/CMakeLists.txt \
+      --replace-fail 'qmake -query QT_INSTALL_QML' 'echo "''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"'
+
+    substituteInPlace tests/qml/CMakeLists.txt \
+      --replace-fail 'NO_DEFAULT_PATH' ""
+  ''
+  + lib.optionalString finalAttrs.finalPackage.doCheck ''
+    patchShebangs tests/qml/buteo-syncfw.py
+  ''
+  + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'add_subdirectory(tests)' 'message(NOTICE "Tests are being skipped")'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    qtbase
+    qtdeclarative
+  ];
+
+  nativeCheckInputs = [
+    dbus-test-runner
+    (python3.withPackages (
+      ps: with ps; [
+        dbus-python
+        pygobject3
+      ]
+    ))
+    qtdeclarative # qmltestrunner
+  ];
+
+  # QML module
+  dontWrapQtApps = true;
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck = ''
+    export QT_PLUGIN_PATH=${lib.makeSearchPath qtbase.qtPluginPrefix [ qtbase ]}
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "QML bindings for the Buteo sync framework";
+    homepage = "https://gitlab.com/ubports/development/core/buteo-syncfw-qml";
+    changelog = "https://gitlab.com/ubports/development/core/buteo-syncfw-qml/-/blob/${
+      if (finalAttrs.src.tag != null) then finalAttrs.src.tag else finalAttrs.src.rev
+    }/ChangeLog";
+    license = lib.licenses.gpl3Only;
+    teams = [ lib.teams.lomiri ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Builds, but

- need to submit some things upstream to make this nicer
- really needs these to be functional
  - #340391
  - #420192 (or some kind of fake `Lomiri.Keyboard` implementation)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
