### PR TITLE
  nixos/luksroot: improve Yubikey LUKS reliability

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -227,6 +227,11 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
 - `services.oauth2-proxy.clientSecret` and `services.oauth2-proxy.cookie.secret` have been replaced with `services.oauth2-proxy.clientSecretFile` and `services.oauth2-proxy.cookie.secretFile` respectively. This was done to ensure secrets don't get made world-readable.
 
+- The YubiKey LUKS salt rotation feature has been removed from `boot.initrd.luks.devices.<name>.yubikey`.
+  The rotation mechanism was fundamentally flawed (an attacker who can observe one challenge-response
+  can equally observe the next) and caused serious issues including race conditions during key changes
+  and incompatibility with backup YubiKeys.
+
 - [`services.grafana.settings.security.secret_key`](#opt-services.grafana.settings.security.secret_key) doesn't have a
   default value anymore. Please generate your own key or hard-code the old one ("SW2YcwTIb9zpOOhoPsMm") explicitly.
   See the [upstream docs](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#secret_key) and

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -232,6 +232,22 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
   can equally observe the next) and caused serious issues including race conditions during key changes
   and incompatibility with backup YubiKeys.
 
+- Adds `boot.initrd.luks.devices.<name>.yubikey.salt` option to embed the
+  luksroot salt directly in configuration.nix rather than storing it on a
+  separate filesystem. This addresses the issue where vfat corruption on the EFI
+  partition could corrupt the sat file and brick the system.
+
+  **Existing setups will continue to work without changes.** The module still reads the salt and
+  iteration count from the storage device if `yubikey.salt` is not configured.
+
+  To migrate an existing setup to inline salt (optional), read your current values and add them
+  to your configuration:
+  ```shell
+  # Read current values (adjust paths to match your yubikey.storage settings)
+  cat /crypt-storage/default/salt
+  cat /crypt-storage/default/iterations
+  ```
+
 - [`services.grafana.settings.security.secret_key`](#opt-services.grafana.settings.security.secret_key) doesn't have a
   default value anymore. Please generate your own key or hard-code the old one ("SW2YcwTIb9zpOOhoPsMm") explicitly.
   See the [upstream docs](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#secret_key) and

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -396,6 +396,8 @@ let
                 else
                     opened=false
                     echo "Authentication failed!"
+                    # Ask for a different passphrase
+                    rm -f /crypt-ramfs/passphrase
                 fi
             done
 

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -159,9 +159,6 @@ let
         + optionalString dev.allowDiscards " --allow-discards"
         + optionalString dev.bypassWorkqueues " --perf-no_read_workqueue --perf-no_write_workqueue"
         + optionalString (dev.header != null) " --header=${dev.header}";
-      cschange = "cryptsetup luksChangeKey ${dev.device} ${
-        optionalString (dev.header != null) "--header=${dev.header}"
-      }";
       fido2luksCredentials =
         dev.fido2.credentials ++ optional (dev.fido2.credential != null) dev.fido2.credential;
     in
@@ -310,11 +307,6 @@ let
             local response
             local k_luks
             local opened
-            local new_salt
-            local new_iterations
-            local new_challenge
-            local new_response
-            local new_k_luks
 
             mount -t ${dev.yubikey.storage.fsType} ${dev.yubikey.storage.device} /crypt-storage || \
               die "Failed to mount YubiKey salt storage device"
@@ -384,45 +376,6 @@ let
 
             [ "$opened" == false ] && die "Maximum authentication errors reached"
 
-            echo -n "Gathering entropy for new salt (please enter random keys to generate entropy if this blocks for long)..."
-            for i in $(seq ${toString dev.yubikey.saltLength}); do
-                byte="$(dd if=/dev/random bs=1 count=1 2>/dev/null | rbtohex)";
-                new_salt="$new_salt$byte";
-                echo -n .
-            done;
-            echo "ok"
-
-            new_iterations="$iterations"
-            ${optionalString (dev.yubikey.iterationStep > 0) ''
-              new_iterations="$(($new_iterations + ${toString dev.yubikey.iterationStep}))"
-            ''}
-
-            new_challenge="$(echo -n $new_salt | openssl-wrap dgst -binary -sha512 | rbtohex)"
-
-            new_response="$(ykchalresp -${toString dev.yubikey.slot} -x $new_challenge 2>/dev/null)"
-
-            if [ -z "$new_response" ]; then
-                echo "Warning: Unable to generate new challenge response, current challenge persists!"
-                umount /crypt-storage
-                return
-            fi
-
-            if [ -n "$k_user" ]; then
-                echo -n $k_user
-            else
-                echo
-            fi | pbkdf2-sha512 ${toString dev.yubikey.keyLength} $new_iterations $new_response > /crypt-ramfs/new_key
-
-            echo -n "$k_luks" | hextorb | ${cschange} --key-file=- /crypt-ramfs/new_key
-
-            if [ $? == 0 ]; then
-                echo -ne "$new_salt\n$new_iterations" > /crypt-storage${dev.yubikey.storage.path}
-                sync /crypt-storage${dev.yubikey.storage.path}
-            else
-                echo "Warning: Could not update LUKS key, current challenge persists!"
-            fi
-
-            rm -f /crypt-ramfs/new_key
             umount /crypt-storage
         }
 
@@ -923,28 +876,31 @@ in
                           description = "Which slot on the YubiKey to challenge.";
                         };
 
-                        saltLength = mkOption {
-                          default = 16;
-                          type = types.int;
-                          description = "Length of the new salt in byte (64 is the effective maximum).";
-                        };
-
                         keyLength = mkOption {
                           default = 64;
                           type = types.int;
                           description = "Length of the LUKS slot key derived with PBKDF2 in byte.";
                         };
 
-                        iterationStep = mkOption {
-                          default = 0;
-                          type = types.int;
-                          description = "How much the iteration count for PBKDF2 is increased at each successful authentication.";
-                        };
-
                         gracePeriod = mkOption {
                           default = 10;
                           type = types.int;
                           description = "Time in seconds to wait for the YubiKey.";
+                        };
+
+                        # Deprecated options - kept for clear error messages
+                        saltLength = mkOption {
+                          default = null;
+                          type = types.nullOr types.int;
+                          visible = false;
+                          description = "Deprecated: Salt rotation has been removed.";
+                        };
+
+                        iterationStep = mkOption {
+                          default = null;
+                          type = types.nullOr types.int;
+                          visible = false;
+                          description = "Deprecated: Salt rotation has been removed.";
                         };
 
                         /*
@@ -1127,6 +1083,26 @@ in
       {
         assertion = config.boot.initrd.systemd.enable -> !luks.yubikeySupport;
         message = systemdStage1HardwareKeyAssertionMessage "boot.initrd.luks.yubikeySupport";
+      }
+      {
+        assertion = all (dev: dev.yubikey == null || dev.yubikey.saltLength == null) (
+          attrValues luks.devices
+        );
+        message = ''
+          boot.initrd.luks.devices.<name>.yubikey.saltLength has been removed.
+          Salt rotation was removed because it was fundamentally flawed and caused
+          issues with backup YubiKeys. Please use a static salt with yubikey.salt instead.
+        '';
+      }
+      {
+        assertion = all (dev: dev.yubikey == null || dev.yubikey.iterationStep == null) (
+          attrValues luks.devices
+        );
+        message = ''
+          boot.initrd.luks.devices.<name>.yubikey.iterationStep has been removed.
+          Salt rotation was removed because it was fundamentally flawed and caused
+          issues with backup YubiKeys. Please use a static iteration count with yubikey.iterations instead.
+        '';
       }
     ];
 

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -308,11 +308,24 @@ let
             local k_luks
             local opened
 
-            mount -t ${dev.yubikey.storage.fsType} ${dev.yubikey.storage.device} /crypt-storage || \
-              die "Failed to mount YubiKey salt storage device"
+            ${
+              if dev.yubikey.salt != null then
+                ''
+                  # Inline salt mode - salt is embedded in initramfs
+                  salt="${dev.yubikey.salt}"
+                  iterations="${toString dev.yubikey.iterations}"
+                ''
+              else
+                ''
+                  # Storage mode - mount and read salt from external device
+                  mount -t ${dev.yubikey.storage.fsType} ${dev.yubikey.storage.device} /crypt-storage || \
+                    die "Failed to mount YubiKey salt storage device"
 
-            salt="$(cat /crypt-storage${dev.yubikey.storage.path} | sed -n 1p | tr -d '\n')"
-            iterations="$(cat /crypt-storage${dev.yubikey.storage.path} | sed -n 2p | tr -d '\n')"
+                  salt="$(cat /crypt-storage${dev.yubikey.storage.path} | sed -n 1p | tr -d '\n')"
+                  iterations="$(cat /crypt-storage${dev.yubikey.storage.path} | sed -n 2p | tr -d '\n')"
+                ''
+            }
+
             challenge="$(echo -n $salt | openssl-wrap dgst -binary -sha512 | rbtohex)"
             response="$(ykchalresp -${toString dev.yubikey.slot} -x $challenge 2>/dev/null)"
 
@@ -376,7 +389,9 @@ let
 
             [ "$opened" == false ] && die "Maximum authentication errors reached"
 
-            umount /crypt-storage
+            ${optionalString (dev.yubikey.salt == null) ''
+              umount /crypt-storage
+            ''}
         }
 
         open_with_hardware() {
@@ -903,10 +918,32 @@ in
                           description = "Deprecated: Salt rotation has been removed.";
                         };
 
-                        /*
-                          TODO: Add to the documentation of the current module:
+                        salt = mkOption {
+                          default = null;
+                          type = types.nullOr types.str;
+                          example = "1a2b3c4d...";
+                          description = ''
+                            Static salt (hex string) for YubiKey challenge-response.
+                            If set, the salt is embedded in the initramfs and the
+                            `storage` options are ignored.
 
-                          Options related to the storing the salt.
+                            Generate with: `dd if=/dev/random bs=1 count=16 | od -An -vtx1 | tr -d ' \n'`
+                          '';
+                        };
+
+                        iterations = mkOption {
+                          default = 1000000;
+                          type = types.int;
+                          description = ''
+                            PBKDF2 iteration count for key derivation.
+                            Only used when `salt` is set (inline mode).
+                            When using storage mode, iterations are read from the salt file.
+                          '';
+                        };
+
+                        /*
+                          Options related to the storing the salt on external storage.
+                          These are ignored when `salt` is set.
                         */
                         storage = {
                           device = mkOption {

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -327,7 +327,19 @@ let
             }
 
             challenge="$(echo -n $salt | openssl-wrap dgst -binary -sha512 | rbtohex)"
-            response="$(ykchalresp -${toString dev.yubikey.slot} -x $challenge 2>/dev/null)"
+
+            while true; do
+                echo "Waiting for YubiKey challenge-response. Touch your YubiKey if required..."
+                response="$(ykchalresp -${toString dev.yubikey.slot} -x $challenge 2>/dev/null)"
+                if [ $? -ne 0 ] || [ -z "$response" ]; then
+                    echo "YubiKey challenge timed out."
+                    echo -n "Press Enter to retry..."
+                    read
+                    echo
+                else
+                    break
+                fi
+            done
 
             for try in $(seq 3); do
                 ${optionalString dev.yubikey.twoFactor ''


### PR DESCRIPTION
This PR makes two changes to improve reliability of Yubikey-based LUKS unlocking:
1. Remove salt rotation after each boot
    The rotation feature was intended to mitigate USB snooping attacks, but is fundamentally flawed: an attacker who can observe one challenge-response can equally observe the next. Meanwhile, rotation introduced serious problems:
    - Race condition between luksChangeKey and writing new salt could brick the system on crash
    - Backup Yubikeys were impossible since using either key invalidated the other
2. Add inline salt option (`yubikey.salt`)
  Allows embedding the salt directly in configuration.nix rather than reading it from external storage (typically the vfat EFI partition). This prevents vfat corruption from bricking the system.

When `salt` is set, the salt is baked into the initramfs at build time and no storage mount is needed. Existing configurations using `storage.*` options continue to work unchanged.

Removed options:
- boot.initrd.luks.devices.<name>.yubikey.saltLength
- boot.initrd.luks.devices.<name>.yubikey.iterationStep

New options:
- boot.initrd.luks.devices.<name>.yubikey.salt
- boot.initrd.luks.devices.<name>.yubikey.iterations

Resolves https://github.com/NixOS/nixpkgs/issues/499289, https://github.com/NixOS/nixpkgs/issues/210329, and https://github.com/NixOS/nixpkgs/issues/141786 by disabling salt rotation
Resolves https://github.com/NixOS/nixpkgs/issues/135462 by making salt an inline parameter
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
