### PR TITLE
nixos/dms-greeter: skip invalid customThemeFile in preStart

### DIFF
--- a/nixos/modules/services/display-managers/dms-greeter.nix
+++ b/nixos/modules/services/display-managers/dms-greeter.nix
@@ -290,7 +290,9 @@ in
         fi
 
         if [ -f settings.json ]; then
-            if cp "$(${jq} -r '.customThemeFile' settings.json)" custom-theme.json; then
+            theme_file="$(${jq} -r '.customThemeFile // empty' settings.json)"
+            if [ -f "$theme_file" ] && [ -r "$theme_file" ]; then
+                cp "$theme_file" custom-theme.json
                 mv settings.json settings.orig.json
                 ${jq} '.customThemeFile = "${cacheDir}/custom-theme.json"' settings.orig.json > settings.json
             fi


### PR DESCRIPTION
Sync upstream changes：

https://github.com/AvengeMedia/DankMaterialShell/pull/1997/commits

Avoid attempting to copy a null/empty/missing customThemeFile path by validating the jq result and file existence before cp.