### PR TITLE
krew: fix version display

### DIFF
--- a/pkgs/by-name/kr/krew/package.nix
+++ b/pkgs/by-name/kr/krew/package.nix
@@ -15,8 +15,8 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "kubernetes-sigs";
     repo = "krew";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-KG4/vtEfwWVddfFoNbC4xakxOynDY6jyxek4JAXW5gY=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KG4/vtEfwWVddfFoNbC4xakxOynDY6jyxek4JAXW5gY=";
   };
 
   vendorHash = "sha256-z0wiYknXcCx4vqROngn58CRe9TBgya4y3v736VBMhQ8=";

--- a/pkgs/by-name/kr/krew/package.nix
+++ b/pkgs/by-name/kr/krew/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   makeWrapper,
   gitMinimal,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -23,10 +25,24 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  ldflags = [
+    "-s"
+    "-X"
+    "sigs.k8s.io/krew/internal/version.gitTag=v${finalAttrs.version}"
+  ];
+
   postFixup = ''
     wrapProgram $out/bin/krew \
       --prefix PATH : ${lib.makeBinPath [ gitMinimal ]}
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+  versionCheckProgramArg = "version";
 
   meta = {
     description = "Package manager for kubectl plugins";

--- a/pkgs/by-name/kr/krew/package.nix
+++ b/pkgs/by-name/kr/krew/package.nix
@@ -16,7 +16,12 @@ buildGoModule (finalAttrs: {
     owner = "kubernetes-sigs";
     repo = "krew";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KG4/vtEfwWVddfFoNbC4xakxOynDY6jyxek4JAXW5gY=";
+    hash = "sha256-rhl4qVHwl876OSDrcLSS07x3H/x/zmFLPHdRw+fcYsw=";
+    leaveDotGit = true;
+    postFetch = ''
+      git -C "$out" rev-parse --short HEAD > "$out/.git_head"
+      rm -rf "$out/.git"
+    '';
   };
 
   vendorHash = "sha256-z0wiYknXcCx4vqROngn58CRe9TBgya4y3v736VBMhQ8=";
@@ -30,6 +35,10 @@ buildGoModule (finalAttrs: {
     "-X"
     "sigs.k8s.io/krew/internal/version.gitTag=v${finalAttrs.version}"
   ];
+
+  preBuild = ''
+    ldflags+=" -X=sigs.k8s.io/krew/internal/version.gitCommit=$(<.git_head)"
+  '';
 
   postFixup = ''
     wrapProgram $out/bin/krew \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

While reviewing [this change](https://github.com/NixOS/nixpkgs/pull/480951/changes#diff-633a159d8a1e76c114e8c1f627294170e3f22222d90895931fadf0382de67ce9R37), I found the version display is missing.
Because it only shows a warning for the plugin and the exit code is 0, we don't need `kubectl` in `nativeBuildInputs`.


Before

```console
> krew version 2>/dev/null | grep -i tag
GitTag            unknown
```

After

```console
> ./result/bin/krew version 2>/dev/null | grep -i tag
GitTag            v0.5.0
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @vdemeester