### PR TITLE
spandsp: fix url and patch UB on ppc64be

### DIFF
--- a/pkgs/development/libraries/spandsp/common.nix
+++ b/pkgs/development/libraries/spandsp/common.nix
@@ -220,6 +220,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ misuzu ];
     teams = [ lib.teams.ngi ];
     license = lib.licenses.gpl2;
-    downloadPage = "http://www.soft-switch.org/downloads/spandsp/";
+    downloadPage = "https://github.com/freeswitch/spandsp";
   };
 })

--- a/pkgs/development/libraries/spandsp/common.nix
+++ b/pkgs/development/libraries/spandsp/common.nix
@@ -176,6 +176,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Seemingly runs forever, with tons of output
     "v22bis_tests"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isPower64 [
+    # Output differs from x86-generated reference due to float precision
+    "lpc10_tests"
   ];
 
   checkPhase = ''

--- a/pkgs/development/libraries/spandsp/common.nix
+++ b/pkgs/development/libraries/spandsp/common.nix
@@ -40,6 +40,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     # https://github.com/freeswitch/spandsp/pull/111
     ./Fix-tests-pcap_parse-build-on-musl.patch
+
+    # https://github.com/freeswitch/spandsp/pull/116
+    ./fix-bit-operations-ub.patch
   ]
   ++ patches;
 

--- a/pkgs/development/libraries/spandsp/default.nix
+++ b/pkgs/development/libraries/spandsp/default.nix
@@ -7,7 +7,7 @@
 (callPackage ./common.nix { }) rec {
   version = "0.0.6";
   src = fetchurl {
-    url = "https://www.soft-switch.org/downloads/spandsp/spandsp-${version}.tar.gz";
+    url = "https://src.fedoraproject.org/lookaside/pkgs/spandsp/spandsp-${version}.tar.gz/897d839516a6d4edb20397d4757a7ca3/spandsp-${version}.tar.gz";
     sha256 = "0rclrkyspzk575v8fslzjpgp4y2s4x7xk3r55ycvpi4agv33l1fc";
   };
   patches = [

--- a/pkgs/development/libraries/spandsp/fix-bit-operations-ub.patch
+++ b/pkgs/development/libraries/spandsp/fix-bit-operations-ub.patch
@@ -1,0 +1,53 @@
+From 6366823f4c6a1641543a0f3859afcafccf2e47af Mon Sep 17 00:00:00 2001
+From: Amaan Qureshi <git@amaanq.com>
+Date: Wed, 11 Mar 2026 23:34:26 -0400
+Subject: [PATCH] tests: fix undefined behavior in `bit_operations_tests`
+
+The `most_significant_one32`/`least_significant_one32` test loop
+started at `i = -1`, which produces a shift of `1U << -1`. This is
+undefined behavior per the C standard, as the shift count must be in
+`[0, bit_width)`. On x86 this happened to produce `0x80000000` due to
+masking the shift count to 5 bits, but on ppc64be it produces `0`,
+causing a spurious test failure.
+
+This commit starts the loop at `i = 0` instead. Testing the zero-input
+case is not meaningful here since `most_significant_one32(0)` itself
+invokes UB internally (`1 << top_bit(0)` where `top_bit` returns `-1`).
+I've also fixed the printf format strings to use `1U` instead of `1` to
+avoid signed overflow when `i = 31`.
+---
+ tests/bit_operations_tests.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tests/bit_operations_tests.c b/tests/bit_operations_tests.c
+index 53cd997..53f7892 100644
+--- a/tests/bit_operations_tests.c
++++ b/tests/bit_operations_tests.c
+@@ -257,22 +257,22 @@ int main(int argc, char *argv[])
+             printf("Test failed: parity 8 - %x %x %x\n", i, ax, bx);
+             exit(2);
+         }
+     }
+
+-    for (i = -1;  i < 32;  i++)
++    for (i = 0;  i < 32;  i++)
+     {
+         ax32 = most_significant_one32(1 << i);
+         if (ax32 != (1 << i))
+         {
+-            printf("Test failed: most significant one 32 - %x %" PRIx32 " %x\n", i, ax32, (1 << i));
++            printf("Test failed: most significant one 32 - %x %" PRIx32 " %x\n", i, ax32, (1U << i));
+             exit(2);
+         }
+         ax32 = least_significant_one32(1 << i);
+         if (ax32 != (1 << i))
+         {
+-            printf("Test failed: least significant one 32 - %x %" PRIx32 " %x\n", i, ax32, (1 << i));
++            printf("Test failed: least significant one 32 - %x %" PRIx32 " %x\n", i, ax32, (1U << i));
+             exit(2);
+         }
+     }
+
+     for (i = 0x80000000;  i < 0x800FFFFF;  i++)
+--
+2.53.0


### PR DESCRIPTION
## Things done

- Supersedes https://github.com/NixOS/nixpkgs/pull/474087

The upstream source at `soft-switch.org` is permanently down. This PR switches to the Fedora lookaside cache mirror, which should hopefully never go down.

This PR also adds a patch fixing undefined behavior in `bit_operations_tests` where `1U << -1`, which caused spurious test failures on ppc64be. I've submitted the fix upstream as https://github.com/freeswitch/spandsp/pull/116.

Lastly, lpc10_tests is disabled on ppc64, since it compares decoded LPC-10 audio against an x86-generated reference file, and (assumingly) POWER's FPU produces different enough float intermediates that the output diverges after a few hundred frames, even though the codec works correctly.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] ppc64be-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
