### PR TITLE
ci/eval/compare/maintainers: Handle nonexistent attribute in changedByNameAttrPaths

### DIFF
--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -96,6 +96,8 @@ let
     (lib.filter (path: lib.length path > 3))
     (map (path: lib.elemAt path 3))
     (map lib.singleton)
+    # Filter out new packages
+    (lib.filter (attrPath: lib.hasAttrByPath attrPath pkgs))
   ];
 
   # An attribute can appear in affected *and* touched

--- a/ci/eval/compare/test.nix
+++ b/ci/eval/compare/test.nix
@@ -138,6 +138,21 @@ let
         ];
       };
     };
+    testByNameNonExistentChanged = {
+      expr = fun {
+        pkgs = mockPkgs {
+          packages = [ ];
+        };
+        # Happens when a new package was added to pkgs/by-name
+        changedFiles = [ "pkgs/by-name/he/hello/sources.json" ];
+        affectedAttrPaths = [ ];
+      };
+      expected = {
+        packages = [ ];
+        teams = { };
+        users = { };
+      };
+    };
     testByNameReadmeChanged = {
       expr = fun {
         pkgs = mockPkgs {


### PR DESCRIPTION
Fixes #499751

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [X] `ci/eval/compare/test.nix` including new test
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
