### PR TITLE
postgresqlPackages.pgx_ulid 0.2.2 -> 0.2.3

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pgx_ulid.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgx_ulid.nix
@@ -1,6 +1,6 @@
 {
   buildPgrxExtension,
-  cargo-pgrx_0_16_1,
+  cargo-pgrx_0_17_0,
   fetchFromGitHub,
   lib,
   nix-update-script,
@@ -9,19 +9,19 @@
 }:
 buildPgrxExtension (finalAttrs: {
   inherit postgresql;
-  cargo-pgrx = cargo-pgrx_0_16_1;
+  cargo-pgrx = cargo-pgrx_0_17_0;
 
   pname = "pgx_ulid";
-  version = "0.2.2";
+  version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "pksunkara";
     repo = "pgx_ulid";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7zOAjQPdwaDwAz2Es5KX3HstTwY6wKNuB9b+xnnXNP0=";
+    hash = "sha256-j4whXsKyDiV+3F5Xp5Q5vODT7LGS4IVz4VfrhsyYw14=";
   };
 
-  cargoHash = "sha256-4YuTOCE142BDDteB9ZQdxzI8EUXN+jRZfy1eq64qHtg=";
+  cargoHash = "sha256-oQTetxtIqrVqSDcO8GEMAJ20/RKyYoBAIVflAcWHrPA=";
 
   postInstall = ''
     # Upstream renames the extension when packaging as well as upgrade scripts
@@ -37,8 +37,6 @@ buildPgrxExtension (finalAttrs: {
   };
 
   meta = {
-    # Support for PostgreSQL 13 was removed in 0.2.0: https://github.com/pksunkara/pgx_ulid/blob/084778c3e2af08d16ec5ec3ef4e8f345ba0daa33/CHANGELOG.md?plain=1#L6
-    broken = lib.versionOlder postgresql.version "14";
     description = "ULID Postgres extension written in Rust";
     homepage = "https://github.com/pksunkara/pgx_ulid";
     changelog = "https://github.com/pksunkara/pgx_ulid/blob/v${finalAttrs.version}/CHANGELOG.md";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
