### PR TITLE
octoprint: use headless ffmpeg by default

### DIFF
--- a/nixos/modules/services/misc/octoprint.nix
+++ b/nixos/modules/services/misc/octoprint.nix
@@ -11,7 +11,7 @@ let
   baseConfig = lib.recursiveUpdate {
     plugins.curalegacy.cura_engine = "${pkgs.curaengine_stable}/bin/CuraEngine";
     server.port = cfg.port;
-    webcam.ffmpeg = "${pkgs.ffmpeg.bin}/bin/ffmpeg";
+    webcam.ffmpeg = "${pkgs.ffmpeg-headless.bin}/bin/ffmpeg";
   } (lib.optionalAttrs (cfg.host != null) { server.host = cfg.host; });
 
   fullConfig = lib.recursiveUpdate cfg.extraConfig baseConfig;

--- a/pkgs/by-name/oc/octoprint/package.nix
+++ b/pkgs/by-name/oc/octoprint/package.nix
@@ -172,7 +172,7 @@ let
 
             # hardcore path to ffmpeg and hide related settings
             (replaceVars ./ffmpeg-path.patch {
-              ffmpeg = "${pkgs.ffmpeg}/bin/ffmpeg";
+              ffmpeg = "${pkgs.ffmpeg-headless}/bin/ffmpeg";
             })
           ];
 


### PR DESCRIPTION
ffmpeg carries many gui dependencies by default, that are not required by octoprint

Switching to ffmpeg-headless greatly reduces the closure size for most use-cases (people don't usually install octoprint on machines with gui)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
