### PR TITLE
rocmPackages.clr: add impureTest that runs openctl-cts test_basic 

### DIFF
--- a/pkgs/by-name/op/opencl-cts/package.nix
+++ b/pkgs/by-name/op/opencl-cts/package.nix
@@ -48,6 +48,11 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "OPENCL_LIBRARIES" "OpenCL")
   ];
 
+  # Upstream installs to bin/$<CONFIG> (e.g. bin/Release/); flatten it.
+  postInstall = ''
+    mv "$out/bin/''${cmakeBuildType:-Release}"/* "$out"/bin/
+  '';
+
   meta = {
     description = "OpenCL Conformance Test Suite";
     homepage = "https://github.com/KhronosGroup/OpenCL-CTS";

--- a/pkgs/development/rocm-modules/clr/default.nix
+++ b/pkgs/development/rocm-modules/clr/default.nix
@@ -263,11 +263,15 @@ stdenv.mkDerivation (finalAttrs: {
     };
 
     impureTests = {
+      # bash $(nix-build -A rocmPackages.clr.impureTests.rocm-smi)
       rocm-smi = callPackage ./test-rocm-smi.nix {
         inherit rocm-smi;
         clr = finalAttrs.finalPackage;
       };
-      # TODO(@LunNova): add OpenCL test with opencl-cts
+      # Simple subset of opencl-cts test_basic
+      opencl-cts = callPackage ./test-opencl-cts.nix {
+        clr = finalAttrs.finalPackage;
+      };
       generic-arch = callPackage ./test-isa-compat.nix {
         clr = finalAttrs.finalPackage;
         name = "generic-arch";

--- a/pkgs/development/rocm-modules/clr/test-opencl-cts.nix
+++ b/pkgs/development/rocm-modules/clr/test-opencl-cts.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  makeImpureTest,
+  opencl-cts,
+  clr,
+}:
+
+makeImpureTest {
+  name = "opencl-cts";
+  testedPackage = "rocmPackages.clr";
+
+  sandboxPaths = [
+    "/sys"
+    "/dev/dri"
+    "/dev/kfd"
+  ];
+
+  nativeBuildInputs = [ opencl-cts ];
+  OCL_ICD_VENDORS = "${clr.icd}/etc/OpenCL/vendors";
+
+  testScript = ''
+    test_basic arraycopy arrayreadwrite astype barrier vector_swizzle work_item_functions
+  '';
+
+  meta = {
+    teams = [ lib.teams.rocm ];
+  };
+}


### PR DESCRIPTION
Followup to previous PR which dropped the old broken OpenCL test.

- #498583

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
