### PR TITLE
cvc5: 1.3.2 → 1.3.3; libpoly: 0.2.0 → 0.2.1

### DIFF
--- a/pkgs/by-name/cv/cvc5/package.nix
+++ b/pkgs/by-name/cv/cvc5/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cvc5";
-  version = "1.3.2";
+  version = "1.3.3";
 
   src = fetchFromGitHub {
     owner = "cvc5";
     repo = "cvc5";
     tag = "cvc5-${finalAttrs.version}";
-    hash = "sha256-Um1x+XgQ5yWSoqtx1ZWbVAnNET2C4GVasIbn0eNfico=";
+    hash = "sha256-tXhOMrf/sZwEZFWB2Amp9lApWEsfuPqaj9H7RmI733o=";
   };
 
   __structuredAttrs = true;

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -13,6 +13,7 @@
   vampire,
   eprover-ho,
   cvc5,
+  libpoly,
   csdp,
   rlwrap,
   perl,
@@ -102,15 +103,22 @@ let
     '';
   };
 
-  cvc5' = cvc5.overrideAttrs {
-    version = "1.2.0";
-    src = fetchFromGitHub {
-      owner = "cvc5";
-      repo = "cvc5";
-      tag = "cvc5-1.2.0";
-      hash = "sha256-Um1x+XgQ5yWSoqtx1ZWbVAnNET2C4GVasIbn0eNfico=";
-    };
-  };
+  cvc5' =
+    (cvc5.override {
+      libpoly = libpoly.overrideAttrs {
+        version = "0.2.0";
+        __intentionallyOverridingVersion = true;
+      };
+    }).overrideAttrs
+      {
+        version = "1.2.0";
+        src = fetchFromGitHub {
+          owner = "cvc5";
+          repo = "cvc5";
+          tag = "cvc5-1.2.0";
+          hash = "sha256-Um1x+XgQ5yWSoqtx1ZWbVAnNET2C4GVasIbn0eNfico=";
+        };
+      };
 
 in
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/li/libpoly/package.nix
+++ b/pkgs/by-name/li/libpoly/package.nix
@@ -9,14 +9,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libpoly";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "SRI-CSL";
     repo = "libpoly";
     # they've pushed to the release branch, use explicit tag
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-gE2O1YfiVab/aIqheoMP8GhE+N3yho7kb5EP56pzjW8=";
+    hash =
+      {
+        "0.2.1" = "sha256-uDWDio+RzJrgGKbWfT6S6voaJrJR0PzPfyr+33dr0ds=";
+        "0.2.0" = "sha256-gE2O1YfiVab/aIqheoMP8GhE+N3yho7kb5EP56pzjW8=";
+      }
+      ."${finalAttrs.version}";
   };
 
   postPatch = ''
@@ -24,11 +29,13 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-warn " -Werror " " "
   '';
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    python3
+  ];
 
   buildInputs = [
     gmp
-    python3
   ];
 
   strictDeps = true;


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
