### PR TITLE
age-plugin-fido2prf: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5042,6 +5042,11 @@
     githubId = 9336788;
     name = "Claes Hallström";
   };
+  claraphyll = {
+    github = "claraphyll";
+    githubId = 22559310;
+    name = "Clara Rostock";
+  };
   claymorwan = {
     name = "claymorwan";
     github = "claymorwan";

--- a/pkgs/by-name/ag/age-plugin-fido2prf/package.nix
+++ b/pkgs/by-name/ag/age-plugin-fido2prf/package.nix
@@ -33,4 +33,5 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [ claraphyll ];
     mainProgram = "age-plugin-fido2prf";
   };
+  __structuredAttrs = true;
 })

--- a/pkgs/by-name/ag/age-plugin-fido2prf/package.nix
+++ b/pkgs/by-name/ag/age-plugin-fido2prf/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  libfido2,
+}:
+buildGoModule (finalAttrs: {
+  pname = "age-plugin-fido2prf";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "FiloSottile";
+    repo = "typage";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JGEn1xIzfLyoCWd/aRRG08Z/OoviEyZF+tGEfcj9DXw=";
+  };
+
+  srcRoot = "${finalAttrs.src}/fido2prf/cmd/age-plugin-fido2prf";
+  vendorHash = "sha256-XrgZBvNyVUhKJ87vfd9aZh6aW+JifJWUu/ggNQZKwo0=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${finalAttrs.version}"
+  ];
+
+  buildInputs = [ libfido2 ];
+
+  meta = {
+    description = "Age plugin to encrypt files with FIDO2 tokens in a way compatible to typage";
+    homepage = "https://github.com/FiloSottile/typage/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ claraphyll ];
+    mainProgram = "age-plugin-fido2prf";
+  };
+})


### PR DESCRIPTION
This adds `age-plugin-fido2prf`, which is provided in the typeage repo. It's written by the author of `age`, FiloSottille and allows using FIDO2 keys with the PRF extension for secure, stateless age encryption. I've tested that the binary works with actual hardware (can generate an identity, encrypt, and decrypt text).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
