### PR TITLE
xonsh: clean up disabled tests

### DIFF
--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -63,7 +64,8 @@ buildPythonPackage rec {
     pytest-subprocess
     pytestCheckHook
     requests
-
+  ]
+  ++ lib.optionals (!stdenv.isDarwin) [
     # required by test_man_completion
     man
     util-linux
@@ -101,6 +103,15 @@ buildPythonPackage rec {
     # flaky tests in test_vc.py
     "test_vc_get_branch"
     "test_dirty_working_directory"
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    # fails on Darwin
+    "test_bash_and_is_alias_is_only_functional_alias"
+    "test_complete_command"
+    "test_man_completion"
+    "test_on_command_not_found_replacement"
+    "test_skipper_command"
+    "test_xonsh_lexer_no_win"
   ];
 
   # https://github.com/NixOS/nixpkgs/issues/248978

--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -19,6 +19,9 @@
   pytestCheckHook,
   requests,
 
+  man,
+  util-linux,
+
   coreutils,
 
   nix-update-script,
@@ -60,48 +63,44 @@ buildPythonPackage rec {
     pytest-subprocess
     pytestCheckHook
     requests
+
+    # required by test_man_completion
+    man
+    util-linux
   ];
 
   disabledTests = [
     # fails on sandbox
-    "test_bsd_man_page_completions"
     "test_colorize_file"
-    "test_loading_correctly"
-    "test_no_command_path_completion"
     "test_xonsh_activator"
 
-    # fails on non-interactive shells
-    "test_bash_and_is_alias_is_only_functional_alias"
-    "test_capture_always"
-    "test_casting"
-    "test_command_pipeline_capture"
-    "test_dirty_working_directory"
-    "test_man_completion"
-    "test_vc_get_branch"
-
-    # flaky tests
-    "test_alias_stability"
-    "test_alias_stability_exception"
-    "test_complete_import"
+    # flaky tests in test_integrations.py
     "test_script"
+    "test_catching_system_exit"
+    "test_catching_exit_signal"
+    "test_alias_stability"
+    "test_captured_subproc_is_not_affected_next_command"
+    "test_spec_decorator_alias"
+    "test_alias_stability_exception"
+
+    # flaky tests in test_python.py
+    "test_complete_import"
+
+    # flaky tests in test_pipelines.py
+    "test_command_pipeline_capture"
+    "test_remove_hide_escape"
+
+    # flaky tests in test_specs.py
+    "test_capture_always"
+    "test_callias_captured_redirect"
+    "test_interrupted_process_returncode"
+    "test_proc_raise_subproc_error"
+    "test_specs_with_suspended_captured_process_pipeline"
     "test_subproc_output_format"
 
-    # broken tests
-    "test_repath_backslash"
-
-    # https://github.com/xonsh/xonsh/issues/5569
-    "test_spec_decorator_alias_output_format"
-    "test_trace_in_script"
-  ];
-
-  disabledTestPaths = [
-    # fails on sandbox
-    "tests/completers/test_command_completers.py"
-    "tests/shell/test_ptk_highlight.py"
-
-    # fails on non-interactive shells
-    "tests/prompt/test_gitstatus.py"
-    "tests/completers/test_bash_completer.py"
+    # flaky tests in test_vc.py
+    "test_vc_get_branch"
+    "test_dirty_working_directory"
   ];
 
   # https://github.com/NixOS/nixpkgs/issues/248978


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Follow-up to upstream fix https://github.com/xonsh/xonsh/pull/6132

1. add test dependencies for test_man_completion
2. update list of flaky tests
3. re-enable non-flaky tests that no longer fails

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
