### PR TITLE
nimlsp:0.4.6 -> 0-unstable-09-02-2026

### DIFF
--- a/pkgs/by-name/cl/clash-rs/Cargo.patch
+++ b/pkgs/by-name/cl/clash-rs/Cargo.patch
@@ -1,15 +1,15 @@
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1249,7 +1249,7 @@
-  "sha2",
+@@ -1265,7 +1265,7 @@
+  "sha2 0.10.9",
   "shadowquic",
   "shadowsocks",
 - "smoltcp 0.12.0 (git+https://github.com/smoltcp-rs/smoltcp.git?rev=ac32e64)",
 + "smoltcp",
   "sock2proc",
-  "socket2 0.6.1",
-  "tempfile",
-@@ -4234,7 +4234,7 @@
+  "socket2 0.6.2",
+  "ssh-key",
+@@ -4636,7 +4636,7 @@
   "etherparse 0.16.0",
   "futures",
   "rand 0.8.5",
@@ -18,7 +18,7 @@
   "spin 0.9.8",
   "tokio",
   "tokio-util",
-@@ -6632,20 +6632,6 @@
+@@ -7293,20 +7293,6 @@
  ]
  
  [[package]]
@@ -38,13 +38,13 @@
 -[[package]]
  name = "sock2proc"
  version = "0.1.0"
- source = "git+https://github.com/Watfaq/sock2proc.git?rev=1097e6b#1097e6ba692025f80567446e0035af1222f5231f"
-@@ -8964,7 +8950,7 @@
+ source = "git+https://github.com/Watfaq/sock2proc.git?rev=9f9e630#9f9e6304d62285115b2e4fa632527ae563bf0fcc"
+@@ -9797,7 +9783,7 @@
   "netstack-lwip",
   "netstack-smoltcp",
   "rand 0.9.2",
 - "smoltcp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 + "smoltcp",
-  "socket2 0.6.1",
+  "socket2 0.6.2",
   "tokio",
   "tracing",

--- a/pkgs/by-name/cl/clash-rs/package.nix
+++ b/pkgs/by-name/cl/clash-rs/package.nix
@@ -10,16 +10,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clash-rs";
-  version = "0.9.4";
+  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner = "Watfaq";
     repo = "clash-rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WtNnBw0/eAz/uO/dlD2yRZHW38CXIT8zhh4lZ3HaIFs=";
+    hash = "sha256-ymxT6AGBDTfiMbpU4Ou/SwAnUZF3vKvtt/BgWRtQTJc=";
   };
 
-  cargoHash = "sha256-8SLBsYtO6qVihc/C9R3ZptHCKgl2iXiQrOWqgDBXdTc=";
+  cargoHash = "sha256-G1RLUFnQVX6tbLIF6ql6RDGZUwGPGFBHgx15KT3/tNQ=";
 
   cargoPatches = [ ./Cargo.patch ];
 
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env = {
     # requires features: sync_unsafe_cell, unbounded_shifts, let_chains, ip
     RUSTC_BOOTSTRAP = 1;
-    RUSTFLAGS = "--cfg tokio_unstable";
+    RUSTFLAGS = "--cfg tokio_unstable -A stable_features";
     NIX_CFLAGS_COMPILE = "-Wno-error";
   };
 

--- a/pkgs/by-name/ni/nimlsp/package.nix
+++ b/pkgs/by-name/ni/nimlsp/package.nix
@@ -3,25 +3,17 @@
   buildNimPackage,
   fetchFromGitHub,
   srcOnly,
-  nim-2_0,
-  nim-unwrapped-2_0,
-}:
-
-let
-  buildNimPackage' = buildNimPackage.override {
-    # Do not build with Nim-2.2.x.
-    nim2 = nim-2_0;
-  };
-in
-buildNimPackage' (finalAttrs: {
+  nim,
+  nim-unwrapped,
+}: buildNimPackage ({
   pname = "nimlsp";
-  version = "0.4.6";
+  version = "0-unstable-09-02-2026";
 
   src = fetchFromGitHub {
     owner = "PMunch";
     repo = "nimlsp";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-MCtpCx8jMQp0VXuMowh69d1DQreU5cDftBf0lww7PUM=";
+    rev = "5fa2846f04600c2cf1173625976e037389db4489";
+    hash = "sha256-lpOhlKWbHej0OATdqnCA0Dv7S89v76wRMNwuTVsH4nw=";
   };
 
   lockFile = ./lock.json;
@@ -40,7 +32,7 @@ buildNimPackage' (finalAttrs: {
 
   nimFlags = [
     "--threads:on"
-    "-d:explicitSourcePath=${srcOnly nim-unwrapped-2_0}"
+    "-d:explicitSourcePath=${srcOnly nim-unwrapped}"
     "-d:tempDir=/tmp"
   ];
 
@@ -58,6 +50,6 @@ buildNimPackage' (finalAttrs: {
     homepage = "https://github.com/PMunch/nimlsp";
     license = lib.licenses.mit;
     mainProgram = "nimlsp";
-    maintainers = with lib.maintainers; [ xtrayambak ];
+    maintainers = with lib.maintainers; [ xtrayambak zodman ];
   };
 })


### PR DESCRIPTION
The latest version of the nimlsp requires upstream version of nim.

That means if you want Nimlsp running, it requires the latest version of Nim.

For that, I drop the version to unstable...

cc @xTrayambak the other maintainer 