### PR TITLE
lib/attrsets: use builtins.filterAttrs when available

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -659,7 +659,9 @@ rec {
 
     :::
   */
-  filterAttrs = pred: set: removeAttrs set (filter (name: !pred name set.${name}) (attrNames set));
+  filterAttrs =
+    builtins.filterAttrs
+      or (pred: set: removeAttrs set (filter (name: !pred name set.${name}) (attrNames set)));
 
   /**
     Filter an attribute set recursively by removing all attributes for


### PR DESCRIPTION
Determinate Nix provides `builtins.filterAttrs` as a native builtin, which is more efficient than the current pure-Nix implementation. This PR uses it when available, with a fallback to the existing implementation for standard Nix.

This follows the same `builtins.X or (fallback)` pattern already used for:
- `builtins.groupBy` in `lib/lists.nix`
- `builtins.zipAttrsWith` in `lib/attrsets.nix`
- `builtins.warn` in `lib/trivial.nix`
- `builtins.hasContext` in `lib/sources.nix`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test