### PR TITLE
deadbranch: init at 0.3.0

### DIFF
--- a/pkgs/by-name/de/deadbranch/package.nix
+++ b/pkgs/by-name/de/deadbranch/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  installShellFiles,
+
+  # nativeCheckInputs
+  gitMinimal,
+  writableTmpDirAsHomeHook,
+
+  # nativeInstallCheckInputs
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "deadbranch";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "armgabrielyan";
+    repo = "deadbranch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8KNo/6hdeBY8RbLlXt2gpLCk2DfvSuoeXJ0oh2NDX2s=";
+  };
+
+  cargoHash = "sha256-iY39RBA0fl/BpX6mlCH2bHuN+XsLdq4f7CTzjHz9Ots=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  nativeCheckInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
+  ];
+
+  postInstall = ''
+    installManPage $releaseDir/build/deadbranch-*/out/deadbranch.1
+    installShellCompletion --cmd deadbranch \
+      --bash <($out/bin/deadbranch completions bash) \
+      --fish <($out/bin/deadbranch completions fish) \
+      --zsh <($out/bin/deadbranch completions zsh)
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Clean up stale git branches safely";
+    homepage = "https://github.com/armgabrielyan/deadbranch";
+    license = lib.licenses.mit;
+    mainProgram = "deadbranch";
+    maintainers = with lib.maintainers; [ mahyarmirrashed ];
+  };
+})


### PR DESCRIPTION
Adds [deadbranch](https://github.com/armgabrielyan/deadbranch): a tool to help you identify and remove old, unused git branches that clutter your repository.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
