### PR TITLE
firefox_decrypt: remove all-packages.nix override of by-name definition

### DIFF
--- a/pkgs/by-name/fi/firefox_decrypt/package.nix
+++ b/pkgs/by-name/fi/firefox_decrypt/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  nss,
+  nss_latest,
   nixosTests,
   nix-update-script,
   stdenv,
@@ -30,16 +30,16 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "--prefix"
     (if stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH")
     ":"
-    (lib.makeLibraryPath [ nss ])
+    (lib.makeLibraryPath [ nss_latest ])
   ];
 
   checkPhase = ''
     runHook preCheck
 
     patchShebangs tests
-    (cd tests && ${
-      if stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH"
-    }=${lib.makeLibraryPath [ nss ]} ./run_all)
+    (cd tests && ${if stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH"}=${
+      lib.makeLibraryPath [ nss_latest ]
+    } ./run_all)
 
     runHook postCheck
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6344,8 +6344,6 @@ with pkgs;
     fmt_12
     ;
 
-  firefox_decrypt = callPackage ../by-name/fi/firefox_decrypt/package.nix { nss = nss_latest; };
-
   fmt = fmt_12;
 
   fontconfig = callPackage ../development/libraries/fontconfig { };


### PR DESCRIPTION
This is one of the last steps towards #483820, which will help enable checking for additional by-name directories (e.g. Python) in nixpkgs-vet.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Verified 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
