### PR TITLE
amf: 1.4.34-1787253 -> 1.4.37-2203192

### DIFF
--- a/pkgs/by-name/am/amdenc/package.nix
+++ b/pkgs/by-name/am/amdenc/package.nix
@@ -7,16 +7,16 @@
 }:
 
 let
-  amdgpuVersion = "6.1.3";
-  ubuntuVersion = "22.04";
+  amdgpuVersion = "6.4.4";
+  ubuntuVersion = "24.04";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "amdenc";
-  version = "1.0-1787253";
+  version = "25.10-2203192";
 
   src = fetchurl {
     url = "https://repo.radeon.com/amdgpu/${amdgpuVersion}/ubuntu/pool/proprietary/liba/libamdenc-amdgpu-pro/libamdenc-amdgpu-pro_${finalAttrs.version}.${ubuntuVersion}_amd64.deb";
-    hash = "sha256-RSkWQ3g++uKVrk5J9R8WA6qL0f+B2z8/mlflQ/cQZcg=";
+    hash = "sha256-jEvHZxTzN8TzZJuouYaOGw9xaRINA/zEg+56s/13ruw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/am/amf/package.nix
+++ b/pkgs/by-name/am/amf/package.nix
@@ -9,16 +9,16 @@
 }:
 
 let
-  amdgpuVersion = "6.1.3";
-  ubuntuVersion = "22.04";
+  amdgpuVersion = "6.4.4";
+  ubuntuVersion = "24.04";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "amf";
-  version = "1.4.34-1787253";
+  version = "1.4.37-2203192";
 
   src = fetchurl {
     url = "https://repo.radeon.com/amdgpu/${amdgpuVersion}/ubuntu/pool/proprietary/a/amf-amdgpu-pro/amf-amdgpu-pro_${finalAttrs.version}.${ubuntuVersion}_amd64.deb";
-    hash = "sha256-5sMI0ktqQDTu5xOKP9T9vjaSIHQizF1wHhqJcVnY40c=";
+    hash = "sha256-pklpKaWLrcClRRaY9jJhFZLbyFXPUY9H5UpmARrgFPU=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
There are more recent versions available at https://repo.radeon.com/amf/ but they are not compatible with RDNA 1 and 2 hardware. This is the latest version that does not break backwards compatibility.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
