### PR TITLE
static-web-server: handle files from nix store epoch+1

### DIFF
--- a/pkgs/by-name/st/static-web-server/include-unix-time-plus-one.diff
+++ b/pkgs/by-name/st/static-web-server/include-unix-time-plus-one.diff
@@ -1,0 +1,13 @@
+diff --git a/src/response.rs b/src/response.rs
+index 25da3d3..92d6203 100644
+--- a/src/response.rs
++++ b/src/response.rs
+@@ -42,7 +42,7 @@ pub(crate) fn response_body(
+     let modified = meta
+         .modified()
+         .ok()
+-        .filter(|&t| t != std::time::UNIX_EPOCH)
++        .filter(|&t| t > (std::time::UNIX_EPOCH + std::time::Duration::from_secs(1)))
+         .map(LastModified::from);
+ 
+     match conditionals.check(modified) {

--- a/pkgs/by-name/st/static-web-server/package.nix
+++ b/pkgs/by-name/st/static-web-server/package.nix
@@ -18,9 +18,14 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-rNrGlgUvPezX7RnKhprRjl9DiJ/Crt4phmxnfY9tNXA=";
 
-  # Some tests rely on timestamps newer than 18 Nov 1974 00:00:00
-  preCheck = ''
-    find docker/public -exec touch -m {} \;
+  # static-web-server already has special handling for files with modification
+  # time = unix epoch, but the nix store is unix epoch + 1 second.
+  patches = [ ./include-unix-time-plus-one.diff ];
+
+  # Some tests which implicitly relied on the above behavior now break.  Force
+  # an mtime update to fix.
+  postUnpack = ''
+    find . -exec touch -m {} +
   '';
 
   # Need to copy in the systemd units for systemd.packages to discover them


### PR DESCRIPTION
files served from the nix store have time of epoch+1 and static-web-server assumes they're old unchanged files and doesn't send partial updates or refresh the file when it changes. It already has special handling for files with the unix epoch, but the nix store time is epoch+1s.
add that special case in the check for the file timestamp to see if it's not greater than epoch +1 second (checking for epoch or epoch+1s).

backstory: https://xn--xp5a.anterior.app/auth/login.html#article-20260227

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
