### PR TITLE
convoyeur: init at 0.1.1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -970,6 +970,11 @@ lib.mapAttrs mkLicense (
       fullName = "libtiff License";
     };
 
+    liliq-p-11 = {
+      spdxId = "LiLiQ-P-1.1";
+      fullName = "Licence Libre du Québec – Permissive version 1.1";
+    };
+
     llgpl21 = {
       fullName = "Lisp LGPL; GNU Lesser General Public License version 2.1 with Franz Inc. preamble for clarification of LGPL terms in context of Lisp";
       url = "https://opensource.franz.com/preamble.html";

--- a/pkgs/by-name/co/convoyeur/package.nix
+++ b/pkgs/by-name/co/convoyeur/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromCodeberg,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "convoyeur";
+  version = "0.1.1";
+
+  src = fetchFromCodeberg {
+    owner = "classabbyamp";
+    repo = "convoyeur";
+    tag = "v${version}";
+    hash = "sha256-gfOmi3yyGEjGPooWocCBIO5wR5hKgz4HmbJBiIMh4RE=";
+  };
+
+  cargoHash = "sha256-rMRKTaKleO5QNeLM0jAOJ2kCKGfJxQWACWTqU8A8wt8=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "IRCv3 FILEHOST extension adapter to external file upload services";
+    homepage = "https://codeberg.org/classabbyamp/convoyeur";
+    mainProgram = "convoyeur";
+    license = lib.licenses.liliq-p-11;
+    maintainers = with lib.maintainers; [ lenny ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
