### PR TITLE
apacheKafka: 4_2: init at 4.2.0

### DIFF
--- a/nixos/tests/kafka/base.nix
+++ b/nixos/tests/kafka/base.nix
@@ -121,5 +121,6 @@ with pkgs;
   };
   kafka_4_0 = makeKafkaTest "kafka_4_0" { kafkaPackage = apacheKafka_4_0; };
   kafka_4_1 = makeKafkaTest "kafka_4_1" { kafkaPackage = apacheKafka_4_1; };
+  kafka_4_2 = makeKafkaTest "kafka_4_2" { kafkaPackage = apacheKafka_4_2; };
   kafka = makeKafkaTest "kafka" { kafkaPackage = apacheKafka; };
 }

--- a/pkgs/servers/apache-kafka/4_2.nix
+++ b/pkgs/servers/apache-kafka/4_2.nix
@@ -1,0 +1,5 @@
+import ./generic.nix {
+  kafkaVersion = "4.2.0";
+  scalaVersion = "2.13";
+  hash = "sha256-ZklCfC0GKQih+guUHY0idPUlNiAvqhsT41RbOVoihfs=";
+}

--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -1,5 +1,6 @@
 { callPackage }:
 {
+  apacheKafka_4_2 = callPackage ./4_2.nix { };
   apacheKafka_4_1 = callPackage ./4_1.nix { };
   apacheKafka_4_0 = callPackage ./4_0.nix { };
   apacheKafka_3_9 = callPackage ./3_9.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5415,9 +5415,10 @@ with pkgs;
     apacheKafka_3_9
     apacheKafka_4_0
     apacheKafka_4_1
+    apacheKafka_4_2
     ;
 
-  apacheKafka = apacheKafka_4_1;
+  apacheKafka = apacheKafka_4_2;
 
   asn2quickder = python3Packages.callPackage ../development/tools/asn2quickder { };
 


### PR DESCRIPTION
Similiarly branches off #499401

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
