### PR TITLE
libphonenumber: downgrade deprecated-declarations errors to warnings

### DIFF
--- a/pkgs/by-name/li/libphonenumber/package.nix
+++ b/pkgs/by-name/li/libphonenumber/package.nix
@@ -66,15 +66,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   checkTarget = "tests";
 
-  cmakeFlags =
-    lib.optionals (!enableTests) [
-      (lib.cmakeBool "REGENERATE_METADATA" false)
-      (lib.cmakeBool "USE_BOOST" false)
-    ]
-    ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-      (lib.cmakeFeature "CMAKE_CROSSCOMPILING_EMULATOR" (stdenv.hostPlatform.emulator buildPackages))
-      (lib.cmakeFeature "PROTOC_BIN" (lib.getExe buildPackages.protobuf))
-    ];
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-Wno-error=deprecated-declarations")
+  ]
+  ++ lib.optionals (!enableTests) [
+    (lib.cmakeBool "REGENERATE_METADATA" false)
+    (lib.cmakeBool "USE_BOOST" false)
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    (lib.cmakeFeature "CMAKE_CROSSCOMPILING_EMULATOR" (stdenv.hostPlatform.emulator buildPackages))
+    (lib.cmakeFeature "PROTOC_BIN" (lib.getExe buildPackages.protobuf))
+  ];
 
   meta = {
     changelog = "https://github.com/google/libphonenumber/blob/${finalAttrs.src.rev}/release_notes.txt";


### PR DESCRIPTION
~~libphonenumber pins a specific abseil version that does not match the one we use. This leads to breakage with the update to `abseil-cpp_202601` on staging-next. Example resulting build failure: https://hydra.nixos.org/build/323941412~~

~~We could patch this instead, but given upstream libphonenumber explicitly [pins its own abseil](https://github.com/google/libphonenumber/blob/db1e15b24fb0f6bd236c5c47f1350252c8301986/cpp/CMakeLists.txt#L109-L115
), and abseil considers this an LTS release, pinning doesn't seem inappropriate.~~

Upstream libphonenumber uses an abseil version version that has a different declaration of `absl::MutexLock`, leading to warnings about using a deprecated declaration in new versions.

Failing build logs: https://hydra.nixos.org/build/323941412/nixlog/3

In order to bypass this without abseil version proliferation, we downgrade these warnings to errors.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 499321`
Commit: `87dab9762d54d7118b15f0a555188c54d7792f2a`

### `x86_64-linux`
<details>
  <summary>:fast_forward: 5 packages marked as broken and skipped:</summary>
  <ul>
    <li>chatty</li>
    <li>kdePackages.itinerary</li>
    <li>kdePackages.itinerary.debug</li>
    <li>kdePackages.itinerary.dev</li>
    <li>kdePackages.itinerary.devtools</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 89 packages built:</summary>
  <ul>
    <li>adapta-gtk-theme</li>
    <li>almanah</li>
    <li>ayatana-indicator-datetime</li>
    <li>bubblemail</li>
    <li>bubblemail.dist</li>
    <li>calls</li>
    <li>calls.devdoc</li>
    <li>cinnamon</li>
    <li>cinnamon-gsettings-overrides</li>
    <li>cinnamon-screensaver</li>
    <li>endeavour</li>
    <li>evolution</li>
    <li>evolution-data-server</li>
    <li>evolution-data-server-gtk4</li>
    <li>evolution-data-server-gtk4.dev</li>
    <li>evolution-data-server.dev</li>
    <li>evolution-ews</li>
    <li>evolution.man</li>
    <li>evolutionWithPlugins</li>
    <li>folks</li>
    <li>folks.dev</li>
    <li>folks.devdoc</li>
    <li>geary</li>
    <li>gnome-applets</li>
    <li>gnome-browser-connector</li>
    <li>gnome-calendar</li>
    <li>gnome-contacts</li>
    <li>gnome-flashback</li>
    <li>gnome-notes</li>
    <li>gnome-panel</li>
    <li>gnome-panel-with-modules</li>
    <li>gnome-panel.dev</li>
    <li>gnome-panel.man</li>
    <li>gnome-session</li>
    <li>gnome-session.debug</li>
    <li>gnome-session.sessions</li>
    <li>gnome-shell</li>
    <li>gnome-shell.debug</li>
    <li>gnome-shell.devdoc</li>
    <li>gnome-tweaks</li>
    <li>gnome.nixos-gsettings-overrides</li>
    <li>gnomeExtensions.easyScreenCast</li>
    <li>gnomeExtensions.gsconnect</li>
    <li>gnomeExtensions.gsconnect.installedTests</li>
    <li>kdePackages.kdepim-addons</li>
    <li>kdePackages.kdepim-addons.debug</li>
    <li>kdePackages.kdepim-addons.dev</li>
    <li>kdePackages.kdepim-addons.devtools</li>
    <li>kdePackages.kitinerary</li>
    <li>kdePackages.kitinerary.debug</li>
    <li>kdePackages.kitinerary.dev</li>
    <li>kdePackages.kitinerary.devtools</li>
    <li>kdePackages.plasma-dialer</li>
    <li>kdePackages.plasma-dialer.debug</li>
    <li>kdePackages.plasma-dialer.dev</li>
    <li>kdePackages.plasma-dialer.devtools</li>
    <li>kdePackages.spacebar</li>
    <li>kdePackages.spacebar.debug</li>
    <li>kdePackages.spacebar.dev</li>
    <li>kdePackages.spacebar.devtools</li>
    <li>libphonenumber</li>
    <li>libphonenumber.dev</li>
    <li>lomiri.lomiri</li>
    <li>lomiri.lomiri-history-service</li>
    <li>lomiri.lomiri-history-service.dev</li>
    <li>lomiri.lomiri-session</li>
    <li>lomiri.lomiri-telephony-service</li>
    <li>marble-shell-theme</li>
    <li>matrix-gtk-theme</li>
    <li>mmsd-tng</li>
    <li>mojave-gtk-theme</li>
    <li>pantheon.elementary-calendar</li>
    <li>pantheon.elementary-greeter</li>
    <li>pantheon.elementary-gsettings-schemas</li>
    <li>pantheon.elementary-mail</li>
    <li>pantheon.elementary-session-settings</li>
    <li>pantheon.elementary-tasks</li>
    <li>pantheon.switchboard-plug-onlineaccounts</li>
    <li>pantheon.switchboard-with-plugs</li>
    <li>pantheon.wingpanel-applications-menu</li>
    <li>pantheon.wingpanel-indicator-datetime</li>
    <li>pantheon.wingpanel-with-indicators</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>planify</li>
    <li>themechanger</li>
    <li>tokyonight-gtk-theme</li>
    <li>valent</li>
    <li>vimix-gtk-themes</li>
  </ul>
</details>

### `aarch64-linux`
<details>
  <summary>:fast_forward: 5 packages marked as broken and skipped:</summary>
  <ul>
    <li>chatty</li>
    <li>kdePackages.itinerary</li>
    <li>kdePackages.itinerary.debug</li>
    <li>kdePackages.itinerary.dev</li>
    <li>kdePackages.itinerary.devtools</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 89 packages built:</summary>
  <ul>
    <li>adapta-gtk-theme</li>
    <li>almanah</li>
    <li>ayatana-indicator-datetime</li>
    <li>bubblemail</li>
    <li>bubblemail.dist</li>
    <li>calls</li>
    <li>calls.devdoc</li>
    <li>cinnamon</li>
    <li>cinnamon-gsettings-overrides</li>
    <li>cinnamon-screensaver</li>
    <li>endeavour</li>
    <li>evolution</li>
    <li>evolution-data-server</li>
    <li>evolution-data-server-gtk4</li>
    <li>evolution-data-server-gtk4.dev</li>
    <li>evolution-data-server.dev</li>
    <li>evolution-ews</li>
    <li>evolution.man</li>
    <li>evolutionWithPlugins</li>
    <li>folks</li>
    <li>folks.dev</li>
    <li>folks.devdoc</li>
    <li>geary</li>
    <li>gnome-applets</li>
    <li>gnome-browser-connector</li>
    <li>gnome-calendar</li>
    <li>gnome-contacts</li>
    <li>gnome-flashback</li>
    <li>gnome-notes</li>
    <li>gnome-panel</li>
    <li>gnome-panel-with-modules</li>
    <li>gnome-panel.dev</li>
    <li>gnome-panel.man</li>
    <li>gnome-session</li>
    <li>gnome-session.debug</li>
    <li>gnome-session.sessions</li>
    <li>gnome-shell</li>
    <li>gnome-shell.debug</li>
    <li>gnome-shell.devdoc</li>
    <li>gnome-tweaks</li>
    <li>gnome.nixos-gsettings-overrides</li>
    <li>gnomeExtensions.easyScreenCast</li>
    <li>gnomeExtensions.gsconnect</li>
    <li>gnomeExtensions.gsconnect.installedTests</li>
    <li>kdePackages.kdepim-addons</li>
    <li>kdePackages.kdepim-addons.debug</li>
    <li>kdePackages.kdepim-addons.dev</li>
    <li>kdePackages.kdepim-addons.devtools</li>
    <li>kdePackages.kitinerary</li>
    <li>kdePackages.kitinerary.debug</li>
    <li>kdePackages.kitinerary.dev</li>
    <li>kdePackages.kitinerary.devtools</li>
    <li>kdePackages.plasma-dialer</li>
    <li>kdePackages.plasma-dialer.debug</li>
    <li>kdePackages.plasma-dialer.dev</li>
    <li>kdePackages.plasma-dialer.devtools</li>
    <li>kdePackages.spacebar</li>
    <li>kdePackages.spacebar.debug</li>
    <li>kdePackages.spacebar.dev</li>
    <li>kdePackages.spacebar.devtools</li>
    <li>libphonenumber</li>
    <li>libphonenumber.dev</li>
    <li>lomiri.lomiri</li>
    <li>lomiri.lomiri-history-service</li>
    <li>lomiri.lomiri-history-service.dev</li>
    <li>lomiri.lomiri-session</li>
    <li>lomiri.lomiri-telephony-service</li>
    <li>marble-shell-theme</li>
    <li>matrix-gtk-theme</li>
    <li>mmsd-tng</li>
    <li>mojave-gtk-theme</li>
    <li>pantheon.elementary-calendar</li>
    <li>pantheon.elementary-greeter</li>
    <li>pantheon.elementary-gsettings-schemas</li>
    <li>pantheon.elementary-mail</li>
    <li>pantheon.elementary-session-settings</li>
    <li>pantheon.elementary-tasks</li>
    <li>pantheon.switchboard-plug-onlineaccounts</li>
    <li>pantheon.switchboard-with-plugs</li>
    <li>pantheon.wingpanel-applications-menu</li>
    <li>pantheon.wingpanel-indicator-datetime</li>
    <li>pantheon.wingpanel-with-indicators</li>
    <li>phosh</li>
    <li>phosh-mobile-settings</li>
    <li>planify</li>
    <li>themechanger</li>
    <li>tokyonight-gtk-theme</li>
    <li>valent</li>
    <li>vimix-gtk-themes</li>
  </ul>
</details>