### PR TITLE
cargo-tauri: only install .app bundles on Darwin

### DIFF
--- a/pkgs/by-name/ca/cargo-tauri/hook.nix
+++ b/pkgs/by-name/ca/cargo-tauri/hook.nix
@@ -48,8 +48,18 @@ makeSetupHook {
     installScript =
       {
         darwin = ''
-          mkdir -p $out
-          mv "$targetDir"/bundle/macos $out/Applications
+          mkdir -p "$out/Applications"
+
+          shopt -s nullglob
+          appBundles=("$targetDir"/bundle/macos/*.app)
+          shopt -u nullglob
+
+          if [ "''${#appBundles[@]}" -eq 0 ]; then
+            echo "cargo-tauri.hook: no .app bundles found in $targetDir/bundle/macos" >&2
+            exit 1
+          fi
+
+          mv -- "''${appBundles[@]}" "$out/Applications/"
         '';
 
         linux = ''

--- a/pkgs/by-name/ca/cargo-tauri/test-app.nix
+++ b/pkgs/by-name/ca/cargo-tauri/test-app.nix
@@ -64,10 +64,40 @@ stdenv.mkDerivation (finalAttrs: {
   preBuild = ''
     pnpm --filter '@tauri-apps/api' build
   '';
+  postBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    bundleDir="target/${stdenv.hostPlatform.rust.cargoShortTarget}/''${cargoBuildType:-release}/bundle/macos"
+    touch "$bundleDir/.test-hidden-entry"
+    touch "$bundleDir/test-visible-entry"
+  '';
 
   # No one should be actually running this, so lets save some time
   buildType = "debug";
   doCheck = false;
+  doInstallCheck = stdenv.hostPlatform.isDarwin;
+  installCheckPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    runHook preInstallCheck
+
+    test -d "$out/Applications"
+
+    shopt -s nullglob dotglob
+    appBundles=("$out"/Applications/*.app)
+    nonAppEntries=("$out"/Applications/*)
+    shopt -u nullglob dotglob
+
+    test "''${#appBundles[@]}" -gt 0
+
+    for entry in "''${nonAppEntries[@]}"; do
+      case "$entry" in
+        *.app) ;;
+        *)
+          echo "unexpected non-.app entry in Applications: $entry" >&2
+          exit 1
+          ;;
+      esac
+    done
+
+    runHook postInstallCheck
+  '';
 
   meta = {
     inherit (cargo-tauri.hook.meta) platforms;


### PR DESCRIPTION
`cargo-tauri` currently installs the entire `target/.../bundle/macos` directory into `$out/Applications` on Darwin. For apps that enable Tauri updater artifacts, that leaks files like `*.app.tar.gz` into the installed `Applications` output, which Home Manager then exposes into `~/Applications`.

This change makes the Darwin install hook move only `*.app` bundles into `Applications` and fail if no app bundle was produced. It also extends the existing `cargo-tauri` test app on Darwin to enable updater artifacts and assert that the installed `Applications` directory contains only `.app` entries.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
