### PR TITLE
yubihsm-shell: fix checkPhase race condition

### DIFF
--- a/pkgs/by-name/yu/yubihsm-shell/package.nix
+++ b/pkgs/by-name/yu/yubihsm-shell/package.nix
@@ -94,6 +94,12 @@ stdenv.mkDerivation (finalAttrs: {
     # so we expect a failure here, but it should at least try to connect
     yubihsm-connector -d </dev/null 1>&2 2>connector.log &
     yubihsm_pid=$!
+    idx=0
+    while ! grep takeoff connector.log >/dev/null && [ $idx -lt 10 ]; do
+      idx=$((idx+1))
+      echo "Waiting for yubihsm-connector startup (try: $idx)" >&2
+      sleep 1
+    done
     $out/bin/yubihsm-shell -Pv1 </dev/null || true
     kill -INT "$yubihsm_pid" && { wait "$yubihsm_pid" || true; }
     cat connector.log >&2


### PR DESCRIPTION
This passed locally but failed on hydra, guess my machine was too fast.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
