### PR TITLE
gnutls: fix cross-compilation failure since 3.8.12

### DIFF
--- a/pkgs/by-name/gn/gnutls/package.nix
+++ b/pkgs/by-name/gn/gnutls/package.nix
@@ -117,6 +117,13 @@ stdenv.mkDerivation rec {
   # https://gitlab.com/gnutls/gnutls/-/issues/1721
   + ''
     sed '2iexit 77' -i tests/system-override-compress-cert.sh
+  ''
+  # Upstream packaging bug: stamp_error_codes is missing from EXTRA_DIST in
+  # the release tarball, causing the build to try regenerating it by compiling
+  # and running `errcodes` — which fails when cross-compiling since the binary
+  # is for the target architecture. https://gitlab.com/gnutls/gnutls/-/issues/1797
+  + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    touch doc/stamp_error_codes
   '';
 
   preConfigure = "patchShebangs .";


### PR DESCRIPTION
## Description

The gnutls 3.8.12 release tarball is missing `stamp_error_codes` from `EXTRA_DIST` ([upstream bug](https://gitlab.com/gnutls/gnutls/-/issues/1797)). This causes the build system to regenerate it by compiling and running the `errcodes` tool. When cross-compiling, the resulting binary is for the target architecture and cannot execute on the build host:

```
./errcodes > error_codes.texi-tmp
./errcodes: line 117: /build/gnutls-3.8.12/doc/.libs/lt-errcodes: cannot execute binary file: Exec format error
make[3]: *** [Makefile:6310: stamp_error_codes] Error 126
```

This breaks cross-compilation of gnutls and anything that transitively depends on it (e.g. gstreamer via elfutils → libmicrohttpd → gnutls).

## Fix

Touch `doc/stamp_error_codes` in `postPatch` when cross-compiling, so the build system skips regeneration. This is the minimal workaround [suggested by @jackwilsdon](https://github.com/NixOS/nixpkgs/issues/493526#issuecomment-2756133647) in #493526.

Native builds are unaffected — the `touch` is guarded by `stdenv.buildPlatform != stdenv.hostPlatform`.

## Testing

Tested on x86_64-linux:

- **Cross (armv7l)**: `nix-build -E '(import <nixpkgs> {}).pkgsCross.armv7l-hf-multiplatform.gnutls'` — **fails** without fix, **succeeds** with fix
- **Native (x86_64)**: `nix-build -E '(import <nixpkgs> {}).gnutls'` — succeeds with fix (no behavior change)

Fixes #493526.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin