### PR TITLE
email-oauth2-proxy: init at 2025-10-04

### DIFF
--- a/pkgs/by-name/em/email-oauth2-proxy/package.nix
+++ b/pkgs/by-name/em/email-oauth2-proxy/package.nix
@@ -1,0 +1,42 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "email-oauth2-proxy";
+  version = "2025-10-04";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "simonrob";
+    repo = "email-oauth2-proxy";
+    tag = version;
+    hash = "sha256-ZWacjTO+2xeZv8lwcU5tFYsF61p7hduPQB1iOCSdeS4=";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+  dependencies = with python3Packages; [
+    cryptography
+    prompt-toolkit
+    pyasyncore
+    pyjwt
+    # GUI dependencies
+    packaging
+    pillow
+    pystray
+    pywebview
+    timeago
+  ];
+
+  pythonImportsCheck = [ "emailproxy" ];
+
+  meta = {
+    changelog = "https://github.com/simonrob/email-oauth2-proxy/releases/tag/${version}";
+    mainProgram = "emailproxy";
+    maintainers = with lib.maintainers; [ xddxdd ];
+    description = "IMAP/POP/SMTP proxy that transparently adds OAuth 2.0 authentication for email clients";
+    homepage = "https://github.com/simonrob/email-oauth2-proxy";
+    license = with lib.licenses; [ asl20 ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
