### PR TITLE
grpc 1.78.0 -> 1.78.1

### DIFF
--- a/pkgs/by-name/gr/grpc/package.nix
+++ b/pkgs/by-name/gr/grpc/package.nix
@@ -25,7 +25,7 @@
 # nixpkgs-update: no auto update
 stdenv.mkDerivation (finalAttrs: {
   pname = "grpc";
-  version = "1.78.0"; # N.B: if you change this, please update:
+  version = "1.78.1"; # N.B: if you change this, please update:
   # pythonPackages.grpcio
   # pythonPackages.grpcio-channelz
   # pythonPackages.grpcio-health-checking
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "grpc";
     repo = "grpc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hupso9w++lYtAMoLS/qVmUYqZyQAX3rH0I8zCLyBo40=";
+    hash = "sha256-YgluQqrJj0NfrNqRjNkLISjEpEmXvjS5UmqAl3Xtf64=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/python-modules/grpcio-channelz/default.nix
+++ b/pkgs/development/python-modules/grpcio-channelz/default.nix
@@ -12,13 +12,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-channelz";
-  version = "1.78.0";
+  version = "1.78.1";
   pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_channelz";
     inherit version;
-    hash = "sha256-5E/gR414spB1xtJYuMUQdhnAZGXAE6sYSeW+9JOvFT4=";
+    hash = "sha256-OnUpauDkLIQsZQVeC45nZWtqAikIZUdPxGTxPKvp35Q=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/grpcio-health-checking/default.nix
+++ b/pkgs/development/python-modules/grpcio-health-checking/default.nix
@@ -11,13 +11,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-health-checking";
-  version = "1.78.0";
+  version = "1.78.1";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "grpcio_health_checking";
     inherit version;
-    hash = "sha256-eFJtXGC5uZ/RiVS4n4bXADPHAulq1szJdJuvFhNpebM=";
+    hash = "sha256-Vjy6PPp3auc5FT3ImxTd111J26MX+Cwj6vIOWzoB9VQ=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/grpcio-reflection/default.nix
+++ b/pkgs/development/python-modules/grpcio-reflection/default.nix
@@ -12,13 +12,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-reflection";
-  version = "1.78.0";
+  version = "1.78.1";
   pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_reflection";
     inherit version;
-    hash = "sha256-5uYMC4XbzfljtNTRUMDx0ji6iR2AW1dcUsA2XQf8DEA=";
+    hash = "sha256-IkwNYEIHlUkj/W+NvsVB4JdqZKsb5l0u5AhEzhbHYqs=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/grpcio-status/default.nix
+++ b/pkgs/development/python-modules/grpcio-status/default.nix
@@ -12,13 +12,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-status";
-  version = "1.78.0";
+  version = "1.78.1";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "grpcio_status";
     inherit version;
-    hash = "sha256-o0z9KBAb/qhLWqD5NrS0IwGekhOIKQcWavazvdxZ4Yk=";
+    hash = "sha256-R+f6kDVJxYgTRPHLojyBS19p0JIzVBA26yVkLTJJfI4=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/grpcio-testing/default.nix
+++ b/pkgs/development/python-modules/grpcio-testing/default.nix
@@ -12,13 +12,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-testing";
-  version = "1.78.0";
+  version = "1.78.1";
   pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_testing";
     inherit version;
-    hash = "sha256-BuQoB75GlJvciDOaA6cQ7AVbBta8ghy1ljZuUWWRU8w=";
+    hash = "sha256-2oIOIvOggc9AhFyRa+vwQDa4VmajHq7Y/e36T7qab2Y=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/grpcio-tools/default.nix
+++ b/pkgs/development/python-modules/grpcio-tools/default.nix
@@ -13,13 +13,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-tools";
-  version = "1.78.0";
+  version = "1.78.1";
   pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_tools";
     inherit version;
-    hash = "sha256-Sw3YZWAnQxbhVdklFYJ2+FZFCBkwiLxD4g0/Xf+Vays=";
+    hash = "sha256-9Ht0awapQJVLmqhrGCSqSHTwaKfsLUtAeYDSAshqaRo=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/grpcio/default.nix
+++ b/pkgs/development/python-modules/grpcio/default.nix
@@ -18,12 +18,12 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio";
-  version = "1.78.0";
+  version = "1.78.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-c4K5UYlUbzdcF09TpfqHPO+RxLgAX6oFzFs77qnE8cU=";
+    hash = "sha256-J8YlUy0zrORdV+d17fGYLhg/+GQccuTpHve6ZnoUnXI=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Updates grpc and its corresponding python packages.
Changelog: https://github.com/grpc/grpc/releases/tag/v1.78.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
