### PR TITLE
neovim: computing python3 deps

### DIFF
--- a/pkgs/applications/editors/neovim/module.nix
+++ b/pkgs/applications/editors/neovim/module.nix
@@ -13,7 +13,7 @@ let
         optional = false;
       };
     in
-    map (x: defaultPlugin // (if (x ? plugin) then x else { plugin = x; })) plugins;
+    map (x: defaultPlugin // (if x ? plugin then x else { plugin = x; })) plugins;
 
   pluginWithConfigType =
     with lib;
@@ -78,9 +78,18 @@ in
 
     userPluginViml = lib.mkOption {
       readOnly = true;
-      type = lib.types.listOf (lib.types.lines);
+      type = lib.types.listOf lib.types.lines;
       description = ''
         The viml config set by the user.
+      '';
+    };
+
+    pluginPython3Packages = lib.mkOption {
+      readOnly = true;
+      type = lib.types.listOf (lib.types.functionTo (lib.types.listOf lib.types.package));
+      example = lib.literalExpression "[ (ps: [ ps.python-language-server ]) ]";
+      description = ''
+        Packages required by the plugins to work with the python3 provider.
       '';
     };
 
@@ -88,7 +97,7 @@ in
 
   config =
     let
-      pluginsNormalized = normalizePlugins config.plugins;
+      pluginsNormalized = config.plugins;
     in
     {
       pluginAdvisedLua =
@@ -111,5 +120,7 @@ in
       userPluginViml = lib.foldl (
         acc: p: if p.config != null then acc ++ [ p.config ] else acc
       ) [ ] pluginsNormalized;
+
+      pluginPython3Packages = map (plugin: plugin.python3Dependencies or (_: [ ])) pluginsNormalized;
     };
 }

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -99,24 +99,19 @@ let
         inherit plugins;
       };
 
-      pluginsNormalized = normalizePlugins plugins;
+      pluginsNormalized = checked_cfg.plugins;
 
       vimPackage = normalizedPluginsToVimPackage pluginsNormalized;
 
-      getDeps = attrname: map (plugin: plugin.${attrname} or (_: [ ]));
-
-      requiredPlugins = vimUtils.requiredPluginsForPackage vimPackage;
-      pluginPython3Packages = getDeps "python3Dependencies" requiredPlugins;
     in
     {
-      # plugins' python dependencies
-      inherit pluginPython3Packages;
 
       # viml config set by the user along with the plugin
       inherit (checked_cfg)
         userPluginViml
         runtimeDeps
         pluginAdvisedLua
+        pluginPython3Packages
         ;
 
       # A Vim "package", see ':h packages'


### PR DESCRIPTION
this should be a simple refactor as part of self-documenting neovim interface.
The type of `pluginPython3Packages` might be too restrictive compared to
how it's used in the while (with null ?). Hopefully it doesn't trigger too many issues.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
