### PR TITLE
maintainers: update caverav email

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4470,7 +4470,7 @@
     name = "Claas Augner";
   };
   caverav = {
-    email = "camilo@fvv.cl";
+    email = "nixpkgs@caverav.cl";
     github = "caverav";
     githubId = 66751764;
     name = "Camilo Vera Vidales";


### PR DESCRIPTION
## Summary

- Update `lib.maintainers.caverav.email` from `camilo@fvv.cl` to `nixpkgs@caverav.cl`

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in `nixos/tests`.
  - [ ] Package tests at `passthru.tests`.
  - [ ] Tests in `lib/tests` or `pkgs/test` for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See nixpkgs-review usage.
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md` and other READMEs.

