### PR TITLE
monero: systemd service sandboxing configuration

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -164,6 +164,8 @@
     and the default changed to a UNIX domain socket.
   - A cookie-cutter nginx vhost can be enabled at [](#opt-services.netbox.nginx.enable).
 
+- The [monero](#opt-services.monero.enable) systemd service has been security hardened.
+
 - `security.run0.enableSudoAlias` now uses the `run0-sudo-shim` instead of a shell-script to improve compatibility.
 
 - With `system.etc.overlay.mutable = false`, NixOS now ships an empty `/etc/machine-id` in the image. Previously the file was absent and systemd logged `System cannot boot: Missing /etc/machine-id and /etc/ is read-only` while `ConditionFirstBoot` fired on every boot. With this change, systemd now overlays a transient ID from `/run/machine-id` for the session, and `systemd-machine-id-commit.service` has `ConditionFirstBoot` so it writes the machine-id through to a persistent backing file when one is bind-mounted over `/etc/machine-id`. To persist the machine-id across reboots, bind-mount a writable file containing `uninitialized` over `/etc/machine-id` from the initrd, or set `systemd.machine_id=` on the kernel command line (use `systemd.machine_id=firmware` to derive a stable ID on hardware that supports it).

--- a/nixos/modules/services/networking/monero.nix
+++ b/nixos/modules/services/networking/monero.nix
@@ -271,7 +271,7 @@ in
       group = "monero";
       description = "Monero daemon user";
       home = cfg.dataDir;
-      createHome = true;
+      createHome = !(lib.strings.hasPrefix "/var/lib/" cfg.dataDir);
     };
 
     users.groups.monero = { };
@@ -298,6 +298,34 @@ in
           0
           1
         ];
+        StateDirectory = lib.mkIf (lib.strings.hasPrefix "/var/lib/" cfg.dataDir) (
+          lib.strings.removePrefix "/var/lib/" cfg.dataDir
+        );
+        ReadWritePaths = lib.mkIf (!(lib.strings.hasPrefix "/var/lib/" cfg.dataDir)) [ cfg.dataDir ];
+        WorkingDirectory = "${cfg.dataDir}";
+        LockPersonality = lib.mkDefault true;
+        NoNewPrivileges = lib.mkDefault true;
+        PrivateDevices = lib.mkDefault true;
+        PrivateMounts = lib.mkDefault true;
+        PrivateNetwork = lib.mkDefault false;
+        PrivateTmp = lib.mkDefault true;
+        PrivateUsers = lib.mkDefault true;
+        ProcSubset = lib.mkDefault "pid";
+        ProtectClock = lib.mkDefault true;
+        ProtectHome = lib.mkDefault true;
+        ProtectHostname = lib.mkDefault true;
+        ProtectSystem = lib.mkDefault "strict";
+        ProtectControlGroups = lib.mkDefault true;
+        ProtectKernelLogs = lib.mkDefault true;
+        ProtectKernelModules = lib.mkDefault true;
+        ProtectKernelTunables = lib.mkDefault true;
+        ProtectProc = lib.mkDefault "invisible";
+        CapabilityBoundingSet = lib.mkDefault "";
+        RemoveIPC = lib.mkDefault true;
+        RestrictNamespaces = lib.mkDefault true;
+        RestrictRealtime = lib.mkDefault true;
+        RestrictSUIDSGID = lib.mkDefault true;
+        SystemCallFilter = "@system-service";
       };
     };
 

--- a/nixos/modules/services/networking/monero.nix
+++ b/nixos/modules/services/networking/monero.nix
@@ -271,7 +271,7 @@ in
       group = "monero";
       description = "Monero daemon user";
       home = cfg.dataDir;
-      createHome = true;
+      createHome = !(lib.strings.hasPrefix "/var/lib/" cfg.dataDir);
     };
 
     users.groups.monero = { };
@@ -297,6 +297,40 @@ in
         SuccessExitStatus = [
           0
           1
+        ];
+        StateDirectory = lib.mkIf (lib.strings.hasPrefix "/var/lib/" cfg.dataDir) (
+          lib.strings.removePrefix "/var/lib/" cfg.dataDir
+        );
+        ReadWritePaths = lib.mkIf (!(lib.strings.hasPrefix "/var/lib/" cfg.dataDir)) [ cfg.dataDir ];
+        WorkingDirectory = "${cfg.dataDir}";
+        LockPersonality = lib.mkDefault true;
+        NoNewPrivileges = lib.mkDefault true;
+        PrivateDevices = lib.mkDefault true;
+        PrivateMounts = lib.mkDefault true;
+        PrivateNetwork = lib.mkDefault false;
+        PrivateTmp = lib.mkDefault true;
+        PrivateUsers = lib.mkDefault true;
+        ProcSubset = lib.mkDefault "pid";
+        ProtectClock = lib.mkDefault true;
+        ProtectHome = lib.mkDefault true;
+        ProtectHostname = lib.mkDefault true;
+        ProtectSystem = lib.mkDefault "strict";
+        ProtectControlGroups = lib.mkDefault true;
+        ProtectKernelLogs = lib.mkDefault true;
+        ProtectKernelModules = lib.mkDefault true;
+        ProtectKernelTunables = lib.mkDefault true;
+        ProtectProc = lib.mkDefault "invisible";
+        CapabilityBoundingSet = lib.mkDefault "";
+        RemoveIPC = lib.mkDefault true;
+        RestrictNamespaces = lib.mkDefault true;
+        RestrictRealtime = lib.mkDefault true;
+        RestrictSUIDSGID = lib.mkDefault true;
+        SystemCallFilter = "@system-service";
+        UMask = "0077";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
         ];
       };
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Add systemd hardening configurations, e.g. `ProtectSystem=strict`, to `monero.service`
- When `services.monero.dataDir` is left to its default value of `/var/lib/monero`, set `users.users.monero.createHome` to `false` and instead have it created by systemd's `StateDirectory` mechanism.

<details>
<summary>
Note: it is preferable to use the <code>StateDirectory</code> feature of <a href="https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#Sandboxing">sytemd.exec</a>
</summary>
because it creates the directory when needed, lazily, sets the correct permissions on it, and ensures access from within the sandbox.
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
