### PR TITLE
offpunk: 3.0 -> 3.1

### DIFF
--- a/pkgs/by-name/of/offpunk/package.nix
+++ b/pkgs/by-name/of/offpunk/package.nix
@@ -1,14 +1,13 @@
 {
-  lib,
-  python3Packages,
   fetchFromSourcehut,
   file,
   gettext,
   installShellFiles,
   less,
-  offpunk,
-  testers,
+  lib,
+  python3Packages,
   timg,
+  versionCheckHook,
   xdg-utils,
   xsel,
 }:
@@ -21,7 +20,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   src = fetchFromSourcehut {
     owner = "~lioploum";
     repo = "offpunk";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-RwigItHVNsgq6k3O8YrSMFBaZMJwJSzB6dfnNiYsefY=";
   };
 
@@ -66,11 +65,22 @@ python3Packages.buildPythonApplication (finalAttrs: {
     installManPage man/*.1
   '';
 
-  passthru.tests.version = testers.testVersion { package = offpunk; };
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
-    description = "Command-line and offline-first smolnet browser/feed reader";
-    homepage = finalAttrs.src.meta.homepage;
+    changelog = "https://git.sr.ht/~lioploum/offpunk/tree/v${finalAttrs.version}/item/CHANGELOG";
+    description = "CLI and offline-first smolnet browser/feed reader";
+    longDescription = ''
+      Offpunk allows you to browse the Web, Gemini, Gopher and
+      subscribe to RSS feeds without leaving your terminal and while
+      being offline.
+
+      The goal of Offpunk is to be able to synchronise your content
+      once (a day, a week, a month) and then browse/organise it while
+      staying disconnected.
+    '';
+    homepage = "https://offpunk.net";
     license = lib.licenses.agpl3Plus;
     mainProgram = "offpunk";
     maintainers = with lib.maintainers; [ DamienCassou ];

--- a/pkgs/by-name/of/offpunk/package.nix
+++ b/pkgs/by-name/of/offpunk/package.nix
@@ -15,14 +15,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "offpunk";
-  version = "3.0";
+  version = "3.1";
   pyproject = true;
 
   src = fetchFromSourcehut {
     owner = "~lioploum";
     repo = "offpunk";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-5SoMa93QbwbsryeHGc3pkkDA8v9eonZvuflSuDV2hmI=";
+    hash = "sha256-RwigItHVNsgq6k3O8YrSMFBaZMJwJSzB6dfnNiYsefY=";
   };
 
   build-system = with python3Packages; [ hatchling ];
@@ -44,10 +44,23 @@ python3Packages.buildPythonApplication (finalAttrs: {
     chardet
     cryptography
     feedparser
+    hatch-requirements-txt
     readability-lxml
     requests
     setproctitle
   ]);
+
+  /*
+    False positive from pythonRuntimeDepsCheckHook:
+      - "bs4" is the import name for beautifulsoup4 (not the PyPI
+        package name)
+      - "file" refers to the system `file` binary, not a Python
+        package
+  */
+  pythonRemoveDeps = [
+    "bs4"
+    "file"
+  ];
 
   postInstall = ''
     installManPage man/*.1


### PR DESCRIPTION
Resolves #499851

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
