### PR TITLE
makeOverridable: set meta.position

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -151,6 +151,37 @@ rec {
     :::
   */
   makeOverridable =
+    let
+      positionFrom =
+        attrs:
+        if attrs == { } then
+          null
+        else
+          let
+            loc = unsafeGetAttrPos (head (attrNames attrs)) attrs;
+          in
+          if loc == null then null else "${loc.file}:${toString loc.line}";
+      updateMeta =
+        position: result:
+        if position != null && isDerivation result && result ? meta then
+          extendDerivation true {
+            meta = result.meta // {
+              inherit position;
+            };
+
+            # extendDerivation is weird about this and I'm afraid to change it
+            # with all the TODOs floating around in there. If you do, check
+            # that
+            #
+            #     ((pkg.override ...).dev.overrideAttrs ...).outputName == "dev"
+            #
+            # for a package with a dev output, which is not true right now
+            # unless I do this.
+            ${if result ? overrideAttrs then "overrideAttrs" else null} = result.overrideAttrs;
+          } result
+        else
+          result;
+    in
     f:
     let
       # Creates a functor with the same arguments as f
@@ -178,9 +209,6 @@ rec {
       let
         result = f origArgs;
 
-        # Changes the original arguments with (potentially a function that returns) a set of new attributes
-        overrideWith = newArgs: origArgs // (if isFunction newArgs then newArgs origArgs else newArgs);
-
         # Re-call the function but with different arguments
         overrideArgs = mirrorArgs (
           /**
@@ -190,7 +218,13 @@ rec {
 
             This function was provided by `lib.makeOverridable`.
           */
-          newArgs: makeOverridable f (overrideWith newArgs)
+          newArgs:
+          let
+            overlay = if isFunction newArgs then newArgs origArgs else newArgs;
+          in
+          makeOverridable (mirrorArgs (finalArgs: updateMeta (positionFrom overlay) (f finalArgs))) (
+            origArgs // overlay
+          )
         );
         # Change the result of the function call by applying g to it
         overrideResult = g: makeOverridable (mirrorArgs (args: g (f args))) origArgs;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -96,6 +96,7 @@ let
               let
                 prev = f final;
                 thisOverlay = overlay final prev;
+                pos = builtins.unsafeGetAttrPos (head (attrNames thisOverlay)) thisOverlay;
                 warnForBadVersionOverride = (
                   prev ? src
                   && thisOverlay ? version
@@ -108,28 +109,37 @@ let
                 );
                 pname = args.pname or "<unknown name>";
                 version = args.version or "<unknown version>";
-                pos = builtins.unsafeGetAttrPos "version" thisOverlay;
+                versionPos = builtins.unsafeGetAttrPos "version" thisOverlay;
               in
-              lib.warnIf warnForBadVersionOverride ''
-                ${
-                  args.name or "${pname}-${version}"
-                } was overridden with `version` but not `src` at ${pos.file or "<unknown file>"}:${
-                  toString pos.line or "<unknown line>"
-                }:${toString pos.column or "<unknown column>"}.
+              if thisOverlay == { } then
+                prev
+              else
+                lib.warnIf warnForBadVersionOverride
+                  ''
+                    ${args.name or "${pname}-${version}"} was overridden with `version` but not `src` at ${
+                      versionPos.file or "<unknown file>"
+                    }:${toString versionPos.line or "<unknown line>"}:${
+                      toString versionPos.column or "<unknown column>"
+                    }.
 
-                This is most likely not what you want. In order to properly change the version of a package, override
-                both the `version` and `src` attributes:
+                    This is most likely not what you want. In order to properly change the version of a package, override
+                    both the `version` and `src` attributes:
 
-                hello.overrideAttrs (oldAttrs: rec {
-                  version = "1.0.0";
-                  src = pkgs.fetchurl {
-                    url = "mirror://gnu/hello/hello-''${version}.tar.gz";
-                    hash = "...";
-                  };
-                })
+                    hello.overrideAttrs (oldAttrs: rec {
+                      version = "1.0.0";
+                      src = pkgs.fetchurl {
+                        url = "mirror://gnu/hello/hello-''${version}.tar.gz";
+                        hash = "...";
+                      };
+                    })
 
-                (To silence this warning, set `__intentionallyOverridingVersion = true` in your `overrideAttrs` call.)
-              '' (prev // (removeAttrs thisOverlay [ "__intentionallyOverridingVersion" ]))
+                    (To silence this warning, set `__intentionallyOverridingVersion = true` in your `overrideAttrs` call.)
+                  ''
+                  (
+                    prev
+                    // removeAttrs thisOverlay [ "__intentionallyOverridingVersion" ]
+                    // optionalAttrs (pos != null) { inherit pos; }
+                  )
             );
         in
         makeDerivationExtensible (extends' (lib.toExtension f0) rattrs);


### PR DESCRIPTION
Less memory-hungry alternative to #498346. Still inspired by #495822.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
