### PR TITLE
xcompose: init at 0.5.1

### DIFF
--- a/pkgs/by-name/xc/xcompose/package.nix
+++ b/pkgs/by-name/xc/xcompose/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  xorgproto,
+  libx11,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "xcompose";
+  version = "0.5.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Udzu";
+    repo = "xcompose";
+    rev = "v${version}";
+    hash = "sha256-TO7HqGoq9uq6USkvvDubBK3VC0i23yOqSo/t5B1xTiI=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/xcompose/__init__.py \
+      --replace-fail /usr/include/X11 ${xorgproto}/include/X11 \
+      --replace-fail /usr/share/X11 ${libx11}/share/X11
+  '';
+
+  build-system = [
+    python3.pkgs.hatchling
+  ];
+
+  dependencies = with python3.pkgs; [
+    pygtrie
+  ];
+
+  pythonImportsCheck = [
+    "xcompose"
+  ];
+
+  meta = {
+    description = "Utility for managing X11 compose key sequences";
+    homepage = "https://github.com/Udzu/xcompose";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ncfavier ];
+    mainProgram = "xcompose";
+  };
+}


### PR DESCRIPTION
Utility for managing X11 compose key sequences https://github.com/Udzu/xcompose

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
