### PR TITLE
woxi: init at 0.1.0

### DIFF
--- a/pkgs/by-name/wo/woxi/package.nix
+++ b/pkgs/by-name/wo/woxi/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "woxi";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ad-si";
+    repo = "woxi";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-ra7IEPhics8BhBpQpjqSIYRlgETAquGCyuqiDopFNxE=";
+  };
+
+  cargoHash = "sha256-CW59x2a/n6rFhdJjIBz5TwkX9Bg3dE/1mH/IZh/LFZI=";
+
+  meta = {
+    description = "Wolfram Language / Mathematica reimplementation in Rust";
+    homepage = "https://woxi.ad-si.com/";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "woxi";
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
