### PR TITLE
collision: 3.11.0 -> 3.14.0

### DIFF
--- a/pkgs/by-name/co/collision/package.nix
+++ b/pkgs/by-name/co/collision/package.nix
@@ -21,13 +21,13 @@
 
 crystal.buildCrystalPackage rec {
   pname = "Collision";
-  version = "3.11.0";
+  version = "3.14.0";
 
   src = fetchFromGitHub {
     owner = "GeopJr";
     repo = "Collision";
-    rev = "v${version}";
-    hash = "sha256-OCFy7DFSRsqiw+b6zlJy9Us44zQXf150zVDu3GmclOk=";
+    tag = "v${version}";
+    hash = "sha256-GcCqItSHUhhS0yrOM8bMzkVsVHyC97c+yccw5ZP61IU=";
   };
 
   postPatch = ''
@@ -100,9 +100,6 @@ crystal.buildCrystalPackage rec {
         supportedFeatures = [ "silent" ];
       }
     ];
-    shardLock = runCommand "shard.lock" { inherit src; } ''
-      cp $src/shard.lock $out
-    '';
   };
 
   meta = {

--- a/pkgs/by-name/co/collision/shards.nix
+++ b/pkgs/by-name/co/collision/shards.nix
@@ -11,13 +11,13 @@
   };
   "gi-crystal" = {
     url = "https://github.com/hugopl/gi-crystal.git";
-    rev = "v0.25.0";
-    sha256 = "0lgs85khg6yzmw7vnkjxygrga1618440hayjc51jmjcfh2lff1k2";
+    rev = "v0.25.1";
+    sha256 = "0283isgrann4r3ily8c7fip0x6h947g9s3hgmrja0m6si3lkgizs";
   };
   "gtk4" = {
     url = "https://github.com/hugopl/gtk4.cr.git";
-    rev = "v0.17.0";
-    sha256 = "0lv3nvsanxi4g2322zvkf1jxx5zgzaapk228vcw2cl0ja1drm06d";
+    rev = "v0.18.0";
+    sha256 = "03kab6nbkgxnnrp7g0gr4cv7rjsp7y8m7kz2rzb1ci63qzkzqlqi";
   };
   "harfbuzz" = {
     url = "https://github.com/hugopl/harfbuzz.cr.git";


### PR DESCRIPTION
Removed old copy shard lock passthru command. Migrated to tag instead of rev.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
