### PR TITLE
imagemagick: 7.1.2-15 -> 7.1.2-16

### DIFF
--- a/pkgs/by-name/im/imagemagick/package.nix
+++ b/pkgs/by-name/im/imagemagick/package.nix
@@ -86,13 +86,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "imagemagick";
-  version = "7.1.2-15";
+  version = "7.1.2-16";
 
   src = fetchFromGitHub {
     owner = "ImageMagick";
     repo = "ImageMagick";
     tag = finalAttrs.version;
-    hash = "sha256-qL7CYq+aGCB3ZLgIcSBy2Dw69g0F68xGXxrE7xJhdNc=";
+    hash = "sha256-tuCJgns/ecbRbN0OwAZt3E65usA0ZyNLkIey4eQfzOg=";
   };
 
   outputs = [

--- a/pkgs/development/python-modules/wand/default.nix
+++ b/pkgs/development/python-modules/wand/default.nix
@@ -2,42 +2,37 @@
   stdenv,
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   imagemagickBig,
-  py,
   pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "wand";
-  version = "0.6.13";
-  format = "setuptools";
+  version = "0.7.0";
+  pyproject = true;
 
-  src = fetchPypi {
-    pname = "Wand";
-    inherit version;
-    hash = "sha256-9QE0hOr3og6yLRghqu/mC1DMMpciNytfhWXUbUqq/Mo=";
+  src = fetchFromGitHub {
+    owner = "emcconville";
+    repo = "wand";
+    tag = version;
+    hash = "sha256-U4qxtOC72YSgo74OZdFmMG8W2s4wFI0ohJ7uJ4caabA=";
   };
 
   postPatch = ''
-    substituteInPlace wand/api.py --replace \
+    substituteInPlace wand/api.py --replace-fail \
       "magick_home = os.environ.get('MAGICK_HOME')" \
       "magick_home = '${imagemagickBig}'"
   '';
 
+  build-system = [ setuptools ];
+
   nativeCheckInputs = [
-    py
     pytestCheckHook
   ];
 
-  disabledTests = [
-    # https://github.com/emcconville/wand/issues/558
-    "test_forward_fourier_transform"
-    "test_inverse_fourier_transform"
-    # our imagemagick doesn't set MagickReleaseDate
-    "test_configure_options"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # AssertionError: assert wand.color.Color('srgb(255,0,1.41553e-14)') == wand.color.Color('srgb(255,0,0)')
     "test_sparse_color"
   ];


### PR DESCRIPTION
Diff: https://github.com/ImageMagick/ImageMagick/compare/7.1.2-15...7.1.2-16

Changelog: https://github.com/ImageMagick/Website/blob/main/ChangeLog.md

fixes https://github.com/NixOS/nixpkgs/issues/498842
fixes https://github.com/NixOS/nixpkgs/issues/498843
fixes https://github.com/NixOS/nixpkgs/issues/498846
fixes https://github.com/NixOS/nixpkgs/issues/498850
fixes https://github.com/NixOS/nixpkgs/issues/498825
fixes https://github.com/NixOS/nixpkgs/issues/498831
fixes https://github.com/NixOS/nixpkgs/issues/498838
fixes https://github.com/NixOS/nixpkgs/issues/498844
fixes https://github.com/NixOS/nixpkgs/issues/498826
fixes https://github.com/NixOS/nixpkgs/issues/498827
fixes https://github.com/NixOS/nixpkgs/issues/498836
fixes https://github.com/NixOS/nixpkgs/issues/498834
fixes https://github.com/NixOS/nixpkgs/issues/498824
fixes https://github.com/NixOS/nixpkgs/issues/498823
fixes https://github.com/NixOS/nixpkgs/issues/498832
fixes https://github.com/NixOS/nixpkgs/issues/498835
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
