### PR TITLE
python3Packages.colcon-cargo: disable broken tests

### DIFF
--- a/pkgs/development/python-modules/colcon-cargo/default.nix
+++ b/pkgs/development/python-modules/colcon-cargo/default.nix
@@ -38,6 +38,12 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
+  disabledTests = [
+    # Attempts to download https://index.crates.io/config.json at test time
+    "test_build_and_test_package"
+    "test_skip_pure_library_package"
+  ];
+
   disabledTestPaths = [
     # Skip the linter tests
     "test/test_flake8.py"

--- a/pkgs/development/python-modules/colcon-cargo/default.nix
+++ b/pkgs/development/python-modules/colcon-cargo/default.nix
@@ -11,7 +11,7 @@
   toml,
   writableTmpDirAsHomeHook,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "colcon-cargo";
   version = "0.2.0";
   pyproject = true;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "colcon";
     repo = "colcon-cargo";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-jhc5mN4jnLk2zLj01sBm63acrku/FIexnIWCQ6GKDKA=";
   };
 
@@ -56,7 +56,8 @@ buildPythonPackage rec {
   meta = {
     description = "Extension for colcon-core to support Rust packages built with Cargo";
     homepage = "https://github.com/colcon/colcon-cargo";
+    changelog = "https://github.com/colcon/colcon-cargo/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ guelakais ];
   };
-}
+})


### PR DESCRIPTION
```sh
       > Caused by:
       >   download of config.json failed
       >
       > Caused by:
       >   failed to download from `https://index.crates.io/config.json`
       >
       > Caused by:
       >   [6] Could not resolve hostname (Could not resolve host: index.crates.io)
```

Downloading files at test time isn't permitted. Disabled the affected tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
