### PR TITLE
swagger-codegen: 2.4.50 -> 2.4.51, use buildMavenPackage

### DIFF
--- a/pkgs/by-name/sw/swagger-codegen/package.nix
+++ b/pkgs/by-name/sw/swagger-codegen/package.nix
@@ -1,39 +1,54 @@
 {
   lib,
-  stdenv,
-  fetchurl,
+  maven,
+  fetchFromGitHub,
   jre,
   makeWrapper,
 }:
 
-stdenv.mkDerivation rec {
-  version = "2.4.50";
+maven.buildMavenPackage rec {
   pname = "swagger-codegen";
+  version = "2.4.50";
 
-  jarfilename = "${pname}-cli-${version}.jar";
+  src = fetchFromGitHub {
+    owner = "swagger-api";
+    repo = "swagger-codegen";
+    tag = "v${version}";
+    hash = "sha256-mlnUg+23Uv/SDgi9zT5MK8592YaLQORpFRTxcQFfcoQ=";
+  };
+
+  mvnHash = "sha256-QyH8AEKX94ieRS6dqFy0QJxwqtpRmnl+E2dJwNLS9kQ=";
+
+  mvnParameters = toString [
+    "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z"
+  ];
 
   nativeBuildInputs = [
     makeWrapper
   ];
 
-  src = fetchurl {
-    url = "mirror://maven/io/swagger/${pname}-cli/${version}/${jarfilename}";
-    sha256 = "sha256-rsoQFd5XTIcAz32jv2vv/OkqSSC3wCvxBeRbVJhZfLA=";
-  };
-
-  dontUnpack = true;
-
   installPhase = ''
-    install -D $src $out/share/java/${jarfilename}
+    runHook preInstall
 
-    makeWrapper ${jre}/bin/java $out/bin/${pname} \
-      --add-flags "-jar $out/share/java/${jarfilename}"
+    mkdir -p $out/bin $out/share/java
+    install -Dm644 modules/swagger-codegen-cli/target/swagger-codegen-cli.jar $out/share/java
+
+    makeWrapper ${jre}/bin/java $out/bin/swagger-codegen \
+      --add-flags "-jar $out/share/java/swagger-codegen-cli.jar"
+
+    runHook postInstall
   '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
     homepage = "https://github.com/swagger-api/swagger-codegen";
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.jraygauthier ];
     mainProgram = "swagger-codegen";

--- a/pkgs/by-name/sw/swagger-codegen/package.nix
+++ b/pkgs/by-name/sw/swagger-codegen/package.nix
@@ -53,7 +53,10 @@ maven.buildMavenPackage rec {
       binaryBytecode
     ];
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.jraygauthier ];
+    maintainers = with lib.maintainers; [
+      anthonyroussel
+      jraygauthier
+    ];
     mainProgram = "swagger-codegen";
   };
 }

--- a/pkgs/by-name/sw/swagger-codegen/package.nix
+++ b/pkgs/by-name/sw/swagger-codegen/package.nix
@@ -4,17 +4,18 @@
   fetchFromGitHub,
   jre,
   makeWrapper,
+  versionCheckHook,
 }:
 
 maven.buildMavenPackage rec {
   pname = "swagger-codegen";
-  version = "2.4.50";
+  version = "2.4.51";
 
   src = fetchFromGitHub {
     owner = "swagger-api";
     repo = "swagger-codegen";
     tag = "v${version}";
-    hash = "sha256-mlnUg+23Uv/SDgi9zT5MK8592YaLQORpFRTxcQFfcoQ=";
+    hash = "sha256-bclFD2Kn5Xn6dxEaS1M69LDUc5lvMLFNFoKZkT1JbVM=";
   };
 
   mvnHash = "sha256-QyH8AEKX94ieRS6dqFy0QJxwqtpRmnl+E2dJwNLS9kQ=";
@@ -41,10 +42,12 @@ maven.buildMavenPackage rec {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
+  versionCheckProgramArg = "version";
 
   meta = {
     description = "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
     homepage = "https://github.com/swagger-api/swagger-codegen";
+    changelog = "https://github.com/swagger-api/swagger-codegen/releases/tag/v${version}";
     sourceProvenance = with lib.sourceTypes; [
       fromSource
       binaryBytecode


### PR DESCRIPTION
* Upgrade to 2.4.51: https://github.com/swagger-api/swagger-codegen/compare/v2.4.50...v2.4.51
* Use buildMavenPackage
* Add versionCheckHook

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
