### PR TITLE
build-support/node/import-npm-lock: use structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/build-support/node/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/default.nix
@@ -12,6 +12,7 @@ let
     match
     elemAt
     toJSON
+    toFile
     removeAttrs
     ;
   inherit (lib) importJSON mapAttrs;
@@ -157,18 +158,15 @@ lib.fix (self: {
       {
         inherit pname version;
 
-        passAsFile = [
-          "package"
-          "packageLock"
-        ];
+        package = toFile (toJSON packageJSON');
+        packageLock = toFile (toJSON packageLock');
 
-        package = toJSON packageJSON';
-        packageLock = toJSON packageLock';
+        __structuredAttrs = true;
       }
       ''
         mkdir $out
-        cp "$packagePath" $out/package.json
-        cp "$packageLockPath" $out/package-lock.json
+        cp "${package}" > $out/package.json
+        cp "${packageLock}" > $out/package-lock.json
       '';
 
   # Build node modules from package.json & package-lock.json
@@ -180,6 +178,11 @@ lib.fix (self: {
       nodejs,
       derivationArgs ? { },
     }:
+    let
+      # Backwards compatibility: if derivationArgs contains passAsFile,
+      # we can't force structuredAttrs here yet.
+      __structuredAttrs = !(derivationArgs ? passAsFile);
+    in
     stdenv.mkDerivation (
       {
         pname = derivationArgs.pname or "${getName package}-node-modules";
@@ -213,17 +216,29 @@ lib.fix (self: {
         ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools ]
         ++ derivationArgs.nativeBuildInputs or [ ];
 
+        postPatch =
+          (
+            if __structuredAttrs then
+              ''
+                echo -n "$package" > package.json
+                echo -n "$packageLock" > package-lock.json
+              ''
+            else
+              ''
+                cp --no-preserve=mode "$packagePath" package.json
+                cp --no-preserve=mode "$packageLockPath" package-lock.json
+              ''
+          )
+          + derivationArgs.postPatch or "";
+
+        inherit __structuredAttrs;
+      }
+      // lib.optionalAttrs (!__structuredAttrs) {
         passAsFile = [
           "package"
           "packageLock"
         ]
-        ++ derivationArgs.passAsFile or [ ];
-
-        postPatch = ''
-          cp --no-preserve=mode "$packagePath" package.json
-          cp --no-preserve=mode "$packageLockPath" package-lock.json
-        ''
-        + derivationArgs.postPatch or "";
+        ++ derivationArgs.passAsFile;
       }
     );
 


### PR DESCRIPTION
…


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
