### PR TITLE
calamares-nixos-extensions: Remove BIOS boot partition

### DIFF
--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/config/modules/partition.conf
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/config/modules/partition.conf
@@ -22,17 +22,7 @@ availableFileSystemTypes:
 
 showNotEncryptedBootMessage: false
 
-bios:
-    mountPoint: "/boot"
-    minimumSize: 512MiB
-    recommendedSize: 1GiB
-    label: "BOOT"
-
 partitionLayout:
-    - name: "boot"
-      filesystem: "ext4"
-      mountPoint: "/boot"
-      size: 1GiB
     - name: "root"
       filesystem: "unknown"
       noEncrypt: false


### PR DESCRIPTION
Calamares doesn't handle this well in combination with EFI support. The result is that you get an unencrypted ESP and an encrypted extra partition that isn't even mounted. Since the partition isn't even needed on BIOS systems for any purpose, just get rid of it.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
