### PR TITLE
cs2-chat-translator: init at 0.1.0

### DIFF
--- a/pkgs/by-name/cs/cs2-chat-translator/package.nix
+++ b/pkgs/by-name/cs/cs2-chat-translator/package.nix
@@ -1,13 +1,19 @@
-{ lib, buildNpmPackage, fetchFromGitHub, nodejs_20, xdotool }:
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs_20,
+  xdotool,
+}:
 
 buildNpmPackage {
   pname = "cs2-chat-translator";
   version = "0.1.0";
 
   src = fetchFromGitHub {
-    owner  = "MeckeDev";
-    repo   = "cs2-chat-translator";
-    rev    = "main";  # besser: Tag wie v0.1.0, wenn du einen setzt
+    owner = "MeckeDev";
+    repo = "cs2-chat-translator";
+    rev = "main"; # besser: Tag wie v0.1.0, wenn du einen setzt
     sha256 = "sha256-KgWLpuUe4vyTNS89NnN2GtQsyGraCMuKgv91zNPdVoQ=";
   };
 
@@ -34,9 +40,9 @@ buildNpmPackage {
 
   meta = with lib; {
     description = "CS2 chat translator (Node.js + xdotool + google-translate-api-x).";
-    homepage    = "https://github.com/MeckeDev/cs2-chat-translator";
-    license     = licenses.mit;
-    platforms   = platforms.linux;
+    homepage = "https://github.com/MeckeDev/cs2-chat-translator";
+    license = licenses.mit;
+    platforms = platforms.linux;
     # optional, wenn du dich als Maintainer in nixpkgs einträgst:
     # maintainers = with maintainers; [ meckeDev ];
   };

--- a/pkgs/by-name/cs/cs2-chat-translator/package.nix
+++ b/pkgs/by-name/cs/cs2-chat-translator/package.nix
@@ -1,4 +1,4 @@
-{
+{ 
   lib,
   buildNpmPackage,
   fetchFromGitHub,
@@ -13,7 +13,7 @@ buildNpmPackage {
   src = fetchFromGitHub {
     owner = "MeckeDev";
     repo = "cs2-chat-translator";
-    rev = "main"; # besser: Tag wie v0.1.0, wenn du einen setzt
+    rev = "main";
     sha256 = "sha256-KgWLpuUe4vyTNS89NnN2GtQsyGraCMuKgv91zNPdVoQ=";
   };
 
@@ -43,7 +43,5 @@ buildNpmPackage {
     homepage = "https://github.com/MeckeDev/cs2-chat-translator";
     license = licenses.mit;
     platforms = platforms.linux;
-    # optional, wenn du dich als Maintainer in nixpkgs einträgst:
-    # maintainers = with maintainers; [ meckeDev ];
   };
 }

--- a/pkgs/by-name/cs/cs2-chat-translator/package.nix
+++ b/pkgs/by-name/cs/cs2-chat-translator/package.nix
@@ -1,4 +1,4 @@
-{ 
+{
   lib,
   buildNpmPackage,
   fetchFromGitHub,

--- a/pkgs/by-name/cs/cs2-chat-translator/package.nix
+++ b/pkgs/by-name/cs/cs2-chat-translator/package.nix
@@ -1,0 +1,43 @@
+{ lib, buildNpmPackage, fetchFromGitHub, nodejs_20, xdotool }:
+
+buildNpmPackage {
+  pname = "cs2-chat-translator";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner  = "MeckeDev";
+    repo   = "cs2-chat-translator";
+    rev    = "main";  # besser: Tag wie v0.1.0, wenn du einen setzt
+    sha256 = "sha256-KgWLpuUe4vyTNS89NnN2GtQsyGraCMuKgv91zNPdVoQ=";
+  };
+
+  npmDepsHash = "sha256-P4NEXFda+U1V6NXL9dv2H0uEcwbV8jKgpWorP8vRB68=";
+
+  nodejs = nodejs_20;
+  buildInputs = [ xdotool ];
+
+  dontNpmBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules/cs2-chat-translator
+    mkdir -p $out/bin
+
+    cp -r . $out/lib/node_modules/cs2-chat-translator
+
+    ln -s $out/lib/node_modules/cs2-chat-translator/bin/cs2-chat-translator.js \
+          $out/bin/cs2-chat-translator
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "CS2 chat translator (Node.js + xdotool + google-translate-api-x).";
+    homepage    = "https://github.com/MeckeDev/cs2-chat-translator";
+    license     = licenses.mit;
+    platforms   = platforms.linux;
+    # optional, wenn du dich als Maintainer in nixpkgs einträgst:
+    # maintainers = with maintainers; [ meckeDev ];
+  };
+}


### PR DESCRIPTION
This adds `cs2-chat-translator`, a small Node.js-based tool that:

- watches CS2's `console.log` in real time,
- parses in-game chat messages,
- translates them using `google-translate-api-x`,
- sends translated messages back into the game via xdotool and a cfg file,
- and provides a small CLI (`cs2-chat-translator`) for configuration and usage.

The package is built with `buildNpmPackage` using `package-lock.json` and `npmDepsHash`
to keep NPM dependencies reproducible.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
