### PR TITLE
nixos/zeronet: Update TOR settings

### DIFF
--- a/nixos/modules/services/networking/zeronet.nix
+++ b/nixos/modules/services/networking/zeronet.nix
@@ -96,13 +96,13 @@ with lib;
   config = mkIf cfg.enable {
     services.tor = mkIf cfg.tor {
       enable = true;
-      controlPort = 9051;
 
-      extraConfig = ''
-        CacheDirectoryGroupReadable 1
-        CookieAuthentication 1
-        CookieAuthFileGroupReadable 1
-      '';
+      settings = {
+        ControlPort = 9051;
+        CacheDirectoryGroupReadable = true;
+        CookieAuthentication = true;
+        CookieAuthFileGroupReadable = true;
+      };
     };
 
     systemd.services.zeronet = {


### PR DESCRIPTION
Previously, trying to enable `programs.zeronet.tor = true;` would result in 

```       error:
       Failed assertions:
       - The option definition `services.tor.extraConfig' in `/nix/store/4baj17vw5xfkwqjc1c9lyyw5l83wpyir-source/nixos/modules/services/networking/zeronet.nix' no longer has any effect; please remove it.
       Please use services.tor.settings instead.
```

This pull request fixes this. `nixos/modules/services/networking/zeronet.nix` is updated to use `services.tor.settings` instead.

I haven't rebuilt my system against this `nixpkgs` as a whole, but i've tested the code snippet i contributed and have verified
- It doesn't throw any nix errors anymore
- It configures TOR as the module intended
```
~> cat  /nix/store/q1ay8z3f849sw5jzbw41ghaasswm95vz-torrc
AutomapHostsSuffixes .onion,.exit
BridgeRelay 0
CacheDirectoryGroupReadable 1
ControlPort 9051
CookieAuthFileGroupReadable 1
CookieAuthentication 1
DataDirectory /var/lib/tor
ExitPolicy reject *:*
GeoIPFile /nix/store/9kznw3llvm1gxpzqwzh2b75fcmcd563y-tor-0.4.9.5-geoip/share/tor/geoip
GeoIPv6File /nix/store/9kznw3llvm1gxpzqwzh2b75fcmcd563y-tor-0.4.9.5-geoip/share/tor/geoip6
PublishServerDescriptor 0
SOCKSPort 0
ShutdownWaitLength 30
```

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
