### PR TITLE
nixos/frigate: fix PWA manifest URLs

### DIFF
--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -623,6 +623,10 @@ in
               add_header Cache-Control "public";
               default_type application/json;
               proxy_set_header Accept-Encoding "";
+              sub_filter_once off;
+              sub_filter_types application/manifest+json;
+              sub_filter '"start_url": "/BASE_PATH/"' '"start_url" : "$http_x_ingress_path/"';
+              sub_filter '"src": "/BASE_PATH/' '"src": "$http_x_ingress_path/';
             '';
           };
           "/" = {


### PR DESCRIPTION
Upstream Frigate relies on [nginx configuration](https://github.com/blakeblackshear/frigate/blob/687fefb343ea597df420ea44998474da66911720/docker/main/rootfs/usr/local/nginx/conf/nginx.conf#L343-L346) to substitute in a base URL for the webapp in the PWA manifest. Without this, the PWA manifest contains URLs prefixed with `/BASE_PATH/`, which are incorrect. Upstream's solution here seems like a horrible hack, but whatever.

I had to tweak the `sub_filter_types` clause slightly, but this change (applied manually in my NixOS configuration) was enough to get the PWA installation flow to work on desktop and mobile Chrome. I notice there's a bunch of additional substitutions applied in the upstream config which we don't have, but it's not obvious to me if/where they're needed, so I haven't touched further; probably someone needs to go in and audit the whole config for divergence at some point.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
