### PR TITLE
see-cat: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/by-name/se/see-cat/package.nix
+++ b/pkgs/by-name/se/see-cat/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "guilhermeprokisch";
     repo = "see";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-BlceC8XgKvSLOTKHlfQHxn0rhaFKL8rHqUcYBNntB5s=";
   };
 

--- a/pkgs/by-name/se/see-cat/package.nix
+++ b/pkgs/by-name/se/see-cat/package.nix
@@ -5,16 +5,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "see-cat";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "guilhermeprokisch";
     repo = "see";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Ej8lk9btUcIhhgpSmnHo2n33wQtyEkmuWVFoahYgAaI=";
+    hash = "sha256-BlceC8XgKvSLOTKHlfQHxn0rhaFKL8rHqUcYBNntB5s=";
   };
 
-  cargoHash = "sha256-gADA6Ioxz8YM/SRYsT+43bKNS2Ov1XtTElDr7vx8T14=";
+  cargoHash = "sha256-ccSuJqENO8DElZM5Nz+/rt7yAIMipcVJ3qOi9JR0CQY=";
 
   meta = {
     description = "Cute cat(1) for the terminal";


### PR DESCRIPTION
Summary
- bump see-cat from 0.9.0 to 0.9.1
- update the source hash
- update the cargo hash

Testing
- nix-build -A see-cat

Release notes
- https://github.com/guilhermeprokisch/see/releases/tag/v0.9.1