### PR TITLE
linux_lqx: remove

### DIFF
--- a/pkgs/os-specific/linux/kernel/update-zen.py
+++ b/pkgs/os-specific/linux/kernel/update-zen.py
@@ -58,30 +58,30 @@ def nix_prefetch_url(url, unpack=False):
     return out.decode('utf-8').rstrip()
 
 
-def update_file(relpath, variant, version, suffix, sha256):
+def update_file(relpath, version, suffix, sha256):
     file_path = os.path.join(DIR, relpath)
     with fileinput.FileInput(file_path, inplace=True) as f:
         for line in f:
             result = line
             result = re.sub(
-                fr'^      version = ".+"; # {variant}',
-                f'      version = "{version}"; # {variant}',
+                fr'^  version = ".+";',
+                f'  version = "{version}";',
                 result)
             result = re.sub(
-                fr'^      suffix = ".+"; # {variant}',
-                f'      suffix = "{suffix}"; # {variant}',
+                fr'^  suffix = ".+";',
+                f'  suffix = "{suffix}";',
                 result)
             result = re.sub(
-                fr'^      sha256 = ".+"; # {variant}',
-                f'      sha256 = "{sha256}"; # {variant}',
+                fr'^    sha256 = ".+";',
+                f'    sha256 = "{sha256}";',
                 result)
             print(result, end='')
 
 
-def read_file(relpath, variant):
+def read_file(relpath):
     file_path = os.path.join(DIR, relpath)
-    re_version = re.compile(fr'^\s*version = "(.+)"; # {variant}')
-    re_suffix = re.compile(fr'^\s*suffix = "(.+)"; # {variant}')
+    re_version = re.compile(fr'^\s*version = "(.+)";')
+    re_suffix = re.compile(fr'^\s*suffix = "(.+)";')
     version = None
     suffix = None
     with fileinput.FileInput(file_path, mode='r') as f:
@@ -102,12 +102,7 @@ def read_file(relpath, variant):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) == 1:
-        panic("Update variant expected")
-    variant = sys.argv[1]
-    if variant not in ("zen", "lqx"):
-        panic(f"Unexepected variant instead of 'zen' or 'lqx': {sys.argv[1]}")
-    pattern = re.compile(fr"v(\d+\.\d+\.?\d*)-({variant}\d+)")
+    pattern = re.compile(fr"v(\d+\.\d+\.?\d*)-(zen\d+)")
     zen_tags = github_api_request('repos/zen-kernel/zen-kernel/releases')
     for tag in zen_tags:
         zen_match = pattern.match(tag['tag_name'])
@@ -116,7 +111,7 @@ if __name__ == "__main__":
             zen_version = zen_match.group(1)
             zen_suffix = zen_match.group(2)
             break
-    old_version, old_suffix = read_file('zen-kernels.nix', variant)
+    old_version, old_suffix = read_file('zen-kernels.nix')
     if old_version != zen_version or old_suffix != zen_suffix:
         zen_hash = nix_prefetch_git('https://github.com/zen-kernel/zen-kernel.git', zen_tag)
-        update_file('zen-kernels.nix', variant, zen_version, zen_suffix, zen_hash)
+        update_file('zen-kernels.nix', zen_version, zen_suffix, zen_hash)

--- a/pkgs/os-specific/linux/kernel/zen-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/zen-kernels.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   buildLinux,
-  variant,
   ...
 }@args:
 
@@ -12,160 +11,92 @@ let
   # file), we need something lower to override them, but we still want users to
   # override options if they need using lib.mkForce (that has 50 priority)
   mkKernelOverride = lib.mkOverride 90;
-  # Comments with variant added for update script
-  variants = {
-    # ./update-zen.py zen
-    zen = {
-      version = "6.18.13"; # zen
-      suffix = "zen1"; # zen
-      sha256 = "0x6s3pa7c6zlvr3w2fv6i15v54cy1pschvgk7b4vrzx1bcrjdxf7"; # zen
-      isLqx = false;
-    };
-    # ./update-zen.py lqx
-    lqx = {
-      version = "6.19.6"; # lqx
-      suffix = "lqx1"; # lqx
-      sha256 = "19ayfp9wiax25ji81dk7ylrdjjgzyahb9d27hcvhgbbr1irlg3w6"; # lqx
-      isLqx = true;
-    };
-  };
-  zenKernelsFor =
-    {
-      version,
-      suffix,
-      sha256,
-      isLqx,
-    }:
-    buildLinux (
-      args
-      // {
-        inherit version;
-        pname = "linux-${if isLqx then "lqx" else "zen"}";
-        modDirVersion = lib.versions.pad 3 "${version}-${suffix}";
-        isZen = true;
 
-        src = fetchFromGitHub {
-          owner = "zen-kernel";
-          repo = "zen-kernel";
-          rev = "v${version}-${suffix}";
-          inherit sha256;
-        };
-
-        # This is based on the following sources:
-        # - zen: https://gitlab.archlinux.org/archlinux/packaging/packages/linux-zen/-/blob/main/config
-        # - lqx: https://github.com/damentz/liquorix-package/blob/6.13/master/linux-liquorix/debian/config/kernelarch-x86/config-arch-64
-        # - Liquorix features: https://liquorix.net/
-        # The list below is not exhaustive, so the kernels probably doesn't match
-        # the upstream, but should bring most of the improvements that will be
-        # expected by users
-        structuredExtraConfig =
-          with lib.kernel;
-          {
-            # Zen Interactive tuning
-            ZEN_INTERACTIVE = yes;
-
-            # FQ-Codel Packet Scheduling
-            NET_SCH_DEFAULT = yes;
-            DEFAULT_FQ_CODEL = yes;
-
-            # Preempt (low-latency)
-            PREEMPT = mkKernelOverride yes;
-            PREEMPT_VOLUNTARY = mkKernelOverride no;
-
-            # Preemptible tree-based hierarchical RCU
-            TREE_RCU = yes;
-            PREEMPT_RCU = yes;
-            RCU_EXPERT = yes;
-            TREE_SRCU = yes;
-            TASKS_RCU_GENERIC = yes;
-            TASKS_RCU = yes;
-            TASKS_RUDE_RCU = yes;
-            TASKS_TRACE_RCU = yes;
-            RCU_STALL_COMMON = yes;
-            RCU_NEED_SEGCBLIST = yes;
-            RCU_FANOUT = freeform "64";
-            RCU_FANOUT_LEAF = freeform "16";
-            RCU_BOOST = yes;
-            RCU_BOOST_DELAY = option (freeform "500");
-            RCU_NOCB_CPU = yes;
-            RCU_LAZY = yes;
-            RCU_DOUBLE_CHECK_CB_TIME = yes;
-
-            # BFQ I/O scheduler
-            IOSCHED_BFQ = mkKernelOverride yes;
-
-            # Futex WAIT_MULTIPLE implementation for Wine / Proton Fsync.
-            FUTEX = yes;
-            FUTEX_PI = yes;
-
-            # NT synchronization primitive emulation
-            NTSYNC = yes;
-
-            # Preemptive Full Tickless Kernel at 1000Hz
-            HZ = freeform "1000";
-            HZ_1000 = yes;
-
-          }
-          // lib.optionalAttrs isLqx {
-            # https://github.com/damentz/liquorix-package/commit/07b176edc002f2a7825ae181613e1f79a3650fd2
-            CMDLINE_BOOL = yes;
-            CMDLINE = freeform "audit=0 intel_pstate=disable amd_pstate=disable ";
-
-            # Google's BBRv3 TCP congestion Control
-            TCP_CONG_BBR = yes;
-            DEFAULT_BBR = yes;
-
-            # PDS Process Scheduler
-            SCHED_ALT = yes;
-            SCHED_PDS = yes;
-
-            # https://github.com/damentz/liquorix-package/commit/a7055b936c0f4edb8f6afd5263fe1d2f8a5cd877
-            RCU_BOOST = no;
-            RCU_LAZY = mkKernelOverride no;
-
-            # Swap storage is compressed with LZ4 using zswap
-            ZSWAP_COMPRESSOR_DEFAULT_LZ4 = yes;
-            ZSWAP_COMPRESSOR_DEFAULT_ZSTD = mkKernelOverride no;
-
-            # https://github.com/damentz/liquorix-package/commit/3a82381a4db3452599e2b2a607046a379c72ad27
-            SLAB_BUCKETS = mkKernelOverride (option no);
-            # https://github.com/damentz/liquorix-package/commit/ca7efe07abd478f3f4cbe0725a3383fd235aa5be
-            ENERGY_MODE = mkKernelOverride (option no);
-            # https://github.com/damentz/liquorix-package/commit/fdc93f5633d22c26f0994fba751a26de0cb51a17
-            WQ_POWER_EFFICIENT_DEFAULT = mkKernelOverride (option no);
-
-            # Fix error: unused option: XXX.
-            CFS_BANDWIDTH = mkKernelOverride (option no);
-            PSI = mkKernelOverride (option no);
-            RT_GROUP_SCHED = mkKernelOverride (option no);
-            SCHED_AUTOGROUP = mkKernelOverride (option no);
-            SCHED_CLASS_EXT = mkKernelOverride (option no);
-            SCHED_CORE = mkKernelOverride (option no);
-            UCLAMP_TASK = mkKernelOverride (option no);
-            UCLAMP_TASK_GROUP = mkKernelOverride (option no);
-          };
-
-        extraPassthru.updateScript = [
-          ./update-zen.py
-          (if isLqx then "lqx" else "zen")
-        ];
-
-        extraMeta = {
-          branch = lib.versions.majorMinor version + "/master";
-          maintainers = with lib.maintainers; [
-            thiagokokada
-            jerrysm64
-            axertheaxe
-          ];
-          teams = [ ];
-          description =
-            "Built using the best configuration and kernel sources for desktop, multimedia, and gaming workloads."
-            + lib.optionalString isLqx " (Same as linux_zen, but less aggressive release schedule and additional extra config)";
-          broken = stdenv.hostPlatform.isAarch64;
-        };
-
-      }
-      // (args.argsOverride or { })
-    );
+  suffix = "zen1"; # zen
 in
-zenKernelsFor variants.${variant}
+
+buildLinux (
+  args
+  // rec {
+    version = "6.18.13";
+    pname = "linux-zen";
+    modDirVersion = lib.versions.pad 3 "${version}-${suffix}";
+    isZen = true;
+
+    src = fetchFromGitHub {
+      owner = "zen-kernel";
+      repo = "zen-kernel";
+      rev = "v${version}-${suffix}";
+      sha256 = "0x6s3pa7c6zlvr3w2fv6i15v54cy1pschvgk7b4vrzx1bcrjdxf7";
+    };
+
+    # This is based on the following source:
+    # https://gitlab.archlinux.org/archlinux/packaging/packages/linux-zen/-/blob/main/config
+    # The list below is not exhaustive, so the kernel probably doesn't match
+    # the upstream, but should bring most of the improvements that will be
+    # expected by users
+    structuredExtraConfig = with lib.kernel; {
+      # Zen Interactive tuning
+      ZEN_INTERACTIVE = yes;
+
+      # FQ-Codel Packet Scheduling
+      NET_SCH_DEFAULT = yes;
+      DEFAULT_FQ_CODEL = yes;
+
+      # Preempt (low-latency)
+      PREEMPT = mkKernelOverride yes;
+      PREEMPT_VOLUNTARY = mkKernelOverride no;
+
+      # Preemptible tree-based hierarchical RCU
+      TREE_RCU = yes;
+      PREEMPT_RCU = yes;
+      RCU_EXPERT = yes;
+      TREE_SRCU = yes;
+      TASKS_RCU_GENERIC = yes;
+      TASKS_RCU = yes;
+      TASKS_RUDE_RCU = yes;
+      TASKS_TRACE_RCU = yes;
+      RCU_STALL_COMMON = yes;
+      RCU_NEED_SEGCBLIST = yes;
+      RCU_FANOUT = freeform "64";
+      RCU_FANOUT_LEAF = freeform "16";
+      RCU_BOOST = yes;
+      RCU_BOOST_DELAY = option (freeform "500");
+      RCU_NOCB_CPU = yes;
+      RCU_LAZY = yes;
+      RCU_DOUBLE_CHECK_CB_TIME = yes;
+
+      # BFQ I/O scheduler
+      IOSCHED_BFQ = mkKernelOverride yes;
+
+      # Futex WAIT_MULTIPLE implementation for Wine / Proton Fsync.
+      FUTEX = yes;
+      FUTEX_PI = yes;
+
+      # NT synchronization primitive emulation
+      NTSYNC = yes;
+
+      # Preemptive Full Tickless Kernel at 1000Hz
+      HZ = freeform "1000";
+      HZ_1000 = yes;
+    };
+
+    extraPassthru.updateScript = [
+      ./update-zen.py
+    ];
+
+    extraMeta = {
+      branch = lib.versions.majorMinor version + "/master";
+      maintainers = with lib.maintainers; [
+        thiagokokada
+        jerrysm64
+        axertheaxe
+      ];
+      teams = [ ];
+      description = "Built using the best configuration and kernel sources for desktop, multimedia, and gaming workloads.";
+      broken = stdenv.hostPlatform.isAarch64;
+    };
+
+  }
+  // (args.argsOverride or { })
+)

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1152,6 +1152,7 @@ mapAliases {
   linux_ham = throw "linux_ham has been removed in favour of the standard kernel packages"; # Added 2025-06-24
   linux_hardened = linuxPackages_hardened.kernel; # Added 2025-08-10
   linux_latest-libre = throw "linux_latest_libre has been removed due to lack of maintenance"; # Added 2025-10-01
+  linux_lqx = throw "linux_lqx has been removed due to lack of maintenance"; # Added 2026-03-13
   linux_rpi0 = linuxKernel.kernels.linux_rpi1;
   linux_rpi1 = linuxKernel.kernels.linux_rpi1;
   linux_rpi2 = linuxKernel.kernels.linux_rpi2;
@@ -1184,6 +1185,7 @@ mapAliases {
   linuxPackages_hardened = linuxKernel.packages.linux_hardened; # Added 2025-08-10
   linuxPackages_latest-libre = throw "linux_latest_libre has been removed due to lack of maintenance"; # Added 2025-10-01
   linuxPackages_latest_xen_dom0 = throw "'linuxPackages_latest_xen_dom0' has been renamed to/replaced by 'linuxPackages_latest'"; # Converted to throw 2025-10-27
+  linuxPackages_lqx = throw "linuxPackages_lqx has been removed due to lack of maintenance"; # Added 2026-03-13
   linuxPackages_rpi0 = linuxKernel.packages.linux_rpi1;
   linuxPackages_rpi1 = linuxKernel.packages.linux_rpi1;
   linuxPackages_rpi2 = linuxKernel.packages.linux_rpi2;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8665,8 +8665,6 @@ with pkgs;
   # zen-kernel
   linuxPackages_zen = linuxKernel.packages.linux_zen;
   linux_zen = linuxPackages_zen.kernel;
-  linuxPackages_lqx = linuxKernel.packages.linux_lqx;
-  linux_lqx = linuxPackages_lqx.kernel;
 
   # XanMod kernel
   linuxPackages_xanmod = linuxKernel.packages.linux_xanmod;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -231,20 +231,7 @@ in
 
         linux_latest = packageAliases.linux_latest.kernel;
 
-        # Using zenKernels like this due lqx&zen came from one source, but may have different base kernel version
-        # https://github.com/NixOS/nixpkgs/pull/161773#discussion_r820134708
-        zenKernels = callPackage ../os-specific/linux/kernel/zen-kernels.nix;
-
-        linux_zen = zenKernels {
-          variant = "zen";
-          kernelPatches = [
-            kernelPatches.bridge_stp_helper
-            kernelPatches.request_key_helper
-          ];
-        };
-
-        linux_lqx = zenKernels {
-          variant = "lqx";
+        linux_zen = callPackage ../os-specific/linux/kernel/zen-kernels.nix {
           kernelPatches = [
             kernelPatches.bridge_stp_helper
             kernelPatches.request_key_helper
@@ -281,6 +268,7 @@ in
         linux_hardened = linux_6_12_hardened;
       }
       // lib.optionalAttrs config.allowAliases {
+        linux_lqx = throw "linux_lqx has been removed due to lack of maintenance";
         linux_libre = throw "linux_libre has been removed due to lack of maintenance";
         linux_latest_libre = throw "linux_latest_libre has been removed due to lack of maintenance";
 
@@ -785,12 +773,12 @@ in
       linux_6_12_hardened = recurseIntoAttrs (packagesFor kernels.linux_6_12_hardened);
 
       linux_zen = recurseIntoAttrs (packagesFor kernels.linux_zen);
-      linux_lqx = recurseIntoAttrs (packagesFor kernels.linux_lqx);
       linux_xanmod = recurseIntoAttrs (packagesFor kernels.linux_xanmod);
       linux_xanmod_stable = recurseIntoAttrs (packagesFor kernels.linux_xanmod_stable);
       linux_xanmod_latest = recurseIntoAttrs (packagesFor kernels.linux_xanmod_latest);
     }
     // lib.optionalAttrs config.allowAliases {
+      linux_lqx = throw "linux_lqx has been removed due to lack of maintenance";
       linux_libre = throw "linux_libre has been removed due to lack of maintenance";
       linux_latest_libre = throw "linux_latest_libre has been removed due to lack of maintenance";
 


### PR DESCRIPTION
Updated almost exclusively by r-ryantm.  Backports are frequently missed, and only caught up with after I sort them out, despite me not using or caring about this package.  I don't think linux_lqx is being maintained to the standards people expect of kernels in Nixpkgs.

If it is to stay, I think it needs a strong commitment from the package maintainers to actually keep up with maintenance, including backports, at a pace comparable with other packaged kernels.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
