### PR TITLE
ungoogled-chromium: 146.0.7680.75-1 -> 146.0.7680.80-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -823,7 +823,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "146.0.7680.75",
+    "version": "146.0.7680.80",
     "deps": {
       "depot_tools": {
         "rev": "42786f6e46c25c30dd58f69283ab6fcd0c959f58",
@@ -835,16 +835,16 @@
         "hash": "sha256-wFCuu4GR0N7QZCwT8UAhqH5moicYQjZ4ZLI58AM4pJ0="
       },
       "ungoogled-patches": {
-        "rev": "146.0.7680.75-1",
-        "hash": "sha256-wZxGOs7cwM+ORAq4waOOpa771AYCNZvtm2ZCeh+3Wy8="
+        "rev": "146.0.7680.80-1",
+        "hash": "sha256-/vM1Rw5YgGxTu+/y4bK15bzW6deeREPL/m+1kx+O5Do="
       },
       "npmHash": "sha256-ByB1Ea5tduIJZXyydeBWsoS8OPABOgwHe+dNXRssdvc="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "d865c3fe495882da3a7c6575337a02867c4536b1",
-        "hash": "sha256-/hjpcI4GTw0bGqZ5/9gzM4Pc6/5fhk5dmdtw5EfidiY=",
+        "rev": "f08938029c887ea624da7a1717059788ed95034d",
+        "hash": "sha256-PCQeTdc6Fl74TLyvxjli4scIUIm0GgZ3e9wbC18Tclw=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -1474,8 +1474,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "50841da4a7b7064b3cea8a851e60ef921c87a103",
-        "hash": "sha256-RoLgaE5mj9UqePhnfH+BOTit04TyiAvgF7/2PLuBG4Y="
+        "rev": "248acd90d9a35ac46b2ec30201ae50f301b8a173",
+        "hash": "sha256-zOL5j9X72ZvYmS8MzQ+pqSkT8AWBz2IwmaH7I3LN1IE="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",


### PR DESCRIPTION
Same underlying changes as #499825

https://chromereleases.googleblog.com/2026/03/stable-channel-update-for-desktop_13.html

This update includes 1 security fix. Google is aware that an exploit for CVE-2026-3909 exists in the wild.

CVEs:
CVE-2026-3909

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
