### PR TITLE
isabelle: use default CVC5

### DIFF
--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -102,16 +102,6 @@ let
     '';
   };
 
-  cvc5' = cvc5.overrideAttrs {
-    version = "1.2.0";
-    src = fetchFromGitHub {
-      owner = "cvc5";
-      repo = "cvc5";
-      tag = "cvc5-1.2.0";
-      hash = "sha256-Um1x+XgQ5yWSoqtx1ZWbVAnNET2C4GVasIbn0eNfico=";
-    };
-  };
-
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "isabelle";
@@ -144,7 +134,7 @@ stdenv.mkDerivation (finalAttrs: {
     vampire'
     eprover-ho
     net-tools
-    cvc5'
+    cvc5
     csdp
   ];
 
@@ -188,9 +178,9 @@ stdenv.mkDerivation (finalAttrs: {
     EOF
 
     cat >contrib/cvc5-*/etc/settings <<EOF
-      CVC5_HOME=${cvc5'}
-      CVC5_VERSION=${cvc5'.version}
-      CVC5_SOLVER=${cvc5'}/bin/cvc5
+      CVC5_HOME=${cvc5}
+      CVC5_VERSION=${cvc5.version}
+      CVC5_SOLVER=${cvc5}/bin/cvc5
       CVC5_INSTALLED=yes
     EOF
 
@@ -349,7 +339,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     vampire = vampire';
     polyml = polyml';
-    cvc5 = cvc5';
+    cvc5 = cvc5;
     sha1 = sha1;
     withComponents =
       f:


### PR DESCRIPTION
I’d like to update libpoly (as required by latest versions of CVC5), but old versions of CVC5 are not compatible with up-to-date libpoly.

As a first step, this PR drops uses of legacy CVC5 (version 1.2.0).

cc @sempiternal-aurora who introduced this pinning of CVC5.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
