### PR TITLE
libmtp: 1.1.22 -> 1.1.23

### DIFF
--- a/pkgs/by-name/li/libmtp/package.nix
+++ b/pkgs/by-name/li/libmtp/package.nix
@@ -3,7 +3,6 @@
   autoconf,
   automake,
   fetchFromGitHub,
-  fetchpatch,
   gettext,
   lib,
   libiconv,
@@ -15,28 +14,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libmtp";
-  version = "1.1.22";
+  version = "1.1.23";
 
   src = fetchFromGitHub {
     owner = "libmtp";
     repo = "libmtp";
     rev = "libmtp-${builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version}";
-    sha256 = "sha256-hIH6W8qQ6DB4ST7SlFz6CCnLsEGOWgmUb9HoHMNA3wY=";
+    sha256 = "sha256-FlPj9PEeOAWabU11dFTzDgY9TBbgmJclbeL0iULYw6A=";
   };
-
-  patches = [
-    # gettext-0.25 support
-    (fetchpatch {
-      name = "gettext-0.25.patch";
-      url = "https://github.com/libmtp/libmtp/commit/5e53ee68e61cc6547476b942b6aa9776da5d4eda.patch";
-      hash = "sha256-eXDNDHg8K+ZiO9n4RqQPJrh4V9GNiK/ZxZOA/oIX83M=";
-    })
-    (fetchpatch {
-      name = "gettext-0.25-p2.patch";
-      url = "https://github.com/libmtp/libmtp/commit/122eb9d78b370955b9c4d7618b12a2429f01b81a.patch";
-      hash = "sha256-Skqr6REBl/Egf9tS5q8k5qmEhFY+rG2fymbiu9e4Mho=";
-    })
-  ];
 
   outputs = [
     "bin"


### PR DESCRIPTION
Changes: https://github.com/libmtp/libmtp/releases/tag/v1.1.23
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
