### PR TITLE
nixos/lib/make-options-doc: use structuredAttrs instead of passAsFile

### DIFF
--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -214,13 +214,15 @@ rec {
           pkgs.brotli
           pkgs.python3
         ];
-        passAsFile = [ "options" ];
         options = builtins.unsafeDiscardStringContext (builtins.toJSON optionsNix);
         # merge with an empty set if baseOptionsJSON is null to run markdown
         # processing on the input options
         baseJSON = if baseOptionsJSON == null then builtins.toFile "base.json" "{}" else baseOptionsJSON;
+        __structuredAttrs = true;
       }
       ''
+          optionsPath=$TMPDIR/options
+          printf "%s" "$options" > "$optionsPath"
           # Export list of options in different format.
           dst=$out/share/doc/nixos
           mkdir -p $dst

--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -221,17 +221,17 @@ rec {
         __structuredAttrs = true;
       }
       ''
-          optionsPath=$TMPDIR/options
-          printf "%s" "$options" > "$optionsPath"
-          # Export list of options in different format.
-          dst=$out/share/doc/nixos
-          mkdir -p $dst
+        optionsPath=$TMPDIR/options
+        printf "%s" "$options" > "$optionsPath"
+        # Export list of options in different format.
+        dst=$out/share/doc/nixos
+        mkdir -p $dst
 
-          TOUCH_IF_DB=$dst/.used-docbook \
-          python ${./mergeJSON.py} \
-            ${lib.optionalString warningsAreErrors "--warnings-are-errors"} \
-            $baseJSON $optionsPath \
-            > $dst/options.json
+        TOUCH_IF_DB=$dst/.used-docbook \
+        python ${./mergeJSON.py} \
+          ${lib.optionalString warningsAreErrors "--warnings-are-errors"} \
+          $baseJSON $optionsPath \
+          > $dst/options.json
 
         if grep /nixpkgs/nixos/modules $dst/options.json; then
           echo "The manual appears to depend on the location of Nixpkgs, which is bad"
@@ -241,10 +241,10 @@ rec {
           exit 1
         fi
 
-          brotli -9 < $dst/options.json > $dst/options.json.br
+        brotli -9 < $dst/options.json > $dst/options.json.br
 
-          mkdir -p $out/nix-support
-          echo "file json $dst/options.json" >> $out/nix-support/hydra-build-products
-          echo "file json-br $dst/options.json.br" >> $out/nix-support/hydra-build-products
+        mkdir -p $out/nix-support
+        echo "file json $dst/options.json" >> $out/nix-support/hydra-build-products
+        echo "file json-br $dst/options.json.br" >> $out/nix-support/hydra-build-products
       '';
 }

--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -214,15 +214,14 @@ rec {
           pkgs.brotli
           pkgs.python3
         ];
-        options = builtins.unsafeDiscardStringContext (builtins.toJSON optionsNix);
+        options = optionsNix;
         # merge with an empty set if baseOptionsJSON is null to run markdown
         # processing on the input options
-        baseJSON = if baseOptionsJSON == null then builtins.toFile "base.json" "{}" else baseOptionsJSON;
+        baseOptionsPath =
+          if baseOptionsJSON == null then builtins.toFile "base.json" "{}" else baseOptionsJSON;
         __structuredAttrs = true;
       }
       ''
-        optionsPath=$TMPDIR/options
-        printf "%s" "$options" > "$optionsPath"
         # Export list of options in different format.
         dst=$out/share/doc/nixos
         mkdir -p $dst
@@ -230,7 +229,6 @@ rec {
         TOUCH_IF_DB=$dst/.used-docbook \
         python ${./mergeJSON.py} \
           ${lib.optionalString warningsAreErrors "--warnings-are-errors"} \
-          $baseJSON $optionsPath \
           > $dst/options.json
 
         if grep /nixpkgs/nixos/modules $dst/options.json; then

--- a/nixos/lib/make-options-doc/mergeJSON.py
+++ b/nixos/lib/make-options-doc/mergeJSON.py
@@ -43,14 +43,14 @@ def unpivot(options: Dict[Key, Option]) -> Dict[str, JSON]:
     return result
 
 warningsAreErrors = False
-optOffset = 0
 for arg in sys.argv[1:]:
     if arg == "--warnings-are-errors":
-        optOffset += 1
         warningsAreErrors = True
 
-options = pivot(json.load(open(sys.argv[1 + optOffset], 'r')))
-overrides = pivot(json.load(open(sys.argv[2 + optOffset], 'r')))
+attrs = json.load(open(os.environ["NIX_ATTRS_JSON_FILE"], 'r'))
+
+options = pivot(json.load(open(attrs['baseOptionsPath'], 'r')))
+overrides = pivot(attrs['options'])
 
 # merge both descriptions
 for (k, v) in overrides.items():


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
