### PR TITLE
oxlint: 1.51.0 -> 1.55.0

### DIFF
--- a/pkgs/by-name/ox/oxlint/package.nix
+++ b/pkgs/by-name/ox/oxlint/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "oxlint";
-  version = "1.51.0";
+  version = "1.55.0";
 
   src = fetchFromGitHub {
     owner = "oxc-project";
     repo = "oxc";
     tag = "oxlint_v${finalAttrs.version}";
-    hash = "sha256-J5EChGADug+SEvhjStyS1s5kek5QNc2VrjEa5MEWTpA=";
+    hash = "sha256-A2cq1WgZg8csNGB3yFNo21450f46n4ZVblke1yqlBCc=";
   };
 
-  cargoHash = "sha256-chNxYraN9upILXCqDQ/TrN3xiKhxKhZlN2HGrPF4qT8=";
+  cargoHash = "sha256-Oz9u2+5lq+z9A81BEn2T4jvVMqf1uNXip+OH4AxiTG0=";
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
https://github.com/oxc-project/oxc/compare/oxlint_v1.51.0...oxlint_v1.55.0

- v1.55.0
  - Bug Fixes:
    - Ignore inherited root-only options in nested configs
    - Omit useless `| null` for `Option<T>` field from schema
    - Make `generate-plugin-eslint` script work on windows
  - Documentation:
    - Add JSDoc comments to raw transfer constants
    - Promote JS plugins to alpha status

- v1.54.0
  - Bug Fixes:
    - Skip `vite.config.ts` exports `defineConfig(fn)`
    - Skip `vite.config.ts` w/o `.lint` field in auto-discovery
    - Only check aggregated exports in no-duplicate-imports
    - Ignore constructor callbacks in explicit-module-boundary-types
  - Performance:
    - Reduce array lookups in visitor compilation
  - Documentation:
    - Fix extra closing brace in example config
    - Update conformance README

- v1.53.0
  - Features:
    - Support `vite.config.ts` `.lint` field
    - Implement `react/no-clone-element` rule
    - Implement `react/no-react-children` rule
    - Add `oxlint-plugin-eslint` package
  - Bug Fixes:
    - Multiple rule option deserialization fixes (no-inline-comments, default-case, no-fallthrough, new-cap)
    - Ignore type-only typeof deps in exhaustive-deps
    - Add help messages to import plugin diagnostics
    - Ensure `after` hooks always run
    - Check `globals` entry for `no-undef`
    - `reportUsedIgnorePattern` should not report used rest siblings
    - Various plugin error handling improvements
  - Performance:
    - Pre-populate cache of `EnterExit` and `VisitProp` objects
    - Replace arrays with `Uint8Array`s
    - Free visit functions earlier
    - Faster reset of visitor state
    - Avoid computing diagnostics for non invoked code actions requests

- v1.52.0
  - Features:
    - Auto-enable gitlab formatter on GitLab
    - Add .oxlintrc.jsonc config file support
    - Add `options.reportUnusedDisableDirectives` to config file
    - Auto-enable github formatter on GitHub Actions
    - Implement typescript/no-unecessary-type-conversion
    - Introduce denyWarnings config option
    - Introduce maxWarnings config option
  - Bug Fixes:
    - Remove getters from `Context` in plugins
    - Fix types for `walkProgram` and `walkProgramWithCfg`
    - Send other code actions besides `source.fixAll` if requested
    - Handle array-type shorthand inside union members
    - Allow unused type params in ambient module blocks
    - Apply regex pattern checks to side-effect imports
    - Error when --type-check is used without --type-aware
    - Avoid unsafe autofix for substr-to-slice
    - Allow `null` and `undefined` for `rule.meta.fixable`
    - Multiple fixes for no-loss-of-precision
    - Avoid prefer-const false positives for mixed-scope destructuring and operator reassignments
    - Mark no-useless-constructor fixer as suggestion
    - Many other bug fixes
  - Performance:
    - Make tokens class instances
    - Reduce memory copies for tokens
    - Cache token objects
    - Store tokens as a `Box<[Token]>`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
