### PR TITLE
nixos/tests/systemd-coredump: Fix test

### DIFF
--- a/nixos/tests/systemd-coredump.nix
+++ b/nixos/tests/systemd-coredump.nix
@@ -37,10 +37,10 @@ in
       machine1.wait_for_unit("systemd-coredump.socket")
       machine1.systemctl("start crasher");
       machine1.wait_until_succeeds("coredumpctl list | grep crasher", timeout=10)
-      machine1.fail("stat /var/lib/crasher/core")
+      machine1.fail("stat /var/lib/crasher/core*")
 
     with subtest("systemd-coredump disabled"):
       machine2.systemctl("start crasher");
-      machine2.wait_until_succeeds("stat /var/lib/crasher/core", timeout=10)
+      machine2.wait_until_succeeds("stat /var/lib/crasher/core*", timeout=10)
   '';
 }


### PR DESCRIPTION
1ee2f0b0caeb0c126858307db96edd15ea1c64d8 broke this test because now the core file has the PID in the name, even when systemd-coredump is disabled.

Previous PR: #498495

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
