### PR TITLE
backintime: 1.5.6 -> 1.6.1

### DIFF
--- a/pkgs/by-name/ba/backintime-common/package.nix
+++ b/pkgs/by-name/ba/backintime-common/package.nix
@@ -10,6 +10,9 @@
   openssh,
   sshfs-fuse,
   encfs,
+  which,
+  ps,
+  gnugrep,
 }:
 
 let
@@ -57,8 +60,15 @@ stdenv.mkDerivation rec {
     substituteInPlace configure \
       --replace-fail "/.." "" \
       --replace-fail "share/backintime" "${python'.sitePackages}/backintime"
+
     substituteInPlace "backintime" "backintime-askpass" \
       --replace-fail "share" "${python'.sitePackages}"
+
+    substituteInPlace "schedule.py" \
+      --replace-fail "'crontab'" "'${cron}/bin/crontab'" \
+      --replace-fail "'which'" "'${lib.getExe which}'" \
+      --replace-fail "'ps'" "'${lib.getExe ps}'" \
+      --replace-fail "'grep'" "'${lib.getExe gnugrep}'" \
   '';
 
   dontAddPrefix = true;

--- a/pkgs/by-name/ba/backintime-common/package.nix
+++ b/pkgs/by-name/ba/backintime-common/package.nix
@@ -10,6 +10,7 @@
   openssh,
   sshfs-fuse,
   encfs,
+  gocryptfs,
   which,
   ps,
   gnugrep,
@@ -33,6 +34,7 @@ let
     rsync
     sshfs-fuse
     encfs
+    gocryptfs
   ];
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/ba/backintime-common/package.nix
+++ b/pkgs/by-name/ba/backintime-common/package.nix
@@ -13,6 +13,8 @@
   which,
   ps,
   gnugrep,
+  man,
+  asciidoctor,
 }:
 
 let
@@ -33,22 +35,27 @@ let
     encfs
   ];
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "backintime-common";
-  version = "1.5.6";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "bit-team";
     repo = "backintime";
-    rev = "v${version}";
-    sha256 = "sha256-y9uo/6R9OXK9hqUD0pCLJXF2B80lr2gXf6v8+Ca6u5M=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/33Lx62S/9RcqrfJumE6/o3KnAObBa3DcmuGkcOXIQE=";
   };
 
   nativeBuildInputs = [
     makeWrapper
     gettext
   ];
-  buildInputs = [ python' ];
+
+  buildInputs = [
+    python'
+    man
+    asciidoctor
+  ];
 
   installFlags = [ "DEST=$(out)" ];
 
@@ -56,9 +63,10 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     patchShebangs --build updateversion.sh
+    patchShebangs --build doc/manpages/build_manpages.sh
     cd common
     substituteInPlace configure \
-      --replace-fail "/.." "" \
+      --replace-fail "/../etc" "/etc" \
       --replace-fail "share/backintime" "${python'.sitePackages}/backintime"
 
     substituteInPlace "backintime" "backintime-askpass" \
@@ -69,6 +77,9 @@ stdenv.mkDerivation rec {
       --replace-fail "'which'" "'${lib.getExe which}'" \
       --replace-fail "'ps'" "'${lib.getExe ps}'" \
       --replace-fail "'grep'" "'${lib.getExe gnugrep}'" \
+
+    substituteInPlace "bitlicense.py" \
+      --replace-fail "/usr/share/doc" "$out/share/doc" \
   '';
 
   dontAddPrefix = true;
@@ -91,4 +102,4 @@ stdenv.mkDerivation rec {
       done by taking snapshots of a specified set of directories.
     '';
   };
-}
+})

--- a/pkgs/by-name/ba/backintime-qt/package.nix
+++ b/pkgs/by-name/ba/backintime-qt/package.nix
@@ -9,6 +9,8 @@
   coreutils,
   util-linux,
   qt6,
+  man,
+  asciidoctor,
 }:
 
 let
@@ -37,6 +39,8 @@ stdenv.mkDerivation {
     backintime-common
     qt6.qtbase
     qt6.qtwayland
+    man
+    asciidoctor
   ];
 
   nativeBuildInputs = backintime-common.nativeBuildInputs or [ ] ++ [
@@ -47,9 +51,10 @@ stdenv.mkDerivation {
 
   preConfigure = ''
     patchShebangs --build updateversion.sh
+    patchShebangs --build doc/manpages/build_manpages.sh
     cd qt
     substituteInPlace qttools_path.py \
-      --replace "__file__, os.pardir, os.pardir" '"${backintime-common}/${python'.sitePackages}/backintime"'
+      --replace-fail "Path(__file__).parent.parent" '"${backintime-common}/${python'.sitePackages}/backintime"'
   '';
 
   preFixup = ''

--- a/pkgs/by-name/ba/backintime-qt/package.nix
+++ b/pkgs/by-name/ba/backintime-qt/package.nix
@@ -16,6 +16,7 @@ let
     ps: with ps; [
       pyqt6
       backintime-common
+      keyring
       packaging
     ]
   );

--- a/pkgs/by-name/ba/backintime-qt/package.nix
+++ b/pkgs/by-name/ba/backintime-qt/package.nix
@@ -4,6 +4,10 @@
   backintime-common,
   python3,
   polkit,
+  meld ? null,
+  meldSupport ? true,
+  kdePackages ? null,
+  kompareSupport ? false,
   which,
   su,
   coreutils,
@@ -22,6 +26,13 @@ let
       packaging
     ]
   );
+  diffProgram =
+    if meldSupport then
+      "${lib.getBin meld}/bin"
+    else if kompareSupport then
+      "${lib.getBin kdePackages.kompare}/bin"
+    else
+      "";
 in
 stdenv.mkDerivation {
   inherit (backintime-common)
@@ -59,7 +70,8 @@ stdenv.mkDerivation {
 
   preFixup = ''
     wrapQtApp "$out/bin/backintime-qt" \
-      --prefix PATH : "${lib.getBin backintime-common}/bin:$PATH"
+      --prefix PATH : "${lib.getBin backintime-common}/bin:$PATH" \
+      --prefix PATH : "${diffProgram}:$PATH"
 
     substituteInPlace "$out/share/polkit-1/actions/net.launchpad.backintime.policy" \
       --replace-fail "/usr/bin/backintime-qt" "$out/bin/backintime-qt"

--- a/pkgs/by-name/ba/backintime-qt/package.nix
+++ b/pkgs/by-name/ba/backintime-qt/package.nix
@@ -15,16 +15,26 @@
   qt6,
   man,
   asciidoctor,
+  keyringBackends ?
+    ps: with ps; [
+      secretstorage
+      keyrings-alt
+      keyring-pass
+    ],
 }:
 
 let
   python' = python3.withPackages (
-    ps: with ps; [
+    ps:
+    with ps;
+    [
       pyqt6
       backintime-common
+      dbus-python
       keyring
       packaging
     ]
+    ++ (keyringBackends ps)
   );
   diffProgram =
     if meldSupport then


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Changelog](https://github.com/bit-team/backintime/blob/dev/CHANGELOG.md#160-2026-02-08). Add gocryptfs which is preferred over encfs since [1.6.0](https://github.com/bit-team/backintime/releases/tag/v1.6.0) and meld/kompare for [diffs](https://github.com/bit-team/backintime/blob/dev/CONTRIBUTING.md#dependencies) (they are mutually exclusive; I chose to prefer meld mirroring the [upstream logic](https://github.com/bit-team/backintime/blob/v1.6.1/qt/snapshotsdialog.py#L46-L51)).

Note: one annoyance is keyring often depends on a backend, e.g. I use `keyring_pass.PasswordStoreBackend` which gives an error since keyring-pass isn't installed. Do we have a turnkey solution for this in nixpkgs? For now I have just added some common backends through an overridable `keyringBackends`.

Fixes https://github.com/NixOS/nixpkgs/issues/499012. (For those merging, this should be backported to nixos-stable.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
