### PR TITLE
nixos/nginx: add missing upstream.server options

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -137,7 +137,9 @@ let
           ${toString (
             flip mapAttrsToList upstream.servers (
               name: server: ''
-                server ${name} ${concatStringsSep " " (mapAttrsToList toUpstreamParameter server)};
+                server ${name} ${
+                  concatStringsSep " " (mapAttrsToList toUpstreamParameter (filterAttrs (_: v: v != null) server))
+                };
               ''
             )
           )}
@@ -1195,12 +1197,103 @@ in
                       ]
                     );
                     options = {
+                      weight = mkOption {
+                        type = types.nullOr types.ints.positive;
+                        default = null;
+                        description = ''
+                          Sets the weight of the server, by default, 1.
+                        '';
+                      };
+                      max_conns = mkOption {
+                        type = types.nullOr types.ints.unsigned;
+                        default = null;
+                        description = ''
+                          Limits the maximum number of simultaneous active connections to the proxied
+                          server. Default value is zero, meaning there is no limit. If the server
+                          group does not reside in the shared memory, the limitation works per each
+                          worker process.
+                        '';
+                      };
+                      max_fails = mkOption {
+                        type = types.nullOr types.ints.unsigned;
+                        default = null;
+                        description = ''
+                          Sets the number of unsuccessful attempts to communicate with the server
+                          that should happen in the duration set by the {option}`fail_timeout`
+                          parameter to consider the server unavailable for a duration also set by
+                          the {option}`fail_timeout` parameter. By default, the number of
+                          unsuccessful attempts is set to 1. The zero value disables the accounting
+                          of attempts.
+                        '';
+                      };
+                      fail_timeout = mkOption {
+                        type = types.nullOr types.str;
+                        default = null;
+                        example = "30s";
+                        description = ''
+                          Sets the time during which the specified number of unsuccessful attempts
+                          to communicate with the server should happen to consider the server
+                          unavailable; and the period of time the server will be considered
+                          unavailable. By default, the parameter is set to 10 seconds.
+                        '';
+                      };
                       backup = mkOption {
                         type = types.bool;
                         default = false;
                         description = ''
                           Marks the server as a backup server. It will be passed
                           requests when the primary servers are unavailable.
+
+                          The parameter cannot be used along with the hash, ip_hash,
+                          and random load balancing methods.
+                        '';
+                      };
+                      down = mkOption {
+                        type = types.bool;
+                        default = false;
+                        description = ''
+                          Marks the server as permanently unavailable.
+                        '';
+                      };
+                      resolve = mkOption {
+                        type = types.bool;
+                        default = false;
+                        description = ''
+                          Monitors changes of the IP addresses that correspond to a domain name of
+                          the server, and automatically modifies the upstream configuration without
+                          the need of restarting nginx. The server group must reside in the shared
+                          memory.
+
+                          In order for this parameter to work, the
+                          [resolver](https://nginx.org/en/docs/http/ngx_http_core_module.html#resolver)
+                          directive must be specified in the http block or in the corresponding
+                          upstream block.
+                        '';
+                      };
+                      service = mkOption {
+                        type = types.nullOr types.str;
+                        default = null;
+                        example = "http";
+                        description = ''
+                          Enables resolving of DNS SRV records and sets the service name. In order
+                          for this parameter to work, it is necessary to specify the
+                          {option}`resolve` parameter for the server and specify a hostname without
+                          a port number.
+                        '';
+                      };
+                      route = mkOption {
+                        type = types.nullOr types.str;
+                        default = null;
+                        description = ''
+                          Sets the server route name.
+                        '';
+                      };
+                      drain = mkOption {
+                        type = types.bool;
+                        default = false;
+                        description = ''
+                          Puts the server into the "draining" mode. In this mode, only requests
+                          bound to the server will be proxied to it.
                         '';
                       };
                     };


### PR DESCRIPTION
Taken from https://nginx.org/en/docs/http/ngx_http_upstream_module.html#server as of 12-03-2026

Of course the freeform option also allows the same options but this adds some typechecking

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
