### PR TITLE
triangle: init at 1.6 and octavePackages.femoctave: init at 2.1.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29005,6 +29005,12 @@
     githubId = 78392041;
     name = "Winter";
   };
+  WiredMic = {
+    name = "Rasmus Enevoldsen";
+    github = "WiredMic";
+    githubId = 111731519;
+    email = "rasmus@enev.dk";
+  };
   wirew0rm = {
     email = "alex@wirew0rm.de";
     github = "wirew0rm";

--- a/pkgs/by-name/tr/triangle/package.nix
+++ b/pkgs/by-name/tr/triangle/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  versionCheckHook,
+  # deps
+  libx11,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "triangle";
+  version = "1.6";
+
+  src = fetchzip {
+    url = "http://www.netlib.org/voronoi/${finalAttrs.pname}.zip";
+    sha256 = "sha256-alRqdXDt+vphEU/rSTOz8iS+ixp25rlx5xKL75tWuW4=";
+    stripRoot = false;
+  };
+
+  buildInputs = lib.optional stdenv.hostPlatform.isLinux libx11;
+
+  patches = lib.optional stdenv.hostPlatform.isLinux ./showme.c-font-patch.patch;
+
+  # Old K&R-style function declarations
+  NIX_CFLAGS_COMPILE = [ "-std=gnu11" ] ++ lib.optional stdenv.hostPlatform.isLinux "-DLINUX";
+
+  buildPhase = ''
+    $CC -O -o triangle triangle.c -lm
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      $CC -O -o showme showme.c -I${libx11.dev}/include -L${libx11}/lib -lX11
+    ''}
+    $CC -DTRILIBRARY -O -std=gnu11 -c -o triangle.o triangle.c
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin $dev/include $dev/lib
+    cp triangle $out/bin
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      cp showme $out/bin
+    ''}
+    cp triangle.o $dev/lib
+    cp $src/triangle.h $dev/include
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "-h";
+
+  meta = {
+    homepage = "https://www.cs.cmu.edu/~quake/triangle.html";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ WiredMic ];
+    description = "A Two-Dimensional Quality Mesh Generator and Delaunay Triangulator.";
+    mainProgram = "triangle";
+  };
+})

--- a/pkgs/by-name/tr/triangle/package.nix
+++ b/pkgs/by-name/tr/triangle/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  pkg-config,
+
+  # Depencies
+  libx11,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "triangle";
+  version = "1.6";
+
+  src = fetchzip {
+    url = "http://www.netlib.org/voronoi/${finalAttrs.pname}.zip";
+    sha256 = "sha256-alRqdXDt+vphEU/rSTOz8iS+ixp25rlx5xKL75tWuW4=";
+    stripRoot = false;
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux pkg-config;
+  buildInputs = lib.optional stdenv.hostPlatform.isLinux libx11;
+
+  patches = lib.optional stdenv.hostPlatform.isLinux ./showme.c-font-patch.patch;
+
+  # Old K&R-style function declarations
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "CSWITCHES=-O2 -std=gnu17 ${lib.optionalString stdenv.hostPlatform.isLinux " -DLINUX -I${libx11.dev}/include -L${lib.getLib libx11}/lib"}"
+  ];
+
+  buildFlags = [
+    "triangle"
+    "trilibrary"
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux "showme";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp triangle $out/bin
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      cp showme $out/bin
+    ''}
+
+    mkdir -p $dev/include $dev/lib
+    cp triangle.o $dev/lib
+    cp $src/triangle.h $dev/include
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/triangle -h
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      $out/bin/showme -h
+    ''}
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    homepage = "https://www.cs.cmu.edu/~quake/triangle.html";
+    license = lib.licenses.free;
+    maintainers = with lib.maintainers; [ WiredMic ];
+    description = "A Two-Dimensional Quality Mesh Generator and Delaunay Triangulator.";
+    mainProgram = "triangle";
+  };
+})

--- a/pkgs/by-name/tr/triangle/showme.c-font-patch.patch
+++ b/pkgs/by-name/tr/triangle/showme.c-font-patch.patch
@@ -1,0 +1,18 @@
+diff --git a/showme.c b/showme.c
+index c0294cb..cac3da8 100644
+--- a/showme.c
++++ b/showme.c
+@@ -2272,6 +2272,13 @@ char **argv;
+     showme_foreground = white;
+   }
+   font = XLoadQueryFont(display, "9x15");
++  if (font == NULL) {
++    font = XLoadQueryFont(display, "fixed");
++  }
++  if (font == NULL) {
++    printf("Error: Cannot load font.\n");
++    exit(1);
++  }
+   fontvalues.background = black;
+   fontvalues.font = font->fid;
+   fontvalues.fill_style = FillSolid;

--- a/pkgs/development/octave-modules/femoctave/default.nix
+++ b/pkgs/development/octave-modules/femoctave/default.nix
@@ -1,0 +1,46 @@
+{
+  buildOctavePackage,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  # deps
+  triangle,
+  withTriangle ? false,
+}:
+
+buildOctavePackage rec {
+  pname = "femoctave";
+  version = "2.1.8";
+
+  src = fetchFromGitHub {
+    owner = "AndreasStahel";
+    repo = "FEMoctave";
+    tag = "v.${version}";
+    sha256 = "sha256-7N1tY5z1TnQyRbbzh40HgNLThGi/VdILfEqjDe05xL4=";
+  };
+
+  propagatedBuildInputs =
+    [ ]
+    ++ lib.optionals withTriangle [
+      triangle
+    ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=v.(.*)" ]; };
+
+  meta = {
+    homepage = "https://gnu-octave.github.io/packages/femoctave/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      KarlJoad
+      WiredMic
+    ];
+    description = "Use FEM for solving boundary value problems in two space dimensions.";
+    longDescription = ''
+      Use FEM for solving boundary value problems in two space dimensions.
+
+      Note:
+      If using the Triangle features of femoctave use
+        octavePackages.femotave.override { withTriangle = true; }
+    '';
+  };
+}

--- a/pkgs/development/octave-modules/femoctave/default.nix
+++ b/pkgs/development/octave-modules/femoctave/default.nix
@@ -1,0 +1,46 @@
+{
+  buildOctavePackage,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  # deps
+  triangle,
+  withTriangle ? false,
+}:
+
+buildOctavePackage rec {
+  pname = "femoctave";
+  version = "2.1.8";
+
+  src = fetchFromGitHub {
+    owner = "AndreasStahel";
+    repo = "FEMoctave";
+    tag = "v.${version}";
+    sha256 = "sha256-7N1tY5z1TnQyRbbzh40HgNLThGi/VdILfEqjDe05xL4=";
+  };
+
+  propagatedBuildInputs =
+    [ ]
+    ++ lib.optionals withTriangle [
+      triangle
+    ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=v.(.*)" ]; };
+
+  meta = {
+    homepage = "https://gnu-octave.github.io/packages/femoctave/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      ravenjoad
+      WiredMic
+    ];
+    description = "Use FEM for solving boundary value problems in two space dimensions.";
+    longDescription = ''
+      Use FEM for solving boundary value problems in two space dimensions.
+
+      Note:
+      If using the Triangle features of femoctave use
+        octavePackages.femotave.override { withTriangle = true; }
+    '';
+  };
+}

--- a/pkgs/top-level/octave-packages.nix
+++ b/pkgs/top-level/octave-packages.nix
@@ -94,6 +94,10 @@ makeScope newScope (
 
     econometrics = callPackage ../development/octave-modules/econometrics { };
 
+    femoctave = callPackage ../development/octave-modules/femoctave {
+      inherit (pkgs) triangle;
+    };
+
     fits = callPackage ../development/octave-modules/fits { };
 
     financial = callPackage ../development/octave-modules/financial { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
@hesiod @KarlJoad
I am sorry I do not know what happened to https://github.com/NixOS/nixpkgs/pull/497588. I cannot open it.

## Things done
Triangle is a two-dimensional quality mesh generator and Delaunay
triangulator by Jonathan Shewchuk. This adds:

    triangle binary
    showme viewer (Linux only, requires X11)
    triangle.o and triangle.h in the dev output for use as a library

I packaged this application because it was needed for femoctave, an octave packages I am also packaging.
femoctave does not use Triangle as a library.
It uses it as a binary on the path.

The showme viewer hardcodes the 9x15 bitmap font which is not
available in all X11 setups and causes a null pointer dereference on
startup. A small patch adds a fallback to the fixed font.

Note: Triangle has a custom non-commercial license.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
