### PR TITLE
ioskeley-mono: init at v2.0.0-beta.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19697,6 +19697,12 @@
     github = "Noodlesalat";
     githubId = 12748782;
   };
+  nuexq = {
+    email = "nuexqq@gmail.com";
+    github = "nuexq";
+    githubId = 145666753;
+    name = "nuexq";
+  };
   nukaduka = {
     email = "ksgokte@gmail.com";
     github = "NukaDuka";

--- a/pkgs/data/fonts/ioskeley-mono/default.nix
+++ b/pkgs/data/fonts/ioskeley-mono/default.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  installFonts,
+}:
+
+let
+  version = "v2.0.0-beta.1";
+
+  mkFont =
+    {
+      width,
+      hash,
+      isNF ? false,
+      variant ? "Hinted",
+    }:
+    let
+      variantName = lib.toLower width;
+      pkgSuffix = if isNF then "${variantName}-NF" else variantName;
+      fileName = "IoskeleyMono-${if isNF then "NerdFont-" else ""}${width}.zip";
+    in
+    stdenvNoCC.mkDerivation {
+      pname = "ioskeley-mono-${pkgSuffix}";
+      inherit version;
+
+      src = fetchzip {
+        url = "https://github.com/ahatem/IoskeleyMono/releases/download/${version}/${fileName}";
+        stripRoot = false;
+        inherit hash;
+      };
+      sourceRoot = if isNF then "." else "source/${variant}";
+
+      nativeBuildInputs = [ installFonts ];
+
+      fontDirectories = [
+        "."
+        "Hinted"
+      ];
+
+      meta = {
+        homepage = "https://github.com/ahatem/IoskeleyMono";
+        description = "Iosevka configuration mimicking Berkeley Mono (${width}${
+          if isNF then ", Nerd Font" else ""
+        })";
+        license = lib.licenses.ofl;
+        platforms = lib.platforms.all;
+        maintainers = with lib.maintainers; [ nuexq ];
+      };
+    };
+in
+{
+  normal = mkFont {
+    width = "Normal";
+    hash = "sha256-ZuV4yg6H0SayGo3LB2Naqn4axR0Lnmw95u/jiRk5B/U=";
+  };
+  normal-unhinted = mkFont {
+    width = "Normal";
+    hash = "sha256-ZuV4yg6H0SayGo3LB2Naqn4axR0Lnmw95u/jiRk5B/U=";
+    variant = "Unhinted";
+  };
+  semiCondensed = mkFont {
+    width = "SemiCondensed";
+    hash = "sha256-fOuQmf+ANuKy3kaLRbAu9RIsL3rORGJUlR/BerDg60U=";
+  };
+  semiCondensed-unhinted = mkFont {
+    width = "SemiCondensed";
+    hash = "sha256-fOuQmf+ANuKy3kaLRbAu9RIsL3rORGJUlR/BerDg60U=";
+    variant = "Unhinted";
+  };
+  condensed = mkFont {
+    width = "Condensed";
+    hash = "sha256-bzEh9YvbERZrIvXZPopHwhkSe87y3MdHhLaRGWLvTQU=";
+  };
+  condensed-unhinted = mkFont {
+    width = "Condensed";
+    hash = "sha256-bzEh9YvbERZrIvXZPopHwhkSe87y3MdHhLaRGWLvTQU=";
+    variant = "Unhinted";
+  };
+  normal-NF = mkFont {
+    width = "Normal";
+    hash = "sha256-rhSU4Md6D7hLT6EeH3TMetPgQGuiYowpYVaZqewGgh8=";
+    isNF = true;
+  };
+  semiCondensed-NF = mkFont {
+    width = "SemiCondensed";
+    hash = "sha256-W1ykPzdsoXfRBJ5YuxrjOc/J7uzwLQRjZTc9G2cj06Y=";
+    isNF = true;
+  };
+  condensed-NF = mkFont {
+    width = "Condensed";
+    hash = "sha256-TAneNRImlRNsvTr6xDCG+VKFycttbTxkP6hfh9Kr+X4=";
+    isNF = true;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3002,6 +3002,8 @@ with pkgs;
     hdf5 = hdf5-mpi.override { usev110Api = true; };
   };
 
+  ioskeley-mono = recurseIntoAttrs (callPackage ../data/fonts/ioskeley-mono { });
+
   # Not in aliases because it wouldn't get picked up by callPackage
   netbox = netbox_4_4;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR introduces `ioskeley-mono`, an Iosevka configuration designed to mimic the look and feel of Berkeley Mono as closely as possible. 

I am also adding myself (`nuexq`) to the maintainers list as this is my first contribution.

**Homepage:** https://github.com/ahatem/IoskeleyMono

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
