### PR TITLE
{app-icon-preview,palette,typography}: init

### DIFF
--- a/pkgs/by-name/ap/app-icon-preview/package.nix
+++ b/pkgs/by-name/ap/app-icon-preview/package.nix
@@ -1,0 +1,62 @@
+{
+  cargo,
+  desktop-file-utils,
+  fetchFromGitLab,
+  lib,
+  libadwaita,
+  libxml2,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  rustc,
+  rustPlatform,
+  stdenv,
+  wrapGAppsHook4,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "app-icon-preview";
+  version = "3.5.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    group = "World";
+    owner = "design";
+    repo = "app-icon-preview";
+    tag = finalAttrs.version;
+    hash = "sha256-sfQFmQ27JUu92ArCi1dTnD3sWoUl/0tJguMvR1BoK/Q=";
+    forceFetchGit = true;
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-WGzXjIgZBwuBbSWK+EWDMW2kfqeoYHMsP4TXglR2Sc4=";
+  };
+
+  nativeBuildInputs = [
+    cargo
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    rustc
+    rustPlatform.cargoSetupHook
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    libadwaita
+    libxml2
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for designing applications icons";
+    homepage = "https://gitlab.gnome.org/World/design/app-icon-preview";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "app-icon-preview";
+    maintainers = with lib.maintainers; [ hythera ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/pa/palette/package.nix
+++ b/pkgs/by-name/pa/palette/package.nix
@@ -1,0 +1,51 @@
+{
+  appstream,
+  desktop-file-utils,
+  fetchFromGitLab,
+  lib,
+  libadwaita,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  stdenv,
+  vala,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "palette";
+  version = "3.0.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    group = "World";
+    owner = "design";
+    repo = "palette";
+    tag = finalAttrs.version;
+    hash = "sha256-DfLK5a2wJnwC8N90qOjSDNpMbM0jpauGTlgDwjQ5+kU=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    appstream
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    vala
+  ];
+
+  buildInputs = [
+    libadwaita
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Colour Palette tool";
+    homepage = "https://gitlab.gnome.org/World/design/palette";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "org.gnome.design.Palette";
+    maintainers = with lib.maintainers; [ hythera ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ty/typography/package.nix
+++ b/pkgs/by-name/ty/typography/package.nix
@@ -1,0 +1,49 @@
+{
+  appstream,
+  desktop-file-utils,
+  fetchFromGitLab,
+  lib,
+  libadwaita,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "typography";
+  version = "0.3.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    group = "World";
+    owner = "design";
+    repo = "typography";
+    tag = finalAttrs.version;
+    hash = "sha256-XAoqB3Gvd/sRrbM4m5s3aYia7bZgPB9UEJ26Bzkj8Ws=";
+    forceFetchGit = true;
+  };
+
+  nativeBuildInputs = [
+    appstream
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libadwaita
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for looking up text styles";
+    homepage = "https://gitlab.gnome.org/World/design/typography";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "org.gnome.design.Typography";
+    maintainers = with lib.maintainers; [ hythera ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This adds some of the suggested [GNOME](https://developer.gnome.org/hig/resources.html) design-tools to `nixpkgs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
