### PR TITLE
imagemagick: add libultrahdr support flag

### DIFF
--- a/pkgs/by-name/im/imagemagick/package.nix
+++ b/pkgs/by-name/im/imagemagick/package.nix
@@ -41,6 +41,8 @@
   pango,
   libtiffSupport ? true,
   libtiff,
+  libultrahdrSupport ? true,
+  libultrahdr,
   libxml2Support ? true,
   libxml2,
   openjpegSupport ? !stdenv.hostPlatform.isMinGW,
@@ -115,6 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.withFeature librsvgSupport "pango")
     (lib.withFeature liblqr1Support "lqr")
     (lib.withFeature libjxlSupport "jxl")
+    (lib.withFeature libultrahdrSupport "uhdr")
     (lib.withFeatureAs ghostscriptSupport "gs-font-dir" "${ghostscript.fonts}/share/fonts")
     (lib.withFeature ghostscriptSupport "gslib")
     (lib.withFeature fftwSupport "fftw")
@@ -141,6 +144,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional libraqmSupport libraqm
   ++ lib.optional librawSupport libraw
   ++ lib.optional libtiffSupport libtiff
+  ++ lib.optional libultrahdrSupport libultrahdr
   ++ lib.optional libxml2Support libxml2
   ++ lib.optional libheifSupport libheif
   ++ lib.optional djvulibreSupport djvulibre


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add `libultrahdrSupport` flag to enable building with `uhdr` feature. 
https://imagemagick.org/script/formats.php#gsc.tab=0

No idea if it should be true by default, please advise.

```
./result/bin/magick -version
Version: ImageMagick 7.1.2-13 Q16-HDRI x86_64 2fae24192:20260118 https://imagemagick.org
Copyright: (C) 1999 ImageMagick Studio LLC
License: https://imagemagick.org/license/
Features: Cipher DPC HDRI OpenMP(4.5) 
Delegates (built-in): bzlib cairo djvu fftw fontconfig freetype heic jng jp2 jpeg jxl lcms lqr openexr pangocairo png raqm raw rsvg tiff uhdr webp x xml zlib zstd
Compiler: gcc (15.2)
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
