### PR TITLE
python3Packages.uqbar: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/uqbar/default.nix
+++ b/pkgs/development/python-modules/uqbar/default.nix
@@ -57,6 +57,11 @@ buildPythonPackage (finalAttrs: {
     # assert not ["\x1b[91mWARNING: dot command 'dot' cannot be run (needed for
     # graphviz output), check the graphviz_dot setting\x1b[39;49;00m"]
     "test_sphinx_style_latex"
+    # Fails with line wrapping differences
+    "test_sphinx_api_2"
+    # Fails with changed wording in the summary (but semantically equivalent output)
+    # https://github.com/supriya-project/uqbar/issues/107
+    "SummarizingRootDocumenter"
   ]
   ++ lib.optional (pythonAtLeast "3.11") [
     # assert not '\x1b[91m/build/uqbar-0.7.0/tests/fake_package/enums.py:docstring


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/322439730

Disabled two failed tests

Tracking #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
