### PR TITLE
nixos-rebuild-ng: add support for `ssh-ng://`

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -206,17 +206,20 @@ def copy_closure(
             append_local_env=env,
         )
 
-    def nix_copy(to_host: Remote, from_host: Remote) -> None:
+    def nix_copy(to_host: Remote | None, from_host: Remote | None) -> None:
+        host_flags = []
+        if from_host is not None:
+            host_flags += ["--from", f"{from_host.store_type}://{from_host.host}"]
+        if to_host is not None:
+            host_flags += ["--to", f"{to_host.store_type}://{to_host.host}"]
+
         run_wrapper(
             [
                 "nix",
                 *FLAKE_FLAGS,
                 "copy",
                 *dict_to_flags(copy_flags),
-                "--from",
-                f"ssh://{from_host.host}",
-                "--to",
-                f"ssh://{to_host.host}",
+                *host_flags,
                 closure,
             ],
             append_local_env=env,
@@ -225,9 +228,12 @@ def copy_closure(
     match (to_host, from_host):
         case (x, y) if x == y:
             return
-        case (Remote(_) as host, None) | (None, Remote(_) as host):
+        # nix-copy-closure doesn't support store types other than "ssh".
+        case (Remote(_) as host, None) | (None, Remote(_) as host) if (
+            host.store_type == "ssh"
+        ):
             nix_copy_closure(host, to=bool(to_host))
-        case (Remote(_), Remote(_)):
+        case (Remote(_), _) | (_, Remote(_)):
             nix_copy(to_host, from_host)
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -46,6 +46,7 @@ class Remote:
     host: str
     opts: list[str]
     sudo_password: str | None
+    store_type: str
 
     @classmethod
     def from_arg(
@@ -57,13 +58,18 @@ class Remote:
         if not host:
             return None
 
+        try:
+            store_type, host = host.split("://", 1)
+        except ValueError:
+            store_type = "ssh"
+
         opts = shlex.split(os.getenv("NIX_SSHOPTS", ""))
         if validate_opts:
             cls._validate_opts(opts, ask_sudo_password)
         sudo_password = None
         if ask_sudo_password:
             sudo_password = getpass.getpass(f"[sudo] password for {host}: ")
-        return cls(host, opts, sudo_password)
+        return cls(host, opts, sudo_password, store_type)
 
     @staticmethod
     def _validate_opts(opts: list[str], ask_sudo_password: bool | None) -> None:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -43,7 +43,7 @@ def test_flake_parse(mock_node: Mock, tmpdir: Path, monkeypatch: MonkeyPatch) ->
         autospec=True,
         return_value=subprocess.CompletedProcess([], 0, stdout="remote\n"),
     ):
-        target_host = m.Remote("target@remote", [], None)
+        target_host = m.Remote("target@remote", [], None, "ssh")
         assert m.Flake.parse("/path/to/flake", target_host) == m.Flake(
             "/path/to/flake", 'nixosConfigurations."remote"'
         )
@@ -162,9 +162,9 @@ def test_flake_from_arg(
             return_value=subprocess.CompletedProcess([], 0, "remote-hostname\n"),
         ),
     ):
-        assert m.Flake.from_arg("/path/to", m.Remote("user@host", [], None)) == m.Flake(
-            "/path/to", 'nixosConfigurations."remote-hostname"'
-        )
+        assert m.Flake.from_arg(
+            "/path/to", m.Remote("user@host", [], None, "ssh")
+        ) == m.Flake("/path/to", 'nixosConfigurations."remote-hostname"')
 
 
 @patch("pathlib.Path.mkdir", autospec=True)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -83,7 +83,7 @@ def test_build_flake(mock_run: Mock, monkeypatch: MonkeyPatch, tmpdir: Path) -> 
 def test_build_remote(
     mock_uuid4: Mock, mock_run: Mock, monkeypatch: MonkeyPatch
 ) -> None:
-    build_host = m.Remote("user@host", [], None)
+    build_host = m.Remote("user@host", [], None, "ssh")
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
 
     def run_wrapper_side_effect(
@@ -177,7 +177,7 @@ def test_build_remote_flake(
 ) -> None:
     monkeypatch.chdir(tmpdir)
     flake = m.Flake.parse("/flake.nix#hostname")
-    build_host = m.Remote("user@host", [], None)
+    build_host = m.Remote("user@host", [], None, "ssh")
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
 
     assert n.build_remote_flake(
@@ -237,12 +237,28 @@ def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
         n.copy_closure(closure, None)
         mock_run.assert_not_called()
 
-    target_host = m.Remote("user@target.host", [], None)
-    build_host = m.Remote("user@build.host", [], None)
+    target_host = m.Remote("user@target.host", [], None, "ssh")
+    build_host = m.Remote("user@build.host", [], None, "ssh")
+    target_host_ng = m.Remote("user@target.host", [], None, "ssh-ng")
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.copy_closure(closure, target_host)
         mock_run.assert_called_with(
             ["nix-copy-closure", "--to", "user@target.host", closure],
+            append_local_env={"NIX_SSHOPTS": " ".join(p.SSH_DEFAULT_OPTS)},
+        )
+
+    with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
+        n.copy_closure(closure, target_host_ng)
+        mock_run.assert_called_with(
+            [
+                "nix",
+                "--extra-experimental-features",
+                "nix-command flakes",
+                "copy",
+                "--to",
+                "ssh-ng://user@target.host",
+                closure,
+            ],
             append_local_env={"NIX_SSHOPTS": " ".join(p.SSH_DEFAULT_OPTS)},
         )
 
@@ -518,7 +534,7 @@ def test_get_generations_from_nix_env(tmp_path: Path) -> None:
             sudo=False,
         )
 
-    remote = m.Remote("user@host", [], "password")
+    remote = m.Remote("user@host", [], "password", "ssh")
     with patch(
         get_qualified_name(n.run_wrapper, n), autospec=True, return_value=return_value
     ) as mock_run:
@@ -580,7 +596,6 @@ def test_list_generations(mock_get_generations: Mock, tmp_path: Path) -> None:
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_diff_closures(mock_run: Mock) -> None:
-
     n.diff_closures(
         Path("/run/current-system"), Path("/nix/var/nix/profiles/system"), None
     )
@@ -632,7 +647,7 @@ def test_rollback(mock_run: Mock, tmp_path: Path) -> None:
         sudo=False,
     )
 
-    target_host = m.Remote("user@localhost", [], None)
+    target_host = m.Remote("user@localhost", [], None, "ssh")
     assert n.rollback(profile, target_host, True) == profile.path
     mock_run.assert_called_with(
         ["nix-env", "--rollback", "-p", path],
@@ -672,7 +687,7 @@ def test_rollback_temporary_profile(tmp_path: Path) -> None:
             sudo=False,
         )
 
-        target_host = m.Remote("user@localhost", [], None)
+        target_host = m.Remote("user@localhost", [], None, "ssh")
         assert (
             n.rollback_temporary_profile(m.Profile("foo", path), target_host, True)
             == path.parent / "foo-2083-link"
@@ -770,7 +785,7 @@ def test_switch_to_configuration_without_systemd_run(
         == "error: '--specialisation' can only be used with 'switch' and 'test'"
     )
 
-    target_host = m.Remote("user@localhost", [], None)
+    target_host = m.Remote("user@localhost", [], None, "ssh")
     with monkeypatch.context() as mp:
         mp.setenv("LOCALE_ARCHIVE", "/path/to/locale")
         mp.setenv("PATH", "/path/to/bin")
@@ -833,7 +848,7 @@ def test_switch_to_configuration_with_systemd_run(
         remote=None,
     )
 
-    target_host = m.Remote("user@localhost", [], None)
+    target_host = m.Remote("user@localhost", [], None, "ssh")
     with monkeypatch.context() as mp:
         mp.setenv("LOCALE_ARCHIVE", "/path/to/locale")
         mp.setenv("PATH", "/path/to/bin")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -112,7 +112,7 @@ def test_run_wrapper(mock_run: Any) -> None:
     p.run_wrapper(
         ["test", "--with", "some flags"],
         check=True,
-        remote=m.Remote("user@localhost", ["--ssh", "opt"], "password"),
+        remote=m.Remote("user@localhost", ["--ssh", "opt"], "password", "ssh"),
     )
     mock_run.assert_called_with(
         [
@@ -142,7 +142,7 @@ def test_run_wrapper(mock_run: Any) -> None:
         check=True,
         sudo=True,
         env={"FOO": "bar"},
-        remote=m.Remote("user@localhost", ["--ssh", "opt"], "password"),
+        remote=m.Remote("user@localhost", ["--ssh", "opt"], "password", "ssh"),
     )
     mock_run.assert_called_with(
         [
@@ -181,7 +181,7 @@ def test__kill_long_running_ssh_process(mock_run: Any) -> None:
             "build",
             "/nix/store/la0c8nmpr9xfclla0n4f3qq9iwgdrq4g-nixos-system-sankyuu-nixos-25.05.20250424.f771eb4.drv^*",
         ],
-        m.Remote("user@localhost", opts=[], sudo_password=None),
+        m.Remote("user@localhost", opts=[], sudo_password=None, store_type="ssh"),
     )
     mock_run.assert_called_with(
         [
@@ -208,6 +208,7 @@ def test_remote_from_name(monkeypatch: MonkeyPatch) -> None:
         "user@localhost",
         opts=[],
         sudo_password=None,
+        store_type="ssh",
     )
 
     with patch("getpass.getpass", autospec=True, return_value="password"):
@@ -216,11 +217,12 @@ def test_remote_from_name(monkeypatch: MonkeyPatch) -> None:
             "user@localhost",
             opts=["-f", "foo", "-b", "bar", "-t"],
             sudo_password="password",
+            store_type="ssh",
         )
 
 
 def test_ssh_host() -> None:
-    remotes = {
+    ssh_remotes = {
         "user@[fe80::1%25eth0]": "user@fe80::1%eth0",
         "[fe80::c98b%25enp4s0]": "fe80::c98b%enp4s0",
         "user@[2001::5fce:a:198]": "user@2001::5fce:a:198",
@@ -231,12 +233,23 @@ def test_ssh_host() -> None:
         "localhost": "localhost",
         "user@example.org": "user@example.org",
         "example.org": "example.org",
+        "ssh://explicit-store@localhost": "explicit-store@localhost",
+    }
+    ssh_ng_remotes = {
+        "ssh-ng://example.org": "example.org",
     }
 
-    for host_input, expected in remotes.items():
+    for host_input, expected in ssh_remotes.items():
         remote = m.Remote.from_arg(host_input, None, False)
         assert remote is not None
         assert remote.ssh_host() == expected
+        assert remote.store_type == "ssh"
+
+    for host_input, expected in ssh_ng_remotes.items():
+        remote = m.Remote.from_arg(host_input, None, False)
+        assert remote is not None
+        assert remote.ssh_host() == expected
+        assert remote.store_type == "ssh-ng"
 
 
 @patch("subprocess.run", autospec=True)
@@ -275,7 +288,7 @@ def test_custom_sudo_args(mock_run: Any) -> None:
             ["test"],
             check=False,
             sudo=True,
-            remote=m.Remote("user@localhost", [], None),
+            remote=m.Remote("user@localhost", [], None, "ssh"),
         )
     mock_run.assert_called_with(
         [


### PR DESCRIPTION
I've been playing around with using `nixos-rebuild-ng --build-host= --target-host=` to manage the configuration of a remote server. Unfortunately the server is on the other side of the world (with significant latency). Applying the configuration worked fine as long as I was just tweaking the settings, but as soon as I updated the pinned nixpkgs `nix-copy-closure` would keep churning for tens of minutes checking the presence of 2800 derivations on the remote server at a pace of a derivation every few seconds.

I looked around for possible solutions, and saw that there was an [experimental SSH store](https://nix.dev/manual/nix/2.24/store/types/experimental-ssh-store). I tried using it, with little success:

```
$ nixos-rebuild switch --sudo \
    --build-host=ssh-ng://user@server --target-host=ssh-ng://user@server \
    --use-substitutes --flake=.#server
[...]
error: invalid URL authority: 'ssh-ng//user@server': leftover
Command 'nix-copy-closure -s --to ssh-ng://user@server /nix/store/[...].drv' returned non-zero exit status 1.
```

After digging into this a bit more, it seems like `ssh-ng` is only supported with `nix copy`, not with `nix-copy-closure`, but even if I coerced `nixos-rebuild-ng` to use `nix copy` that wouldn't have worked, since it forces the `ssh://` store type.

This PR adds support for using `ssh-ng`. It tries to maintain the existing behavior as much as possible, and only when it detects a `ssh-ng` remote it forces the use of `nix copy` with the right store type. I used it to deploy to my server, and the `nix copy` took just a few seconds (rather than the infinite amount it took before).

This is my first contribution to `nixos-rebuild-ng`, so I'm not sure if the approach I took to fix this is the correct one. I'm happy to rework the PR however you all prefer! Also, I'm not sure why there is still the fallback to `nix-copy-closure`, but I'm probably missing something.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
