### PR TITLE
mate-terminal: 1.28.1 -> 1.28.2

### DIFF
--- a/pkgs/by-name/ma/mate-terminal/package.nix
+++ b/pkgs/by-name/ma/mate-terminal/package.nix
@@ -1,7 +1,10 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoconf-archive,
+  autoreconfHook,
+  mate-common,
   pkg-config,
   gettext,
   itstool,
@@ -11,27 +14,35 @@
   vte,
   pcre2,
   wrapGAppsHook3,
+  yelp-tools,
   gitUpdater,
   nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mate-terminal";
-  version = "1.28.1";
+  version = "1.28.2";
 
-  src = fetchurl {
-    url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor finalAttrs.version}/mate-terminal-${finalAttrs.version}.tar.xz";
-    sha256 = "8TXrGp4q4ieY7LLcGRT9tM/XdOa7ZcAVK+N8xslGnpI=";
+  src = fetchFromGitHub {
+    owner = "mate-desktop";
+    repo = "mate-terminal";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-tyYHMn+qwytpSNUZg4xfwnuVClxj2IcyB4C4Dsn+1Nc=";
   };
 
   strictDeps = true;
 
   nativeBuildInputs = [
+    autoconf-archive
+    autoreconfHook
     gettext
     itstool
+    mate-common # mate-common.m4 macros
     pkg-config
     libxml2 # xmllint
     wrapGAppsHook3
+    yelp-tools
   ];
 
   buildInputs = [
@@ -44,7 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   passthru.updateScript = gitUpdater {
-    url = "https://git.mate-desktop.org/mate-terminal";
     odd-unstable = true;
     rev-prefix = "v";
   };


### PR DESCRIPTION
https://github.com/mate-desktop/mate-terminal/compare/v1.28.1...v1.28.2



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
