### PR TITLE
chatbox: enable native Wayland support

### DIFF
--- a/pkgs/by-name/ch/chatbox/package.nix
+++ b/pkgs/by-name/ch/chatbox/package.nix
@@ -14,9 +14,21 @@ let
   };
 
   appimageContents = appimageTools.extract { inherit pname version src; };
+
+  # Custom runScript to enable native Wayland support
+  runScript = writeScript "chatbox-run" ''
+    #!/bin/sh
+    if [ "''${NIXOS_OZONE_WL:-}" = "1" ] && [ -n "''${WAYLAND_DISPLAY:-}" ]; then
+      exec appimage-exec.sh -w ${appimageContents} -- --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=wayland "$@"
+    else
+      exec appimage-exec.sh -w ${appimageContents} -- "$@"
+    fi
+  '';
 in
 appimageTools.wrapType2 {
   inherit pname version src;
+
+  runScript = runScript;
 
   extraInstallCommands = ''
     install -m 444 -D ${appimageContents}/xyz.chatboxapp.app.desktop $out/share/applications/chatbox.desktop


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Continuation of #499464

Add custom runScript to enable native Wayland support via `NIXOS_OZONE_WL=1` environment variable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
