### PR TITLE
Refactor stdenv adapters in terms of `overrideMkDerivationArgs`

### DIFF
--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -121,27 +121,23 @@ rec {
 
   # Return a modified stdenv that builds static libraries instead of
   # shared libraries.
-  makeStaticLibraries =
-    stdenv:
-    stdenv.override (old: {
-      mkDerivationFromStdenv = extendMkDerivationArgs old (
-        args:
-        {
-          dontDisableStatic = true;
-        }
-        // lib.optionalAttrs (!(args.dontAddStaticConfigureFlags or false)) {
-          configureFlags = (args.configureFlags or [ ]) ++ [
-            "--enable-static"
-            "--disable-shared"
-          ];
-          cmakeFlags = (args.cmakeFlags or [ ]) ++ [ "-DBUILD_SHARED_LIBS:BOOL=OFF" ];
-          mesonFlags = (args.mesonFlags or [ ]) ++ [
-            "-Ddefault_library=static"
-            "-Ddefault_both_libraries=static"
-          ];
-        }
-      );
-    });
+  makeStaticLibraries = overrideMkDerivationArgs (
+    args:
+    {
+      dontDisableStatic = true;
+    }
+    // lib.optionalAttrs (!(args.dontAddStaticConfigureFlags or false)) {
+      configureFlags = (args.configureFlags or [ ]) ++ [
+        "--enable-static"
+        "--disable-shared"
+      ];
+      cmakeFlags = (args.cmakeFlags or [ ]) ++ [ "-DBUILD_SHARED_LIBS:BOOL=OFF" ];
+      mesonFlags = (args.mesonFlags or [ ]) ++ [
+        "-Ddefault_library=static"
+        "-Ddefault_both_libraries=static"
+      ];
+    }
+  );
 
   # Best effort static binaries. Will still be linked to libSystem,
   # but more portable than Nix store binaries.
@@ -190,14 +186,10 @@ rec {
     Modify a stdenv so that all buildInputs are implicitly propagated to
     consuming derivations
   */
-  propagateBuildInputs =
-    stdenv:
-    stdenv.override (old: {
-      mkDerivationFromStdenv = extendMkDerivationArgs old (args: {
-        propagatedBuildInputs = (args.propagatedBuildInputs or [ ]) ++ (args.buildInputs or [ ]);
-        buildInputs = [ ];
-      });
-    });
+  propagateBuildInputs = overrideMkDerivationArgs (args: {
+    propagatedBuildInputs = (args.propagatedBuildInputs or [ ]) ++ (args.buildInputs or [ ]);
+    buildInputs = [ ];
+  });
 
   /*
     Modify a stdenv so that the specified attributes are added to
@@ -209,11 +201,7 @@ rec {
           { env.NIX_CFLAGS_COMPILE = "-O0"; }
           stdenv;
   */
-  addAttrsToDerivation =
-    extraAttrs: stdenv:
-    stdenv.override (old: {
-      mkDerivationFromStdenv = extendMkDerivationArgs old (_: extraAttrs);
-    });
+  addAttrsToDerivation = extraAttrs: overrideMkDerivationArgs (_: extraAttrs);
 
   /*
     Modify a stdenv so as to extend `mkDerivation`'s arguments.
@@ -263,28 +251,20 @@ rec {
     binaries have debug info, and compiler optimisations are
     disabled.
   */
-  keepDebugInfo =
-    stdenv:
-    stdenv.override (old: {
-      mkDerivationFromStdenv = extendMkDerivationArgs old (args: {
-        dontStrip = true;
-        env = (args.env or { }) // {
-          NIX_CFLAGS_COMPILE = toString (args.env.NIX_CFLAGS_COMPILE or "") + " -ggdb -Og";
-          NIX_RUSTFLAGS = toString (args.env.NIX_RUSTFLAGS or "") + " -g -C opt-level=0 -C strip=none";
-        };
-      });
-    });
+  keepDebugInfo = overrideMkDerivationArgs (args: {
+    dontStrip = true;
+    env = (args.env or { }) // {
+      NIX_CFLAGS_COMPILE = toString (args.env.NIX_CFLAGS_COMPILE or "") + " -ggdb -Og";
+      NIX_RUSTFLAGS = toString (args.env.NIX_RUSTFLAGS or "") + " -g -C opt-level=0 -C strip=none";
+    };
+  });
 
   # Modify a stdenv so that it uses the Gold linker.
-  useGoldLinker =
-    stdenv:
-    stdenv.override (old: {
-      mkDerivationFromStdenv = extendMkDerivationArgs old (args: {
-        env = (args.env or { }) // {
-          NIX_CFLAGS_LINK = toString (args.env.NIX_CFLAGS_LINK or "") + " -fuse-ld=gold";
-        };
-      });
-    });
+  useGoldLinker = overrideMkDerivationArgs (args: {
+    env = (args.env or { }) // {
+      NIX_CFLAGS_LINK = toString (args.env.NIX_CFLAGS_LINK or "") + " -fuse-ld=gold";
+    };
+  });
 
   /*
     Copy the libstdc++ from the model stdenv to the target stdenv.
@@ -383,20 +363,16 @@ rec {
 
     WARNING: this breaks purity!
   */
-  impureUseNativeOptimizations =
-    stdenv:
-    stdenv.override (old: {
-      mkDerivationFromStdenv = extendMkDerivationArgs old (args: {
-        env = (args.env or { }) // {
-          NIX_CFLAGS_COMPILE = toString (args.env.NIX_CFLAGS_COMPILE or "") + " -march=native";
-        };
+  impureUseNativeOptimizations = overrideMkDerivationArgs (args: {
+    env = (args.env or { }) // {
+      NIX_CFLAGS_COMPILE = toString (args.env.NIX_CFLAGS_COMPILE or "") + " -march=native";
+    };
 
-        NIX_ENFORCE_NO_NATIVE = false;
+    NIX_ENFORCE_NO_NATIVE = false;
 
-        preferLocalBuild = true;
-        allowSubstitutes = false;
-      });
-    });
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+  });
 
   /*
     Modify a stdenv so that it builds binaries with the specified list of
@@ -413,13 +389,11 @@ rec {
       ];
   */
   withCFlags =
-    compilerFlags: stdenv:
-    stdenv.override (old: {
-      mkDerivationFromStdenv = extendMkDerivationArgs old (args: {
-        env = (args.env or { }) // {
-          NIX_CFLAGS_COMPILE = toString (args.env.NIX_CFLAGS_COMPILE or "") + " ${toString compilerFlags}";
-        };
-      });
+    compilerFlags:
+    overrideMkDerivationArgs (args: {
+      env = (args.env or { }) // {
+        NIX_CFLAGS_COMPILE = toString (args.env.NIX_CFLAGS_COMPILE or "") + " ${toString compilerFlags}";
+      };
     });
 
   withDefaultHardeningFlags =


### PR DESCRIPTION
This commit refactors `stdenv/adapters.nix` in terms of the newly added `overrideMkDerivationArgs`, since that function is strictly more powerful than some functions currently present.

This is a potential follow-up to https://github.com/NixOS/nixpkgs/pull/496862, and has been attempted before in https://github.com/NixOS/nixpkgs/pull/350350.

The original attempt met with technical agreement, and ultimately stalled for non-technical reasons. This is another attempt of getting this functionally identical feature set merged.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
