### PR TITLE
python3Packages.{tenable,faraday-agent-parameters-types},faraday-agent-dispatcher: fix build

### DIFF
--- a/pkgs/by-name/fa/faraday-agent-dispatcher/package.nix
+++ b/pkgs/by-name/fa/faraday-agent-dispatcher/package.nix
@@ -6,27 +6,34 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "faraday-agent-dispatcher";
-  version = "3.4.2";
+  version = "3.9.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "infobyte";
     repo = "faraday_agent_dispatcher";
     tag = finalAttrs.version;
-    hash = "sha256-Qr3ZGU4y7f6yHD78ecdv7a6IBFDpT+/4Yez0n/MenN0=";
+    hash = "sha256-uf1oXE8pFvIPTDgcHXRbZDz8NZn9NecPe1eYuYhb1Xw=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace-fail '"pytest-runner",' ""
-  '';
+      --replace-fail '"pytest-runner",' ""  '';
 
   pythonRelaxDeps = [
     "python-socketio"
   ];
 
+  pythonRemoveDeps = [
+    "python-owasp-zap-v2.4"
+  ];
+
   build-system = with python3.pkgs; [
     setuptools-scm
+  ];
+
+  nativeBuildInputs = [
+    python3.pkgs.python-owasp-zap-v2-4
   ];
 
   dependencies = with python3.pkgs; [
@@ -42,6 +49,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     python-socketio
     pyyaml
     requests
+    requests-ratelimiter
     syslog-rfc5424-formatter
     websockets
   ];

--- a/pkgs/development/python-modules/faraday-agent-parameters-types/default.nix
+++ b/pkgs/development/python-modules/faraday-agent-parameters-types/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   marshmallow,
   packaging,
   pytestCheckHook,
@@ -14,10 +14,11 @@ buildPythonPackage rec {
   version = "1.9.1";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "faraday_agent_parameters_types";
-    inherit version;
-    hash = "sha256-PWO4wufHGIgAi1BHoM/+6ZjsUDB4oY26NsHOdNYYTJc=";
+  src = fetchFromGitHub {
+    owner = "infobyte";
+    repo = "faraday_agent_parameters_types";
+    tag = version;
+    hash = "sha256-Oe/9/zKOoCLK3JHMacOhk2+d91MrhzkBTW3POoFm71M=";
   };
 
   pythonRelaxDeps = [ "validators" ];

--- a/pkgs/development/python-modules/faraday-agent-parameters-types/default.nix
+++ b/pkgs/development/python-modules/faraday-agent-parameters-types/default.nix
@@ -9,7 +9,7 @@
   validators,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "faraday-agent-parameters-types";
   version = "1.9.1";
   pyproject = true;
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "infobyte";
     repo = "faraday_agent_parameters_types";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Oe/9/zKOoCLK3JHMacOhk2+d91MrhzkBTW3POoFm71M=";
   };
 
@@ -51,8 +51,8 @@ buildPythonPackage rec {
   meta = {
     description = "Collection of Faraday agent parameters types";
     homepage = "https://github.com/infobyte/faraday_agent_parameters_types";
-    changelog = "https://github.com/infobyte/faraday_agent_parameters_types/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/infobyte/faraday_agent_parameters_types/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/faraday-agent-parameters-types/default.nix
+++ b/pkgs/development/python-modules/faraday-agent-parameters-types/default.nix
@@ -2,13 +2,32 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  marshmallow,
+  flit-core,
   packaging,
   pytestCheckHook,
   setuptools,
   validators,
 }:
+let
+  marshmallow' = buildPythonPackage {
+    pname = "marshmallow";
+    version = "3.26.2";
+    pyproject = true;
 
+    src = fetchFromGitHub {
+      owner = "marshmallow-code";
+      repo = "marshmallow";
+      tag = "3.26.2";
+      hash = "sha256-ioe+aZHOW8r3wF3UknbTjAP0dEggd/NL9PTkPVQ46zM=";
+    };
+
+    build-system = [ flit-core ];
+
+    doCheck = false;
+
+    pythonImportsCheck = [ "marshmallow" ];
+  };
+in
 buildPythonPackage (finalAttrs: {
   pname = "faraday-agent-parameters-types";
   version = "1.9.1";
@@ -31,7 +50,7 @@ buildPythonPackage (finalAttrs: {
   build-system = [ setuptools ];
 
   dependencies = [
-    marshmallow
+    marshmallow'
     packaging
     validators
   ];

--- a/pkgs/development/python-modules/pytenable/default.nix
+++ b/pkgs/development/python-modules/pytenable/default.nix
@@ -11,7 +11,6 @@
   defusedxml,
   gql,
   graphql-core,
-  marshmallow,
   pydantic,
   pydantic-extra-types,
   python-box,
@@ -22,6 +21,9 @@
   semver,
   typing-extensions,
 
+  # marshmallow build system
+  flit-core,
+
   # tests
   pytest-cov-stub,
   pytest-datafiles,
@@ -30,7 +32,26 @@
   requests-pkcs12,
   responses,
 }:
+let
+  marshmallow' = buildPythonPackage {
+    pname = "marshmallow";
+    version = "3.26.2";
+    pyproject = true;
 
+    src = fetchFromGitHub {
+      owner = "marshmallow-code";
+      repo = "marshmallow";
+      tag = "3.26.2";
+      hash = "sha256-ioe+aZHOW8r3wF3UknbTjAP0dEggd/NL9PTkPVQ46zM=";
+    };
+
+    build-system = [ flit-core ];
+
+    doCheck = false;
+
+    pythonImportsCheck = [ "marshmallow" ];
+  };
+in
 buildPythonPackage (finalAttrs: {
   pname = "pytenable";
   version = "1.9.0";
@@ -55,7 +76,7 @@ buildPythonPackage (finalAttrs: {
     defusedxml
     gql
     graphql-core
-    marshmallow
+    marshmallow'
     pydantic
     pydantic-extra-types
     python-box
@@ -109,4 +130,3 @@ buildPythonPackage (finalAttrs: {
     maintainers = with lib.maintainers; [ fab ];
   };
 })
-

--- a/pkgs/development/python-modules/pytenable/default.nix
+++ b/pkgs/development/python-modules/pytenable/default.nix
@@ -1,28 +1,34 @@
 {
   lib,
   buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   cryptography,
   defusedxml,
-  fetchFromGitHub,
   gql,
   graphql-core,
   marshmallow,
-  pydantic-extra-types,
   pydantic,
+  pydantic-extra-types,
+  python-box,
+  python-dateutil,
+  requests,
+  requests-toolbelt,
+  restfly,
+  semver,
+  typing-extensions,
+
+  # tests
   pytest-cov-stub,
   pytest-datafiles,
   pytest-vcr,
   pytestCheckHook,
-  python-box,
-  python-dateutil,
   requests-pkcs12,
-  requests-toolbelt,
-  requests,
   responses,
-  restfly,
-  semver,
-  setuptools,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/pytenable/default.nix
+++ b/pkgs/development/python-modules/pytenable/default.nix
@@ -31,7 +31,7 @@
   responses,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytenable";
   version = "1.9.0";
   pyproject = true;
@@ -39,7 +39,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "tenable";
     repo = "pyTenable";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-ml5364D3qvd6VNhF2JyGoCzxbdO0DBkaBMoD38O5x8o=";
   };
 
@@ -104,8 +104,9 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for the Tenable.io and TenableSC API";
     homepage = "https://github.com/tenable/pyTenable";
-    changelog = "https://github.com/tenable/pyTenable/releases/tag/${src.tag}";
+    changelog = "https://github.com/tenable/pyTenable/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})
+

--- a/pkgs/development/python-modules/pytenable/default.nix
+++ b/pkgs/development/python-modules/pytenable/default.nix
@@ -97,6 +97,10 @@ buildPythonPackage (finalAttrs: {
     responses
   ];
 
+  pytestFlags = [
+    "-Wignore::pytest.PytestRemovedIn9Warning"
+  ];
+
   disabledTestPaths = [
     # Disable tests that requires network access
     "tests/io/"


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/321995445

`python3Packages.tenable` and `python3Packages. faraday-agent-parameters-types` want the pre-4.0 version of `python3Packages.marshmallow`. Relaxing `marshmallow` breaks multiple tests. So, pin `marshmallow` as needed:

1. Apply `finalAttrs` to `tenable`, `marshmallow`, and `faraday-agent-parameters-types` to simplify overrides
2. Override `marshmallow` to the last pre-4.0 release (`tenable`, `faraday-agent-parameters-types`)
3. Then fix a broken test in `tenable` by disabling `PytestRemovedIn9` warning.

`faraday-agent-dispatcher`:
1. Version bump
2. Fix unfound owasp dependency by moving it to `nativeBuildInputs`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
