### PR TITLE
flamethrower: init at 0.12.0

### DIFF
--- a/pkgs/by-name/fl/flamethrower/package.nix
+++ b/pkgs/by-name/fl/flamethrower/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  gnutls,
+  ldns,
+  libuv,
+  nghttp2,
+  dohSupport ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "flamethrower";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "DNS-OARC";
+    repo = "flamethrower";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-5L9Unt6EXOhvPltUMQXtwJyrQhRnb1XfxIB9s+WYg6Q=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    gnutls
+    ldns
+    libuv
+  ]
+  ++ lib.optionals dohSupport [
+    nghttp2
+  ];
+
+  mesonFlags = [
+    (lib.mesonBool "doh" dohSupport)
+  ];
+
+  meta = {
+    description = "DNS performance and functional testing utility";
+    longDescription = ''
+      Flamethrower is a small, fast, configurable tool for functional testing,
+      benchmarking, and stress testing DNS servers and networks. It supports
+      IPv4, IPv6, UDP, TCP, DoT, and DoH and has a modular system for
+      generating queries used in the tests.
+    '';
+    homepage = "https://github.com/DNS-OARC/flamethrower";
+    changelog = "https://github.com/DNS-OARC/flamethrower/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ cpu ];
+    mainProgram = "flame";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds a new package, `flamethrower`, initialized at [v0.12.0](https://github.com/DNS-OARC/flamethrower/releases/tag/v0.12.0):

> Flamethrower is a small, fast, configurable tool for functional testing, benchmarking, and stress testing DNS servers and networks. It supports IPv4, IPv6, UDP, TCP, DoT, and DoH and has a modular system for generating queries used in the tests.

See [DNS-OARC/flamethrower](https://github.com/DNS-OARC/flamethrower) for more information.

<details>
<summary>Example usage:</summary>

```
$ ./result/bin/flame -P dot -p 853 -c 1 -q 1 -n 1 -f <(cat <<< $'example.com A\ncloudflare.com A\ngoogle.com A') 1.1.1.1
binding traffic generators to 0.0.0.0
flaming target(s) [] on port 853 with 1 concurrent generators, each sending 1 queries every 1000ms on protocol dot
query generator [file] contains 3 record(s)
0.914598s: send: 1, avg send: 1, recv: 1, avg recv: 1, min/avg/max resp: 102.137/102.137/102.137ms, in flight: 1, timeouts: 0
1.91441s: send: 1, avg send: 1, recv: 1, avg recv: 1, min/avg/max resp: 98.5957/98.5957/98.5957ms, in flight: 1, timeouts: 0
2.41479s: send: 1, avg send: 1, recv: 0, avg recv: 1, min/avg/max resp: 0/-nan/0ms, in flight: 1, timeouts: 0
stopping, waiting up to 3s for in flight to finish...
5.4156s: send: 0, avg send: 1, recv: 1, avg recv: 1, min/avg/max resp: 87.8427/0/87.8427ms, in flight: 1, timeouts: 0

------
run id      : 7ffd71e74870
run start   : 2026-03-15T15:19:40Z
runtime     : 5.4156 s
total sent  : 3
total rcvd  : 3
min resp    : 87.8427 ms
avg resp    : -nan ms
max resp    : 102.137 ms
avg r qps   : 1
avg s qps   : 1
avg pkt     : 42.6667 bytes
tcp conn.   : 3
timeouts    : 0 (0%)
bad recv    : 0
net errors  : 0
responses   :
  NOERROR: 3
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
