### PR TITLE
lucky-cli: 1.1.0 -> 1.4.1

### DIFF
--- a/pkgs/by-name/lu/lucky-cli/package.nix
+++ b/pkgs/by-name/lu/lucky-cli/package.nix
@@ -8,18 +8,23 @@
 
 crystal.buildCrystalPackage rec {
   pname = "lucky-cli";
-  version = "1.1.0";
+  version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "luckyframework";
     repo = "lucky_cli";
-    rev = "v${version}";
-    hash = "sha256-mDUx9cQoYpU9kSAls36kzNVYZ8a4aqHEMIWfzS41NBk=";
+    tag = "v${version}";
+    hash = "sha256-68As7PSRYwhJGcQwI4FgM9aN0nhNrEjcv+10jKnlXeA=";
   };
 
   # the integration tests will try to clone a remote repos
   postPatch = ''
     rm -rf spec/integration
+  '';
+
+  preConfigure = ''
+    substituteInPlace "./src/lucky_cli/version.cr" \
+      --replace-fail '`shards version #{__DIR__}`' '"${version}"'
   '';
 
   format = "crystal";

--- a/pkgs/by-name/lu/lucky-cli/shard.lock
+++ b/pkgs/by-name/lu/lucky-cli/shard.lock
@@ -1,9 +1,5 @@
 version: 2.0
 shards:
-  ameba:
-    git: https://github.com/crystal-ameba/ameba.git
-    version: 1.5.0
-
   lucky_task:
     git: https://github.com/luckyframework/lucky_task.git
     version: 0.3.0
@@ -14,5 +10,5 @@ shards:
 
   nox:
     git: https://github.com/crystal-loot/nox.git
-    version: 0.2.2
+    version: 0.2.3
 

--- a/pkgs/by-name/lu/lucky-cli/shards.nix
+++ b/pkgs/by-name/lu/lucky-cli/shards.nix
@@ -1,22 +1,17 @@
 {
-  ameba = {
-    url = "https://github.com/crystal-ameba/ameba.git";
-    rev = "v1.5.0";
-    sha256 = "1idivsbpmi40aqvs82fsv37nrgikirprxrj3ls9chsb876fq9p2d";
-  };
-  lucky_task = {
+  "lucky_task" = {
     url = "https://github.com/luckyframework/lucky_task.git";
     rev = "v0.3.0";
     sha256 = "0lp2wv01wdcfr3h43n3dqgaymvypy0i6kbffb4mg4l30lijgpfb6";
   };
-  lucky_template = {
+  "lucky_template" = {
     url = "https://github.com/luckyframework/lucky_template.git";
     rev = "v0.2.0";
     sha256 = "1xix82d0xanq4xkcv83hm56nj5f2rsbrqhk70j5zr37d3kydfypl";
   };
-  nox = {
+  "nox" = {
     url = "https://github.com/crystal-loot/nox.git";
-    rev = "v0.2.2";
-    sha256 = "1dfq0aknrxwp9wc0glri4w5j8pfbc6b1xrsxkahci109p6dhcna5";
+    rev = "v0.2.3";
+    sha256 = "0393v0lrk58i68nd96gqsb89w9a4ykbcyqvmrvp1c32nspqynyaz";
   };
 }


### PR DESCRIPTION
Substituted version in place to get rid of the compiler macro.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
