### PR TITLE
rpi-imager: support aarch64-darwin

### DIFF
--- a/pkgs/by-name/rp/rpi-imager/package.nix
+++ b/pkgs/by-name/rp/rpi-imager/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (
                        'COMMAND ''${CMAKE_COMMAND} -E echo "Skipping macdeployqt under Nix"'
 
       grep -Fq "name 'objects-*'" src/mac/PlatformPackaging.cmake
-      sed -i "/name 'objects-\\*'/c\\    COMMAND /bin/sh -c \":\"" src/mac/PlatformPackaging.cmake
+      sed -i "/name 'objects-\\*'/c\\    COMMAND ''${CMAKE_COMMAND} -E true" src/mac/PlatformPackaging.cmake
     '';
 
     preConfigure = ''
@@ -145,7 +145,7 @@ stdenv.mkDerivation (
       ''
       + lib.optionalString stdenv.hostPlatform.isDarwin ''
         wrapQtApp "$out/Applications/rpi-imager.app/Contents/MacOS/rpi-imager"
-        makeQtWrapper "$out/Applications/rpi-imager.app/Contents/MacOS/rpi-imager" "$out/bin/rpi-imager"
+        ln -s ../Applications/rpi-imager.app/Contents/MacOS/rpi-imager "$out/bin/rpi-imager"
       '';
 
     env.LANG = "C.UTF-8";

--- a/pkgs/by-name/rp/rpi-imager/package.nix
+++ b/pkgs/by-name/rp/rpi-imager/package.nix
@@ -20,7 +20,8 @@
   enableUring ? stdenv.hostPlatform.isLinux,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs:
+{
   pname = "rpi-imager";
   version = "2.0.6";
 
@@ -39,6 +40,12 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace src/CMakeLists.txt \
       --replace-fail 'qt_add_lupdate(TS_FILES ''${TRANSLATIONS} SOURCE_TARGETS ''${PROJECT_NAME} OPTIONS -no-obsolete -locations none)' ""
+
+    substituteInPlace src/mac/PlatformPackaging.cmake \
+      --replace-fail 'COMMAND "''${MACDEPLOYQT}" "''${APP_BUNDLE_PATH}" -qmldir="''${CMAKE_CURRENT_SOURCE_DIR}" -always-overwrite' \
+                     'COMMAND ''${CMAKE_COMMAND} -E echo "Skipping macdeployqt under Nix"'
+
+    sed -i "/name 'objects-\\*'/c\\    COMMAND /bin/sh -c \":\"" src/mac/PlatformPackaging.cmake
   '';
 
   preConfigure = ''
@@ -53,9 +60,19 @@ stdenv.mkDerivation (finalAttrs: {
       '';
 
       # Upstream uses `git describe` to define a `IMAGER_VERSION` CMake variable,
-      # and we fool it to take a version from a fake `git` executable.
+      # and some CMake dependency probes also check `git --version`.
       fake-git = writeShellScriptBin "git" ''
-        echo "v${finalAttrs.version}"
+        case "$1" in
+          describe)
+            echo "v${finalAttrs.version}"
+            ;;
+          --version)
+            echo "git version 2.49.0"
+            ;;
+          *)
+            echo "git version 2.49.0"
+            ;;
+        esac
       '';
     in
     [
@@ -64,8 +81,8 @@ stdenv.mkDerivation (finalAttrs: {
       fake-lsblk
       pkg-config
       qt6.wrapQtAppsHook
-      wrapGAppsHook4
-    ];
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
 
   buildInputs = [
     curl
@@ -92,6 +109,20 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "GENERATE_CAPITAL_CITIES" false)
     (lib.cmakeBool "GENERATE_COUNTRIES_FROM_REGDB" false)
     (lib.cmakeBool "GENERATE_TIMEZONES_FROM_IANA" false)
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    (lib.cmakeFeature "CMAKE_OSX_ARCHITECTURES" stdenv.hostPlatform.darwinArch)
+    (lib.cmakeFeature "CMAKE_C_COMPILER_AR" "${stdenv.cc.bintools.bintools}/bin/ar")
+    (lib.cmakeFeature "CMAKE_C_COMPILER_RANLIB" "${stdenv.cc.bintools.bintools}/bin/ranlib")
+    (lib.cmakeFeature "CMAKE_CXX_COMPILER_AR" "${stdenv.cc.bintools.bintools}/bin/ar")
+    (lib.cmakeFeature "CMAKE_CXX_COMPILER_RANLIB" "${stdenv.cc.bintools.bintools}/bin/ranlib")
+    (lib.cmakeFeature "LIBLZMA_INCLUDE_DIR" "${lib.getDev xz}/include")
+    (lib.cmakeFeature "LIBLZMA_INCLUDE_DIRS" "${lib.getDev xz}/include")
+    (lib.cmakeFeature "LIBLZMA_LIBRARY" "${lib.getLib xz}/lib/liblzma${stdenv.hostPlatform.extensions.sharedLibrary}")
+    (lib.cmakeFeature "LIBLZMA_LIBRARIES" "${lib.getLib xz}/lib/liblzma${stdenv.hostPlatform.extensions.sharedLibrary}")
+    (lib.cmakeBool "LIBLZMA_HAS_AUTO_DECODER" true)
+    (lib.cmakeBool "LIBLZMA_HAS_EASY_ENCODER" true)
+    (lib.cmakeBool "LIBLZMA_HAS_LZMA_PRESET" true)
   ];
 
   qtWrapperArgs = [
@@ -99,10 +130,15 @@ stdenv.mkDerivation (finalAttrs: {
     "--unset QT_STYLE_OVERRIDE"
   ];
 
-  dontWrapGApps = true;
+  dontWrapGApps = stdenv.hostPlatform.isLinux;
+  dontWrapQtApps = stdenv.hostPlatform.isDarwin;
 
-  preFixup = ''
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    wrapQtApp "$out/Applications/rpi-imager.app/Contents/MacOS/rpi-imager"
+    makeQtWrapper "$out/Applications/rpi-imager.app/Contents/MacOS/rpi-imager" "$out/bin/rpi-imager"
   '';
 
   env.LANG = "C.UTF-8";
@@ -127,7 +163,15 @@ stdenv.mkDerivation (finalAttrs: {
       anthonyroussel
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    # could not find xz
-    badPlatforms = lib.platforms.darwin;
   };
+}
+// lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{Applications,bin}
+    cp -r rpi-imager.app $out/Applications/
+
+    runHook postInstall
+  '';
 })

--- a/pkgs/by-name/rp/rpi-imager/package.nix
+++ b/pkgs/by-name/rp/rpi-imager/package.nix
@@ -42,11 +42,17 @@ stdenv.mkDerivation (
 
       substituteInPlace src/CMakeLists.txt \
         --replace-fail 'qt_add_lupdate(TS_FILES ''${TRANSLATIONS} SOURCE_TARGETS ''${PROJECT_NAME} OPTIONS -no-obsolete -locations none)' ""
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace src/CMakeLists.txt \
+        --replace-fail '        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)' \
+                       '        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)'
 
       substituteInPlace src/mac/PlatformPackaging.cmake \
         --replace-fail 'COMMAND "''${MACDEPLOYQT}" "''${APP_BUNDLE_PATH}" -qmldir="''${CMAKE_CURRENT_SOURCE_DIR}" -always-overwrite' \
                        'COMMAND ''${CMAKE_COMMAND} -E echo "Skipping macdeployqt under Nix"'
 
+      grep -Fq "name 'objects-*'" src/mac/PlatformPackaging.cmake
       sed -i "/name 'objects-\\*'/c\\    COMMAND /bin/sh -c \":\"" src/mac/PlatformPackaging.cmake
     '';
 
@@ -114,10 +120,8 @@ stdenv.mkDerivation (
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       (lib.cmakeFeature "CMAKE_OSX_ARCHITECTURES" stdenv.hostPlatform.darwinArch)
-      (lib.cmakeFeature "CMAKE_C_COMPILER_AR" "${stdenv.cc.bintools.bintools}/bin/ar")
-      (lib.cmakeFeature "CMAKE_C_COMPILER_RANLIB" "${stdenv.cc.bintools.bintools}/bin/ranlib")
-      (lib.cmakeFeature "CMAKE_CXX_COMPILER_AR" "${stdenv.cc.bintools.bintools}/bin/ar")
-      (lib.cmakeFeature "CMAKE_CXX_COMPILER_RANLIB" "${stdenv.cc.bintools.bintools}/bin/ranlib")
+      (lib.cmakeFeature "CMAKE_AR" "${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar")
+      (lib.cmakeFeature "CMAKE_RANLIB" "${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib")
       (lib.cmakeFeature "LIBLZMA_INCLUDE_DIR" "${lib.getDev xz}/include")
       (lib.cmakeFeature "LIBLZMA_INCLUDE_DIRS" "${lib.getDev xz}/include")
       (lib.cmakeFeature "LIBLZMA_LIBRARY" "${lib.getLib xz}/lib/liblzma${stdenv.hostPlatform.extensions.sharedLibrary}")

--- a/pkgs/by-name/rp/rpi-imager/package.nix
+++ b/pkgs/by-name/rp/rpi-imager/package.nix
@@ -11,6 +11,7 @@
   nix-update-script,
   pkg-config,
   qt6,
+  runCommand,
   testers,
   wrapGAppsHook4,
   writeShellScriptBin,
@@ -146,10 +147,24 @@ stdenv.mkDerivation (
     env.LANG = "C.UTF-8";
 
     passthru = {
-      tests.version = testers.testVersion {
-        package = finalAttrs.finalPackage;
-        command = "QT_QPA_PLATFORM=offscreen rpi-imager --version";
-        version = "v${finalAttrs.version}";
+      tests = {
+        version = testers.testVersion {
+          package = finalAttrs.finalPackage;
+          command = "QT_QPA_PLATFORM=offscreen rpi-imager --version";
+          version = "v${finalAttrs.version}";
+        };
+      }
+      // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+        bundle =
+          runCommand "${finalAttrs.pname}-bundle-test"
+            {
+              nativeBuildInputs = [ finalAttrs.finalPackage ];
+            }
+            ''
+              test -d ${finalAttrs.finalPackage}/Applications/rpi-imager.app
+              test -x ${finalAttrs.finalPackage}/bin/rpi-imager
+              touch $out
+            '';
       };
       updateScript = nix-update-script { };
     };

--- a/pkgs/by-name/rp/rpi-imager/package.nix
+++ b/pkgs/by-name/rp/rpi-imager/package.nix
@@ -20,158 +20,161 @@
   enableUring ? stdenv.hostPlatform.isLinux,
 }:
 
-stdenv.mkDerivation (finalAttrs:
-{
-  pname = "rpi-imager";
-  version = "2.0.6";
+stdenv.mkDerivation (
+  finalAttrs:
+  {
+    pname = "rpi-imager";
+    version = "2.0.6";
 
-  src = fetchFromGitHub {
-    owner = "raspberrypi";
-    repo = "rpi-imager";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-YbPGxc6EWE3B+7MWgtwTDRdjin9FM7KpWfw38FqKXYA=";
-  };
-
-  patches = [ ./remove-vendoring.patch ];
-
-  postPatch = ''
-    substituteInPlace debian/com.raspberrypi.rpi-imager.desktop \
-      --replace-fail "/usr/bin/" ""
-
-    substituteInPlace src/CMakeLists.txt \
-      --replace-fail 'qt_add_lupdate(TS_FILES ''${TRANSLATIONS} SOURCE_TARGETS ''${PROJECT_NAME} OPTIONS -no-obsolete -locations none)' ""
-
-    substituteInPlace src/mac/PlatformPackaging.cmake \
-      --replace-fail 'COMMAND "''${MACDEPLOYQT}" "''${APP_BUNDLE_PATH}" -qmldir="''${CMAKE_CURRENT_SOURCE_DIR}" -always-overwrite' \
-                     'COMMAND ''${CMAKE_COMMAND} -E echo "Skipping macdeployqt under Nix"'
-
-    sed -i "/name 'objects-\\*'/c\\    COMMAND /bin/sh -c \":\"" src/mac/PlatformPackaging.cmake
-  '';
-
-  preConfigure = ''
-    cd src
-  '';
-
-  nativeBuildInputs =
-    let
-      # Fool upstream's cmake lsblk check a bit
-      fake-lsblk = writeShellScriptBin "lsblk" ''
-        echo "our lsblk has --json support but it doesn't work in our sandbox"
-      '';
-
-      # Upstream uses `git describe` to define a `IMAGER_VERSION` CMake variable,
-      # and some CMake dependency probes also check `git --version`.
-      fake-git = writeShellScriptBin "git" ''
-        case "$1" in
-          describe)
-            echo "v${finalAttrs.version}"
-            ;;
-          --version)
-            echo "git version 2.49.0"
-            ;;
-          *)
-            echo "git version 2.49.0"
-            ;;
-        esac
-      '';
-    in
-    [
-      cmake
-      fake-git
-      fake-lsblk
-      pkg-config
-      qt6.wrapQtAppsHook
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
-
-  buildInputs = [
-    curl
-    gnutls
-    libarchive
-    libtasn1
-    qt6.qtbase
-    qt6.qtdeclarative
-    qt6.qtsvg
-    qt6.qttools
-    xz
-    zstd
-  ]
-  ++ lib.optional enableUring liburing
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    qt6.qtwayland
-  ];
-
-  cmakeFlags = [
-    # Isn't relevant for Nix
-    (lib.cmakeBool "ENABLE_CHECK_VERSION" false)
-    (lib.cmakeBool "ENABLE_TELEMETRY" enableTelemetry)
-    # Disable fetching external data files
-    (lib.cmakeBool "GENERATE_CAPITAL_CITIES" false)
-    (lib.cmakeBool "GENERATE_COUNTRIES_FROM_REGDB" false)
-    (lib.cmakeBool "GENERATE_TIMEZONES_FROM_IANA" false)
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    (lib.cmakeFeature "CMAKE_OSX_ARCHITECTURES" stdenv.hostPlatform.darwinArch)
-    (lib.cmakeFeature "CMAKE_C_COMPILER_AR" "${stdenv.cc.bintools.bintools}/bin/ar")
-    (lib.cmakeFeature "CMAKE_C_COMPILER_RANLIB" "${stdenv.cc.bintools.bintools}/bin/ranlib")
-    (lib.cmakeFeature "CMAKE_CXX_COMPILER_AR" "${stdenv.cc.bintools.bintools}/bin/ar")
-    (lib.cmakeFeature "CMAKE_CXX_COMPILER_RANLIB" "${stdenv.cc.bintools.bintools}/bin/ranlib")
-    (lib.cmakeFeature "LIBLZMA_INCLUDE_DIR" "${lib.getDev xz}/include")
-    (lib.cmakeFeature "LIBLZMA_INCLUDE_DIRS" "${lib.getDev xz}/include")
-    (lib.cmakeFeature "LIBLZMA_LIBRARY" "${lib.getLib xz}/lib/liblzma${stdenv.hostPlatform.extensions.sharedLibrary}")
-    (lib.cmakeFeature "LIBLZMA_LIBRARIES" "${lib.getLib xz}/lib/liblzma${stdenv.hostPlatform.extensions.sharedLibrary}")
-    (lib.cmakeBool "LIBLZMA_HAS_AUTO_DECODER" true)
-    (lib.cmakeBool "LIBLZMA_HAS_EASY_ENCODER" true)
-    (lib.cmakeBool "LIBLZMA_HAS_LZMA_PRESET" true)
-  ];
-
-  qtWrapperArgs = [
-    "--unset QT_QPA_PLATFORMTHEME"
-    "--unset QT_STYLE_OVERRIDE"
-  ];
-
-  dontWrapGApps = stdenv.hostPlatform.isLinux;
-  dontWrapQtApps = stdenv.hostPlatform.isDarwin;
-
-  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
-    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    wrapQtApp "$out/Applications/rpi-imager.app/Contents/MacOS/rpi-imager"
-    makeQtWrapper "$out/Applications/rpi-imager.app/Contents/MacOS/rpi-imager" "$out/bin/rpi-imager"
-  '';
-
-  env.LANG = "C.UTF-8";
-
-  passthru = {
-    tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage;
-      command = "QT_QPA_PLATFORM=offscreen rpi-imager --version";
-      version = "v${finalAttrs.version}";
+    src = fetchFromGitHub {
+      owner = "raspberrypi";
+      repo = "rpi-imager";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-YbPGxc6EWE3B+7MWgtwTDRdjin9FM7KpWfw38FqKXYA=";
     };
-    updateScript = nix-update-script { };
-  };
 
-  meta = {
-    description = "Raspberry Pi Imaging Utility";
-    homepage = "https://github.com/raspberrypi/rpi-imager/";
-    changelog = "https://github.com/raspberrypi/rpi-imager/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.asl20;
-    mainProgram = "rpi-imager";
-    maintainers = with lib.maintainers; [
-      ymarkus
-      anthonyroussel
+    patches = [ ./remove-vendoring.patch ];
+
+    postPatch = ''
+      substituteInPlace debian/com.raspberrypi.rpi-imager.desktop \
+        --replace-fail "/usr/bin/" ""
+
+      substituteInPlace src/CMakeLists.txt \
+        --replace-fail 'qt_add_lupdate(TS_FILES ''${TRANSLATIONS} SOURCE_TARGETS ''${PROJECT_NAME} OPTIONS -no-obsolete -locations none)' ""
+
+      substituteInPlace src/mac/PlatformPackaging.cmake \
+        --replace-fail 'COMMAND "''${MACDEPLOYQT}" "''${APP_BUNDLE_PATH}" -qmldir="''${CMAKE_CURRENT_SOURCE_DIR}" -always-overwrite' \
+                       'COMMAND ''${CMAKE_COMMAND} -E echo "Skipping macdeployqt under Nix"'
+
+      sed -i "/name 'objects-\\*'/c\\    COMMAND /bin/sh -c \":\"" src/mac/PlatformPackaging.cmake
+    '';
+
+    preConfigure = ''
+      cd src
+    '';
+
+    nativeBuildInputs =
+      let
+        # Fool upstream's cmake lsblk check a bit
+        fake-lsblk = writeShellScriptBin "lsblk" ''
+          echo "our lsblk has --json support but it doesn't work in our sandbox"
+        '';
+
+        # Upstream uses `git describe` to define a `IMAGER_VERSION` CMake variable,
+        # and some CMake dependency probes also check `git --version`.
+        fake-git = writeShellScriptBin "git" ''
+          case "$1" in
+            describe)
+              echo "v${finalAttrs.version}"
+              ;;
+            --version)
+              echo "git version 2.49.0"
+              ;;
+            *)
+              echo "git version 2.49.0"
+              ;;
+          esac
+        '';
+      in
+      [
+        cmake
+        fake-git
+        fake-lsblk
+        pkg-config
+        qt6.wrapQtAppsHook
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+    buildInputs = [
+      curl
+      gnutls
+      libarchive
+      libtasn1
+      qt6.qtbase
+      qt6.qtdeclarative
+      qt6.qtsvg
+      qt6.qttools
+      xz
+      zstd
+    ]
+    ++ lib.optional enableUring liburing
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      qt6.qtwayland
     ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-  };
-}
-// lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-  installPhase = ''
-    runHook preInstall
 
-    mkdir -p $out/{Applications,bin}
-    cp -r rpi-imager.app $out/Applications/
+    cmakeFlags = [
+      # Isn't relevant for Nix
+      (lib.cmakeBool "ENABLE_CHECK_VERSION" false)
+      (lib.cmakeBool "ENABLE_TELEMETRY" enableTelemetry)
+      # Disable fetching external data files
+      (lib.cmakeBool "GENERATE_CAPITAL_CITIES" false)
+      (lib.cmakeBool "GENERATE_COUNTRIES_FROM_REGDB" false)
+      (lib.cmakeBool "GENERATE_TIMEZONES_FROM_IANA" false)
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      (lib.cmakeFeature "CMAKE_OSX_ARCHITECTURES" stdenv.hostPlatform.darwinArch)
+      (lib.cmakeFeature "CMAKE_C_COMPILER_AR" "${stdenv.cc.bintools.bintools}/bin/ar")
+      (lib.cmakeFeature "CMAKE_C_COMPILER_RANLIB" "${stdenv.cc.bintools.bintools}/bin/ranlib")
+      (lib.cmakeFeature "CMAKE_CXX_COMPILER_AR" "${stdenv.cc.bintools.bintools}/bin/ar")
+      (lib.cmakeFeature "CMAKE_CXX_COMPILER_RANLIB" "${stdenv.cc.bintools.bintools}/bin/ranlib")
+      (lib.cmakeFeature "LIBLZMA_INCLUDE_DIR" "${lib.getDev xz}/include")
+      (lib.cmakeFeature "LIBLZMA_INCLUDE_DIRS" "${lib.getDev xz}/include")
+      (lib.cmakeFeature "LIBLZMA_LIBRARY" "${lib.getLib xz}/lib/liblzma${stdenv.hostPlatform.extensions.sharedLibrary}")
+      (lib.cmakeFeature "LIBLZMA_LIBRARIES" "${lib.getLib xz}/lib/liblzma${stdenv.hostPlatform.extensions.sharedLibrary}")
+      (lib.cmakeBool "LIBLZMA_HAS_AUTO_DECODER" true)
+      (lib.cmakeBool "LIBLZMA_HAS_EASY_ENCODER" true)
+      (lib.cmakeBool "LIBLZMA_HAS_LZMA_PRESET" true)
+    ];
 
-    runHook postInstall
-  '';
-})
+    qtWrapperArgs = [
+      "--unset QT_QPA_PLATFORMTHEME"
+      "--unset QT_STYLE_OVERRIDE"
+    ];
+
+    dontWrapGApps = stdenv.hostPlatform.isLinux;
+    dontWrapQtApps = stdenv.hostPlatform.isDarwin;
+
+    preFixup =
+      lib.optionalString stdenv.hostPlatform.isLinux ''
+        qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+      ''
+      + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        wrapQtApp "$out/Applications/rpi-imager.app/Contents/MacOS/rpi-imager"
+        makeQtWrapper "$out/Applications/rpi-imager.app/Contents/MacOS/rpi-imager" "$out/bin/rpi-imager"
+      '';
+
+    env.LANG = "C.UTF-8";
+
+    passthru = {
+      tests.version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+        command = "QT_QPA_PLATFORM=offscreen rpi-imager --version";
+        version = "v${finalAttrs.version}";
+      };
+      updateScript = nix-update-script { };
+    };
+
+    meta = {
+      description = "Raspberry Pi Imaging Utility";
+      homepage = "https://github.com/raspberrypi/rpi-imager/";
+      changelog = "https://github.com/raspberrypi/rpi-imager/releases/tag/v${finalAttrs.version}";
+      license = lib.licenses.asl20;
+      mainProgram = "rpi-imager";
+      maintainers = with lib.maintainers; [
+        ymarkus
+        anthonyroussel
+      ];
+      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    };
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/{Applications,bin}
+      cp -r rpi-imager.app $out/Applications/
+
+      runHook postInstall
+    '';
+  }
+)


### PR DESCRIPTION
Enable `rpi-imager` on `aarch64-darwin` by using a Nix-native macOS app bundle install and Qt wrapping instead of `macdeployqt`'s copied runtime, while keeping Linux-specific wrapping Linux-only.

This keeps `passthru.updateScript = nix-update-script { };`, forces system `liblzma` on Darwin to avoid vendored `xz`, and preserves the existing Linux build path.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## Verification

- `nix build .#rpi-imager -L --cores 0`
- `result/bin/rpi-imager --version`
  - `Raspberry Pi Imager v2.0.6`
- `test -d result/Applications/rpi-imager.app`
- `nix build .#rpi-imager.passthru.tests.version -L --cores 0`
- `nix build .#legacyPackages.x86_64-linux.rpi-imager -L --cores 0`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
