### PR TITLE
linux/common-config: EFI_VARS_PSTORE=y

### DIFF
--- a/nixos/tests/systemd-pstore.nix
+++ b/nixos/tests/systemd-pstore.nix
@@ -1,14 +1,39 @@
 {
   name = "systemd-pstore";
 
-  nodes.machine = { };
+  nodes.machine = {
+    virtualisation.useEFIBoot = true;
+    boot.initrd.systemd.enable = true;
+    testing.initrdBackdoor = true;
+  };
 
   testScript = ''
+    machine.switch_root()
     with subtest("pstore API fs is mounted"):
       machine.succeed("stat /sys/fs/pstore")
 
     with subtest("systemd-pstore.service doesn't run because nothing crashed"):
       output = machine.execute("systemctl status systemd-pstore.service", check_return=False)[1]
       t.assertIn("condition unmet", output)
+      machine.fail("stat /var/lib/systemd/pstore/*/*/dmesg.txt")
+
+    with subtest("systemd-pstore.service saves dmesg.txt files"):
+      machine.execute("echo c > /proc/sysrq-trigger", check_return=False, check_output=False)
+      machine.wait_for_shutdown()
+      machine.switch_root()
+      machine.wait_for_unit("systemd-pstore.service")
+      machine.succeed("stat /var/lib/systemd/pstore/*/*/dmesg.txt")
+
+    with subtest("crashes in initrd can be recovered too"):
+      machine.succeed(
+        "rm -r /var/lib/systemd/pstore/*",
+        "sync",
+      )
+      machine.shutdown()
+      machine.execute("echo c > /proc/sysrq-trigger", check_return=False, check_output=False)
+      machine.wait_for_shutdown()
+      machine.switch_root()
+      machine.wait_for_unit("systemd-pstore.service")
+      machine.succeed("stat /var/lib/systemd/pstore/*/*/dmesg.txt")
   '';
 }

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1224,6 +1224,7 @@ let
         EFI = lib.mkIf stdenv.hostPlatform.isEfi yes;
         EFI_STUB = yes; # EFI bootloader in the bzImage itself
         EFI_GENERIC_STUB_INITRD_CMDLINE_LOADER = whenOlder "6.2" yes; # initrd kernel parameter for EFI
+        EFI_VARS_PSTORE = yes;
 
         # Generic compression support for EFI payloads
         # Add new platforms only after they have been verified to build and boot.

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -930,6 +930,7 @@ stdenv.mkDerivation (finalAttrs: {
             systemd-nspawn-configfile
             systemd-oomd
             systemd-portabled
+            systemd-pstore
             systemd-resolved
             systemd-shutdown
             systemd-sysupdate


### PR DESCRIPTION
This enables the kernel to save crash logs much earlier, rather than losing any log from before the efi_pstore module is loaded in stage 2.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
