### PR TITLE
chromium,chromedriver: 146.0.7680.75 -> 146.0.7680.80

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "146.0.7680.75",
+    "version": "146.0.7680.80",
     "chromedriver": {
-      "version": "146.0.7680.76",
-      "hash_darwin": "sha256-zCICFkv0dXZYIIp8xnqEbxBR4Q9+GlCEY6yoJHsqcVg=",
-      "hash_darwin_aarch64": "sha256-UzawlFfX/lIATPL8j6XMkurE1SzhNwyB/jn4v6tWY/g="
+      "version": "146.0.7680.80",
+      "hash_darwin": "sha256-sjCEvFWV07GNhXJ9CfGVtZ6nCeqsqtNtY4sPj/gq13w=",
+      "hash_darwin_aarch64": "sha256-kTxZJiF7mJlVbkDDFP4ZUB2htBn45se1Wuz28RP8pr8="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "d865c3fe495882da3a7c6575337a02867c4536b1",
-        "hash": "sha256-/hjpcI4GTw0bGqZ5/9gzM4Pc6/5fhk5dmdtw5EfidiY=",
+        "rev": "f08938029c887ea624da7a1717059788ed95034d",
+        "hash": "sha256-PCQeTdc6Fl74TLyvxjli4scIUIm0GgZ3e9wbC18Tclw=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -652,8 +652,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "50841da4a7b7064b3cea8a851e60ef921c87a103",
-        "hash": "sha256-RoLgaE5mj9UqePhnfH+BOTit04TyiAvgF7/2PLuBG4Y="
+        "rev": "248acd90d9a35ac46b2ec30201ae50f301b8a173",
+        "hash": "sha256-zOL5j9X72ZvYmS8MzQ+pqSkT8AWBz2IwmaH7I3LN1IE="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/03/stable-channel-update-for-desktop_13.html

This update includes 1 security fix. Google is aware that an exploit for CVE-2026-3909 exists in the wild.

CVEs:
CVE-2026-3909

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
