### PR TITLE
linkNodeModulesHook: replace symlinks atomically

### DIFF
--- a/pkgs/build-support/node/import-npm-lock/hooks/link-node-modules.js
+++ b/pkgs/build-support/node/import-npm-lock/hooks/link-node-modules.js
@@ -71,17 +71,22 @@ async function main() {
       // Don't unlink this file, we just wrote it.
       managed.delete(file);
 
-      // Link file
+      // No need to replace the symlink if it already points to the right target
       try {
-        await fs.promises.symlink(sourcePath, targetPath);
+        if (await fs.promises.readlink(targetPath) === sourcePath) {
+          return
+        }
       } catch (err) {
-        // If the target file already exists remove it and try again
-        if (err.code !== "EEXIST") {
+        // If the symlink doesn't already exist, keep going. If we get a
+        // different error trying to stat it, fail.
+        if (err.code !== "ENOENT") {
           throw err;
         }
-        await fs.promises.unlink(targetPath);
-        await fs.promises.symlink(sourcePath, targetPath);
       }
+      // Replace the link, if it exists, atomically.
+      const tmpPath = `${targetPath}.tmp.${process.pid}`
+      await fs.promises.symlink(sourcePath, tmpPath);
+      await fs.promises.rename(tmpPath, targetPath);
     })
   );
 


### PR DESCRIPTION
Up to now, existing symlinks were replaced by removing the existing link and then creating a new one. This left a window where the link did not exist, which would break cases where the hook was running concurrently with other things using node_modules.

In my case, I would run multiple webpack builds at once like:

  nix develop -c webpack build --mode production
  nix develop -c webpack build --mode development

If one of the shells was ready faster than the other, webpack would start running, then the second would run the linkNodeModules hook, and the earlier webpack build would run into missing files as the second linkNodeModules hook removed symlinks to replace them.


This change mitigates this race condition in two ways:

- Not replacing the symlink if it already points to the right target (this also avoids superfluous filesystem writes)

- Replacing the symlink atomically, using a rename, otherwise. The symlink was replaced atomically prior to db7050bb887b72530d4c65a71af33cb49f710fab as well, but the name of the temporary symlink was always the same, which led to a similar race condition. This change reintroduces the atomic replacement, but adds the PID to the temporary filename in order to avoid conflicting with other instances of the hook running concurrently.

cc @adisbladis
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
