### PR TITLE
gati: init at 0.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29872,6 +29872,12 @@
     githubId = 22890520;
     matrix = "@yusufraji49:matrix.org";
   };
+  yutaura = {
+    email = "yuuta3594@gmail.com";
+    github = "YutaUra";
+    githubId = 45471709;
+    name = "Yuta Ura";
+  };
   yvan-sraka = {
     email = "yvan@sraka.xyz";
     github = "yvan-sraka";

--- a/pkgs/by-name/ga/gati/package.nix
+++ b/pkgs/by-name/ga/gati/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gati";
-  version = "0.5.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "YutaUra";
     repo = "gati";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0zuu3bewFQ2ArlLxBRS6JMJPCyqZCOd/R+vCo9ZahvA=";
+    hash = "sha256-Pp/yWZvGJq0t0HmKBbNKydBBv30aqqMO/DVp1lTrXXg=";
   };
 
-  cargoHash = "sha256-uEukQsY57ZtShJhor4856zw+9lmBDkPn2kl6mjsBxIM=";
+  cargoHash = "sha256-lHgxkelhRXYbYWdtwgYzgi9IYOD9VjKnXYtu+UKXzPI=";
 
   nativeBuildInputs = [
     pkg-config
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [ oniguruma ];
 
-  RUSTONIG_SYSTEM_LIBONIG = 1;
+  env.RUSTONIG_SYSTEM_LIBONIG = 1;
 
   # cli_clipboard requires a display server, unavailable in the sandbox
   checkFlags = [ "--skip=app::tests::export_sets_flash_message_on_success" ];
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "A terminal tool for reviewing code, not writing it";
+    description = "Terminal tool for reviewing code, not writing it";
     homepage = "https://github.com/YutaUra/gati";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yutaura ];

--- a/pkgs/by-name/ga/gati/package.nix
+++ b/pkgs/by-name/ga/gati/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  oniguruma,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gati";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "YutaUra";
+    repo = "gati";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0zuu3bewFQ2ArlLxBRS6JMJPCyqZCOd/R+vCo9ZahvA=";
+  };
+
+  cargoHash = "sha256-uEukQsY57ZtShJhor4856zw+9lmBDkPn2kl6mjsBxIM=";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
+
+  buildInputs = [ oniguruma ];
+
+  RUSTONIG_SYSTEM_LIBONIG = 1;
+
+  # cli_clipboard requires a display server, unavailable in the sandbox
+  checkFlags = [ "--skip=app::tests::export_sets_flash_message_on_success" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A terminal tool for reviewing code, not writing it";
+    homepage = "https://github.com/YutaUra/gati";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yutaura ];
+    mainProgram = "gati";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
[gati](https://github.com/YutaUra/gati) is a terminal tool for reviewing code, not writing it.

It provides a TUI for navigating file trees, viewing syntax-highlighted diffs, and adding inline review comments with clipboard export.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test