### PR TITLE
nixos/zeroclaw: add nixos module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -990,6 +990,7 @@
   ./services/misc/xmrig.nix
   ./services/misc/yarr.nix
   ./services/misc/ytdl-sub.nix
+  ./services/misc/zeroclaw.nix
   ./services/misc/zoneminder.nix
   ./services/misc/zookeeper.nix
   ./services/monitoring/alerta.nix

--- a/nixos/modules/services/misc/zeroclaw.nix
+++ b/nixos/modules/services/misc/zeroclaw.nix
@@ -1,0 +1,359 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.zeroclaw;
+  inherit (lib)
+    attrNames
+    concatMapStrings
+    literalExpression
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    optionalAttrs
+    optionalString
+    types
+    ;
+
+  toml = pkgs.formats.toml { };
+
+  channelsWithSecret = lib.filterAttrs (_: channel: channel.secretFiles != { }) cfg.channels;
+  agentsWithSecret = attrNames (lib.filterAttrs (_: agent: agent.apiKeyFile != null) cfg.agents);
+  nonSecretChannelNames = attrNames (
+    lib.filterAttrs (k: _: !(channelsWithSecret ? ${k})) (cfg.settings.channels_config or { })
+  );
+
+  # Strips channels_config entirely when any channel has secrets to avoid TOML
+  # duplicate-table-header errors. Strips individual agent entries that have an
+  # apiKeyFile. Both sections are re-written by the mergeScript at runtime.
+  filteredSettings =
+    let
+      settingsNoChannelsWithSecret =
+        if channelsWithSecret != { } then
+          lib.filterAttrs (k: _: k != "channels_config") cfg.settings
+        else
+          cfg.settings;
+      agentsWithoutSecret = lib.filterAttrs (
+        k: _: !(builtins.elem k agentsWithSecret)
+      ) settingsNoChannelsWithSecret.agents;
+    in
+    if agentsWithSecret != [ ] && settingsNoChannelsWithSecret ? agents then
+      settingsNoChannelsWithSecret // { agents = agentsWithoutSecret; }
+    else
+      settingsNoChannelsWithSecret;
+
+  configFile = toml.generate "zeroclaw-config.toml" filteredSettings;
+
+  # cli = true belongs to the parent [channels_config] table and must appear
+  # before any [channels_config.*] subtables.
+  channelsConfigHeader = toml.generate "zeroclaw-channels-header.toml" {
+    channels_config.cli = true;
+  };
+
+  channelConfigFile =
+    name:
+    toml.generate "zeroclaw-channel-${name}.toml" {
+      channels_config.${name} = (cfg.settings.channels_config or { }).${name} or { };
+    };
+
+  agentConfigFile =
+    name:
+    toml.generate "zeroclaw-agent-${name}.toml" {
+      agents.${name} = (cfg.settings.agents or { }).${name} or { };
+    };
+
+  mergeScript = pkgs.writeShellScript "zeroclaw-merge-config" ''
+    set -euo pipefail
+    ZEROCLAW_CONFIG="$ZEROCLAW_CONFIG_DIR/config.toml"
+    ${optionalString cfg.mutableConfig ''
+      if [ -f "$ZEROCLAW_CONFIG" ]; then
+        echo "zeroclaw: mutableConfig is enabled and config.toml already exists, skipping update"
+        exit 0
+      fi
+    ''}
+    install -m 0600 ${configFile} "$ZEROCLAW_CONFIG"
+    ${optionalString (channelsWithSecret != { }) ''
+      cat ${channelsConfigHeader} >> "$ZEROCLAW_CONFIG"
+      ${concatMapStrings (channelName: ''
+        cat ${channelConfigFile channelName} >> "$ZEROCLAW_CONFIG"
+      '') nonSecretChannelNames}
+      ${concatMapStrings (channelName: ''
+        cat ${channelConfigFile channelName} >> "$ZEROCLAW_CONFIG"
+        ${concatMapStrings (fieldName: ''
+          printf '${fieldName} = "%s"\n' "$(cat ${
+            lib.escapeShellArg cfg.channels.${channelName}.secretFiles.${fieldName}
+          })" >> "$ZEROCLAW_CONFIG"
+        '') (attrNames cfg.channels.${channelName}.secretFiles)}
+      '') (attrNames channelsWithSecret)}
+    ''}
+    ${concatMapStrings (agentName: ''
+      cat ${agentConfigFile agentName} >> "$ZEROCLAW_CONFIG"
+      printf 'api_key = "%s"\n' "$(cat ${
+        lib.escapeShellArg cfg.agents.${agentName}.apiKeyFile
+      })" >> "$ZEROCLAW_CONFIG"
+    '') agentsWithSecret}
+  '';
+in
+{
+  options.services.zeroclaw = {
+    enable = mkEnableOption "ZeroClaw agent daemon";
+
+    package = mkPackageOption pkgs "zeroclaw" { };
+
+    stateDir = mkOption {
+      type = types.str;
+      default = "zeroclaw";
+      description = ''
+        Relative path under /var/lib for ZeroClaw runtime state.
+        The config.toml is written here at each service start, if mutableConfig is disabled.
+        Use settings and channels.<name>.secretFiles or agents.<name>.apiKeyFile instead.
+      '';
+    };
+
+    host = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = "Host the gateway binds to.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 42617;
+      description = "Port the gateway listens on.";
+    };
+
+    extraGroups = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "users" ];
+      description = ''
+        Additional groups the daemon is member of.
+      '';
+    };
+
+    mutableConfig = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        When false (default), the config.toml is regenerated from module options and
+        settings on every service start.
+
+        When true, config.toml is written only on first start (if it does not
+        already exist). Subsequent starts leave the file untouched, so runtime
+        edits made through the web UI or CLI persist across restarts.
+
+        Switching from false to true takes effect on the next start after the
+        file is first written. To reset to the Nix-managed config, delete
+        /var/lib/''${cfg.stateDir}/config.toml and restart the service.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.attrs;
+      default = { };
+      description = ''
+        Non-secret configuration serialised 1:1 as TOML into config.toml.
+        Keys not set here fall back to Rust-side defaults in the binary.
+
+        This is the primary way to configure the provider, model, memory
+        backend, autonomy policy, heartbeat, observability, and anything
+        else not covered by a dedicated module option.
+
+        Do not place secrets here. The result ends up in the Nix store.
+        Use channels.<name>.secretFiles or agents.<name>.apiKeyFile instead.
+      '';
+      example = literalExpression ''
+        {
+          default_provider = "ollama";
+          default_model = "qwen3-coder-next:q4_K_M";
+          api_url = "http://127.0.0.1:11434";
+          memory.backend = "sqlite";
+          web_fetch = { enabled = true; allowed_domains = [ "*" ]; };
+          web_search.enabled = true;
+          autonomy.auto_approve = [ "file_read" "memory_recall" "web_fetch" "web_search" ];
+          heartbeat = { enabled = true; interval_minutes = 60; };
+          observability.backend = "log";
+        }
+      '';
+    };
+
+    agents = mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          options.apiKeyFile = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            description = ''
+              Path to a file containing the API key for this agent's provider.
+              If null, the agent uses the top-level api_key or ZEROCLAW_API_KEY.
+
+              Non-secret agent settings (provider, model, agentic, allowed_tools,
+              system_prompt, etc.) belong in settings.agents.<name>.
+            '';
+            example = "/run/secrets/anthropic-api-key";
+          };
+        }
+      );
+      default = { };
+      description = ''
+        Per-agent runtime secrets. Keys are agent names matching
+        settings.agents.<name>. Only the API key goes here. All other
+        agent settings belong in settings.agents.<name>.
+      '';
+      example = literalExpression ''
+        {
+          researcher.apiKeyFile = config.sops.secrets.anthropic-api-key.path;
+          coder.apiKeyFile = "/run/secrets/ollama-api-key";
+        }
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Path to a file of environment variables injected into the daemon.
+        Useful for secrets that have environment-variable overrides, most
+        notably ZEROCLAW_API_KEY (the main provider API key). Channel
+        tokens have no env-var overrides: use channels.<name>.secretFiles.
+
+        Example file contents:
+          ZEROCLAW_API_KEY=sk-ant-...
+      '';
+    };
+
+    channels = mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          options.secretFiles = mkOption {
+            type = types.attrsOf types.path;
+            default = { };
+            description = ''
+              Map of TOML field name → path to a file containing that secret value.
+              Read at service start; never written to the Nix store.
+              Having at least one entry here enables the channel.
+
+              Field names must match the zeroclaw config keys exactly (e.g.
+              bot_token, app_token, access_token). Works with any secrets
+              manager (sops-nix, agenix, plain files, ...).
+
+              Non-secret channel settings (allowed_users, stream_mode, etc.)
+              belong in settings.channels_config.<name>.
+            '';
+            example = literalExpression ''
+              { bot_token = "/run/secrets/telegram-bot-token"; }
+            '';
+          };
+        }
+      );
+      default = { };
+      description = ''
+        Per-channel runtime secrets. Keys are channel names as recognised by
+        zeroclaw (telegram, discord, slack, mattermost, matrix, ...).
+
+        Each channel's secretFiles maps TOML field names to secret file paths.
+        Non-secret settings belong in settings.channels_config.<name>.
+
+        Channels with no secrets (e.g. signal, cli) need no entry here:
+        configure them entirely via settings.channels_config.<name>.
+      '';
+      example = literalExpression ''
+        {
+          telegram.secretFiles.bot_token = config.sops.secrets.telegram-bot-token.path;
+          slack.secretFiles = {
+            bot_token = config.sops.secrets.slack-not-token.path;
+            app_token = config.sops.secrets.slack-app-token.path;
+          };
+          matrix.secretFiles.access_token = "/run/secrets/matrix-access-token";
+        }
+      '';
+    };
+
+    web.nginx.virtualHost = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "zeroclaw.example.com";
+      description = ''
+        Hostname of the nginx virtualHost to proxy to the zeroclaw daemon.
+
+        This module only adds a `location /` proxy block to the named
+        virtualHost. You must declare the virtualHost separately to control
+        SSL, ACME, listen addresses, and access rules. E.g. to enable TLS:
+
+        services.nginx.virtualHosts."zeroclaw.example.com" = {
+          forceSSL = true;
+          enableACME = true;
+        };
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.zeroclaw = {
+      description = "ZeroClaw Agent Daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      restartTriggers = [ configFile ];
+
+      environment = {
+        ZEROCLAW_CONFIG_DIR = "/var/lib/${cfg.stateDir}";
+        ZEROCLAW_WORKSPACE = "/var/lib/${cfg.stateDir}/workspace";
+        ZEROCLAW_GATEWAY_HOST = cfg.host;
+        ZEROCLAW_GATEWAY_PORT = toString cfg.port;
+      }
+      # allow_public_bind is required when binding to a non-loopback address
+      // optionalAttrs (cfg.host != "127.0.0.1" && cfg.host != "localhost" && cfg.host != "::1") {
+        ZEROCLAW_ALLOW_PUBLIC_BIND = "1";
+      };
+
+      serviceConfig = {
+        Type = "exec";
+        DynamicUser = true;
+        SupplementaryGroups = cfg.extraGroups;
+        StateDirectory = [
+          cfg.stateDir
+          "${cfg.stateDir}/workspace"
+        ];
+        WorkingDirectory = "%S/${cfg.stateDir}";
+
+        ExecStartPre = "${mergeScript}";
+        ExecStart = "${lib.getExe cfg.package} daemon";
+
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+
+        # Hardening
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+
+    services.nginx.virtualHosts = mkIf (cfg.web.nginx.virtualHost != null) {
+      ${cfg.web.nginx.virtualHost} = {
+        locations."/" = {
+          proxyPass = "http://${cfg.host}:${toString cfg.port}";
+          proxyWebsockets = true;
+          extraConfig = ''
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+          '';
+        };
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1799,6 +1799,7 @@ in
   your_spotify = runTest ./your_spotify.nix;
   zammad = runTest ./zammad.nix;
   zenohd = runTest ./zenohd.nix;
+  zeroclaw = runTest ./zeroclaw.nix;
   zeronet-conservancy = runTest ./zeronet-conservancy.nix;
   zfs = handleTest ./zfs.nix { };
   zigbee2mqtt = runTest ./zigbee2mqtt.nix;

--- a/nixos/tests/zeroclaw.nix
+++ b/nixos/tests/zeroclaw.nix
@@ -1,0 +1,28 @@
+{
+  name = "zeroclaw";
+
+  nodes.machine = {
+    services.zeroclaw = {
+      enable = true;
+      settings = {
+        default_provider = "ollama";
+        default_model = "llama3.2";
+      };
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    let
+      host = nodes.machine.services.zeroclaw.host;
+      port = nodes.machine.services.zeroclaw.port;
+    in
+    # python
+    ''
+      machine.wait_for_unit("zeroclaw.service")
+      machine.wait_for_open_port(${toString port})
+
+      response = machine.succeed("curl -sf http://${host}:${toString port}/")
+      assert "ZeroClaw" in response, f"Expected the ZeroClaw web interface to be served: {response}"
+    '';
+}

--- a/pkgs/by-name/ze/zeroclaw/package.nix
+++ b/pkgs/by-name/ze/zeroclaw/package.nix
@@ -10,6 +10,7 @@
   gitMinimal,
   versionCheckHook,
   nix-update-script,
+  nixosTests,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -57,7 +58,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit (nixosTests) zeroclaw;
+    };
+  };
 
   meta = {
     description = "Fast, small, and fully autonomous AI assistant infrastructure — deploy anywhere, swap anything";


### PR DESCRIPTION
CC @drupol @commandodev 

after #500426

I have already [contributed the package recipe](https://github.com/zeroclaw-labs/zeroclaw/pull/1829) to zeroclaw upstream, and @commandodev has contributed the package independently to llm-agents.nix

I also had a PR open to add a nixos module, which I closed in favor of getting it into nixpkgs:
https://github.com/zeroclaw-labs/zeroclaw/pull/2955

I had to add a patch for the AutonomyConfig, otherwise one needs to specify every single field of it, even though one only wants to change one.

Since there are many different configuration settings, I think it's not feasible to replicate everything as a nixos option. What is most critical are any secrets. So secrets can be specified with options.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
