### PR TITLE
picgo: 2.5.2 -> 2.5.3

### DIFF
--- a/pkgs/by-name/pi/picgo/package.nix
+++ b/pkgs/by-name/pi/picgo/package.nix
@@ -6,7 +6,7 @@
   pnpm,
   fetchPnpmDeps,
   pnpmConfigHook,
-  electron_38,
+  electron_40,
   makeWrapper,
   copyDesktopItems,
   makeDesktopItem,
@@ -16,19 +16,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "picgo";
-  version = "2.5.2";
+  version = "2.5.3";
 
   src = fetchFromGitHub {
     owner = "Molunerfinn";
     repo = "PicGo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fEj5ymnDBxeJ33GeIrcciQW3Wg7jMQaitwhUHne9a14=";
+    hash = "sha256-4Ih7PPBo6scJoUS8yTAR0iyG5vxNc/c0CCw5FGaIbHM=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) version src;
     pname = "picgo";
-    hash = "sha256-hYQM1KiKfsQL0AbYpHtmpDHbG3HsdXFbpgGzcZVW7R0=";
+    hash = "sha256-tILvWDoHAN5XT1F/cJYgfeMzowuO/fhiughI+0FvHzc=";
     fetcherVersion = 3; # lockfileVersion 9.0 corresponds to fetcherVersion 3
   };
 
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Create startup script
     mkdir -p $out/bin
-    makeWrapper ${lib.getExe electron_38} $out/bin/picgo \
+    makeWrapper ${lib.getExe electron_40} $out/bin/picgo \
       --add-flags "$out/lib/picgo/.launcher.cjs" \
       --add-flags "--name picgo" \
       --set NODE_ENV production \


### PR DESCRIPTION
see https://github.com/Molunerfinn/PicGo/releases/tag/v2.5.3
bump electron from 38 to 40

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
