### PR TITLE
nixos/foot: move mkIf outside .source option

### DIFF
--- a/nixos/modules/programs/foot/default.nix
+++ b/nixos/modules/programs/foot/default.nix
@@ -75,13 +75,16 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    environment = {
-      systemPackages = [ cfg.package ];
-      etc."xdg/foot/foot.ini".source = settingsFormat.generate "foot.ini" cfg.settings;
-
-      etc."xdg/autostart/foot-server.desktop".source =
-        lib.mkIf cfg.xdg.serverAutostart "${cfg.package}/share/applications/foot-server.desktop";
-    };
+    environment = lib.mkMerge [
+      {
+        systemPackages = [ cfg.package ];
+        etc."xdg/foot/foot.ini".source = settingsFormat.generate "foot.ini" cfg.settings;
+      }
+      (lib.mkIf cfg.xdg.serverAutostart {
+        etc."xdg/autostart/foot-server.desktop".source =
+          "${cfg.package}/share/applications/foot-server.desktop";
+      })
+    ];
 
     programs = {
       foot.settings.main.include = lib.optionals (cfg.theme != null) [


### PR DESCRIPTION
Should resolve https://github.com/NixOS/nixpkgs/pull/493708#discussion_r2935397639


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
