### PR TITLE
nixos/atuin: add system-wide atuin program option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -57,6 +57,8 @@
 
 - [OpenThread Border Router](https://openthread.io/), a Thread border router for POSIX-based platforms that bridges Thread mesh networks to IP networks. Available as [services.openthread-border-router](#opt-services.openthread-border-router.enable).
 
+- [Atuin](https://atuin.sh), magical shell history — sync, search and backup your terminal history. Available as [programs.atuin](#opt-programs.atuin.enable).
+
 - [Meshtastic](https://meshtastic.org), an open-source, off-grid, decentralised mesh network
   designed to run on affordable, low-power devices. Available as [services.meshtasticd]
   (#opt-services.meshtasticd.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -168,6 +168,7 @@
   ./programs/appimage.nix
   ./programs/arp-scan.nix
   ./programs/atop.nix
+  ./programs/atuin.nix
   ./programs/ausweisapp.nix
   ./programs/autoenv.nix
   ./programs/autojump.nix

--- a/nixos/modules/programs/atuin.nix
+++ b/nixos/modules/programs/atuin.nix
@@ -1,0 +1,195 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) escapeShellArgs;
+
+  cfg = config.programs.atuin;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  settingsFile = tomlFormat.generate "atuin-config" cfg.settings;
+in
+{
+  options.programs.atuin = {
+    enable = lib.mkEnableOption "atuin";
+
+    package = lib.mkPackageOption pkgs "atuin" { };
+
+    enableBashIntegration = lib.mkEnableOption "Bash integration" // {
+      default = config.programs.bash.enable;
+      defaultText = lib.literalExpression "config.programs.bash.enable";
+    };
+
+    enableZshIntegration = lib.mkEnableOption "Zsh integration" // {
+      default = config.programs.zsh.enable;
+      defaultText = lib.literalExpression "config.programs.zsh.enable";
+    };
+
+    enableFishIntegration = lib.mkEnableOption "Fish integration" // {
+      default = config.programs.fish.enable;
+      defaultText = lib.literalExpression "config.programs.fish.enable";
+    };
+
+    flags = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "--disable-up-arrow"
+        "--disable-ctrl-r"
+      ];
+      description = ''
+        Flags to append to the shell hook.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          auto_sync = true;
+          sync_frequency = "5m";
+          sync_address = "https://api.atuin.sh";
+          search_mode = "prefix";
+        }
+      '';
+      description = ''
+        Configuration written to {file}`/etc/atuin/config.toml`.
+
+        See <https://docs.atuin.sh/configuration/config/> for the full list
+        of options.
+      '';
+    };
+
+    daemon = {
+      enable = lib.mkEnableOption "the Atuin daemon" // {
+        default = pkgs.stdenv.hostPlatform.isLinux;
+        defaultText = lib.literalExpression "pkgs.stdenv.hostPlatform.isLinux";
+      };
+
+      logLevel = lib.mkOption {
+        type = lib.types.enum [
+          "trace"
+          "debug"
+          "info"
+          "warn"
+          "error"
+        ];
+        default = "info";
+        description = ''
+          Log level for the Atuin daemon.
+        '';
+      };
+    };
+
+    themes = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.oneOf [
+          tomlFormat.type
+          lib.types.path
+          lib.types.lines
+        ]
+      );
+      description = ''
+        Each theme is written to
+        {file}`/etc/atuin/themes/theme-name.toml`
+        where the name of each attribute is the theme-name
+
+        See <https://docs.atuin.sh/guide/theming/> for the full list
+        of options.
+      '';
+      default = { };
+      example = lib.literalExpression ''
+        {
+          "my-theme" = {
+            theme.name = "My Theme";
+            colors = {
+              Base = "#000000";
+              Title = "#FFFFFF";
+            };
+          };
+        }
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    # Atuin only reads from ATUIN_CONFIG_DIR or XDG_CONFIG_HOME, not XDG_CONFIG_DIRS,
+    # so we must set ATUIN_CONFIG_DIR to point to the system-wide config location.
+    environment.variables.ATUIN_CONFIG_DIR = "/etc/atuin";
+
+    environment.etc = lib.mkMerge [
+      (lib.mkIf (cfg.settings != { }) {
+        "atuin/config.toml".source = settingsFile;
+      })
+
+      (lib.mkIf (cfg.themes != { }) (
+        builtins.mapAttrs' (
+          name: theme:
+          lib.nameValuePair "atuin/themes/${name}.toml" {
+            source =
+              if builtins.isString theme then
+                pkgs.writeText "atuin-theme-${name}" theme
+              else if builtins.isPath theme || lib.isStorePath theme then
+                theme
+              else
+                tomlFormat.generate "atuin-theme-${name}" theme;
+          }
+        ) cfg.themes
+      ))
+    ];
+
+    programs.bash.interactiveShellInit = lib.mkIf cfg.enableBashIntegration ''
+      if [[ :$SHELLOPTS: =~ :(vi|emacs): ]]; then
+        eval "$(${lib.getExe cfg.package} init bash ${escapeShellArgs cfg.flags})"
+      fi
+    '';
+
+    programs.zsh.interactiveShellInit = lib.mkIf cfg.enableZshIntegration ''
+      if [[ $options[zle] = on ]]; then
+        eval "$(${lib.getExe cfg.package} init zsh ${escapeShellArgs cfg.flags})"
+      fi
+    '';
+
+    programs.fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
+      ${lib.getExe cfg.package} init fish ${escapeShellArgs cfg.flags} | source
+    '';
+
+    systemd = lib.mkIf (cfg.daemon.enable && pkgs.stdenv.hostPlatform.isLinux) {
+      user.services.atuin-daemon = {
+        unitConfig = {
+          Description = "Atuin daemon";
+          Requires = [ "atuin-daemon.socket" ];
+        };
+        serviceConfig = {
+          ExecStart = "${lib.getExe cfg.package} daemon start";
+          Environment = [ "ATUIN_LOG=${cfg.daemon.logLevel}" ];
+          Restart = "on-failure";
+          RestartSteps = 3;
+          RestartMaxDelaySec = 6;
+        };
+      };
+
+      user.sockets.atuin-daemon = {
+        unitConfig = {
+          Description = "Atuin daemon socket";
+        };
+        socketConfig = {
+          ListenStream = "%t/atuin/atuin.sock";
+          SocketMode = "0640";
+          DirectoryMode = "0740";
+          RemoveOnStop = true;
+        };
+        wantedBy = [ "sockets.target" ];
+      };
+    };
+  };
+
+  meta.maintainers = cfg.package.meta.maintainers;
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -236,6 +236,7 @@ in
   atticd = runTest ./atticd.nix;
   attr = pkgs.callPackage ./attr.nix { };
   atuin = runTest ./atuin.nix;
+  atuin-programs = runTest ./atuin-programs.nix;
   audiobookshelf = runTest ./audiobookshelf.nix;
   audit = runTest ./audit.nix;
   audit-testsuite = runTest ./audit-testsuite.nix;

--- a/nixos/tests/atuin-programs.nix
+++ b/nixos/tests/atuin-programs.nix
@@ -1,0 +1,39 @@
+{ pkgs, ... }:
+{
+  name = "atuin";
+  meta.maintainers = pkgs.atuin.meta.maintainers;
+
+  nodes.machine = {
+    programs = {
+      bash.enable = true;
+      fish.enable = true;
+      zsh.enable = true;
+
+      atuin = {
+        enable = true;
+        settings = {
+          auto_sync = false;
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("default.target")
+
+    # Check atuin is installed
+    machine.succeed("atuin --version")
+
+    # Check shell integration - verify the init scripts can be sourced without error
+    machine.succeed("bash -c 'eval \"$(atuin init bash)\"'")
+    machine.succeed("zsh -c 'eval \"$(atuin init zsh)\"'")
+    machine.succeed("fish -c 'atuin init fish | source'")
+
+    # Verify config file was created
+    machine.succeed("grep -q 'auto_sync = false' /etc/atuin/config.toml")
+
+    # Verify daemon socket unit is enabled
+    machine.succeed("systemctl --user --machine=root@ is-enabled atuin-daemon.socket")
+  '';
+}

--- a/pkgs/by-name/at/atuin/package.nix
+++ b/pkgs/by-name/at/atuin/package.nix
@@ -58,7 +58,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru = {
     tests = {
-      inherit (nixosTests) atuin;
+      inherit (nixosTests) atuin atuin-programs;
     };
     updateScript = nix-update-script { };
   };


### PR DESCRIPTION
Adds a `programs.atuin` module to enable atuin shell history integration system-wide, without requiring home-manager.

This implements most of the [options available](https://mynixos.com/home-manager/options/programs.atuin) in the home-manager [atuin module](https://github.com/nix-community/home-manager/blob/master/modules/programs/atuin.nix):

- Shell integration for bash, zsh, and fish (enabled by default)
- Configuration via `settings` (written to ~~[XDG_CONFIG_HOME/atuin/config.toml](https://docs.atuin.sh/cli/configuration/config/)~~ `/etc/atuin/config.toml`)
- Custom themes support
- Package selection via `package` option
- Additional flags via `flags` option
- Daemon option to enable the Atuin daemon as a systemd user service with socket activation. This is required for
some configurations such as root-on-zfs. Mirrors the daemon support available in the home-manager [atuin module](https://github.com/nix-community/home-manager/blob/master/modules/programs/atuin.nix).

Example usage:

```nix
programs.atuin = {
  enable = true;
  settings = {
    auto_sync = true;
    search_mode = "prefix";
  };
};
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
