### PR TITLE
pear-desktop: add configurable launch flags

### DIFF
--- a/pkgs/by-name/pe/pear-desktop/package.nix
+++ b/pkgs/by-name/pe/pear-desktop/package.nix
@@ -13,7 +13,7 @@
   makeDesktopItem,
   nix-update-script,
 
-  # Extra Chromium/Electron flags for driver-specific GPU tuning.
+  # Extra Chromium/Electron flags for eg driver-specific GPU tuning
   commandLineArgs ? "",
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -98,22 +98,21 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  postFixup =
-    lib.optionalString (!stdenv.hostPlatform.isDarwin) (
-      ''
-        makeWrapper ${electron}/bin/electron $out/bin/pear-desktop \
-      ''
-      + lib.optionalString (commandLineArgs != "") ''
-          --add-flags ${lib.escapeShellArg commandLineArgs} \
-        ''
-      + ''
-          --add-flags $out/share/pear-desktop/resources/app.asar \
-          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
-          --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
-          --set-default ELECTRON_IS_DEV 0 \
-          --inherit-argv0
-      ''
-    );
+  postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) (
+    ''
+      makeWrapper ${electron}/bin/electron $out/bin/pear-desktop \
+    ''
+    + lib.optionalString (commandLineArgs != "") ''
+      --add-flags ${lib.escapeShellArg commandLineArgs} \
+    ''
+    + ''
+      --add-flags $out/share/pear-desktop/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
+    ''
+  );
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/pe/pear-desktop/package.nix
+++ b/pkgs/by-name/pe/pear-desktop/package.nix
@@ -12,6 +12,9 @@
   pnpmConfigHook,
   makeDesktopItem,
   nix-update-script,
+
+  # Extra Chromium/Electron flags for driver-specific GPU tuning.
+  commandLineArgs ? "",
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "pear-desktop";
@@ -95,14 +98,22 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    makeWrapper ${electron}/bin/electron $out/bin/pear-desktop \
-      --add-flags $out/share/pear-desktop/resources/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
-      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
-      --set-default ELECTRON_IS_DEV 0 \
-      --inherit-argv0
-  '';
+  postFixup =
+    lib.optionalString (!stdenv.hostPlatform.isDarwin) (
+      ''
+        makeWrapper ${electron}/bin/electron $out/bin/pear-desktop \
+      ''
+      + lib.optionalString (commandLineArgs != "") ''
+          --add-flags ${lib.escapeShellArg commandLineArgs} \
+        ''
+      + ''
+          --add-flags $out/share/pear-desktop/resources/app.asar \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+          --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+          --set-default ELECTRON_IS_DEV 0 \
+          --inherit-argv0
+      ''
+    );
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/pe/pear-desktop/package.nix
+++ b/pkgs/by-name/pe/pear-desktop/package.nix
@@ -14,7 +14,7 @@
   nix-update-script,
 
   # Extra Chromium/Electron flags for eg driver-specific GPU tuning
-  commandLineArgs ? "",
+  commandLineArgs ? [ ],
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "pear-desktop";
@@ -102,8 +102,8 @@ stdenv.mkDerivation (finalAttrs: {
     ''
       makeWrapper ${electron}/bin/electron $out/bin/pear-desktop \
     ''
-    + lib.optionalString (commandLineArgs != "") ''
-      --add-flags ${lib.escapeShellArg commandLineArgs} \
+    + lib.optionalString (commandLineArgs != [ ]) ''
+      --add-flags ${lib.escapeShellArg (lib.concatStringsSep " " commandLineArgs)} \
     ''
     + ''
       --add-flags $out/share/pear-desktop/resources/app.asar \


### PR DESCRIPTION
## Summary

Expose a `commandLineArgs` parameter for `pear-desktop` so Linux users can tune Electron/Chromium launch flags without patching the package.

This keeps the default behavior unchanged while allowing driver-specific GPU backend overrides such as `--use-angle=vulkan`. I tested the app on Wayland/NVIDIA locally; the current package already accesses `/dev/dri/renderD128`, so hardcoding a backend would be riskier than exposing a supported override.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
