### PR TITLE
nixos/vikunja: add user/group, allow secret management

### DIFF
--- a/nixos/modules/services/web-apps/vikunja.nix
+++ b/nixos/modules/services/web-apps/vikunja.nix
@@ -4,9 +4,7 @@
   config,
   ...
 }:
-
 with lib;
-
 let
   cfg = config.services.vikunja;
   format = pkgs.formats.yaml { };
@@ -55,7 +53,16 @@ in
       default = 3456;
       description = "The TCP port exposed by the API.";
     };
-
+    user = mkOption {
+      type = types.str;
+      default = "vikunja";
+      description = "The user vikunja should run as.";
+    };
+    group = mkOption {
+      type = types.str;
+      default = "vikunja";
+      description = "The group vikunja should run as.";
+    };
     settings = mkOption {
       type = format.type;
       default = { };
@@ -131,7 +138,8 @@ in
 
       serviceConfig = {
         Type = "simple";
-        DynamicUser = true;
+        User = cfg.user;
+        Group = cfg.group;
         StateDirectory = "vikunja";
         ExecStart = "${cfg.package}/bin/vikunja";
         Restart = "always";
@@ -144,5 +152,22 @@ in
     environment.systemPackages = [
       cfg.package # for admin `vikunja` CLI
     ];
+
+    users = {
+      users = mkIf (cfg.user == "vikunja") {
+        vikunja = {
+          name = "vikunja";
+          group = cfg.group;
+          isSystemUser = true;
+        };
+      };
+      groups = mkIf (cfg.group == "vikunja") { vikunja = { }; };
+    };
+
+    systemd.tmpfiles.settings.vikunja."/var/lib/vikunja".d = {
+      user = cfg.user;
+      group = cfg.group;
+      mode = "0750";
+    };
   };
 }


### PR DESCRIPTION
Migrate vikunka systemd service from dynamic systemd user to user configurable fixed account/group.

Rationale:
NixOS secret management (rage, sops,...) needed for integration with OIDC auth, fixed JWT keys and others is incompatible with the systemd-dynamic user feature. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
