### PR TITLE
dotnetCorePackages.combinePackages: fix runtime discovery with SDK 10+

### DIFF
--- a/pkgs/development/compilers/dotnet/combine-packages.nix
+++ b/pkgs/development/compilers/dotnet/combine-packages.nix
@@ -36,6 +36,13 @@ mkWrapper "sdk" (
     ignoreCollisions = true;
     nativeBuildInputs = [ makeWrapper ];
     postBuild = ''
+      # resolve symlinks so DOTNET_ROOT is self-contained
+      # .NET SDK 10+ resolves symlinks when finding the muxer, bypassing
+      # the combined directory and finding only a single runtime version
+      mv "$out"/share/dotnet{,~}
+      cp -Lr "$out"/share/dotnet{~,}
+      rm -r "$out"/share/dotnet~
+
       mkdir -p "$out"/share/dotnet
       cp "${cli}"/share/dotnet/dotnet $out/share/dotnet
       cp -R "${cli}"/nix-support "$out"/

--- a/pkgs/development/compilers/dotnet/default.nix
+++ b/pkgs/development/compilers/dotnet/default.nix
@@ -120,13 +120,6 @@ let
             ]).unwrapped.overrideAttrs
               (old: {
                 name = fallback.unwrapped.name;
-                # resolve symlinks so DOTNET_ROOT is self-contained
-                postBuild = ''
-                  mv "$out"/share/dotnet{,~}
-                  cp -Lr "$out"/share/dotnet{~,}
-                  rm -r "$out"/share/dotnet~
-                ''
-                + old.postBuild;
                 passthru = old.passthru // {
                   inherit (base)
                     runtime


### PR DESCRIPTION
`combinePackages` is broken with SDK 10+. When you combine multiple dotnet versions, projects targeting older frameworks (net9.0, net8.0, etc.) fail with "You must install or update .NET to run this application."
   
The problem: SDK 10 changed how it finds the `dotnet` muxer (dotnet/sdk@69ae64b). It now walks up two directories from `AppContext.BaseDirectory` (`sdk/<version>/` -> root) instead of checking `DOTNET_HOST_PATH` or `DOTNET_ROOT` first. Since `buildEnv` creates symlinks, this resolves back to the individual SDK store path, where only one runtime version exists.
   
The fix: resolve symlinks with `cp -Lr` in `combinePackages` postBuild, so the combined directory is self-contained. This is the same approach `combineSdk` in `default.nix` already used (that redundant copy is removed here since `combinePackages` now handles it).
   
Fixes #464575

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
