### PR TITLE
gr-dect2: init at 0-unstable-2025-03-16

### DIFF
--- a/pkgs/by-name/gr/gr-dect2/package.nix
+++ b/pkgs/by-name/gr/gr-dect2/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gnuradio,
+  spdlog,
+  mpir,
+  boost,
+  volk,
+  python3Packages,
+  gmpxx,
+}:
+
+stdenv.mkDerivation {
+  pname = "gr-dect2";
+  version = "0-unstable-2025-03-16";
+
+  src = fetchFromGitHub {
+    owner = "pavelyazev";
+    repo = "gr-dect2";
+    rev = "0d973fe433eebfe3eee6e7f2eeb1322f8976ab42";
+    hash = "sha256-zb22toxkVeAeMm3PHRS8crZ1PejjkAhvCFgz30kiPzo=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    gnuradio
+    spdlog
+    mpir
+    boost
+    volk
+    python3Packages.pybind11
+    gmpxx
+    python3Packages.numpy
+  ];
+
+  meta = {
+    description = "Gnuradio module for real-time decoding of unencrypted DECT voice chnanels";
+    homepage = "https://github.com/pavelyazev/gr-dect2";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ felbinger ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
