### PR TITLE
signal-desktop: 8.1.0 -> 8.2.0

### DIFF
--- a/pkgs/by-name/si/signal-desktop/dont-strip-absolute-paths.patch
+++ b/pkgs/by-name/si/signal-desktop/dont-strip-absolute-paths.patch
@@ -1,14 +1,14 @@
 diff --git a/node/build_node_bridge.py b/node/build_node_bridge.py
-index a2da3c8b..cb5d475f 100755
---- i/node/build_node_bridge.py
-+++ w/node/build_node_bridge.py
-@@ -154,9 +154,6 @@ def main(args: Optional[List[str]] = None) -> int:
-     cargo_env['RUSTFLAGS'] += ' --cfg aes_armv8'
-     # Access tokio's unstable metrics
-     cargo_env['RUSTFLAGS'] += ' --cfg tokio_unstable'
+index 82f96eef..95261d53 100755
+--- a/node/build_node_bridge.py
++++ b/node/build_node_bridge.py
+@@ -156,9 +156,6 @@ def main(args: Optional[List[str]] = None) -> int:
+     # Work around CMake bug introduced in cmake-rs v1.49.0
+     # https://github.com/rust-lang/cmake-rs/pull/158#issuecomment-1544782070
+     cargo_env['CMAKE_ARGS'] = '-DCMAKE_SYSTEM_NAME='
 -    # Strip absolute paths
 -    for path in build_helpers.rust_paths_to_remap():
 -        cargo_env['RUSTFLAGS'] += f' --remap-path-prefix {path}='
-
+ 
      # If set (below), will post-process the build library using this instead of just `cp`-ing it.
      objcopy = None

--- a/pkgs/by-name/si/signal-desktop/libsignal-node.nix
+++ b/pkgs/by-name/si/signal-desktop/libsignal-node.nix
@@ -8,39 +8,29 @@
   gitMinimal,
   cmake,
   boringssl,
-  runCommand,
   fetchFromGitHub,
   python3,
   nodejs,
 }:
-let
-  # boring-sys expects the static libraries in build/ instead of lib/
-  boringssl-wrapper = runCommand "boringssl-wrapper" { } ''
-    mkdir $out
-    cd $out
-    ln -s ${boringssl.out}/lib build
-    ln -s ${boringssl.dev}/include include
-  '';
-in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "libsignal-node";
-  version = "0.87.1";
+  version = "0.88.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "libsignal";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yr2+yM7RmUQ7mNDMCcaM5cCpudof14JuO5J6D944k0U=";
+    hash = "sha256-te88kmhMzZWzNNnH5Mn6/lo3v6ZKNq0bC5ZFvvSH7po=";
   };
 
-  cargoHash = "sha256-rqxp+RZuuT+nFudNeCgA8g04C9KT1Qi59K4b2avL5u4=";
+  cargoHash = "sha256-ebEiReugsUrnBOimv90iqRrSjgOG+rgkraS2nb1aFD0=";
 
   npmRoot = "node";
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-npm-deps";
     inherit (finalAttrs) version src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
-    hash = "sha256-dNAHAk7UxFQvbsGSnbw3Nb0N4UARflUWL1+OE3shZMU=";
+    hash = "sha256-wsZNXlFGsZB46evQCRowmy9yU0Au3XwHQXQ6IHLJcWg=";
   };
 
   nativeBuildInputs = [
@@ -53,8 +43,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     npmHooks.npmConfigHook
     rustPlatform.bindgenHook
   ];
-  env.BORING_BSSL_PATH = "${boringssl-wrapper}";
-  env.NIX_LDFLAGS = if stdenv.hostPlatform.isDarwin then "-lc++" else "-lstdc++";
+
+  env = {
+    BORING_BSSL_INCLUDE_PATH = "${boringssl.dev}/include";
+    BORING_BSSL_PATH = boringssl;
+    NIX_LDFLAGS = if stdenv.hostPlatform.isDarwin then "-lc++" else "-lstdc++";
+  };
 
   patches = [
     # This is used to strip absolute paths of dependencies to avoid leaking info about build machine. Nix builders

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -55,13 +55,13 @@ let
     '';
   });
 
-  version = "8.1.0";
+  version = "8.2.0";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "Signal-Desktop";
     tag = "v${version}";
-    hash = "sha256-pxylCBDEHOxcJeo/117661UMHSIKS7NSVJhwU48hPiA=";
+    hash = "sha256-KejUmkTko5xg9LhswYy6qSb+8S+FhqK2cWHYSngUnVs=";
   };
 
   sticker-creator = stdenv.mkDerivation (finalAttrs: {
@@ -163,15 +163,15 @@ stdenv.mkDerivation (finalAttrs: {
     fetcherVersion = 3;
     hash =
       if withAppleEmojis then
-        "sha256-XYLpn4yXEF0xBM2XkgeeGBCDQZepLvKwDJunbefq3XU="
+        "sha256-0Cfhd5s3c4cnUv/YY07fUnsG0WKfYT+EGrHlFIkS1Zw="
       else
-        "sha256-f0aOXmjw/RtQ70qQjwuGxRxhsFMk1jaqGr2Y1YOpMGg=";
+        "sha256-WYyGBA6y/vxf1nPwiNIuXYkuk1ZbZPrM1+7VXupidjA=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
-    SOURCE_DATE_EPOCH = 1772664318;
+    SOURCE_DATE_EPOCH = 1773262210;
   }
   // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
     # Disable code signing during local macOS builds.

--- a/pkgs/by-name/si/signal-desktop/ringrtc.nix
+++ b/pkgs/by-name/si/signal-desktop/ringrtc.nix
@@ -19,16 +19,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ringrtc";
-  version = "2.64.1";
+  version = "2.65.2";
 
   src = fetchFromGitHub {
     owner = "signalapp";
     repo = "ringrtc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+OcWA7qluHM7ZUDKmO6afG2Vi6W7M8mTCI8NQL98R3A=";
+    hash = "sha256-tNdpZlXGg7Fnw/Gnk+HV2f8JIvF2PeHvEzc3VfVGWuI=";
   };
 
-  cargoHash = "sha256-cLZvnnNqvSBBO1sAoYyNB2mWhiNhSYfQxQK4wkjus8U=";
+  cargoHash = "sha256-XukHhZZxbQbFMGvYiC0AgBJG9B1FnmPOkdhE6qPxOkk=";
 
   preConfigure = ''
     # Check for matching webrtc version


### PR DESCRIPTION
Changelog: https://github.com/signalapp/Signal-Desktop/releases/tag/v8.2.0
Diff: https://github.com/signalapp/Signal-Desktop/compare/v8.1.0...v8.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
