### PR TITLE
karakeep: fix cache-from-env-not-nix-store.patch

### DIFF
--- a/pkgs/by-name/ka/karakeep/patches/cache-from-env-not-nix-store.patch
+++ b/pkgs/by-name/ka/karakeep/patches/cache-from-env-not-nix-store.patch
@@ -1,14 +1,14 @@
 diff --git a/apps/web/.next/standalone/node_modules/next/dist/server/image-optimizer.js b/apps/web/.next/standalone/node_modules/next/dist/server/image-optimizer.js
-index cba8876..c3d7c43 100644
+index 3989ecc..c320328 100644
 --- a/apps/web/.next/standalone/node_modules/next/dist/server/image-optimizer.js
 +++ b/apps/web/.next/standalone/node_modules/next/dist/server/image-optimizer.js
-@@ -409,7 +409,8 @@ class ImageOptimizerCache {
+@@ -495,7 +495,8 @@ class ImageOptimizerCache {
          ]);
      }
      constructor({ distDir, nextConfig }){
--        this.cacheDir = (0, _path.join)(distDir, "cache", "images");
-+        const cacheDir = process.env["NEXT_CACHE_DIR"] || (0, _path.join)(distDir, "cache");
-+        this.cacheDir = (0, _path.join)(cacheDir, "images");
+-        this.cacheDir = (0, _path.join)(distDir, 'cache', 'images');
++        const cacheDir = process.env['NEXT_CACHE_DIR'] || (0, _path.join)(distDir, 'cache');
++        this.cacheDir = (0, _path.join)(cacheDir, 'images');
          this.nextConfig = nextConfig;
      }
      async get(cacheKey) {


### PR DESCRIPTION
Introduced in #416531 because did a mistake in unifying "" versus ''..

Closes #499893

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
