### PR TITLE
rofi-firefox-bookmarks: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ro/rofi-firefox-bookmarks/package.nix
+++ b/pkgs/by-name/ro/rofi-firefox-bookmarks/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "rofi-firefox-bookmarks";
+  version = "0.1.0";
+  pyproject = true;
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  src = fetchFromGitHub {
+    owner = "azban";
+    repo = "rofi-firefox-bookmarks";
+    tag = "v${version}";
+    hash = "sha256-tGuBNxGri1jUYgNRaOqvF7x0PuEmiDH5zjn0o73eJ/E=";
+  };
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  meta = {
+    homepage = "https://github.com/azban/rofi-firefox-bookmarks";
+    description = "Rofi script to search and open Firefox bookmarks";
+    maintainers = with lib.maintainers; [ azban ];
+    license = lib.licenses.mit;
+    mainProgram = "rofi-firefox-bookmarks";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
