### PR TITLE
swagger-codegen3: 3.0.75 -> 3.0.81, use buildMavenPackage

### DIFF
--- a/pkgs/by-name/sw/swagger-codegen3/package.nix
+++ b/pkgs/by-name/sw/swagger-codegen3/package.nix
@@ -53,7 +53,10 @@ maven.buildMavenPackage rec {
       binaryBytecode
     ];
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers._1000101 ];
+    maintainers = with lib.maintainers; [
+      _1000101
+      anthonyroussel
+    ];
     mainProgram = "swagger-codegen3";
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/sw/swagger-codegen3/package.nix
+++ b/pkgs/by-name/sw/swagger-codegen3/package.nix
@@ -1,49 +1,60 @@
 {
   lib,
-  stdenv,
-  fetchurl,
+  maven,
+  fetchFromGitHub,
   jre,
   makeWrapper,
-  testers,
-  swagger-codegen3,
+  versionCheckHook,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "swagger-codegen";
-  version = "3.0.75";
+maven.buildMavenPackage rec {
+  pname = "swagger-codegen3";
+  version = "3.0.77";
 
-  src = fetchurl {
-    url = "mirror://maven/io/swagger/codegen/v3/swagger-codegen-cli/${finalAttrs.version}/swagger-codegen-cli-${finalAttrs.version}.jar";
-    hash = "sha256-Na6aWKq1SU/zWfxRf4ZH73lJy/dwbzz7coXP61zFv+E=";
+  src = fetchFromGitHub {
+    owner = "swagger-api";
+    repo = "swagger-codegen";
+    tag = "v${version}";
+    hash = "sha256-TIgn4xyFUoMk5lkYNCK9vl2Z0a46HsC5lIa2QlIBg0w=";
   };
 
-  dontUnpack = true;
+  mvnHash = "sha256-fvzmCLpN3+3D/IZOpJ5ZmraYS+79j9wFiedQmFZ6RIs=";
 
-  nativeBuildInputs = [ makeWrapper ];
+  mvnParameters = toString [
+    "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z"
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
 
   installPhase = ''
     runHook preInstall
 
-    install -D $src $out/share/java/swagger-codegen-cli-${finalAttrs.version}.jar
+    mkdir -p $out/bin $out/share/java
+    install -Dm644 modules/swagger-codegen-cli/target/swagger-codegen-cli.jar $out/share/java
 
     makeWrapper ${jre}/bin/java $out/bin/swagger-codegen3 \
-      --add-flags "-jar $out/share/java/swagger-codegen-cli-${finalAttrs.version}.jar"
+      --add-flags "-jar $out/share/java/swagger-codegen-cli.jar"
 
     runHook postInstall
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = swagger-codegen3;
-    command = "swagger-codegen3 version";
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
 
   meta = {
     description = "Allows generation of API client libraries (SDK generation), server stubs and documentation automatically given an OpenAPI Spec";
     homepage = "https://github.com/swagger-api/swagger-codegen/tree/3.0.0";
-    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    changelog = "https://github.com/swagger-api/swagger-codegen/releases/tag/v${version}";
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers._1000101 ];
     mainProgram = "swagger-codegen3";
     platforms = lib.platforms.all;
   };
-})
+}

--- a/pkgs/by-name/sw/swagger-codegen3/package.nix
+++ b/pkgs/by-name/sw/swagger-codegen3/package.nix
@@ -9,16 +9,16 @@
 
 maven.buildMavenPackage rec {
   pname = "swagger-codegen3";
-  version = "3.0.77";
+  version = "3.0.81";
 
   src = fetchFromGitHub {
     owner = "swagger-api";
     repo = "swagger-codegen";
     tag = "v${version}";
-    hash = "sha256-TIgn4xyFUoMk5lkYNCK9vl2Z0a46HsC5lIa2QlIBg0w=";
+    hash = "sha256-5p8wVdPRsepwuXgl8weotxXrdGJcbe0Qv1VceCFrNdM=";
   };
 
-  mvnHash = "sha256-fvzmCLpN3+3D/IZOpJ5ZmraYS+79j9wFiedQmFZ6RIs=";
+  mvnHash = "sha256-d8OVpSRQWbajXnM1eCKOOmUVHPpBR2AVeZMdJXbBbLg=";
 
   mvnParameters = toString [
     "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z"


### PR DESCRIPTION
* Upgrade to 3.0.77: https://github.com/swagger-api/swagger-codegen/compare/v3.0.75...v3.0.77
* Use buildMavenPackage

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
