### PR TITLE
glfw3-minecraft: expand Wayland window position patch

### DIFF
--- a/pkgs/by-name/gl/glfw3/window-position.patch
+++ b/pkgs/by-name/gl/glfw3/window-position.patch
@@ -1,30 +1,37 @@
-From 807d9b0efe86e85a54cd2daf7da2ba1591b39f14 Mon Sep 17 00:00:00 2001
-From: uku <hi@uku.moe>
-Date: Sat, 27 Dec 2025 19:25:42 +0100
-Subject: [PATCH] fix: dismiss warning about window position being unavailable
+Dismiss warnings about window position being unavailable on Wayland.
 
 In addition to the other glfw patches, this one is required on certain
 compositors such as niri and waywall to be able to launch Minecraft at
 all.
----
- src/wl_window.c | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/src/wl_window.c b/src/wl_window.c
-index ad39b2e0..38f86a17 100644
+This patch expands the suppression to setting positions. This
+prevents Minecraft Forge environments from crashing on Wayland when
+strict error callbacks are used.
+
+Original get-position fix by: uku <hi@uku.moe>
+Expanded to include set-position, inspired by Prior5151's fix on AUR.
+https://aur.archlinux.org/packages/glfw-wayland-minecraft-cursorfix#comment-1013099
+
 --- a/src/wl_window.c
 +++ b/src/wl_window.c
-@@ -2293,8 +2293,8 @@ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
+@@ -2236,16 +2236,16 @@ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
      // A Wayland client is not aware of its position, so just warn and leave it
      // as (0, 0)
  
 -    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
 -                    "Wayland: The platform does not provide the window position");
 +    fprintf(stderr,
-+            "[GLFW] Wayland: The platform does not provide the window position\n");
++                    "[GLFW] Wayland: The platform does not provide the window position\n");
  }
  
  void _glfwSetWindowPosWayland(_GLFWwindow* window, int xpos, int ypos)
--- 
-2.51.2
-
+ {
+     // A Wayland client can not set its position, so just warn
+ 
+-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
+-                    "Wayland: The platform does not support setting the window position");
++    fprintf(stderr,
++                    "[GLFW] Wayland: The platform does not support setting the window position\n");
+ }
+ 
+ void _glfwGetWindowSizeWayland(_GLFWwindow* window, int* width, int* height)


### PR DESCRIPTION
Minecraft Forge utilizes strict error callbacks during initialization. When running on native Wayland, attempting to set the window position triggers a `GLFW_FEATURE_UNAVAILABLE` (0x1000C) error in GLFW 3.4, causing the game to crash immediately.

This updates the existing `window-position.patch` to also demote the error in `_glfwSetWindowPosWayland` to a stderr warning.

Credit to Prior5151 on [AUR](https://aur.archlinux.org/packages/glfw-wayland-minecraft-cursorfix#comment-1013099) for the extended fix approach.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
