### PR TITLE
koules: fix build, move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/ko/koules/package.nix
+++ b/pkgs/by-name/ko/koules/package.nix
@@ -10,6 +10,7 @@
   libx11,
   libxext,
   makeDesktopItem,
+  imagemagick,
 }:
 
 let
@@ -32,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     gccmakedep
     installShellFiles
     copyDesktopItems
+    imagemagick
   ];
   buildInputs = [
     libx11
@@ -60,7 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm755 xkoules $out/bin/xkoules
     install -Dm755 koules.sndsrv.linux $out/lib/koules.sndsrv.linux
     install -m644 sounds/* $out/lib/
-    install -Dm644 Koules.xpm $out/share/pixmaps/koules.xpm
+    mkdir -p $out/share/icons/hicolor/32x32/apps
+    magick Koules.xpm -background none -extent 32x32-1 -gravity center $out/share/icons/hicolor/32x32/apps/koules.png
     installManPage xkoules.6
     runHook postInstall
   '';

--- a/pkgs/by-name/ko/koules/package.nix
+++ b/pkgs/by-name/ko/koules/package.nix
@@ -14,8 +14,8 @@
 
 let
   debian-extras = fetchzip {
-    url = "mirror://debian/pool/main/k/koules/koules_1.4-27.debian.tar.xz";
-    hash = "sha256-g0Z6C1YSZL6N2eYUuZgXkPDoOLc4e9jAFL3ivk3OAS8=";
+    url = "mirror://debian/pool/main/k/koules/koules_1.4-29.debian.tar.xz";
+    hash = "sha256-8AQGU3uAu1nCKeu4nqCDOL7FcSJeYvD1pmidEPLLekY=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #428824 
yay for debian having new patches for us to pull :)
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
