### PR TITLE
anki: fix darwin build, add missing platform wheels

### DIFF
--- a/pkgs/by-name/an/anki/package.nix
+++ b/pkgs/by-name/an/anki/package.nix
@@ -43,57 +43,63 @@ let
   srcHash = "sha256-0hLTQR7f7s58DUgAZbDeREMee6VrqAKHyhS1Hs/Em1A=";
   cargoHash = "sha256-qcB+r9VzBz6ACZaXPL26MOxxtb/h2OIuxyc54vUgfPM=";
   yarnHash = "sha256-EmKeHORr/+qsDzAwtearMi7qodcCgjeAQcy+79HL7Vg=";
-  pythonDeps = with python3Packages; [
-    # anki (pylib) runtime deps
-    decorator
-    distro
-    markdown
-    orjson
-    protobuf
-    requests
-    typing-extensions
+  pythonDeps =
+    with python3Packages;
+    [
+      # anki (pylib) runtime deps
+      decorator
+      distro
+      markdown
+      orjson
+      protobuf
+      requests
+      typing-extensions
 
-    # aqt runtime deps
-    beautifulsoup4
-    flask
-    flask-cors
-    jsonschema
-    pip-system-certs
-    pyqt6
-    pyqt6-sip
-    pyqt6-webengine
-    send2trash
-    waitress
+      # aqt runtime deps
+      beautifulsoup4
+      flask
+      flask-cors
+      jsonschema
+      pip-system-certs
+      pyqt6
+      pyqt6-sip
+      pyqt6-webengine
+      send2trash
+      waitress
 
-    # build-system deps (needed by uv for editable installs)
-    editables
-    hatchling
-    pathspec
-    pluggy
-    setuptools
-    trove-classifiers
+      # build-system deps (needed by uv for editable installs)
+      editables
+      hatchling
+      pathspec
+      pluggy
+      setuptools
+      trove-classifiers
 
-    # transitive deps
-    attrs
-    blinker
-    certifi
-    charset-normalizer
-    click
-    idna
-    itsdangerous
-    jinja2
-    jsonschema-specifications
-    markupsafe
-    packaging
-    pip
-    pysocks
-    referencing
-    rpds-py
-    soupsieve
-    urllib3
-    werkzeug
-    wrapt
-  ];
+      # transitive deps
+      attrs
+      blinker
+      certifi
+      charset-normalizer
+      click
+      idna
+      itsdangerous
+      jinja2
+      jsonschema-specifications
+      markupsafe
+      packaging
+      pip
+      pysocks
+      referencing
+      rpds-py
+      soupsieve
+      urllib3
+      werkzeug
+      wrapt
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      anki-audio
+      anki-mac-helper
+    ];
 
   src = fetchFromGitHub {
     owner = "ankitects";

--- a/pkgs/development/python-modules/anki-audio/default.nix
+++ b/pkgs/development/python-modules/anki-audio/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  stdenv,
+  hatchling,
+  mpv-unwrapped,
+  lame,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "anki-audio";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ankitects";
+    repo = "anki-bundle-extras";
+    rev = "e83c6e64dcb110ed579fc78afbb4e72bed8fb9e9";
+    hash = "sha256-iOAZ7EytEVpvsrnVFk6bkiU8FWf2Q7tTzJjawZQCW6E=";
+  };
+
+  build-system = [ hatchling ];
+
+  env = {
+    ANKI_AUDIO_TARGET_OS = "darwin";
+    ANKI_AUDIO_TARGET_ARCH = stdenv.hostPlatform.darwinArch;
+  };
+
+  preBuild =
+    let
+      archDir = if stdenv.hostPlatform.isAarch64 then "arm64" else "amd64";
+    in
+    ''
+      mkdir -p mac/${archDir}/dist/audio/Resources
+      ln -s ${lib.getExe mpv-unwrapped} ${lib.getExe lame} mac/${archDir}/dist/audio/Resources/
+    '';
+
+  pythonImportsCheck = [ "anki_audio" ];
+
+  meta = {
+    description = "Audio binaries (mpv, lame) for Anki";
+    homepage = "https://github.com/ankitects/anki-bundle-extras";
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = lib.platforms.darwin;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
+      euank
+      junestepp
+      oxij
+    ];
+  };
+})

--- a/pkgs/development/python-modules/anki-mac-helper/default.nix
+++ b/pkgs/development/python-modules/anki-mac-helper/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  stdenv,
+  anki,
+  hatchling,
+  swift,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "anki-mac-helper";
+  inherit (anki) version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/qt/mac";
+
+  build-system = [ hatchling ];
+  nativeBuildInputs = [ swift ];
+
+  # This is intended to emulate github:ankitects/anki/qt/mac/helper_build.py,
+  # but targets the platform directly instead of universal binary + lipo.
+  preBuild = ''
+    swiftc \
+      -target ${stdenv.hostPlatform.darwinArch}-apple-macos11 \
+      -emit-library \
+      -module-name ankihelper \
+      -O \
+      *.swift \
+      -o anki_mac_helper/libankihelper.dylib
+  '';
+
+  pythonImportsCheck = [ "anki_mac_helper" ];
+
+  meta = {
+    description = "Small support library for Anki on Macs";
+    homepage = "https://github.com/ankitects/anki";
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = lib.platforms.darwin;
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [
+      euank
+      junestepp
+      oxij
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -760,6 +760,10 @@ self: super: with self; {
 
   anki-audio = callPackage ../development/python-modules/anki-audio { };
 
+  anki-mac-helper = callPackage ../development/python-modules/anki-mac-helper {
+    inherit (pkgs) swift;
+  };
+
   anndata = callPackage ../development/python-modules/anndata { };
 
   annexremote = callPackage ../development/python-modules/annexremote { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -758,6 +758,8 @@ self: super: with self; {
 
   anitopy = callPackage ../development/python-modules/anitopy { };
 
+  anki-audio = callPackage ../development/python-modules/anki-audio { };
+
   anndata = callPackage ../development/python-modules/anndata { };
 
   annexremote = callPackage ../development/python-modules/annexremote { };


### PR DESCRIPTION
anki-audio and anki-mac-helper aren't available in python3Packages. uv requires them to build on darwin, but sandboxed builder can't fetch them, so fetch them here and link them alongside other wheels.

This fixes the regression on darwin from #498788 which was missing two darwin-specific, anki-only deps. This is less clean than adding those deps to python3Packages, but since they're only used for anki (afaik) this gets darwin back online more quickly. x86_64-linux build is unaffected in my testing since these wheels are platform gated. 

<details>
<summary>before change: failed build output</summary>

without any changes:

```shell-session
error: builder for '/nix/store/l2f015sryd4b047cwb3gfp63wrc2g3ky-anki-25.09.2.drv' failed with exit code 1;
       last 25 log lines:
       > DEBUG No cache entry for: https://pypi.org/simple/referencing/
       > DEBUG Sending fresh GET request for: https://pypi.org/simple/referencing/
       > DEBUG No cache entry for: https://pypi.org/simple/requests/
       > DEBUG Sending fresh GET request for: https://pypi.org/simple/requests/
       > DEBUG No cache entry for: https://pypi.org/simple/pyqt6/
       > DEBUG Sending fresh GET request for: https://pypi.org/simple/pyqt6/
       > DEBUG No cache entry for: https://pypi.org/simple/rpds-py/
       > DEBUG Sending fresh GET request for: https://pypi.org/simple/rpds-py/
       > DEBUG No cache entry for: https://pypi.org/simple/send2trash/
       > DEBUG Sending fresh GET request for: https://pypi.org/simple/send2trash/
       > DEBUG No cache entry for: https://pypi.org/simple/soupsieve/
       > DEBUG Sending fresh GET request for: https://pypi.org/simple/soupsieve/
       > DEBUG No cache entry for: https://pypi.org/simple/typing-extensions/
       > DEBUG Sending fresh GET request for: https://pypi.org/simple/typing-extensions/
       > DEBUG No cache entry for: https://pypi.org/simple/waitress/
       > DEBUG Sending fresh GET request for: https://pypi.org/simple/waitress/
       > DEBUG No cache entry for: https://pypi.org/simple/werkzeug/
       > DEBUG Sending fresh GET request for: https://pypi.org/simple/werkzeug/
       > DEBUG No cache entry for: https://pypi.org/simple/urllib3/
       > DEBUG Sending fresh GET request for: https://pypi.org/simple/urllib3/
       >   × No solution found when resolving dependencies:
       >   ╰─▶ Because there are no versions of anki-audio{sys_platform == 'darwin'
       >       or sys_platform == 'win32'} and you require anki-audio{sys_platform
       >       == 'darwin' or sys_platform == 'win32'}, we can conclude that your
       >       requirements are unsatisfiable.
```

after adding fetch for anki-audio wheel:

```shell-session
error: builder for '/nix/store/hc013n4547yv6digfsnbfy4r6wqkb3bs-anki-25.09.2.drv' failed with exit code 1;
       last 25 log lines:
       > DEBUG Sending fresh GET request for: https://pypi.org/simple/werkzeug/
       > INFO add_decision: Id::<PubGrubPackage>(2) @ 0.1.0 without checking dependencies
       > DEBUG Searching for a compatible version of anki-audio{sys_platform == 'darwin' or sys_platform == 'win32'} (==0.1.0)
       > DEBUG Selecting: anki-audio==0.1.0 [compatible] (anki_audio-0.1.0-cp39-abi3-macosx_11_0_arm64.whl)
       > INFO add_decision: Id::<PubGrubPackage>(37) @ 0.1.0 without checking dependencies
       > DEBUG Searching for a compatible version of anki-mac-helper{sys_platform == 'darwin'} (>=0.1.1)
       > DEBUG No compatible version found for: anki-mac-helper{sys_platform == 'darwin'}
       > INFO Start conflict resolution because incompat satisfied:
       >    anki-mac-helper{sys_platform == 'darwin'} >=0.1.1 is forbidden
       > INFO backtrack to DecisionLevel(1)
       > DEBUG Searching for a compatible version of aqt @ file:///nix/var/nix/b/3vpny2nai9fmpz5ph81gpri493/source/qt (<25.9.2 | >25.9.2)
       > DEBUG No compatible version found for: aqt
       > INFO Start conflict resolution because incompat satisfied:
       >    aqt <25.9.2 | >25.9.2 is forbidden
       > INFO prior cause: aqt depends on anki-mac-helper{sys_platform == 'darwin'} >=0.1.1
       > INFO prior cause: aqt * is forbidden
       > INFO prior cause: root ==0a0.dev0 is forbidden
       >   × No solution found when resolving dependencies:
       >   ╰─▶ Because only aqt==25.9.2 is available and aqt==25.9.2 depends on
       >       anki-mac-helper{sys_platform == 'darwin'}>=0.1.1, we can conclude
       >       that all versions of aqt depend on anki-mac-helper{sys_platform ==
       >       'darwin'}>=0.1.1.
       >       And because only anki-mac-helper{sys_platform == 'darwin'}<0.1.1 is
       >       available and you require aqt, we can conclude that your requirements
       >       are unsatisfiable.
```

</details>

<details>
  <summary>Full nixpkgs-review output</summary>

```shell-session
nixpkgs-review rev 043071890391
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
remote: Enumerating objects: 23, done.
remote: Counting objects: 100% (17/17), done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 23 (delta 12), reused 11 (delta 11), pack-reused 6 (from 3)
Unpacking objects: 100% (23/23), 259.51 KiB | 8.37 MiB/s, done.
From https://github.com/NixOS/nixpkgs
   9d1804292ee4..13875c6d92d2  master     -> refs/nixpkgs-review/0
$ git worktree add /Users/tomrfitz/.cache/nixpkgs-review/rev-0430718903911371abc6776aa11914ebf49c2427-1/nixpkgs 13875c6d92d2277f71e5ca2657ece1b8368a5c6d
Preparing worktree (detached HEAD 13875c6d92d2)
Updating files: 100% (51606/51606), done.
HEAD is now at 13875c6d92d2 pkgs/stdenv/linux: update riscv64-unknown-linux-gnu bootstrap-files (#498702)
Local evaluation for computing rebuilds
$ nix-env --extra-experimental-features no-url-literals --option system aarch64-darwin -f <nixpkgs> --nix-path nixpkgs=/Users/tomrfitz/.cache/nixpkgs-review/rev-0430718903911371abc6776aa11914ebf49c2427-1/nixpkgs nixpkgs-overlays=/var/folders/6l/nw6_9p1j7dl24bztqqbr_b4w0000gn/T/tmpda_tsy0_ -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
evaluation warning: Nixpkgs 26.05 will be the last release to support x86_64-darwin; see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05
$ git merge --no-commit --no-ff 0430718903911371abc6776aa11914ebf49c2427
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system aarch64-darwin -f <nixpkgs> --nix-path nixpkgs=/Users/tomrfitz/.cache/nixpkgs-review/rev-0430718903911371abc6776aa11914ebf49c2427-1/nixpkgs nixpkgs-overlays=/var/folders/6l/nw6_9p1j7dl24bztqqbr_b4w0000gn/T/tmpda_tsy0_ -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
evaluation warning: Nixpkgs 26.05 will be the last release to support x86_64-darwin; see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05
--------- Impacted packages on 'aarch64-darwin' ---------
3 packages updated:
anki ki mnemosyne

warning: Ignoring the client-specified setting 'system', because it is a restricted setting and you are not a trusted user
$ nom build --file /nix/store/69r4ha4fga1xyx9bz47my21pkqy5cqjf-nixpkgs-review-3.6.0/lib/python3.13/site-packages/nixpkgs_review/nix/review-shell.nix --nix-path 'nixpkgs=/Users/tomrfitz/.cache/nixpkgs-review/rev-0430718903911371abc6776aa11914ebf49c2427-1/nixpkgs nixpkgs-overlays=/var/folders/6l/nw6_9p1j7dl24bztqqbr_b4w0000gn/T/tmpda_tsy0_' --extra-experimental-features 'nix-command no-url-literals' --no-link --keep-going --no-allow-import-from-derivation --argstr local-system aarch64-darwin --argstr nixpkgs-path /Users/tomrfitz/.cache/nixpkgs-review/rev-0430718903911371abc6776aa11914ebf49c2427-1/nixpkgs --argstr nixpkgs-config-path /var/folders/6l/nw6_9p1j7dl24bztqqbr_b4w0000gn/T/tmp3troi72k.nix --argstr attrs-path /Users/tomrfitz/.cache/nixpkgs-review/rev-0430718903911371abc6776aa11914ebf49c2427-1/attrs.nix
Finished at 23:35:51 after 5s
--------- Report for 'aarch64-darwin' ---------
8 packages built:
anki anki.doc anki.lib anki.man ki ki.dist mnemosyne mnemosyne.dist

Logs can be found under:
/Users/tomrfitz/.cache/nixpkgs-review/rev-0430718903911371abc6776aa11914ebf49c2427-1/logs

$ /nix/store/qkc1silw07m48blrls2v5qddprvbznkf-nix-output-monitor-2.1.8/bin/nom-shell --argstr local-system aarch64-darwin --argstr nixpkgs-path /Users/tomrfitz/.cache/nixpkgs-review/rev-0430718903911371abc6776aa11914ebf49c2427-1/nixpkgs --argstr nixpkgs-config-path /var/folders/6l/nw6_9p1j7dl24bztqqbr_b4w0000gn/T/tmp3troi72k.nix --argstr attrs-path /Users/tomrfitz/.cache/nixpkgs-review/rev-0430718903911371abc6776aa11914ebf49c2427-1/attrs.nix --nix-path 'nixpkgs=/Users/tomrfitz/.cache/nixpkgs-review/rev-0430718903911371abc6776aa11914ebf49c2427-1/nixpkgs nixpkgs-overlays=/var/folders/6l/nw6_9p1j7dl24bztqqbr_b4w0000gn/T/tmpda_tsy0_' /nix/store/69r4ha4fga1xyx9bz47my21pkqy5cqjf-nixpkgs-review-3.6.0/lib/python3.13/site-packages/nixpkgs_review/nix/review-shell.nix
```

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
