### PR TITLE
pathplanner: init at 2026.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5279,6 +5279,12 @@
     githubId = 327028;
     name = "Cole Mickens";
   };
+  colepearson27 = {
+    name = "Cole Pearson";
+    email = "colepearson27@gmail.com";
+    github = "colepearson27";
+    githubId = 113060096;
+  };
   colescott = {
     email = "colescottsf@gmail.com";
     github = "colescott";

--- a/pkgs/by-name/pa/pathplanner/package.nix
+++ b/pkgs/by-name/pa/pathplanner/package.nix
@@ -1,0 +1,52 @@
+{
+  fetchFromGitHub,
+  flutter335,
+  lib,
+  util-linux,
+  xz,
+}:
+
+flutter335.buildFlutterApplication (finalAttrs: {
+  pname = "pathplanner";
+  version = "2026.1.2";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "mjansen4857";
+    repo = "pathplanner";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ocqBviTfMxjdJdEu++yqUY9JTLs1qEnP94w6HCFp5f0=";
+  };
+
+  pubspecLock = lib.importJSON ./pubspec.lock.json;
+
+  buildInputs = [
+    util-linux # For libblkid
+    xz # For liblzma
+  ];
+
+  configurePhase = ''
+    runHook postConfigure
+  '';
+
+  # Required for Pathplanner to load it's icon
+  postPatch = ''
+    substituteInPlace linux/my_application.cc \
+    --replace-fail "images/icon.ico" "$out/app/pathplanner/data/flutter_assets/images/icon.ico"
+  '';
+
+  postInstall = ''
+    install -Dm0644 $out/app/pathplanner/data/flutter_assets/images/icon.png $out/share/icons/hicolor/512x512/apps/pathplanner.png
+  '';
+
+  meta = {
+    description = "FRC motion profile generator and path editor for robots";
+    homepage = "https://github.com/mjansen4857/pathplanner";
+    changelog = "https://github.com/mjansen4857/pathplanner/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ colepearson27 ];
+  };
+})

--- a/pkgs/by-name/pa/pathplanner/pubspec.lock.json
+++ b/pkgs/by-name/pa/pathplanner/pubspec.lock.json
@@ -1,0 +1,1582 @@
+{
+    "packages": {
+        "_fe_analyzer_shared": {
+            "dependency": "transitive",
+            "description": {
+                "name": "_fe_analyzer_shared",
+                "sha256": "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "67.0.0"
+        },
+        "analyzer": {
+            "dependency": "transitive",
+            "description": {
+                "name": "analyzer",
+                "sha256": "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "6.4.1"
+        },
+        "archive": {
+            "dependency": "transitive",
+            "description": {
+                "name": "archive",
+                "sha256": "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "4.0.7"
+        },
+        "args": {
+            "dependency": "transitive",
+            "description": {
+                "name": "args",
+                "sha256": "d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.7.0"
+        },
+        "async": {
+            "dependency": "transitive",
+            "description": {
+                "name": "async",
+                "sha256": "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.13.0"
+        },
+        "boolean_selector": {
+            "dependency": "transitive",
+            "description": {
+                "name": "boolean_selector",
+                "sha256": "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.1.2"
+        },
+        "build": {
+            "dependency": "transitive",
+            "description": {
+                "name": "build",
+                "sha256": "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.1"
+        },
+        "build_config": {
+            "dependency": "transitive",
+            "description": {
+                "name": "build_config",
+                "sha256": "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.1.2"
+        },
+        "build_daemon": {
+            "dependency": "transitive",
+            "description": {
+                "name": "build_daemon",
+                "sha256": "409002f1adeea601018715d613115cfaf0e31f512cb80ae4534c79867ae2363d",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "4.1.0"
+        },
+        "build_resolvers": {
+            "dependency": "transitive",
+            "description": {
+                "name": "build_resolvers",
+                "sha256": "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.2"
+        },
+        "build_runner": {
+            "dependency": "direct dev",
+            "description": {
+                "name": "build_runner",
+                "sha256": "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.13"
+        },
+        "build_runner_core": {
+            "dependency": "transitive",
+            "description": {
+                "name": "build_runner_core",
+                "sha256": "f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "7.3.2"
+        },
+        "built_collection": {
+            "dependency": "transitive",
+            "description": {
+                "name": "built_collection",
+                "sha256": "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "5.1.1"
+        },
+        "built_value": {
+            "dependency": "transitive",
+            "description": {
+                "name": "built_value",
+                "sha256": "a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "8.12.0"
+        },
+        "change": {
+            "dependency": "transitive",
+            "description": {
+                "name": "change",
+                "sha256": "3bda1ce98526b21927cdea05688563c7065fd7e66d1abbe176c354fef3b2057b",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.7.5"
+        },
+        "characters": {
+            "dependency": "transitive",
+            "description": {
+                "name": "characters",
+                "sha256": "f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.4.0"
+        },
+        "checked_yaml": {
+            "dependency": "transitive",
+            "description": {
+                "name": "checked_yaml",
+                "sha256": "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.0.4"
+        },
+        "cider": {
+            "dependency": "direct dev",
+            "description": {
+                "name": "cider",
+                "sha256": "dfff70e9324f99e315857c596c31f54cb7380cfa20dfdfdca11a3631e05b7d3e",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.2.8"
+        },
+        "cli_util": {
+            "dependency": "transitive",
+            "description": {
+                "name": "cli_util",
+                "sha256": "ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.4.2"
+        },
+        "clock": {
+            "dependency": "transitive",
+            "description": {
+                "name": "clock",
+                "sha256": "fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.1.2"
+        },
+        "code_builder": {
+            "dependency": "transitive",
+            "description": {
+                "name": "code_builder",
+                "sha256": "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "4.11.0"
+        },
+        "collection": {
+            "dependency": "direct main",
+            "description": {
+                "name": "collection",
+                "sha256": "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.19.1"
+        },
+        "console": {
+            "dependency": "transitive",
+            "description": {
+                "name": "console",
+                "sha256": "e04e7824384c5b39389acdd6dc7d33f3efe6b232f6f16d7626f194f6a01ad69a",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "4.1.0"
+        },
+        "convert": {
+            "dependency": "transitive",
+            "description": {
+                "name": "convert",
+                "sha256": "b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.1.2"
+        },
+        "cross_file": {
+            "dependency": "transitive",
+            "description": {
+                "name": "cross_file",
+                "sha256": "942a4791cd385a68ccb3b32c71c427aba508a1bb949b86dff2adbe4049f16239",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.3.5"
+        },
+        "crypto": {
+            "dependency": "transitive",
+            "description": {
+                "name": "crypto",
+                "sha256": "c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.0.7"
+        },
+        "cupertino_icons": {
+            "dependency": "direct main",
+            "description": {
+                "name": "cupertino_icons",
+                "sha256": "ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.0.8"
+        },
+        "dart_style": {
+            "dependency": "transitive",
+            "description": {
+                "name": "dart_style",
+                "sha256": "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.3.6"
+        },
+        "dio": {
+            "dependency": "transitive",
+            "description": {
+                "name": "dio",
+                "sha256": "d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "5.9.0"
+        },
+        "dio_web_adapter": {
+            "dependency": "transitive",
+            "description": {
+                "name": "dio_web_adapter",
+                "sha256": "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.1.1"
+        },
+        "dropdown_button2": {
+            "dependency": "direct main",
+            "description": {
+                "name": "dropdown_button2",
+                "sha256": "b0fe8d49a030315e9eef6c7ac84ca964250155a6224d491c1365061bc974a9e1",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.3.9"
+        },
+        "equatable": {
+            "dependency": "transitive",
+            "description": {
+                "name": "equatable",
+                "sha256": "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.0.7"
+        },
+        "fake_async": {
+            "dependency": "transitive",
+            "description": {
+                "name": "fake_async",
+                "sha256": "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.3.3"
+        },
+        "ffi": {
+            "dependency": "transitive",
+            "description": {
+                "name": "ffi",
+                "sha256": "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.1.4"
+        },
+        "file": {
+            "dependency": "direct main",
+            "description": {
+                "name": "file",
+                "sha256": "a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "7.0.1"
+        },
+        "file_selector": {
+            "dependency": "direct main",
+            "description": {
+                "name": "file_selector",
+                "sha256": "5f1d15a7f17115038f433d1b0ea57513cc9e29a9d5338d166cb0bef3fa90a7a0",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.0.4"
+        },
+        "file_selector_android": {
+            "dependency": "transitive",
+            "description": {
+                "name": "file_selector_android",
+                "sha256": "2db9a2d05f66b49a3b45c4a7c2f040dd5fcd457ca30f39df7cdcf80b8cd7f2d4",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.5.2+1"
+        },
+        "file_selector_ios": {
+            "dependency": "transitive",
+            "description": {
+                "name": "file_selector_ios",
+                "sha256": "fc3c3fc567cd9bcae784dfeb98d37c46a8ded9e8757d37ea67e975c399bc14e0",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.5.3+3"
+        },
+        "file_selector_linux": {
+            "dependency": "transitive",
+            "description": {
+                "name": "file_selector_linux",
+                "sha256": "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.9.3+2"
+        },
+        "file_selector_macos": {
+            "dependency": "transitive",
+            "description": {
+                "name": "file_selector_macos",
+                "sha256": "88707a3bec4b988aaed3b4df5d7441ee4e987f20b286cddca5d6a8270cab23f2",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.9.4+5"
+        },
+        "file_selector_platform_interface": {
+            "dependency": "transitive",
+            "description": {
+                "name": "file_selector_platform_interface",
+                "sha256": "a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.6.2"
+        },
+        "file_selector_web": {
+            "dependency": "transitive",
+            "description": {
+                "name": "file_selector_web",
+                "sha256": "c4c0ea4224d97a60a7067eca0c8fd419e708ff830e0c83b11a48faf566cec3e7",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.9.4+2"
+        },
+        "file_selector_windows": {
+            "dependency": "transitive",
+            "description": {
+                "name": "file_selector_windows",
+                "sha256": "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.9.3+4"
+        },
+        "fixnum": {
+            "dependency": "transitive",
+            "description": {
+                "name": "fixnum",
+                "sha256": "b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.1.1"
+        },
+        "fl_chart": {
+            "dependency": "direct main",
+            "description": {
+                "name": "fl_chart",
+                "sha256": "74959b99b92b9eebeed1a4049426fd67c4abc3c5a0f4d12e2877097d6a11ae08",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.69.2"
+        },
+        "flutter": {
+            "dependency": "direct main",
+            "description": "flutter",
+            "source": "sdk",
+            "version": "0.0.0"
+        },
+        "flutter_animate": {
+            "dependency": "direct main",
+            "description": {
+                "name": "flutter_animate",
+                "sha256": "7befe2d3252728afb77aecaaea1dec88a89d35b9b1d2eea6d04479e8af9117b5",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "4.5.2"
+        },
+        "flutter_colorpicker": {
+            "dependency": "direct main",
+            "description": {
+                "name": "flutter_colorpicker",
+                "sha256": "969de5f6f9e2a570ac660fb7b501551451ea2a1ab9e2097e89475f60e07816ea",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.1.0"
+        },
+        "flutter_lints": {
+            "dependency": "direct dev",
+            "description": {
+                "name": "flutter_lints",
+                "sha256": "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "5.0.0"
+        },
+        "flutter_shaders": {
+            "dependency": "transitive",
+            "description": {
+                "name": "flutter_shaders",
+                "sha256": "34794acadd8275d971e02df03afee3dee0f98dbfb8c4837082ad0034f612a3e2",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.1.3"
+        },
+        "flutter_test": {
+            "dependency": "direct dev",
+            "description": "flutter",
+            "source": "sdk",
+            "version": "0.0.0"
+        },
+        "flutter_web_plugins": {
+            "dependency": "transitive",
+            "description": "flutter",
+            "source": "sdk",
+            "version": "0.0.0"
+        },
+        "frontend_server_client": {
+            "dependency": "transitive",
+            "description": {
+                "name": "frontend_server_client",
+                "sha256": "f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "4.0.0"
+        },
+        "full_coverage": {
+            "dependency": "direct dev",
+            "description": {
+                "name": "full_coverage",
+                "sha256": "2df796384bf6459bed72319c4676d473c270f71a71c3d73de33eddd52658a9b8",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.0.0"
+        },
+        "function_tree": {
+            "dependency": "direct main",
+            "description": {
+                "name": "function_tree",
+                "sha256": "098f41f8c8d55952fd162cbeb709e8213a709065ab6fbebffe323701c785a259",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.9.1"
+        },
+        "get_it": {
+            "dependency": "transitive",
+            "description": {
+                "name": "get_it",
+                "sha256": "ae78de7c3f2304b8d81f2bb6e320833e5e81de942188542328f074978cc0efa9",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "8.3.0"
+        },
+        "github": {
+            "dependency": "direct main",
+            "description": {
+                "name": "github",
+                "sha256": "c88cd9f11e131a05b1910e1c742c80e6dc7708701884d1fcf28147fc95933aa8",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "9.25.0"
+        },
+        "glob": {
+            "dependency": "transitive",
+            "description": {
+                "name": "glob",
+                "sha256": "c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.1.3"
+        },
+        "graphs": {
+            "dependency": "transitive",
+            "description": {
+                "name": "graphs",
+                "sha256": "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.3.2"
+        },
+        "hashcodes": {
+            "dependency": "transitive",
+            "description": {
+                "name": "hashcodes",
+                "sha256": "80f9410a5b3c8e110c4b7604546034749259f5d6dcca63e0d3c17c9258f1a651",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.0.0"
+        },
+        "http": {
+            "dependency": "direct main",
+            "description": {
+                "name": "http",
+                "sha256": "bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.5.0"
+        },
+        "http_multi_server": {
+            "dependency": "transitive",
+            "description": {
+                "name": "http_multi_server",
+                "sha256": "aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.2.2"
+        },
+        "http_parser": {
+            "dependency": "transitive",
+            "description": {
+                "name": "http_parser",
+                "sha256": "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "4.1.2"
+        },
+        "image": {
+            "dependency": "direct main",
+            "description": {
+                "name": "image",
+                "sha256": "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "4.5.4"
+        },
+        "image_size_getter": {
+            "dependency": "direct main",
+            "description": {
+                "name": "image_size_getter",
+                "sha256": "7c26937e0ae341ca558b7556591fd0cc456fcc454583b7cb665d2f03e93e590f",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.1"
+        },
+        "intl": {
+            "dependency": "transitive",
+            "description": {
+                "name": "intl",
+                "sha256": "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.20.2"
+        },
+        "io": {
+            "dependency": "transitive",
+            "description": {
+                "name": "io",
+                "sha256": "dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.0.5"
+        },
+        "isolate_manager": {
+            "dependency": "direct main",
+            "description": {
+                "name": "isolate_manager",
+                "sha256": "0ff8401979b8101fec4019d7aedead083780fea152970799f0f3456dfe323e11",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "5.7.5"
+        },
+        "isolate_manager_generator": {
+            "dependency": "transitive",
+            "description": {
+                "name": "isolate_manager_generator",
+                "sha256": "38e00f63891e39bcd27db34bf99f066f825f3dccaf866df860143f8a4e9c0541",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.0.13"
+        },
+        "js": {
+            "dependency": "transitive",
+            "description": {
+                "name": "js",
+                "sha256": "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.7.2"
+        },
+        "json_annotation": {
+            "dependency": "transitive",
+            "description": {
+                "name": "json_annotation",
+                "sha256": "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "4.9.0"
+        },
+        "leak_tracker": {
+            "dependency": "transitive",
+            "description": {
+                "name": "leak_tracker",
+                "sha256": "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "11.0.2"
+        },
+        "leak_tracker_flutter_testing": {
+            "dependency": "transitive",
+            "description": {
+                "name": "leak_tracker_flutter_testing",
+                "sha256": "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.0.10"
+        },
+        "leak_tracker_testing": {
+            "dependency": "transitive",
+            "description": {
+                "name": "leak_tracker_testing",
+                "sha256": "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.0.2"
+        },
+        "lints": {
+            "dependency": "transitive",
+            "description": {
+                "name": "lints",
+                "sha256": "c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "5.1.1"
+        },
+        "logger": {
+            "dependency": "direct main",
+            "description": {
+                "name": "logger",
+                "sha256": "a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.6.2"
+        },
+        "logging": {
+            "dependency": "transitive",
+            "description": {
+                "name": "logging",
+                "sha256": "c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.3.0"
+        },
+        "logging_appenders": {
+            "dependency": "transitive",
+            "description": {
+                "name": "logging_appenders",
+                "sha256": "7fefa09636824f312432721c0bf77967ab19003116650729bd202bdf98142d70",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.4.0+1"
+        },
+        "macos_secure_bookmarks": {
+            "dependency": "direct main",
+            "description": {
+                "name": "macos_secure_bookmarks",
+                "sha256": "c3163875f8fd530a1654a7cf8aa426e6e208d28bf05724a1d4960e4b7d2ca1c6",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.2.1"
+        },
+        "markdown": {
+            "dependency": "transitive",
+            "description": {
+                "name": "markdown",
+                "sha256": "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "7.3.0"
+        },
+        "marker": {
+            "dependency": "transitive",
+            "description": {
+                "name": "marker",
+                "sha256": "3dadd01f3b0ffae148ffb3b1bc04290a98e54a465cddbab59727bd2a9fe57750",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.6.0"
+        },
+        "matcher": {
+            "dependency": "transitive",
+            "description": {
+                "name": "matcher",
+                "sha256": "dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.12.17"
+        },
+        "material_color_utilities": {
+            "dependency": "transitive",
+            "description": {
+                "name": "material_color_utilities",
+                "sha256": "f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.11.1"
+        },
+        "matrices": {
+            "dependency": "direct main",
+            "description": {
+                "name": "matrices",
+                "sha256": "e1277be104655d46bfe4aeb8917e7c31e2ffc06e9d0461b92fc139391fc931c2",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.2.7"
+        },
+        "messagepack": {
+            "dependency": "transitive",
+            "description": {
+                "name": "messagepack",
+                "sha256": "11e69dd79ba84ba901261558881b42ac8b24155a7846a344875a32c8b0866d71",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.2.1"
+        },
+        "meta": {
+            "dependency": "transitive",
+            "description": {
+                "name": "meta",
+                "sha256": "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.17.0"
+        },
+        "mime": {
+            "dependency": "transitive",
+            "description": {
+                "name": "mime",
+                "sha256": "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.0.0"
+        },
+        "mockito": {
+            "dependency": "direct dev",
+            "description": {
+                "name": "mockito",
+                "sha256": "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "5.4.4"
+        },
+        "msgpack_dart": {
+            "dependency": "transitive",
+            "description": {
+                "name": "msgpack_dart",
+                "sha256": "c2d235ed01f364719b5296aecf43ac330f0d7bc865fa134d0d7910a40454dffb",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.0.1"
+        },
+        "msix": {
+            "dependency": "direct dev",
+            "description": {
+                "name": "msix",
+                "sha256": "f88033fcb9e0dd8de5b18897cbebbd28ea30596810f4a7c86b12b0c03ace87e5",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.16.12"
+        },
+        "multi_split_view": {
+            "dependency": "direct main",
+            "description": {
+                "name": "multi_split_view",
+                "sha256": "d68e129bff71fc9e6b66de59e1b79deaf4b91f30940130bfbd2d704c1c713499",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.0"
+        },
+        "nt4": {
+            "dependency": "direct main",
+            "description": {
+                "name": "nt4",
+                "sha256": "0dac7b51c3487970ad149a294a30fa1b5a8b668132e04855fdee260c87a30122",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.3.3"
+        },
+        "package_config": {
+            "dependency": "transitive",
+            "description": {
+                "name": "package_config",
+                "sha256": "f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.2.0"
+        },
+        "package_info_plus": {
+            "dependency": "direct main",
+            "description": {
+                "name": "package_info_plus",
+                "sha256": "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "8.3.1"
+        },
+        "package_info_plus_platform_interface": {
+            "dependency": "transitive",
+            "description": {
+                "name": "package_info_plus_platform_interface",
+                "sha256": "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.2.1"
+        },
+        "path": {
+            "dependency": "direct main",
+            "description": {
+                "name": "path",
+                "sha256": "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.9.1"
+        },
+        "path_provider": {
+            "dependency": "direct main",
+            "description": {
+                "name": "path_provider",
+                "sha256": "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.1.5"
+        },
+        "path_provider_android": {
+            "dependency": "transitive",
+            "description": {
+                "name": "path_provider_android",
+                "sha256": "e122c5ea805bb6773bb12ce667611265980940145be920cd09a4b0ec0285cb16",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.2.20"
+        },
+        "path_provider_foundation": {
+            "dependency": "transitive",
+            "description": {
+                "name": "path_provider_foundation",
+                "sha256": "efaec349ddfc181528345c56f8eda9d6cccd71c177511b132c6a0ddaefaa2738",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.3"
+        },
+        "path_provider_linux": {
+            "dependency": "transitive",
+            "description": {
+                "name": "path_provider_linux",
+                "sha256": "f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.2.1"
+        },
+        "path_provider_platform_interface": {
+            "dependency": "transitive",
+            "description": {
+                "name": "path_provider_platform_interface",
+                "sha256": "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.1.2"
+        },
+        "path_provider_windows": {
+            "dependency": "transitive",
+            "description": {
+                "name": "path_provider_windows",
+                "sha256": "bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.3.0"
+        },
+        "petitparser": {
+            "dependency": "transitive",
+            "description": {
+                "name": "petitparser",
+                "sha256": "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "7.0.1"
+        },
+        "platform": {
+            "dependency": "transitive",
+            "description": {
+                "name": "platform",
+                "sha256": "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.1.6"
+        },
+        "plugin_platform_interface": {
+            "dependency": "transitive",
+            "description": {
+                "name": "plugin_platform_interface",
+                "sha256": "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.1.8"
+        },
+        "pool": {
+            "dependency": "transitive",
+            "description": {
+                "name": "pool",
+                "sha256": "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.5.2"
+        },
+        "posix": {
+            "dependency": "transitive",
+            "description": {
+                "name": "posix",
+                "sha256": "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "6.0.3"
+        },
+        "pub_semver": {
+            "dependency": "transitive",
+            "description": {
+                "name": "pub_semver",
+                "sha256": "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.2.0"
+        },
+        "pubspec_parse": {
+            "dependency": "transitive",
+            "description": {
+                "name": "pubspec_parse",
+                "sha256": "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.5.0"
+        },
+        "rfc_6901": {
+            "dependency": "transitive",
+            "description": {
+                "name": "rfc_6901",
+                "sha256": "6a43b1858dca2febaf93e15639aa6b0c49ccdfd7647775f15a499f872b018154",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.2.1"
+        },
+        "scidart": {
+            "dependency": "direct main",
+            "description": {
+                "name": "scidart",
+                "sha256": "af816eed552cadb6a9a324c594515b0cdff41617839345c382047927bd8dc02d",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.0.2-dev.12"
+        },
+        "screen_retriever": {
+            "dependency": "transitive",
+            "description": {
+                "name": "screen_retriever",
+                "sha256": "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.2.0"
+        },
+        "screen_retriever_linux": {
+            "dependency": "transitive",
+            "description": {
+                "name": "screen_retriever_linux",
+                "sha256": "f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.2.0"
+        },
+        "screen_retriever_macos": {
+            "dependency": "transitive",
+            "description": {
+                "name": "screen_retriever_macos",
+                "sha256": "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.2.0"
+        },
+        "screen_retriever_platform_interface": {
+            "dependency": "transitive",
+            "description": {
+                "name": "screen_retriever_platform_interface",
+                "sha256": "ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.2.0"
+        },
+        "screen_retriever_windows": {
+            "dependency": "transitive",
+            "description": {
+                "name": "screen_retriever_windows",
+                "sha256": "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.2.0"
+        },
+        "shared_preferences": {
+            "dependency": "direct main",
+            "description": {
+                "name": "shared_preferences",
+                "sha256": "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.5.3"
+        },
+        "shared_preferences_android": {
+            "dependency": "transitive",
+            "description": {
+                "name": "shared_preferences_android",
+                "sha256": "34266009473bf71d748912da4bf62d439185226c03e01e2d9687bc65bbfcb713",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.15"
+        },
+        "shared_preferences_foundation": {
+            "dependency": "transitive",
+            "description": {
+                "name": "shared_preferences_foundation",
+                "sha256": "1c33a907142607c40a7542768ec9badfd16293bac51da3a4482623d15845f88b",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.5.5"
+        },
+        "shared_preferences_linux": {
+            "dependency": "transitive",
+            "description": {
+                "name": "shared_preferences_linux",
+                "sha256": "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.1"
+        },
+        "shared_preferences_platform_interface": {
+            "dependency": "transitive",
+            "description": {
+                "name": "shared_preferences_platform_interface",
+                "sha256": "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.1"
+        },
+        "shared_preferences_web": {
+            "dependency": "transitive",
+            "description": {
+                "name": "shared_preferences_web",
+                "sha256": "c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.3"
+        },
+        "shared_preferences_windows": {
+            "dependency": "transitive",
+            "description": {
+                "name": "shared_preferences_windows",
+                "sha256": "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.1"
+        },
+        "shelf": {
+            "dependency": "transitive",
+            "description": {
+                "name": "shelf",
+                "sha256": "e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.4.2"
+        },
+        "shelf_web_socket": {
+            "dependency": "transitive",
+            "description": {
+                "name": "shelf_web_socket",
+                "sha256": "cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.0.1"
+        },
+        "sky_engine": {
+            "dependency": "transitive",
+            "description": "flutter",
+            "source": "sdk",
+            "version": "0.0.0"
+        },
+        "source_gen": {
+            "dependency": "transitive",
+            "description": {
+                "name": "source_gen",
+                "sha256": "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.5.0"
+        },
+        "source_span": {
+            "dependency": "transitive",
+            "description": {
+                "name": "source_span",
+                "sha256": "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.10.1"
+        },
+        "stack_trace": {
+            "dependency": "transitive",
+            "description": {
+                "name": "stack_trace",
+                "sha256": "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.12.1"
+        },
+        "stream_channel": {
+            "dependency": "transitive",
+            "description": {
+                "name": "stream_channel",
+                "sha256": "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.1.4"
+        },
+        "stream_transform": {
+            "dependency": "transitive",
+            "description": {
+                "name": "stream_transform",
+                "sha256": "ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.1.1"
+        },
+        "string_scanner": {
+            "dependency": "transitive",
+            "description": {
+                "name": "string_scanner",
+                "sha256": "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.4.1"
+        },
+        "term_glyph": {
+            "dependency": "transitive",
+            "description": {
+                "name": "term_glyph",
+                "sha256": "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.2.2"
+        },
+        "test_api": {
+            "dependency": "transitive",
+            "description": {
+                "name": "test_api",
+                "sha256": "ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.7.7"
+        },
+        "timing": {
+            "dependency": "transitive",
+            "description": {
+                "name": "timing",
+                "sha256": "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.0.2"
+        },
+        "typed_data": {
+            "dependency": "transitive",
+            "description": {
+                "name": "typed_data",
+                "sha256": "f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.4.0"
+        },
+        "undo": {
+            "dependency": "direct main",
+            "description": {
+                "name": "undo",
+                "sha256": "b44e97f96e372211e54160de7f8b6a0cbc4d07b4b604899ca6e3990538a5b707",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.5.0"
+        },
+        "url_launcher": {
+            "dependency": "direct main",
+            "description": {
+                "name": "url_launcher",
+                "sha256": "f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "6.3.2"
+        },
+        "url_launcher_android": {
+            "dependency": "transitive",
+            "description": {
+                "name": "url_launcher_android",
+                "sha256": "5c8b6c2d89a78f5a1cca70a73d9d5f86c701b36b42f9c9dac7bad592113c28e9",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "6.3.24"
+        },
+        "url_launcher_ios": {
+            "dependency": "transitive",
+            "description": {
+                "name": "url_launcher_ios",
+                "sha256": "6b63f1441e4f653ae799166a72b50b1767321ecc263a57aadf825a7a2a5477d9",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "6.3.5"
+        },
+        "url_launcher_linux": {
+            "dependency": "transitive",
+            "description": {
+                "name": "url_launcher_linux",
+                "sha256": "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.2.1"
+        },
+        "url_launcher_macos": {
+            "dependency": "transitive",
+            "description": {
+                "name": "url_launcher_macos",
+                "sha256": "8262208506252a3ed4ff5c0dc1e973d2c0e0ef337d0a074d35634da5d44397c9",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.2.4"
+        },
+        "url_launcher_platform_interface": {
+            "dependency": "transitive",
+            "description": {
+                "name": "url_launcher_platform_interface",
+                "sha256": "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.3.2"
+        },
+        "url_launcher_web": {
+            "dependency": "transitive",
+            "description": {
+                "name": "url_launcher_web",
+                "sha256": "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.1"
+        },
+        "url_launcher_windows": {
+            "dependency": "transitive",
+            "description": {
+                "name": "url_launcher_windows",
+                "sha256": "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.1.4"
+        },
+        "vector_math": {
+            "dependency": "transitive",
+            "description": {
+                "name": "vector_math",
+                "sha256": "d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.2.0"
+        },
+        "version": {
+            "dependency": "direct main",
+            "description": {
+                "name": "version",
+                "sha256": "3d4140128e6ea10d83da32fef2fa4003fccbf6852217bb854845802f04191f94",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.0.2"
+        },
+        "version_manipulation": {
+            "dependency": "transitive",
+            "description": {
+                "name": "version_manipulation",
+                "sha256": "e90782d610bde19765d2808ec06bc8ed9e04640a4dd07d1a3d370728ce9dae7f",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.2.0"
+        },
+        "visibility_detector": {
+            "dependency": "direct main",
+            "description": {
+                "name": "visibility_detector",
+                "sha256": "dd5cc11e13494f432d15939c3aa8ae76844c42b723398643ce9addb88a5ed420",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.4.0+2"
+        },
+        "vm_service": {
+            "dependency": "transitive",
+            "description": {
+                "name": "vm_service",
+                "sha256": "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "15.0.2"
+        },
+        "watcher": {
+            "dependency": "direct main",
+            "description": {
+                "name": "watcher",
+                "sha256": "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.1.4"
+        },
+        "web": {
+            "dependency": "transitive",
+            "description": {
+                "name": "web",
+                "sha256": "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.5.1"
+        },
+        "web_socket_channel": {
+            "dependency": "transitive",
+            "description": {
+                "name": "web_socket_channel",
+                "sha256": "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "2.4.5"
+        },
+        "widgets_to_image": {
+            "dependency": "direct main",
+            "description": {
+                "name": "widgets_to_image",
+                "sha256": "9a251b95d3a9f10d72420dde9b7e3b0da5eddd47fb19cad066bc68c60b0d1dfb",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.0.0"
+        },
+        "win32": {
+            "dependency": "transitive",
+            "description": {
+                "name": "win32",
+                "sha256": "d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "5.15.0"
+        },
+        "window_manager": {
+            "dependency": "direct main",
+            "description": {
+                "name": "window_manager",
+                "sha256": "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "0.4.3"
+        },
+        "xdg_directories": {
+            "dependency": "transitive",
+            "description": {
+                "name": "xdg_directories",
+                "sha256": "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "1.1.0"
+        },
+        "xml": {
+            "dependency": "transitive",
+            "description": {
+                "name": "xml",
+                "sha256": "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "6.6.1"
+        },
+        "yaml": {
+            "dependency": "transitive",
+            "description": {
+                "name": "yaml",
+                "sha256": "b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce",
+                "url": "https://pub.dev"
+            },
+            "source": "hosted",
+            "version": "3.1.3"
+        }
+    },
+    "sdks": {
+        "dart": ">=3.9.0 <4.0.0",
+        "flutter": ">=3.35.0"
+    }
+}


### PR DESCRIPTION
Added package pathplanner.

https://github.com/mjansen4857/pathplanner

Pathplanner is a FRC motion profile generator and path editor for robots.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
