### PR TITLE
czkawka: fix startup on X11

### DIFF
--- a/pkgs/by-name/cz/czkawka/package.nix
+++ b/pkgs/by-name/cz/czkawka/package.nix
@@ -10,7 +10,11 @@
   gobject-introspection,
   gtk4,
   libglvnd,
+  libx11,
+  libxcursor,
+  libxi,
   libxkbcommon,
+  libxrandr,
   pango,
   pkg-config,
   rustPlatform,
@@ -86,6 +90,10 @@ let
         lib.makeLibraryPath [
           fontconfig
           libglvnd
+          libx11
+          libxcursor
+          libxi
+          libxrandr
           libxkbcommon
           wayland
         ]


### PR DESCRIPTION
Before this when launching on X11 with minimal desktop environment (DE-specific env variables not set) it crashes with

```
23:22:35.618 [INFO] czkawka_core::common::logger: Logging to file "/home/<user>/.cache/czkawka/krokiet.log" and terminal
23:22:35.621 [INFO] czkawka_core::common::logger: Krokiet version: 10.0.0, release mode, rust 1.91.1 (2025-11-07), os NixOS 26.5.0 (x86_64 64-bit), 16 cpu/threads, features(0): [], app cpu version: x86-64-v1 (SSE2), os cpu version: x86-64-v3 (AVX2)
23:22:35.621 [INFO] czkawka_core::common::config_cache_path: Config folder set to "/home/<user>/.config/krokiet" and cache folder set to "/home/<user>/.cache/czkawka"
23:22:35.621 [INFO] krokiet: Krokiet features(2): [winit_femtovg, winit_software]
23:22:35.624 [ERROR] log_panics: thread 'main' panicked at 'Failed to create main window: Could not initialize backend.
Error from Winit backend: Error initializing winit event loop: os error at /build/czkawka-10.0.0-vendor/winit-0.30.12/src/platform_impl/linux/mod.rs:788: Failed to load one of xlib's shared libraries
No backends configured.': krokiet/src/main.rs:77
   0: log_panics::Config::install_panic_hook::{{closure}}
   1: std::panicking::panic_with_hook
   2: std::panicking::panic_handler::{{closure}}
   3: std::sys::backtrace::__rust_end_short_backtrace
   4: __rustc::rust_begin_unwind
   5: core::panicking::panic_fmt
   6: core::result::unwrap_failed
   7: krokiet::main
   8: std::sys::backtrace::__rust_begin_short_backtrace
   9: std::rt::lang_start::{{closure}}
  10: std::rt::lang_start_internal
  11: main
  12: __libc_start_call_main
  13: __libc_start_main_alias_1
  14: _start
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
