### PR TITLE
qemu: Disable gnutls for userOnly for smaller binaries and work around link error

### DIFF
--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -178,12 +178,11 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals (!userOnly) [ dtc ];
 
-  # gnutls is required for crypto support (luks) in qemu-img
   buildInputs = [
     glib
-    gnutls
-    zlib
   ]
+  ++ lib.optionals (!userOnly) [ gnutls ]
+  ++ [ zlib ]
   ++ lib.optionals (!minimal) [
     dtc
     pixman
@@ -298,7 +297,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [
     "--disable-strip" # We'll strip ourselves after separating debug info.
-    "--enable-gnutls" # auto detection only works when building with --enable-system
+
+    # auto detection only works when building with --enable-system
+    # Disable gnutls when userOnly for smaller binaries and work around link error on statically linked aarch64:
+    #   relocation truncated to fit: R_AARCH64_LD64_GOTPAGE_LO15 against symbol `_nettle_aes256_decrypt_arm64' defined in .text section in .../lib/libnettle.a(aes256-decrypt-2.o)
+    # See https://github.com/NixOS/nixpkgs/issues/464805
+    (lib.enableFeature (!userOnly) "gnutls")
+
     (lib.enableFeature enableDocs "docs")
     (lib.enableFeature enableTools "tools")
     "--localstatedir=/var"


### PR DESCRIPTION
I honestly don't know why this is a problem, but apparently statically linking a "fat" nettle into qemu via gnutls is just too much on aarch64.

Since it worked before without gnutls, let's just disable it for userOnly for now. AFAICT it's just used for RNG which is really not worthwhile.

Works around #464805

`gnutls` not put next to `curl` to avoid excessive rebuilds. `buildInputs` list will be cleaned up in #500024

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux (`qemu-user` and `pkgsStatic.qemu-user`. If the other qemu stuff changed it means I messed something up)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
