### PR TITLE
[staging-next] apache-orc: 2.2.1 -> 2.3.0, fix build with protobuf 34

### DIFF
--- a/pkgs/by-name/ap/apache-orc/cmake-link-abseil.patch
+++ b/pkgs/by-name/ap/apache-orc/cmake-link-abseil.patch
@@ -1,0 +1,12 @@
+diff --git a/tools/src/CMakeLists.txt b/tools/src/CMakeLists.txt
+index 81e2da6f19..cdb809aed9 100644
+--- a/tools/src/CMakeLists.txt
++++ b/tools/src/CMakeLists.txt
+@@ -64,6 +64,7 @@
+ target_link_libraries (orc-metadata
+   orc-tools-common
+   orc::protobuf
++  absl::raw_hash_set
+   )
+ 
+  add_executable (orc-statistics

--- a/pkgs/by-name/ap/apache-orc/package.nix
+++ b/pkgs/by-name/ap/apache-orc/package.nix
@@ -27,13 +27,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "apache-orc";
-  version = "2.2.1";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "orc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-H7nowl2pq31RIAmTUz15x48Wc99MljFJboc4F7Ln/zk=";
+    hash = "sha256-QQdRzwmUF1Qwxg53kJv1Q6yFuHqSrLYwUxKt+6wK9Hs=";
   };
 
   nativeBuildInputs = [
@@ -65,12 +65,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   env = {
     GTEST_HOME = gtest.dev;
-    LZ4_ROOT = lz4;
+    LZ4_HOME = lz4;
     ORC_FORMAT_URL = orc-format;
     PROTOBUF_HOME = protobuf;
-    SNAPPY_ROOT = snappy.dev;
-    ZLIB_ROOT = zlib.dev;
-    ZSTD_ROOT = zstd.dev;
+    SNAPPY_HOME = snappy.dev;
+    ZLIB_HOME = zlib.dev;
+    ZSTD_HOME = zstd.dev;
   };
 
   meta = {

--- a/pkgs/by-name/ap/apache-orc/package.nix
+++ b/pkgs/by-name/ap/apache-orc/package.nix
@@ -43,6 +43,11 @@ stdenv.mkDerivation (finalAttrs: {
     # <store path>/bin/ld: <store path>/lib/libabsl_raw_hash-set.so.2601.0.0:
     # error adding symbols: DSO missing from command line
     ./cmake-link-abseil.patch
+
+    # Protobuf 34 adds `[[nodiscard]]` to several serialization functions. In
+    # order to avoid these warnings causing build failures, we add handling for
+    # this failure case.
+    ./protobuf34-nodiscard.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ap/apache-orc/package.nix
+++ b/pkgs/by-name/ap/apache-orc/package.nix
@@ -36,6 +36,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-QQdRzwmUF1Qwxg53kJv1Q6yFuHqSrLYwUxKt+6wK9Hs=";
   };
 
+  patches = [
+    # Orc's CMake declarations do not correctly attempt to link in abseil,
+    # so we add the relevant library they need. Without these, we get errors
+    # like:
+    # <store path>/bin/ld: <store path>/lib/libabsl_raw_hash-set.so.2601.0.0:
+    # error adding symbols: DSO missing from command line
+    ./cmake-link-abseil.patch
+  ];
+
   nativeBuildInputs = [
     cmake
   ];

--- a/pkgs/by-name/ap/apache-orc/protobuf34-nodiscard.patch
+++ b/pkgs/by-name/ap/apache-orc/protobuf34-nodiscard.patch
@@ -1,0 +1,15 @@
+diff --git a/c++/src/ColumnWriter.cc b/c++/src/ColumnWriter.cc
+index 9cdbae0709..d049e91bb1 100644
+--- a/c++/src/ColumnWriter.cc
++++ b/c++/src/ColumnWriter.cc
+@@ -212,7 +212,9 @@
+       }
+     }
+     // write row index to output stream
+-    rowIndex->SerializeToZeroCopyStream(indexStream.get());
++    if (!rowIndex->SerializeToZeroCopyStream(indexStream.get())) {
++      throw std::logic_error("Failed to write index stream.");
++    }
+ 
+     // construct row index stream
+     proto::Stream stream;

--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -131,8 +131,10 @@ stdenv.mkDerivation (finalAttrs: {
       };
 
       # apache-orc looks for things in caps
-      LZ4_ROOT = lz4;
-      ZSTD_ROOT = zstd.dev;
+      LZ4_HOME = lz4;
+      PROTOBUF_HOME = protobuf;
+      SNAPPY_HOME = snappy.dev;
+      ZSTD_HOME = zstd.dev;
       ARROW_TEST_DATA = "${arrow-testing}/data";
       PARQUET_TEST_DATA = "${parquet-testing}/data";
       GTEST_FILTER =


### PR DESCRIPTION
Changelog: https://github.com/apache/orc/releases/tag/v2.3.0

In order to make this update, we have to update Orc's CMake declarations in order to correctly link abseil libraries. I'm not a CMake expert or even knower, but I think this is reasonably correct.

The build is also currently failing on staging-next due to Protobuf 34 adding `[[nodiscard]]` to many serialization functions, to which we handle the error in the place where it occurs. (I'll see if I can upstream this change later.)

We also added the `PROTOBUF_HOME` variable to arrow-cpp, *the* in-tree dependent for apache-orc, as it needs it in order to find the orc libraries and correctly pass the CMake configure step. I'm not familiar enough with CMake to figure out how the error messages it emits correspond to this fix, but it leads to a successful build.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
