### PR TITLE
python3Packages.trezor-agent: 0.12.0 -> 0.13.0

### DIFF
--- a/pkgs/development/python-modules/trezor-agent/default.nix
+++ b/pkgs/development/python-modules/trezor-agent/default.nix
@@ -1,51 +1,41 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   trezor,
   libagent,
-  ecdsa,
-  ed25519,
-  mnemonic,
-  keepkey,
-  semver,
   setuptools,
-  wheel,
   pinentry,
+  nix-update-script,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "trezor-agent";
-  version = "0.12.0";
+  version = "0.13.0";
   format = "setuptools";
 
-  src = fetchPypi {
-    pname = "trezor_agent";
-    inherit version;
-    hash = "sha256-4IylpUvXZYAXFkyFGNbN9iPTsHff3M/RL2Eq9f7wWFU=";
+  src = fetchFromGitHub {
+    owner = "romanz";
+    repo = "trezor-agent";
+    tag = "trezor/${finalAttrs.version}";
+    hash = "sha256-hoaMsdD0LRLF5F33ECYnBRxzmtydHxT1UOkVna1hLYA=";
   };
+
+  sourceRoot = "${finalAttrs.src.name}/agents/trezor";
 
   propagatedBuildInputs = [
     setuptools
     trezor
     libagent
-    ecdsa
-    ed25519
-    mnemonic
-    keepkey
-    semver
-    wheel
     pinentry
   ];
 
-  # relax dependency constraint
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "trezor[hidapi]>=0.12.0,<0.13" "trezor[hidapi]>=0.12.0,<0.14"
-  '';
-
   doCheck = false;
   pythonImportsCheck = [ "libagent" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=trezor/(.*)" ];
+  };
 
   meta = {
     description = "Using Trezor as hardware SSH agent";
@@ -57,4 +47,4 @@ buildPythonPackage rec {
       mmahut
     ];
   };
-}
+})


### PR DESCRIPTION
Updates trezor-agent to 0.13.0.

Depends on https://github.com/NixOS/nixpkgs/pull/499027

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
