### PR TITLE
xperifirm: init at 5.8.1

### DIFF
--- a/pkgs/by-name/xp/xperifirm/package.nix
+++ b/pkgs/by-name/xp/xperifirm/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  gnome-themes-extra,
+  gtk2,
+  mono,
+  makeWrapper,
+}:
+
+let
+  inherit (stdenv) hostPlatform;
+
+  exePlatformSuffix =
+    if hostPlatform.isx86_64 then
+      "x64"
+    else if hostPlatform.isAarch64 then
+      "arm64"
+    else if hostPlatform.isx86_32 then
+      "x86"
+    else
+      throw "Unsupported platform: ${hostPlatform.system}";
+
+  exe = "XperiFirm-" + exePlatformSuffix + ".exe";
+in
+stdenv.mkDerivation {
+  pname = "xperifirm";
+  version = "5.8.1";
+
+  src = fetchzip {
+    url = "https://xdaforums.com/attachments/xperifirm-5-8-1-by-igor-eisberg-zip.6286497/";
+    extension = "zip";
+    stripRoot = false;
+    hash = "sha256-G/wF2wwEbD6+zt20cIoGtFlYCyie2roDP7TO9FBfUuo=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin" "$out/lib/xperifirm" "$out/share/xperifirm/gtk-2.0"
+    cp "${exe}" "$out/lib/xperifirm"
+
+    # Force GTK2 light theme to avoid dark theme readability issues
+    cat >"$out/share/xperifirm/gtk-2.0/gtkrc" <<'EOF'
+    gtk-theme-name = "Adwaita"
+    gtk-application-prefer-dark-theme = 0
+    EOF
+
+    makeWrapper "${lib.getExe mono}" "$out/bin/XperiFirm" \
+      --add-flags "$out/lib/xperifirm/${exe}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk2 ]}" \
+      --suffix GTK_PATH : "${gnome-themes-extra}/lib/gtk-2.0" \
+      --set GTK2_RC_FILES "$out/share/xperifirm/gtk-2.0/gtkrc"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Allows you to download the current firmware for all Sony Xperia-line smartphones, tablets and accessories released since 2013 (excluding Xperia R1/R1 Plus)";
+    homepage = "https://xdaforums.com/t/tool-xperifirm-xperia-firmware-downloader-v5-8-1.2834142/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ toastal ];
+    mainProgram = "XperiFirm";
+    platforms =
+      let
+        # Mono can run on many platforms, but the executables are only built
+        # for these architectures. As Mono platform support expands, so too can
+        # this list.
+        supportedArches = [
+          "x86_64"
+          "x86_32"
+          "aarch64"
+        ];
+        supportedPlatform = platform: lib.any (arch: lib.hasPrefix arch platform) supportedArches;
+      in
+      lib.filter supportedPlatform mono.meta.platforms;
+  };
+}


### PR DESCRIPTION
My phone is in a boot loop & I need this to recover

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
