### PR TITLE
komodo: temporary patch fix for build after rustc 1.9.2

### DIFF
--- a/pkgs/by-name/ko/komodo/package.nix
+++ b/pkgs/by-name/ko/komodo/package.nix
@@ -17,6 +17,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-dLBgdcrIp5QM2TVIa86qX7m1c5n+qOIQJtqJPGvIZ+0=";
   };
 
+  # Temporary fix to get build to pass until https://github.com/moghtech/komodo/pull/1122
+  patches = [
+    ./rustc-1_9_2-fixes.patch
+  ];
+
   cargoHash = "sha256-jf/Jp28g3inGn5jQp3cACdhl//tbXTMc1vP1K3g/CyQ=";
 
   # disable for check. document generation is fail

--- a/pkgs/by-name/ko/komodo/rustc-1_9_2-fixes.patch
+++ b/pkgs/by-name/ko/komodo/rustc-1_9_2-fixes.patch
@@ -1,0 +1,52 @@
+diff --git a/bin/core/src/alert/discord.rs b/bin/core/src/alert/discord.rs
+index 427227d..6d19678 100644
+--- a/bin/core/src/alert/discord.rs
++++ b/bin/core/src/alert/discord.rs
+@@ -230,14 +230,13 @@ pub async fn send_alert(
+       )
+     }
+     AlertData::Custom { message, details } => {
+-      format!(
+-        "{level} | {message}{}",
+-        if details.is_empty() {
+-          format_args!("")
+-        } else {
+-          format_args!("\n{details}")
+-        }
+-      )
++      let details_str = if details.is_empty() {
++        String::new()
++      } else {
++        format!("\n{details} f")
++      };
++
++      format!("{level} | {message}{details_str}")
+     }
+     AlertData::None {} => Default::default(),
+   };
+diff --git a/bin/core/src/alert/mod.rs b/bin/core/src/alert/mod.rs
+index 9eba5da..1f51ac2 100644
+--- a/bin/core/src/alert/mod.rs
++++ b/bin/core/src/alert/mod.rs
+@@ -474,14 +474,13 @@ fn standard_alert_content(alert: &Alert) -> String {
+       )
+     }
+     AlertData::Custom { message, details } => {
+-      format!(
+-        "{level} | {message}{}",
+-        if details.is_empty() {
+-          format_args!("")
+-        } else {
+-          format_args!("\n{details}")
+-        }
+-      )
++      let details_str = if details.is_empty() {
++        String::new()
++      } else {
++        format!("\n{details}")
++      };
++
++      format!("{level} | {message}{details_str}")
+     }
+     AlertData::None {} => Default::default(),
+   }


### PR DESCRIPTION
There was a breaking change in rustc 1.9.2 which caused the komodo build to fail. Including that patch for now until it is in a release that can be updated

Fixes: #499492 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

@r17x 