### PR TITLE
python3Packages.magic-wormhole-transit-relay: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   setuptools,
   autobahn,
   twisted,
@@ -12,24 +11,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "magic-wormhole-transit-relay";
-  version = "0.4.0";
+  version = "0.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "magic-wormhole";
     repo = "magic-wormhole-transit-relay";
     tag = finalAttrs.version;
-    hash = "sha256-AKLmiOlxNDd8rxNeWTDTPxtSoEyTGZ5PMLgyVxcIHcg=";
+    hash = "sha256-UhV0M8Nl9Y850PQcJoDyIvIPRyBS8gyF2Ub9qF3aq0U=";
   };
-
-  patches = [
-    # TODO: drop when updating beyond version 0.4.0
-    (fetchpatch {
-      name = "stock-Twisted-testing-reactor-seems-to-work.patch";
-      url = "https://github.com/magic-wormhole/magic-wormhole-transit-relay/commit/3abb80fd5e55bd0ba8ee66278ccf76be5f904622.patch";
-      hash = "sha256-qMaJ58kPWvEfnSZiFzxO6GlkBiyVMsgGDEa1deITZco=";
-    })
-  ];
 
   postPatch = ''
     # Passing the environment to twistd is necessary to preserve Python's site path.
@@ -42,7 +32,6 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     autobahn
-    setuptools # pkg_resources is referenced at runtime
     twisted
   ];
 

--- a/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
@@ -10,13 +10,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "magic-wormhole-transit-relay";
   version = "0.4.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-kS2DXaIbESZsdxEdybXlgAJj/AuY8KF5liJn30GBnow=";
   };
 
@@ -61,8 +61,8 @@ buildPythonPackage rec {
   meta = {
     description = "Transit Relay server for Magic-Wormhole";
     homepage = "https://github.com/magic-wormhole/magic-wormhole-transit-relay";
-    changelog = "https://github.com/magic-wormhole/magic-wormhole-transit-relay/blob/${version}/NEWS.md";
+    changelog = "https://github.com/magic-wormhole/magic-wormhole-transit-relay/blob/refs/tags/${finalAttrs.version}/NEWS.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mjoerg ];
   };
-}
+})

--- a/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-transit-relay/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   fetchpatch,
   setuptools,
   autobahn,
@@ -15,9 +15,11 @@ buildPythonPackage (finalAttrs: {
   version = "0.4.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-kS2DXaIbESZsdxEdybXlgAJj/AuY8KF5liJn30GBnow=";
+  src = fetchFromGitHub {
+    owner = "magic-wormhole";
+    repo = "magic-wormhole-transit-relay";
+    tag = finalAttrs.version;
+    hash = "sha256-AKLmiOlxNDd8rxNeWTDTPxtSoEyTGZ5PMLgyVxcIHcg=";
   };
 
   patches = [
@@ -61,7 +63,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Transit Relay server for Magic-Wormhole";
     homepage = "https://github.com/magic-wormhole/magic-wormhole-transit-relay";
-    changelog = "https://github.com/magic-wormhole/magic-wormhole-transit-relay/blob/refs/tags/${finalAttrs.version}/NEWS.md";
+    changelog = "https://github.com/magic-wormhole/magic-wormhole-transit-relay/blob/${finalAttrs.src.rev}/NEWS.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mjoerg ];
   };


### PR DESCRIPTION
https://github.com/magic-wormhole/magic-wormhole-transit-relay/compare/refs/tags/0.4.0...refs/tags/0.5.0
https://github.com/magic-wormhole/magic-wormhole-transit-relay/blob/refs/tags/0.5.0/NEWS.md

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 499208`
Commit: `175c8303930386dadc2d447f005f19bc296a7b33`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 15 packages built:</summary>
  <ul>
    <li>gnome-keysign</li>
    <li>gnome-keysign.dist</li>
    <li>magic-wormhole (python313Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python313Packages.magic-wormhole.dist)</li>
    <li>python313Packages.magic-wormhole-transit-relay</li>
    <li>python313Packages.magic-wormhole-transit-relay.dist</li>
    <li>python314Packages.magic-wormhole</li>
    <li>python314Packages.magic-wormhole-transit-relay</li>
    <li>python314Packages.magic-wormhole-transit-relay.dist</li>
    <li>python314Packages.magic-wormhole.dist</li>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
    <li>tahoe-lafs.man</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test