### PR TITLE
nixos/nvidia: remove unnecessary kernel parameter

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -696,7 +696,11 @@ in
                 cfg.powerManagement.enable && cfg.powerManagement.kernelSuspendNotifier
               ) "nvidia.NVreg_UseKernelSuspendNotifiers=1"
               ++ lib.optional cfg.powerManagement.enable "nvidia.NVreg_PreserveVideoMemoryAllocations=1"
-              ++ lib.optional useOpenModules "nvidia.NVreg_OpenRmEnableUnsupportedGpus=1"
+              ++ lib.optional (
+                useOpenModules
+                && lib.versionAtLeast nvidia_x11.version "515.43.04"
+                && lib.versionOlder nvidia_x11.version "545.23.06"
+              ) "nvidia.NVreg_OpenRmEnableUnsupportedGpus=1"
               ++ lib.optional (config.boot.kernelPackages.kernel.kernelAtLeast "6.2" && !ibtSupport) "ibt=off";
 
             # enable finegrained power management


### PR DESCRIPTION
NVreg_OpenRmEnableUnsupportedGpus has had no effect since driver release 545.23.06 of the open kernel modules, where it is documented:

>Option: OpenRmEnableUnsupportedGpus
>This option to require opt in for use of Open RM on non-Data Center
>GPUs is deprecated and no longer required. The kernel module parameter
>is left here, though ignored, for backwards compatibility.

In the following NVIDIA/open-gpu-kernel-modules commit: [b5bf85a8e3](https://github.com/NVIDIA/open-gpu-kernel-modules/commit/b5bf85a8e3eb2516b9abca4d1becaf1172d62822) (would need to clone, `git show b5bf85a8e3 | less` and search for `OpenRmEnableUnsupportedGpus`)

Potentially closes #438930

Backwards compatibility: no expected issues as affected drivers are between 515 and 545, all long outdated (from 2023 or before). Legacy branches likewise unaffected.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
