### PR TITLE
persistent-cache-cpp: 1.0.9 -> 1.0.10

### DIFF
--- a/pkgs/by-name/pe/persistent-cache-cpp/package.nix
+++ b/pkgs/by-name/pe/persistent-cache-cpp/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   testers,
   boost,
@@ -18,28 +17,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "persistent-cache-cpp";
-  version = "1.0.9";
+  version = "1.0.10";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lib-cpp/persistent-cache-cpp";
-    rev = finalAttrs.version;
-    hash = "sha256-1ETr4b0HEJIM6a4ObtKWtxn0y4gQy9fzBjE4QhMPGqU=";
+    tag = finalAttrs.version;
+    hash = "sha256-siZb9D6ZGdKjlxJEgguPi9ZemWS0zY/7RwafWY6u67I=";
   };
 
   outputs = [
     "out"
     "dev"
     "doc"
-  ];
-
-  patches = [
-    # Remove when version > 1.0.9
-    (fetchpatch {
-      name = "0001-persistent-cache-cpp-Fix-compatibility-with-Boost-1.89.patch";
-      url = "https://gitlab.com/ubports/development/core/lib-cpp/persistent-cache-cpp/-/commit/121397b58bdb2d6750a41bec0cf1676e4e9b8cf5.patch";
-      hash = "sha256-QKPf5E49NNZ+rzCCknJNQjcd/bEgHuh23RBM892Xz1o=";
-    })
   ];
 
   postPatch = ''
@@ -86,7 +76,10 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   passthru = {
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
     updateScript = gitUpdater { };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
