### PR TITLE
gsender: init at 1.5.7

### DIFF
--- a/pkgs/by-name/gs/gsender/package.nix
+++ b/pkgs/by-name/gs/gsender/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+
+let
+  version = "1.5.7";
+  pname = "gsender";
+
+  src = fetchurl {
+    url = "https://github.com/Sienci-Labs/gsender/releases/download/v${version}/gSender-${version}-Linux-Intel-64Bit.AppImage";
+    hash = "sha256-J+GpDJ1PU07sxAmLON3GLE6RnsrSGPYfhsdESsFU/jQ=";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+
+in
+appimageTools.wrapType2 rec {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/gsender.desktop -t $out/share/applications/
+    install -Dm444 ${appimageContents}/gsender.png -t $out/share/icons/hicolor/512x512/apps/
+
+    substituteInPlace $out/share/applications/gsender.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${meta.mainProgram}'
+  '';
+
+  meta = {
+    description = "G-code sender for grbl and grblHAL-based CNCs";
+    homepage = "https://sienci.com/gsender/";
+    downloadPage = "https://resources.sienci.com/view/gs-installation/";
+    changelog = "https://github.com/Sienci-Labs/gsender/releases/tag/v${version}";
+    license = lib.licenses.gpl3Plus;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ FlorisMenninga ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "gsender";
+  };
+}


### PR DESCRIPTION
Add gsender, an open source G-code sender for GRBL and grblHAL-based CNCs.

Homepage: https://resources.sienci.com/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
