### PR TITLE
vegur: use installFonts hook

### DIFF
--- a/pkgs/by-name/ve/vegur/package.nix
+++ b/pkgs/by-name/ve/vegur/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -16,13 +17,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     stripRoot = false;
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     homepage = "https://dotcolon.net/fonts/vegur/";


### PR DESCRIPTION
Migrates `vegur` to use the `installFonts` setup hook instead of a manual `installPhase`.

Part of #495640

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Tested basic functionality — built with `nix-build -A vegur`, confirmed fonts present in `result/share/fonts/opentype/`.
  - [ ] Ran `nixpkgs-review` on this PR.
- Nixpkgs Release Notes
  - N/A
- NixOS Release Notes
  - N/A
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.