### PR TITLE
see-cat: 0.8.1 -> 0.9.0

### DIFF
--- a/pkgs/by-name/se/see-cat/package.nix
+++ b/pkgs/by-name/se/see-cat/package.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
-  pkg-config,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "see-cat";
@@ -16,10 +15,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoHash = "sha256-gADA6Ioxz8YM/SRYsT+43bKNS2Ov1XtTElDr7vx8T14=";
-
-  nativeBuildInputs = [
-    pkg-config
-  ];
 
   meta = {
     description = "Cute cat(1) for the terminal";

--- a/pkgs/by-name/se/see-cat/package.nix
+++ b/pkgs/by-name/se/see-cat/package.nix
@@ -6,16 +6,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "see-cat";
-  version = "0.8.1";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "guilhermeprokisch";
     repo = "see";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-VCUrPCaG2fKp9vpFLzNLcfCBu2NiwdY2+bo1pd7anZY=";
+    hash = "sha256-Ej8lk9btUcIhhgpSmnHo2n33wQtyEkmuWVFoahYgAaI=";
   };
 
-  cargoHash = "sha256-Yw6zRvwT+y3CFb6WwKBiMSWz8igLQ7JmyGalHdRDGL0=";
+  cargoHash = "sha256-gADA6Ioxz8YM/SRYsT+43bKNS2Ov1XtTElDr7vx8T14=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Summary
- bump see-cat from 0.8.1 to 0.9.0
- update the source hash
- update the cargo hash

## Testing
- nix build .#see-cat

## Release notes
- https://github.com/guilhermeprokisch/see/releases/tag/v0.9.0