### PR TITLE
qmd: init at 2.8.3

### DIFF
--- a/pkgs/by-name/qm/qmd/package.nix
+++ b/pkgs/by-name/qm/qmd/package.nix
@@ -1,0 +1,98 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  bun,
+  makeBinaryWrapper,
+  sqlite,
+  runCommand,
+}:
+let
+  pin = lib.importJSON ./pin.json;
+  inherit (pin) version;
+
+  pname = "qmd";
+
+  src = fetchFromGitHub {
+    owner = "tobi";
+    repo = pname;
+    tag = "v${version}";
+    hash = pin.srcHash;
+  };
+  node_modules = stdenv.mkDerivation {
+    pname = "${pname}-node_modules";
+    inherit src;
+    inherit (pin) version;
+    impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+      "GIT_PROXY_COMMAND"
+      "SOCKS_SERVER"
+    ];
+    nativeBuildInputs = [ bun ];
+    dontConfigure = true;
+    buildPhase = ''
+      export HOME=$(mktemp -d)
+      bun install --no-progress --ignore-scripts
+    '';
+    installPhase = ''
+      mkdir -p $out/node_modules
+      cp -R ./node_modules $out
+    '';
+    dontPatchShebangs = true;
+    dontFixup = true;
+    outputHash = pin."${stdenv.system}";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname;
+  inherit (pin) version;
+  inherit src;
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+  buildInputs = [ sqlite ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/qmd
+    mkdir -p $out/bin
+
+    ln -s ${node_modules}/node_modules $out/lib/qmd/node_modules
+    cp -r src $out/lib/qmd/
+    cp package.json $out/lib/qmd/
+
+    makeBinaryWrapper ${bun}/bin/bun $out/bin/qmd \
+      --add-flags "run --prefer-offline --no-install --cwd $out/lib/qmd $out/lib/qmd/src/cli/qmd.ts" \
+      --set-default NODE_LLAMA_CPP_GPU false \
+      --set DYLD_LIBRARY_PATH "${sqlite.out}/lib" \
+      --set LD_LIBRARY_PATH "${
+        lib.makeLibraryPath (
+          [ sqlite ]
+          ++ lib.optionals stdenv.isLinux [
+            stdenv.cc.libc
+            stdenv.cc.cc.lib
+          ]
+        )
+      }"
+
+    runHook postInstall
+  '';
+
+  passthru.tests.version = runCommand "qmd-test" { } ''
+    ${lib.getExe finalAttrs.finalPackage} --help > $out
+    grep -q "qmd collection add" $out
+  '';
+
+  meta = {
+    description = "On-device search engine for markdown notes and knowledge bases";
+    homepage = "https://github.com/tobi/qmd";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pbek ];
+    mainProgram = "qmd";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/qm/qmd/package.nix
+++ b/pkgs/by-name/qm/qmd/package.nix
@@ -1,0 +1,119 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  bun,
+  makeWrapper,
+  sqlite,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qmd";
+  version = finalAttrs.passthru.pin.version;
+
+  src = fetchFromGitHub {
+    owner = "tobi";
+    repo = "qmd";
+    tag = "v${finalAttrs.version}";
+    hash = finalAttrs.passthru.pin.srcHash;
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ sqlite ];
+  nativeInstallCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/qmd
+    mkdir -p $out/bin
+
+    ln -s ${finalAttrs.passthru.node_modules}/node_modules $out/lib/qmd/node_modules
+    cp -r src $out/lib/qmd/
+    cp package.json $out/lib/qmd/
+
+    makeWrapper ${bun}/bin/bun $out/bin/qmd \
+      --add-flags "run --prefer-offline --no-install --cwd $out/lib/qmd $out/lib/qmd/src/cli/qmd.ts" \
+      --set-default NODE_LLAMA_CPP_GPU false \
+      --set DYLD_LIBRARY_PATH "${sqlite.out}/lib" \
+      --set LD_LIBRARY_PATH "${
+        lib.makeLibraryPath (
+          [ sqlite ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
+            stdenv.cc.libc
+            stdenv.cc.cc.lib
+          ]
+        )
+      }"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    helpOutput="$($out/bin/qmd --help)"
+    grep -q "qmd collection add" <<< "$helpOutput"
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    pin = lib.importJSON ./pin.json;
+    node_modules = stdenv.mkDerivation {
+      pname = "${finalAttrs.pname}-node_modules";
+      inherit (finalAttrs) version src;
+
+      impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+        "GIT_PROXY_COMMAND"
+        "SOCKS_SERVER"
+      ];
+
+      nativeBuildInputs = [
+        bun
+        writableTmpDirAsHomeHook
+      ];
+
+      dontConfigure = true;
+      buildPhase = ''
+        runHook preBuild
+
+        bun install --no-progress --ignore-scripts
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out
+        cp -R node_modules $out/
+
+        runHook postInstall
+      '';
+
+      dontPatchShebangs = true;
+      dontFixup = true;
+      outputHash = finalAttrs.passthru.pin.hashes.${stdenv.system};
+      outputHashAlgo = "sha256";
+      outputHashMode = "recursive";
+    };
+  };
+
+  meta = {
+    description = "On-device search engine for markdown notes and knowledge bases";
+    homepage = "https://github.com/tobi/qmd";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pbek ];
+    mainProgram = "qmd";
+    platforms = builtins.attrNames finalAttrs.passthru.pin.hashes;
+  };
+})

--- a/pkgs/by-name/qm/qmd/pin.json
+++ b/pkgs/by-name/qm/qmd/pin.json
@@ -1,0 +1,8 @@
+{
+  "version": "2.0.1",
+  "srcHash": "sha256-UoR9iyxqbjwAbEmiC/kxS10lvdBJmDuQigS/aEgEzDs=",
+  "x86_64-linux": "sha256-VJwVhcAw4hHe+hmUAEBQIGp3ibERBQuPdw2zmvLcvVI=",
+  "x86_64-darwin": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+  "aarch64-darwin": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+  "aarch64-linux": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+}

--- a/pkgs/by-name/qm/qmd/pin.json
+++ b/pkgs/by-name/qm/qmd/pin.json
@@ -1,0 +1,9 @@
+{
+  "version": "2.8.3",
+  "srcHash": "sha256-/7Z94r/9rXqzKlz/YkB6/nToSCPamV4Dnxm8EhelTDo=",
+  "hashes": {
+    "x86_64-linux": "sha256-YXsyoYh7zaKTX5VCqDH5ATB6r879AoWQpi0fHhnpbHM=",
+    "aarch64-darwin": "sha256-v687eUTtJM1tislyzHzq2Z+ZKLM/1BtZWLFm76+jWl8=",
+    "aarch64-linux": "sha256-OIPfzQ+uf7AscCiqB7qicc8i/4DqiWonla01kR2lfeA="
+  }
+}


### PR DESCRIPTION
I took over https://github.com/NixOS/nixpkgs/pull/484930, fixed the issues and updated to latest 2.8.3.

Add qmd, an on-device search engine for markdown notes and knowledge bases.
Combines BM25 full-text search, vector semantic search, and LLM re-ranking.

Closes #484930

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
