### PR TITLE
framework-control: init at 0.5.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20425,6 +20425,12 @@
     githubId = 5948762;
     name = "Berk Özkütük";
   };
+  ozturkkl = {
+    email = "97kemalozturk@gmail.com";
+    github = "ozturkkl";
+    githubId = 51798197;
+    name = "Kemal Ozturk";
+  };
   ozwaldorf = {
     email = "self@ossian.dev";
     github = "ozwaldorf";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -665,6 +665,7 @@
   ./services/hardware/dell-bios-fan-control.nix
   ./services/hardware/display.nix
   ./services/hardware/fancontrol.nix
+  ./services/hardware/framework-control.nix
   ./services/hardware/freefall.nix
   ./services/hardware/fwupd.nix
   ./services/hardware/g810-led.nix

--- a/nixos/modules/services/hardware/framework-control.nix
+++ b/nixos/modules/services/hardware/framework-control.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.framework-control;
+in
+{
+  meta.maintainers = [ lib.maintainers.ozturkkl ];
+
+  options.services.framework-control = {
+    enable = lib.mkEnableOption "Framework Control device hardware service";
+    package = lib.mkPackageOption pkgs "framework-control" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.framework-control = {
+      description = "Framework Control Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      # framework-control shells out to framework_tool at runtime for hardware access
+      path = [ pkgs.framework-tool ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = lib.getExe cfg.package;
+        Restart = "on-failure";
+        RestartSec = "5s";
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RestrictNamespaces = true;
+        SystemCallArchitectures = "native";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/fr/framework-control/package.nix
+++ b/pkgs/by-name/fr/framework-control/package.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  rustPlatform,
+  nodejs,
+  npmHooks,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  makeDesktopItem,
+  copyDesktopItems,
+  controlPort ? 30912,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "framework-control";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "ozturkkl";
+    repo = "framework-control";
+    tag = finalAttrs.version;
+    hash = "sha256-xXysqKwHYD5jfbiYddeckj2BE349CYeD20to1BF8jFs=";
+  };
+
+  cargoHash = "sha256-fAx3scGTWIkkqqTmzpxp4Z4LxKxVjED5x9qikJpCGf4=";
+
+  cargoRoot = "service";
+  buildAndTestSubdir = "service";
+
+  npmRoot = "web";
+
+  npmDeps = fetchNpmDeps {
+    name = "framework-control-npm-deps";
+    src = "${finalAttrs.src}/web";
+    hash = "sha256-ZTvYT5x+7X3+PfBxaR6YzRlTKH1DBvwlxC281Srq2Og=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "framework-control";
+      desktopName = "Framework Control";
+      comment = "Lightweight control surface for Framework laptops";
+      exec = "xdg-open http://127.0.0.1:${toString controlPort}";
+      icon = "framework-control";
+      terminal = false;
+      categories = [
+        "Utility"
+        "System"
+      ];
+      startupNotify = true;
+    })
+  ];
+
+  FRAMEWORK_CONTROL_PORT = controlPort;
+
+  preBuild = ''
+    pushd web
+    npm run build
+    popd
+  '';
+
+  buildFeatures = [ "embed-ui" ];
+
+  postInstall = ''
+    mv $out/bin/framework-control-service $out/bin/framework-control
+
+    install -Dm644 web/public/assets/logo.png \
+      $out/share/icons/hicolor/256x256/apps/framework-control.png
+  '';
+
+  meta = {
+    description = "Lightweight control surface for Framework laptops";
+    homepage = "https://github.com/ozturkkl/framework-control";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ozturkkl ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "framework-control";
+  };
+})

--- a/pkgs/by-name/fr/framework-control/package.nix
+++ b/pkgs/by-name/fr/framework-control/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  rustPlatform,
+  nodejs,
+  npmHooks,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  makeDesktopItem,
+  copyDesktopItems,
+  controlPort ? 30912,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "framework-control";
+  version = "0.5.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ozturkkl";
+    repo = "framework-control";
+    tag = finalAttrs.version;
+    hash = "sha256-2+4RxEDtLf7pnAI35Dykx38JDhZykjNZ+mihBhX0yyI=";
+  };
+
+  cargoHash = "sha256-fAx3scGTWIkkqqTmzpxp4Z4LxKxVjED5x9qikJpCGf4=";
+
+  cargoRoot = "service";
+  buildAndTestSubdir = "service";
+
+  npmRoot = "web";
+
+  npmDeps = fetchNpmDeps {
+    name = "framework-control-npm-deps";
+    src = "${finalAttrs.src}/web";
+    hash = "sha256-ZTvYT5x+7X3+PfBxaR6YzRlTKH1DBvwlxC281Srq2Og=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "framework-control";
+      desktopName = "Framework Control";
+      comment = "Lightweight control surface for Framework laptops";
+      exec = "xdg-open http://127.0.0.1:${toString controlPort}";
+      icon = "framework-control";
+      terminal = false;
+      categories = [
+        "Utility"
+        "System"
+      ];
+      startupNotify = true;
+    })
+  ];
+
+  FRAMEWORK_CONTROL_PORT = controlPort;
+
+  preBuild = ''
+    pushd web
+    npm run build
+    popd
+  '';
+
+  buildFeatures = [ "embed-ui" ];
+
+  postInstall = ''
+    mv $out/bin/framework-control-service $out/bin/framework-control
+
+    install -Dm644 web/public/assets/logo.png \
+      $out/share/icons/hicolor/256x256/apps/framework-control.png
+  '';
+
+  meta = {
+    description = "Lightweight control surface for Framework laptops";
+    homepage = "https://github.com/ozturkkl/framework-control";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ozturkkl ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "framework-control";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds `framework-control` (https://github.com/ozturkkl/framework-control), a lightweight web-based control surface for Framework laptops/devices. It wraps `framework-tool` to expose fan curve control, battery charge limits, power management, and hardware telemetry via a local web UI served on `127.0.0.1:30912`.

Also adds a NixOS module at `services.framework-control.enable`. This app is meant to run as a system service since it needs access to the `framework_tool` CLI commands that talk to the Embedded Controller.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (Framework devices are only available with this platform)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
