### PR TITLE
man-pages: fix `can't resolve man7/groff_man.7` error when running `man man`

### DIFF
--- a/pkgs/by-name/ma/man-pages/package.nix
+++ b/pkgs/by-name/ma/man-pages/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   directoryListingUpdater,
   gawk,
+  groff,
   man,
   pcre2,
   nixosTests,
@@ -26,6 +27,13 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://kernel/linux/docs/man-pages/man-pages-${finalAttrs.version}.tar.xz";
     hash = "sha256-0Y8hpgKwl3ilqQlr8b6EQbdzPpmBUEdKzPcD0WX06/Q=";
   };
+
+  # See https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man/man7/man.7,
+  # https://github.com/NixOS/nixpkgs/issues/498875
+  postPatch = ''
+    substituteInPlace man/man7/man.7 \
+      --replace-fail '.so man7/groff_man.7' '.so ${lib.getMan groff}/share/man/man7/groff_man.7'
+  '';
 
   nativeInstallCheckInputs = [
     gawk


### PR DESCRIPTION
Fixes: #498875


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
