### PR TITLE
gui-for-singbox: 1.19.0 -> 1.21.0

### DIFF
--- a/pkgs/by-name/gu/gui-for-singbox/package.nix
+++ b/pkgs/by-name/gu/gui-for-singbox/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  buildGoModule,
+  buildGo126Module,
   fetchFromGitHub,
   autoPatchelfHook,
   copyDesktopItems,
@@ -18,13 +18,13 @@
 
 let
   pname = "gui-for-singbox";
-  version = "1.19.0";
+  version = "1.21.0";
 
   src = fetchFromGitHub {
     owner = "GUI-for-Cores";
     repo = "GUI.for.SingBox";
     tag = "v${version}";
-    hash = "sha256-CY5i5+ObqPVCPiqHLttjxhMOi9fiHp5HWX33fq43txw=";
+    hash = "sha256-IGsH8QHoj2CvrSEc9eIisxySXQkjPSDBXsCPOXqANVM=";
   };
 
   metaCommon = {
@@ -54,7 +54,7 @@ let
         ;
       pnpm = pnpm_10;
       fetcherVersion = 2;
-      hash = "sha256-AHGPAYw/6FRKO2FY1J84NrLcp+bZOclOF6UFY61npFI=";
+      hash = "sha256-dWqwEnXPT+5N+36szm4AF1ChM9M6UJltct+EtQAofGQ=";
     };
 
     buildPhase = ''
@@ -80,7 +80,7 @@ let
   });
 in
 
-buildGoModule {
+buildGo126Module {
   inherit pname version src;
 
   patches = [ ./xdg-path-and-restart-patch.patch ];
@@ -91,7 +91,7 @@ buildGoModule {
       --subst-var out
   '';
 
-  vendorHash = "sha256-xQ6TeVoBe8906+/5X1q4e5QHVo+KHymB+yoxM+Obk18=";
+  vendorHash = "sha256-EeIxt0BzSaZh1F38btUXN9kAvj12nlqEerVgWVGkiuk=";
 
   nativeBuildInputs = [
     autoPatchelfHook

--- a/pkgs/by-name/gu/gui-for-singbox/xdg-path-and-restart-patch.patch
+++ b/pkgs/by-name/gu/gui-for-singbox/xdg-path-and-restart-patch.patch
@@ -1,27 +1,9 @@
 --- a/bridge/bridge.go
 +++ b/bridge/bridge.go
-@@ -55,9 +55,14 @@ func CreateApp(fs embed.FS) *App {
- 
- 	app := NewApp()
- 
--	if Env.OS == "darwin" {
--		createMacOSSymlink()
--		createMacOSMenus(app)
-+	if Env.OS == "linux" || Env.OS == "darwin" {
-+		userConfigDir, err := os.UserConfigDir()
-+		if err == nil {
-+			targetPath := filepath.Join(userConfigDir, Env.AppName)
-+			if err := os.MkdirAll(targetPath, 0755); err == nil {
-+				Env.BasePath = targetPath
-+			}
-+		}
- 	}
- 
- 	if Env.OS == "windows" {
-@@ -80,7 +85,10 @@ func (a *App) IsStartup() bool {
- }
+@@ -93,7 +93,10 @@
  
  func (a *App) RestartApp() FlagResult {
+ 	log.Printf("RestartApp")
 -	exePath := Env.BasePath + "/" + Env.AppName
 +	exePath, err := os.Executable()
 +	if err != nil {


### PR DESCRIPTION
Update gui-for-singbox from 1.19.0 to 1.21.0.

Changelog: https://github.com/GUI-for-Cores/GUI.for.SingBox/releases/tag/v1.21.0

Changes required beyond version bump:
- Updated `vendorHash` and `pnpmDeps.hash` for new dependencies
- Updated `xdg-path-and-restart-patch.patch`: the XDG path hunk is no longer needed as upstream now uses `os.Executable()` to set `BasePath` in `CreateApp`; kept only the `RestartApp` hunk which still applies
- Added `go_1_26` as the build Go toolchain since `go.mod` now requires `go 1.26`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.