### PR TITLE
cataclysm-dda: 0.H -> 0.H-2025-07-10-0402

### DIFF
--- a/pkgs/games/cataclysm-dda/common.nix
+++ b/pkgs/games/cataclysm-dda/common.nix
@@ -66,6 +66,9 @@ stdenv.mkDerivation {
     patchShebangs lang/compile_mo.sh
   '';
 
+  # remove once on O.I/ahead of upstream commit 15b3cb0
+  env.NIX_CFLAGS_COMPILE = optionalString stdenv.hostPlatform.isDarwin "-Wno-missing-noreturn";
+
   makeFlags = [
     "PREFIX=$(out)"
     "LANGUAGES=all"

--- a/pkgs/games/cataclysm-dda/stable.nix
+++ b/pkgs/games/cataclysm-dda/stable.nix
@@ -17,22 +17,17 @@ let
   };
 
   self = common.overrideAttrs (common: rec {
-    version = "0.H";
+    version = "0.H-2025-07-10-0402";
 
     src = fetchFromGitHub {
       owner = "CleverRaven";
       repo = "Cataclysm-DDA";
-      tag = "${version}-RELEASE";
-      sha256 = "sha256-ZCD5qgqYSX7sS+Tc1oNYq9soYwNUUuWamY2uXfLjGoY=";
+      # Head of 0.H-branch
+      tag = "cdda-${version}";
+      sha256 = "sha256-r4cl8cij68WmQRfg+DHQIeDBIwhgwSre6kAUYZaCPR8=n";
     };
 
     patches = [
-      # fix compilation of the vendored flatbuffers under gcc14
-      (fetchpatch {
-        name = "fix-flatbuffers-with-gcc14";
-        url = "https://github.com/CleverRaven/Cataclysm-DDA/commit/1400b1018ff37196bd24ba4365bd50beb571ac14.patch";
-        hash = "sha256-H0jct6lSQxu48eOZ4f8HICxo89qX49Ksw+Xwwtp7iFM=";
-      })
       # Unconditionally look for translation files in $out/share/locale
       ./locale-path.patch
     ];


### PR DESCRIPTION
Instead of cherry picking backports ourselves in Nixpkgs, use upstream's branch `0.H-branch`, which is 0.H + relevant backports.

Upstream does not seem to do point releases out of the backports branch, but commits in it are tagged by their CI, so that is the tag we are using.

Resolves #499645.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
