### PR TITLE
nixos/systemd-networkd: add overrideStrategy to commonNetworkOptions

### DIFF
--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1884,6 +1884,24 @@ let
       '';
     };
 
+    overrideStrategy = mkOption {
+      default = "asDropinIfExists";
+      type = types.enum [
+        "asDropinIfExists"
+        "asDropin"
+      ];
+      description = ''
+        Defines how unit configuration is provided for systemd-networkd:
+
+        `asDropinIfExists` (default) creates a standalone unit file.
+
+        `asDropin` creates a drop-in file named `overrides.conf`, which extends
+        an upstream unit with the same name (e.g. one shipped by the systemd package).
+
+        See also {manpage}`systemd.network(5)`.
+      '';
+    };
+
     matchConfig = mkOption {
       default = { };
       example = {
@@ -3194,10 +3212,21 @@ let
   mkUnitFiles =
     prefix: cfg:
     listToAttrs (
-      map (name: {
-        name = "${prefix}systemd/network/${name}";
-        value.source = "${cfg.units.${name}.unit}/${name}";
-      }) (attrNames cfg.units)
+      map (
+        name:
+        let
+          unit = cfg.units.${name};
+          useDropin = unit.enable && unit.overrideStrategy == "asDropin";
+        in
+        {
+          name =
+            if useDropin then
+              "${prefix}systemd/network/${name}.d/overrides.conf"
+            else
+              "${prefix}systemd/network/${name}";
+          value.source = "${unit.unit}/${name}";
+        }
+      ) (attrNames cfg.units)
     );
 
   commonOptions = visible: {
@@ -3331,7 +3360,7 @@ let
     let
       cfg = config.systemd.network;
       mkUnit = f: def: {
-        inherit (def) enable;
+        inherit (def) enable overrideStrategy;
         text = f def;
       };
     in
@@ -3404,7 +3433,10 @@ let
 
         systemd.services.systemd-networkd =
           let
-            isReloadableUnitFileName = unitFileName: strings.hasSuffix ".network" unitFileName;
+            isReloadableUnitFileName =
+              unitFileName:
+              strings.hasSuffix ".network" unitFileName
+              || strings.hasSuffix ".network.d/overrides.conf" unitFileName;
             reloadableUnitFiles = attrsets.filterAttrs (k: v: isReloadableUnitFileName k) unitFiles;
             nonReloadableUnitFiles = attrsets.filterAttrs (k: v: !isReloadableUnitFileName k) unitFiles;
             unitFileSources = unitFiles: map (x: x.source) (attrValues unitFiles);

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1609,6 +1609,7 @@ in
   systemd-networkd-ipv6-prefix-delegation =
     handleTest ./systemd-networkd-ipv6-prefix-delegation.nix
       { };
+  systemd-networkd-override-strategy = runTest ./systemd-networkd-override-strategy.nix;
   systemd-networkd-vrf = runTest ./systemd-networkd-vrf.nix;
   systemd-no-tainted = runTest ./systemd-no-tainted.nix;
   systemd-nspawn = runTest ./systemd-nspawn.nix;

--- a/nixos/tests/systemd-networkd-override-strategy.nix
+++ b/nixos/tests/systemd-networkd-override-strategy.nix
@@ -1,0 +1,47 @@
+{ lib, ... }:
+{
+  name = "systemd-networkd-override-strategy";
+
+  meta = {
+    maintainers = [ ];
+  };
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      networking = {
+        useNetworkd = true;
+        useDHCP = false;
+      };
+
+      systemd.network = {
+        enable = true;
+        networks = {
+          # A regular unit without overrideStrategy should be a standalone file.
+          "50-regular" = {
+            matchConfig.Name = "eth0";
+            networkConfig.DHCP = "yes";
+          };
+
+          # A unit with overrideStrategy = "asDropin" should always be a drop-in.
+          "80-container-host0" = {
+            overrideStrategy = "asDropin";
+            matchConfig.Name = "host0";
+            networkConfig.DHCP = "yes";
+          };
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("systemd-networkd.service")
+
+    # Regular unit should be a standalone file.
+    machine.succeed("test -f /etc/systemd/network/50-regular.network")
+    machine.fail("test -d /etc/systemd/network/50-regular.network.d")
+
+    # Unit with overrideStrategy = "asDropin" should be a drop-in.
+    machine.succeed("test -f /etc/systemd/network/80-container-host0.network.d/overrides.conf")
+    machine.fail("test -f /etc/systemd/network/80-container-host0.network")
+  '';
+}


### PR DESCRIPTION
This allows overriding the built-in container network configuration without having to redeclare the whole config.

Fixes #310493


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
