### PR TITLE
bitwig-studio6: init at 6.0

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio6.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio6.nix
@@ -1,0 +1,146 @@
+{
+  stdenv,
+  fetchurl,
+  alsa-lib,
+  atk,
+  cairo,
+  dpkg,
+  ffmpeg,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  harfbuzz,
+  lcms,
+  lib,
+  libglvnd,
+  libjack2,
+  libjpeg,
+  libnghttp2,
+  libudev-zero,
+  libxkbcommon,
+  makeWrapper,
+  pango,
+  pipewire,
+  vulkan-loader,
+  wrapGAppsHook3,
+  xcb-imdkit,
+  xdg-utils,
+  libxcb-util,
+  libxcb-wm,
+  libxtst,
+  libxcursor,
+  libx11,
+  libxcb,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bitwig-studio-unwrapped";
+  version = "6.0";
+
+  src = fetchurl {
+    name = "bitwig-studio-${finalAttrs.version}.deb";
+    url = "https://www.bitwig.com/dl/Bitwig%20Studio/${finalAttrs.version}/installer_linux/";
+    hash = "sha256-jrCTgaxfeWhfKwLeKLmqTQWS7RVbVnHqJ0InCipmm8k=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    wrapGAppsHook3
+  ];
+
+  dontBuild = true;
+  dontWrapGApps = true; # we only want $gappsWrapperArgs here
+
+  buildInputs = [
+    alsa-lib
+    atk
+    cairo
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    harfbuzz
+    lcms
+    libglvnd
+    libjack2
+    # libjpeg8 is required for converting jpeg's to colour palettes
+    libjpeg
+    libnghttp2
+    libxcb
+    libxcursor
+    libx11
+    libxtst
+    libxkbcommon
+    libudev-zero
+    pango
+    pipewire
+    (lib.getLib stdenv.cc.cc)
+    vulkan-loader
+    xcb-imdkit
+    libxcb-util
+    libxcb-wm
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r opt/bitwig-studio $out/libexec
+    ln -s $out/libexec/bitwig-studio $out/bin/bitwig-studio
+    cp -r usr/share $out/share
+
+    # Bitwig includes a copy of libxcb-imdkit.
+    # Removing it will force it to use our version.
+    rm $out/libexec/lib/bitwig-studio/libxcb-imdkit.so.1
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    # patchelf fails to set rpath on BitwigStudioEngine, so we use
+    # the LD_LIBRARY_PATH way
+
+    find $out -type f -executable \
+      -not -name '*.so.*' \
+      -not -name '*.so' \
+      -not -name '*.jar' \
+      -not -name 'jspawnhelper' \
+      -not -path '*/resources/*' | \
+    while IFS= read -r f ; do
+      patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $f
+      # make xdg-open overrideable at runtime
+      wrapProgram $f \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix PATH : "${lib.makeBinPath [ ffmpeg ]}" \
+        --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}" \
+        --suffix LD_LIBRARY_PATH : "${lib.strings.makeLibraryPath finalAttrs.buildInputs}"
+    done
+
+    find $out -type f -executable -name 'jspawnhelper' | \
+    while IFS= read -r f ; do
+      patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" $f
+    done
+  '';
+
+  meta = {
+    description = "Digital audio workstation";
+    longDescription = ''
+      Bitwig Studio is a multi-platform music-creation system for
+      production, performance and DJing, with a focus on flexible
+      editing tools and a super-fast workflow.
+    '';
+    homepage = "https://www.bitwig.com/";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [
+      bfortz
+      michalrus
+      mrVanDalo
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9269,11 +9269,19 @@ with pkgs;
     libjpeg = libjpeg8;
   };
 
+  bitwig-studio6-unwrapped = callPackage ../applications/audio/bitwig-studio/bitwig-studio6.nix {
+    libjpeg = libjpeg8;
+  };
+
   bitwig-studio5 = callPackage ../applications/audio/bitwig-studio/bitwig-wrapper.nix {
     bitwig-studio-unwrapped = bitwig-studio5-unwrapped;
   };
 
-  bitwig-studio = bitwig-studio5;
+  bitwig-studio6 = callPackage ../applications/audio/bitwig-studio/bitwig-wrapper.nix {
+    bitwig-studio-unwrapped = bitwig-studio6-unwrapped;
+  };
+
+  bitwig-studio = bitwig-studio6;
 
   blucontrol = callPackage ../applications/misc/blucontrol/wrapper.nix {
     inherit (haskellPackages) ghcWithPackages;


### PR DESCRIPTION
## Things done

Bitwig 6.0 was released today: https://www.bitwig.com/stories/on-another-level-bitwig-studio-6-is-out-now-416/

The new nix file is a copy of the one for version 5, I only adjusted the version and the hash. I haven't tested the package in depth but I wasn't able to see any obvious defects.

@bfortz @michalrus @mrVanDalo

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
