### PR TITLE
chromium,chromedriver: 146.0.7680.71 -> 146.0.7680.75

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "146.0.7680.71",
+    "version": "146.0.7680.75",
     "chromedriver": {
-      "version": "146.0.7680.72",
-      "hash_darwin": "sha256-pm7HJA+yr7gQFYHpYC1ELD8zDFzrzcRDpkjbqmjWcbs=",
-      "hash_darwin_aarch64": "sha256-ffgeYa2Rvrg9LUTpKJ4tkBysVkMMUkrBkju6ULHU/dI="
+      "version": "146.0.7680.76",
+      "hash_darwin": "sha256-zCICFkv0dXZYIIp8xnqEbxBR4Q9+GlCEY6yoJHsqcVg=",
+      "hash_darwin_aarch64": "sha256-UzawlFfX/lIATPL8j6XMkurE1SzhNwyB/jn4v6tWY/g="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "e00a64ead1abef9447943efede7bc26362ac3797",
-        "hash": "sha256-hZPRH4Q2PQqXDhMXHHcav+37US+7vuN176rhpcoOeq8=",
+        "rev": "d865c3fe495882da3a7c6575337a02867c4536b1",
+        "hash": "sha256-/hjpcI4GTw0bGqZ5/9gzM4Pc6/5fhk5dmdtw5EfidiY=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -817,8 +817,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "bc343986bd4cb17e49ef15b70c4bdac710e27167",
-        "hash": "sha256-dsjddO/LCNAYLJ1XyDkJLJ9TToiy7pENlBryF1VcmtY="
+        "rev": "70253f966a7c3936f5a5ff57c6a4a4face1f16ad",
+        "hash": "sha256-8tA9nWXsiQ2Qt7pbALrhsnNFHOFLw/wlcz5OrFjYEI8="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/03/stable-channel-update-for-desktop_12.html

This update includes 2 security fixes. Google is aware that exploits for both CVE-2026-3909 and CVE-2026-3910 exist in the wild.

CVEs:
CVE-2026-3909 CVE-2026-3910

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
