### PR TITLE
qemu: Add --disable-pie if isStatic && isAarch64

### DIFF
--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -333,7 +333,13 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional (!pluginsSupport) "--disable-plugins"
   ++ lib.optional (!enableBlobs) "--disable-install-blobs"
   ++ lib.optional userOnly "--disable-system"
-  ++ lib.optional stdenv.hostPlatform.isStatic "--static";
+  ++ lib.optional stdenv.hostPlatform.isStatic "--static"
+  # Works around: https://github.com/NixOS/nixpkgs/issues/464805
+  # We should revisit this when pkgsStatic is static-pie by default.
+  # (Note that --disable-pie causes -fno-pie -no-pie to be passed, overriding Nixpkg's hardening handling.
+  # Therefore it should be limited to affected platforms.
+  # See: https://gitlab.com/qemu-project/qemu/-/blob/v10.2.1/meson.build?ref_type=tags#L462-482 for details.)
+  ++ lib.optional (stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isAarch64) "--disable-pie";
 
   dontWrapGApps = true;
 


### PR DESCRIPTION
This seems to be broken in a way that the configure script does not detect, causing PIE to still be enabled, resulting in linker errors and/or broken executables, depending on exact configuration. Add a specific workaround in this case.

Works around #464805


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux (`pkgStatic.qemu-user`)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`. (`qemu-x86_64` from `pkgStatic.qemu-user`)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
