### PR TITLE
nixos-rebuild-ng: fix list-generations -p <profile>

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -437,7 +437,10 @@ def get_generations(profile: Profile) -> list[Generation]:
         )
 
     return sorted(
-        [parse_path(p, profile) for p in profile.path.parent.glob("system-*-link")],
+        [
+            parse_path(p, profile)
+            for p in profile.path.parent.glob(f"{profile.name}-*-link")
+        ],
         key=lambda d: d.id,
     )
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -458,7 +458,32 @@ def test_get_generations(tmp_path: Path) -> None:
     (tmp_path / "system-3-link").symlink_to(nixos_path)
     (tmp_path / "system-2-link").symlink_to(nixos_path)
 
+    # An alternate profile; this shouldn't appear.
+    (tmp_path / "custom").symlink_to(tmp_path / "custom-1-link")
+    (tmp_path / "custom-1-link").symlink_to(nixos_path)
+
     assert n.get_generations(m.Profile("system", tmp_path / "system")) == [
+        m.Generation(id=1, current=False, timestamp=ANY),
+        m.Generation(id=2, current=True, timestamp=ANY),
+        m.Generation(id=3, current=False, timestamp=ANY),
+    ]
+
+
+def test_get_generations_with_profile(tmp_path: Path) -> None:
+    nixos_path = tmp_path / "nixos-system"
+    nixos_path.mkdir()
+
+    (tmp_path / "custom").symlink_to(tmp_path / "custom-2-link")
+    # In the "wrong" order on purpose to make sure we are sorting the results
+    (tmp_path / "custom-1-link").symlink_to(nixos_path)
+    (tmp_path / "custom-3-link").symlink_to(nixos_path)
+    (tmp_path / "custom-2-link").symlink_to(nixos_path)
+
+    # An alternate profile; none of these should appear.
+    (tmp_path / "system").symlink_to(tmp_path / "system-1-link")
+    (tmp_path / "system-1-link").symlink_to(nixos_path)
+
+    assert n.get_generations(m.Profile("custom", tmp_path / "custom")) == [
         m.Generation(id=1, current=False, timestamp=ANY),
         m.Generation(id=2, current=True, timestamp=ANY),
         m.Generation(id=3, current=False, timestamp=ANY),


### PR DESCRIPTION
"system" is only correct for the system profile.

`glob` doesn't have an injection risk, so we can include the profile name directly.

Fixes #499476

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I read through the contributing docs. I'd rather rely on CI to run tests for a change of this size, rather than trying to figure out how to run tests myself.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
