### PR TITLE
yaziPlugins: update on 2026-03-10

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "25.5.31-unstable-2026-02-22";
+  version = "26.1.22-unstable-2026-03-08";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "20ecff6dd154da4c6e28fc7f754e865fd5f9d1b3";
-    hash = "sha256-br8UDDPxVe4ZfoHIURD2zzjmyUImhKak0DYwCF9r2vw=";
+    rev = "6fbed8d3b34e2f72a52a481ea1461db112ea835d";
+    hash = "sha256-wmUseJ1li+J3euxtYtImIQ/NmbyAp8HhRZscC7Pib9s=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/ouch/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/ouch/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "ouch.yazi";
-  version = "0-unstable-2026-01-09";
+  version = "0-unstable-2026-03-03";
 
   src = fetchFromGitHub {
     owner = "ndtoan96";
     repo = "ouch.yazi";
-    rev = "594b8a2b246633d46b03a3261c9aebd1c4b5abf3";
-    hash = "sha256-+M0ZFh2jKts5GP9KgKsbpeNe0ldXQGyUZlYjDbp4yhw=";
+    rev = "406ce6c13ec3a18d4872b8f64b62f4a530759b2c";
+    hash = "sha256-14x/bD0aD9hXONaqQD8Dt7rLBCMq7bkVLH6uCPOQ0C8=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/rsync/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/rsync/default.nix
@@ -5,12 +5,12 @@
 }:
 mkYaziPlugin {
   pname = "rsync.yazi";
-  version = "0-unstable-2026-02-28";
+  version = "0-unstable-2026-03-07";
   src = fetchFromGitHub {
     owner = "GianniBYoung";
     repo = "rsync.yazi";
-    rev = "c094a5ce2dc2ebdb37f97a6f1f15af6c14c06402";
-    hash = "sha256-SqN3jDwHtsVDqawJyYHWdndi9IaCKPJH9+d7ffX9H7c=";
+    rev = "44f6979e5739c04039b1a8b0a04b2e2cb6cde46c";
+    hash = "sha256-54tXRwE1a+aq2cP4+ErXKQoHhUNx630sJZqiJpbrFT4=";
   };
 
   meta = {


### PR DESCRIPTION
- mediainfo: 25.5.31-unstable-2026-02-22 → 26.1.22-unstable-2026-03-08
  Compare: https://github.com/boydaihungst/mediainfo.yazi/compare/20ecff6dd154da4c6e28fc7f754e865fd5f9d1b3...6fbed8d3b34e2f72a52a481ea1461db112ea835d
- ouch: 0-unstable-2026-01-09 → 0-unstable-2026-03-03
  Compare: https://github.com/ndtoan96/ouch.yazi/compare/594b8a2b246633d46b03a3261c9aebd1c4b5abf3...406ce6c13ec3a18d4872b8f64b62f4a530759b2c
- rsync: 0-unstable-2026-02-28 → 0-unstable-2026-03-07
  Compare: https://github.com/GianniBYoung/rsync.yazi/compare/c094a5ce2dc2ebdb37f97a6f1f15af6c14c06402...44f6979e5739c04039b1a8b0a04b2e2cb6cde46c


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
