### PR TITLE
[Backport release-25.11] open-webui: fix self-reference of mariadb

### DIFF
--- a/nixos/tests/open-webui.nix
+++ b/nixos/tests/open-webui.nix
@@ -1,4 +1,9 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   mainPort = "8080";
   webuiName = "NixOS Test";
@@ -16,6 +21,10 @@ in
         services.open-webui = {
           enable = true;
           host = "";
+          # Use package with all optional dependencies to ensure they are buildable
+          package = pkgs.open-webui.overridePythonAttrs (old: {
+            dependencies = old.dependencies ++ pkgs.open-webui.optional-dependencies.all;
+          });
           environment = {
             # Requires network connection
             RAG_EMBEDDING_MODEL = "";

--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -203,7 +203,7 @@ python3Packages.buildPythonApplication rec {
     ];
 
     mariadb = [
-      mariadb
+      python3Packages.mariadb
     ];
 
     all = [
@@ -212,7 +212,6 @@ python3Packages.buildPythonApplication rec {
       elasticsearch
       firecrawl-py
       gcp-storage-emulator
-      mariadb
       moto
       oracledb
       pinecone-client
@@ -222,8 +221,9 @@ python3Packages.buildPythonApplication rec {
       qdrant-client
       weaviate-client
     ]
-    ++ moto.optional-dependencies.s3
-    ++ postgres;
+    ++ mariadb
+    ++ postgres
+    ++ moto.optional-dependencies.s3;
   };
 
   pythonImportsCheck = [ "open_webui" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backporting #498948 to `release-25.11` to fix self-reference of `mariadb`. **Manually created** due to `buildPythonApplication` does not take functions (`finalAttrs: { }`) in `25.11` branch, refer #499042

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
