### PR TITLE
routersploit, python3Packages.threat9-test-bed: fixes

### DIFF
--- a/pkgs/by-name/ro/routersploit/package.nix
+++ b/pkgs/by-name/ro/routersploit/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   python3,
 }:
@@ -17,16 +18,18 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   build-system = with python3.pkgs; [ setuptools ];
 
-  dependencies = with python3.pkgs; [
-    paramiko
-    pycryptodome
-    pysnmp
-    requests
-    setuptools
-  ];
-
-  # Tests are out-dated and support for newer pysnmp is not implemented yet
-  doCheck = false;
+  dependencies =
+    with python3.pkgs;
+    [
+      paramiko
+      pycryptodome
+      pysnmp
+      requests
+      setuptools
+    ]
+    ++ lib.optionals (pythonAtLeast "3.13") [
+      standard-telnetlib
+    ];
 
   nativeCheckInputs = with python3.pkgs; [
     pytest-xdist
@@ -45,6 +48,27 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "tests/core/"
     "tests/test_exploit_scenarios.py"
     "tests/test_module_info.py"
+  ];
+
+  disabledTests = [
+    # AttributeError: module 'paramiko' has no attribute 'DSSKey'.
+    "test_exploit_empty_response"
+    "test_exploit_error_response"
+    "test_exploit_not_found_response"
+    "test_exploit_redirect_response"
+    "test_exploit_trash_response"
+
+    # Runs substantially slower, making this test flaky
+    "test_exploit_timeout_response"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # port conflict when running simultaneous builds
+    "test_http_scenario_service_empty_response"
+    "test_http_scenario_service_error"
+    "test_http_scenario_service_found"
+    "test_http_scenario_service_not_found"
+    "test_http_scenario_service_redirect"
+    "test_http_scenario_service_trash"
   ];
 
   meta = {

--- a/pkgs/by-name/ro/routersploit/package.nix
+++ b/pkgs/by-name/ro/routersploit/package.nix
@@ -3,19 +3,15 @@
   fetchFromGitHub,
   python3,
 }:
-
-let
-  version = "3.4.7";
-in
-python3.pkgs.buildPythonApplication {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "routersploit";
-  inherit version;
+  version = "3.4.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "threat9";
     repo = "routersploit";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-10NBSY/mYjOWoz2XCJ1UvXUIYUW4csRJHHtDlWMO420=";
   };
 
@@ -54,6 +50,7 @@ python3.pkgs.buildPythonApplication {
   meta = {
     description = "Exploitation Framework for Embedded Devices";
     homepage = "https://github.com/threat9/routersploit";
+    changelog = "https://github.com/threat9/routersploit/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       fab
@@ -61,4 +58,4 @@ python3.pkgs.buildPythonApplication {
     ];
     mainProgram = "rsf";
   };
-}
+})

--- a/pkgs/development/python-modules/threat9-test-bed/asyncio-loop.patch
+++ b/pkgs/development/python-modules/threat9-test-bed/asyncio-loop.patch
@@ -1,0 +1,18 @@
+diff --git a/threat9_test_bed/telnet_service/telnet_server.py b/threat9_test_bed/telnet_service/telnet_server.py
+index 7d29e8f..77f5e48 100644
+--- a/threat9_test_bed/telnet_service/telnet_server.py
++++ b/threat9_test_bed/telnet_service/telnet_server.py
+@@ -6,8 +6,11 @@ logger = logging.getLogger(__name__)
+ 
+ class TelnetServer:
+     def __init__(self, host: str, port: int, protocol):
+-        self.loop = asyncio.get_event_loop()
+-
++        try:
++            self.loop = asyncio.get_running_loop()
++        except RuntimeError:
++            self.loop = asyncio.new_event_loop()
++            asyncio.set_event_loop(self.loop)
+         coro = self.loop.create_server(protocol, host, port)
+         self.server = self.loop.run_until_complete(coro)
+ 

--- a/pkgs/development/python-modules/threat9-test-bed/default.nix
+++ b/pkgs/development/python-modules/threat9-test-bed/default.nix
@@ -26,6 +26,8 @@ buildPythonPackage rec {
     hash = "sha256-0YSjMf2gDdrvkDaT77iwfCkiDDXKHnZyI8d7JmBSuCg=";
   };
 
+  patches = [ ./asyncio-loop.patch ];
+
   build-system = [ setuptools-scm ];
 
   dependencies = [


### PR DESCRIPTION
`python3Packages.threat9-test-bench`:
1. ~~drop as unmaintained since 2018, broken on python 3.14~~
2. Filed https://github.com/threat9/threat9-test-bed/issues/23 re: test breakage on python 3.14
3. Filed https://github.com/threat9/threat9-test-bed/pull/24 with a fix
4. Applied a local copy of the above fix as a patch

routersploit:
1. Migrate to `finalAttrs`
2. Enable testing
3. Filed https://github.com/threat9/routersploit/issues/898

Tracking: #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
