### PR TITLE
nixos: replace container activation scripts

### DIFF
--- a/nixos/maintainers/scripts/incus/incus-container-image.nix
+++ b/nixos/maintainers/scripts/incus/incus-container-image.nix
@@ -13,18 +13,24 @@
     ];
   };
 
-  # copy the config for nixos-rebuild
-  system.activationScripts.config =
+  # Create a default configuration.nix on first boot so nixos-rebuild works
+  # out of the box.
+  systemd.services.incus-create-nixos-config =
     let
-      config = pkgs.replaceVars ./incus-container-image-inner.nix {
+      configFile = pkgs.replaceVars ./incus-container-image-inner.nix {
         stateVersion = lib.trivial.release;
       };
     in
-    ''
-      if [ ! -e /etc/nixos/configuration.nix ]; then
-        install -m 0644 -D ${config} /etc/nixos/configuration.nix
-      fi
-    '';
+    {
+      description = "Create default NixOS configuration for Incus";
+      wantedBy = [ "multi-user.target" ];
+      unitConfig.ConditionPathExists = "!/etc/nixos/configuration.nix";
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${pkgs.coreutils}/bin/install -m 0644 -D ${configFile} /etc/nixos/configuration.nix";
+      };
+    };
 
   networking = {
     dhcpcd.enable = false;

--- a/nixos/maintainers/scripts/incus/incus-virtual-machine-image.nix
+++ b/nixos/maintainers/scripts/incus/incus-virtual-machine-image.nix
@@ -13,18 +13,24 @@
     ];
   };
 
-  # copy the config for nixos-rebuild
-  system.activationScripts.config =
+  # Create a default configuration.nix on first boot so nixos-rebuild works
+  # out of the box.
+  systemd.services.incus-create-nixos-config =
     let
-      config = pkgs.replaceVars ./incus-virtual-machine-image-inner.nix {
+      configFile = pkgs.replaceVars ./incus-virtual-machine-image-inner.nix {
         stateVersion = lib.trivial.release;
       };
     in
-    ''
-      if [ ! -e /etc/nixos/configuration.nix ]; then
-        install -m 0644 -D ${config} /etc/nixos/configuration.nix
-      fi
-    '';
+    {
+      description = "Create default NixOS configuration for Incus";
+      wantedBy = [ "multi-user.target" ];
+      unitConfig.ConditionPathExists = "!/etc/nixos/configuration.nix";
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${pkgs.coreutils}/bin/install -m 0644 -D ${configFile} /etc/nixos/configuration.nix";
+      };
+    };
 
   # Network
   networking = {

--- a/nixos/modules/profiles/docker-container.nix
+++ b/nixos/modules/profiles/docker-container.nix
@@ -57,8 +57,9 @@ in
     ${config.nix.package.out}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
   '';
 
-  # Install new init script
-  system.activationScripts.installInitScript = ''
-    ln -fs $systemConfig/init /init
+  # Update /init symlink when switching configurations so the container
+  # boots the new system on restart.
+  system.build.installBootLoader = pkgs.writeShellScript "install-docker-init" ''
+    ${pkgs.coreutils}/bin/ln -fs "$1/init" /init
   '';
 }

--- a/nixos/modules/virtualisation/lxc-container.nix
+++ b/nixos/modules/virtualisation/lxc-container.nix
@@ -119,8 +119,5 @@
 
       systemd.packages = [ pkgs.distrobuilder.generator ];
 
-      system.activationScripts.installInitScript = lib.mkForce ''
-        ln -fs $systemConfig/init /sbin/init
-      '';
     };
 }

--- a/nixos/tests/incus/incus-tests-module.nix
+++ b/nixos/tests/incus/incus-tests-module.nix
@@ -156,6 +156,16 @@ in
 
                       server.succeed(f"incus exec {instance_name} -- test -e /dev/tpm0")
                       server.succeed(f"incus exec {instance_name} -- test -e /dev/tpmrm0")
+
+                  with subtest("[${image_id}] default configuration.nix is created on first boot"):
+                      server.succeed(f"incus exec {instance_name} -- test -f /etc/nixos/configuration.nix")
+
+                  with subtest("[${image_id}] configuration.nix create service does not overwrite existing config"):
+                      server.succeed(f"incus exec {instance_name} -- systemctl restart incus-create-nixos-config.service")
+                      status = server.succeed(
+                          f"incus exec {instance_name} -- systemctl show -p ActiveState incus-create-nixos-config.service"
+                      ).strip()
+                      assert "inactive" in status, f"Expected inactive (ConditionPathExists should prevent start), got {status}"
                 ''
                 #
                 # container specific
@@ -164,6 +174,21 @@ in
                   lib.optionalString (config.type == "container")
                     # python
                     ''
+                      with subtest("[${image_id}] switch-to-configuration updates /sbin/init via installBootLoader"):
+                          # Remove /sbin/init so we can verify installBootLoader recreates it
+                          server.succeed(f"incus exec {instance_name} -- rm -f /sbin/init")
+                          server.fail(f"incus exec {instance_name} -- test -e /sbin/init")
+
+                          server.succeed(
+                              f"incus exec {instance_name} -- /run/current-system/bin/switch-to-configuration switch"
+                          )
+
+                          # Verify installBootLoader recreated /sbin/init pointing to the system's init
+                          server.succeed(f"incus exec {instance_name} -- test -x /sbin/init")
+                          target = server.succeed(f"incus exec {instance_name} -- readlink -f /sbin/init").strip()
+                          current = server.succeed(f"incus exec {instance_name} -- readlink -f /run/current-system/init").strip()
+                          assert target == current, f"/sbin/init -> {target}, expected {current}"
+
                       # TODO troubleshoot VM hot memory resizing which was introduced in 6.12
                       with subtest("[${image_id}] memory limits can be hotplug changed"):
                           server.set_instance_config(instance_name, "limits.memory 512MB")


### PR DESCRIPTION
## Things done

Replace container `system.activationScripts`, see https://github.com/NixOS/nixpkgs/issues/475305.

* docker: move `/init` symlink creation from activation script to `installBootLoader`. This is the mechanism `switch-to-configuration` already uses for making a system profile bootable. The LXC module was already using `installBootLoader` for this purpose.
* lxc: remove the redundant `installInitScript` activation script, `installBootLoader` was already set to update `/sbin/init`.
* incus: replace activationScript with a oneshot systemd service that uses `ConditionPathExists` to create `/etc/nixos/configuration.nix` only on first boot.

The existing VM tests don't exercise these code paths, so I did some manual testing by booting up containers and checking that switch-to-configuration creates the correct new init scripts.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
