### PR TITLE
augustus-go: init at 0.0.8

### DIFF
--- a/pkgs/by-name/au/augustus-go/package.nix
+++ b/pkgs/by-name/au/augustus-go/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "augustus-go";
+  version = "0.0.8";
+
+  src = fetchFromGitHub {
+    owner = "praetorian-inc";
+    repo = "augustus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yC7Wxx7PCWLpIMdXieks7oTdW5Ot6e6zIJHnRyZUOlo=";
+  };
+
+  vendorHash = "sha256-4PQX87yICvP6h4IPjFTWnhbftPBx53im95V0oiL3v6E=";
+
+  ldflags = [ "-s" ];
+
+  preCheck = ''
+    # We don't care about Benchmarks
+    rm -r benchmarks
+    # Assert mismatch
+    substituteInPlace internal/detectors/packagehallucination/rubygems_test.go \
+      --replace-fail "TestRubyGems_Detect_FakeGem" "Skip_TestRubyGems_Detect_FakeGem"
+    # Tests require network access
+    rm  internal/generators/bedrock/bedrock_test.go
+  '';
+
+  meta = {
+    description = "LLM security testing framework for detecting prompt injection, jailbreaks and adversarial attacks";
+    homepage = "https://github.com/praetorian-inc/augustus";
+    changelog = "https://github.com/praetorian-inc/augustus/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "augustus";
+  };
+})


### PR DESCRIPTION
LLM security testing framework for detecting prompt injection, jailbreaks and adversarial attacks

https://github.com/praetorian-inc/augustus

Related https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
