### PR TITLE
schemesh: init at 0.9.3

### DIFF
--- a/pkgs/by-name/sc/schemesh/package.nix
+++ b/pkgs/by-name/sc/schemesh/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  chez,
+  libuuid,
+  lz4,
+  ncurses,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "schemesh";
+  version = "0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "cosmos72";
+    repo = "schemesh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OhQpXFg3eroVpw4zkENM4zwqHqGNolstlq9oLhQ2cbY=";
+  };
+
+  buildInputs = [
+    chez
+    libuuid
+    lz4
+    ncurses
+    zlib
+  ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = {
+    description = "A Unix shell and Lisp REPL, fused together";
+    homepage = "https://github.com/cosmos72/schemesh";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.sikmir ];
+    platforms = lib.platforms.linux;
+    mainProgram = "schemesh";
+  };
+})


### PR DESCRIPTION
[Schemesh](https://github.com/cosmos72/schemesh) is an interactive shell scriptable in Lisp.

cc @NixOS/lisp

[![Packaging status](https://repology.org/badge/tiny-repos/schemesh.svg)](https://repology.org/project/schemesh/versions)

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
