### PR TITLE
nixos-container: use `machinectl shell` and `systemd-run`

### DIFF
--- a/pkgs/by-name/ni/nixos-container/nixos-container.pl
+++ b/pkgs/by-name/ni/nixos-container/nixos-container.pl
@@ -380,14 +380,6 @@ sub restartContainer {
     startContainer;
 }
 
-# Run a command in the container.
-sub runInContainer {
-    my @args = @_;
-    my $leader = getLeader;
-    exec($nsenter, "--all", "-t", $leader, "--", @args);
-    die "cannot run ‘nsenter’: $!\n";
-}
-
 sub evalAttribute {
     my ($attribute, $nixosF, $nixosConfigF, $extraArgs) = @_;
     run [
@@ -520,14 +512,14 @@ elsif ($action eq "login") {
 }
 
 elsif ($action eq "root-login") {
-    runInContainer("@su@", "root", "-l");
+    exec("machinectl", "shell", "-q", "--", "root@" . $containerName);
 }
 
 elsif ($action eq "run") {
     shift @ARGV; shift @ARGV;
     # Escape command.
     my $s = join(' ', map { s/'/'\\''/g; "'$_'" } @ARGV);
-    runInContainer("@su@", "root", "-l", "-c", "exec " . $s);
+    exec("systemd-run", "--quiet", "--pipe", "--wait", "-M", $containerName, "/bin/sh", "-l", "-c", $s);
 }
 
 elsif ($action eq "show-ip") {


### PR DESCRIPTION
This switches the `nixos-container` Perl script to use the `machinectl` and `systemd-run` programs for entering into a root-shell on the container, or executing a command in the container respectively.

The previous approach using `nsenter` causes issues with stuck state in the `systemd-machined` daemon, as this creates processes in the container's namespace but that are outside of the container's scope. This can then prevent a container from being restarted, as it is being prevented from re-registering with machined until the respective orphaned `nsenter` processes are manually terminated.

Using `machinectl shell` for getting a root shell, and `systemd-run --wait` for executing commands within the container does not suffer from these issues. For instance, when a long running command gets interrupted by a container restart, a `systemd-run` backed `nixos-container run` will exit with the following error (albeit with an exit status of 0; regular process exit statuses will be forwarded to the `nixos-container run` invocation):

    $ sudo nixos-container run <name> -- sleep 300
    Bus call failed due to connection problems. Trying to reconnect...
    Failed to re-add reference to unit: Transport endpoint is not connected

    (Process exits with status 0)

Similarly, a root-shell opened using `machinectl shell` will simply terminate:

    $ sudo nixos-container root-login <name>

    [root@<name>:~]#

    (Process exits with status 0)

This seems strictly better than the prior approach and would resolve the issues reported in [1].

[1]: https://github.com/NixOS/nixpkgs/issues/43652


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
