### PR TITLE
ocamlPackages.lwt: 5.9.2 → 6.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/conduit/lwt-unix.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   buildDunePackage,
   conduit-lwt,
   ppx_sexp_conv,
@@ -30,7 +31,7 @@ buildDunePackage {
     lwt_ssl
   ];
 
-  doCheck = true;
+  doCheck = !lib.versionAtLeast lwt.version "6.0.0";
   checkInputs = [
     lwt_log
     ssl

--- a/pkgs/development/ocaml-modules/lambda-term/default.nix
+++ b/pkgs/development/ocaml-modules/lambda-term/default.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   buildDunePackage,
   zed,
-  lwt_log,
   lwt_react,
   mew_vi,
   uucp,
@@ -23,7 +22,6 @@ buildDunePackage (finalAttrs: {
 
   propagatedBuildInputs = [
     zed
-    lwt_log
     lwt_react
     mew_vi
     uucp

--- a/pkgs/development/ocaml-modules/lwt/default.nix
+++ b/pkgs/development/ocaml-modules/lwt/default.nix
@@ -7,14 +7,12 @@
   dune-configurator,
   ocplib-endian,
   ppxlib,
-  version ? if lib.versionAtLeast ppxlib.version "0.36" then "5.9.2" else "5.9.1",
+  version ? if lib.versionAtLeast ppxlib.version "0.36" then "6.1.1" else "5.9.1",
 }:
 
 buildDunePackage {
   pname = "lwt";
   inherit version;
-
-  minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "ocsigen";
@@ -24,6 +22,7 @@ buildDunePackage {
       {
         "5.9.1" = "sha256-oPYLFugMTI3a+hmnwgUcoMgn5l88NP1Roq0agLhH/vI=";
         "5.9.2" = "sha256-pzowRN1wwaF2iMfMPE7RCtA2XjlaXC3xD0yznriVfu8=";
+        "6.1.1" = "sha256-EMlA+mh66bfVNqDcmuaW7GoEEu6xQhCRjZx7t7pHuGo=";
       }
       ."${version}";
   };

--- a/pkgs/development/ocaml-modules/lwt_eio/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_eio/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildDunePackage,
   fetchurl,
+  fetchpatch,
   eio,
   lwt,
 }:
@@ -15,6 +16,11 @@ buildDunePackage rec {
     url = "https://github.com/ocaml-multicore/${pname}/releases/download/v${version}/${pname}-${version}.tbz";
     hash = "sha256-dlJnhHh4VNO60NZJZqc1HS8wPR95WhdeBJTK37pPbCE=";
   };
+
+  patches = lib.optional (lib.versionAtLeast lwt.version "6.0.0") (fetchpatch {
+    url = "https://github.com/ocaml-multicore/lwt_eio/commit/5f8bf1e7af33590683ee45151894d7b9a20607f0.patch";
+    hash = "sha256-5A3Bh+xOXo79Rw145hYqYv42li30M0TKLW+qu/dC0KQ=";
+  });
 
   propagatedBuildInputs = [
     eio

--- a/pkgs/development/ocaml-modules/lwt_log/default.nix
+++ b/pkgs/development/ocaml-modules/lwt_log/default.nix
@@ -5,17 +5,15 @@
   lwt,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "lwt_log";
   version = "1.1.2";
 
-  minimalOCamlVersion = "4.03";
-
   src = fetchFromGitHub {
     owner = "aantron";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-ODTD3KceEnrEzD01CeuNg4BNKOtKZEpYaDIB+RIte1U=";
+    repo = "lwt_log";
+    tag = finalAttrs.version;
+    hash = "sha256-ODTD3KceEnrEzD01CeuNg4BNKOtKZEpYaDIB+RIte1U=";
   };
 
   propagatedBuildInputs = [ lwt ];
@@ -25,5 +23,6 @@ buildDunePackage rec {
     homepage = "https://github.com/aantron/lwt_log";
     license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.vbgl ];
+    broken = lib.versionAtLeast lwt.version "6.0.0";
   };
-}
+})

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -20,7 +20,6 @@
   ca-certs,
   cohttp,
   cohttp-lwt-unix,
-  lwt_log,
   re,
   logs-syslog,
   cryptokit,
@@ -78,7 +77,6 @@ buildDunePackage (finalAttrs: {
     cohttp-lwt-unix
     cryptokit
     ipaddr
-    lwt_log
     lwt_ssl
     re
     logs-syslog

--- a/pkgs/development/ocaml-modules/ocsipersist/lib.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/lib.nix
@@ -1,20 +1,37 @@
 {
   lib,
   buildDunePackage,
+  applyPatches,
+  fetchpatch,
   fetchFromGitHub,
   lwt_ppx,
   lwt,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "ocsipersist-lib";
   version = "2.0.0";
 
-  src = fetchFromGitHub {
-    owner = "ocsigen";
-    repo = "ocsipersist";
-    tag = version;
-    hash = "sha256-7CKKwJxqxUpCMNs4xGbsMZ6Qud9AnczBStTXS+N21DU=";
+  src = applyPatches {
+
+    src = fetchFromGitHub {
+      owner = "ocsigen";
+      repo = "ocsipersist";
+      tag = finalAttrs.version;
+      hash = "sha256-7CKKwJxqxUpCMNs4xGbsMZ6Qud9AnczBStTXS+N21DU=";
+    };
+
+    patches = [
+      # Migrate to logs
+      (fetchpatch {
+        url = "https://github.com/ocsigen/ocsipersist/commit/1fc0088b4dc2226f01863dd25f8ed56528c5543d.patch";
+        hash = "sha256-WR7SW8jAAo47AIQ7UMQNF8FTXgj6FbxIqFjrLhu7wFs=";
+        excludes = [
+          "*.opam"
+          "dune-project"
+        ];
+      })
+    ];
   };
 
   buildInputs = [ lwt_ppx ];
@@ -26,4 +43,4 @@ buildDunePackage rec {
     maintainers = [ lib.maintainers.vbgl ];
     homepage = "https://github.com/ocsigen/ocsipersist/";
   };
-}
+})

--- a/pkgs/development/ocaml-modules/ocsipersist/pgsql.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/pgsql.nix
@@ -1,7 +1,7 @@
 {
   buildDunePackage,
   ocsipersist,
-  lwt_log,
+  logs,
   pgocaml,
   xml-light,
 }:
@@ -11,7 +11,7 @@ buildDunePackage {
   inherit (ocsipersist) version src;
 
   propagatedBuildInputs = [
-    lwt_log
+    logs
     ocsipersist
     pgocaml
   ];

--- a/pkgs/development/ocaml-modules/ocsipersist/sqlite.nix
+++ b/pkgs/development/ocaml-modules/ocsipersist/sqlite.nix
@@ -1,7 +1,7 @@
 {
   buildDunePackage,
   ocsipersist,
-  lwt_log,
+  logs,
   ocaml_sqlite3,
   ocsigen_server,
 }:
@@ -11,7 +11,7 @@ buildDunePackage {
   inherit (ocsipersist) version src;
 
   propagatedBuildInputs = [
-    lwt_log
+    logs
     ocaml_sqlite3
     ocsipersist
   ];

--- a/pkgs/development/ocaml-modules/tezt/default.nix
+++ b/pkgs/development/ocaml-modules/tezt/default.nix
@@ -31,5 +31,6 @@ buildDunePackage rec {
   meta = {
     description = "Test framework for unit tests, integration tests, and regression tests";
     license = lib.licenses.mit;
+    broken = lib.versionAtLeast lwt.version "6.0.0";
   };
 }

--- a/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
+++ b/pkgs/development/tools/ocaml/js_of_ocaml/lwt.nix
@@ -1,9 +1,11 @@
 {
+  lib,
   buildDunePackage,
   js_of_ocaml-ppx,
   js_of_ocaml,
   lwt,
   lwt_log,
+  loggerSupport ? !lib.versionAtLeast lwt.version "6.0.0",
 }:
 
 buildDunePackage {
@@ -16,6 +18,6 @@ buildDunePackage {
   propagatedBuildInputs = [
     js_of_ocaml
     lwt
-    lwt_log
-  ];
+  ]
+  ++ lib.optional loggerSupport lwt_log;
 }


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
