### PR TITLE
oxfmt: 0.27.0 -> 0.40.0

### DIFF
--- a/pkgs/by-name/ox/oxfmt/package.nix
+++ b/pkgs/by-name/ox/oxfmt/package.nix
@@ -21,33 +21,25 @@
 # A pure Rust build would lack the Prettier plugin functionality.
 stdenv.mkDerivation (finalAttrs: {
   pname = "oxfmt";
-  version = "0.27.0";
+  version = "0.40.0";
 
   src = fetchFromGitHub {
     owner = "oxc-project";
     repo = "oxc";
     tag = "oxfmt_v${finalAttrs.version}";
-    hash = "sha256-EAM1DxA/TqnIRN5Tlvg5/jvbyOUtSuwQ4RCBeO9esCw=";
+    hash = "sha256-A2cq1WgZg8csNGB3yFNo21450f46n4ZVblke1yqlBCc=";
   };
-
-  # Remove patchedDependencies from both workspace and lockfile
-  # to avoid LOCKFILE_CONFIG_MISMATCH error
-  postPatch = ''
-    substituteInPlace pnpm-workspace.yaml pnpm-lock.yaml \
-      --replace-fail "patchedDependencies:" "_patchedDependencies:"
-  '';
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-okwkhcT6mekIvo52T8eSrXUcp/LQhcEYvHyIc5CLdrE=";
+    hash = "sha256-Oz9u2+5lq+z9A81BEn2T4jvVMqf1uNXip+OH4AxiTG0=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 2;
-    hash = "sha256-GOsSTfM93VgGhVlgzXhJIJG9MSf306cEnRru/aTA+oY=";
-    prePnpmInstall = finalAttrs.postPatch;
+    hash = "sha256-iO1MRUTO8Ce1YGH/qDWQmdfvTfvsmgwGBaybWw3wiu0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/oxc-project/oxc/compare/apps_v1.42.0...apps_v1.55.0

- v0.40.0
  - Bug Fixes:
    - Ensure stdin blocking mode is set for non-TTY environments
    - Omit useless `| null` for `Option<T>` field from schema
- v0.39.0
  - Bug Fixes:
    - Skip `vite.config.ts` exports `defineConfig(fn)`
    - Skip `vite.config.ts` w/o `.fmt` field in auto-discovery
- v0.38.0
  - Features:
    - Support `vite.config.*` `.fmt` field
    - .js/.ts config file support
  - Bug Fixes:
    - Avoid double-escaping in css-in-js
- v0.37.0
  - Features:
    - Support css-in-js substitution
    - Display default settings was used message in cli stats
    - Reintroduce stats line for write mode
  - Bug Fixes:
    - Apply `is_ignored_dir` for glob paths too
  - Performance:
    - Prefer language_id over file extension when formatting
- v0.36.0
  - Features:
    - Support trailing ignore comments
    - Support other schemes beside `file://` and `untitled://` in LSP
    - Support `graphql()` variant for gql-in-js
    - Support gql-in-js substitution
    - Support js-in-vue (partially)
    - Collect tokens in parser and convert to ESTree format
  - Bug Fixes:
    - Avoid embedded TSFN crash by returning errors as data
    - Add `preferUnplugged` for Yarn PnP compatibility
    - Support tailwind sort for CSS/LESS/SCSS
    - Trim trailing whitespace before breaking line
    - Drop blank line between terminal call and first chain member
- v0.35.0
  - Features:
    - Strip `"experimental"SortXxx` prefix
  - Bug Fixes:
    - Update API types for `sortPackageJsonOptions`
- v0.34.0
  - Features:
    - Support `untitled://` schema in LSP
  - Bug Fixes:
    - Fix outdated `sortImports.groups` doc comments
- v0.33.0
  - Breaking Changes:
    - Change default `groups` order in sort_imports
    - Report invalid group name with renaming `side-effect` > `side_effect` in sort_imports
  - Features:
    - Support `{ newlinesBetween: bool }` inside `groups` in sort_imports
    - Support `customGroups` attributes (`selector` and `modifiers`) in sort_imports
  - Bug Fixes:
    - Explicitly pass `process.env` for the forked process
    - Arrow function body incorrectly broken when return type has comment
    - Update tailwind plugin which fixes crash on non-js file
    - Treat `PrivateFieldExpression` as simple call argument
    - Match Prettier union indentation with leading comments
- v0.32.0
  - Features:
    - Add `node_id` field to all AST struct nodes
  - Bug Fixes:
    - Avoid unnecessary parentheses for string literal in labeled statement
- v0.31.0
  - Bug Fixes:
    - Update `bindings.js` files
    - Add missing riscv64/s390x napi targets
- v0.29.0
  - Breaking Changes:
    - Replace prefix match with glob pattern in `customGroups.elementNamePattern` in sort_imports
  - Features:
    - Do not refer `.gitignore` in LSP
    - Better Tailwind CSS integration
    - Add riscv64 and s390x napi targets
    - Support glob for CLI paths
    - Use `oxc_formatter` in js-in-xxx part
    - Add more native builds
  - Bug Fixes:
    - Resolve relative -> absolute path for other usages
    - Fix relative -> absolute path resolution with refactoring
    - Temporarily disable the override for js-in-xxx (not ready yet)
    - Handle `isSingleJsxExpressionStatementInMarkdown()` check for js-in-md
    - Preserve numeric separators in number literals
    - Fallback to formatting when package.json sorting fails
    - Preserve comment between callee and optional chaining operator
    - Remove unnecessary parentheses for single-member union types
    - Preserve parentheses around await with private field access
    - Preserve parentheses around nested sequence expressions
    - Do not override `babel-ts` for now
    - Add space before type annotation with leading comment
    - Keep spread with callback on same line
    - Workaround Node.js ThreadsafeFunction cleanup race condition
    - Require string first arg in test calls
    - Avoid breaking generic call assignments
    - Preserve trailing comma in mts/cts arrow generics
    - Do not count `TemplateLiteral` content in detect_code_removal
  - Performance:
    - Collect glob paths in parallel
    - Use RwLock instead of Mutex for TSFN handles
- v0.28.0
  - Features:
    - Add config migration from biome
  - Bug Fixes:
    - Set `experimentalSortPackagejson: false` by default in migrate-prettier
    - Keep decorated function pattern hugged when params break
    - Quote numeric property keys with `quoteProps: consistent`
    - Ignore comment does not work for sequence expressions in arrow function body
    - Handle leading comments in arrow function sequence expressions
    - Correctly expand JSX returned from arrow callbacks in JSX expression containers
    - Tailwindcss sorting doesn't work for object property keys
    - Prevent ThreadsafeFunction crash on Node.js exit
    - Follow Prettier's approach for for-in initializer parentheses
    - Preserve quote for class property key in TypeScript
    - Incorrect comments placement for union type in `TSTypeIntersection`
    - Handle CRLF with embedded formatting
    - Preserve comments on rest elements
    - Preserve type cast comments on rest parameters
    - Don't add extra semicolon on suppressed class properties
    - Use `empty_line` IR for empty xxx-in-js line
    - Dedent xxx-in-js templates before calling prettier
    - Trim whitespace only xxx-in-js templates


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
