### PR TITLE
gargoyle: 2023.1 -> 2026.1.1

### DIFF
--- a/pkgs/by-name/ga/gargoyle/package.nix
+++ b/pkgs/by-name/ga/gargoyle/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   fetchDebianPatch,
-  fetchpatch,
   cmake,
   pkg-config,
   fluidsynth,
@@ -20,13 +19,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gargoyle";
-  version = "2023.1";
+  version = "2026.1.1";
 
   src = fetchFromGitHub {
     owner = "garglk";
     repo = "garglk";
     tag = finalAttrs.version;
-    hash = "sha256-XsN5FXWJb3DSOjipxr/HW9R7QS+7iEaITERTrbGEMwA=";
+    hash = "sha256-cBFsxbXQa2xqCwW6Gd90vupAykkHvRjeM5yjA383doQ=";
   };
 
   patches = [
@@ -37,17 +36,12 @@ stdenv.mkDerivation (finalAttrs: {
       patch = "ftbfs_gcc14.patch";
       hash = "sha256-eMx/RlUpq5Ez+1L8VZo40Y3h2ZKkqiQEmKTlkZRMXnI=";
     })
-    (fetchpatch {
-      name = "cmake4-fix";
-      url = "https://github.com/garglk/garglk/commit/8d976852e2db0215e9cf4f926e626f1aa766f751.patch?full_index=1";
-      hash = "sha256-lJAuiOErSp3oDmeoqrfCdnHH816VLYiVthIG4U8BJ5E=";
-    })
   ];
 
   postPatch = ''
     substituteInPlace garglk/garglk.pc.in \
-      --replace "\''${prefix}/@CMAKE_INSTALL_LIBDIR@" "@CMAKE_INSTALL_FULL_LIBDIR@" \
-      --replace "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" "@CMAKE_INSTALL_FULL_INCLUDEDIR@"
+      --replace-fail "\''${prefix}/@CMAKE_INSTALL_LIBDIR@" "@CMAKE_INSTALL_FULL_LIBDIR@" \
+      --replace-fail "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" "@CMAKE_INSTALL_FULL_INCLUDEDIR@"
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
Resolves #499132

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
