### PR TITLE
pnpm-config-hook: propagate writableTmpDirAsHomeHook

### DIFF
--- a/pkgs/build-support/node/fetch-pnpm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-pnpm-deps/default.nix
@@ -7,6 +7,7 @@
   cacert,
   makeSetupHook,
   pnpm,
+  writableTmpDirAsHomeHook,
   yq,
   zstd,
 }:
@@ -198,6 +199,7 @@ in
   pnpmConfigHook = makeSetupHook {
     name = "pnpm-config-hook";
     propagatedBuildInputs = [
+      writableTmpDirAsHomeHook
       zstd
     ];
     substitutions = {

--- a/pkgs/build-support/node/fetch-pnpm-deps/pnpm-config-hook.sh
+++ b/pkgs/build-support/node/fetch-pnpm-deps/pnpm-config-hook.sh
@@ -25,7 +25,6 @@ pnpmConfigHook() {
 
     echo "Configuring pnpm store"
 
-    export HOME=$(mktemp -d)
     export STORE_PATH=$(mktemp -d)
     export npm_config_arch="@npmArch@"
     export npm_config_platform="@npmPlatform@"
@@ -41,7 +40,7 @@ pnpmConfigHook() {
 
     # If the packageManager field in package.json is set to a different pnpm version than what is in nixpkgs,
     # any pnpm command would fail in that directory, the following disables this
-    pushd ..
+    pushd $HOME
     pnpm config set manage-package-manager-versions false
     popd
 


### PR DESCRIPTION
This should bring this in line with other packages in nixpkgs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
