### PR TITLE
tiled: 1.11.2 -> 1.12.0

### DIFF
--- a/pkgs/applications/editors/tiled/default.nix
+++ b/pkgs/applications/editors/tiled/default.nix
@@ -28,14 +28,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tiled";
-  # nixpkgs-update: no auto update
-  version = "1.11.2";
+  version = "1.12.0";
 
   src = fetchFromGitHub {
     owner = "mapeditor";
     repo = "tiled";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-9oUKn51MQcsStgIJrp9XW5YAIpAUcO0kzfGnYA3gz/E=";
+    sha256 = "sha256-SDsz7IAxCJde21CIL9DrZMJkEim6syHD5kn9/dwpZXs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update tiled to 1.12.0. Release [blog post](https://www.mapeditor.org/2026/03/13/tiled-1-12-released.html) and [github release](https://github.com/mapeditor/tiled/releases/tag/v1.12.0).

Also enable auto-updates again, in the hope that the version bump will fix [the previous issue](https://github.com/NixOS/nixpkgs/pull/433572).

Note: Somewhat annoyingly, `nixpkgs-update` also refuses to run locally if auto-updates are disabled, and it lacks a `--force`-switch or similar to override. This is the main reason I think it would be nice to not have auto-updates disabled.

I'm happy to remove this again (aka keep auto-updates disabled).

I don't think this needs release notes, but can add them if you want.

Tagging @NickCao @wolfgangwalther and @ryan4yin from the last revert PR, and @dywedir who is also a package maintainer.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
