### PR TITLE
[release-25.11] kimai: add an upstream patch to fix CVE-2026-28685

### DIFF
--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -1,6 +1,7 @@
 {
   php,
   fetchFromGitHub,
+  fetchpatch2,
   lib,
   nixosTests,
 }:
@@ -15,6 +16,18 @@ php.buildComposerProject2 (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-sZjDl3nQ4i5KVnM2fLVvaQxMlE225q7EBkgFmTn+ugc=";
   };
+
+  patches = [
+    # https://github.com/kimai/kimai/pull/5849
+    (fetchpatch2 {
+      name = "CVE-2026-28685.patch";
+      url = "https://github.com/kimai/kimai/commit/a0601c8cb28fed1cca19051a8272425069ab758f.patch?full_index=1";
+      # Kimai specifies `tests export-ignore` in its `.gitattributes`, and
+      # `fetchFromGitHub` uses export archive from GitHub.
+      excludes = [ "tests/*" ];
+      hash = "sha256-LOGyGpkhfDBOy9MojJMm9IIlqqeGqKAejfLVIX6FnJw=";
+    })
+  ];
 
   php = php.buildEnv {
     extensions = (


### PR DESCRIPTION
This is done instead of bumping Kimai to 2.51.0 because Kimai 2.50.0 introduces a breaking change in which it "removed support for file:// urls in Markdown" [^1].

Fixes https://github.com/NixOS/nixpkgs/issues/497620 for 25.11.

[^1]: https://github.com/kimai/kimai/releases/tag/2.50.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
