### PR TITLE
searchix: 0.4.4 -> 0.4.5

### DIFF
--- a/pkgs/by-name/se/searchix/darwin-sandbox-fix.patch
+++ b/pkgs/by-name/se/searchix/darwin-sandbox-fix.patch
@@ -1,0 +1,20 @@
+--- vendor/modernc.org/libc/honnef.co/go/netdb/netdb.go
++++ vendor/modernc.org/libc/honnef.co/go/netdb/netdb.go
+@@ -696,7 +696,7 @@ func init() {
+ 	// Load protocols
+ 	data, err := ioutil.ReadFile("/etc/protocols")
+ 	if err != nil {
+-		if !os.IsNotExist(err) {
++		if !os.IsNotExist(err) && !os.IsPermission(err) {
+ 			panic(err)
+ 		}
+ 
+@@ -732,7 +732,7 @@ func init() {
+ 	// Load services
+ 	data, err = ioutil.ReadFile("/etc/services")
+ 	if err != nil {
+-		if !os.IsNotExist(err) {
++		if !os.IsNotExist(err) && !os.IsPermission(err) {
+ 			panic(err)
+ 		}
+ 

--- a/pkgs/by-name/se/searchix/package.nix
+++ b/pkgs/by-name/se/searchix/package.nix
@@ -19,14 +19,14 @@ in
 
 buildGoModule (finalAttrs: {
   pname = "searchix";
-  version = "0.4.4";
+  version = "0.4.5";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "alinnow";
     repo = "searchix";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-R8/iR8QoeUwNQCFkr+JtoPq/iKkJRIe8dsbvGfFqinE=";
+    hash = "sha256-2pffyKBX+ICYEN+42gwN2byjw+T9H4esi2+oTqs52GE=";
   };
 
   vendorHash = "sha256-yfcQgy4cQFRvtsyLHLojnJaWhle1ZR3unmaFQj8ljuw=";

--- a/pkgs/by-name/se/searchix/package.nix
+++ b/pkgs/by-name/se/searchix/package.nix
@@ -31,6 +31,13 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-yfcQgy4cQFRvtsyLHLojnJaWhle1ZR3unmaFQj8ljuw=";
 
+  overrideModAttrs = old: {
+    # netdb.go allows /etc/protocols and /etc/services to not exist and happily proceeds, but it panic()s if they exist but return permission denied.
+    postBuild = ''
+      patch -p0 < ${./darwin-sandbox-fix.patch}
+    '';
+  };
+
   subPackages = [ "cmd/searchix-web" ];
 
   tags = [ "embed" ];
@@ -45,7 +52,7 @@ buildGoModule (finalAttrs: {
     cp ${simpleCss}/simple.css frontend/static/base.css
   '';
 
-  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+  postInstall = ''
     $out/bin/searchix-web generate-error-page --outdir $out/share/searchix/
   '';
 


### PR DESCRIPTION
https://codeberg.org/alinnow/searchix/compare/v0.4.4...v0.4.5

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
