### PR TITLE
lib.types: add types.option

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -704,6 +704,9 @@ checkConfigError 'In module .*/options-type-error-configuration.nix: expected an
 # Check that that merging of option collisions doesn't depend on type being set
 checkConfigError 'The option .group..*would be a parent of the following options, but its type .<no description>. does not support nested options.\n\s*- option.s. with prefix .group.enable..*' config.group.enable ./merge-typeless-option.nix
 
+# types.optionDeclaration
+checkConfigOutput '^10$' config.anOption ./option.nix
+
 # Test that types.optionType merges types correctly
 checkConfigOutput '^10$' config.theOption.int ./optionTypeMerging.nix
 checkConfigOutput '^"hello"$' config.theOption.str ./optionTypeMerging.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -706,6 +706,7 @@ checkConfigError 'The option .group..*would be a parent of the following options
 
 # types.optionDeclaration
 checkConfigOutput '^10$' config.anOption ./option.nix
+checkConfigError 'A definition for option .aBadOptionDef. is not of type .option declaration.' config.aBadOptionDef ./option.nix
 
 # Test that types.optionType merges types correctly
 checkConfigOutput '^10$' config.theOption.int ./optionTypeMerging.nix

--- a/lib/tests/modules/option.nix
+++ b/lib/tests/modules/option.nix
@@ -1,0 +1,15 @@
+{ config, lib, ... }:
+{
+  options = {
+    theOption = lib.mkOption {
+      type = lib.types.optionDeclaration;
+    };
+    anOption = config.theOption;
+  };
+  config = {
+    theOption = lib.mkOption {
+      type = lib.types.int;
+    };
+    anOption = 10;
+  };
+}

--- a/lib/tests/modules/option.nix
+++ b/lib/tests/modules/option.nix
@@ -1,15 +1,27 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  options,
+  ...
+}:
 {
   options = {
     theOption = lib.mkOption {
       type = lib.types.optionDeclaration;
     };
     anOption = config.theOption;
+    aBadOptionDef = lib.mkOption {
+      type = lib.types.optionDeclaration;
+      description = ''
+        This option is perfectly fine, but will have a bad definition.
+      '';
+    };
   };
   config = {
     theOption = lib.mkOption {
       type = lib.types.int;
     };
     anOption = 10;
+    aBadOptionDef = options.theOption; # Not a declaration
   };
 }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1180,6 +1180,13 @@ rec {
       };
     };
 
+  optionDeclaration = mkOptionType {
+    name = "optionDeclaration";
+    description = "option declaration";
+    descriptionClass = "noun";
+    check = opt: isType "option" opt && !(opt ? value);
+  };
+
   # The type of a type!
   optionType = mkOptionType {
     name = "optionType";

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -137,6 +137,22 @@ Users must still be careful about how they reference these paths.
     multiple option definitions are correctly merged together. The main use
     case is as the type of the `_module.freeformType` option.
 
+`types.optionDeclaration`
+
+:   The type of a module system option declaration, as created by `lib.mkOption`.
+    This allows an option to hold another option declaration as its value, which
+    can then be spliced into a module's `options` attrset. Note that this only
+    accepts option declarations, not evaluated options (i.e. options that have
+    been processed by `evalModules` and have a `value` field).
+
+    ::: {.warning}
+    Use of this type is a form of metaprogramming that makes modules harder
+    to reason about, since options and their types become dynamic values
+    rather than statically declared structure. Prefer conventional module
+    patterns where possible, and only reach for `types.optionDeclaration` when the
+    added complexity is justified.
+    :::
+
 `types.attrs`
 
 :   A free-form attribute set.


### PR DESCRIPTION
i noticed that while we had a `types.optionType`, describing what goes into a module system `type`, we seemingly did not yet have a type to describe an actual module system option itself.
this change fills that gap.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
