### PR TITLE
[25.11] envoy: 1.36.2 -> 1.36.5

### DIFF
--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -38,9 +38,9 @@ let
     # However, the version string is more useful for end-users.
     # These are contained in a attrset of their own to make it obvious that
     # people should update both.
-    version = "1.36.2";
-    rev = "dc2d3098ae5641555f15c71d5bb5ce0060a8015c";
-    hash = "sha256-ll7gn3y2dUW3kMtbUTjfi7ZTviE87S30ptiRlCPec9Q=";
+    version = "1.36.5";
+    rev = "41749943780b54b70b510b1b1a4805ae529e174a";
+    hash = "sha256-dT6ehfmW/huuyitqIlYAlEzUE6WrVA39sDKxatkZGaY=";
   };
 
   # these need to be updated for any changes to fetchAttrs
@@ -49,8 +49,8 @@ let
       depsHash
     else
       {
-        x86_64-linux = "sha256-cUpCkmJmFyd2mTImMKt5Cgi+A4bAWAXLYjJjMnV6haQ=";
-        aarch64-linux = "sha256-f1FbdFDunlF7uhCpkb5AqmKN5uimuKnFYBzXjIcRabk=";
+        x86_64-linux = "sha256-G4IFhSfWKWj8FrYPYphBToWoFUFuikzVLwlbMG2WsBM=";
+        aarch64-linux = "sha256-k/SuT7Vnj6GHRzv5ZxSlyF0ZHW7a2bl+ezh0QQ45S8c=";
       }
       .${stdenv.system} or (throw "unsupported system ${stdenv.system}");
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backport of #498994.

* https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.36/v1.36.3
* https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.36/v1.36.4
* https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.36/v1.36.5

Fixes https://github.com/NixOS/nixpkgs/issues/498813 (https://github.com/advisories/GHSA-c23c-rp3m-vpg3)
Fixes https://github.com/NixOS/nixpkgs/issues/498814 (https://github.com/advisories/GHSA-ghc4-35x6-crw5)
Fixes https://github.com/NixOS/nixpkgs/issues/498817 (https://github.com/advisories/GHSA-3cw6-2j68-868p)
Fixes https://github.com/NixOS/nixpkgs/issues/498819 (https://github.com/advisories/GHSA-56cj-wgg3-x943)
Fixes https://github.com/NixOS/nixpkgs/issues/498816 (https://github.com/advisories/GHSA-84xm-r438-86px)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
