### PR TITLE
net-cpp: 3.2.0 -> 3.2.1

### DIFF
--- a/pkgs/by-name/ne/net-cpp/package.nix
+++ b/pkgs/by-name/ne/net-cpp/package.nix
@@ -31,13 +31,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "net-cpp";
-  version = "3.2.0";
+  version = "3.2.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lib-cpp/net-cpp";
-    rev = finalAttrs.version;
-    hash = "sha256-JfVSAwBWtHw7a0CtY5C1xuxThO3FbS4MgNuIO1CGuts=";
+    tag = finalAttrs.version;
+    hash = "sha256-1rUPdN62u4eYtrXgoVaeSHro4gnAfFAl1brt+tE45oE=";
   };
 
   outputs = [
@@ -47,25 +47,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    # Remove when version > 3.2.0
+    # Remove when version > 3.2.1
     (fetchpatch {
-      name = "0001-net-cpp-fix-compatibility-with-Boost-1.88.patch";
-      url = "https://gitlab.com/ubports/development/core/lib-cpp/net-cpp/-/commit/9ff8651b11eb9dc0f64147001e10a57d1546a626.patch";
-      hash = "sha256-IEa3nhnv0oa5WmhIDG3OMrZmmoAZFeedAzKXAKVTIQg=";
+      name = "0001-net-cpp-Look-for-python3-executable-at-configure-time-instead-of-hardcoding-a-path.patch";
+      url = "https://gitlab.com/ubports/development/core/lib-cpp/net-cpp/-/commit/811da28f36f34cc2ea32dc96b2c65932d4f954b0.patch";
+      hash = "sha256-CC7fEuRNuf5TNEfhFJr9VLWFWfTnFtIvSTUoCcwGe68=";
     })
   ];
-
-  postPatch =
-    # https://gitlab.com/ubports/development/core/lib-cpp/net-cpp/-/merge_requests/22, too basic to bother with fetchpatch
-    ''
-      substituteInPlace src/CMakeLists.txt \
-        --replace-fail 'find_package(Boost COMPONENTS system' 'find_package(Boost COMPONENTS'
-    ''
-    + lib.optionalString finalAttrs.finalPackage.doCheck ''
-      # Use wrapped python. Removing just the /usr/bin doesn't seem to work?
-      substituteInPlace tests/httpbin.h.in \
-        --replace '/usr/bin/python3' '${lib.getExe pythonEnv}'
-    '';
 
   strictDeps = true;
 
@@ -107,7 +95,10 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelChecking = false;
 
   passthru = {
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
     updateScript = gitUpdater { };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
