### PR TITLE
texlive.withPackages: use revision number for detailed version

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -3,7 +3,7 @@
   tl,
   bin,
 
-  version,
+  tlpdbVersion,
 
   lib,
   buildEnv,
@@ -49,10 +49,9 @@ lib.fix (
       args:
       (buildEnv (
         {
-          pname = name;
-          version = "${toString version.texliveYear}-unstable-${version.year}-${version.month}-${version.day}";
+          inherit pname version;
 
-          inherit (args) name paths;
+          inherit (args) paths;
         }
         // lib.optionalAttrs (args ? extraOutputsToInstall) { inherit (args) extraOutputsToInstall; }
         // lib.optionalAttrs (args ? pathsToLink) { inherit (args) pathsToLink; }
@@ -216,11 +215,20 @@ lib.fix (
       ]
     ) pkgList.bin;
 
-    name =
+    pname =
       if __combine then
-        "texlive-${__extraName}-${bin.texliveYear}${__extraVersion}" # texlive.combine: old name name
+        "texlive-${__extraName}" # texlive.combine: old name
       else
-        "texlive-${bin.texliveYear}-" + (if __formatsOf != null then "${__formatsOf.pname}-fmt" else "env");
+        "texlive";
+    version =
+      if __combine then
+        "${toString tlpdbVersion.year}${__extraVersion}" # texlive.combine: old version
+      else
+        "${toString tlpdbVersion.year}-r${toString tlpdbVersion.revision}-"
+        + (lib.optionalString tlpdbVersion.frozen "final-")
+        + (if __formatsOf != null then "${__formatsOf.pname}-fmt" else "env");
+
+    name = "${pname}-${version}";
 
     texmfdist = buildEnv' {
       name = "${name}-texmfdist";

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -198,7 +198,7 @@ let
   # function for creating a working environment
   buildTeXEnv = import ./build-tex-env.nix {
     inherit bin tl;
-    inherit version;
+    inherit tlpdbVersion;
     ghostscript = ghostscript_headless;
     inherit
       lib


### PR DESCRIPTION
Replace the `-unstable-YYYY-MM-DD` added in #487432 with `-rNNNNN` where `NNNNN` is the SVN revision number embedded into the TeX Live package database. It also appends `-final` when the TeX Live release has stopped receiving updates.

This is a cosmetic change, but kind of sensible in preparation for `texliveUnstable`, because the `-unstable` tag is misleading for TeX Live.

PS: this also supercedes #289759.

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
