### PR TITLE
Add vscode-extensions.sst-dev.opencode and vscode-extensions.sst-dev.opencode-beta

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4451,6 +4451,12 @@
     githubId = 1945;
     name = "Casey Rodarmor";
   };
+  cassis163 = {
+    email = "c.aangeenbrug@protonmail.com";
+    github = "cassis163";
+    githubId = 42798012;
+    name = "Casper Aangeenbrug";
+  };
   catap = {
     email = "kirill@korins.ky";
     github = "catap";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -4334,6 +4334,10 @@ let
 
       sourcery.sourcery = callPackage ./sourcery.sourcery { };
 
+      sst-dev.opencode = callPackage ./sst-dev.opencode { };
+
+      sst-dev.opencode-beta = callPackage ./sst-dev.opencode-beta { };
+
       spywhere.guides = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "guides";

--- a/pkgs/applications/editors/vscode/extensions/sst-dev.opencode-beta/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/sst-dev.opencode-beta/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "opencode-v2";
+    publisher = "sst-dev";
+    version = "0.1.1";
+    hash = "sha256-11a8JaishNyy6XkTeh6s36efdt1tSNYclOdkglx8x30=";
+  };
+  meta = {
+    changelog = "https://opencode.ai/changelog/";
+    description = "A Visual Studio Code extension that integrates opencode directly into your development workflow with an enhanced chat interface.";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=sst-dev.opencode-v2";
+    homepage = "https://github.com/anomalyco/opencode";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [cassis163];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/sst-dev.opencode-beta/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/sst-dev.opencode-beta/default.nix
@@ -16,6 +16,6 @@ vscode-utils.buildVscodeMarketplaceExtension {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=sst-dev.opencode-v2";
     homepage = "https://github.com/anomalyco/opencode";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [cassis163];
+    maintainers = with lib.maintainers; [ cassis163 ];
   };
 }

--- a/pkgs/applications/editors/vscode/extensions/sst-dev.opencode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/sst-dev.opencode/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "opencode";
+    publisher = "sst-dev";
+    version = "0.0.13";
+    hash = "sha256-6adXUaoh/OP5yYItH3GAQ7GpupfmTGaxkKP6hYUMYNQ=";
+  };
+  meta = {
+    changelog = "https://opencode.ai/changelog/";
+    description = "A Visual Studio Code extension that integrates opencode directly into your development workflow.";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=sst-dev.opencode";
+    homepage = "https://github.com/anomalyco/opencode";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [cassis163];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/sst-dev.opencode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/sst-dev.opencode/default.nix
@@ -16,6 +16,6 @@ vscode-utils.buildVscodeMarketplaceExtension {
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=sst-dev.opencode";
     homepage = "https://github.com/anomalyco/opencode";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [cassis163];
+    maintainers = with lib.maintainers; [ cassis163 ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR aims to add the normal and beta VSCode extensions for opencode. Similar extensions for GitHub Copilot and Claude Code are already available, making the addition of opencode seem natural.

Please note that this is my first potential contribution to nixpkgs. I'm willing to adapt as you see fit. **Also, I'm unsure if the beta version is suitable for nixpkgs in terms of stability. If not, then I'm perfectly willing to remove it.**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
