### PR TITLE
gpu-burn: 0-unstable-2024-04-09 -> 0-unstable-2025-11-04

### DIFF
--- a/pkgs/by-name/gp/gpu-burn/package.nix
+++ b/pkgs/by-name/gp/gpu-burn/package.nix
@@ -84,7 +84,10 @@ backendStdenv.mkDerivation {
     homepage = "http://wili.cc/blog/gpu-burn.html";
     license = lib.licenses.bsd2;
     mainProgram = "gpu_burn";
-    maintainers = with lib.maintainers; [ connorbaker ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      connorbaker
+    ];
     platforms = optionals cudaSupport lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/gp/gpu-burn/package.nix
+++ b/pkgs/by-name/gp/gpu-burn/package.nix
@@ -1,9 +1,10 @@
 {
+  lib,
   autoAddDriverRunpath,
   config,
   cudaPackages,
   fetchFromGitHub,
-  lib,
+  nix-update-script,
 }:
 let
   inherit (lib.lists) last map optionals;
@@ -20,15 +21,15 @@ let
 in
 backendStdenv.mkDerivation {
   pname = "gpu-burn";
-  version = "0-unstable-2024-04-09";
+  version = "0-unstable-2025-11-04";
 
   strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "wilicc";
     repo = "gpu-burn";
-    rev = "9aefd7c0cc603bbc8c3c102f5338c6af26f8127c";
-    hash = "sha256-Nz0yaoHGfodaYl2HJ7p+1nasqRmxwPJ9aL9oxitXDpM=";
+    rev = "671f4be92477ce01cd9b536bc534a006dbee058f";
+    hash = "sha256-zaGzwpdvF9dw3RypBO+g6FhjOFN8/F9+yI1+lLxLjgs=";
   };
 
   postPatch = ''
@@ -68,6 +69,10 @@ backendStdenv.mkDerivation {
     install -Dm644 compare.ptx $out/share/
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   # NOTE: Certain packages may be missing from cudaPackages on non-Linux platforms. To avoid evaluation failure,
   # we only include the platforms where we know the package is available -- thus the conditionals setting the


### PR DESCRIPTION
## Things done

- **gpu-burn: 0-unstable-2024-04-09 -> 0-unstable-2025-11-04**
- **gpu-burn: add GaetanLepage to maintainers**

cc @ConnorBaker

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
