### PR TITLE
librelane: 3.0.0rc0 -> 3.0.0rc1

### DIFF
--- a/pkgs/by-name/li/librelane/package.nix
+++ b/pkgs/by-name/li/librelane/package.nix
@@ -23,14 +23,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "librelane";
-  version = "3.0.0rc0";
+  version = "3.0.0rc1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "librelane";
     repo = "librelane";
     tag = finalAttrs.version;
-    hash = "sha256-YG1/Exm1sXqydBvXQcSvRH3DcJbBMxu4P/AHytu9JMI=";
+    hash = "sha256-oEMybXxnOyCbUEsJWtBMuV+6XSg9Y8wKrbR9pm/GI5U=";
   };
 
   build-system = [


### PR DESCRIPTION
https://github.com/librelane/librelane/releases/tag/3.0.0rc1

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Ran librelane --smoke-test successfully
