### PR TITLE
nixpkgs-plugin-update: disable updateScript passthru

### DIFF
--- a/pkgs/development/python-modules/nixpkgs-plugin-update/default.nix
+++ b/pkgs/development/python-modules/nixpkgs-plugin-update/default.nix
@@ -32,6 +32,9 @@ buildPythonPackage {
     mypy
   '';
 
+  # NOTE: Causes "Could not find a url in the derivations src attribute" crash in maintainer scripts
+  passthru.updateScript = null;
+
   meta = {
     description = "Library for updating plugin collections in Nixpkgs";
     license = lib.licenses.mit;


### PR DESCRIPTION
Causes error when running maintainer scripts for updating for a specific maintainer.

"/nix/store/w35a8nwnl6vbrs7xf072iz4h0bzd9lrs-nix-update-1.14.0/lib/python3.13/site-packages/nix_update/update.py", line 78, in fetch_new_version
    raise UpdateError(msg)
nix_update.errors.UpdateError: Could not find a url in the derivations src attribute


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
