### PR TITLE
onnxruntime: 1.23.2 -> 1.24.3

### DIFF
--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -3,8 +3,6 @@
   config,
   stdenv,
   fetchFromGitHub,
-  applyPatches,
-  fetchpatch,
   fetchurl,
   abseil-cpp_202508,
   cmake,
@@ -87,14 +85,14 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "onnxruntime";
-  version = "1.24.1";
+  version = "1.24.3";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "onnxruntime";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-Hsv5spRI6LwaDxANdveAuM7gb59F40TGGq0p7FsWeM8=";
+    hash = "sha256-1Vr0b38lHLYU4rlwDuZtyHUuKxcG6+cC5M1BiiDII/A=";
   };
 
   patches = [

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -6,7 +6,7 @@
   applyPatches,
   fetchpatch,
   fetchurl,
-  abseil-cpp_202407,
+  abseil-cpp_202508,
   cmake,
   cpuinfo,
   eigen,
@@ -59,39 +59,20 @@ let
     hash = "sha256-pjwjrqq6dfiVsXIhbBtbolhiysiFlFTnx5XcX77f+C0=";
   };
 
-  onnx-src = applyPatches {
+  onnx-src = fetchFromGitHub {
     name = "onnx-src";
-    src = fetchFromGitHub {
-      owner = "onnx";
-      repo = "onnx";
-      tag = "v1.18.0";
-      hash = "sha256-UhtF+CWuyv5/Pq/5agLL4Y95YNP63W2BraprhRqJOag=";
-    };
-
-    patches = [
-      # Fix "error: conversion from 'onnx::OpSchema' to non-scalar type 'onnx::OpSchemaRegistry::OpSchemaRegisterOnce'"
-      # https://github.com/microsoft/onnxruntime/issues/26229
-      # Fix from https://github.com/onnx/onnx/pull/7390
-      (fetchpatch {
-        url = "https://github.com/onnx/onnx/commit/595a069aaac07586f111681245bc808ee63551f8.patch";
-        includes = [ "onnx/defs/schema.h" ];
-        hash = "sha256-FFAJuJse4nmNT3ixvEdlqzbr3edY46SqEFv7z/oo6m0=";
-      })
-
-      # Fix "undefined reference to `onnx::RNNShapeInference(onnx::InferenceContext&)'"
-      (fetchpatch {
-        url = "https://github.com/onnx/onnx/commit/6769c41ad64ebca0358da8c7211d2c6d0e627b2b.patch";
-        hash = "sha256-VlTHs0om20kTNvSVQaasSsa5JROliQy4k9BECTsBtbU=";
-      })
-    ];
+    owner = "onnx";
+    repo = "onnx";
+    tag = "v1.20.1";
+    hash = "sha256-XZJXD6sBvVJ6cLPyDkKOW8oSkjqcw9whUqDWd7dxY3c=";
   };
 
   cutlass-src = fetchFromGitHub {
     name = "cutlass-src";
     owner = "NVIDIA";
     repo = "cutlass";
-    tag = "v3.9.2";
-    hash = "sha256-teziPNA9csYvhkG5t2ht8W8x5+1YGGbHm8VKx4JoxgI=";
+    tag = "v4.2.1";
+    hash = "sha256-iP560D5Vwuj6wX1otJhwbvqe/X4mYVeKTpK533Wr5gY=";
   };
 
   dlpack-src = fetchFromGitHub {
@@ -106,30 +87,17 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "onnxruntime";
-  version = "1.23.2";
+  version = "1.24.1";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "onnxruntime";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-hZ2L5+0Enkw4rGDKVpRECnKXP87w6Kbiyp6Fdxwt6hk=";
+    hash = "sha256-Hsv5spRI6LwaDxANdveAuM7gb59F40TGGq0p7FsWeM8=";
   };
 
   patches = [
-    # Missing cstdint include (GCC 15 compatibility)
-    (fetchpatch {
-      url = "https://github.com/microsoft/onnxruntime/commit/d6e712c5b7b6260a61e54d1fe40107cf5366ee77.patch";
-      hash = "sha256-FSuPybX8f2VoxvLhcYx4rdChaiK8bSUDR32sN3Efwfc=";
-    })
-
-    # Correct maybe-uninitialized and range-loop-construct warnings
-    # https://github.com/microsoft/onnxruntime/pull/26201
-    (fetchpatch {
-      url = "https://github.com/microsoft/onnxruntime/commit/8ebd0bf1cf02414584d15d7244b07fa97d65ba02.patch";
-      hash = "sha256-vX+kaFiNdmqWI91JELcLpoaVIHBb5EPbI7rCAMYAx04=";
-    })
-
     # Skip execinfo include on musl
     # https://github.com/microsoft/onnxruntime/pull/25726
     ./musl-execinfo.patch
@@ -255,7 +223,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "ABSL_ENABLE_INSTALL" true)
     (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
     (lib.cmakeBool "FETCHCONTENT_QUIET" false)
-    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_ABSEIL_CPP" "${abseil-cpp_202407.src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_ABSEIL_CPP" "${abseil-cpp_202508.src}")
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_DLPACK" "${dlpack-src}")
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_FLATBUFFERS" "${flatbuffers_23.src}")
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_MP11" "${mp11-src}")
@@ -342,12 +310,12 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     substituteInPlace cmake/libonnxruntime.pc.cmake.in \
       --replace-fail '$'{prefix}/@CMAKE_INSTALL_ @CMAKE_INSTALL_
     echo "find_package(cudnn_frontend REQUIRED)" > cmake/external/cudnn_frontend.cmake
-  ''
-  # https://github.com/microsoft/onnxruntime/blob/c4f3742bb456a33ee9c826ce4e6939f8b84ce5b0/onnxruntime/core/platform/env.h#L249
-  + ''
-    substituteInPlace onnxruntime/core/platform/env.h --replace-fail \
-      "GetRuntimePath() const { return PathString(); }" \
-      "GetRuntimePath() const { return PathString(\"$out/lib/\"); }"
+    cat >> cmake/external/abseil-cpp.cmake << 'EOF'
+    if(TARGET absl::hash AND NOT TARGET absl::low_level_hash)
+      add_library(absl::low_level_hash INTERFACE IMPORTED)
+      target_link_libraries(absl::low_level_hash INTERFACE absl::hash)
+    endif()
+    EOF
   ''
   + lib.optionalString rocmSupport ''
     patchShebangs tools/ci_build/hipify-perl


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Bump `onnxruntime` from 1.23.2 to 1.24.3. See https://github.com/microsoft/onnxruntime/releases/tag/v1.24.3.
- Align bundled deps (`onnx`, `cutlass`, `abseil-cpp`, etc.) with upstream `cmake/deps.txt` for v1.24.3.
- Add a small CMake shim to provide `absl::low_level_hash` as an alias for `absl::hash`, matching the new abseil-cpp LTS layout and fixing the link failure.
- Drop ONNX and onnxruntime patches that are already included upstream and were failing as “Reversed (or previously applied)”.
- Keep existing musl/Alpine patches and Nix-specific bits (CUDA, Python wheel, header install) unchanged.

EDIT: I updated this PR from 1.24.1 to 1.24.3. Both 1.24.2 and 1.24.3 are patch releases for the 1.24 series of ONNX Runtime, so moving directly to 1.24.3 keeps us on the latest stable patch without changing the underlying major/minor version.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - `nixpkgs-review --package onnxruntime` on `x86_64-linux` built:
    - `onnxruntime`
    - `onnxruntime.debug`
    - `onnxruntime.dev`
    - `onnxruntime.dist`
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Tested Python bindings:
  - `import onnxruntime; onnxruntime.__version__ == "1.24.3"`
  - Loaded `onnxruntime.datasets.mul_1.onnx` and ran inference via `InferenceSession(..., providers=["CPUExecutionProvider"])` on `x = np.ones((3, 2), dtype=np.float32)`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
