### PR TITLE
protobuf: fix big-endian upb decoding issues

### DIFF
--- a/pkgs/development/libraries/protobuf/fix-upb-packed-enum-be.patch
+++ b/pkgs/development/libraries/protobuf/fix-upb-packed-enum-be.patch
@@ -1,0 +1,22 @@
+From 3935d8b9fd740e0ed45fade633ab967baee1dfcc Mon Sep 17 00:00:00 2001
+From: Jonathan Albrecht <jonathan.albrecht@ibm.com>
+Date: Tue, 3 Feb 2026 15:07:37 -0500
+Subject: [PATCH] Fix an endian problem when memcpying in
+ _upb_Decoder_DecodeEnumPacked
+
+---
+ upb/wire/decode.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/upb/wire/decode.c b/upb/wire/decode.c
+index 9b050866b45ea..0810ba3e6116b 100644
+--- a/upb/wire/decode.c
++++ b/upb/wire/decode.c
+@@ -359,6 +359,7 @@ static const char* _upb_Decoder_DecodeEnumPacked(
+       _upb_Decoder_AddEnumValueToUnknown(d, msg, field, &elem);
+       continue;
+     }
++    _upb_Decoder_MungeInt32(&elem);
+     if (_upb_Decoder_Reserve(d, arr, 1)) {
+       out = UPB_PTR_AT(upb_Array_MutableDataPtr(arr),
+                        arr->UPB_PRIVATE(size) * 4, void);

--- a/pkgs/development/libraries/protobuf/generic.nix
+++ b/pkgs/development/libraries/protobuf/generic.nix
@@ -65,6 +65,17 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-2/vc4anc+kH7otfLHfBtW8dRowPyObiXZn0+HtQktak=";
       })
     ]
+    ++ lib.optionals (lib.versionAtLeast version "33") [
+      # Fix protoc plugins crashing on big-endian platforms
+      # https://github.com/protocolbuffers/protobuf/pull/25363
+      (fetchpatch {
+        url = "https://github.com/protocolbuffers/protobuf/commit/8282f0f8ecf8b847e5964a308e041ba3b049811c.patch";
+        hash = "sha256-4c/yLuAd29Cxrz6I9F2Lj02lW2bazIcGb+86uxZY7qA=";
+      })
+      # Fix packed enum decoding on big-endian platforms
+      # https://github.com/protocolbuffers/protobuf/pull/25683
+      ./fix-upb-packed-enum-be.patch
+    ]
     ++ lib.optionals (lib.versionAtLeast version "34") [
       # upb linker-array fix for newer toolchains (notably GCC 15):
       # `UPB_linkarr_internal_empty_upb_AllExts` can conflict with extension


### PR DESCRIPTION
## Things done

The upb wire decoder was missing `_upb_Decoder_MungeInt32` calls for closed enum values, causing `protoc-gen-upb*` to segfault on big-endian systems. This commit backports two upstream fixes not yet included in v33.5.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] powerpc64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
