### PR TITLE
open-websearch: init at 1.2.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23035,6 +23035,11 @@
     github = "Reputable2772";
     githubId = 153411261;
   };
+  ReStranger = {
+    name = "ReStranger";
+    github = "ReStranger";
+    githubId = 69393944;
+  };
   ret2pop = {
     email = "ret2pop@gmail.com";
     github = "ret2pop";

--- a/pkgs/by-name/op/open-websearch/package.nix
+++ b/pkgs/by-name/op/open-websearch/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "open-websearch";
+  version = "1.2.7";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "Aas-ee";
+    repo = "open-webSearch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ko216HwLEFhVOsyOBTDZNK0MfXL55OFrIM7RR1BRJJM=";
+  };
+
+  npmDepsHash = "sha256-yhWFDXEPvm7HWFOiO3X1YRFYpAT0QeZJuFt65yxu+E0=";
+
+  meta = {
+    description = "Web search MCP server";
+    homepage = "https://github.com/Aas-ee/open-webSearch";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ ReStranger ];
+    mainProgram = "open-websearch";
+  };
+})


### PR DESCRIPTION
## Description

This PR adds a new package `open-websearch` (v1.2.7), a web-search Model Context Protocol (MCP) server.

Upstream: https://github.com/Aas-ee/open-webSearch

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
