### PR TITLE
texlive.bin: inherit arguments from texlive

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -16,7 +16,7 @@
   gd,
   libxaw,
   icu,
-  ghostscript,
+  ghostscript_headless,
   libxpm,
   libxmu,
   libxext,
@@ -29,7 +29,7 @@
   libpaper,
   graphite2,
   zziplib,
-  harfbuzz,
+  harfbuzzFull,
   potrace,
   gmp,
   mpfr,
@@ -44,11 +44,12 @@
   woff2,
   xxHash,
   makeWrapper,
-  useFixedHashes,
+  useFixedHashes ? true,
   asymptote,
   biber-ms,
   tlpdb,
   luajit,
+  ...
 }@args:
 
 # Useful resource covering build options:
@@ -411,7 +412,7 @@ rec {
     buildInputs = core.buildInputs ++ [
       core
       cairo
-      harfbuzz
+      harfbuzzFull
       icu
       graphite2
       libx11
@@ -607,7 +608,7 @@ rec {
     buildInputs = [
       core
       brotli
-      ghostscript
+      ghostscript_headless
       zlib
       freetype
       ttfautohint
@@ -637,7 +638,7 @@ rec {
       libpng
       freetype
       gd
-      ghostscript
+      ghostscript_headless
     ];
 
     preConfigure = ''
@@ -651,7 +652,7 @@ rec {
       "--disable-debug"
     ];
 
-    GS = "${ghostscript}/bin/gs";
+    GS = lib.getExe ghostscript_headless;
 
     enableParallelBuilding = true;
   };
@@ -750,7 +751,7 @@ rec {
     buildInputs = [
       core # kpathsea
       freetype
-      ghostscript
+      ghostscript_headless
       libx11
       libxaw
       libxi

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -12,10 +12,9 @@
   writeShellScript,
   writeText,
   buildEnv,
-  callPackage,
   ghostscript_headless,
   git-latexdiff,
-  harfbuzz,
+  harfbuzzFull,
   makeWrapper,
   installShellFiles,
   python3,
@@ -45,18 +44,48 @@
   extraMirrors ? [ ],
   nixfmt,
   luajit,
-}:
+  # for bin.nix
+  perlPackages,
+  python3Packages,
+  pkg-config,
+  cmake,
+  ninja,
+  libpaper,
+  graphite2,
+  zziplib,
+  potrace,
+  gmp,
+  mpfr,
+  mupdf-headless,
+  brotli,
+  cairo,
+  pixman,
+  libxi,
+  libxfixes,
+  clisp,
+  biber,
+  woff2,
+  xxHash,
+  fetchzip,
+  fetchFromGitHub,
+  buildPackages,
+  texlive,
+  zlib,
+  libiconv,
+  libpng,
+  libx11,
+  freetype,
+  ttfautohint,
+  gd,
+  libxaw,
+  icu,
+  libxpm,
+  libxmu,
+  libxext,
+}@args:
 let
   # various binaries (compiled)
-  bin = callPackage ./bin.nix {
-    ghostscript = ghostscript_headless;
-    harfbuzz = harfbuzz.override {
-      withIcu = true;
-      withGraphite2 = true;
-    };
-    inherit useFixedHashes;
-    tlpdb = overriddenTlpdb;
-  };
+  bin = import ./bin.nix (args // { tlpdb = overriddenTlpdb; });
 
   tlpdb = import ./tlpdb.nix;
 


### PR DESCRIPTION
Trying to address the issue that `texlive.override` is not usable, because TeX Live uses `callPackage` to create `texlive.bin`. See report at https://discourse.nixos.org/t/override-texlive-bin/60294

This change allows `texlive.override` to work as expected at the cost of writing all of the arguments twice.

This shouldn't cause any rebuild.

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
