### PR TITLE
pdf-cli: rename from lnreader

### DIFF
--- a/pkgs/by-name/pd/pdf-cli/package.nix
+++ b/pkgs/by-name/pd/pdf-cli/package.nix
@@ -7,17 +7,17 @@
 }:
 
 buildGoModule (finalAttrs: {
-  pname = "lnreader";
-  version = "1.0";
+  pname = "pdf-cli";
+  version = "2.0";
 
   src = fetchFromGitHub {
     owner = "Yujonpradhananga";
-    repo = "CLI-PDF-EPUB-reader";
+    repo = "pdf-cli";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-JeVS0wnShlD4+UfnMsuHMYi6R7pse4Gvh0PdREwmG6k=";
+    hash = "sha256-TvfSauT9UWjQjkzQtepEVyxm/LaiCANmxMtVmjiw8kI=";
   };
 
-  vendorHash = "sha256-66rqTJeV6u4aVciifp41n2onx81w9KE0PGYHlVwsl54=";
+  vendorHash = "sha256-LCIv135ywuq494hZbrKdbqkGPSsSlSkVQ9hCE8i7www=";
 
   nativeBuildInputs = [
     pkg-config
@@ -34,10 +34,10 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Lightweight, fast and responsive terminal PDF/EPUB viewer with image support";
-    homepage = "https://github.com/Yujonpradhananga/CLI-PDF-EPUB-reader";
+    homepage = "https://github.com/Yujonpradhananga/pdf-cli";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yujonpradhananga ];
-    mainProgram = "lnreader";
+    mainProgram = "pdf-cli";
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1228,6 +1228,7 @@ mapAliases {
   llvmPackages_15 = throw "llvmPackages_15 has been removed, as it is unmaintained and obsolete"; # Added 2025-08-12
   llvmPackages_16 = throw "llvmPackages_16 has been removed, as it is unmaintained and obsolete"; # Added 2025-08-09
   llvmPackages_17 = throw "llvmPackages_17 has been removed, as it is unmaintained and obsolete"; # Added 2025-08-09
+  lnreader = warnAlias "'lnreader' has been renamed to 'pdf-cli'" pdf-cli; # Added 2026-03-18
   lockfileProgs = warnAlias "'lockfileProgs' has been renamed to 'lockfile-progs'" lockfile-progs; # Added 2026-02-08
   loco-cli = throw "'loco-cli' has been renamed to/replaced by 'loco'"; # Converted to throw 2025-10-27
   log4j-detect = throw "'log4j-detect' has been removed, as it was unmaintained upstream and no longer relevant given that the Log4Shell vulnerability has been fixed."; # Added 2025-11-15


### PR DESCRIPTION
Replaces #490109 (lnreader).

Package has been renamed to pdf-cli in v2.0. This PR removes the old 
lnreader package and adds pdf-cli in its place.

- Built and tested on x86_64-linux
- ./result/bin/pdf-cli confirmed working