### PR TITLE
linuxPackages.kernel.configfile: use writeText instead of passAsFile

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -2,6 +2,7 @@
   buildPackages,
   pkgsBuildBuild,
   callPackage,
+  writeText,
   perl,
   bison ? null,
   flex ? null,
@@ -165,9 +166,6 @@ lib.makeOverridable (
 
       generateConfig = ./generate-config.pl;
 
-      kernelConfig = kernelConfigFun intermediateNixConfig;
-      passAsFile = [ "kernelConfig" ];
-
       depsBuildBuild = [ buildPackages.stdenv.cc ];
       nativeBuildInputs = [
         perl
@@ -183,11 +181,7 @@ lib.makeOverridable (
         rustc-unwrapped
       ];
 
-      RUST_LIB_SRC = lib.optionalString withRust rustPlatform.rustLibSrc;
-
-      # e.g. "defconfig"
-      kernelBaseConfig =
-        if defconfig != null then defconfig else stdenv.hostPlatform.linux-kernel.baseConfig or "defconfig";
+      env.RUST_LIB_SRC = lib.optionalString withRust rustPlatform.rustLibSrc;
 
       makeFlags = import ./common-flags.nix {
         inherit
@@ -208,41 +202,50 @@ lib.makeOverridable (
 
       inherit (kernel) src patches;
 
-      buildPhase = ''
-        export buildRoot="''${buildRoot:-build}"
+      buildPhase =
+        let
+          # e.g. "defconfig"
+          kernelBaseConfig =
+            if defconfig != null then defconfig else stdenv.hostPlatform.linux-kernel.baseConfig or "defconfig";
+          kernelIntermediateConfig = writeText "kernel-intermediate-config" (
+            kernelConfigFun intermediateNixConfig
+          );
+        in
+        ''
+          export buildRoot="''${buildRoot:-build}"
 
-        # Get a basic config file for later refinement with $generateConfig.
-        make $makeFlags \
-            -C . O="$buildRoot" $kernelBaseConfig \
-            ARCH=$kernelArch CROSS_COMPILE=${stdenv.cc.targetPrefix} \
-            $makeFlags
+          # Get a basic config file for later refinement with $generateConfig.
+          make $makeFlags \
+              -C . O="$buildRoot" ${kernelBaseConfig} \
+              ARCH=$kernelArch CROSS_COMPILE=${stdenv.cc.targetPrefix} \
+              $makeFlags
 
-        # Create the config file.
-        echo "generating kernel configuration..."
-        ln -s "$kernelConfigPath" "$buildRoot/kernel-config"
-        DEBUG=1 ARCH=$kernelArch CROSS_COMPILE=${stdenv.cc.targetPrefix} \
-          KERNEL_CONFIG="$buildRoot/kernel-config" AUTO_MODULES=$autoModules \
-          PREFER_BUILTIN=$preferBuiltin BUILD_ROOT="$buildRoot" SRC=. MAKE_FLAGS="$makeFlags" \
-          perl -w $generateConfig
-      ''
-      + lib.optionalString stdenv.cc.isClang ''
-        if ! grep -Fq CONFIG_CC_IS_CLANG=y $buildRoot/.config; then
-          echo "Kernel config didn't recognize the clang compiler?"
-          exit 1
-        fi
-      ''
-      + lib.optionalString stdenv.cc.bintools.isLLVM ''
-        if ! grep -Fq CONFIG_LD_IS_LLD=y $buildRoot/.config; then
-          echo "Kernel config didn't recognize the LLVM linker?"
-          exit 1
-        fi
-      ''
-      + lib.optionalString withRust ''
-        if ! grep -Fq CONFIG_RUST_IS_AVAILABLE=y $buildRoot/.config; then
-          echo "Kernel config didn't find Rust toolchain?"
-          exit 1
-        fi
-      '';
+          # Create the config file.
+          echo "generating kernel configuration..."
+          ln -s "${kernelIntermediateConfig}" "$buildRoot/kernel-config"
+          DEBUG=1 ARCH=$kernelArch CROSS_COMPILE=${stdenv.cc.targetPrefix} \
+            KERNEL_CONFIG="$buildRoot/kernel-config" AUTO_MODULES=$autoModules \
+            PREFER_BUILTIN=$preferBuiltin BUILD_ROOT="$buildRoot" SRC=. MAKE_FLAGS="$makeFlags" \
+            perl -w $generateConfig
+        ''
+        + lib.optionalString stdenv.cc.isClang ''
+          if ! grep -Fq CONFIG_CC_IS_CLANG=y $buildRoot/.config; then
+            echo "Kernel config didn't recognize the clang compiler?"
+            exit 1
+          fi
+        ''
+        + lib.optionalString stdenv.cc.bintools.isLLVM ''
+          if ! grep -Fq CONFIG_LD_IS_LLD=y $buildRoot/.config; then
+            echo "Kernel config didn't recognize the LLVM linker?"
+            exit 1
+          fi
+        ''
+        + lib.optionalString withRust ''
+          if ! grep -Fq CONFIG_RUST_IS_AVAILABLE=y $buildRoot/.config; then
+            echo "Kernel config didn't find Rust toolchain?"
+            exit 1
+          fi
+        '';
 
       installPhase = "mv $buildRoot/.config $out";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
