### PR TITLE
autodiff: init at 1.1.2

### DIFF
--- a/pkgs/by-name/au/autodiff/package.nix
+++ b/pkgs/by-name/au/autodiff/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  eigen,
+  catch2_3,
+  python3Packages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "autodiff";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "autodiff";
+    repo = "autodiff";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hKIufS5o5tfsbVchwTJxms1n5Im1iTfY3KGWD1s5g9M=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    eigen
+    catch2_3
+    python3Packages.pybind11
+    python3Packages.distutils
+  ];
+
+  postPatch =
+    # https://github.com/autodiff/autodiff/pull/391
+    ''
+      substituteInPlace python/package/CMakeLists.txt \
+        --replace-fail PYTHON_EXECUTABLE Python_EXECUTABLE
+    '';
+
+  meta = {
+    description = "Automatic differentiation made easier for C++";
+    homepage = "https://github.com/autodiff/autodiff/tree/main";
+    maintainers = [ lib.maintainers.athas ];
+    license = lib.licenses.mit;
+  };
+})


### PR DESCRIPTION
autodiff is a C++ package for automatic differentiation. One more step towards making Nixpkgs the largest collection of AD-related tools!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
