### PR TITLE
jai: 0.2.025 -> 0.2.026

### DIFF
--- a/pkgs/by-name/ja/jai/package.nix
+++ b/pkgs/by-name/ja/jai/package.nix
@@ -9,7 +9,7 @@
 let
   pname = "jai";
   minor = "2";
-  patch = "025";
+  patch = "026";
   version = "0.${minor}.${patch}";
   zipName = "jai-beta-${minor}-${patch}.zip";
   jai = stdenv.mkDerivation {
@@ -20,7 +20,7 @@ let
           nix-store --add-fixed sha256 ${zipName}
       '';
       name = zipName;
-      sha256 = "sha256-pr43599kdVne9USVvb9p35SYQk2zkT03pO66UGl9IuQ=";
+      sha256 = "sha256-iWPMVGzcDlR3cP4ruPZJBAAdvFLZeM8+pCxbsSk2ZLw=";
     };
     nativeBuildInputs = [ unzip ];
     buildCommand = "unzip $src -d $out";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Like #484114 , this PR updates the Jai package to beta version 0.2.026, released on `22 February 2026` (the day i got it).
Used `$ nix hash file sha256 ~/Downloads/jai-beta-2-026.zip` to get the hash.

```shell
nix-store --add-fixed sha256 ~/Downloads/jai-beta-2-026.zip
git clone --depth=1 https://github.com/lalishansh/nixpkgs --branch patch-2 nixpkgs
cd nixpkgs/
export NIXPKGS_ALLOW_UNFREE=1
nix-build -A jai
result/bin/jai -version
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
