### PR TITLE
defuddle: 0.6.4 -> 0.17.0; rename from defuddle-cli

### DIFF
--- a/pkgs/by-name/de/defuddle-cli/package.nix
+++ b/pkgs/by-name/de/defuddle-cli/package.nix
@@ -1,28 +1,32 @@
 {
   buildNpmPackage,
   fetchFromGitHub,
-  gitUpdater,
   lib,
+  nix-update-script,
 }:
 
 buildNpmPackage rec {
   pname = "defuddle-cli";
-  version = "0.6.4";
+  version = "0.17.0";
 
   src = fetchFromGitHub {
     owner = "kepano";
-    repo = "defuddle-cli";
+    repo = "defuddle";
     tag = version;
-    hash = "sha256-28XmpFKzBKNhRkPOGaacJVw8hjQUZq2nwuR0vNo8aW0=";
+    hash = "sha256-w1V2xdaE8Htl6NeDyfKLFHOt3UEUuI4eBPW433qD1WI=";
   };
 
-  npmDepsHash = "sha256-rRo+ty/E09OS+cWDnKQkROEdDc0hiB5g1h/+NbJe+/M=";
+  npmDepsHash = "sha256-D+Gn9Dcc+YNeRonnKjEcp3BzpxIdwy7J4lJvxefJSvs=";
 
-  passthru.updateScript = gitUpdater { };
+  # jsdom is both a peerDependency and devDependency; pruning
+  # devDependencies removes it, but the CLI needs it at runtime.
+  dontNpmPrune = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Command line utility to extract clean html, markdown and metadata from web pages";
-    homepage = "https://github.com/kepano/defuddle-cli";
+    homepage = "https://github.com/kepano/defuddle";
     license = lib.licenses.mit;
     mainProgram = "defuddle";
     maintainers = with lib.maintainers; [ surfaceflinger ];

--- a/pkgs/by-name/de/defuddle/package.nix
+++ b/pkgs/by-name/de/defuddle/package.nix
@@ -6,7 +6,7 @@
 }:
 
 buildNpmPackage rec {
-  pname = "defuddle-cli";
+  pname = "defuddle";
   version = "0.17.0";
 
   src = fetchFromGitHub {
@@ -23,6 +23,8 @@ buildNpmPackage rec {
   dontNpmPrune = true;
 
   passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Command line utility to extract clean html, markdown and metadata from web pages";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -594,6 +594,7 @@ mapAliases {
   deco = throw "'deco' has been removed as it is unused"; # Added 2025-12-18
   deepin = throw "the Deepin desktop environment and associated tools have been removed from nixpkgs due to lack of maintenance"; # Added 2025-08-21
   deepsea = throw "deepsea has been removed because it has been marked as broken since at least November 2024."; # Added 2025-09-28
+  defuddle-cli = warnAlias "defuddle-cli has been renamed to/replaced by 'defuddle'" defuddle; # Added 2026-04-16
   degit-rs = throw "'degit-rs' has been removed because it is unmaintained upstream and has vulnerable dependencies."; # Added 2025-07-11
   deltachat-cursed = throw "'deltachat-cursed' has been renamed to/replaced by 'arcanechat-tui'"; # Converted to throw 2025-10-27
   devdocs-desktop = throw "'devdocs-desktop' has been removed as it is unmaintained upstream and vendors insecure dependencies"; # Added 2025-06-11


### PR DESCRIPTION
Fixes #497794

also CLI moved from `kepano/defuddle-cli` to `kepano/defuddle` repository.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
