### PR TITLE
protonmail-desktop: add X11 fallback

### DIFF
--- a/pkgs/by-name/pr/protonmail-desktop/package.nix
+++ b/pkgs/by-name/pr/protonmail-desktop/package.nix
@@ -78,6 +78,7 @@ stdenv.mkDerivation {
     makeWrapper ${lib.getExe electron} $out/bin/${mainProgram} \
       --add-flags $out/share/proton-mail/app.asar \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --add-flags "\''${PROTONMAIL_FORCE_X11:+--ozone-platform=x11}" \
       --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0


### PR DESCRIPTION
Adds a `PROTONMAIL_FORCE_X11` env variable option that users can set to force
ProtonMail Desktop to run under X11/XWayland instead of native Wayland, given
that under wayland the app gets a segfault.

This provides an escape hatch without breaking native Wayland support for everyone else.

Usage:
```bash
PROTONMAIL_FORCE_X11=1 proton-mail
```

Testing:
- [x] Built on x86_64-linux
- [x] Tested that the package launches
- [x] Verified that PROTONMAIL_FORCE_X11=1 forces XWayland mode

