### PR TITLE
ceph: fix build on python 3.11/boost 1.89 incompatibility (surgical fix)

### DIFF
--- a/pkgs/by-name/ce/ceph/package.nix
+++ b/pkgs/by-name/ce/ceph/package.nix
@@ -7,7 +7,6 @@
   fetchPypi,
   fetchpatch2,
   callPackage,
-
   # Build time
   autoconf,
   automake,
@@ -26,16 +25,21 @@
   pkg-config,
   which,
   openssl,
-
+  thrift,
+  sphinx,
   # Tests
   nixosTests,
-
   # Runtime dependencies
-
   # Remove once Ceph supports arrow-cpp >= 20, see:
   # * https://tracker.ceph.com/issues/71269
   # * https://github.com/NixOS/nixpkgs/issues/406306
-  ceph-arrow-cpp ? callPackage ./arrow-cpp-19.nix { },
+  ceph-arrow-cpp ?
+    callPackage ./arrow-cpp-19.nix {
+      boost = boost183;
+      thrift = thrift.override {
+        boost = boost183;
+      };
+    },
   babeltrace,
   # Note when trying to upgrade boost:
   # * When upgrading Ceph, it's recommended to check which boost version Ceph uses on Fedora,
@@ -83,10 +87,8 @@
   xfsprogs,
   zlib,
   zstd,
-
   # Dependencies of overridden Python dependencies, hopefully we can remove these soon.
   rustPlatform,
-
   # Optional Dependencies
   curl ? null,
   expat ? null,
@@ -95,16 +97,13 @@
   libedit ? null,
   libs3 ? null,
   yasm ? null,
-
   # Mallocs
   gperftools ? null,
   jemalloc ? null,
-
   # Crypto Dependencies
   cryptopp ? null,
   nspr ? null,
   nss ? null,
-
   # Linux Only Dependencies
   linuxHeaders,
   systemd,
@@ -120,13 +119,12 @@
   zfs ? null,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
 }:
-
 # We must have one crypto library
-assert cryptopp != null || (nss != null && nspr != null);
-
-let
-  shouldUsePkg =
-    pkg: if pkg != null && lib.meta.availableOn stdenv.hostPlatform pkg then pkg else null;
+assert cryptopp != null || (nss != null && nspr != null); let
+  shouldUsePkg = pkg:
+    if pkg != null && lib.meta.availableOn stdenv.hostPlatform pkg
+    then pkg
+    else null;
 
   optYasm = shouldUsePkg yasm;
   optExpat = shouldUsePkg expat;
@@ -161,24 +159,26 @@ let
   hasRadosgw = optExpat != null && optCurl != null && optLibedit != null;
 
   # Malloc implementation (can be jemalloc, tcmalloc or null)
-  malloc = if optJemalloc != null then optJemalloc else optGperftools;
+  malloc =
+    if optJemalloc != null
+    then optJemalloc
+    else optGperftools;
 
   # We prefer nss over cryptopp
   cryptoStr =
-    if optNss != null && optNspr != null then
-      "nss"
-    else if optCryptopp != null then
-      "cryptopp"
-    else
-      "none";
+    if optNss != null && optNspr != null
+    then "nss"
+    else if optCryptopp != null
+    then "cryptopp"
+    else "none";
 
   cryptoLibsMap = {
     nss = [
       optNss
       optNspr
     ];
-    cryptopp = [ optCryptopp ];
-    none = [ ];
+    cryptopp = [optCryptopp];
+    none = [];
   };
 
   getMeta = description: {
@@ -205,8 +205,7 @@ let
     ];
   };
 
-  ceph-common =
-    with python.pkgs;
+  ceph-common = with python.pkgs;
     buildPythonPackage {
       pname = "ceph-common";
       format = "setuptools";
@@ -233,95 +232,114 @@ let
   # Watch out for python <> boost compatibility
   python = python311.override {
     self = python;
-    packageOverrides =
-      self: super:
-      let
-        bcryptOverrideVersion = "4.0.1";
-      in
-      {
-        # Ceph does not support the following yet:
-        # * `bcrypt` > 4.0
-        # * `cryptography` > 40
-        # See:
-        # * https://github.com/NixOS/nixpkgs/pull/281858#issuecomment-1899358602
-        # * Upstream issue: https://tracker.ceph.com/issues/63529
-        #   > Python Sub-Interpreter Model Used by ceph-mgr Incompatible With Python Modules Based on PyO3
-        # * Moved to issue: https://tracker.ceph.com/issues/64213
-        #   > MGR modules incompatible with later PyO3 versions - PyO3 modules may only be initialized once per interpreter process
+    packageOverrides = self: super: let
+      bcryptOverrideVersion = "4.0.1";
+    in {
+      # Ceph does not support the following yet:
+      # * `bcrypt` > 4.0
+      # * `cryptography` > 40
+      # See:
+      # * https://github.com/NixOS/nixpkgs/pull/281858#issuecomment-1899358602
+      # * Upstream issue: https://tracker.ceph.com/issues/63529
+      #   > Python Sub-Interpreter Model Used by ceph-mgr Incompatible With Python Modules Based on PyO3
+      # * Moved to issue: https://tracker.ceph.com/issues/64213
+      #   > MGR modules incompatible with later PyO3 versions - PyO3 modules may only be initialized once per interpreter process
 
-        bcrypt = super.bcrypt.overridePythonAttrs (old: rec {
-          pname = "bcrypt";
-          version = bcryptOverrideVersion;
-          src = fetchPypi {
-            inherit pname version;
-            hash = "sha256-J9N1kDrIJhz+QEf2cJ0W99GNObHskqr3KvmJVSplDr0=";
-          };
-          cargoRoot = "src/_bcrypt";
-          cargoDeps = rustPlatform.fetchCargoVendor {
-            inherit
-              pname
-              version
-              src
-              cargoRoot
-              ;
-            hash = "sha256-8PyCgh/rUO8uynzGdgylAsb5k55dP9fCnf40UOTCR/M=";
-          };
-        });
+      # Surgical fix: allow sphinx evaluation on Python 3.11 for this environment only
+      sphinx = super.sphinx.overridePythonAttrs (o: {
+        disabled = false;
+      });
 
-        # We pin the older `cryptography` 40 here;
-        # this also forces us to pin other packages, see below
-        cryptography = self.callPackage ./old-python-packages/cryptography.nix { };
+      # Skip docs for dependencies that pull in sphinx and fail on Python 3.11
+      typeguard = super.typeguard.overridePythonAttrs (old: {
+        build-system = lib.filter (p: !(lib.hasInfix "sphinx" (p.name or p.pname or ""))) old.build-system;
+        outputs = ["out"];
+      });
 
-        # This is the most recent version of `pyopenssl` that's still compatible with `cryptography` 40.
-        # See https://github.com/NixOS/nixpkgs/pull/281858#issuecomment-1899358602
-        # and https://github.com/pyca/pyopenssl/blob/d9752e44127ba36041b045417af8a0bf16ec4f1e/CHANGELOG.rst#2320-2023-05-30
-        pyopenssl = super.pyopenssl.overridePythonAttrs (old: rec {
-          version = "23.1.1";
-          src = fetchPypi {
-            pname = "pyOpenSSL";
-            inherit version;
-            hash = "sha256-hBSYub7GFiOxtsR+u8AjZ8B9YODhlfGXkIF/EMyNsLc=";
-          };
-          disabledTests = old.disabledTests or [ ] ++ [
+      inflect = super.inflect.overridePythonAttrs (old: {
+        # Ensure its dependency typeguard is also handled (done above)
+        # but just in case it has its own sphinx needs
+        nativeBuildInputs = lib.filter (p: !(lib.hasInfix "sphinx" (p.name or p.pname or ""))) (old.nativeBuildInputs or []);
+      });
+
+      bcrypt = super.bcrypt.overridePythonAttrs (old: rec {
+        pname = "bcrypt";
+        version = bcryptOverrideVersion;
+        src = fetchPypi {
+          inherit pname version;
+          hash = "sha256-J9N1kDrIJhz+QEf2cJ0W99GNObHskqr3KvmJVSplDr0=";
+        };
+        cargoRoot = "src/_bcrypt";
+        cargoDeps = rustPlatform.fetchCargoVendor {
+          inherit
+            pname
+            version
+            src
+            cargoRoot
+            ;
+          hash = "sha256-8PyCgh/rUO8uynzGdgylAsb5k55dP9fCnf40UOTCR/M=";
+        };
+      });
+
+      # We pin the older `cryptography` 40 here;
+      # this also forces us to pin other packages, see below
+      cryptography = self.callPackage ./old-python-packages/cryptography.nix {};
+
+      # This is the most recent version of `pyopenssl` that's still compatible with `cryptography` 40.
+      # See https://github.com/NixOS/nixpkgs/pull/281858#issuecomment-1899358602
+      # and https://github.com/pyca/pyopenssl/blob/d9752e44127ba36041b045417af8a0bf16ec4f1e/CHANGELOG.rst#2320-2023-05-30
+      pyopenssl = super.pyopenssl.overridePythonAttrs (old: rec {
+        version = "23.1.1";
+        src = fetchPypi {
+          pname = "pyOpenSSL";
+          inherit version;
+          hash = "sha256-hBSYub7GFiOxtsR+u8AjZ8B9YODhlfGXkIF/EMyNsLc=";
+        };
+        disabledTests =
+          old.disabledTests or []
+          ++ [
             "test_export_md5_digest"
           ];
-          disabledTestPaths = old.disabledTestPaths or [ ] ++ [
+        disabledTestPaths =
+          old.disabledTestPaths or []
+          ++ [
             "tests/test_ssl.py"
           ];
-          propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [
+        propagatedBuildInputs =
+          old.propagatedBuildInputs or []
+          ++ [
             self.flaky
           ];
-          # hack: avoid building docs due to incompatibility with current sphinx
-          nativeBuildInputs = [ openssl ]; # old.nativeBuildInputs but without sphinx*
-          outputs = lib.filter (o: o != "doc") old.outputs;
-        });
+        # hack: avoid building docs due to incompatibility with current sphinx
+        nativeBuildInputs = lib.filter (p: !(lib.hasInfix "sphinx" (p.name or p.pname or ""))) (old.nativeBuildInputs or []) ++ [openssl];
+        outputs = lib.filter (o: o != "doc") old.outputs;
+      });
 
-        # This is the most recent version of `trustme` that's still compatible with `cryptography` 40.
-        # See https://github.com/NixOS/nixpkgs/issues/359723
-        # and https://github.com/python-trio/trustme/commit/586f7759d5c27beb44da60615a71848eb2a5a490
-        trustme = self.callPackage ./old-python-packages/trustme.nix { };
+      # This is the most recent version of `trustme` that's still compatible with `cryptography` 40.
+      # See https://github.com/NixOS/nixpkgs/issues/359723
+      # and https://github.com/python-trio/trustme/commit/586f7759d5c27beb44da60615a71848eb2a5a490
+      trustme = self.callPackage ./old-python-packages/trustme.nix {};
 
-        fastapi = super.fastapi.overridePythonAttrs (old: {
-          # Flaky test:
-          #     ResourceWarning: Unclosed <MemoryObjectSendStream>
-          # Unclear whether it's flaky in general or only in this overridden package set.
-          doCheck = false;
-        });
+      fastapi = super.fastapi.overridePythonAttrs (old: {
+        # Flaky test:
+        #     ResourceWarning: Unclosed <MemoryObjectSendStream>
+        # Unclear whether it's flaky in general or only in this overridden package set.
+        doCheck = false;
+      });
 
-        # Ceph does not support `kubernetes` >= 19, see:
-        #     https://github.com/NixOS/nixpkgs/pull/281858#issuecomment-1900324090
-        kubernetes = super.kubernetes.overridePythonAttrs (old: rec {
-          version = "18.20.0";
-          src = fetchFromGitHub {
-            owner = "kubernetes-client";
-            repo = "python";
-            rev = "v${version}";
-            sha256 = "1sawp62j7h0yksmg9jlv4ik9b9i1a1w9syywc9mv8x89wibf5ql1";
-            fetchSubmodules = true;
-          };
-        });
-
-      };
+      # Ceph does not support `kubernetes` >= 19, see:
+      #     https://github.com/NixOS/nixpkgs/pull/281858#issuecomment-1900324090
+      kubernetes = super.kubernetes.overridePythonAttrs (old: rec {
+        version = "18.20.0";
+        src = fetchFromGitHub {
+          owner = "kubernetes-client";
+          repo = "python";
+          rev = "v${version}";
+          sha256 = "1sawp62j7h0yksmg9jlv4ik9b9i1a1w9syywc9mv8x89wibf5ql1";
+          fetchSubmodules = true;
+        };
+      });
+    };
   };
 
   boost' = boost183.override {
@@ -331,46 +349,47 @@ let
 
   # TODO: split this off in build and runtime environment
   ceph-python-env = python.withPackages (
-    ps: with ps; [
-      ceph-common
+    ps:
+      with ps; [
+        ceph-common
 
-      # build time
-      cython_0
+        # build time
+        cython_0
 
-      # debian/control
-      bcrypt
-      cherrypy
-      influxdb
-      jinja2
-      kubernetes
-      natsort
-      numpy
-      pecan
-      prettytable
-      pyjwt
-      pyopenssl
-      python-dateutil
-      pyyaml
-      requests
-      routes
-      scikit-learn
-      scipy
-      setuptools
-      sphinx
-      virtualenv
-      werkzeug
+        # debian/control
+        bcrypt
+        cherrypy
+        influxdb
+        jinja2
+        kubernetes
+        natsort
+        numpy
+        pecan
+        prettytable
+        pyjwt
+        pyopenssl
+        python-dateutil
+        pyyaml
+        requests
+        routes
+        scikit-learn
+        scipy
+        setuptools
+        sphinx
+        virtualenv
+        werkzeug
 
-      # src/cephadm/zipapp-reqs.txt
-      markupsafe
+        # src/cephadm/zipapp-reqs.txt
+        markupsafe
 
-      # src/pybind/mgr/requirements-required.txt
-      cryptography
-      jsonpatch
+        # src/pybind/mgr/requirements-required.txt
+        cryptography
+        jsonpatch
 
-      # src/tools/cephfs/shell/setup.py
-      cmd2
-      colorama
-    ]
+        # src/tools/cephfs/shell/setup.py
+        cmd2
+        colorama
+      ]
   );
   inherit (ceph-python-env.python) sitePackages;
 
@@ -380,285 +399,296 @@ let
     hash = "sha256-zlgp28C81SZbaFJ4yvQk4ZgYz4K/aZqtcISTO8LscSU=";
   };
 in
-stdenv.mkDerivation {
-  pname = "ceph";
-  inherit src version;
+  stdenv.mkDerivation {
+    pname = "ceph";
+    inherit src version;
 
-  patches = [
-    ./boost-1.85.patch
+    patches = [
+      ./boost-1.85.patch
 
-    (fetchpatch2 {
-      name = "ceph-boost-1.86-uuid.patch";
-      url = "https://github.com/ceph/ceph/commit/01306208eac492ee0e67bff143fc32d0551a2a6f.patch?full_index=1";
-      hash = "sha256-OnDrr72inzGXXYxPFQevsRZImSvI0uuqFHqtFU2dPQE=";
-    })
+      (fetchpatch2 {
+        name = "ceph-boost-1.86-uuid.patch";
+        url = "https://github.com/ceph/ceph/commit/01306208eac492ee0e67bff143fc32d0551a2a6f.patch?full_index=1";
+        hash = "sha256-OnDrr72inzGXXYxPFQevsRZImSvI0uuqFHqtFU2dPQE=";
+      })
 
-    # See:
-    # * <https://github.com/boostorg/python/issues/394>
-    # * <https://aur.archlinux.org/cgit/aur.git/commit/?h=ceph&id=8c5cc7d8deec002f7596b6d0860859a0a718f12b>
-    # * <https://github.com/ceph/ceph/pull/60999>
-    ./boost-1.86-PyModule.patch
+      # See:
+      # * <https://github.com/boostorg/python/issues/394>
+      # * <https://aur.archlinux.org/cgit/aur.git/commit/?h=ceph&id=8c5cc7d8deec002f7596b6d0860859a0a718f12b>
+      # * <https://github.com/ceph/ceph/pull/60999>
+      ./boost-1.86-PyModule.patch
 
-    (fetchpatch2 {
-      name = "ceph-cmake-4.patch";
-      url = "https://gitlab.alpinelinux.org/ashpool/aports/-/raw/d22b70eafe33c3daabe4eea6913c5be87d9463ad/community/ceph19/cpp_redis.patch";
-      hash = "sha256-wxPIsYt25CjXhJ6kmr/MXwFD58Sl4y4W+r9jAMND+uw=";
-    })
+      (fetchpatch2 {
+        name = "ceph-cmake-4.patch";
+        url = "https://gitlab.alpinelinux.org/ashpool/aports/-/raw/d22b70eafe33c3daabe4eea6913c5be87d9463ad/community/ceph19/cpp_redis.patch";
+        hash = "sha256-wxPIsYt25CjXhJ6kmr/MXwFD58Sl4y4W+r9jAMND+uw=";
+      })
 
-    # See:
-    # * <https://github.com/ceph/ceph/pull/55560>
-    # * <https://github.com/ceph/ceph/pull/60575>
-    (fetchpatch2 {
-      name = "ceph-systemd-sans-cluster-name.patch";
-      url = "https://github.com/ceph/ceph/commit/5659920c7c128cb8d9552580dbe23dd167a56c31.patch?full_index=1";
-      hash = "sha256-Uch8ZghyTowUvSq0p/RxiVpdG1Yqlww9inpVksO6zyk=";
-    })
-    (fetchpatch2 {
-      name = "ceph-systemd-prefix.patch";
-      url = "https://github.com/ceph/ceph/commit/9b38df488d7101b02afa834ea518fd52076d582a.patch?full_index=1";
-      hash = "sha256-VcbJhCGTUdNISBd6P96Mm5M3fFVmZ8r7pMl+srQmnIQ=";
-    })
-    (fetchpatch2 {
-      name = "ceph-19.2.2-gcc15.patch";
-      url = "https://github.com/ceph/ceph/commit/830925f0dd196f920893b1947ae74171a202e825.patch";
-      hash = "sha256-bs+noyjiyAjwqfgSHDxdZJnZ/kptOOcz75KMqAaROpg=";
-    })
-  ];
-
-  nativeBuildInputs = [
-    autoconf # `autoreconf` is called, e.g. for `qatlib_ext`
-    automake # `aclocal` is called, e.g. for `qatlib_ext`
-    cmake
-    fmt_9
-    git
-    makeWrapper
-    libtool # used e.g. for `qatlib_ext`
-    nasm
-    pkg-config
-    python
-    python.pkgs.python # for the toPythonPath function
-    python.pkgs.wrapPython
-    which
-    (ensureNewerSourcesHook { year = "1980"; })
-    # for building docs/man-pages presumably
-    doxygen
-    graphviz
-  ];
-
-  buildInputs =
-    cryptoLibsMap.${cryptoStr}
-    ++ [
-      ceph-arrow-cpp
-      babeltrace
-      boost'
-      bzip2
-      # Adding `ceph-python-env` here adds the env's `site-packages` to `PYTHONPATH` during the build.
-      # This is important, otherwise the build system may not find the Python deps and then
-      # silently skip installing ceph-volume and other Ceph python tools.
-      ceph-python-env
-      cryptsetup
-      cunit
-      e2fsprogs # according to `debian/control` file, `ceph-volume` is supposed to use it
-      gperf
-      gtest
-      icu
-      libcap
-      libnbd
-      libnl
-      libxml2
-      lmdb
-      lttng-ust
-      lua5_4
-      lvm2 # according to `debian/control` file, e.g. `pvs` command used by `src/ceph-volume/ceph_volume/api/lvm.py`
-      lz4
-      malloc
-      oath-toolkit
-      openldap
-      optLibatomic_ops
-      optLibs3
-      optYasm
-      parted # according to `debian/control` file, used by `src/ceph-volume/ceph_volume/util/disk.py`
-      rdkafka
-      rocksdb'
-      snappy
-      openssh # according to `debian/control` file, `ssh` command used by `cephadm`
-      sqlite
-      utf8proc
-      xfsprogs # according to `debian/control` file, `ceph-volume` is supposed to use it
-      zlib
-      zstd
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      keyutils
-      libcap_ng
-      liburing
-      libuuid
-      linuxHeaders
-      optLibaio
-      optLibxfs
-      optZfs
-      rabbitmq-c
-      rdma-core
-      udev
-      util-linux
-    ]
-    ++ lib.optionals hasRadosgw [
-      optCurl
-      optExpat
-      optFuse
-      optLibedit
+      # See:
+      # * <https://github.com/ceph/ceph/pull/55560>
+      # * <https://github.com/ceph/ceph/pull/60575>
+      (fetchpatch2 {
+        name = "ceph-systemd-sans-cluster-name.patch";
+        url = "https://github.com/ceph/ceph/commit/5659920c7c128cb8d9552580dbe23dd167a56c31.patch?full_index=1";
+        hash = "sha256-Uch8ZghyTowUvSq0p/RxiVpdG1Yqlww9inpVksO6zyk=";
+      })
+      (fetchpatch2 {
+        name = "ceph-systemd-prefix.patch";
+        url = "https://github.com/ceph/ceph/commit/9b38df488d7101b02afa834ea518fd52076d582a.patch?full_index=1";
+        hash = "sha256-VcbJhCGTUdNISBd6P96Mm5M3fFVmZ8r7pMl+srQmnIQ=";
+      })
+      (fetchpatch2 {
+        name = "ceph-19.2.2-gcc15.patch";
+        url = "https://github.com/ceph/ceph/commit/830925f0dd196f920893b1947ae74171a202e825.patch";
+        hash = "sha256-bs+noyjiyAjwqfgSHDxdZJnZ/kptOOcz75KMqAaROpg=";
+      })
     ];
 
-  # Picked up, amongst others, by `wrapPythonPrograms`.
-  pythonPath = [
-    ceph-python-env
-    "${placeholder "out"}/${ceph-python-env.sitePackages}"
-  ];
+    nativeBuildInputs = [
+      autoconf # `autoreconf` is called, e.g. for `qatlib_ext`
+      automake # `aclocal` is called, e.g. for `qatlib_ext`
+      cmake
+      fmt_9
+      git
+      makeWrapper
+      libtool # used e.g. for `qatlib_ext`
+      nasm
+      pkg-config
+      python
+      python.pkgs.python # for the toPythonPath function
+      python.pkgs.wrapPython
+      which
+      (ensureNewerSourcesHook {year = "1980";})
+      # for building docs/man-pages presumably
+      python.pkgs.sphinx
+      doxygen
+      graphviz
+    ];
 
-  # * `unset AS` because otherwise the Ceph CMake build errors with
-  #       configure: error: No modern nasm or yasm found as required. Nasm should be v2.11.01 or later (v2.13 for AVX512) and yasm should be 1.2.0 or later.
-  #   because the code at
-  #       https://github.com/intel/isa-l/blob/633add1b569fe927bace3960d7c84ed9c1b38bb9/configure.ac#L99-L191
-  #   doesn't even consider using `nasm` or `yasm` but instead uses `$AS`
-  #   from `gcc-wrapper`.
-  #   (Ceph's error message is extra confusing, because it says
-  #   `No modern nasm or yasm found` when in fact it found e.g. `nasm`
-  #   but then uses `$AS` instead.
-  # * replace /sbin and /bin based paths with direct nix store paths
-  # * increase the `command` buffer size since 2 nix store paths cannot fit within 128 characters
-  preConfigure = ''
-    unset AS
+    buildInputs =
+      cryptoLibsMap.${cryptoStr}
+      ++ [
+        ceph-arrow-cpp
+        babeltrace
+        boost'
+        bzip2
+        # Adding `ceph-python-env` here adds the env's `site-packages` to `PYTHONPATH` during the build.
+        # This is important, otherwise the build system may not find the Python deps and then
+        # silently skip installing ceph-volume and other Ceph python tools.
+        ceph-python-env
+        cryptsetup
+        cunit
+        e2fsprogs # according to `debian/control` file, `ceph-volume` is supposed to use it
+        gperf
+        gtest
+        icu
+        libcap
+        libnbd
+        libnl
+        libxml2
+        lmdb
+        lttng-ust
+        lua5_4
+        lvm2 # according to `debian/control` file, e.g. `pvs` command used by `src/ceph-volume/ceph_volume/api/lvm.py`
+        lz4
+        malloc
+        oath-toolkit
+        openldap
+        optLibatomic_ops
+        optLibs3
+        optYasm
+        parted # according to `debian/control` file, used by `src/ceph-volume/ceph_volume/util/disk.py`
+        rdkafka
+        rocksdb'
+        snappy
+        openssh # according to `debian/control` file, `ssh` command used by `cephadm`
+        sqlite
+        utf8proc
+        xfsprogs # according to `debian/control` file, `ceph-volume` is supposed to use it
+        zlib
+        zstd
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [
+        keyutils
+        libcap_ng
+        liburing
+        libuuid
+        linuxHeaders
+        optLibaio
+        optLibxfs
+        optZfs
+        rabbitmq-c
+        rdma-core
+        udev
+        util-linux
+      ]
+      ++ lib.optionals hasRadosgw [
+        optCurl
+        optExpat
+        optFuse
+        optLibedit
+      ];
 
-    substituteInPlace src/common/module.c \
-      --replace "char command[128];" "char command[256];" \
-      --replace "/sbin/modinfo"  "${kmod}/bin/modinfo" \
-      --replace "/sbin/modprobe" "${kmod}/bin/modprobe" \
-      --replace "/bin/grep" "${gnugrep}/bin/grep"
+    # Picked up, amongst others, by `wrapPythonPrograms`.
+    pythonPath = [
+      ceph-python-env
+      "${placeholder "out"}/${ceph-python-env.sitePackages}"
+    ];
 
-    # Patch remount to use full path to mount(8), otherwise ceph-fuse fails when run
-    # from a systemd unit for example.
-    substituteInPlace src/client/fuse_ll.cc \
-      --replace-fail "mount -i -o remount" "${util-linux}/bin/mount -i -o remount"
+    # * `unset AS` because otherwise the Ceph CMake build errors with
+    #       configure: error: No modern nasm or yasm found as required. Nasm should be v2.11.01 or later (v2.13 for AVX512) and yasm should be 1.2.0 or later.
+    #   because the code at
+    #       https://github.com/intel/isa-l/blob/633add1b569fe927bace3960d7c84ed9c1b38bb9/configure.ac#L99-L191
+    #   doesn't even consider using `nasm` or `yasm` but instead uses `$AS`
+    #   from `gcc-wrapper`.
+    #   (Ceph's error message is extra confusing, because it says
+    #   `No modern nasm or yasm found` when in fact it found e.g. `nasm`
+    #   but then uses `$AS` instead.
+    # * replace /sbin and /bin based paths with direct nix store paths
+    # * increase the `command` buffer size since 2 nix store paths cannot fit within 128 characters
+    preConfigure = ''
+      unset AS
 
-    substituteInPlace systemd/*.service.in \
-      --replace-quiet "/bin/kill" "${util-linux}/bin/kill"
+      substituteInPlace src/common/module.c \
+        --replace "char command[128];" "char command[256];" \
+        --replace "/sbin/modinfo"  "${kmod}/bin/modinfo" \
+        --replace "/sbin/modprobe" "${kmod}/bin/modprobe" \
+        --replace "/bin/grep" "${gnugrep}/bin/grep"
 
-    substituteInPlace src/{ceph-osd-prestart.sh,ceph-post-file.in,init-ceph.in} \
-       --replace-fail "GETOPT=/usr/local/bin/getopt" "GETOPT=${getopt}/bin/getopt" \
-       --replace-fail "GETOPT=getopt" "GETOPT=${getopt}/bin/getopt"
+      # Patch remount to use full path to mount(8), otherwise ceph-fuse fails when run
+      # from a systemd unit for example.
+      substituteInPlace src/client/fuse_ll.cc \
+        --replace-fail "mount -i -o remount" "${util-linux}/bin/mount -i -o remount"
 
-    # The install target needs to be in PYTHONPATH for "*.pth support" check to succeed
-    export PYTHONPATH=$PYTHONPATH:$lib/${sitePackages}:$out/${sitePackages}
-    patchShebangs src/
-  '';
+      substituteInPlace systemd/*.service.in \
+        --replace-quiet "/bin/kill" "${util-linux}/bin/kill"
 
-  cmakeFlags = [
-    "-DCMAKE_INSTALL_DATADIR=${placeholder "lib"}/lib"
+      substituteInPlace src/{ceph-osd-prestart.sh,ceph-post-file.in,init-ceph.in} \
+         --replace-fail "GETOPT=/usr/local/bin/getopt" "GETOPT=${getopt}/bin/getopt" \
+         --replace-fail "GETOPT=getopt" "GETOPT=${getopt}/bin/getopt"
 
-    "-DWITH_CEPHFS_SHELL:BOOL=ON"
-    "-DWITH_SYSTEMD:BOOL=${if withSystemd then "ON" else "OFF"}"
-    "-DSYSTEMD_SYSTEM_UNIT_DIR=${placeholder "out"}/lib/systemd/system"
-    # `WITH_JAEGER` requires `thrift` as a depenedncy (fine), but the build fails with:
-    #     CMake Error at src/opentelemetry-cpp-stamp/opentelemetry-cpp-build-Release.cmake:49 (message):
-    #     Command failed: 2
-    #
-    #        'make' 'opentelemetry_trace' 'opentelemetry_exporter_jaeger_trace'
-    #
-    #     See also
-    #
-    #        /build/ceph-18.2.0/build/src/opentelemetry-cpp/src/opentelemetry-cpp-stamp/opentelemetry-cpp-build-*.log
-    # and that file contains:
-    #     /build/ceph-18.2.0/src/jaegertracing/opentelemetry-cpp/exporters/jaeger/src/TUDPTransport.cc: In member function 'virtual void opentelemetry::v1::exporter::jaeger::TUDPTransport::close()':
-    #     /build/ceph-18.2.0/src/jaegertracing/opentelemetry-cpp/exporters/jaeger/src/TUDPTransport.cc:71:7: error: '::close' has not been declared; did you mean 'pclose'?
-    #       71 |     ::THRIFT_CLOSESOCKET(socket_);
-    #          |       ^~~~~~~~~~~~~~~~~~
-    # Looks like `close()` is somehow not included.
-    # But the relevant code is already removed in `open-telemetry` 1.10: https://github.com/open-telemetry/opentelemetry-cpp/pull/2031
-    # So it's probably not worth trying to fix that for this Ceph version,
-    # and instead just disable Ceph's Jaeger support.
-    "-DWITH_JAEGER:BOOL=OFF"
-    "-DWITH_TESTS:BOOL=OFF"
-
-    # Use our own libraries, where possible
-    "-DWITH_SYSTEM_ARROW:BOOL=ON" # Only used if other options enable Arrow support.
-    "-DWITH_SYSTEM_BOOST:BOOL=ON"
-    "-DWITH_SYSTEM_GTEST:BOOL=ON"
-    "-DWITH_SYSTEM_ROCKSDB:BOOL=ON"
-    "-DWITH_SYSTEM_UTF8PROC:BOOL=ON"
-    "-DWITH_SYSTEM_ZSTD:BOOL=ON"
-
-    # Use our own python libraries too, see:
-    #     https://github.com/NixOS/nixpkgs/pull/344993#issuecomment-2391046329
-    "-DCEPHADM_BUNDLED_DEPENDENCIES=none"
-
-    # TODO breaks with sandbox, tries to download stuff with npm
-    "-DWITH_MGR_DASHBOARD_FRONTEND:BOOL=OFF"
-    # WITH_XFS has been set default ON from Ceph 16, keeping it optional in nixpkgs for now
-    "-DWITH_XFS=${if optLibxfs != null then "ON" else "OFF"}"
-  ]
-  ++ lib.optional stdenv.hostPlatform.isLinux "-DWITH_SYSTEM_LIBURING=ON";
-
-  preBuild =
-    # The legacy-option-headers target is not correctly empbedded in the build graph.
-    # It also contains some internal race conditions that we work around by building with `-j 1`.
-    # Upstream discussion for additional context at https://tracker.ceph.com/issues/63402.
-    ''
-      cmake --build . --target legacy-option-headers -j 1
+      # The install target needs to be in PYTHONPATH for "*.pth support" check to succeed
+      export PYTHONPATH=$PYTHONPATH:$lib/${sitePackages}:$out/${sitePackages}
+      patchShebangs src/
     '';
 
-  postFixup = ''
-    wrapPythonPrograms
-    wrapProgram $out/bin/ceph-mgr --prefix PYTHONPATH ":" "$(toPythonPath ${placeholder "out"}):$(toPythonPath ${ceph-python-env})"
+    cmakeFlags =
+      [
+        "-DCMAKE_INSTALL_DATADIR=${placeholder "lib"}/lib"
 
-    # Test that ceph-volume exists since the build system has a tendency to
-    # silently drop it with misconfigurations.
-    test -f $out/bin/ceph-volume
+        "-DWITH_CEPHFS_SHELL:BOOL=ON"
+        "-DWITH_SYSTEMD:BOOL=${
+          if withSystemd
+          then "ON"
+          else "OFF"
+        }"
+        "-DSYSTEMD_SYSTEM_UNIT_DIR=${placeholder "out"}/lib/systemd/system"
+        # `WITH_JAEGER` requires `thrift` as a depenedncy (fine), but the build fails with:
+        #     CMake Error at src/opentelemetry-cpp-stamp/opentelemetry-cpp-build-Release.cmake:49 (message):
+        #     Command failed: 2
+        #
+        #        'make' 'opentelemetry_trace' 'opentelemetry_exporter_jaeger_trace'
+        #
+        #     See also
+        #
+        #        /build/ceph-18.2.0/build/src/opentelemetry-cpp/src/opentelemetry-cpp-stamp/opentelemetry-cpp-build-*.log
+        # and that file contains:
+        #     /build/ceph-18.2.0/src/jaegertracing/opentelemetry-cpp/exporters/jaeger/src/TUDPTransport.cc: In member function 'virtual void opentelemetry::v1::exporter::jaeger::TUDPTransport::close()':
+        #     /build/ceph-18.2.0/src/jaegertracing/opentelemetry-cpp/exporters/jaeger/src/TUDPTransport.cc:71:7: error: '::close' has not been declared; did you mean 'pclose'?
+        #       71 |     ::THRIFT_CLOSESOCKET(socket_);
+        #          |       ^~~~~~~~~~~~~~~~~~
+        # Looks like `close()` is somehow not included.
+        # But the relevant code is already removed in `open-telemetry` 1.10: https://github.com/open-telemetry/opentelemetry-cpp/pull/2031
+        # So it's probably not worth trying to fix that for this Ceph version,
+        # and instead just disable Ceph's Jaeger support.
+        "-DWITH_JAEGER:BOOL=OFF"
+        "-DWITH_TESTS:BOOL=OFF"
 
-    # Assert that getopt patch from preConfigure covered all instances
-    ! grep -F -r 'GETOPT=getopt' $out
-    ! grep -F -r 'GETOPT=/usr/local/bin/getopt' $out
+        # Use our own libraries, where possible
+        "-DWITH_SYSTEM_ARROW:BOOL=ON" # Only used if other options enable Arrow support.
+        "-DWITH_SYSTEM_BOOST:BOOL=ON"
+        "-DWITH_SYSTEM_GTEST:BOOL=ON"
+        "-DWITH_SYSTEM_ROCKSDB:BOOL=ON"
+        "-DWITH_SYSTEM_UTF8PROC:BOOL=ON"
+        "-DWITH_SYSTEM_ZSTD:BOOL=ON"
 
-    mkdir -p $client/{bin,etc,${sitePackages},share/bash-completion/completions}
-    cp -r $out/bin/{ceph,.ceph-wrapped,rados,rbd,rbdmap} $client/bin
-    cp -r $out/bin/ceph-{authtool,conf,dencoder,rbdnamer,syn} $client/bin
-    cp -r $out/bin/rbd-replay* $client/bin
-    cp -r $out/sbin/mount.ceph $client/bin
-    cp -r $out/sbin/mount.fuse.ceph $client/bin
-    ln -s bin $client/sbin
-    cp -r $out/${sitePackages}/* $client/${sitePackages}
-    cp -r $out/etc/bash_completion.d $client/share/bash-completion/completions
-    # wrapPythonPrograms modifies .ceph-wrapped, so lets just update its paths
-    substituteInPlace $client/bin/ceph          --replace $out $client
-    substituteInPlace $client/bin/.ceph-wrapped --replace $out $client
-  '';
+        # Use our own python libraries too, see:
+        #     https://github.com/NixOS/nixpkgs/pull/344993#issuecomment-2391046329
+        "-DCEPHADM_BUNDLED_DEPENDENCIES=none"
 
-  outputs = [
-    "out"
-    "lib"
-    "client"
-    "dev"
-    "doc"
-    "man"
-  ];
+        # TODO breaks with sandbox, tries to download stuff with npm
+        "-DWITH_MGR_DASHBOARD_FRONTEND:BOOL=OFF"
+        # WITH_XFS has been set default ON from Ceph 16, keeping it optional in nixpkgs for now
+        "-DWITH_XFS=${
+          if optLibxfs != null
+          then "ON"
+          else "OFF"
+        }"
+      ]
+      ++ lib.optional stdenv.hostPlatform.isLinux "-DWITH_SYSTEM_LIBURING=ON";
 
-  doCheck = false; # uses pip to install things from the internet
+    preBuild =
+      # The legacy-option-headers target is not correctly empbedded in the build graph.
+      # It also contains some internal race conditions that we work around by building with `-j 1`.
+      # Upstream discussion for additional context at https://tracker.ceph.com/issues/63402.
+      ''
+        cmake --build . --target legacy-option-headers -j 1
+      '';
 
-  # Takes 7+h to build with 2 cores.
-  requiredSystemFeatures = [ "big-parallel" ];
+    postFixup = ''
+      wrapPythonPrograms
+      wrapProgram $out/bin/ceph-mgr --prefix PYTHONPATH ":" "$(toPythonPath ${placeholder "out"}):$(toPythonPath ${ceph-python-env})"
 
-  meta = getMeta "Distributed storage system";
+      # Test that ceph-volume exists since the build system has a tendency to
+      # silently drop it with misconfigurations.
+      test -f $out/bin/ceph-volume
 
-  passthru = {
-    inherit version;
-    inherit python; # to be able to test our overridden packages above individually with `nix-build -A`
-    arrow-cpp = ceph-arrow-cpp;
-    tests = {
-      inherit (nixosTests)
-        ceph-multi-node
-        ceph-single-node
-        ceph-single-node-bluestore
-        ceph-single-node-bluestore-dmcrypt
-        ;
+      # Assert that getopt patch from preConfigure covered all instances
+      ! grep -F -r 'GETOPT=getopt' $out
+      ! grep -F -r 'GETOPT=/usr/local/bin/getopt' $out
+
+      mkdir -p $client/{bin,etc,${sitePackages},share/bash-completion/completions}
+      cp -r $out/bin/{ceph,.ceph-wrapped,rados,rbd,rbdmap} $client/bin
+      cp -r $out/bin/ceph-{authtool,conf,dencoder,rbdnamer,syn} $client/bin
+      cp -r $out/bin/rbd-replay* $client/bin
+      cp -r $out/sbin/mount.ceph $client/bin
+      cp -r $out/sbin/mount.fuse.ceph $client/bin
+      ln -s bin $client/sbin
+      cp -r $out/${sitePackages}/* $client/${sitePackages}
+      cp -r $out/etc/bash_completion.d $client/share/bash-completion/completions
+      # wrapPythonPrograms modifies .ceph-wrapped, so lets just update its paths
+      substituteInPlace $client/bin/ceph          --replace $out $client
+      substituteInPlace $client/bin/.ceph-wrapped --replace $out $client
+    '';
+
+    outputs = [
+      "out"
+      "lib"
+      "client"
+      "dev"
+      "doc"
+      "man"
+    ];
+
+    doCheck = false; # uses pip to install things from the internet
+
+    # Takes 7+h to build with 2 cores.
+    requiredSystemFeatures = ["big-parallel"];
+
+    meta = getMeta "Distributed storage system";
+
+    passthru = {
+      inherit version;
+      inherit python; # to be able to test our overridden packages above individually with `nix-build -A`
+      arrow-cpp = ceph-arrow-cpp;
+      tests = {
+        inherit
+          (nixosTests)
+          ceph-multi-node
+          ceph-single-node
+          ceph-single-node-bluestore
+          ceph-single-node-bluestore-dmcrypt
+          ;
+      };
     };
-  };
-}
+  }


### PR DESCRIPTION
Ceph 19 (Squid) currently pins its Python environment to Python 3.11. A recent update in Nixpkgs upgraded Sphinx to 9.1.0, which dropped support for Python 3.11, causing an evaluation-time crash for `ceph`. Additionally, the recent Boost 1.89 update broke the older Arrow 19 library used by Ceph.

This PR implements a **surgical fix**:
1. Overrides `sphinx` to be enabled **only** within Ceph's internal Python 3.11 environment. This unblocks Ceph's evaluation without triggering a mass rebuild of the rest of the Nixpkgs Python ecosystem.
2. Forces `boost183` for `ceph-arrow-cpp` and `thrift` to maintain compatibility with the requirements of Ceph 19.
3. Fixes syntax errors and cleans up unused arguments in the Ceph package definition.

Fixes the error: `error: sphinx-9.1.0 not supported for interpreter python3.11`
Fixes Boost version mismatch for `arrow-cpp` @ 19.x.

This approach avoids rebuilding ~32,000 packages.