### PR TITLE
kcl-kafka: init at 0.17.0

### DIFF
--- a/pkgs/by-name/kc/kcl-kafka/package.nix
+++ b/pkgs/by-name/kc/kcl-kafka/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "kcl-kafka";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "twmb";
+    repo = "kcl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-P55k9PIUDtYMzgPHCQYQLNgprnC9MDUX6ZfgZhI9fC0=";
+  };
+
+  vendorHash = "sha256-o7iSFI0zRwjlE2MVqKSpPMowR4mD2zW6wez4sqNX4Cw=";
+
+  subPackages = [ "." ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "One stop shop to do anything with Apache Kafka";
+    homepage = "https://github.com/twmb/kcl";
+    changelog = "https://github.com/twmb/kcl/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ chillcicada ];
+    mainProgram = "kcl";
+  };
+})


### PR DESCRIPTION
init [kcl](https://github.com/twmb/kcl)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
