### PR TITLE
raysession: 0.14.4 -> 0.18.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28745,6 +28745,12 @@
     githubId = 7038383;
     name = "Vojta Káně";
   };
+  vojtechstep = {
+    email = "code@vojtechstep.eu";
+    github = "VojtechStep";
+    githubId = 15523887;
+    name = "Vojta Štěpančík";
+  };
   volfyd = {
     email = "lb.nix@lisbethmail.com";
     github = "volfyd";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29914,6 +29914,12 @@
     githubId = 7038383;
     name = "Vojta Káně";
   };
+  vojtechstep = {
+    email = "code@vojtechstep.eu";
+    github = "VojtechStep";
+    githubId = 15523887;
+    name = "Vojta Štěpančík";
+  };
   vokinn = {
     github = "vokinn";
     githubId = 113241287;

--- a/pkgs/by-name/ra/raysession/package.nix
+++ b/pkgs/by-name/ra/raysession/package.nix
@@ -1,57 +1,69 @@
 {
   lib,
-  fetchurl,
+  fetchFromGitHub,
   python3Packages,
-  libjack2,
   which,
   bash,
-  qt5,
+  qt6,
+  coreutils,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "raysession";
-  version = "0.14.4";
+  version = "0.18.0";
 
-  src = fetchurl {
-    url = "https://github.com/Houston4444/RaySession/releases/download/v${finalAttrs.version}/RaySession-${finalAttrs.version}-source.tar.gz";
-    hash = "sha256-cr9kqZdqY6Wq+RkzwYxNrb/PLFREKUgWeVNILVUkc7A=";
+  src = fetchFromGitHub {
+    owner = "Houston4444";
+    repo = "RaySession";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YCQl7PEmkC68WkoOpUX4TrsCAm+jJyONakZp+VSKjts=";
+    fetchSubmodules = true;
   };
 
   postPatch = ''
     # Fix installation path of xdg schemas.
-    substituteInPlace Makefile --replace '$(DESTDIR)/' '$(DESTDIR)$(PREFIX)/'
-    # Do not wrap an importable module with a shell script.
+    substituteInPlace Makefile --replace-fail '$(DESTDIR)/' '$(DESTDIR)$(PREFIX)/'
+    # Fix the python3 invocation in the completions
+    substituteInPlace src/completion/ray_completion.sh \
+      --replace-fail python3 ${lib.getExe python3Packages.python}
+
+    # Mark importable modules as non-executable as to not binwrap them
+    chmod -x src/control/ray_control.py
     chmod -x src/daemon/desktops_memory.py
-    chmod -x src/clients/jackpatch/main_loop.py
+    chmod -x src/daemon/ray_daemon.py
+    chmod -x src/gui/raysession.py
+    chmod -x src/patchbay_daemon/patchbay_daemon.py
   '';
 
   pyproject = false;
 
   nativeBuildInputs = [
-    python3Packages.pyqt5 # pyuic5 and pyrcc5 to build resources.
-    qt5.qttools # lrelease to build translations.
-    which # which to find lrelease.
-    qt5.wrapQtAppsHook
+    python3Packages.pyqt6 # pyuic6 and rcc to build resources.
+    qt6.qttools # lrelease to build translations.
+    which # which to find lrelease
+    qt6.wrapQtAppsHook
   ];
   buildInputs = [
-    libjack2
     bash
+    coreutils # Some shebangs use "env -S"
   ];
-  dependencies = [
-    python3Packages.pyliblo3
-    python3Packages.pyqt5
+
+  dependencies = with python3Packages; [
+    pyqt6
+    qtpy
+    pyliblo3
+    jack-client
   ];
 
   dontWrapQtApps = true; # The program is a python script.
 
   installFlags = [ "PREFIX=$(out)" ];
 
-  makeWrapperArgs = [
-    "--suffix"
-    "LD_LIBRARY_PATH"
-    ":"
-    (lib.makeLibraryPath [ libjack2 ])
+  makeFlags = [
+    "RCC=${qt6.qtbase}/libexec/rcc"
   ];
+
+  strictDeps = true;
 
   postFixup = ''
     wrapPythonProgramsIn "$out/share/raysession/src" "$out ''${pythonPath[*]}"
@@ -64,7 +76,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/Houston4444/RaySession";
     description = "Session manager for Linux musical programs";
     license = lib.licenses.gpl2;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ vojtechstep ];
     platforms = lib.platforms.linux;
+    mainProgram = "raysession";
   };
 })

--- a/pkgs/development/python-modules/jack-client/default.nix
+++ b/pkgs/development/python-modules/jack-client/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  replaceVars,
+  stdenv,
+
+  libjack2,
+
+  cffi,
+  setuptools,
+  setuptools-scm,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "jack-client";
+  version = "0.5.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "spatialaudio";
+    repo = "jackclient-python";
+    tag = finalAttrs.version;
+    hash = "sha256-SqDHFUlAtGbT/UJALykPvdP7+5KUlZkMpwYDjq+rU98=";
+  };
+
+  patches = [
+    (replaceVars ./hardcode-jack.patch {
+      ext = stdenv.hostPlatform.extensions.sharedLibrary;
+      libenv = if stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+      jack = libjack2.outPath;
+    })
+  ];
+
+  pythonImportsCheck = [ "jack" ];
+
+  build-system = [
+    setuptools
+    setuptools-scm
+    cffi
+  ];
+
+  dependencies = [ cffi ];
+
+  meta = {
+    description = "JACK Audio Connection Kit (JACK) Client for Python";
+    homepage = "https://github.com/spatialaudio/jackclient-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ vojtechstep ];
+  };
+})

--- a/pkgs/development/python-modules/jack-client/hardcode-jack.patch
+++ b/pkgs/development/python-modules/jack-client/hardcode-jack.patch
@@ -1,0 +1,26 @@
+diff --git a/src/jack.py b/src/jack.py
+index e309214..d12f30e 100644
+--- a/src/jack.py
++++ b/src/jack.py
+@@ -38,7 +38,20 @@ if _platform.system() == 'Windows':
+     else:
+         _libname = _find_library('libjack')
+ else:
+-    _libname = _find_library('jack')
++    # Ideally we would just stick the default after the current LD_LIBRARY_PATH
++    # and let dlopen find the implementation, but the dynamic loader won't
++    # respect any changes after starting the process.
++    # Instead we resolve the library manually to its absolute path.
++    import os
++    _relativepath = '/libjack@ext@'
++    _libname = '@jack@/lib' + _relativepath
++    libpath = os.environ.get('@libenv@')
++    if libpath:
++        for d in libpath.split(':'):
++            candidate = d + _relativepath
++            if os.path.isfile(candidate):
++                _libname = candidate
++                break
+ 
+ if _libname is None:
+     if _platform.system() == 'Darwin' and _platform.machine() == 'arm64':

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7787,6 +7787,8 @@ self: super: with self; {
 
   j2lint = callPackage ../development/python-modules/j2lint { };
 
+  jack-client = callPackage ../development/python-modules/jack-client { };
+
   jaconv = callPackage ../development/python-modules/jaconv { };
 
   jalali-core = callPackage ../development/python-modules/jalali-core { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8322,6 +8322,8 @@ self: super: with self; {
 
   j2lint = callPackage ../development/python-modules/j2lint { };
 
+  jack-client = callPackage ../development/python-modules/jack-client { };
+
   jaconv = callPackage ../development/python-modules/jaconv { };
 
   jalali-core = callPackage ../development/python-modules/jalali-core { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

RaySession 0.17 switched from Qt5 to Qt6 and changed the underlying JACK python bindings from pyjacklib to jack-client, so I packaged that as well. I'd appreciate some feedback on the way I ended up handling the libpath.

I'm actively using this with pipewire-jack, so I guess this fixes #323195. ~~On the other hand 0.17 doesn't work for me with jackd; IIUC it's because jackd doesn't support the metadata API, which should be optional for raysession but is currently not handled properly. Upstream [patched this](https://github.com/Houston4444/RaySession/commit/c50b22eec800c2c70a0a13fe51d97407f5cf12e2) in an unreleased version, which I tried using~~
```nix
rev = "c50b22eec800c2c70a0a13fe51d97407f5cf12e2";
hash = "sha256-nvJIXW29AFNdf7/NWGr+YukJE2XU0pGh54dV/mLJcPc=";
```
~~and that worked with jackd for me.~~ Upstream released 0.18 with the fix.

I also fixed the bash completions for `ray_control`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
