### PR TITLE
nimlsp: 0.4.6 -> 0-unstable-09-02-2026

### DIFF
--- a/pkgs/by-name/cl/clash-rs/Cargo.patch
+++ b/pkgs/by-name/cl/clash-rs/Cargo.patch
@@ -1,15 +1,15 @@
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1249,7 +1249,7 @@
-  "sha2",
+@@ -1265,7 +1265,7 @@
+  "sha2 0.10.9",
   "shadowquic",
   "shadowsocks",
 - "smoltcp 0.12.0 (git+https://github.com/smoltcp-rs/smoltcp.git?rev=ac32e64)",
 + "smoltcp",
   "sock2proc",
-  "socket2 0.6.1",
-  "tempfile",
-@@ -4234,7 +4234,7 @@
+  "socket2 0.6.2",
+  "ssh-key",
+@@ -4636,7 +4636,7 @@
   "etherparse 0.16.0",
   "futures",
   "rand 0.8.5",
@@ -18,7 +18,7 @@
   "spin 0.9.8",
   "tokio",
   "tokio-util",
-@@ -6632,20 +6632,6 @@
+@@ -7293,20 +7293,6 @@
  ]
  
  [[package]]
@@ -38,13 +38,13 @@
 -[[package]]
  name = "sock2proc"
  version = "0.1.0"
- source = "git+https://github.com/Watfaq/sock2proc.git?rev=1097e6b#1097e6ba692025f80567446e0035af1222f5231f"
-@@ -8964,7 +8950,7 @@
+ source = "git+https://github.com/Watfaq/sock2proc.git?rev=9f9e630#9f9e6304d62285115b2e4fa632527ae563bf0fcc"
+@@ -9797,7 +9783,7 @@
   "netstack-lwip",
   "netstack-smoltcp",
   "rand 0.9.2",
 - "smoltcp 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 + "smoltcp",
-  "socket2 0.6.1",
+  "socket2 0.6.2",
   "tokio",
   "tracing",

--- a/pkgs/by-name/cl/clash-rs/package.nix
+++ b/pkgs/by-name/cl/clash-rs/package.nix
@@ -10,16 +10,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clash-rs";
-  version = "0.9.4";
+  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner = "Watfaq";
     repo = "clash-rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WtNnBw0/eAz/uO/dlD2yRZHW38CXIT8zhh4lZ3HaIFs=";
+    hash = "sha256-ymxT6AGBDTfiMbpU4Ou/SwAnUZF3vKvtt/BgWRtQTJc=";
   };
 
-  cargoHash = "sha256-8SLBsYtO6qVihc/C9R3ZptHCKgl2iXiQrOWqgDBXdTc=";
+  cargoHash = "sha256-G1RLUFnQVX6tbLIF6ql6RDGZUwGPGFBHgx15KT3/tNQ=";
 
   cargoPatches = [ ./Cargo.patch ];
 
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env = {
     # requires features: sync_unsafe_cell, unbounded_shifts, let_chains, ip
     RUSTC_BOOTSTRAP = 1;
-    RUSTFLAGS = "--cfg tokio_unstable";
+    RUSTFLAGS = "--cfg tokio_unstable -A stable_features";
     NIX_CFLAGS_COMPILE = "-Wno-error";
   };
 


### PR DESCRIPTION
Moving away from the version to the latest version.

The main reason in upstream it's because:

nimlsp depends on the nimsuggest sources from nim.



cc @xtrayambak