### PR TITLE
treewide: Remove my maintainer status from some modules

### DIFF
--- a/nixos/modules/services/web-apps/freshrss.nix
+++ b/nixos/modules/services/web-apps/freshrss.nix
@@ -23,7 +23,6 @@ let
 in
 {
   meta.maintainers = with maintainers; [
-    etu
     stunkymonkey
     mattchrist
   ];

--- a/nixos/tests/docuseal-postgres.nix
+++ b/nixos/tests/docuseal-postgres.nix
@@ -2,7 +2,6 @@
 {
   name = "docuseal";
   meta.maintainers = with lib.maintainers; [
-    etu
     stunkymonkey
   ];
 

--- a/nixos/tests/docuseal-sqlite.nix
+++ b/nixos/tests/docuseal-sqlite.nix
@@ -2,7 +2,6 @@
 {
   name = "docuseal";
   meta.maintainers = with lib.maintainers; [
-    etu
     stunkymonkey
   ];
 

--- a/nixos/tests/freshrss/caddy-sqlite.nix
+++ b/nixos/tests/freshrss/caddy-sqlite.nix
@@ -2,7 +2,6 @@
 {
   name = "freshrss-caddy-sqlite";
   meta.maintainers = with lib.maintainers; [
-    etu
     stunkymonkey
   ];
 

--- a/nixos/tests/freshrss/nginx-sqlite.nix
+++ b/nixos/tests/freshrss/nginx-sqlite.nix
@@ -2,7 +2,6 @@
 {
   name = "freshrss-nginx-sqlite";
   meta.maintainers = with lib.maintainers; [
-    etu
     stunkymonkey
   ];
 

--- a/nixos/tests/freshrss/pgsql.nix
+++ b/nixos/tests/freshrss/pgsql.nix
@@ -2,7 +2,6 @@
 {
   name = "freshrss-pgsql";
   meta.maintainers = with lib.maintainers; [
-    etu
     stunkymonkey
   ];
 


### PR DESCRIPTION
I haven't had time to contribute to nixpkgs in quite some time and found some more maintainer flags.

So just removing those for now, I may still come back some day when life balance is restored.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
