### PR TITLE
mastermind: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ma/mastermind/package.nix
+++ b/pkgs/by-name/ma/mastermind/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  installShellFiles,
+  scdoc,
+
+  # nativeInstallCheckInputs
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mastermind";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "mahyarmirrashed";
+    repo = "mastermind";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WWM3OnPJm5BvD2l5KnKrlfKqvMcyrpStcji1joq28hg=";
+  };
+
+  cargoHash = "sha256-N6zjgcaJRwRdmvIXzwFeiW1YCpRV6P2P7uj7D2EK0IQ=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    scdoc
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  postInstall = ''
+    scdoc < doc/mastermind.6.scd > mastermind.6
+    installManPage mastermind.6
+  '';
+
+  meta = {
+    description = "A game of cunning and logic";
+    homepage = "https://github.com/mahyarmirrashed/mastermind";
+    license = lib.licenses.mit;
+    mainProgram = "mastermind";
+    maintainers = with lib.maintainers; [ mahyarmirrashed ];
+  };
+})


### PR DESCRIPTION
Adds [mastermind](https://github.com/mahyarmirrashed/mastermind), a game of cunning and logic. It's nice to have more games in the nixpkgs :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
