### PR TITLE
update LightGBM links

### DIFF
--- a/pkgs/by-name/li/lightgbm/package.nix
+++ b/pkgs/by-name/li/lightgbm/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # Fix boost 1.83+ compatibility
-    # https://github.com/microsoft/LightGBM/issues/6786
+    # https://github.com/lightgbm-org/LightGBM/issues/6786
     # Patch taken from https://github.com/conda-forge/lightgbm-feedstock/pull/69
     (fetchpatch {
       name = "fix-boost-sha1";
@@ -219,8 +219,8 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Gradient boosting framework that uses tree based learning algorithms";
     mainProgram = "lightgbm";
-    homepage = "https://github.com/microsoft/LightGBM";
-    changelog = "https://github.com/microsoft/LightGBM/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/lightgbm-org/LightGBM";
+    changelog = "https://github.com/lightgbm-org/LightGBM/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ nviets ];

--- a/pkgs/development/python-modules/lightgbm/default.nix
+++ b/pkgs/development/python-modules/lightgbm/default.nix
@@ -127,8 +127,8 @@ buildPythonPackage rec {
 
   meta = {
     description = "Fast, distributed, high performance gradient boosting (GBDT, GBRT, GBM or MART) framework";
-    homepage = "https://github.com/Microsoft/LightGBM";
-    changelog = "https://github.com/microsoft/LightGBM/releases/tag/v${version}";
+    homepage = "https://github.com/lightgbm-org/LightGBM";
+    changelog = "https://github.com/lightgbm-org/LightGBM/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ teh ];
   };


### PR DESCRIPTION

LightGBM has moved out of `Microsoft/` to its own organization: https://github.com/lightgbm-org/LightGBM/issues/7187

This updates links in this project to reflect that.

Thanks for helping people use LightGBM!

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
