### PR TITLE
whatsapp-for-mac: 2.25.22.79 -> 26.8.76

### DIFF
--- a/pkgs/by-name/wh/whatsapp-for-mac/package.nix
+++ b/pkgs/by-name/wh/whatsapp-for-mac/package.nix
@@ -10,13 +10,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "whatsapp-for-mac";
-  version = "2.25.22.79";
+  version = "26.8.76";
 
   src = fetchzip {
     extension = "zip";
     name = "WhatsApp.app";
-    url = "https://web.whatsapp.com/desktop/mac_native/release/?version=${finalAttrs.version}&extension=zip&configuration=Release&branch=relbranch";
-    hash = "sha256-LYjPMiXLD1U5ZNt/acBagrV2RS7U/OGMJ06mUFBluSQ=";
+    url = "https://web.whatsapp.com/desktop/mac_native/release/?version=2.${finalAttrs.version}&extension=zip&configuration=Release&branch=relbranch&is_buck=true";
+    hash = "sha256-YPx3VpGYyCNfneaISHAezTY+wx79paCy88t0APE1EGc=";
   };
 
   dontConfigure = true;
@@ -41,8 +41,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       common-updater-scripts
     ];
     text = ''
-      url=$(curl --silent "https://web.whatsapp.com/desktop/mac_native/updates/?branch=relbranch&configuration=Release")
-      version=$(echo "$url" | xmlstarlet sel -t -v "substring-before(substring-after(//enclosure/@url, 'version='), '&')")
+      feed_url="https://web.whatsapp.com/desktop/mac_native/updates/?branch=relbranch&configuration=Release"
+      version=$(curl --silent "$feed_url" | xmlstarlet sel -N sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" -t -v "//sparkle:shortVersionString")
       update-source-version whatsapp-for-mac "$version" --file=./pkgs/by-name/wh/whatsapp-for-mac/package.nix
     '';
   });


### PR DESCRIPTION
## Summary

- update `whatsapp-for-mac` to `26.8.76`
- switch the fetch URL to the current upstream archive format
- read the visible version from the Sparkle feed in the update script

The previously pinned download now returns HTTP 500, so the old package no longer builds.

Upstream does not appear to publish separate release notes for the macOS app beyond the download page and Sparkle feed:
- https://www.whatsapp.com/download
- https://web.whatsapp.com/desktop/mac_native/updates/?branch=relbranch&configuration=Release

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test