### PR TITLE
trajan: 1.0.0 -> 1.0.2

### DIFF
--- a/pkgs/by-name/tr/trajan/package.nix
+++ b/pkgs/by-name/tr/trajan/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "trajan";
-  version = "1.0.0";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "praetorian-inc";
     repo = "trajan";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ji4IkImpDRQr8BuJCIqRfxyEWFD3Ux99D5lP3ALt+OQ=";
+    hash = "sha256-a6LnK10obwZ/shMKNn32aEOQw9YDOBa/U4oiE2sPTXs=";
   };
 
-  vendorHash = "sha256-Vr9MkEJZOIrryhGOWrUq76J8B7+2bzf5BOV4omVDIY8=";
+  vendorHash = "sha256-xJdfYpVjpkyKlSPeQZ6SlNuq4ckyLw0kA66LXweS1dU=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 


### PR DESCRIPTION
Diff: https://github.com/praetorian-inc/trajan/compare/v1.0.0...v1.0.2

Changelog: https://github.com/praetorian-inc/trajan/releases/tag/vrefs/tags/v1.0.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
