### PR TITLE
python3Packages.imbalanced-learn: fix build, enable upstream fixed test

### DIFF
--- a/pkgs/development/python-modules/imbalanced-learn/default.nix
+++ b/pkgs/development/python-modules/imbalanced-learn/default.nix
@@ -14,6 +14,7 @@
   threadpoolctl,
   pytestCheckHook,
   python,
+  sklearn-compat,
 }:
 
 buildPythonPackage rec {
@@ -39,6 +40,7 @@ buildPythonPackage rec {
     scikit-learn
     scipy
     threadpoolctl
+    sklearn-compat
   ];
 
   optional-dependencies = {

--- a/pkgs/development/python-modules/imbalanced-learn/default.nix
+++ b/pkgs/development/python-modules/imbalanced-learn/default.nix
@@ -76,12 +76,6 @@ buildPythonPackage rec {
     "imblearn/utils/tests/test_min_dependencies.py"
   ];
 
-  disabledTests = [
-    # Broken upstream test https://github.com/scikit-learn-contrib/imbalanced-learn/issues/1131
-    "test_estimators_compatibility_sklearn"
-    "test_balanced_bagging_classifier_with_function_sampler"
-  ];
-
   meta = {
     description = "Library offering a number of re-sampling techniques commonly used in datasets showing strong between-class imbalance";
     homepage = "https://github.com/scikit-learn-contrib/imbalanced-learn";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

'built' on 312, 313, 314

Seems to have broken with 73d6775311df9ae3aac1511f1bfa238968a68c6c . 
Not sure why `sklearn-compat` was not necessary in the .0 version but is in .1, from reading the patch notes, but idrc about looking into it further.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
