### PR TITLE
volatility3: fix read-only symbol/cache paths

### DIFF
--- a/pkgs/by-name/vo/volatility3/package.nix
+++ b/pkgs/by-name/vo/volatility3/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  makeWrapper,
   python3,
 }:
 
@@ -18,6 +19,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   build-system = with python3.pkgs; [ setuptools ];
 
+  nativeBuildInputs = [ makeWrapper ];
+
   dependencies = with python3.pkgs; [
     capstone
     jsonschema
@@ -28,6 +31,18 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   preBuild = ''
     export HOME=$(mktemp -d);
+  '';
+
+  postFixup = ''
+    for executable in vol volshell; do
+      wrapProgram $out/bin/$executable \
+        --run 'volatility3_data_dir="''${XDG_DATA_HOME:-$HOME/.local/share}/volatility3"
+               mkdir -p "$volatility3_data_dir/symbols"' \
+        --run 'volatility3_cache_dir="''${XDG_CACHE_HOME:-$HOME/.cache}/volatility3"
+               mkdir -p "$volatility3_cache_dir"' \
+        --add-flags '--symbol-dirs "''${XDG_DATA_HOME:-$HOME/.local/share}/volatility3/symbols"' \
+        --add-flags '--cache-path "''${XDG_CACHE_HOME:-$HOME/.cache}/volatility3"'
+    done
   '';
 
   # Project has no tests

--- a/pkgs/by-name/vo/volatility3/package.nix
+++ b/pkgs/by-name/vo/volatility3/package.nix
@@ -59,6 +59,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       free = false;
       url = "https://www.volatilityfoundation.org/license/vsl-v1.0";
     };
-    maintainers = with lib.maintainers; [ fab ];
+    maintainers = with lib.maintainers; [
+      caverav
+      fab
+    ];
   };
 })


### PR DESCRIPTION
 ## Summary

  - Wrap `vol` and `volshell` so Volatility 3 uses writable XDG-style defaults for symbols and cache instead of trying to write under `/nix/store`
  - Add `caverav` to `volatility3`'s `meta.maintainers`

Resolves #395974
Resolves #374085

Cause: Volatility 3 includes packaged symbol directories under its installed Python module tree. On NixOS those paths live in `/nix/store` and are read-only. When Volatility needs to generate or download Windows symbols, upstream writes to the first symbol directory, which can fail against the store path.

Why wrapping: Upstream already supports `--symbol-dirs` and `--cache-path`, so nixpkgs can redirect runtime state without patching Python sources. Wrapping the installed executables is the (I think) smallest upstream-aligned fix and preserves normal CLI behavior.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

