### PR TITLE
moe: adds myself as maintainer, and package update

### DIFF
--- a/pkgs/by-name/mo/moe/package.nix
+++ b/pkgs/by-name/mo/moe/package.nix
@@ -5,21 +5,14 @@
   lzip,
   ncurses,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "moe";
-  version = "1.15";
+  version = "1.16";
 
   src = fetchurl {
     url = "mirror://gnu/moe/moe-${finalAttrs.version}.tar.lz";
-    hash = "sha256-QfjIsJnOMEeUXKTgl6YNkkPpxz+7JowZShLaiw2fCmY=";
+    hash = "sha256-TCXNeJGScq6+wKf4wSYBG7Wktdh0IoB6NCMhbwoXqGg=";
   };
-
-  prePatch = ''
-    substituteInPlace window_vector.cc --replace \
-      "insert( 0U, 1," \
-      "insert( 0U, 1U,"
-  '';
 
   nativeBuildInputs = [
     lzip
@@ -49,4 +42,3 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "moe";
   };
 })
-# TODO: a configurable, global moerc file

--- a/pkgs/by-name/mo/moe/package.nix
+++ b/pkgs/by-name/mo/moe/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
       delimiter matching, text conversion from/to UTF-8, romanization, etc.
     '';
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ videl ];
     platforms = lib.platforms.unix;
     mainProgram = "moe";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Noticed the open PR from r-ryantm https://github.com/NixOS/nixpkgs/pull/489773 for this abandoned package, so I'd like to add myself. Also contains the package update.

meta.description for moe is: Small, 8-bit clean editor

meta.homepage for moe is: https://www.gnu.org/software/moe/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
