### PR TITLE
nixos/systemd-networkd: align config with upstream

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -301,6 +301,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - Support for Bluetooth audio based on `bluez-alsa` has been added to the `hardware.alsa` module. It can be enabled with the new [enableBluetooth](#opt-hardware.alsa.enableBluetooth) option.
 
+- `systemd.network.*` has been updated to support all configuration options from upstream `networkd` version 259.
+
 - `services.openssh` now supports generating host SSH keys by setting `services.openssh.generateHostKeys = true` while leaving `services.openssh.enable` disabled.  This is particularly useful for systems that have no need of an SSH daemon but want SSH host keys for other purposes such as using agenix or sops-nix.
 
 - IPVLAN interfaces can now be configured through the `networking.ipvlans` option in the networking module.

--- a/nixos/lib/systemd-network-units.nix
+++ b/nixos/lib/systemd-network-units.nix
@@ -41,6 +41,14 @@ in
       [VLAN]
       ${attrsToSection def.vlanConfig}
     ''
+    + optionalString (def.macvlanConfig != { }) ''
+      [MACVLAN]
+      ${attrsToSection def.macvlanConfig}
+    ''
+    + optionalString (def.macvtapConfig != { }) ''
+      [MACVTAP]
+      ${attrsToSection def.macvtapConfig}
+    ''
     + optionalString (def.ipvlanConfig != { }) ''
       [IPVLAN]
       ${attrsToSection def.ipvlanConfig}
@@ -49,14 +57,50 @@ in
       [IPVTAP]
       ${attrsToSection def.ipvtapConfig}
     ''
-    + optionalString (def.macvlanConfig != { }) ''
-      [MACVLAN]
-      ${attrsToSection def.macvlanConfig}
-    ''
     + optionalString (def.vxlanConfig != { }) ''
       [VXLAN]
       ${attrsToSection def.vxlanConfig}
     ''
+    + optionalString (def.geneveConfig != { }) ''
+      [GENEVE]
+      ${attrsToSection def.geneveConfig}
+    ''
+    + optionalString (def.hsrConfig != { }) ''
+      [HSR]
+      ${attrsToSection def.hsrConfig}
+    ''
+    + optionalString (def.bareUDPConfig != { }) ''
+      [BareUDP]
+      ${attrsToSection def.bareUDPConfig}
+    ''
+    + optionalString (def.l2tpConfig != { }) ''
+      [L2TP]
+      ${attrsToSection def.l2tpConfig}
+    ''
+    + flip concatMapStrings def.l2tpSessions (x: ''
+      [L2TPSession]
+      ${attrsToSection x}
+    '')
+    + optionalString (def.macsecConfig != { }) ''
+      [MACsec]
+      ${attrsToSection def.macsecConfig}
+    ''
+    + optionalString (def.macsecConfig != { }) ''
+      [MACsec]
+      ${attrsToSection def.macsecConfig}
+    ''
+    + flip concatMapStrings def.macsecReceiveChannels (x: ''
+      [MACsecReceiveChannel]
+      ${attrsToSection x}
+    '')
+    + flip concatMapStrings def.macsecTransmitAssociations (x: ''
+      [MACsecTransmitAssociation]
+      ${attrsToSection x}
+    '')
+    + flip concatMapStrings def.macsecReceiveAssociations (x: ''
+      [MACsecReceiveAssociation]
+      ${attrsToSection x}
+    '')
     + optionalString (def.tunnelConfig != { }) ''
       [Tunnel]
       ${attrsToSection def.tunnelConfig}
@@ -69,6 +113,10 @@ in
       [Peer]
       ${attrsToSection def.peerConfig}
     ''
+    + optionalString (def.vxcanConfig != { }) ''
+      [VXCAN]
+      ${attrsToSection def.vxcanConfig}
+    ''
     + optionalString (def.tunConfig != { }) ''
       [Tun]
       ${attrsToSection def.tunConfig}
@@ -77,14 +125,6 @@ in
       [Tap]
       ${attrsToSection def.tapConfig}
     ''
-    + optionalString (def.l2tpConfig != { }) ''
-      [L2TP]
-      ${attrsToSection def.l2tpConfig}
-    ''
-    + flip concatMapStrings def.l2tpSessions (x: ''
-      [L2TPSession]
-      ${attrsToSection x}
-    '')
     + optionalString (def.wireguardConfig != { }) ''
       [WireGuard]
       ${attrsToSection def.wireguardConfig}
@@ -105,13 +145,17 @@ in
       [VRF]
       ${attrsToSection def.vrfConfig}
     ''
-    + optionalString (def.wlanConfig != { }) ''
-      [WLAN]
-      ${attrsToSection def.wlanConfig}
-    ''
     + optionalString (def.batmanAdvancedConfig != { }) ''
       [BatmanAdvanced]
       ${attrsToSection def.batmanAdvancedConfig}
+    ''
+    + optionalString (def.ipoibConfig != { }) ''
+      [IPoIB]
+      ${attrsToSection def.ipoibConfig}
+    ''
+    + optionalString (def.wlanConfig != { }) ''
+      [WLAN]
+      ${attrsToSection def.wlanConfig}
     ''
     + def.extraConfig;
 
@@ -121,6 +165,10 @@ in
     + optionalString (def.linkConfig != { }) ''
       [Link]
       ${attrsToSection def.linkConfig}
+    ''
+    + optionalString (def.sriovConfig != { }) ''
+      [SR-IOV]
+      ${attrsToSection def.sriovConfig}
     ''
     + ''
       [Network]
@@ -147,9 +195,6 @@ in
     + optionalString (def.vrf != [ ]) ''
       ${concatStringsSep "\n" (map (s: "VRF=${s}") def.vrf)}
     ''
-    + optionalString (def.vlan != [ ]) ''
-      ${concatStringsSep "\n" (map (s: "VLAN=${s}") def.vlan)}
-    ''
     + optionalString (def.macvlan != [ ]) ''
       ${concatStringsSep "\n" (map (s: "MACVLAN=${s}") def.macvlan)}
     ''
@@ -159,11 +204,14 @@ in
     + optionalString (def.macvtap != [ ]) ''
       ${concatStringsSep "\n" (map (s: "MACVTAP=${s}") def.macvtap)}
     ''
-    + optionalString (def.vxlan != [ ]) ''
-      ${concatStringsSep "\n" (map (s: "VXLAN=${s}") def.vxlan)}
-    ''
     + optionalString (def.tunnel != [ ]) ''
       ${concatStringsSep "\n" (map (s: "Tunnel=${s}") def.tunnel)}
+    ''
+    + optionalString (def.vlan != [ ]) ''
+      ${concatStringsSep "\n" (map (s: "VLAN=${s}") def.vlan)}
+    ''
+    + optionalString (def.vxlan != [ ]) ''
+      ${concatStringsSep "\n" (map (s: "VXLAN=${s}") def.vxlan)}
     ''
     + optionalString (def.xfrm != [ ]) ''
       ${concatStringsSep "\n" (map (s: "Xfrm=${s}") def.xfrm)}
@@ -173,8 +221,20 @@ in
       [Address]
       ${attrsToSection x}
     '')
+    + flip concatMapStrings def.neighbors (x: ''
+      [Neighbor]
+      ${attrsToSection x}
+    '')
+    + flip concatMapStrings def.ipv6AddressLabels (x: ''
+      [IPv6AddressLabel]
+      ${attrsToSection x}
+    '')
     + flip concatMapStrings def.routingPolicyRules (x: ''
       [RoutingPolicyRule]
+      ${attrsToSection x}
+    '')
+    + flip concatMapStrings def.nextHops (x: ''
+      [NextHop]
       ${attrsToSection x}
     '')
     + flip concatMapStrings def.routes (x: ''
@@ -201,14 +261,14 @@ in
       [DHCPServer]
       ${attrsToSection def.dhcpServerConfig}
     ''
+    + flip concatMapStrings def.dhcpServerStaticLeases (x: ''
+      [DHCPServerStaticLease]
+      ${attrsToSection x}
+    '')
     + optionalString (def.ipv6SendRAConfig != { }) ''
       [IPv6SendRA]
       ${attrsToSection def.ipv6SendRAConfig}
     ''
-    + flip concatMapStrings def.ipv6PREF64Prefixes (x: ''
-      [IPv6PREF64Prefix]
-      ${attrsToSection x}
-    '')
     + flip concatMapStrings def.ipv6Prefixes (x: ''
       [IPv6Prefix]
       ${attrsToSection x}
@@ -217,8 +277,8 @@ in
       [IPv6RoutePrefix]
       ${attrsToSection x}
     '')
-    + flip concatMapStrings def.dhcpServerStaticLeases (x: ''
-      [DHCPServerStaticLease]
+    + flip concatMapStrings def.ipv6PREF64Prefixes (x: ''
+      [IPv6PREF64Prefix]
       ${attrsToSection x}
     '')
     + optionalString (def.bridgeConfig != { }) ''
@@ -332,6 +392,14 @@ in
     + optionalString (def.hierarchyTokenBucketClassConfig != { }) ''
       [HierarchyTokenBucketClass]
       ${attrsToSection def.hierarchyTokenBucketClassConfig}
+    ''
+    + optionalString (def.classfulMultiQueueingConfig != { }) ''
+      [ClassfulMultiQueueing]
+      ${attrsToSection def.classfulMultiQueueingConfig}
+    ''
+    + optionalString (def.bandMultiQueueingConfig != { }) ''
+      [BandMultiQueueing]
+      ${attrsToSection def.bandMultiQueueingConfig}
     ''
     + optionalString (def.heavyHitterFilterConfig != { }) ''
       [HeavyHitterFilter]

--- a/nixos/modules/system/boot/networkd.nix
+++ b/nixos/modules/system/boot/networkd.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   utils,
   ...
 }:
@@ -10,6 +9,9 @@ with utils.systemdUtils.unitOptions;
 with utils.systemdUtils.lib;
 with utils.systemdUtils.network.units;
 with lib;
+
+# When updating this file please use the same ording of options/sections as
+# in the man pages / documentation. This makes future updates easier.
 
 let
 
@@ -24,9 +26,9 @@ let
           "ManageForeignRoutes"
           "ManageForeignNextHops"
           "RouteTable"
-          "IPv6PrivacyExtensions"
           "IPv4Forwarding"
           "IPv6Forwarding"
+          "IPv6PrivacyExtensions"
           "UseDomains"
         ])
         (assertValueOneOf "SpeedMeter" boolValues)
@@ -46,24 +48,52 @@ let
         (assertValueOneOf "UseDomains" (boolValues ++ [ "route" ]))
       ];
 
+      sectionIPv6AcceptRA = checkUnitConfig "IPv6AcceptRA" [
+        (assertOnlyFields [
+          "UseDomains"
+        ])
+        (assertValueOneOf "UseDomains" (boolValues ++ [ "route" ]))
+      ];
+
+      sectionIPv6AddressLabel = checkUnitConfig "IPv6AddressLabel" [
+        (assertOnlyFields [
+          "Name"
+          "Prefix"
+        ])
+        (assertHasField "Label")
+        (assertHasField "Prefix")
+        (assertRange "Label" 1 4294967295)
+      ];
+
       sectionDHCPv4 = checkUnitConfig "DHCPv4" [
         (assertOnlyFields [
           "ClientIdentifier"
           "DUIDType"
           "DUIDRawData"
+          "UseDomains"
         ])
         (assertValueOneOf "ClientIdentifier" [
           "mac"
           "duid"
           "duid-only"
         ])
+        (assertValueOneOf "UseDomains" (boolValues ++ [ "route" ]))
       ];
 
       sectionDHCPv6 = checkUnitConfig "DHCPv6" [
         (assertOnlyFields [
           "DUIDType"
           "DUIDRawData"
+          "UseDomains"
         ])
+        (assertValueOneOf "UseDomains" (boolValues ++ [ "route" ]))
+      ];
+
+      sectionDHCPServer = checkUnitConfig "DHCPServer" [
+        (assertOnlyFields [
+          "PersistLeases"
+        ])
+        (assertValueOneOf "PersistLeases" (boolValues ++ [ "runtime" ]))
       ];
     };
 
@@ -72,6 +102,9 @@ let
       sectionLink = checkUnitConfig "Link" [
         (assertOnlyFields [
           "Description"
+          "Property"
+          "ImportProperty"
+          "UnsetProperty"
           "Alias"
           "MACAddressPolicy"
           "MACAddress"
@@ -79,6 +112,9 @@ let
           "Name"
           "AlternativeNamesPolicy"
           "AlternativeName"
+          "TransmitQueues"
+          "ReceiveQueues"
+          "TransmitQueueLength"
           "MTUBytes"
           "BitsPerSecond"
           "Duplex"
@@ -100,6 +136,7 @@ let
           "ReceiveVLANCTAGHardwareAcceleration"
           "TransmitVLANCTAGHardwareAcceleration"
           "ReceiveVLANCTAGFilter"
+          "TransmitVLANSTAGHardwareAcceleration"
           "NTupleFilter"
           "ReceiveFCS"
           "ReceiveAll"
@@ -143,12 +180,6 @@ let
           "StatisticsBlockCoalesceSec"
           "MDI"
           "SR-IOVVirtualFunctions"
-          "ReceiveQueues"
-          "TransmitQueues"
-          "TransmitQueueLength"
-          "RxFlowControl"
-          "TxFlowControl"
-          "AutoNegotiationFlowControl"
         ])
         (assertValueOneOf "MACAddressPolicy" [
           "persistent"
@@ -156,6 +187,9 @@ let
           "none"
         ])
         (assertMacAddress "MACAddress")
+        (assertRange "ReceiveQueues" 1 16384)
+        (assertRange "TransmitQueues" 1 16384)
+        (assertRange "TransmitQueueLength" 1 4294967294)
         (assertByteFormat "MTUBytes")
         (assertByteFormat "BitsPerSecond")
         (assertValueOneOf "Duplex" [
@@ -184,11 +218,17 @@ let
         (assertValueOneOf "TCPSegmentationOffload" boolValues)
         (assertValueOneOf "TCP6SegmentationOffload" boolValues)
         (assertValueOneOf "GenericSegmentationOffload" boolValues)
+        (assertValueOneOf "PartialGenericSegmentationOffload" boolValues)
         (assertValueOneOf "GenericReceiveOffload" boolValues)
+        (assertValueOneOf "GenericReceiveOffloadHardware" boolValues)
         (assertValueOneOf "LargeReceiveOffload" boolValues)
-        (assertValueOneOf "RxFlowControl" boolValues)
-        (assertValueOneOf "TxFlowControl" boolValues)
-        (assertValueOneOf "AutoNegotiationFlowControl" boolValues)
+        (assertValueOneOf "ReceiveVLANCTAGHardwareAcceleration" boolValues)
+        (assertValueOneOf "TransmitVLANCTAGHardwareAcceleration" boolValues)
+        (assertValueOneOf "ReceiveVLANCTAGFilter" boolValues)
+        (assertValueOneOf "TransmitVLANSTAGHardwareAcceleration" boolValues)
+        (assertValueOneOf "NTupleFilter" boolValues)
+        (assertValueOneOf "ReceiveFCS" boolValues)
+        (assertValueOneOf "ReceiveAll" boolValues)
         (assertInt "RxChannels")
         (assertRange "RxChannels" 1 4294967295)
         (assertInt "TxChannels")
@@ -199,10 +239,79 @@ let
         (assertRange "CombinedChannels" 1 4294967295)
         (assertInt "RxBufferSize")
         (assertInt "TxBufferSize")
-        (assertRange "ReceiveQueues" 1 16384)
-        (assertRange "TransmitQueues" 1 16384)
-        (assertRange "TransmitQueueLength" 1 4294967294)
+        (assertRangeOrOneOf "RxBufferSize" 0 4294967295 [ "max" ])
+        (assertRangeOrOneOf "RxMiniBufferSize" 0 4294967295 [ "max" ])
+        (assertRangeOrOneOf "RxJumboBufferSize" 0 4294967295 [ "max" ])
+        (assertRangeOrOneOf "TxBufferSize" 0 4294967295 [ "max" ])
+        (assertValueOneOf "RxFlowControl" boolValues)
+        (assertValueOneOf "TxFlowControl" boolValues)
+        (assertValueOneOf "AutoNegotiationFlowControl" boolValues)
+        (assertRange "GenericSegmentOffloadMaxBytes" 1 65536)
+        (assertRange "GenericSegmentOffloadMaxSegments" 1 65536)
+        (assertValueOneOf "UseAdaptiveRxCoalesce" boolValues)
+        (assertValueOneOf "UseAdaptiveTxCoalesce" boolValues)
+        (assertInt "RxMaxCoalescedFrames")
+        (assertInt "RxMaxCoalescedIrqFrames")
+        (assertInt "RxMaxCoalescedLowFrames")
+        (assertInt "RxMaxCoalescedHighFrames")
+        (assertInt "TxMaxCoalescedFrames")
+        (assertInt "TxMaxCoalescedIrqFrames")
+        (assertInt "TxMaxCoalescedLowFrames")
+        (assertInt "TxMaxCoalescedHighFrames")
+        (assertInt "CoalescePacketRateLow")
+        (assertInt "CoalescePacketRateHigh")
+        (assertInt "CoalescePacketRateSampleIntervalSec")
+        (assertRange "StatisticsBlockCoalesceSec" 1 4294967295)
+        (assertValueOneOf "MDI" [
+          "straight"
+          "mdi"
+          "crossover"
+          "mdi-x"
+          "mdix"
+          "auto"
+        ])
+        (assertRange "SR-IOVVirtualFunctions" 0 2147483647)
       ];
+
+      sectionSR-IOV = checkUnitConfig "SR-IOV" [
+        (assertOnlyFields [
+          "VirtualFunction"
+          "VLANId"
+          "QualityOfService"
+          "VLANProtocol"
+          "MACSpoofCheck"
+          "QueryReceiveSideScaling"
+          "Trust"
+          "LinkState"
+          "MACAddress"
+        ])
+        (assertHasField "VirtualFunction")
+        (assertRange "VirtualFunction" 0 2147483646)
+        (assertRange "VLANId" 1 4095)
+        (assertRange "QualityOfService" 1 4294967294)
+        (assertValueOneOf "VLANProtocol" [
+          "802.1Q"
+          "802.1ad"
+        ])
+        (assertValueOneOf "MACSpoofCheck" boolValues)
+        (assertValueOneOf "QueryReceiveSideScaling" boolValues)
+        (assertValueOneOf "Trust" boolValues)
+        (assertValueOneOf "LinkState" (boolValues ++ [ "auto" ]))
+        (assertMacAddress "MACAddress")
+      ];
+
+      sectionEnergyEfficientEthernet = checkUnitConfig "EnergyEfficientEthernet" [
+        (assertOnlyFields [
+          "Enable"
+          "TxLowPowerIdle"
+          "TxLowPowerIdleSec"
+          "LinkMode"
+        ])
+        (assertValueOneOf "Enable" boolValues)
+        (assertValueOneOf "TxLowPowerIdle" boolValues)
+        (assertInt "TxLowPowerIdleSec")
+      ];
+
     };
 
     netdev =
@@ -221,6 +330,25 @@ let
           (assertValueOneOf "PacketInfo" boolValues)
           (assertValueOneOf "VNetHeader" boolValues)
           (assertValueOneOf "KeepCarrier" boolValues)
+        ];
+
+        # See https://www.freedesktop.org/software/systemd/man/latest/systemd.netdev.html#%5BMACVLAN%5D%20Section%20Options
+        macVlanVtapChecks = [
+          (assertOnlyFields [
+            "Mode"
+            "SourceMACAddress"
+            "BroadcastMulticastQueueLength"
+            "BroadcastQueueThreshold"
+          ])
+          (assertValueOneOf "Mode" [
+            "private"
+            "vepa"
+            "bridge"
+            "passthru"
+            "source"
+          ])
+          (assertRange "BroadcastMulticastQueueLength" 0 4294967294)
+          (assertRangeOrOneOf "BroadcastQueueThreshold" 0 2147483647 [ "no" ])
         ];
 
         # See https://www.freedesktop.org/software/systemd/man/latest/systemd.netdev.html#%5BIPVTAP%5D%20Section%20Options
@@ -277,19 +405,21 @@ let
             "vti6"
             "vxlan"
             "geneve"
+            "hsr"
             "l2tp"
             "macsec"
-            "wlan"
             "vrf"
             "vcan"
             "vxcan"
             "wireguard"
-            "netdevsim"
             "nlmon"
             "fou"
             "xfrm"
             "ifb"
+            "bareudp"
             "batadv"
+            "ipoib"
+            "wlan"
           ])
           (assertByteFormat "MTUBytes")
           (assertNetdevMacAddress "MACAddress")
@@ -310,6 +440,8 @@ let
             "VLANProtocol"
             "STP"
             "MulticastIGMPVersion"
+            "FDBMaxLearned"
+            "LinkLocalLearning"
           ])
           (assertInt "HelloTimeSec")
           (assertInt "MaxAgeSec")
@@ -330,6 +462,8 @@ let
             2
             3
           ])
+          (assertInt "FDBMaxLearned")
+          (assertValueOneOf "LinkLocalLearning" boolValues)
         ];
 
         sectionVLAN = checkUnitConfig "VLAN" [
@@ -355,21 +489,13 @@ let
           (assertValueOneOf "ReorderHeader" boolValues)
         ];
 
+        sectionMACVLAN = checkUnitConfig "MACVLAN" macVlanVtapChecks;
+
+        sectionMACVTAP = checkUnitConfig "MACVTAP" macVlanVtapChecks;
+
         sectionIPVLAN = checkUnitConfig "IPVLAN" ipVlanVtapChecks;
 
         sectionIPVTAP = checkUnitConfig "IPVTAP" ipVlanVtapChecks;
-
-        sectionMACVLAN = checkUnitConfig "MACVLAN" [
-          (assertOnlyFields [
-            "Mode"
-          ])
-          (assertValueOneOf "Mode" [
-            "private"
-            "vepa"
-            "bridge"
-            "passthru"
-          ])
-        ];
 
         sectionVXLAN = checkUnitConfig "VXLAN" [
           (assertOnlyFields [
@@ -398,9 +524,12 @@ let
             "FlowLabel"
             "IPDoNotFragment"
             "Independent"
+            "External"
+            "VNIFilter"
           ])
           (assertInt "VNI")
           (assertRange "VNI" 1 16777215)
+          (assertRange "TTL" 0 255)
           (assertValueOneOf "MacLearning" boolValues)
           (assertInt "MaximumFDBEntries")
           (assertValueOneOf "ReduceARPProxy" boolValues)
@@ -418,85 +547,64 @@ let
           (assertRange "FlowLabel" 0 1048575)
           (assertValueOneOf "IPDoNotFragment" (boolValues + [ "inherit" ]))
           (assertValueOneOf "Independent" boolValues)
+          (assertValueOneOf "External" boolValues)
+          (assertValueOneOf "VNIFilter" boolValues)
         ];
 
-        sectionTunnel = checkUnitConfig "Tunnel" [
+        sectionGENEVE = checkUnitConfig "GENEVE" [
           (assertOnlyFields [
-            "Local"
+            "Id"
             "Remote"
             "TOS"
             "TTL"
-            "DiscoverPathMTU"
-            "IgnoreDontFragment"
-            "IPv6FlowLabel"
-            "CopyDSCP"
-            "EncapsulationLimit"
-            "Key"
-            "InputKey"
-            "OutputKey"
-            "Mode"
-            "Independent"
-            "AssignToLoopback"
-            "AllowLocalRemote"
-            "FooOverUDP"
-            "FOUDestinationPort"
-            "FOUSourcePort"
-            "Encapsulation"
-            "IPv6RapidDeploymentPrefix"
-            "ISATAP"
-            "SerializeTunneledPackets"
-            "ERSPANIndex"
+            "UDPChecksum"
+            "UDP6ZeroChecksumTx"
+            "UDP6ZeroChecksumRx"
+            "DestinationPort"
+            "FlowLabel"
+            "IPDoNotFragment"
+            "InheritInnerProtocol"
           ])
-          (assertInt "TTL")
+          (assertInt "Id")
+          (assertRange "Id" 0 16777215)
+          (assertRange "TOS" 0 255)
           (assertRange "TTL" 0 255)
-          (assertValueOneOf "DiscoverPathMTU" boolValues)
-          (assertValueOneOf "IgnoreDontFragment" boolValues)
-          (assertValueOneOf "CopyDSCP" boolValues)
-          (assertValueOneOf "Mode" [
-            "ip6ip6"
-            "ipip6"
-            "any"
-          ])
-          (assertValueOneOf "Independent" boolValues)
-          (assertValueOneOf "AssignToLoopback" boolValues)
-          (assertValueOneOf "AllowLocalRemote" boolValues)
-          (assertValueOneOf "FooOverUDP" boolValues)
-          (assertPort "FOUDestinationPort")
-          (assertPort "FOUSourcePort")
-          (assertValueOneOf "Encapsulation" [
-            "FooOverUDP"
-            "GenericUDPEncapsulation"
-          ])
-          (assertValueOneOf "ISATAP" boolValues)
-          (assertValueOneOf "SerializeTunneledPackets" boolValues)
-          (assertInt "ERSPANIndex")
-          (assertRange "ERSPANIndex" 1 1048575)
+          (assertValueOneOf "UDPChecksum" boolValues)
+          (assertValueOneOf "UDP6ZeroChecksumTx" boolValues)
+          (assertValueOneOf "UDP6ZeroChecksumRx" boolValues)
+          (assertPort "DestinationPort")
+          (assertValueOneOf "IPDoNotFragment" (boolValues + [ "inherit" ]))
+          (assertValueOneOf "InheritInnerProtocol" boolValues)
         ];
 
-        sectionFooOverUDP = checkUnitConfig "FooOverUDP" [
+        sectionHSR = checkUnitConfig "GENEVE" [
           (assertOnlyFields [
-            "Port"
-            "Encapsulation"
+            "Ports"
             "Protocol"
+            "Supervision"
           ])
-          (assertPort "Port")
-          (assertValueOneOf "Encapsulation" [
-            "FooOverUDP"
-            "GenericUDPEncapsulation"
+          (assertValueOneOf "Protocol" [
+            "hsr"
+            "prp"
           ])
+          (assertRange "Supervision" 0 255)
         ];
 
-        sectionPeer = checkUnitConfig "Peer" [
+        sectionBareUDP = checkUnitConfig "BareUDP" [
           (assertOnlyFields [
-            "Name"
-            "MACAddress"
+            "DestinationPort"
+            "EtherType"
+            "MinSourcePort"
           ])
-          (assertMacAddress "MACAddress")
+          (assertPort "DestinationPort")
+          (assertValueOneOf "EtherType" [
+            "ipv4"
+            "ipv6"
+            "mpls-uc"
+            "mpls-mc"
+          ])
+          (assertRange "MinSourcePort" 1 65535)
         ];
-
-        sectionTun = checkUnitConfig "Tun" tunChecks;
-
-        sectionTap = checkUnitConfig "Tap" tunChecks;
 
         sectionL2TP = checkUnitConfig "L2TP" [
           (assertOnlyFields [
@@ -546,6 +654,157 @@ let
           ])
         ];
 
+        sectionMACsec = checkUnitConfig "MACsec" [
+          (assertOnlyFields [
+            "Port"
+            "Encrypt"
+          ])
+          (assertRange "Port" 1 65535)
+          (assertValueOneOf "Encrypt" boolValues)
+        ];
+
+        sectionMACsecReceiveChannel = checkUnitConfig "MACsecReceiveChannel" [
+          (assertOnlyFields [
+            "Port"
+            "MACAddress"
+          ])
+          (assertRange "Port" 1 65535)
+          (assertMacAddress "MACAddress")
+          (assertHasField "Port")
+          (assertHasField "MACAddress")
+        ];
+
+        sectionMACsecTransmitAssociation = checkUnitConfig "MACsecTransmitAssociation" [
+          (assertOnlyFields [
+            "PacketNumber"
+            "KeyId"
+            "Key"
+            "KeyFile"
+            "Activate"
+            "UseForEncoding"
+          ])
+          (assertRange "PacketNumber" 1 4294967295)
+          (assertRange "KeyId" 0 255)
+          (assertValueOneOf "Activate" boolValues)
+          (assertValueOneOf "UseForEncoding" boolValues)
+        ];
+
+        sectionMACsecReceiveAssociation = checkUnitConfig "MACsecReceiveAssociation" [
+          (assertOnlyFields [
+            "Port"
+            "MACAddress"
+            "PacketNumber"
+            "KeyId"
+            "Key"
+            "KeyFile"
+            "Activate"
+          ])
+          (assertRange "Port" 1 65535)
+          (assertMacAddress "MACAddress")
+          (assertRange "PacketNumber" 1 4294967295)
+          (assertRange "KeyId" 0 255)
+          (assertValueOneOf "Activate" boolValues)
+        ];
+
+        sectionTunnel = checkUnitConfig "Tunnel" [
+          (assertOnlyFields [
+            "External"
+            "Local"
+            "Remote"
+            "TOS"
+            "TTL"
+            "DiscoverPathMTU"
+            "IgnoreDontFragment"
+            "IPv6FlowLabel"
+            "CopyDSCP"
+            "EncapsulationLimit"
+            "Key"
+            "InputKey"
+            "OutputKey"
+            "Mode"
+            "Independent"
+            "AssignToLoopback"
+            "AllowLocalRemote"
+            "FooOverUDP"
+            "FOUDestinationPort"
+            "FOUSourcePort"
+            "Encapsulation"
+            "IPv6RapidDeploymentPrefix"
+            "ISATAP"
+            "SerializeTunneledPackets"
+            "ERSPANVersion"
+            "ERSPANIndex"
+            "ERSPANDirection"
+            "ERSPANHardwareId"
+          ])
+          (assertValueOneOf "External" boolValues)
+          (assertInt "TTL")
+          (assertRange "TTL" 0 255)
+          (assertValueOneOf "DiscoverPathMTU" boolValues)
+          (assertValueOneOf "IgnoreDontFragment" boolValues)
+          (assertValueOneOf "CopyDSCP" boolValues)
+          (assertValueOneOf "Mode" [
+            "ip6ip6"
+            "ipip6"
+            "any"
+          ])
+          (assertValueOneOf "Independent" boolValues)
+          (assertValueOneOf "AssignToLoopback" boolValues)
+          (assertValueOneOf "AllowLocalRemote" boolValues)
+          (assertValueOneOf "FooOverUDP" boolValues)
+          (assertPort "FOUDestinationPort")
+          (assertPort "FOUSourcePort")
+          (assertValueOneOf "Encapsulation" [
+            "FooOverUDP"
+            "GenericUDPEncapsulation"
+          ])
+          (assertValueOneOf "ISATAP" boolValues)
+          (assertValueOneOf "SerializeTunneledPackets" boolValues)
+          (assertRange "ERSPANVersion" 0 2)
+          (assertInt "ERSPANIndex")
+          (assertRange "ERSPANIndex" 1 1048575)
+          (assertValueOneOf "ERSPANDirection" [
+            "ingress"
+            "egress"
+          ])
+          (assertRange "ERSPANHardwareId" 0 63)
+        ];
+
+        sectionFooOverUDP = checkUnitConfig "FooOverUDP" [
+          (assertOnlyFields [
+            "Encapsulation"
+            "Port"
+            "PeerPort"
+            "Protocol"
+            "Peer"
+            "Local"
+          ])
+          (assertPort "Port")
+          (assertValueOneOf "Encapsulation" [
+            "FooOverUDP"
+            "GenericUDPEncapsulation"
+          ])
+          (assertPort "PeerPort")
+        ];
+
+        sectionPeer = checkUnitConfig "Peer" [
+          (assertOnlyFields [
+            "Name"
+            "MACAddress"
+          ])
+          (assertMacAddress "MACAddress")
+        ];
+
+        sectionVXCAN = checkUnitConfig "VXCAN" [
+          (assertOnlyFields [
+            "Peer"
+          ])
+        ];
+
+        sectionTun = checkUnitConfig "Tun" tunChecks;
+
+        sectionTap = checkUnitConfig "Tap" tunChecks;
+
         # NOTE Check whether the key starts with an @, in which case it is
         # interpreted as the name of the credential from which the actual key
         # shall be read by systemd-creds.
@@ -591,6 +850,7 @@ let
             "TransmitHashPolicy"
             "LACPTransmitRate"
             "MIIMonitorSec"
+            "PeerNotifyDelaySec"
             "UpDelaySec"
             "DownDelaySec"
             "LearnPacketIntervalSec"
@@ -610,6 +870,7 @@ let
             "AllSlavesActive"
             "DynamicTransmitLoadBalancing"
             "MinLinks"
+            "ARPMissedMax"
           ])
           (assertValueOneOf "Mode" [
             "balance-rr"
@@ -631,6 +892,7 @@ let
             "slow"
             "fast"
           ])
+          (assertRange "PeerNotifyDelaySec" 0 300)
           (assertValueOneOf "AdSelect" [
             "stable"
             "bandwidth"
@@ -670,6 +932,8 @@ let
           (assertValueOneOf "DynamicTransmitLoadBalancing" boolValues)
           (assertInt "MinLinks")
           (assertMinimum "MinLinks" 0)
+          (assertInt "ARPMissedMax")
+          (assertMinimum "ARPMissedMax" 0)
         ];
 
         sectionXfrm = checkUnitConfig "Xfrm" [
@@ -688,30 +952,6 @@ let
           ])
           (assertInt "Table")
           (assertMinimum "Table" 0)
-        ];
-
-        sectionWLAN = checkUnitConfig "WLAN" [
-          (assertOnlyFields [
-            "PhysicalDevice" # systemd supports both strings ("phy0") and indexes (0) here.
-            "Type"
-            "WDS"
-          ])
-          # See https://github.com/systemd/systemd/blob/main/src/basic/linux/nl80211.h#L3382
-          (assertValueOneOf "Type" [
-            "ad-hoc"
-            "station"
-            "ap"
-            "ap-vlan"
-            "wds"
-            "monitor"
-            "mesh-point"
-            "p2p-client"
-            "p2p-go"
-            "p2p-device"
-            "ocb"
-            "nan"
-          ])
-          (assertValueOneOf "WDS" boolValues)
         ];
 
         sectionBatmanAdvanced = checkUnitConfig "BatmanAdvanced" [
@@ -743,6 +983,43 @@ let
             "batman-iv"
           ])
         ];
+
+        sectionIPoIB = checkUnitConfig "IPoIB" [
+          (assertOnlyFields [
+            "PartitionKey"
+            "Mode"
+            "IgnoreUserspaceMulticastGroups"
+          ])
+          (assertValueOneOf "Mode" [
+            "datagram"
+            "connected"
+          ])
+          (assertValueOneOf "IgnoreUserspaceMulticastGroups" boolValues)
+        ];
+
+        sectionWLAN = checkUnitConfig "WLAN" [
+          (assertOnlyFields [
+            "PhysicalDevice" # systemd supports both strings ("phy0") and indexes (0) here.
+            "Type"
+            "WDS"
+          ])
+          # See https://github.com/systemd/systemd/blob/main/src/basic/linux/nl80211.h#L3382
+          (assertValueOneOf "Type" [
+            "ad-hoc"
+            "station"
+            "ap"
+            "ap-vlan"
+            "wds"
+            "monitor"
+            "mesh-point"
+            "p2p-client"
+            "p2p-go"
+            "p2p-device"
+            "ocb"
+            "nan"
+          ])
+          (assertValueOneOf "WDS" boolValues)
+        ];
       };
 
     network = {
@@ -754,12 +1031,12 @@ let
           "ARP"
           "Multicast"
           "AllMulticast"
+          "Promiscuous"
           "Unmanaged"
           "Group"
           "RequiredForOnline"
           "RequiredFamilyForOnline"
           "ActivationPolicy"
-          "Promiscuous"
         ])
         (assertMacAddress "MACAddress")
         (assertByteFormat "MTUBytes")
@@ -809,6 +1086,32 @@ let
         ])
       ];
 
+      sectionSR-IOV = checkUnitConfig "SR-IOV" [
+        (assertOnlyFields [
+          "VirtualFunction"
+          "VLANId"
+          "QualityOfService"
+          "VLANProtocol"
+          "MACSpoofCheck"
+          "QueryReceiveSideScaling"
+          "Trust"
+          "LinkState"
+          "MACAddress"
+        ])
+        (assertRange "VirtualFunction" 0 2147483646)
+        (assertRange "VLANId" 1 4095)
+        (assertRange "QualityOfService" 1 4294967294)
+        (assertValueOneOf "VLANProtocol" [
+          "802.1Q"
+          "802.1ad"
+        ])
+        (assertValueOneOf "MACSpoofCheck" boolValues)
+        (assertValueOneOf "QueryReceiveSideScaling" boolValues)
+        (assertValueOneOf "Trust" boolValues)
+        (assertValueOneOf "LinkState" (boolValues ++ [ "auto" ]))
+        (assertMacAddress "MACAddress")
+      ];
+
       sectionNetwork = checkUnitConfig "Network" [
         (assertOnlyFields [
           "Description"
@@ -844,7 +1147,9 @@ let
           "IPv6DuplicateAddressDetection"
           "IPv6HopLimit"
           "IPv6RetransmissionTimeSec"
+          "IPv4DuplicateAddressDetectionTimeoutSec"
           "IPv4ReversePathFilter"
+          "MulticastIGMPVersion"
           "IPv4AcceptLocal"
           "IPv4RouteLocalnet"
           "IPv4ProxyARP"
@@ -854,25 +1159,27 @@ let
           "IPv6SendRA"
           "DHCPPrefixDelegation"
           "IPv6MTUBytes"
+          "MPLSRouting"
           "KeepMaster"
+          "BatmanAdvanced"
           "Bridge"
           "Bond"
           "VRF"
-          "VLAN"
+          "IPoIB"
           "IPVLAN"
           "IPVTAP"
+          "MACsec"
           "MACVLAN"
           "MACVTAP"
-          "VXLAN"
           "Tunnel"
-          "MACsec"
+          "VLAN"
+          "VXLAN"
+          "Xfrm"
           "ActiveSlave"
           "PrimarySlave"
           "ConfigureWithoutCarrier"
           "IgnoreCarrierLoss"
-          "Xfrm"
           "KeepConfiguration"
-          "BatmanAdvanced"
         ])
         # Note: For DHCP the values both, none, v4, v6 are deprecated
         (assertValueOneOf "DHCP" (
@@ -888,8 +1195,6 @@ let
           ++ [
             "ipv4"
             "ipv6"
-            "fallback"
-            "ipv4-fallback"
           ]
         ))
         (assertValueOneOf "IPv6LinkLocalAddressGenerationMode" [
@@ -944,6 +1249,12 @@ let
           "strict"
           "loose"
         ])
+        (assertValueOneOf "MulticastIGMPVersion" [
+          "no"
+          "v1"
+          "v2"
+          "v3"
+        ])
         (assertValueOneOf "IPv4AcceptLocal" boolValues)
         (assertValueOneOf "IPv4RouteLocalnet" boolValues)
         (assertValueOneOf "IPv4ProxyARP" boolValues)
@@ -952,6 +1263,7 @@ let
         (assertValueOneOf "IPv6SendRA" boolValues)
         (assertValueOneOf "DHCPPrefixDelegation" boolValues)
         (assertByteFormat "IPv6MTUBytes")
+        (assertValueOneOf "MPLSRouting" boolValues)
         (assertValueOneOf "KeepMaster" boolValues)
         (assertValueOneOf "ActiveSlave" boolValues)
         (assertValueOneOf "PrimarySlave" boolValues)
@@ -1003,6 +1315,20 @@ let
         (assertValueOneOf "AutoJoin" boolValues)
       ];
 
+      sectionNeighbor = checkUnitConfig "Neighbor" [
+        (assertOnlyFields [
+          "Address"
+          "LinkLayerAddress"
+        ])
+      ];
+
+      sectionIPv6AddressLabel = checkUnitConfig "IPv6AddressLabel" [
+        (assertOnlyFields [
+          "Label"
+          "Prefix"
+        ])
+      ];
+
       sectionRoutingPolicyRule =
         checkUnitConfigWithLegacyKey "routingPolicyRuleConfig" "RoutingPolicyRule"
           [
@@ -1013,6 +1339,7 @@ let
               "FirewallMark"
               "Table"
               "Priority"
+              "GoTo"
               "IncomingInterface"
               "OutgoingInterface"
               "L3MasterDevice"
@@ -1023,13 +1350,14 @@ let
               "Family"
               "User"
               "SuppressPrefixLength"
-              "Type"
               "SuppressInterfaceGroup"
+              "Type"
             ])
             (assertInt "TypeOfService")
             (assertRange "TypeOfService" 0 255)
             (assertRangeWithOptionalMask "FirewallMark" 1 4294967295)
             (assertInt "Priority")
+            (assertRange "GoTo" 1 4294967295)
             (assertValueOneOf "L3MasterDevice" boolValues)
             (assertPortOrPortRange "SourcePort")
             (assertPortOrPortRange "DestinationPort")
@@ -1041,13 +1369,31 @@ let
             ])
             (assertInt "SuppressPrefixLength")
             (assertRange "SuppressPrefixLength" 0 128)
+            (assertRange "SuppressInterfaceGroup" 0 2147483647)
             (assertValueOneOf "Type" [
               "blackhole"
               "unreachable"
               "prohibit"
             ])
-            (assertRange "SuppressInterfaceGroup" 0 2147483647)
           ];
+
+      sectionNextHop = checkUnitConfig "NextHop" [
+        (assertOnlyFields [
+          "Id"
+          "Gateway"
+          "Family"
+          "OnLink"
+          "Blackhole"
+          "Group"
+        ])
+        (assertRange "Id" 1 4294967295)
+        (assertValueOneOf "Family" [
+          "ipv4"
+          "ipv6"
+        ])
+        (assertValueOneOf "OnLink" boolValues)
+        (assertValueOneOf "Blackhole" boolValues)
+      ];
 
       sectionRoute = checkUnitConfigWithLegacyKey "routeConfig" "Route" [
         (assertOnlyFields [
@@ -1060,16 +1406,19 @@ let
           "Scope"
           "PreferredSource"
           "Table"
+          "HopLimit"
           "Protocol"
           "Type"
           "InitialCongestionWindow"
           "InitialAdvertisedReceiveWindow"
           "QuickAck"
           "FastOpenNoCookie"
-          "TTLPropagate"
           "MTUBytes"
-          "IPServiceType"
+          "TCPAdvertisedMaximumSegmentSize"
+          "TCPCongestionControlAlgorithm"
+          "TCPRetransmissionTimeoutSec"
           "MultiPathRoute"
+          "NextHop"
         ])
         (assertValueOneOf "GatewayOnLink" boolValues)
         (assertInt "Metric")
@@ -1085,6 +1434,7 @@ let
           "host"
           "nowhere"
         ])
+        (assertRange "HopLimit" 1 255)
         (assertValueOneOf "Type" [
           "unicast"
           "local"
@@ -1098,146 +1448,182 @@ let
           "nat"
           "xresolve"
         ])
+        (assertRange "InitialCongestionWindow" 1 1023)
+        (assertRange "InitialAdvertisedReceiveWindow" 1 1023)
         (assertValueOneOf "QuickAck" boolValues)
         (assertValueOneOf "FastOpenNoCookie" boolValues)
-        (assertValueOneOf "TTLPropagate" boolValues)
         (assertByteFormat "MTUBytes")
-        (assertValueOneOf "IPServiceType" [
-          "CS6"
-          "CS4"
-        ])
+        (assertByteFormat "TCPAdvertisedMaximumSegmentSize")
+        (assertRange "NextHop" 1 4294967295)
       ];
 
       sectionDHCPv4 = checkUnitConfig "DHCPv4" [
         (assertOnlyFields [
-          "UseDNS"
-          "UseDNR"
-          "RoutesToDNS"
-          "UseNTP"
-          "UseSIP"
-          "UseMTU"
-          "Anonymize"
+          "RequestAddress"
           "SendHostname"
-          "UseHostname"
           "Hostname"
-          "UseDomains"
-          "UseGateway"
-          "UseRoutes"
-          "UseTimezone"
-          "IPv6OnlyMode"
+          "MUDURL"
           "ClientIdentifier"
           "VendorClassIdentifier"
           "UserClass"
-          "MaxAttempts"
           "DUIDType"
           "DUIDRawData"
           "IAID"
-          "RequestAddress"
-          "RequestBroadcast"
-          "RouteMetric"
           "RapidCommit"
-          "RouteTable"
-          "RouteMTUBytes"
-          "ListenPort"
-          "SendRelease"
-          "SendDecline"
-          "BlackList"
+          "Anonymize"
           "RequestOptions"
           "SendOption"
-          "FallbackLeaseLifetimeSec"
+          "SendVendorOption"
+          "IPServiceType"
+          "SocketPriority"
+          "BOOTP"
           "Label"
+          "UseDNS"
+          "RoutesToDNS"
+          "UseNTP"
+          "RoutesToNTP"
+          "UseSIP"
+          "UseCaptivePortal"
+          "UseDNR"
+          "UseMTU"
+          "UseHostname"
+          "UseDomains"
+          "UseRoutes"
+          "RouteMetric"
+          "RouteTable"
+          "RouteMTUBytes"
+          "QuickAck"
+          "InitialCongestionWindow"
+          "InitialAdvertisedReceiveWindow"
+          "UseGateway"
+          "UseTimezone"
           "Use6RD"
+          "UnassignedSubnetPolicy"
+          "IPv6OnlyMode"
+          "FallbackLeaseLifetimeSec"
+          "RequestBroadcast"
+          "MaxAttempts"
+          "ListenPort"
+          "ServerPort"
+          "DenyList"
+          "AllowList"
+          "SendRelease"
+          "SendDecline"
           "NetLabel"
           "NFTSet"
-          "UseCaptivePortal"
+          "BlackList" # removed
         ])
-        (assertValueOneOf "UseDNS" boolValues)
-        (assertValueOneOf "UseDNR" boolValues)
-        (assertValueOneOf "RoutesToDNS" boolValues)
-        (assertValueOneOf "UseNTP" boolValues)
-        (assertValueOneOf "UseSIP" boolValues)
-        (assertValueOneOf "UseMTU" boolValues)
-        (assertValueOneOf "Anonymize" boolValues)
+        (assertRemoved "BlackList" "Use DenyList instead")
         (assertValueOneOf "SendHostname" boolValues)
-        (assertValueOneOf "UseHostname" boolValues)
-        (assertValueOneOf "UseDomains" (boolValues ++ [ "route" ]))
-        (assertValueOneOf "UseGateway" boolValues)
-        (assertValueOneOf "UseRoutes" boolValues)
-        (assertValueOneOf "UseTimezone" boolValues)
-        (assertValueOneOf "IPv6OnlyMode" boolValues)
         (assertValueOneOf "ClientIdentifier" [
           "mac"
           "duid"
-          "duid-only"
         ])
         (assertInt "IAID")
-        (assertValueOneOf "RequestBroadcast" boolValues)
-        (assertInt "RouteMetric")
         (assertValueOneOf "RapidCommit" boolValues)
-        (assertInt "RouteTable")
-        (assertRange "RouteTable" 0 4294967295)
+        (assertValueOneOf "Anonymize" boolValues)
+        (assertValueOneOf "IPServiceType" [
+          "none"
+          "CS6"
+          "CS4"
+        ])
+        (assertRange "SocketPriority" 0 255)
+        (assertValueOneOf "BOOTP" boolValues)
+        (assertValueOneOf "UseDNS" boolValues)
+        (assertValueOneOf "RoutesToDNS" boolValues)
+        (assertValueOneOf "UseNTP" boolValues)
+        (assertValueOneOf "RoutesToNTP" boolValues)
+        (assertValueOneOf "UseSIP" boolValues)
+        (assertValueOneOf "UseCaptivePortal" boolValues)
+        (assertValueOneOf "UseDNR" boolValues)
+        (assertValueOneOf "UseMTU" boolValues)
+        (assertValueOneOf "UseHostname" boolValues)
+        (assertValueOneOf "UseDomains" (boolValues ++ [ "route" ]))
+        (assertValueOneOf "UseRoutes" boolValues)
+        (assertInt "RouteMetric")
+        (assertRange "RouteMetric" 0 4294967295)
         (assertByteFormat "RouteMTUBytes")
-        (assertPort "ListenPort")
-        (assertValueOneOf "SendRelease" boolValues)
-        (assertValueOneOf "SendDecline" boolValues)
+        (assertValueOneOf "QuickAck" boolValues)
+        (assertRange "InitialCongestionWindow" 1 1023)
+        (assertRange "InitialAdvertisedReceiveWindow" 1 1023)
+        (assertValueOneOf "UseGateway" boolValues)
+        (assertValueOneOf "UseTimezone" boolValues)
+        (assertValueOneOf "Use6RD" boolValues)
+        (assertValueOneOf "UnassignedSubnetPolicy" [
+          "none"
+          "unreachable"
+          "prohibit"
+          "blackhole"
+          "throw"
+        ])
+        (assertValueOneOf "IPv6OnlyMode" boolValues)
         (assertValueOneOf "FallbackLeaseLifetimeSec" [
           "forever"
           "infinity"
         ])
-        (assertValueOneOf "Use6RD" boolValues)
-        (assertValueOneOf "UseCaptivePortal" boolValues)
+        (assertValueOneOf "RequestBroadcast" boolValues)
+        (assertPort "ListenPort")
+        (assertPort "ServerPort")
+        (assertValueOneOf "SendRelease" boolValues)
+        (assertValueOneOf "SendDecline" boolValues)
       ];
 
       sectionDHCPv6 = checkUnitConfig "DHCPv6" [
         (assertOnlyFields [
+          "MUDURL"
+          "IAID"
+          "DUIDType"
+          "DUIDRawData"
+          "RequestOptions"
+          "SendOption"
+          "SendVendorOption"
+          "UserClass"
+          "VendorClass"
+          "PrefixDelegationHint"
+          "UnassignedSubnetPolicy"
+          "RapidCommit"
+          "SendHostname"
+          "Hostname"
           "UseAddress"
+          "UseCaptivePortal"
+          "UseDelegatedPrefix"
           "UseDNS"
           "UseDNR"
           "UseNTP"
           "UseSIP"
-          "SendHostname"
           "UseHostname"
-          "Hostname"
           "UseDomains"
-          "RouteMetric"
-          "RapidCommit"
-          "MUDURL"
-          "RequestOptions"
-          "SendVendorOption"
-          "PrefixDelegationHint"
-          "WithoutRA"
-          "SendOption"
-          "UserClass"
-          "VendorClass"
-          "DUIDType"
-          "DUIDRawData"
-          "IAID"
-          "UseDelegatedPrefix"
-          "SendRelease"
           "NetLabel"
+          "SendRelease"
           "NFTSet"
-          "UseCaptivePortal"
+          "WithoutRA"
         ])
+        (assertInt "IAID")
+        (assertRange "SendOption" 1 65536)
+        (assertValueOneOf "UnassignedSubnetPolicy" [
+          "none"
+          "unreachable"
+          "prohibit"
+          "blackhole"
+          "throw"
+        ])
+        (assertValueOneOf "RapidCommit" boolValues)
+        (assertValueOneOf "SendHostname" boolValues)
         (assertValueOneOf "UseAddress" boolValues)
+        (assertValueOneOf "UseCaptivePortal" boolValues)
+        (assertValueOneOf "UseDelegatedPrefix" boolValues)
         (assertValueOneOf "UseDNS" boolValues)
         (assertValueOneOf "UseDNR" boolValues)
         (assertValueOneOf "UseNTP" boolValues)
         (assertValueOneOf "UseSIP" boolValues)
-        (assertValueOneOf "SendHostname" boolValues)
         (assertValueOneOf "UseHostname" boolValues)
         (assertValueOneOf "UseDomains" (boolValues ++ [ "route" ]))
-        (assertInt "RouteMetric")
-        (assertValueOneOf "RapidCommit" boolValues)
+        (assertValueOneOf "SendRelease" boolValues)
         (assertValueOneOf "WithoutRA" [
           "no"
           "solicit"
           "information-request"
         ])
-        (assertRange "SendOption" 1 65536)
-        (assertInt "IAID")
-        (assertValueOneOf "UseDelegatedPrefix" boolValues)
-        (assertValueOneOf "SendRelease" boolValues)
-        (assertValueOneOf "UseCaptivePortal" boolValues)
       ];
 
       sectionDHCPPrefixDelegation = checkUnitConfig "DHCPPrefixDelegation" [
@@ -1256,14 +1642,31 @@ let
         (assertValueOneOf "Assign" boolValues)
         (assertValueOneOf "ManageTemporaryAddress" boolValues)
         (assertRange "RouteMetric" 0 4294967295)
+        (assertValueOneOf "WithoutRA" [
+          "no"
+          "solicit"
+          "information-request"
+        ])
       ];
 
       sectionIPv6AcceptRA = checkUnitConfig "IPv6AcceptRA" [
         (assertOnlyFields [
+          "UseRedirect"
+          "Token"
           "UseDNS"
           "UseDNR"
           "UseDomains"
           "RouteTable"
+          "RouteMetric"
+          "QuickAck"
+          "UseMTU"
+          "UseHopLimit"
+          "UseReachableTime"
+          "UseRetransmissionTime"
+          "UseGateway"
+          "UseRoutePrefix"
+          "UseCaptivePortal"
+          "UsePREF64"
           "UseAutonomousPrefix"
           "UseOnLinkPrefix"
           "RouterDenyList"
@@ -1273,36 +1676,27 @@ let
           "RouteDenyList"
           "RouteAllowList"
           "DHCPv6Client"
-          "RouteMetric"
-          "UseMTU"
-          "UseGateway"
-          "UseRoutePrefix"
-          "Token"
-          "UsePREF64"
           "NetLabel"
           "NFTSet"
-          "UseCaptivePortal"
-          "UseRedirect"
-          "UseHopLimit"
-          "UseReachableTime"
-          "UseRetransmissionTime"
         ])
+        (assertValueOneOf "UseRedirect" boolValues)
         (assertValueOneOf "UseDNS" boolValues)
         (assertValueOneOf "UseDNR" boolValues)
         (assertValueOneOf "UseDomains" (boolValues ++ [ "route" ]))
         (assertRange "RouteTable" 0 4294967295)
-        (assertValueOneOf "UseAutonomousPrefix" boolValues)
-        (assertValueOneOf "UseOnLinkPrefix" boolValues)
-        (assertValueOneOf "DHCPv6Client" (boolValues ++ [ "always" ]))
+        (assertRange "RouteMetric" 0 4294967295)
+        (assertValueOneOf "QuickAck" boolValues)
         (assertValueOneOf "UseMTU" boolValues)
-        (assertValueOneOf "UseGateway" boolValues)
-        (assertValueOneOf "UseRoutePrefix" boolValues)
-        (assertValueOneOf "UsePREF64" boolValues)
-        (assertValueOneOf "UseCaptivePortal" boolValues)
-        (assertValueOneOf "UseRedirect" boolValues)
         (assertValueOneOf "UseHopLimit" boolValues)
         (assertValueOneOf "UseReachableTime" boolValues)
         (assertValueOneOf "UseRetransmissionTime" boolValues)
+        (assertValueOneOf "UseGateway" boolValues)
+        (assertValueOneOf "UseRoutePrefix" boolValues)
+        (assertValueOneOf "UseCaptivePortal" boolValues)
+        (assertValueOneOf "UsePREF64" boolValues)
+        (assertValueOneOf "UseAutonomousPrefix" boolValues)
+        (assertValueOneOf "UseOnLinkPrefix" boolValues)
+        (assertValueOneOf "DHCPv6Client" (boolValues ++ [ "always" ]))
       ];
 
       sectionDHCPServer = checkUnitConfig "DHCPServer" [
@@ -1329,17 +1723,21 @@ let
           "Router"
           "EmitTimezone"
           "Timezone"
+          "EmitDomain"
+          "Domain"
+          "BootServerAddress"
+          "BootServerName"
+          "BootFilename"
+          "IPv6OnlyPreferredSec"
           "SendOption"
           "SendVendorOption"
           "BindToInterface"
           "RelayTarget"
           "RelayAgentCircuitId"
           "RelayAgentRemoteId"
-          "BootServerAddress"
-          "BootServerName"
-          "BootFilename"
-          "IPv6OnlyPreferredSec"
+          "RapidCommit"
           "PersistLeases"
+          "LocalLeaseDomain"
         ])
         (assertInt "PoolOffset")
         (assertMinimum "PoolOffset" 0)
@@ -1353,9 +1751,23 @@ let
         (assertValueOneOf "EmitLPR" boolValues)
         (assertValueOneOf "EmitRouter" boolValues)
         (assertValueOneOf "EmitTimezone" boolValues)
+        (assertValueOneOf "EmitDomain" boolValues)
         (assertValueOneOf "BindToInterface" boolValues)
+        (assertValueOneOf "RapidCommit" boolValues)
         (assertValueOneOf "PersistLeases" (boolValues ++ [ "runtime" ]))
       ];
+
+      sectionDHCPServerStaticLease =
+        checkUnitConfigWithLegacyKey "dhcpServerStaticLeaseConfig" "DHCPServerStaticLease"
+          [
+            (assertOnlyFields [
+              "MACAddress"
+              "Address"
+            ])
+            (assertHasField "MACAddress")
+            (assertHasField "Address")
+            (assertMacAddress "MACAddress")
+          ];
 
       sectionIPv6SendRA = checkUnitConfig "IPv6SendRA" [
         (assertOnlyFields [
@@ -1391,14 +1803,6 @@ let
         (assertInt "HomeAgentPreference")
       ];
 
-      sectionIPv6PREF64Prefix = checkUnitConfigWithLegacyKey "ipv6PREF64PrefixConfig" "IPv6PREF64Prefix" [
-        (assertOnlyFields [
-          "Prefix"
-          "LifetimeSec"
-        ])
-        (assertInt "LifetimeSec")
-      ];
-
       sectionIPv6Prefix = checkUnitConfigWithLegacyKey "ipv6PrefixConfig" "IPv6Prefix" [
         (assertOnlyFields [
           "AddressAutoconfiguration"
@@ -1408,32 +1812,37 @@ let
           "ValidLifetimeSec"
           "Assign"
           "Token"
+          "RouteMetric"
         ])
         (assertValueOneOf "AddressAutoconfiguration" boolValues)
         (assertValueOneOf "OnLink" boolValues)
         (assertValueOneOf "Assign" boolValues)
+        (assertInt "RouteMetric")
+        (assertRange "RouteMetric" 0 4294967295)
       ];
 
       sectionIPv6RoutePrefix = checkUnitConfigWithLegacyKey "ipv6RoutePrefixConfig" "IPv6RoutePrefix" [
         (assertOnlyFields [
           "Route"
           "LifetimeSec"
+          "Preference"
         ])
         (assertHasField "Route")
         (assertInt "LifetimeSec")
+        (assertValueOneOf "Preference" [
+          "high"
+          "medium"
+          "low"
+        ])
       ];
 
-      sectionDHCPServerStaticLease =
-        checkUnitConfigWithLegacyKey "dhcpServerStaticLeaseConfig" "DHCPServerStaticLease"
-          [
-            (assertOnlyFields [
-              "MACAddress"
-              "Address"
-            ])
-            (assertHasField "MACAddress")
-            (assertHasField "Address")
-            (assertMacAddress "MACAddress")
-          ];
+      sectionIPv6PREF64Prefix = checkUnitConfigWithLegacyKey "ipv6PREF64PrefixConfig" "IPv6PREF64Prefix" [
+        (assertOnlyFields [
+          "Prefix"
+          "LifetimeSec"
+        ])
+        (assertInt "LifetimeSec")
+      ];
 
       sectionBridge = checkUnitConfig "Bridge" [
         (assertOnlyFields [
@@ -1452,6 +1861,9 @@ let
           "MulticastRouter"
           "Cost"
           "Priority"
+          "Locked"
+          "MACAuthenticationBypass"
+          "VLANTunnel"
         ])
         (assertValueOneOf "UnicastFlood" boolValues)
         (assertValueOneOf "MulticastFlood" boolValues)
@@ -1475,6 +1887,9 @@ let
         (assertRange "Cost" 1 65535)
         (assertInt "Priority")
         (assertRange "Priority" 0 63)
+        (assertValueOneOf "Locked" boolValues)
+        (assertValueOneOf "MACAuthenticationBypass" boolValues)
+        (assertValueOneOf "VLANTunnel" boolValues)
       ];
 
       sectionBridgeFDB = checkUnitConfigWithLegacyKey "bridgeFDBConfig" "BridgeFDB" [
@@ -1715,8 +2130,8 @@ let
           "FirewallMark"
           "Wash"
           "SplitGSO"
-          "AckFilter"
           "RTTSec"
+          "AckFilter"
         ])
         (assertValueOneOf "AutoRateIngress" boolValues)
         (assertInt "OverheadBytes")
@@ -1880,6 +2295,20 @@ let
           "CeilRate"
           "BufferBytes"
           "CeilBufferBytes"
+        ])
+      ];
+
+      sectionClassfulMultiQueueing = checkUnitConfig "ClassfulMultiQueueing" [
+        (assertOnlyFields [
+          "Parent"
+          "Handle"
+        ])
+      ];
+
+      sectionBandMultiQueueing = checkUnitConfig "BandMultiQueueing" [
+        (assertOnlyFields [
+          "Parent"
+          "Handle"
         ])
       ];
 
@@ -2090,6 +2519,31 @@ let
       '';
     };
 
+    macvlanConfig = mkOption {
+      default = { };
+      example = {
+        Mode = "private";
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionMACVLAN;
+      description = ''
+        Each attribute in this set specifies an option in the
+        `[MACVLAN]` section of the unit.  See
+        {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    macvtapConfig = mkOption {
+      default = { };
+      example = {
+        Mode = "private";
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionMACVTAP;
+      description = ''
+        Each attribute in this set specifies an option in the `[MACVTAP]` section of the unit.
+        See {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
     ipvlanConfig = mkOption {
       default = { };
       example = {
@@ -2116,25 +2570,155 @@ let
       '';
     };
 
-    macvlanConfig = mkOption {
-      default = { };
-      example = {
-        Mode = "private";
-      };
-      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionMACVLAN;
-      description = ''
-        Each attribute in this set specifies an option in the
-        `[MACVLAN]` section of the unit.  See
-        {manpage}`systemd.netdev(5)` for details.
-      '';
-    };
-
     vxlanConfig = mkOption {
       default = { };
       type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionVXLAN;
       description = ''
         Each attribute in this set specifies an option in the
         `[VXLAN]` section of the unit.  See
+        {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    geneveConfig = mkOption {
+      default = { };
+      example = {
+        Id = 1;
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionGENEVE;
+      description = ''
+        Each attribute in this set specifies an option in the
+        `[GENEVE]` section of the unit.  See
+        {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    hsrConfig = mkOption {
+      default = { };
+      example = {
+        Ports = [
+          "eth1"
+          "eth2"
+        ];
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionHSR;
+      description = ''
+        Each attribute in this set specifies an option in the
+        `[HSR]` section of the unit.  See
+        {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    bareUDPConfig = mkOption {
+      default = { };
+      example = {
+        DestinationPort = 1234;
+        EtherType = "ipv4";
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionBareUDP;
+      description = ''
+        Each attribute in this set specifies an option in the
+        `[BareUDP]` section of the unit.  See
+        {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    l2tpConfig = mkOption {
+      default = { };
+      example = {
+        TunnelId = 10;
+        PeerTunnelId = 12;
+        Local = "static";
+        Remote = "192.168.30.101";
+        EncapsulationType = "ip";
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionL2TP;
+      description = ''
+        Each attribute in this set specifies an option in the
+        `[L2TP]` section of the unit. See
+        {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    l2tpSessions = mkOption {
+      default = [ ];
+      example = [
+        {
+          SessionId = 25;
+          PeerSessionId = 26;
+          Name = "l2tp-sess";
+        }
+      ];
+      type = types.listOf (mkSubsectionType "l2tpSessionConfig" check.netdev.sectionL2TPSession);
+      description = ''
+        Each item in this array specifies an option in the
+        `[L2TPSession]` section of the unit. See
+        {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    macsecConfig = mkOption {
+      default = { };
+      example = {
+        Port = 1234;
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionMACsec;
+      description = ''
+        Each attribute in this set specifies an option in the
+        `[MACsec]` section of the unit.  See
+        {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    macsecReceiveChannels = mkOption {
+      default = [ ];
+      example = [
+        {
+          Port = 1234;
+          MACAddress = "ab:cd:de:ef:ab:cd";
+        }
+      ];
+      type = types.listOf (
+        mkSubsectionType "macsecReceiveConfig" check.netdev.sectionMACsecReceiveChannel
+      );
+      description = ''
+        Each item in this array specifies an option in the
+        `[MACsecReceiveChannel]` section of the unit. See
+        {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    macsecTransmitAssociations = mkOption {
+      default = [ ];
+      example = [
+        {
+          Activate = true;
+        }
+      ];
+      type = types.listOf (
+        mkSubsectionType "TransmitAssociationConfig" check.netdev.sectionMACsecTransmitAssociation
+      );
+      description = ''
+        Each item in this array specifies an option in the
+        `[MACsecTransmitAssociation]` section of the unit. See
+        {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    macsecReceiveAssociations = mkOption {
+      default = [ ];
+      example = [
+        {
+          Port = 1234;
+          MACAddress = "ab:cd:de:ef:ab:cd";
+        }
+      ];
+      type = types.listOf (
+        mkSubsectionType "ReceiveAssociationConfig" check.netdev.sectionMACsecReceiveAssociation
+      );
+      description = ''
+        Each item in this array specifies an option in the
+        `[MACsecReceiveAssociation]` section of the unit. See
         {manpage}`systemd.netdev(5)` for details.
       '';
     };
@@ -2178,6 +2762,19 @@ let
       '';
     };
 
+    vxcanConfig = mkOption {
+      default = { };
+      example = {
+        Peer = "vxcanpeer";
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionVXCAN;
+      description = ''
+        Each attribute in this set specifies an option in the
+        `[VXCAN]` section of the unit.  See
+        {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
     tunConfig = mkOption {
       default = { };
       example = {
@@ -2200,40 +2797,6 @@ let
       description = ''
         Each attribute in this set specifies an option in the
         `[Tap]` section of the unit.  See
-        {manpage}`systemd.netdev(5)` for details.
-      '';
-    };
-
-    l2tpConfig = mkOption {
-      default = { };
-      example = {
-        TunnelId = 10;
-        PeerTunnelId = 12;
-        Local = "static";
-        Remote = "192.168.30.101";
-        EncapsulationType = "ip";
-      };
-      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionL2TP;
-      description = ''
-        Each attribute in this set specifies an option in the
-        `[L2TP]` section of the unit. See
-        {manpage}`systemd.netdev(5)` for details.
-      '';
-    };
-
-    l2tpSessions = mkOption {
-      default = [ ];
-      example = [
-        {
-          SessionId = 25;
-          PeerSessionId = 26;
-          Name = "l2tp-sess";
-        }
-      ];
-      type = types.listOf (mkSubsectionType "l2tpSessionConfig" check.netdev.sectionL2TPSession);
-      description = ''
-        Each item in this array specifies an option in the
-        `[L2TPSession]` section of the unit. See
         {manpage}`systemd.netdev(5)` for details.
       '';
     };
@@ -2319,19 +2882,6 @@ let
       '';
     };
 
-    wlanConfig = mkOption {
-      default = { };
-      example = {
-        PhysicalDevice = 0;
-        Type = "station";
-      };
-      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionWLAN;
-      description = ''
-        Each attribute in this set specifies an option in the `[WLAN]` section of the unit.
-        See {manpage}`systemd.netdev(5)` for details.
-      '';
-    };
-
     batmanAdvancedConfig = mkOption {
       default = { };
       example = {
@@ -2343,6 +2893,31 @@ let
         Each attribute in this set specifies an option in the
         `[BatmanAdvanced]` section of the unit. See
         {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    ipoibConfig = mkOption {
+      default = { };
+      example = {
+        PartitionKey = 1;
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionIPoIB;
+      description = ''
+        Each attribute in this set specifies an option in the `[IPoIB]` section of the unit.
+        See {manpage}`systemd.netdev(5)` for details.
+      '';
+    };
+
+    wlanConfig = mkOption {
+      default = { };
+      example = {
+        PhysicalDevice = 0;
+        Type = "station";
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.netdev.sectionWLAN;
+      description = ''
+        Each attribute in this set specifies an option in the `[WLAN]` section of the unit.
+        See {manpage}`systemd.netdev(5)` for details.
       '';
     };
 
@@ -2363,6 +2938,20 @@ let
       '';
     };
 
+    sriovConfig = mkOption {
+      default = { };
+      example = {
+        VirtualFunction = 1;
+        VLANId = 1;
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.network.sectionSR-IOV;
+      description = ''
+        Each attribute in this set specifies an option in the
+        `[SR-IOV]` section of the unit.  See
+        {manpage}`systemd.network(5)` for details.
+      '';
+    };
+
     networkConfig = mkOption {
       default = { };
       example = {
@@ -2372,6 +2961,91 @@ let
       description = ''
         Each attribute in this set specifies an option in the
         `[Network]` section of the unit.  See
+        {manpage}`systemd.network(5)` for details.
+      '';
+    };
+
+    addresses = mkOption {
+      default = [ ];
+      example = [ { Address = "192.168.0.100/24"; } ];
+      type = types.listOf (mkSubsectionType "addressConfig" check.network.sectionAddress);
+      description = ''
+        A list of `[Address]` sections to be added to the unit.  See
+        {manpage}`systemd.network(5)` for details.
+      '';
+    };
+
+    neighbors = mkOption {
+      default = [ ];
+      example = [
+        {
+          Address = "192.168.0.100/24";
+          LinkLayerAddress = "aa:bb:cc:dd:ee:ff";
+        }
+      ];
+      type = types.listOf (mkSubsectionType "neighborConfig" check.network.sectionNeighbor);
+      description = ''
+        A list of `[Neighbor]` sections to be added to the unit.  See
+        {manpage}`systemd.network(5)` for details.
+      '';
+    };
+
+    ipv6AddressLabels = mkOption {
+      default = [ ];
+      example = [
+        {
+          Label = 0;
+          Prefix = "3fff::/20";
+        }
+      ];
+      type = types.listOf (
+        mkSubsectionType "ipv6AddressLabelConfig" check.network.sectionIPv6AddressLabel
+      );
+      description = ''
+        A list of `[IPv6AddressLabel]` sections to be added to the unit.  See
+        {manpage}`systemd.network(5)` for details.
+      '';
+    };
+
+    routingPolicyRules = mkOption {
+      default = [ ];
+      example = [
+        {
+          Table = 10;
+          IncomingInterface = "eth1";
+          Family = "both";
+        }
+      ];
+      type = types.listOf (
+        mkSubsectionType "routingPolicyRuleConfig" check.network.sectionRoutingPolicyRule
+      );
+      description = ''
+        A list of routing policy rules sections to be added to the unit.  See
+        {manpage}`systemd.network(5)` for details.
+      '';
+    };
+
+    nextHops = mkOption {
+      default = [ ];
+      example = [
+        {
+          Id = 10;
+          Gateway = "192.168.1.1";
+        }
+      ];
+      type = types.listOf (mkSubsectionType "nextHopConfig" check.network.sectionNextHop);
+      description = ''
+        A list of NextHop sections to be added to the unit.  See
+        {manpage}`systemd.network(5)` for details.
+      '';
+    };
+
+    routes = mkOption {
+      default = [ ];
+      example = [ { Gateway = "192.168.0.1"; } ];
+      type = types.listOf (mkSubsectionType "routeConfig" check.network.sectionRoute);
+      description = ''
+        A list of route sections to be added to the unit.  See
         {manpage}`systemd.network(5)` for details.
       '';
     };
@@ -2410,13 +3084,6 @@ let
         `[DHCPv6]` section of the unit.  See
         {manpage}`systemd.network(5)` for details.
       '';
-    };
-
-    dhcpV6PrefixDelegationConfig = mkOption {
-      visible = false;
-      apply =
-        _:
-        throw "The option `systemd.network.networks.<name>.dhcpV6PrefixDelegationConfig` has been renamed to `systemd.network.networks.<name>.dhcpPrefixDelegationConfig`.";
     };
 
     dhcpPrefixDelegationConfig = mkOption {
@@ -2461,6 +3128,30 @@ let
       '';
     };
 
+    dhcpServerStaticLeases = mkOption {
+      default = [ ];
+      example = [
+        {
+          MACAddress = "65:43:4a:5b:d8:5f";
+          Address = "192.168.1.42";
+        }
+      ];
+      type = types.listOf (
+        mkSubsectionType "dhcpServerStaticLeaseConfig" check.network.sectionDHCPServerStaticLease
+      );
+      description = ''
+        A list of DHCPServerStaticLease sections to be added to the unit.  See
+        {manpage}`systemd.network(5)` for details.
+      '';
+    };
+
+    dhcpV6PrefixDelegationConfig = mkOption {
+      visible = false;
+      apply =
+        _:
+        throw "The option `systemd.network.networks.<name>.dhcpV6PrefixDelegationConfig` has been renamed to `systemd.network.networks.<name>.dhcpPrefixDelegationConfig`.";
+    };
+
     # systemd.network.networks.*.ipv6PrefixDelegationConfig has been deprecated
     # in 247 in favor of systemd.network.networks.*.ipv6SendRAConfig.
     ipv6PrefixDelegationConfig = mkOption {
@@ -2481,35 +3172,6 @@ let
       description = ''
         Each attribute in this set specifies an option in the
         `[IPv6SendRA]` section of the unit.  See
-        {manpage}`systemd.network(5)` for details.
-      '';
-    };
-
-    ipv6PREF64Prefixes = mkOption {
-      default = [ ];
-      example = [ { Prefix = "64:ff9b::/96"; } ];
-      type = types.listOf (
-        mkSubsectionType "ipv6PREF64PrefixConfig" check.network.sectionIPv6PREF64Prefix
-      );
-      description = ''
-        A list of IPv6PREF64Prefix sections to be added to the unit. See
-        {manpage}`systemd.network(5)` for details.
-      '';
-    };
-
-    dhcpServerStaticLeases = mkOption {
-      default = [ ];
-      example = [
-        {
-          MACAddress = "65:43:4a:5b:d8:5f";
-          Address = "192.168.1.42";
-        }
-      ];
-      type = types.listOf (
-        mkSubsectionType "dhcpServerStaticLeaseConfig" check.network.sectionDHCPServerStaticLease
-      );
-      description = ''
-        A list of DHCPServerStaticLease sections to be added to the unit.  See
         {manpage}`systemd.network(5)` for details.
       '';
     };
@@ -2540,6 +3202,18 @@ let
       type = types.listOf (mkSubsectionType "ipv6RoutePrefixConfig" check.network.sectionIPv6RoutePrefix);
       description = ''
         A list of ipv6RoutePrefix sections to be added to the unit.  See
+        {manpage}`systemd.network(5)` for details.
+      '';
+    };
+
+    ipv6PREF64Prefixes = mkOption {
+      default = [ ];
+      example = [ { Prefix = "64:ff9b::/96"; } ];
+      type = types.listOf (
+        mkSubsectionType "ipv6PREF64PrefixConfig" check.network.sectionIPv6PREF64Prefix
+      );
+      description = ''
+        A list of IPv6PREF64Prefix sections to be added to the unit. See
         {manpage}`systemd.network(5)` for details.
       '';
     };
@@ -2932,6 +3606,32 @@ let
       '';
     };
 
+    classfulMultiQueueingConfig = mkOption {
+      default = { };
+      example = {
+        Parent = "root";
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.network.sectionClassfulMultiQueueing;
+      description = ''
+        Each attribute in this set specifies an option in the
+        `[ClassfulMultiQueueing]` section of the unit.  See
+        {manpage}`systemd.network(5)` for details.
+      '';
+    };
+
+    bandMultiQueueingConfig = mkOption {
+      default = { };
+      example = {
+        Parent = "root";
+      };
+      type = types.addCheck (types.attrsOf unitOption) check.network.sectionBandMultiQueueing;
+      description = ''
+        Each attribute in this set specifies an option in the
+        `[BandMultiQueueing]` section of the unit.  See
+        {manpage}`systemd.network(5)` for details.
+      '';
+    };
+
     heavyHitterFilterConfig = mkOption {
       default = { };
       example = {
@@ -3130,44 +3830,6 @@ let
       description = ''
         A list of xfrm interfaces to be added to the network section of the
         unit.  See {manpage}`systemd.network(5)` for details.
-      '';
-    };
-
-    addresses = mkOption {
-      default = [ ];
-      example = [ { Address = "192.168.0.100/24"; } ];
-      type = types.listOf (mkSubsectionType "addressConfig" check.network.sectionAddress);
-      description = ''
-        A list of address sections to be added to the unit.  See
-        {manpage}`systemd.network(5)` for details.
-      '';
-    };
-
-    routingPolicyRules = mkOption {
-      default = [ ];
-      example = [
-        {
-          Table = 10;
-          IncomingInterface = "eth1";
-          Family = "both";
-        }
-      ];
-      type = types.listOf (
-        mkSubsectionType "routingPolicyRuleConfig" check.network.sectionRoutingPolicyRule
-      );
-      description = ''
-        A list of routing policy rules sections to be added to the unit.  See
-        {manpage}`systemd.network(5)` for details.
-      '';
-    };
-
-    routes = mkOption {
-      default = [ ];
-      example = [ { Gateway = "192.168.0.1"; } ];
-      type = types.listOf (mkSubsectionType "routeConfig" check.network.sectionRoute);
-      description = ''
-        A list of route sections to be added to the unit.  See
-        {manpage}`systemd.network(5)` for details.
       '';
     };
 


### PR DESCRIPTION
I updated all `systemd.network` options to the current documentation for systemd 259. I reordered the settings so that they are in the same order as in the documentation. This way it should be easier to do this update in the future. I tested this on 2 setups that used networkd for network configuration, tested some of the new keys and I also ran `nixosTests.systemd-networkd` and `nixosTests.networking.networkd` (except for fou which failed on master too).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
