### PR TITLE
gsd: init at 3.0.0

### DIFF
--- a/pkgs/by-name/gs/gsd/package.nix
+++ b/pkgs/by-name/gs/gsd/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nodejs_22,
+  makeWrapper,
+  fd,
+  ripgrep,
+  gh,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "gsd";
+  version = "3.0.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "gsd-build";
+    repo = "gsd-2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IXdsW7rUE6TIaIVqLSzVDwYZE+plvRwCXfepoMj/wQQ=";
+  };
+
+  npmDepsHash = "sha256-qOrMx2yBywxjavt7g5253mcWmYhTO6bbS6eecn04Kew=";
+
+  webNpmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-web-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/web";
+    hash = "sha256-K6WndhLeST6jDgCetvUDeiJVkdPDzg6gz7pJjBqSi34=";
+  };
+
+  nodejs = nodejs_22;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+
+  # buildNpmPackage's hooks read these as plain env vars; under
+  # __structuredAttrs they are bash variables that need to be exported.
+  prePatch = ''
+    export npmDeps webNpmDeps
+  '';
+
+  postPatch = ''
+    # The npm "files" array omits "extensions/" so workspace symlinks under
+    # node_modules/@gsd-extensions/* end up dangling after `npm pack`. Include
+    # the extensions sources so they ship with the package.
+    substituteInPlace package.json \
+      --replace-fail '"packages",' '"packages",
+        "extensions",'
+  '';
+
+  preBuild = ''
+    pushd web
+    makeCacheWritable=1 npmDeps="$webNpmDeps" npmConfigHook
+    popd
+  '';
+
+  postFixup =
+    let
+      binPath = lib.makeBinPath [
+        fd
+        ripgrep
+        gh
+      ];
+    in
+    ''
+      for bin in gsd gsd-cli; do
+        wrapProgram $out/bin/$bin --prefix PATH : ${binPath}
+      done
+    '';
+
+  meta = {
+    description = "Meta-prompting and spec-driven development system for autonomous coding agents";
+    homepage = "https://github.com/gsd-build/gsd-2";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ otavio ];
+    mainProgram = "gsd";
+  };
+})


### PR DESCRIPTION
[gsd](https://github.com/gsd-build/gsd-2) is a powerful meta-prompting, context engineering and spec-driven development system that enables agents to work for long periods of time autonomously without losing track of the big picture.

The package is built using `buildNpmPackage` with Node.js 22 and wraps the `gsd` and `gsd-cli` binaries so that runtime dependencies (`fd`, `ripgrep`, `gh`) are available in PATH.

The v3.0.0 release introduced a Next.js sub-build under `web/` with its own `package-lock.json`, plus a workspace at `extensions/google-search` that is symlinked from `node_modules/@gsd-extensions/*`. The expression accordingly:

- fetches the `web/` npm cache separately via `fetchNpmDeps` and runs `npm ci` there in `preBuild`, and
- patches the root `package.json` `files` array to include `extensions/`, so the workspace symlink is not left dangling after `npm pack` (which would otherwise trip `noBrokenSymlinks`).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test