### PR TITLE
claude-code-transcripts: init at 0.6

### DIFF
--- a/pkgs/by-name/cl/claude-code-transcripts/package.nix
+++ b/pkgs/by-name/cl/claude-code-transcripts/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "claude-code-transcripts";
+  version = "0.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = "claude-code-transcripts";
+    tag = finalAttrs.version;
+    hash = "sha256-MCs8B00K/D4rO4kWi3PlATo44rvBlQWYF7gU2c5tFrk=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail 'uv_build>=0.9.7,<0.10.0' 'uv_build'
+  '';
+
+  build-system = with python3Packages; [ uv-build ];
+  dependencies = with python3Packages; [
+    click
+    click-default-group
+    httpx
+    jinja2
+    markdown
+    questionary
+  ];
+
+  pythonImportsCheck = [ "claude_code_transcripts" ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-httpx
+    syrupy
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tools for publishing transcripts for Claude Code sessions";
+    homepage = "https://github.com/simonw/claude-code-transcripts";
+    changelog = "https://github.com/simonw/claude-code-transcripts/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "claude-code-transcripts";
+    maintainers = with lib.maintainers; [ winter ];
+  };
+})


### PR DESCRIPTION
[claude-code-transcripts](https://github.com/simonw/claude-code-transcripts) is a tool for publishing transcripts for Claude Code sessions (lol, who'd have thought).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
