### PR TITLE
[staging-next] prisma-engines_6: fix build with rust 1.94

### DIFF
--- a/pkgs/by-name/pr/prisma-engines_6/0001-bump-metrics-to-0.23.1.diff
+++ b/pkgs/by-name/pr/prisma-engines_6/0001-bump-metrics-to-0.23.1.diff
@@ -1,0 +1,16 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 25e92d6dc0a..0ede6ae714d 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -2683,9 +2683,9 @@ dependencies = [
+
+ [[package]]
+ name = "metrics"
+-version = "0.23.0"
++version = "0.23.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
++checksum = "3045b4193fbdc5b5681f32f11070da9be3609f189a79f3390706d42587f46bb5"
+ dependencies = [
+  "ahash 0.8.11",
+  "portable-atomic",

--- a/pkgs/by-name/pr/prisma-engines_6/package.nix
+++ b/pkgs/by-name/pr/prisma-engines_6/package.nix
@@ -21,7 +21,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-z3GdnrLEMJIGPKXXbz2wrbiGpuNlgYxqg3iYINYTnPI=";
   };
 
-  cargoHash = "sha256-PgCfBcmK9RCA5BMacJ5oYEpo2DnBKx2xPbdLb79yCCY=";
+  cargoPatches = [
+    ./0001-bump-metrics-to-0.23.1.diff
+  ];
+
+  cargoHash = "sha256-8sAjYLSmNneQVrNh9iOmk5lVajtiFPWYSC8jfo5CK5U=";
 
   # Use system openssl.
   env.OPENSSL_NO_VENDOR = 1;

--- a/pkgs/by-name/um/umami/package.nix
+++ b/pkgs/by-name/um/umami/package.nix
@@ -49,11 +49,12 @@ let
       tag = version;
       hash = "sha256-icFgoKIrr3fGSVmSczlMJiT5KSb746kVldtrk+Q0wW8=";
     };
-    cargoHash = "sha256-PgCfBcmK9RCA5BMacJ5oYEpo2DnBKx2xPbdLb79yCCY=";
+    cargoHash = "sha256-8sAjYLSmNneQVrNh9iOmk5lVajtiFPWYSC8jfo5CK5U=";
 
     cargoDeps = rustPlatform.fetchCargoVendor {
       inherit (old) pname;
       inherit src version;
+      patches = old.cargoDeps.vendorStaging.patches or [ ];
       hash = cargoHash;
     };
   });


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/497493#issuecomment-4060311407

The metrics crate needs a version bump to be compatible with rust 1.94. The upstream commit fixing the issue is https://github.com/metrics-rs/metrics/commit/cdd0676b4be9a0c8ccee4c5886da206902bfaa07

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
