### PR TITLE
writeShellApplication: fix inheritPath without runtimeInputs

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -356,10 +356,16 @@ rec {
           export ${name}
         '') runtimeEnv
       )
-      + lib.optionalString (runtimeInputs != [ ]) ''
+      + ''
 
-        export PATH="${lib.makeBinPath runtimeInputs}${lib.optionalString inheritPath ":$PATH"}"
+        export PATH="${
+          lib.concatStringsSep ":" (
+            (lib.optionals (runtimeInputs != [ ]) [ (lib.makeBinPath runtimeInputs) ])
+            ++ (lib.optionals inheritPath [ "$PATH" ])
+          )
+        }"
       ''
+
       + ''
 
         ${text}

--- a/pkgs/build-support/trivial-builders/test/writeShellApplication.nix
+++ b/pkgs/build-support/trivial-builders/test/writeShellApplication.nix
@@ -83,6 +83,50 @@ linkFarm "writeShellApplication-tests" {
     '';
   };
 
+  test-no-inherit-path-no-runtimeInputs = checkShellApplication {
+    name = "test-no-inherit-path-no-runtimeInputs";
+    inheritPath = false;
+    runtimeInputs = [ ];
+    text = ''
+      if [[ ''${#PATH} -eq 0 ]]; then
+        echo -n "PATH is empty"
+      fi
+    '';
+    expected = "PATH is empty";
+  };
+
+  test-no-inherit-path-runtimeInputs = checkShellApplication {
+    name = "test-no-inherit-path-runtimeInputs";
+    inheritPath = false;
+    runtimeInputs = [ hello ];
+    text = ''
+      extra_colon_pattern='(^:|:$)'
+      if [[ ''${PATH} =~ $extra_colon_pattern ]]; then
+        echo "PATH should not start or end with a colon: $PATH"
+      fi
+      if [[ ''${#PATH} -gt 0 ]]; then
+        echo -n "PATH is not empty"
+      fi
+    '';
+    expected = "PATH is not empty";
+  };
+
+  test-inherit-path-no-runtimeInputs = checkShellApplication {
+    name = "test-inherit-path-no-runtimeInputs";
+    inheritPath = true;
+    runtimeInputs = [ ];
+    text = ''
+      extra_colon_pattern='(^:|:$)'
+      if [[ ''${PATH} =~ $extra_colon_pattern ]]; then
+        echo "PATH should not start or end with a colon: $PATH"
+      fi
+      if [[ ''${#PATH} -gt 0 ]]; then
+        echo -n "PATH is not empty"
+      fi
+    '';
+    expected = "PATH is not empty";
+  };
+
   test-check-phase = checkShellApplication {
     name = "test-check-phase";
     text = "";


### PR DESCRIPTION
`inheritPath` `false` should be also followed when `runtimeInputs` is empty.

Writing a shell application without any dependencies that does not inherit the environments `$PATH` was not possible before this change, because `inheritPath` was only taken into account when `runtimeInputs` was non-empty. Shell applications that do not depend on any additional packages might still want to run with a clean `$PATH` in order to not accidentally rely on packages available in the execution environment.

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
