### PR TITLE
python3Packages.qcs-sdk-python: 0.21.22 -> 0.26.0

### DIFF
--- a/pkgs/development/python-modules/qcs-sdk-python/default.nix
+++ b/pkgs/development/python-modules/qcs-sdk-python/default.nix
@@ -7,7 +7,6 @@
   opentelemetry-sdk,
   pytest-asyncio,
   pytestCheckHook,
-  pythonAtLeast,
   qcs-api-client-common,
   quil,
   rustPlatform,
@@ -16,25 +15,22 @@
 
 buildPythonPackage rec {
   pname = "qcs-sdk-python";
-  version = "0.21.22";
+  version = "0.26.0";
   pyproject = true;
-
-  # error: the configured Python interpreter version (3.13) is newer than PyO3's maximum supported version (3.12)
-  disabled = pythonAtLeast "3.13";
 
   src = fetchFromGitHub {
     owner = "rigetti";
     repo = "qcs-sdk-rust";
-    tag = "python/v${version}";
-    hash = "sha256-uaoXSkc8yg+WZONgvRkOARaf9kvLKv6S+K5yMDuXbbA=";
+    tag = "lib/v${version}";
+    hash = "sha256-A404lYKGAigzsnqWO4BAphOK/Juj4Fa2EHXQO8N1U9I=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-/SkYzQisSACTedC4FsEp4rXXdWV5f64gA33I/Ubu80E=";
+    hash = "sha256-NAcCZks5N1KPqeA5v72NAcJqHGexRU99yXQHg21vkPA=";
   };
 
-  buildAndTestSubdir = "crates/python";
+  buildAndTestSubdir = "crates/lib";
 
   nativeBuildInputs = [
     rustPlatform.cargoSetupHook
@@ -71,11 +67,11 @@ buildPythonPackage rec {
   ];
 
   passthru.updateScript = gitUpdater {
-    rev-prefix = "python/v";
+    rev-prefix = "lib/v";
   };
 
   meta = {
-    changelog = "https://github.com/rigetti/qcs-sdk-rust/blob/${src.tag}/crates/python/CHANGELOG.md";
+    changelog = "https://github.com/rigetti/qcs-sdk-rust/blob/${src.tag}/${buildAndTestSubdir}/CHANGELOG.md";
     description = "Python interface for the QCS Rust SDK";
     homepage = "https://github.com/rigetti/qcs-sdk-rust/tree/main/crates/python";
     license = lib.licenses.asl20;

--- a/pkgs/development/python-modules/quil/default.nix
+++ b/pkgs/development/python-modules/quil/default.nix
@@ -10,19 +10,19 @@
 
 buildPythonPackage rec {
   pname = "quil";
-  version = "0.34.0";
+  version = "0.35.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rigetti";
     repo = "quil-rs";
     tag = "quil-rs/v${version}";
-    hash = "sha256-to6eKStXiJPqP22kN+gNiroiBUFiK7Q84BuTZHMr5SI=";
+    hash = "sha256-QWW8+cup81eyedDTU3jgslNanaj0+D2jI5XQMS3ZUIo=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-vNa4RUIecCHDb9rvMdiC8jtBdM/6C2bKagX1YkSMuhk=";
+    hash = "sha256-cIWnTuxoFqkl+0W6NH9DwNokq7RKdNggFLwPYgkbHho=";
   };
 
   buildAndTestSubdir = "quil-rs";


### PR DESCRIPTION
Diff: https://github.com/rigetti/qcs-sdk-rust/compare/python/v0.21.22...lib/v0.26.0

Changelog: https://github.com/rigetti/qcs-sdk-rust/blob/lib/v0.26.0/crates/lib/CHANGELOG.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
