### PR TITLE
buteo-syncfw: 0.11.10 -> 0.11.11

### DIFF
--- a/pkgs/by-name/bu/buteo-syncfw/package.nix
+++ b/pkgs/by-name/bu/buteo-syncfw/package.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "buteo-syncfw";
-  version = "0.11.10";
+  version = "0.11.11";
 
   outputs = [
     "out"
@@ -26,12 +26,12 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "sailfishos";
     repo = "buteo-syncfw";
     tag = finalAttrs.version;
-    hash = "sha256-WZ70dFrQeHO0c9MM3wS8aWMd0DDhTW9Ks4hhw7pPmu8=";
+    hash = "sha256-t69jUOTCyVWlbEinCesm8YVnYuT+SQ10z+2GXAtAPTA=";
   };
 
   postPatch = ''
     # Wildcard breaks file installation (tries to run ~ "install source/* target/*")
-    substituteInPlace doc/doc.pri \
+    substituteInPlace doc/doc.pro \
       --replace-fail 'htmldocs.files = $${PWD}/html/*' 'htmldocs.files = $${PWD}/html' \
       --replace-fail '/usr/share/doc' "$doc/share/doc"
 


### PR DESCRIPTION
https://github.com/sailfishos/buteo-syncfw/releases/tag/0.11.11

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
