### PR TITLE
lstk: init at 0.5.7

### DIFF
--- a/pkgs/by-name/ls/lstk/package.nix
+++ b/pkgs/by-name/ls/lstk/package.nix
@@ -1,0 +1,42 @@
+{
+  fetchFromGitHub,
+  buildGoModule,
+  lib,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "lstk";
+  version = "0.5.7";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "localstack";
+    repo = "lstk";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-HWkCDnbg/D2zX3rdvmFTdKrx03SO6FaiA/Pzj0f4hlA=";
+  };
+
+  vendorHash = "sha256-rEcVtSFnBQ+3bbU5pjbCXEJZo89+lL/1HJG9bCn8OSE=";
+
+  excludedPackages = "test/integration";
+
+  __darwinAllowLocalNetworking = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command line interface for LocalStack";
+    mainProgram = "lstk";
+    homepage = "https://github.com/localstack/lstk";
+    changelog = "https://github.com/localstack/lstk/releases/tag/v${finalAttrs.version}";
+    longDescription = ''
+      lstk is a command-line interface for LocalStack built in Go with a modern
+      terminal Ul, and native CLI experience for managing and interacting with
+      LocalStack deployments.
+    '';
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ purcell ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds the [`lstk` CLI utility](https://github.com/localstack/lstk) for managing [localstack](https://www.localstack.cloud/).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
