### PR TITLE
makeScriptWriter: use structuredAttrs instead of passAsFile, enable strictDeps

### DIFF
--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -108,65 +108,70 @@ rec {
       # at least two files: the executable and the wrapper.
       inner =
         pkgs.runCommandLocal name
-          (
-            {
-              inherit makeWrapperArgs;
-              nativeBuildInputs = [ makeBinaryWrapper ];
-              meta.mainProgram = name;
-            }
-            // (
-              if (types.str.check content) then
-                {
-                  inherit content interpreter;
-                  passAsFile = [ "content" ];
-                }
-              else
-                {
-                  inherit interpreter;
-                  contentPath = content;
-                }
-            )
-          )
-          ''
-            # On darwin a script cannot be used as an interpreter in a shebang but
-            # there doesn't seem to be a limit to the size of shebang and multiple
-            # arguments to the interpreter are allowed.
-            if [[ -n "${toString pkgs.stdenvNoCC.hostPlatform.isDarwin}" ]] && isScript $interpreter
-            then
-              wrapperInterpreterLine=$(head -1 "$interpreter" | tail -c+3)
-              # Get first word from the line (note: xargs echo remove leading spaces)
-              wrapperInterpreter=$(echo "$wrapperInterpreterLine" | xargs echo | cut -d " " -f1)
+          {
+            inherit makeWrapperArgs content interpreter;
+            nativeBuildInputs = [ makeBinaryWrapper ];
+            __structuredAttrs = true;
+            meta.mainProgram = name;
+          }
 
-              if isScript $wrapperInterpreter
+          (
+            ''
+              # On darwin a script cannot be used as an interpreter in a shebang but
+              # there doesn't seem to be a limit to the size of shebang and multiple
+              # arguments to the interpreter are allowed.
+              if [[ -n "${toString pkgs.stdenvNoCC.hostPlatform.isDarwin}" ]] && isScript $interpreter
               then
-                echo "error: passed interpreter ($interpreter) is a script which has another script ($wrapperInterpreter) as an interpreter, which is not supported."
-                exit 1
+                wrapperInterpreterLine=$(head -1 "$interpreter" | tail -c+3)
+                # Get first word from the line (note: xargs echo remove leading spaces)
+                wrapperInterpreter=$(echo "$wrapperInterpreterLine" | xargs echo | cut -d " " -f1)
+
+                if isScript $wrapperInterpreter
+                then
+                  echo "error: passed interpreter ($interpreter) is a script which has another script ($wrapperInterpreter) as an interpreter, which is not supported."
+                  exit 1
+                fi
+
+                # This should work as long as wrapperInterpreter is a shell, which is
+                # the case for programs wrapped with makeWrapper, like
+                # python3.withPackages etc.
+                interpreterLine="$wrapperInterpreterLine $interpreter"
+              else
+                interpreterLine=$interpreter
               fi
 
-              # This should work as long as wrapperInterpreter is a shell, which is
-              # the case for programs wrapped with makeWrapper, like
-              # python3.withPackages etc.
-              interpreterLine="$wrapperInterpreterLine $interpreter"
-            else
-              interpreterLine=$interpreter
-            fi
-
-            echo "#! $interpreterLine" > $out
-            cat "$contentPath" >> $out
-            ${optionalString (check != "") ''
+              echo "#! $interpreterLine" > $out
+            ''
+            + (
+              if (types.str.check content) then
+                ''
+                  contentPath="/build/content"
+                  printf "%s" "$content" > "$contentPath"
+                ''
+              else
+                ''
+                  contentPath="$content"
+                ''
+            )
+            + ''
+              cat "$contentPath" >> $out
+            ''
+            + optionalString (check != "") ''
               ${check} $out
-            ''}
-            chmod +x $out
+            ''
+            + ''
+              chmod +x $out
 
-            # Relocate executable
-            # Wrap it if makeWrapperArgs are specified
-            mv $out tmp
+              # Relocate executable
+              # Wrap it if makeWrapperArgs are specified
+              mv $out tmp
               mkdir -p $out/$(dirname "${path}")
               mv tmp $out/${path}
-            if [ -n "''${makeWrapperArgs+''${makeWrapperArgs[@]}}" ]; then
-                wrapProgram $out/${path} ''${makeWrapperArgs[@]}
-            fi
-          '';
+              if [ -n "''${makeWrapperArgs+''${makeWrapperArgs[@]}}" ]; then
+                  wrapProgram $out/${path} ''${makeWrapperArgs[@]}
+              fi
+            ''
+          );
     in
     if nameIsPath then
       inner
@@ -255,36 +260,39 @@ rec {
       # This is required in order to support wrapping, as wrapped programs consist of at least two files: the executable and the wrapper.
       inner =
         pkgs.runCommandLocal name
+          {
+            inherit makeWrapperArgs;
+            nativeBuildInputs = [ makeBinaryWrapper ];
+            __structuredAttrs = true;
+            meta.mainProgram = name;
+          }
           (
-            {
-              inherit makeWrapperArgs;
-              nativeBuildInputs = [ makeBinaryWrapper ];
-              meta.mainProgram = name;
-            }
-            // (
+            (
               if (types.str.check content) then
-                {
-                  inherit content;
-                  passAsFile = [ "content" ];
-                }
+                ''
+                  contentPath="/build/content"
+                  printf "%s" "$content" > "$contentPath"
+                ''
               else
-                { contentPath = content; }
+                ''
+                  contentPath="$content"
+                ''
             )
-          )
-          ''
-            ${compileScript}
-            ${lib.optionalString strip "${lib.getBin buildPackages.bintools-unwrapped}/bin/${buildPackages.bintools-unwrapped.targetPrefix}strip -S $out"}
-            # Sometimes binaries produced for darwin (e. g. by GHC) won't be valid
-            # mach-o executables from the get-go, but need to be corrected somehow
-            # which is done by fixupPhase.
-            ${lib.optionalString pkgs.stdenvNoCC.hostPlatform.isDarwin "fixupPhase"}
-            mv $out tmp
-            mkdir -p $out/$(dirname "${path}")
-            mv tmp $out/${path}
-            if [ -n "''${makeWrapperArgs+''${makeWrapperArgs[@]}}" ]; then
-              wrapProgram $out/${path} ''${makeWrapperArgs[@]}
-            fi
-          '';
+            + ''
+              ${compileScript}
+              ${lib.optionalString strip "${lib.getBin buildPackages.bintools-unwrapped}/bin/${buildPackages.bintools-unwrapped.targetPrefix}strip -S $out"}
+              # Sometimes binaries produced for darwin (e. g. by GHC) won't be valid
+              # mach-o executables from the get-go, but need to be corrected somehow
+              # which is done by fixupPhase.
+              ${lib.optionalString pkgs.stdenvNoCC.hostPlatform.isDarwin "fixupPhase"}
+              mv $out tmp
+              mkdir -p $out/$(dirname "${path}")
+              mv tmp $out/${path}
+              if [ -n "''${makeWrapperArgs+''${makeWrapperArgs[@]}}" ]; then
+                wrapProgram $out/${path} ''${makeWrapperArgs[@]}
+              fi
+            ''
+          );
     in
     if nameIsPath then
       inner
@@ -1107,12 +1115,12 @@ rec {
     pkgs.runCommandLocal name
       {
         inherit text;
-        passAsFile = [ "text" ];
         nativeBuildInputs = [ gixy ];
+        __structuredAttrs = true;
       } # sh
       ''
         # nginx-config-formatter has an error - https://github.com/1connect/nginx-config-formatter/issues/16
-        awk -f ${awkFormatNginx} "$textPath" | sed '/^\s*$/d' > $out
+        printf "%s" "$text" | awk -f ${awkFormatNginx} | sed '/^\s*$/d' > $out
         gixy $out || (echo "\n\nThis can be caused by combining multiple incompatible services on the same hostname.\n\nFull merged config:\n\n"; cat $out; exit 1)
       '';
 

--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -110,25 +110,13 @@ rec {
       # at least two files: the executable and the wrapper.
       inner =
         pkgs.runCommandLocal name
-          (
-            {
-              inherit makeWrapperArgs;
-              nativeBuildInputs = [ makeBinaryWrapper ];
-              meta.mainProgram = name;
-            }
-            // (
-              if (types.str.check content) then
-                {
-                  inherit content interpreter;
-                  passAsFile = [ "content" ];
-                }
-              else
-                {
-                  inherit interpreter;
-                  contentPath = content;
-                }
-            )
-          )
+          {
+            inherit makeWrapperArgs content interpreter;
+            nativeBuildInputs = [ makeBinaryWrapper ];
+            __structuredAttrs = true;
+            meta.mainProgram = name;
+          }
+
           ''
             # On darwin a script cannot be used as an interpreter in a shebang but
             # there doesn't seem to be a limit to the size of shebang and multiple
@@ -154,8 +142,17 @@ rec {
             fi
 
             echo "#! $interpreterLine" > $out
-            cat "$contentPath" >> $out
+            ${
+              if types.str.check content then ''printf "%s" "$content" >> $out'' else ''cat "$content" >> $out''
+            }
             ${optionalString (check != "") ''
+              # Set in case $check refers to deprecated $contentPath
+              ${
+                if types.str.check content then
+                  ''contentPath="$TMPDIR/content"; printf "%s" "$content" > "$contentPath"''
+                else
+                  ''contentPath="$content"''
+              }
               ${check} $out
             ''}
             chmod +x $out
@@ -163,9 +160,9 @@ rec {
             # Relocate executable
             # Wrap it if makeWrapperArgs are specified
             mv $out tmp
-              mkdir -p $out/$(dirname "${path}")
-              mv tmp $out/${path}
-            if [ -n "''${makeWrapperArgs+''${makeWrapperArgs[@]}}" ]; then
+            mkdir -p $out/$(dirname "${path}")
+            mv tmp $out/${path}
+            if [[ -v makeWrapperArgs ]]; then
                 wrapProgram $out/${path} ''${makeWrapperArgs[@]}
             fi
           '';

--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -109,25 +109,13 @@ rec {
       # at least two files: the executable and the wrapper.
       inner =
         pkgs.runCommandLocal name
-          (
-            {
-              inherit makeWrapperArgs;
-              nativeBuildInputs = [ makeBinaryWrapper ];
-              meta.mainProgram = name;
-            }
-            // (
-              if (types.str.check content) then
-                {
-                  inherit content interpreter;
-                  passAsFile = [ "content" ];
-                }
-              else
-                {
-                  inherit interpreter;
-                  contentPath = content;
-                }
-            )
-          )
+          {
+            inherit makeWrapperArgs content interpreter;
+            nativeBuildInputs = [ makeBinaryWrapper ];
+            __structuredAttrs = true;
+            meta.mainProgram = name;
+          }
+
           ''
             # On darwin a script cannot be used as an interpreter in a shebang but
             # there doesn't seem to be a limit to the size of shebang and multiple
@@ -153,8 +141,17 @@ rec {
             fi
 
             echo "#! $interpreterLine" > $out
-            cat "$contentPath" >> $out
+            ${
+              if types.str.check content then ''printf "%s" "$content" >> $out'' else ''cat "$content" >> $out''
+            }
             ${optionalString (check != "") ''
+              # Set in case $check refers to deprecated $contentPath
+              ${
+                if types.str.check content then
+                  ''contentPath="$TMPDIR/content"; printf "%s" "$content" > "$contentPath"''
+                else
+                  ''contentPath="$content"''
+              }
               ${check} $out
             ''}
             chmod +x $out
@@ -162,9 +159,9 @@ rec {
             # Relocate executable
             # Wrap it if makeWrapperArgs are specified
             mv $out tmp
-              mkdir -p $out/$(dirname "${path}")
-              mv tmp $out/${path}
-            if [ -n "''${makeWrapperArgs+''${makeWrapperArgs[@]}}" ]; then
+            mkdir -p $out/$(dirname "${path}")
+            mv tmp $out/${path}
+            if [[ -v makeWrapperArgs ]]; then
                 wrapProgram $out/${path} ''${makeWrapperArgs[@]}
             fi
           '';

--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -175,9 +175,14 @@ rec {
     # This breaks the override pattern.
     # In case this turns out to be a problem, we can still add more magic
     else
-      pkgs.runCommandLocal name { } ''
-        ln -s ${inner}/bin/${name} $out
-      '';
+      pkgs.runCommandLocal name
+        {
+          strictDeps = true;
+          __structuredAttrs = true;
+        }
+        ''
+          ln -s ${inner}/bin/${name} $out
+        '';
 
   /**
     `makeBinWriter` returns a derivation which compiles the given script into an executable format.

--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -113,6 +113,7 @@ rec {
           {
             inherit makeWrapperArgs content interpreter;
             nativeBuildInputs = [ makeBinaryWrapper ];
+            strictDeps = true;
             __structuredAttrs = true;
             meta.mainProgram = name;
           }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
