### PR TITLE
plymouth-gifmouth-theme: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18056,6 +18056,11 @@
     githubId = 3579600;
     name = "Jacob Moody";
   };
+  mooses = {
+    name = "Remu Salminen";
+    github = "RemuSalminen";
+    githubId = 85031022;
+  };
   moosingin3space = {
     email = "moosingin3space@gmail.com";
     github = "moosingin3space";

--- a/pkgs/by-name/pl/plymouth-gifmouth-theme/package.nix
+++ b/pkgs/by-name/pl/plymouth-gifmouth-theme/package.nix
@@ -1,0 +1,78 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  lib,
+  imagemagick,
+  ffmpeg,
+  gifLocal ? null,
+  gifSource ? "",
+  gifHash ? "",
+}:
+
+let
+  plymouthDir = "$out/share/plymouth/themes/gifmouth";
+  gif =
+    if gifLocal == null && gifSource == "" then
+      "./example.gif"
+    else if gifLocal != null then
+      gifLocal
+    else
+      fetchurl {
+        url = gifSource;
+        hash = gifHash;
+      };
+in
+stdenvNoCC.mkDerivation {
+  pname = "plymouth-gifmouth-theme";
+  version = "1.1.0";
+  src = fetchFromGitHub {
+    owner = "RemuSalminen";
+    repo = "gifmouth-plymouth-theme";
+    rev = "6ea689312b7601a02dcb1dbe8b3e28ce789fe1b2";
+    hash = "sha256-UHgpF2H/uu1G8J/ZSzLhr/ww8JjqEJ9gcDK+XHnogao=";
+  };
+
+  nativeBuildInputs = [
+    imagemagick
+    ffmpeg
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    ./gifmouth.sh ${gif}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p ${plymouthDir}
+    mkdir ${plymouthDir}/frames
+    mkdir ${plymouthDir}/scripts
+
+    cp gifmouth.plymouth ${plymouthDir}
+    cp frames/* ${plymouthDir}/frames/
+    cp scripts/gifmouth.script ${plymouthDir}/scripts/
+
+    substituteInPlace ${plymouthDir}/gifmouth.plymouth --replace-fail "/usr/" "$out/"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Plymouth theme that turns any GIF/Video into an Animated theme";
+    homepage = "https://github.com/RemuSalminen/gifmouth-plymouth-theme";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ mooses ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add a [new plymouth theme](https://github.com/RemuSalminen/gifmouth-plymouth-theme) that allows creation of boot splashes from any gif/video. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
