### PR TITLE
cclip: init at 3.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23211,6 +23211,13 @@
     name = "Roosembert (Roosemberth) Palacios";
     keys = [ { fingerprint = "78D9 1871 D059 663B 6117  7532 CAAA ECE5 C224 2BB7"; } ];
   };
+  rootrim = {
+    email = "omuaz01@gmail.com";
+    matrix = "@rootrim:matrix.org";
+    github = "rootrim";
+    githubId = 151086338;
+    name = "Muaz (Johnny) Öztürk";
+  };
   rople380 = {
     name = "rople380";
     github = "rople380";

--- a/pkgs/by-name/cc/cclip/package.nix
+++ b/pkgs/by-name/cc/cclip/package.nix
@@ -1,0 +1,49 @@
+{
+  stdenv,
+  lib,
+  meson,
+  ninja,
+  wayland,
+  wayland-scanner,
+  pkg-config,
+  fetchFromGitHub,
+  gitMinimal,
+  xxHash,
+  sqlite,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cclip";
+  version = "3.3.1";
+
+  src = fetchFromGitHub {
+    owner = "heather7283";
+    repo = "cclip";
+    tag = finalAttrs.version;
+    hash = "sha256-rjDCYag0aG9mZuwzWNS5z/CzeEtpdjc9iMypKqIZK60=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+    gitMinimal
+  ];
+
+  buildInputs = [
+    wayland
+    sqlite
+    xxHash
+  ];
+
+  meta = {
+    description = "clipboard manager for wayland";
+    homepage = "https://github.com/heather7283/cclip";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    mainProgram = "cclip";
+    maintainers = with lib.maintainers; [ rootrim ];
+  };
+})


### PR DESCRIPTION
Add [cclip](https://github.com/heather7283/cclip), a clipboard manager for wayland.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test