### PR TITLE
home-assistant-custom-components.circadian_lighting: init at 2.1.6

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/circadian_lighting/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/circadian_lighting/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  nix-update-script,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "claytonjn";
+  domain = "circadian_lighting";
+  version = "2.1.6";
+
+  src = fetchFromGitHub {
+    owner = "claytonjn";
+    repo = "hass-circadian_lighting";
+    tag = version;
+    hash = "sha256-6S1wIO6UgPdUPt9oDCzIb4duUOql4KgnTd6MjRhrSb0=";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/claytonjn/hass-circadian_lighting/releases/tag/${src.tag}";
+    description = "Circadian Lighting custom component for Home Assistant";
+    homepage = "https://github.com/claytonjn/hass-circadian_lighting";
+    maintainers = with lib.maintainers; [ jpds ];
+    license = lib.licenses.asl20;
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
