### PR TITLE
go-pagerduty: init at 1.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15492,6 +15492,17 @@
     githubId = 918448;
     name = "Anthony Lodi";
   };
+  logan-barnett = {
+    email = "logustus+nixpkgs@gmail.com";
+    github = "LoganBarnett";
+    githubId = 27005;
+    keys = [
+      {
+        fingerprint = "3F29 5F7D 2427 6467 A9B2  3459 41E4 6FB1 ACEA 3EF0";
+      }
+    ];
+    name = "Logan Barnett";
+  };
   logger = {
     name = "Ido Samuelson";
     email = "ido.samuelson@gmail.com";

--- a/pkgs/by-name/go/go-pagerduty/package.nix
+++ b/pkgs/by-name/go/go-pagerduty/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "go-pagerduty";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "PagerDuty";
+    repo = "go-pagerduty";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7RBBbe30RQ74DUK/YhBOMyyF5TFfY4WifkPVU070CGU=";
+  };
+
+  vendorHash = "sha256-sTCnJfnW/tIn6XlgCfFXRDHv380TDGwGVoB19ADL1WU=";
+
+  subPackages = [ "command" ];
+
+  postInstall = ''
+    mv $out/bin/command $out/bin/pd
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI and Go client library for the PagerDuty v2 API";
+    homepage = "https://github.com/PagerDuty/go-pagerduty";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ logan-barnett ];
+    mainProgram = "pd";
+  };
+})


### PR DESCRIPTION
Adds `pkgs.go-pagerduty`, the official PagerDuty Go client library and CLI (`pd`).

The CLI provides full coverage of the PagerDuty v2 API including schedule override management (`pd schedule override create/list/delete`), incident management, escalation policies, teams, and more.

There is no existing nixpkgs package for a PagerDuty CLI with schedule override support.  The commonly referenced `martindstone/pagerduty-cli` (Node.js) has been abandoned by its author.  This is the official PagerDuty-org Go client with an actively maintained CLI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test