### PR TITLE
systemd: 259.3 -> 259.5

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -852,16 +852,6 @@ in
       };
     };
 
-    # Remove with systemd 259.4
-    security.polkit.extraConfig = mkIf config.security.polkit.enable ''
-      polkit.addRule(function(action, subject) {
-          if (action.id == "org.freedesktop.machine1.register-machine" &&
-              subject.user != "root") {
-              return polkit.Result.AUTH_ADMIN_KEEP;
-          }
-      });
-    '';
-
     # run0 is supposed to authenticate the user via polkit and then run a command. Without this next
     # part, run0 would fail to run the command even if authentication is successful and the user has
     # permission to run the command. This next part is only enabled if polkit is enabled because the

--- a/pkgs/by-name/li/libgudev/package.nix
+++ b/pkgs/by-name/li/libgudev/package.nix
@@ -74,6 +74,11 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "tests" finalAttrs.finalPackage.doCheck)
   ];
 
+  # https://gitlab.gnome.org/GNOME/libgudev/-/issues/10
+  preCheck = ''
+    mesonCheckFlagsArray=( $(meson test --list | grep -v libgudev:test-gudevdevice) )
+  '';
+
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "libgudev";

--- a/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
+++ b/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
@@ -10,10 +10,10 @@ container, so checking early whether it exists will fail.
  1 file changed, 2 insertions(+)
 
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 6e615d280a..e16cb17c7f 100644
+index 95626a7012..764e82df8b 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -6223,6 +6223,7 @@ static int run(int argc, char *argv[]) {
+@@ -6233,6 +6233,7 @@ static int run(int argc, char *argv[]) {
                                  goto finish;
                          }
                  } else {
@@ -21,7 +21,7 @@ index 6e615d280a..e16cb17c7f 100644
                          _cleanup_free_ char *p = NULL;
  
                          if (arg_pivot_root_new)
-@@ -6242,6 +6243,7 @@ static int run(int argc, char *argv[]) {
+@@ -6252,6 +6253,7 @@ static int run(int argc, char *argv[]) {
                                  log_error_errno(r, "Unable to determine if %s looks like it has an OS tree (i.e. whether /usr/ exists): %m", arg_directory);
                                  goto finish;
                          }

--- a/pkgs/os-specific/linux/systemd/0007-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+++ b/pkgs/os-specific/linux/systemd/0007-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
@@ -103,7 +103,7 @@ index 38e3adaed6..953ad05fb5 100644
                  return log_error_errno(r, "Failed to create /etc/localtime symlink: %m");
  
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index e16cb17c7f..ff15d9d7f2 100644
+index 764e82df8b..5dc706be4f 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
 @@ -1820,8 +1820,8 @@ int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t uid, gid

--- a/pkgs/os-specific/linux/systemd/0015-tpm2_context_init-fix-driver-name-checking.patch
+++ b/pkgs/os-specific/linux/systemd/0015-tpm2_context_init-fix-driver-name-checking.patch
@@ -27,7 +27,7 @@ filename_is_valid with path_is_valid.
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/shared/tpm2-util.c b/src/shared/tpm2-util.c
-index cf11b50695..7c5daffc23 100644
+index 76951ccfd4..0a1ed3d6a5 100644
 --- a/src/shared/tpm2-util.c
 +++ b/src/shared/tpm2-util.c
 @@ -741,7 +741,7 @@ int tpm2_context_new(const char *device, Tpm2Context **ret_context) {

--- a/pkgs/os-specific/linux/systemd/0017-meson.build-do-not-create-systemdstatedir.patch
+++ b/pkgs/os-specific/linux/systemd/0017-meson.build-do-not-create-systemdstatedir.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] meson.build: do not create systemdstatedir
  1 file changed, 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index 8289d8f28a..d3cf28c631 100644
+index 08f4f99f51..765c1802a2 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -2858,7 +2858,6 @@ install_data('LICENSE.GPL2',

--- a/pkgs/os-specific/linux/systemd/0018-meson-Don-t-link-ssh-dropins.patch
+++ b/pkgs/os-specific/linux/systemd/0018-meson-Don-t-link-ssh-dropins.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] meson: Don't link ssh dropins
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index d3cf28c631..54e17a9e2d 100644
+index 765c1802a2..96013f0327 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -214,13 +214,13 @@ sshconfdir = get_option('sshconfdir')

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -206,13 +206,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   inherit pname;
-  version = "259.3";
+  version = "259.5";
 
   src = fetchFromGitHub {
     owner = "systemd";
     repo = "systemd";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-OmJUIaPwoQFAwTHihP9bM0BJ/KWetyEgZp5jjEwRExY=";
+    hash = "sha256-4w5tszZd6pBJLVGop3kBy3A9DI3YeQCvIuand7oLiL0=";
   };
 
   # On major changes, or when otherwise required, you *must* :


### PR DESCRIPTION
## Things done

https://github.com/systemd/systemd/releases/tag/v259.4

Ran all systemd tests.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
