### PR TITLE
amqpcat: 1.0.2 -> 1.1.0

### DIFF
--- a/pkgs/by-name/am/amqpcat/package.nix
+++ b/pkgs/by-name/am/amqpcat/package.nix
@@ -9,19 +9,25 @@
 
 crystal.buildCrystalPackage rec {
   pname = "amqpcat";
-  version = "1.0.2";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "cloudamqp";
     repo = "amqpcat";
     tag = "v${version}";
-    hash = "sha256-fdDdMjeAlJ0H05LNVdRxwq6RK41d6rXLFQMw6RSlXZM=";
+    hash = "sha256-wUsDqatZVcfvtTlK4eOYvFFCyyO8nkrBksvN6Od4DG0=";
   };
 
   format = "shards";
   shardsFile = ./shards.nix;
 
   buildInputs = [ openssl ];
+
+  preConfigure = ''
+    substituteInPlace "./src/version.cr" --replace-fail \
+      'VERSION = {{ `git describe 2>/dev/null || shards version`.stringify.gsub(/(^v|\n)/, "") }}' \
+      'VERSION = "${version}"'
+  '';
 
   # Tests require network access
   doCheck = false;

--- a/pkgs/by-name/am/amqpcat/shards.nix
+++ b/pkgs/by-name/am/amqpcat/shards.nix
@@ -1,12 +1,12 @@
 {
-  amq-protocol = {
+  "amq-protocol" = {
     url = "https://github.com/cloudamqp/amq-protocol.cr.git";
-    tag = "v1.1.14";
-    sha256 = "1pr5h3lxfhjmarfqpvfldn8d6425g3i56k4p4szk2jkffa0z38nz";
+    rev = "v1.1.15";
+    sha256 = "0zjwhgr1rz1kwrh8qpawqspv8qnyk3khqprhgr4h6gqgckqxkkli";
   };
-  amqp-client = {
+  "amqp-client" = {
     url = "https://github.com/cloudamqp/amqp-client.cr.git";
-    tag = "v1.2.3";
-    sha256 = "1pbiq5srni87hd8q2x3vs4s2hpajlzzlwgalgnmb35dcyih1ff9k";
+    rev = "v1.3.1";
+    sha256 = "00gkfsa20ilbawbhg0c6rxgaf2s2lz4paikwizn182fm7vx67b16";
   };
 }


### PR DESCRIPTION
Substituted the version as it incorrectly reflects its version (git describe on a lightweight tag).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
