### PR TITLE
devenv: fix gc-related crashes on macOS

### DIFF
--- a/pkgs/by-name/de/devenv/package.nix
+++ b/pkgs/by-name/de/devenv/package.nix
@@ -78,7 +78,6 @@ rustPlatform.buildRustPackage {
     openssl
     sqlite
     dbus
-    boehmgc
     llvmPackages.clang-unwrapped
     nix_components.nix-expr-c
     nix_components.nix-store-c


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The Nix libraries already propagate their own customized boehmgc package.
Adding a second version to the build inputs allowed `nix-bindings-rust` to pick up this other version via `pkg-config`, resulting in the devenv binary linking against two different boehmgcs like so:

```
$ DYLD_PRINT_LIBRARIES=1 /nix/store/miq5nl5wr8hnqcsrkb8w10nlaj7wv1ws-devenv-2.0.3/bin/devenv version 2>&1 | rg libgc
dyld[35830]: <50EA88FB-2E5D-3581-9360-3976D543B9CA> /nix/store/hlg1hx8gis7w2gd8x074n0a4c4q9r1c6-boehm-gc-8.2.8/lib/libgc.1.dylib
dyld[35830]: <6CE27DA9-798D-3E69-B1F0-DB88F14138A8> /nix/store/jz6gcj47lfhccv4flvwqg5f2fgkcz0rq-boehm-gc-8.2.8/lib/libgc.1.dylib
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
