### PR TITLE
python313Packages.celery: disable more tests on `aarch64-darwin`

### DIFF
--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -202,6 +202,9 @@ buildPythonPackage rec {
     "test_cleanup"
     "test_with_autoscaler_file_descriptor_safety"
     "test_with_file_descriptor_safety"
+    # OverflowError: Python int too large to convert to C int
+    "test_fd_by_path"
+    "test_open"
   ];
 
   pythonImportsCheck = [ "celery" ];


### PR DESCRIPTION
I extracted this commit from PR #498641 to hopefully merge it faster and move on faster with `swh-*` fixes.

`nixpkgs-review` ongoing at https://github.com/drupol/nixpkgs-review-gha/actions/runs/22997390569

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
