### PR TITLE
parsync: inti at 0.2.0

### DIFF
--- a/pkgs/by-name/pa/parsync/package.nix
+++ b/pkgs/by-name/pa/parsync/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchFromGitHub,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  sqlite,
+  zlib,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "parsync";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "AlpinDale";
+    repo = "parsync";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XeHHfSrutKTL1JFxJrqo9K0lD2ZYuIxcxnusH6Q373M=";
+  };
+
+  cargoHash = "sha256-SHieyv7Kc9Qtx3C11wxjJTI28h2RDh+YY1Ks++Z1rQ8=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    sqlite
+    zlib
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+  };
+
+  meta = {
+    description = "Tool to parallel rsync-like pull sync over SSH";
+    homepage = "https://github.com/AlpinDale/parsync";
+    changelog = "https://github.com/AlpinDale/parsync/releases/tag/${finalAttrs.src.rev}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "parsync";
+  };
+})


### PR DESCRIPTION
Tool to parallel rsync-like pull sync over SSH

https://github.com/AlpinDale/parsync


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
