### PR TITLE
newflasher: init at 59

### DIFF
--- a/pkgs/by-name/ne/newflasher/package.nix
+++ b/pkgs/by-name/ne/newflasher/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  expat,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "newflasher";
+  version = "59";
+
+  src = fetchFromGitHub {
+    owner = "munjeni";
+    repo = "newflasher";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-ulcHbSoMXnu0pauYUaZiTVvl5VtEYnYy3ljtZ0oEvGM=";
+  };
+
+  buildInputs = [
+    expat
+    zlib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 newflasher $out/bin/newflasher
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Flash tool for new Sony flash tool protocol (Xperia XZ Premium and newer)";
+    homepage = "https://github.com/munjeni/newflasher";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+})


### PR DESCRIPTION
Used to upgrade Sony firmware / make partitions consistent

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ x Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.