### PR TITLE
mujoco: 3.5.0 -> 3.6.0

### DIFF
--- a/pkgs/by-name/mu/mujoco/mujoco-system-deps-dont-fetch.patch
+++ b/pkgs/by-name/mu/mujoco/mujoco-system-deps-dont-fetch.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1780f874..3ac02be6 100644
+index 6c1747f3..ab69cf5e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -140,7 +140,7 @@ target_link_libraries(
+@@ -158,7 +158,7 @@ target_link_libraries(
            lodepng
            qhullstatic_r
            tinyobjloader
@@ -12,10 +12,10 @@ index 1780f874..3ac02be6 100644
  
  set_target_properties(
 diff --git a/cmake/MujocoDependencies.cmake b/cmake/MujocoDependencies.cmake
-index 5cdc33cb..a4c9f61f 100644
+index d2404bc1..5c7ddaf6 100644
 --- a/cmake/MujocoDependencies.cmake
 +++ b/cmake/MujocoDependencies.cmake
-@@ -93,8 +93,6 @@ set(BUILD_SHARED_LIBS
+@@ -87,8 +87,6 @@ set(BUILD_SHARED_LIBS
  if(NOT TARGET lodepng)
    FetchContent_Declare(
      lodepng
@@ -24,7 +24,7 @@ index 5cdc33cb..a4c9f61f 100644
    )
  
    FetchContent_GetProperties(lodepng)
-@@ -113,8 +111,6 @@ endif()
+@@ -111,8 +109,6 @@ endif()
  if(NOT TARGET marchingcubecpp)
    FetchContent_Declare(
      marchingcubecpp
@@ -33,7 +33,7 @@ index 5cdc33cb..a4c9f61f 100644
    )
  
    FetchContent_GetProperties(marchingcubecpp)
-@@ -130,13 +126,9 @@ findorfetch(
+@@ -132,13 +128,9 @@ findorfetch(
    USE_SYSTEM_PACKAGE
    OFF
    PACKAGE_NAME
@@ -48,7 +48,7 @@ index 5cdc33cb..a4c9f61f 100644
    TARGETS
    qhull
    EXCLUDE_FROM_ALL
-@@ -157,12 +149,8 @@ findorfetch(
+@@ -160,12 +152,8 @@ findorfetch(
    tinyxml2
    LIBRARY_NAME
    tinyxml2
@@ -62,7 +62,7 @@ index 5cdc33cb..a4c9f61f 100644
    EXCLUDE_FROM_ALL
  )
  target_compile_options(tinyxml2 PRIVATE ${MUJOCO_MACOS_COMPILE_OPTIONS})
-@@ -175,10 +163,6 @@ findorfetch(
+@@ -183,10 +171,6 @@ findorfetch(
    tinyobjloader
    LIBRARY_NAME
    tinyobjloader
@@ -73,16 +73,7 @@ index 5cdc33cb..a4c9f61f 100644
    TARGETS
    tinyobjloader
    EXCLUDE_FROM_ALL
-@@ -187,8 +171,6 @@ findorfetch(
- if(NOT TARGET trianglemeshdistance)
-   FetchContent_Declare(
-     trianglemeshdistance
--    GIT_REPOSITORY https://github.com/InteractiveComputerGraphics/TriangleMeshDistance.git
--    GIT_TAG ${MUJOCO_DEP_VERSION_TriangleMeshDistance}
-   )
- 
-   FetchContent_GetProperties(trianglemeshdistance)
-@@ -207,10 +189,6 @@ findorfetch(
+@@ -216,10 +200,6 @@ findorfetch(
    ccd
    LIBRARY_NAME
    ccd
@@ -93,7 +84,7 @@ index 5cdc33cb..a4c9f61f 100644
    TARGETS
    ccd
    EXCLUDE_FROM_ALL
-@@ -247,10 +225,6 @@ if(MUJOCO_BUILD_TESTS)
+@@ -261,10 +241,6 @@ if(MUJOCO_BUILD_TESTS OR MUJOCO_BUILD_STUDIO OR MUJOCO_USE_FILAMENT)
      absl
      LIBRARY_NAME
      abseil-cpp
@@ -104,7 +95,7 @@ index 5cdc33cb..a4c9f61f 100644
      TARGETS
      absl::core_headers
      EXCLUDE_FROM_ALL
-@@ -274,14 +248,9 @@ if(MUJOCO_BUILD_TESTS)
+@@ -291,14 +267,9 @@ if(MUJOCO_BUILD_TESTS)
      GTest
      LIBRARY_NAME
      googletest
@@ -121,7 +112,7 @@ index 5cdc33cb..a4c9f61f 100644
      EXCLUDE_FROM_ALL
    )
  
-@@ -308,10 +277,6 @@ if(MUJOCO_BUILD_TESTS)
+@@ -323,10 +294,6 @@ if(MUJOCO_BUILD_TESTS)
      benchmark
      LIBRARY_NAME
      benchmark
@@ -132,7 +123,7 @@ index 5cdc33cb..a4c9f61f 100644
      TARGETS
      benchmark::benchmark
      benchmark::benchmark_main
-@@ -322,14 +287,12 @@ endif()
+@@ -337,14 +304,12 @@ endif()
  
  if(MUJOCO_TEST_PYTHON_UTIL)
    add_compile_definitions(EIGEN_MPL2_ONLY)
@@ -149,7 +140,7 @@ index 5cdc33cb..a4c9f61f 100644
  
      FetchContent_GetProperties(Eigen3)
 diff --git a/python/mujoco/util/CMakeLists.txt b/python/mujoco/util/CMakeLists.txt
-index 666a3725..d89bb499 100644
+index 666a3725..8f4ce043 100644
 --- a/python/mujoco/util/CMakeLists.txt
 +++ b/python/mujoco/util/CMakeLists.txt
 @@ -63,8 +63,8 @@ if(BUILD_TESTING)
@@ -185,19 +176,8 @@ index 666a3725..d89bb499 100644
    )
    gtest_add_tests(TARGET func_wrap_test SOURCES func_wrap_test.cc)
  
-@@ -90,8 +90,8 @@ if(BUILD_TESTING)
-   target_link_libraries(
-     tuple_tools_test
-     func_wrap
--    gmock
--    gtest_main
-+    GTest::gmock
-+    GTest::gtest_main
-   )
-   gtest_add_tests(TARGET tuple_tools_test SOURCES tuple_tools_test.cc)
- endif()
 diff --git a/simulate/cmake/SimulateDependencies.cmake b/simulate/cmake/SimulateDependencies.cmake
-index 5141406c..75ff7884 100644
+index 7885f5f9..97b8b783 100644
 --- a/simulate/cmake/SimulateDependencies.cmake
 +++ b/simulate/cmake/SimulateDependencies.cmake
 @@ -81,10 +81,6 @@ findorfetch(
@@ -212,17 +192,17 @@ index 5141406c..75ff7884 100644
    glfw
    EXCLUDE_FROM_ALL
 diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
-index a286a1c6..982f2e68 100644
+index f459a6ca..6830509d 100644
 --- a/test/CMakeLists.txt
 +++ b/test/CMakeLists.txt
-@@ -81,8 +81,8 @@ target_link_libraries(
+@@ -82,8 +82,8 @@ target_link_libraries(
           absl::synchronization
           absl::flat_hash_map
           absl::flat_hash_set
 -         gtest
 -         gmock
-+         GTest::gtest
 +         GTest::gmock
++         GTest::gtest_main
           mujoco::mujoco
  )
  target_include_directories(fixture PRIVATE ${mujoco_SOURCE_DIR}/include gmock)

--- a/pkgs/by-name/mu/mujoco/package.nix
+++ b/pkgs/by-name/mu/mujoco/package.nix
@@ -25,8 +25,8 @@ let
     benchmark = fetchFromGitHub {
       owner = "google";
       repo = "benchmark";
-      rev = "5f7d66929fb66869d96dfcbacf0d8a586b33766d";
-      hash = "sha256-G9jMWq8BxKvRGP4D2/tcogdLwmek4XGYESqepnZIlCw=";
+      rev = "5c55f5d4f45a1b09c5d98aa63a671993ebd42c69";
+      hash = "sha256-CChXn58cqam3d6Q61ZJMr5NFq1Ezc5uywA7FSPhk4GI=";
     };
     ccd = fetchFromGitHub {
       owner = "danfis";
@@ -76,18 +76,12 @@ let
       rev = "f03a1b3ec29b1d7d865691ca8aea4f1eb2c2873d";
       hash = "sha256-90ei0lpJA8XuVGI0rGb3md0Qtq8/bdkU7dUCHpp88Bw=";
     };
-    trianglemeshdistance = fetchFromGitHub {
-      owner = "InteractiveComputerGraphics";
-      repo = "TriangleMeshDistance";
-      rev = "2cb643de1436e1ba8e2be49b07ec5491ac604457";
-      hash = "sha256-qG/8QKpOnUpUQJ1nLj+DFoLnUr+9oYkJPqUhwEQD2pc=";
-    };
   };
 
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "mujoco";
-  version = "3.5.0";
+  version = "3.6.0";
 
   # Bumping version? Make sure to look though the MuJoCo's commit
   # history for bumped dependency pins!
@@ -95,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "google-deepmind";
     repo = "mujoco";
     tag = finalAttrs.version;
-    hash = "sha256-5i+QQIwu8olwsMaYvO8b1vLkOkA4jZVR0xcFMuieF5w=";
+    hash = "sha256-Gxr8AH9grTjrMTHHOVseLuTC3rNuQEZRWhSvR4HgIc4=";
   };
 
   patches = [ ./mujoco-system-deps-dont-fetch.patch ];
@@ -146,10 +140,6 @@ stdenv.mkDerivation (finalAttrs: {
   + ''
     ln -s ${pin.tinyobjloader} build/_deps/tinyobjloader-src
     ln -s ${pin.tinyxml2} build/_deps/tinyxml2-src
-  ''
-  # Mujoco's cmake apply a patch on the trianglemeshdistance source code. Requires write permission.
-  + ''
-    cp -r ${pin.trianglemeshdistance} build/_deps/trianglemeshdistance-src
     ln -s ${pin.marchingcubecpp} build/_deps/marchingcubecpp-src
   '';
 

--- a/pkgs/development/python-modules/dm-control/default.nix
+++ b/pkgs/development/python-modules/dm-control/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "dm-control";
-  version = "1.0.37";
+  version = "1.0.38";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "google-deepmind";
     repo = "dm_control";
     tag = finalAttrs.version;
-    hash = "sha256-IRUAHadZMN9XCSoZj0m48lF/s/5s76Jlrdwe3BBmRNg=";
+    hash = "sha256-3Bo4XOR3iEf9H0RgMq/62CyKHua9nPU8gpYgze1GMno=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/mujoco/default.nix
+++ b/pkgs/development/python-modules/mujoco/default.nix
@@ -26,7 +26,7 @@
   python,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mujoco";
   inherit (mujoco) version;
 
@@ -37,8 +37,8 @@ buildPythonPackage rec {
   # <https://github.com/google-deepmind/mujoco/blob/main/python/make_sdist.sh>
   # in the project's CI.
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-XIWm/HVgq1+kU081/0WeEtw2CWgfMH5FfbtJtiF/TXM=";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-FcifQj4zvOCGCtcGF2O3IyNCbWNI17Lkbr3MN7EeCQU=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -61,7 +61,7 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  pythonImportsCheck = [ "${pname}" ];
+  pythonImportsCheck = [ "mujoco" ];
 
   env.MUJOCO_PATH = "${mujoco}";
   env.MUJOCO_PLUGIN_PATH = "${mujoco}/lib";
@@ -87,7 +87,7 @@ buildPythonPackage rec {
         ${lib.getExe perl} -0777 -i -pe "s/GIT_REPO\n.*\n.*GIT_TAG\n.*\n//gm" mujoco/CMakeLists.txt
         ${lib.getExe perl} -0777 -i -pe "s/(FetchContent_Declare\(\n.*lodepng\n.*)(GIT_REPO.*\n.*GIT_TAG.*\n)(.*\))/\1\3/gm" mujoco/simulate/CMakeLists.txt
 
-        build="/build/${pname}-${version}/build/temp.${platform}-cpython-${pythonVersionMajorMinor}/"
+        build="/build/${finalAttrs.pname}-${finalAttrs.version}/build/temp.${platform}-cpython-${pythonVersionMajorMinor}/"
         mkdir -p $build/_deps
         ln -s ${mujoco.pin.lodepng} $build/_deps/lodepng-src
         ln -s ${mujoco.pin.eigen3} $build/_deps/eigen-src
@@ -103,4 +103,4 @@ buildPythonPackage rec {
       tmplt
     ];
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/google-deepmind/mujoco/compare/3.5.0...3.6.0
Changelog: https://mujoco.readthedocs.io/en/3.6.0/changelog.html

cc @samuela @tmplt

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test