### PR TITLE
ysfx: switch to JoepVanlier fork, adopt

### DIFF
--- a/pkgs/by-name/ys/ysfx/package.nix
+++ b/pkgs/by-name/ys/ysfx/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "ysfx";
-  version = "0-unstable-2022-07-31";
+  version = "0-unstable-2026-03-13";
 
   src = fetchFromGitHub {
-    owner = "jpcima";
+    owner = "JoepVanlier";
     repo = "ysfx";
-    rev = "8077347ccf4115567aed81400281dca57acbb0cc";
-    hash = "sha256-pObuOb/PA9WkKB2FdMDCOd9TKmML+Sj2MybLP0YwT+8=";
+    rev = "370c91915b0f26f5051705620b0712d06753bd41";
+    hash = "sha256-9PFBDUOvLCQcZvL8TsG8MVZYzdHsaKK/Pb7S5A1dJBE=";
   };
 
   # Provide latest dr_libs.
@@ -33,9 +33,20 @@ stdenv.mkDerivation rec {
     hash = "sha256-rWabyCP47vd+EfibBWy6iQY/nFN/OXPNhkuOTSboJaU=";
   };
 
+  # Provide latest clap-juce-extensions.
+  clap-juce-extensions = fetchFromGitHub {
+    fetchSubmodules = true;
+    owner = "free-audio";
+    repo = "clap-juce-extensions";
+    rev = "e1f67893cc409a40c1154fa2e78c97046da24ce0";
+    hash = "sha256-JHHK9GcW0CUgUbDZeOavNRKOaAI+9pECVo9UfksPnLg=";
+  };
+
   prePatch = ''
     rmdir thirdparty/dr_libs
     ln -s ${dr_libs} thirdparty/dr_libs
+    rmdir thirdparty/clap-juce-extensions
+    ln -s ${clap-juce-extensions} thirdparty/clap-juce-extensions
   '';
 
   nativeBuildInputs = [
@@ -64,13 +75,14 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/lib
     cp -r ysfx_plugin_artefacts/Release/VST3 $out/lib/vst3
+    cp -r ysfx_plugin_artefacts/Release/CLAP $out/lib/clap
 
     runHook postInstall
   '';
 
   meta = {
     description = "Hosting library for JSFX";
-    homepage = "https://github.com/jpcima/ysfx";
+    homepage = "https://github.com/JoepVanlier/ysfx";
     license = lib.licenses.asl20;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ys/ysfx/package.nix
+++ b/pkgs/by-name/ys/ysfx/package.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
     description = "Hosting library for JSFX";
     homepage = "https://github.com/JoepVanlier/ysfx";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.bitbloxhub ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
From the [README](https://github.com/joepVanlier/ysfx?tab=readme-ov-file#remarks):
> Unfortunately, the original maintainer (jpcima) seems to have disappeared, so I (Joep Vanlier) have decided to fork the project to update it with some more recent JSFX features and bugfixes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
