### PR TITLE
felix86: init at 26.04

### DIFF
--- a/pkgs/by-name/fe/felix86/package.nix
+++ b/pkgs/by-name/fe/felix86/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  cmake,
+  pkg-config,
+
+  libGL,
+  libx11,
+  vulkan-headers,
+  vulkan-loader,
+
+  callPackage,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "felix86";
+  version = "26.04";
+
+  src = fetchFromGitHub {
+    owner = "OFFTKP";
+    repo = "felix86";
+    tag = finalAttrs.version;
+    hash = "sha256-onhPibvO74yo95zop7EhG+EILn4M70X9ivhS9I+fIBY=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    vulkan-headers
+  ];
+
+  buildInputs = [
+    libGL
+    libx11
+    vulkan-loader
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 felix86 $out/bin/felix86
+
+    runHook postInstall
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeBool "ZYDIS_BUILD_DOXYGEN" false)
+    (lib.cmakeBool "BUILD_TESTS" true)
+  ];
+
+  passthru.tests = callPackage ./test.nix { };
+
+  meta = {
+    description = "x86 and x86-64 userspace emulator for RISC-V Linux";
+    homepage = "https://github.com/OFFTKP/felix86";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+    mainProgram = "felix86";
+    platforms = [ "riscv64-linux" ];
+  };
+})

--- a/pkgs/by-name/fe/felix86/test.nix
+++ b/pkgs/by-name/fe/felix86/test.nix
@@ -1,0 +1,35 @@
+{
+  pkgs,
+  ...
+}:
+
+pkgs.testers.nixosTest {
+  name = "felix86";
+
+  nodes.machine =
+    {
+      config,
+      pkgs,
+      ...
+    }:
+    {
+      boot.binfmt.emulatedSystems = [ "riscv64-linux" ];
+
+      environment.systemPackages = [
+        pkgs.pkgsCross.riscv64.felix86
+      ];
+    };
+
+  testScript =
+    # python
+    ''
+      machine.wait_for_unit("multi-user.target")
+      machine.succeed("felix86 --help")
+    '';
+
+  interactive.nodes.machine = {
+    virtualisation.graphics = false;
+    environment.systemPackages = [ pkgs.binutils ];
+  };
+  interactive.sshBackdoor.enable = true;
+}


### PR DESCRIPTION
[felix86](https://github.com/OFFTKP/felix86) is a Linux userspace emulator that allows you to run x86 and x86-64 programs on RISC-V processors.

If anyone has a RISC-V machine, testing this would be greatly appreciated since I personally don't have one and my tests are limited to cross-compilation:

```shellSession
$ nix-build -A pkgsCross.riscv64.felix86
$ nix-shell -p qemu --run 'qemu-riscv64 ./result/bin/felix86 --help'
Usage: felix86 [OPTION...] TARGET_BINARY [TARGET_ARGS...]
felix86 - a userspace x86 and x86_64 emulator for RISC-V

  -b, --binfmt-misc          Register the emulator in binfmt_misc so that
                             x86-64 executables can run without prepending the
                             emulator path
  -c, --configs              Print the emulator configurations
  -d, --detect-binfmt-misc   Check if we are correctly registered in
                             binfmt_misc, returns 0 if ok
  -g, --get-rootfs           Get the rootfs path from config.toml
  -i, --info                 Print system info
  -k, --kill-all             Kill all open emulator instances
  -l, --log-server           Start just the log server in the background
      --shell                Enter the rootfs through a shell
      --shell-debug          Enter the rootfs through a shell, enable logging
  -s, --set-rootfs=DIR       Set the rootfs path in config.toml
  -S, --set-thunks=DIR       Set the thunks path in config.toml
  -u, --unregister-binfmt-misc   Unregister the emulator from binfmt_misc
  -?, --help                 Give this help list
      --usage                Give a short usage message
  -V, --version              Print program version

Mandatory or optional arguments to long options are also mandatory or optional
for any corresponding short options.

Report bugs to <https://github.com/OFFTKP/felix86/issues>.
```

```shellSession
$ nix-build -A pkgsCross.riscv64.felix86
$ wget https://cdn.felix86.com/rootfs/Fedora-43-Tiny.tar.gz
$ mkdir -p /tmp/felix86-rootfs
$ tar -xvf Fedora-43-Tiny.tar.gz -C /tmp/felix86-rootfs/
$ nix-shell -p qemu --run 'qemu-riscv64 -cpu max,vlen=256 ./result/bin/felix86 -s /tmp/felix86-rootfs'
Setting rootfs to /tmp/felix86-rootfs
$ nix-shell -p qemu --run 'qemu-riscv64 -cpu max,vlen=256 ./result/bin/felix86 /tmp/felix86-rootfs/bin/bash -c "echo hello, world!"'
felix86 26.03
Linux 6.19
Environment:
FELIX86_ROOTFS=/tmp/felix86-rootfs
Extensions enabled for the recompiler: g,v256,c,b,zacas,zicond,zfa,zvbb,zvkned,zvfhmin,zicclsm
Zacas & CMPXCHG, untested
hello, world!
Main process 427954 exited with reason: Exit group syscall. Exit code: 0
```

**PS:** Work done as part of the [Nix@NGI packaging effort](https://nixos.org/community/teams/ngi/) (tracked in https://github.com/ngi-nix/projects/issues/169)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test