### PR TITLE
python3Packages.sentence-transformers: 5.2.3 -> 5.3.0

### DIFF
--- a/pkgs/development/python-modules/sentence-transformers/default.nix
+++ b/pkgs/development/python-modules/sentence-transformers/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "sentence-transformers";
-  version = "5.2.3";
+  version = "5.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "sentence-transformers";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-btbyPSsRAltd/hz5wFx70IKqn72e4VImaSgsqiFzTpM=";
+    hash = "sha256-xf5ujZH7OH81ofavytI/Zd0PCkRf6rIoXzWI9kUjoDE=";
   };
 
   build-system = [ setuptools ];
@@ -100,7 +100,9 @@ buildPythonPackage (finalAttrs: {
     "test_mse_loss_matryoshka"
     "test_nanobeir_evaluator"
     "test_negative_dimension_raises_error"
+    "test_pairwise_angle_sim_even_and_odd_sparse_embeddings"
     "test_paraphrase_mining"
+    "test_pooling_prompt_attention_mask_respects_include_prompt"
     "test_pretrained_model"
     "test_router_as_middle_module"
     "test_router_backwards_compatibility"
@@ -151,14 +153,17 @@ buildPythonPackage (finalAttrs: {
   disabledTestPaths = [
     # Tests require network access
     "tests/cross_encoder/test_cross_encoder.py"
+    "tests/cross_encoder/test_model_card.py"
     "tests/cross_encoder/test_train_stsb.py"
     "tests/evaluation/test_information_retrieval_evaluator.py"
     "tests/sparse_encoder/models/test_csr.py"
     "tests/sparse_encoder/models/test_sparse_static_embedding.py"
+    "tests/sparse_encoder/test_model_card.py"
     "tests/sparse_encoder/test_opensearch_models.py"
     "tests/sparse_encoder/test_pretrained.py"
     "tests/sparse_encoder/test_sparse_encoder.py"
     "tests/test_compute_embeddings.py"
+    "tests/test_model_card.py"
     "tests/test_model_card_data.py"
     "tests/test_multi_process.py"
     "tests/test_pretrained_stsb.py"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/huggingface/sentence-transformers/compare/v5.2.3...v5.3.0
Changelog: https://github.com/huggingface/sentence-transformers/releases/tag/v5.3.0

cc @dit7ya

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test