### PR TITLE
vrcx: fix URI scheme

### DIFF
--- a/pkgs/by-name/vr/vrcx/package.nix
+++ b/pkgs/by-name/vr/vrcx/package.nix
@@ -79,7 +79,7 @@ buildNpmPackage (finalAttrs: {
     (makeDesktopItem {
       name = "vrcx";
       icon = "vrcx";
-      exec = "vrcx";
+      exec = "vrcx %u";
       terminal = false;
       desktopName = "VRCX";
       comment = "Friendship management tool for VRChat";


### PR DESCRIPTION
when VRCX is called with the vrcx:// URI scheme, it needs this %u or %U to pass the url along

see docs: https://specifications.freedesktop.org/desktop-entry/latest/exec-variables.html

I did this change in response to the following KIO error i received after trying to open such a link via xdg-open.
GUI Error:
> Unable to create KIO worker. Unknown protocol 'vrcx'.

cli error:
> kf.kio.core: "/nix/store/m35drq8zk5c15fny0zdk9n4m1pkvb2h9-system-path/share/applications/vrcx.desktop" contains supported protocols but doesn't use %u or %U in its Exec line! This is inconsistent.

To test this, use e.g.: `xdg-open "vrcx://world/wrld_ae001ea3-ed05-42f0-adf2-3d47efd10a77"`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
