### PR TITLE
python3Packages.telethon, mautrix-telethon: fix build

### DIFF
--- a/pkgs/by-name/ma/mautrix-telegram/package.nix
+++ b/pkgs/by-name/ma/mautrix-telegram/package.nix
@@ -1,31 +1,31 @@
 {
   lib,
-  python3,
   fetchPypi,
   fetchFromGitHub,
+  python3,
+
   withE2BE ? true,
 }:
 
 let
-  python = python3.override {
-    self = python;
-    packageOverrides = self: super: {
-      tulir-telethon = self.telethon.overridePythonAttrs (oldAttrs: rec {
-        version = "1.99.0a6";
-        pname = "tulir_telethon";
-        src = fetchPypi {
-          inherit pname version;
-          hash = "sha256-ewqc6s5xXquZJTZVBsFmHeamBLDw6PnTSNcmTNKD0sk=";
-        };
-        patches = [ ];
-        doCheck = false;
-      });
-    };
-  };
+  tulir-telethon = python3.pkgs.telethon.overrideAttrs (
+    finalAttrs: previousAttrs: {
+      version = "1.99.0a6";
+      pname = "tulir_telethon";
+      src = fetchFromGitHub {
+        owner = "tulir";
+        repo = "Telethon";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-ulnA+xKbZDOTzXYmF9oBWNBNhgxSiF+mKx1ijoCyo/w=";
+      };
+      dontUsePytestCheck = true;
+    }
+  );
 in
-python.pkgs.buildPythonPackage (finalAttrs: {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "mautrix-telegram";
   version = "0.15.3";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mautrix";
@@ -34,47 +34,50 @@ python.pkgs.buildPythonPackage (finalAttrs: {
     hash = "sha256-w3BqWyAJV/lZPoOFDzxhootpw451lYruwM9efwS6cEc=";
   };
 
-  format = "setuptools";
+  build-system = with python3.pkgs; [ setuptools ];
 
   patches = [ ./0001-Re-add-entrypoint.patch ];
 
-  propagatedBuildInputs =
-    with python.pkgs;
-    (
-      [
-        ruamel-yaml
-        python-magic
-        commonmark
-        aiohttp
-        yarl
-        (mautrix.override { withOlm = withE2BE; })
-        tulir-telethon
-        asyncpg
-        mako
-        setuptools
-        # speedups
-        cryptg
-        aiodns
-        brotli
-        # qr_login
-        pillow
-        qrcode
-        # formattednumbers
-        phonenumbers
-        # metrics
-        prometheus-client
-        # sqlite
-        aiosqlite
-        # proxy support
-        pysocks
-      ]
-      ++ lib.optionals withE2BE [
-        # e2be
-        python-olm
-        pycryptodome
-        unpaddedbase64
-      ]
-    );
+  pythonRelaxDeps = [
+    "mautrix"
+    "ruamel.yaml"
+  ];
+
+  dependencies =
+    with python3.pkgs;
+    [
+      ruamel-yaml
+      python-magic
+      commonmark
+      aiohttp
+      yarl
+      (mautrix.override { withOlm = withE2BE; })
+      tulir-telethon
+      asyncpg
+      mako
+      setuptools
+      # speedups
+      cryptg
+      aiodns
+      brotli
+      # qr_login
+      pillow
+      qrcode
+      # formattednumbers
+      phonenumbers
+      # metrics
+      prometheus-client
+      # sqlite
+      aiosqlite
+      # proxy support
+      pysocks
+    ]
+    ++ lib.optionals withE2BE [
+      # e2be
+      python-olm
+      pycryptodome
+      unpaddedbase64
+    ];
 
   # has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/telethon/default.nix
+++ b/pkgs/development/python-modules/telethon/default.nix
@@ -1,8 +1,8 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  fetchpatch,
+  fetchFromCodeberg,
+  pythonAtLeast,
   openssl,
   rsa,
   pyaes,
@@ -17,28 +17,14 @@ buildPythonPackage rec {
   version = "1.42.0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "LonamiWebs";
+  src = fetchFromCodeberg {
+    owner = "Lonami";
     repo = "Telethon";
     tag = "v${version}";
     hash = "sha256-NMHJkSTGR3/tck0k97EfVN9f85PAWst+EZ6G7Tgrt5s=";
   };
 
-  patches = [
-    # https://github.com/LonamiWebs/Telethon/pull/4670
-    (fetchpatch {
-      url = "https://github.com/LonamiWebs/Telethon/commit/8e2a46568ef9193f5887aea1abf919ac4ca6d31e.patch";
-      name = "fix_async_test.patch";
-      hash = "sha256-oVpLnO4OxNam/mq945OskVEHkbS5TDSUXk/0xPHVv3I=";
-    })
-  ]
-  ++ lib.optionals (lib.versionOlder version "1.40.1") [
-    (fetchpatch {
-      url = "https://github.com/LonamiWebs/Telethon/commit/ae9c798e2c3648ff40dee1b3f371f5d66851642e.patch";
-      name = "fix_test_messages_test.patch";
-      hash = "sha256-8SJm8EE6w7zRQxt1NuTX6KP1MTYPiYO/maJ5tOA2I9w=";
-    })
-  ];
+  disabled = pythonAtLeast "3.14";
 
   postPatch = ''
     substituteInPlace telethon/crypto/libssl.py --replace-fail \
@@ -61,13 +47,14 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-asyncio
     pytestCheckHook
-  ];
+  ]
+  ++ lib.concatAttrValues optional-dependencies;
 
   meta = {
-    homepage = "https://github.com/LonamiWebs/Telethon";
+    homepage = "https://codeberg.org/Lonami/Telethon";
     description = "Full-featured Telegram client library for Python 3";
     license = lib.licenses.mit;
-    changelog = "https://github.com/LonamiWebs/Telethon/blob/${src.tag}/readthedocs/misc/changelog.rst";
+    changelog = "https://codeberg.org/Lonami/Telethon/blob/${src.tag}/readthedocs/misc/changelog.rst";
     maintainers = with lib.maintainers; [ nyanloutre ];
   };
 }

--- a/pkgs/development/python-modules/telethon/default.nix
+++ b/pkgs/development/python-modules/telethon/default.nix
@@ -12,7 +12,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "telethon";
   version = "1.42.0";
   pyproject = true;
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   src = fetchFromCodeberg {
     owner = "Lonami";
     repo = "Telethon";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-NMHJkSTGR3/tck0k97EfVN9f85PAWst+EZ6G7Tgrt5s=";
   };
 
@@ -48,13 +48,13 @@ buildPythonPackage rec {
     pytest-asyncio
     pytestCheckHook
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   meta = {
     homepage = "https://codeberg.org/Lonami/Telethon";
     description = "Full-featured Telegram client library for Python 3";
     license = lib.licenses.mit;
-    changelog = "https://codeberg.org/Lonami/Telethon/blob/${src.tag}/readthedocs/misc/changelog.rst";
+    changelog = "https://codeberg.org/Lonami/Telethon/blob/${finalAttrs.src.tag}/readthedocs/misc/changelog.rst";
     maintainers = with lib.maintainers; [ nyanloutre ];
   };
-}
+})


### PR DESCRIPTION
1. Dropped outdated patches
2. Disabled on python >= 3.14
3. Migrated to codeberg
4. Migrated to `finalAttrs`

`mautrix-telethon`
1. `pythonOverrideAttrs` -> `overrideAttrs`
2. Add `ruaml-yaml` override
3. Modernize build

Tracking #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
