### PR TITLE
stalk: init at 0.7.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22563,6 +22563,11 @@
     githubId = 21069876;
     name = "Reed Williams";
   };
+  refactoriel = {
+    name = "Daniel Hähnke";
+    github = "refactoriel";
+    githubId = 11663234;
+  };
   refi64 = {
     name = "Ryan Gonzalez";
     email = "git@refi64.dev";

--- a/pkgs/by-name/st/stalk/package.nix
+++ b/pkgs/by-name/st/stalk/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchFromCodeberg,
+  buildGoModule,
+}:
+buildGoModule (finalAttrs: {
+  pname = "stalk";
+  version = "0.7.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "xrstf";
+    repo = "stalk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DeDmfoNYoF1JRHg4LkQrjbntOhgjdOrBFTxp2JAgSnA=";
+  };
+
+  proxyVendor = true;
+
+  vendorHash = "sha256-cWpj9MgqwsoTNTu/Wf5Nq/tDQUUhbNyCBxjZGZH+hoI=";
+
+  meta = {
+    description = "Watch your Kubernetes Resources change";
+    longDescription = ''
+      A command line tool to watch a given set of kubernetes resources and print the diffs for every change.
+    '';
+    homepage = "https://codeberg.org/xrstf/stalk";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ refactoriel ];
+    mainProgram = "stalk";
+  };
+})


### PR DESCRIPTION
Adds [`stalk`](https://codeberg.org/xrstf/stalk), which is a cli tool that shows diffs as kubernetes resources evolve, thus helping with debugging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
