### PR TITLE
icon-library: 0.0.19 -> 0.0.22

### DIFF
--- a/pkgs/by-name/ic/icon-library/package.nix
+++ b/pkgs/by-name/ic/icon-library/package.nix
@@ -10,6 +10,7 @@
   ninja,
   pkg-config,
   rustc,
+  rustPlatform,
   gettext,
   gdk-pixbuf,
   glib,
@@ -20,11 +21,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "icon-library";
-  version = "0.0.19";
+  version = "0.0.22";
 
   src = fetchurl {
-    url = "https://gitlab.gnome.org/World/design/icon-library/uploads/7725604ce39be278abe7c47288085919/icon-library-${finalAttrs.version}.tar.xz";
-    hash = "sha256-nWGTYoSa0/fxnD0Mb2132LkeB1oa/gj/oIXBbI+FDw8=";
+    url = "https://gitlab.gnome.org/World/design/icon-library/-/releases/${finalAttrs.version}/downloads/icon-library-${finalAttrs.version}.tar.xz";
+    hash = "sha256-2Yh50TH+MHGpW1lZZXJ0FbP6VwPTmuesfhAZNSIt0bw=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-OkVUAQnui0PzYXjoC6nTcLNqD/TLkz5pVtjV+7KSUq4=";
   };
 
   env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
@@ -42,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     rustc
+    rustPlatform.cargoSetupHook
     wrapGAppsHook4
   ];
   buildInputs = [

--- a/pkgs/by-name/ic/icon-library/package.nix
+++ b/pkgs/by-name/ic/icon-library/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
   wrapGAppsHook4,
   buildPackages,
   cargo,
@@ -10,6 +10,7 @@
   ninja,
   pkg-config,
   rustc,
+  rustPlatform,
   gettext,
   gdk-pixbuf,
   glib,
@@ -20,11 +21,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "icon-library";
-  version = "0.0.19";
+  version = "0.0.22";
 
-  src = fetchurl {
-    url = "https://gitlab.gnome.org/World/design/icon-library/uploads/7725604ce39be278abe7c47288085919/icon-library-${finalAttrs.version}.tar.xz";
-    hash = "sha256-nWGTYoSa0/fxnD0Mb2132LkeB1oa/gj/oIXBbI+FDw8=";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    group = "World";
+    owner = "design";
+    repo = "icon-library";
+    tag = finalAttrs.version;
+    hash = "sha256-XpvD7AYFx3GRcYqdDBrMo7vQIUYaE3zxtsoSgLNDDzU=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-OkVUAQnui0PzYXjoC6nTcLNqD/TLkz5pVtjV+7KSUq4=";
   };
 
   env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
@@ -42,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     rustc
+    rustPlatform.cargoSetupHook
     wrapGAppsHook4
   ];
   buildInputs = [


### PR DESCRIPTION
Diff: https://gitlab.gnome.org/World/design/icon-library/-/compare/0.0.19...0.0.22

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
