### PR TITLE
hyprquickframe: init at 1.1.0

### DIFF
--- a/pkgs/by-name/hy/hyprquickframe/package.nix
+++ b/pkgs/by-name/hy/hyprquickframe/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  qt6,
+  quickshell,
+  grim,
+  imagemagick,
+  wl-clipboard,
+  libnotify,
+  satty,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "hyprquickframe";
+  version = "1.1.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "Ronin-CK";
+    repo = "HyprQuickFrame";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hyu7ihDIVXfswghbY8I4kBkNqft5kZ7ARD9frethQx8=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qt5compat
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/hyprquickframe
+    cp -r . $out/share/hyprquickframe/
+
+    mkdir -p $out/bin
+    makeWrapper ${quickshell}/bin/quickshell $out/bin/hyprquickframe \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          quickshell
+          grim
+          imagemagick
+          wl-clipboard
+          libnotify
+          satty
+        ]
+      } \
+      --add-flags "-c $out/share/hyprquickframe -n"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Quickshell-based screenshot utility for Hyprland";
+    homepage = "https://github.com/Ronin-CK/HyprQuickFrame";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.sophronesis ];
+    mainProgram = "hyprquickframe";
+  };
+})


### PR DESCRIPTION
HyprQuickFrame is a polished, native screenshot utility for Hyprland built with Quickshell. It features three capture modes (region, window, and temp/clipboard-only), shader-based dimming effects, animated UI elements, and integrates with satty for image annotation and KDE Connect for mobile sharing.

Homepage: https://github.com/Ronin-CK/HyprQuickFrame

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
