### PR TITLE
racket{,-minimal}: update platforms and badPlatforms

### DIFF
--- a/pkgs/by-name/ra/racket/minimal.nix
+++ b/pkgs/by-name/ra/racket/minimal.nix
@@ -160,5 +160,10 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ rc-zb ];
     mainProgram = "racket";
     platforms = lib.platforms.all;
+    /*
+      > checking size of void *... 0
+      > Something has gone wrong getting the pointer size; see config.log
+    */
+    badPlatforms = lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ra/racket/package.nix
+++ b/pkgs/by-name/ra/racket/package.nix
@@ -127,7 +127,7 @@ minimal.overrideAttrs (
         libraries support applications from web servers and databases to
         GUIs and charts.
       '';
-      platforms = lib.platforms.unix;
+      badPlatforms = [ ];
     };
   }
 )


### PR DESCRIPTION
In #496512, we knew that

1. The source archive of the full distribution of Racket is said to be intended for "All Platforms" by the upstream.
2. `racket-minimal` does now build on Darwin no matter why.

So we have to update the `platforms` and `badPlatforms` for the new status quo.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
