### PR TITLE
extism-js: build from source

### DIFF
--- a/pkgs/by-name/ex/extism-js-core/package.nix
+++ b/pkgs/by-name/ex/extism-js-core/package.nix
@@ -1,0 +1,92 @@
+{
+  binaryen,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  lib,
+  lld,
+  nodejs,
+  npmHooks,
+  runCommand,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "extism-js-core";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "extism";
+    repo = "js-pdk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CLyH0gDtw988cTcw4B86/kejfbYWMXEVG9Y6PKAZazE=";
+  };
+
+  cargoHash = "sha256-9lFX+Q4318ClVIRT4/uCesyNYwU9H2vV+fD3553M2Dc=";
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
+    hash = "sha256-XrydnNXXhy/2sZXUGHuZvy+WF7dYIywrUAj8OHGlVRM=";
+  };
+  npmRoot = "crates/core/src/prelude";
+
+  # https://github.com/extism/js-pdk/pull/154
+  postPatch = ''
+    substituteInPlace Cargo.toml \
+      --replace-fail '1.5.1' '${finalAttrs.version}'
+  '';
+
+  preBuild = ''
+    pushd ${finalAttrs.npmRoot}
+    npm run build
+    popd
+  '';
+
+  # https://github.com/extism/js-pdk/blob/v1.6.0/Makefile#L25
+  preFixup = ''
+    wasm-opt --enable-reference-types --enable-bulk-memory --strip -O3 $out/bin/js_pdk_core.wasm -o $out/bin/js_pdk_core.wasm
+  '';
+
+  nativeBuildInputs = [
+    binaryen
+    lld
+    nodejs
+    npmHooks.npmConfigHook
+    rustPlatform.bindgenHook
+  ];
+
+  # io-extras v0.18.4 uses #![feature]
+  env.RUSTC_BOOTSTRAP = 1;
+
+  env.RUSTFLAGS = "-C linker=wasm-ld";
+
+  # rquickjs-sys expects the dir structure from wasi-sdk
+  # https://github.com/DelSkayn/rquickjs/blob/v0.11.0/sys/build.rs#L216-L230
+  # TODO: revisit when https://github.com/DelSkayn/rquickjs/pull/648 is released and extism updated
+  env.WASI_SDK = runCommand "wasi-sdk" { } ''
+    mkdir -p $out/bin
+    ln -s ${lib.getExe' stdenv.cc "wasm32-unknown-wasi-clang"} $out/bin/clang
+    ln -s ${lib.getExe' stdenv.cc "wasm32-unknown-wasi-ar"} $out/bin/ar
+    ln -s ${stdenv.cc}/nix-support $out/nix-support
+    mkdir -p $out/share
+    ln -s ${stdenv.cc.libc} $out/share/wasi-sysroot
+  '';
+
+  cargoBuildFlags = [ "--package=js-pdk-core" ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    changelog = "https://github.com/extism/js-pdk/releases/tag/v${finalAttrs.version}";
+    description = "Write Extism plugins in JavaScript & TypeScript (WASM core)";
+    homepage = "https://github.com/extism/js-pdk";
+    license = lib.licenses.bsd3;
+    maintainers = [
+      lib.maintainers.diogotcorreia
+      lib.maintainers.dotlambda
+    ];
+    platforms = lib.platforms.wasi;
+  };
+})

--- a/pkgs/by-name/ex/extism-js-core/package.nix
+++ b/pkgs/by-name/ex/extism-js-core/package.nix
@@ -1,0 +1,92 @@
+{
+  binaryen,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  lib,
+  lld,
+  nodejs,
+  npmHooks,
+  runCommand,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "extism-js-core";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "extism";
+    repo = "js-pdk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CLyH0gDtw988cTcw4B86/kejfbYWMXEVG9Y6PKAZazE=";
+  };
+
+  cargoHash = "sha256-9lFX+Q4318ClVIRT4/uCesyNYwU9H2vV+fD3553M2Dc=";
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/${finalAttrs.npmRoot}";
+    hash = "sha256-XrydnNXXhy/2sZXUGHuZvy+WF7dYIywrUAj8OHGlVRM=";
+  };
+  npmRoot = "crates/core/src/prelude";
+
+  # https://github.com/extism/js-pdk/pull/154
+  postPatch = ''
+    substituteInPlace Cargo.toml \
+      --replace-fail '1.5.1' '${finalAttrs.version}'
+  '';
+
+  preBuild = ''
+    pushd ${finalAttrs.npmRoot}
+    npm run build
+    popd
+  '';
+
+  # https://github.com/extism/js-pdk/blob/v1.6.0/Makefile#L25
+  preFixup = ''
+    wasm-opt --enable-reference-types --enable-bulk-memory --strip -O3 $out/bin/js_pdk_core.wasm -o $out/bin/js_pdk_core.wasm
+  '';
+
+  nativeBuildInputs = [
+    binaryen
+    lld
+    nodejs
+    npmHooks.npmConfigHook
+    rustPlatform.bindgenHook
+  ];
+
+  # io-extras v0.18.4 uses #![feature]
+  env.RUSTC_BOOTSTRAP = 1;
+
+  env.RUSTFLAGS = "-C linker=wasm-ld";
+
+  # rquickjs-sys expects the dir structure from wasi-sdk
+  # https://github.com/DelSkayn/rquickjs/blob/v0.11.0/sys/build.rs#L216-L230
+  # TODO: revisit when https://github.com/DelSkayn/rquickjs/pull/648 is released and extism updated
+  env.WASI_SDK = runCommand "wasi-sdk" { } ''
+    mkdir -p $out/bin
+    ln -s ${lib.getExe' stdenv.cc "wasm32-unknown-wasi-clang"} $out/bin/clang
+    ln -s ${lib.getExe' stdenv.cc "wasm32-unknown-wasi-ar"} $out/bin/ar
+    ln -s ${stdenv.cc}/nix-support $out/nix-support
+    mkdir -p $out/share
+    ln -s ${stdenv.cc.libc} $out/share/wasi-sysroot
+  '';
+
+  cargoBuildFlags = [ "--package=js-pdk-core" ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    changelog = "https://github.com/extism/js-pdk/releases/tag/${finalAttrs.src.tag}";
+    description = "Write Extism plugins in JavaScript & TypeScript (WASM core)";
+    homepage = "https://github.com/extism/js-pdk";
+    license = lib.licenses.bsd3;
+    maintainers = [
+      lib.maintainers.diogotcorreia
+      lib.maintainers.dotlambda
+    ];
+    platforms = lib.platforms.wasi;
+  };
+})

--- a/pkgs/by-name/ex/extism-js/package.nix
+++ b/pkgs/by-name/ex/extism-js/package.nix
@@ -1,59 +1,46 @@
-# Building this from source requires cross-compiling Rust to wasm32-wasip1.
-# An attempt to do so was made in https://github.com/NixOS/nixpkgs/pull/463349.
-# FIXME revisit once https://github.com/NixOS/nixpkgs/pull/463720 is merged
-
 {
-  autoPatchelfHook,
-  fetchurl,
+  binaryen,
+  extism-cli,
   lib,
-  libgcc,
-  stdenvNoCC,
+  pkg-config,
+  pkgsCross,
+  rustPlatform,
+  testers,
   versionCheckHook,
+  writableTmpDirAsHomeHook,
+  zstd,
 }:
 
 let
-  version = "1.6.0";
-  tag = "v${version}";
-  system = lib.replaceStrings [ "darwin" ] [ "macos" ] stdenvNoCC.hostPlatform.system;
-  hashes = {
-    aarch64-darwin = "sha256-VI4lvaOXGgfDLXiiSRNc+Mt7Pu3hAeh44G5T4BrC4M4=";
-    aarch64-linux = "sha256-FaGGJQ5o1r/07IOf/yddRakOODppIJ3MEjnrnjrubhs=";
-    x86_64-darwin = "sha256-2FqHXCoHHwwp/lcnZMUsOkmfFXq3+e+siTmkNkOQ4ps=";
-    x86_64-linux = "sha256-Te0nHM9GUDHM0Nw156FA4TTX8wchZxzEqOH/gF1KrWg=";
-  };
+  inherit (pkgsCross.wasi32) extism-js-core;
 in
-stdenvNoCC.mkDerivation {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "extism-js";
-  inherit version;
 
-  src = fetchurl {
-    url = "https://github.com/extism/js-pdk/releases/download/${tag}/extism-js-${system}-${tag}.gz";
-    hash = hashes.${stdenvNoCC.hostPlatform.system};
-  };
+  inherit (extism-js-core)
+    version
+    src
+    cargoDeps
+    postPatch
+    ;
 
-  unpackPhase = ''
-    runHook preUnpack
-
-    gunzip -cf "$src" > extism-js
-
-    runHook postUnpack
-  '';
-
-  nativeBuildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
-    autoPatchelfHook
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
   ];
 
-  buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
-    libgcc
+  buildInputs = [
+    zstd
   ];
 
-  installPhase = ''
-    runHook preInstall
+  # fs-set-times v0.20.3 uses #![feature]
+  env.RUSTC_BOOTSTRAP = 1;
 
-    install -Dt $out/bin extism-js
+  env.EXTISM_ENGINE_PATH = "${pkgsCross.wasi32.extism-js-core}/bin/js_pdk_core.wasm";
+  env.ZSTD_SYS_USE_PKG_CONFIG = true;
 
-    runHook postInstall
-  '';
+  cargoBuildFlags = [ "--package=js-pdk-cli" ];
+  cargoTestFlags = [ "--package=js-pdk-cli" ];
 
   doInstallCheck = true;
 
@@ -61,19 +48,51 @@ stdenvNoCC.mkDerivation {
     versionCheckHook
   ];
 
-  # https://github.com/extism/js-pdk/pull/154
-  preInstallCheck = ''
-    version=1.5.1
-  '';
+  passthru = {
+    tests.simple-js = testers.runCommand {
+      # Based on https://github.com/extism/js-pdk/tree/v1.6.0/examples/simple_js
+      name = "${finalAttrs.pname}-simple-js-test";
+      nativeBuildInputs = [
+        finalAttrs.finalPackage
+
+        binaryen
+        extism-cli
+        writableTmpDirAsHomeHook
+      ];
+      script = ''
+        cat <<'EOF' > script.js
+        function helloWorld() {
+          Host.outputString(`Hello, ''${Host.inputString()}!`);
+        }
+
+        module.exports = { helloWorld };
+        EOF
+
+        cat <<EOF > script.d.ts
+        declare module "main" {
+          export function helloWorld(): I32;
+        }
+        EOF
+
+        cat <<EOF > expected
+        Hello, nixpkgs!
+        EOF
+
+        extism-js script.js -i script.d.ts -o script.wasm
+        extism call script.wasm helloWorld --wasi --input="nixpkgs" > output
+
+        diff output expected && touch $out
+      '';
+    };
+  };
+
+  __structuredAttrs = true;
 
   meta = {
-    changelog = "https://github.com/extism/js-pdk/releases/tag/${tag}";
-    description = "Write Extism plugins in JavaScript & TypeScript";
-    homepage = "https://github.com/extism/js-pdk";
-    license = lib.licenses.bsd3;
+    changelog = "https://github.com/extism/js-pdk/releases/tag/v${finalAttrs.version}";
+    description = "Write Extism plugins in JavaScript & TypeScript (CLI)";
     mainProgram = "extism-js";
-    maintainers = [ lib.maintainers.dotlambda ];
-    platforms = lib.attrNames hashes;
-    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = lib.platforms.unix;
+    inherit (extism-js-core.meta) homepage license maintainers;
   };
-}
+})

--- a/pkgs/by-name/ex/extism-js/package.nix
+++ b/pkgs/by-name/ex/extism-js/package.nix
@@ -1,59 +1,46 @@
-# Building this from source requires cross-compiling Rust to wasm32-wasip1.
-# An attempt to do so was made in https://github.com/NixOS/nixpkgs/pull/463349.
-# FIXME revisit once https://github.com/NixOS/nixpkgs/pull/463720 is merged
-
 {
-  autoPatchelfHook,
-  fetchurl,
+  binaryen,
+  extism-cli,
   lib,
-  libgcc,
-  stdenvNoCC,
+  pkg-config,
+  pkgsCross,
+  rustPlatform,
+  testers,
   versionCheckHook,
+  writableTmpDirAsHomeHook,
+  zstd,
 }:
 
 let
-  version = "1.6.0";
-  tag = "v${version}";
-  system = lib.replaceStrings [ "darwin" ] [ "macos" ] stdenvNoCC.hostPlatform.system;
-  hashes = {
-    aarch64-darwin = "sha256-VI4lvaOXGgfDLXiiSRNc+Mt7Pu3hAeh44G5T4BrC4M4=";
-    aarch64-linux = "sha256-FaGGJQ5o1r/07IOf/yddRakOODppIJ3MEjnrnjrubhs=";
-    x86_64-darwin = "sha256-2FqHXCoHHwwp/lcnZMUsOkmfFXq3+e+siTmkNkOQ4ps=";
-    x86_64-linux = "sha256-Te0nHM9GUDHM0Nw156FA4TTX8wchZxzEqOH/gF1KrWg=";
-  };
+  inherit (pkgsCross.wasi32) extism-js-core;
 in
-stdenvNoCC.mkDerivation {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "extism-js";
-  inherit version;
 
-  src = fetchurl {
-    url = "https://github.com/extism/js-pdk/releases/download/${tag}/extism-js-${system}-${tag}.gz";
-    hash = hashes.${stdenvNoCC.hostPlatform.system};
-  };
+  inherit (extism-js-core)
+    version
+    src
+    cargoDeps
+    postPatch
+    ;
 
-  unpackPhase = ''
-    runHook preUnpack
-
-    gunzip -cf "$src" > extism-js
-
-    runHook postUnpack
-  '';
-
-  nativeBuildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
-    autoPatchelfHook
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
   ];
 
-  buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
-    libgcc
+  buildInputs = [
+    zstd
   ];
 
-  installPhase = ''
-    runHook preInstall
+  # fs-set-times v0.20.3 uses #![feature]
+  env.RUSTC_BOOTSTRAP = 1;
 
-    install -Dt $out/bin extism-js
+  env.EXTISM_ENGINE_PATH = "${pkgsCross.wasi32.extism-js-core}/bin/js_pdk_core.wasm";
+  env.ZSTD_SYS_USE_PKG_CONFIG = true;
 
-    runHook postInstall
-  '';
+  cargoBuildFlags = [ "--package=js-pdk-cli" ];
+  cargoTestFlags = [ "--package=js-pdk-cli" ];
 
   doInstallCheck = true;
 
@@ -61,19 +48,51 @@ stdenvNoCC.mkDerivation {
     versionCheckHook
   ];
 
-  # https://github.com/extism/js-pdk/pull/154
-  preInstallCheck = ''
-    version=1.5.1
-  '';
+  passthru = {
+    tests.simple-js = testers.runCommand {
+      # Based on https://github.com/extism/js-pdk/tree/v1.6.0/examples/simple_js
+      name = "${finalAttrs.pname}-simple-js-test";
+      nativeBuildInputs = [
+        finalAttrs.finalPackage
+
+        binaryen
+        extism-cli
+        writableTmpDirAsHomeHook
+      ];
+      script = ''
+        cat <<'EOF' > script.js
+        function helloWorld() {
+          Host.outputString(`Hello, ''${Host.inputString()}!`);
+        }
+
+        module.exports = { helloWorld };
+        EOF
+
+        cat <<EOF > script.d.ts
+        declare module "main" {
+          export function helloWorld(): I32;
+        }
+        EOF
+
+        cat <<EOF > expected
+        Hello, nixpkgs!
+        EOF
+
+        extism-js script.js -i script.d.ts -o script.wasm
+        extism call script.wasm helloWorld --wasi --input="nixpkgs" > output
+
+        diff output expected && touch $out
+      '';
+    };
+  };
+
+  __structuredAttrs = true;
 
   meta = {
-    changelog = "https://github.com/extism/js-pdk/releases/tag/${tag}";
-    description = "Write Extism plugins in JavaScript & TypeScript";
-    homepage = "https://github.com/extism/js-pdk";
-    license = lib.licenses.bsd3;
+    changelog = "https://github.com/extism/js-pdk/releases/tag/${finalAttrs.src.tag}";
+    description = "Write Extism plugins in JavaScript & TypeScript (CLI)";
     mainProgram = "extism-js";
-    maintainers = [ lib.maintainers.dotlambda ];
-    platforms = lib.attrNames hashes;
-    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = lib.platforms.unix;
+    inherit (extism-js-core.meta) homepage license maintainers;
   };
-}
+})


### PR DESCRIPTION
Blockers:
- https://github.com/NixOS/nixpkgs/pull/463720
- https://github.com/NixOS/nixpkgs/pull/507470 (https://github.com/NixOS/nixpkgs/pull/487974)

Builds and appears to work. Immich works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
