### PR TITLE
libptytty: update src url

### DIFF
--- a/pkgs/by-name/li/libptytty/package.nix
+++ b/pkgs/by-name/li/libptytty/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchurl,
+  fetchFromGitHub,
   cmake,
 }:
 
@@ -15,9 +15,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libptytty";
   version = "2.0";
 
-  src = fetchurl {
-    url = "http://dist.schmorp.de/libptytty/libptytty-${finalAttrs.version}.tar.gz";
-    sha256 = "1xrikmrsdkxhdy9ggc0ci6kg5b1hn3bz44ag1mk5k1zjmlxfscw0";
+  src = fetchFromGitHub {
+    owner = "yusiwen";
+    repo = "libptytty";
+    rev = "b9694ea18e0dbd78213f55233a430325c13ad63e";
+    hash = "sha256-Yyq0n/UqkRWNTatVAz/QEhBaWyO8nhHuIZkob2rwC70=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
As of writing, http://dist.schmorp.de/libptytty/ redirects to https://www.anthropic.com//<random number>

This commit changes the src url to github/yusiwen/libptytti, specifically the commit labeled '2.0'. The sha256sum of lib/libptytty.so.0 remains unchanged (`9aa6bd7816568e6e58cecd26e93e2e922852b9b33e9bf5a5057001c7324e4db6`).

Guix is also using this upstream: https://codeberg.org/guix/guix/src/commit/3ec1e8297d651bf667fe0d89dbee327c2758d6b7/gnu/packages/terminals.scm#L145, I also checked Arch & Debian - their source url hasn't changed as far as I can tell.

According to TWM, dist.schmorp.de/libptytty was still fine on 2026-02-16: https://web.archive.org/web/20260216120357/https://dist.schmorp.de/libptytty/, so the current redirect to anthropic.com must've happened fairly recently.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
