### PR TITLE
graylog-7.0: init at 7.0.5

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -215,6 +215,14 @@
 
 - `services.taskchampion-sync-server` module have been added an option `services.taskchampion-sync-server.dynamicUser` to use systemd's DynamicUser feature. This is enabled by default when stateVersion is at least 26.05, and disabled otherwise. If you need this feature, you need to set `services.taskchampion-sync-server.dynamicUser` to `true` and migrate `/var/lib/taskchampion-sync-server` to `/var/lib/private/taskchampion-sync-server`.
 
+- Graylog has been updated to 7.0
+  This introduces some breaking changes Refer to the [upstream migration guide](https://go2docs.graylog.org/current/upgrading_graylog/upgrade_to_graylog_7.0.htm#BreakingChanges) for details.
+
+- The `services.graylog` module has been refactored with the following breaking changes:
+   - The `services.graylog.extraConfig` option has been removed. Configuration should now be specified directly via `services.graylog.settings`.
+   - The `services.graylog.passwordSecret` option has been removed. Use `services.graylog.passwordSecretFile` to securely load from a file via systemd credencials.
+   - The `services.graylog.rootPasswordSha2` option has been removed. Use `services.graylog.rootPasswordSha2File` to securely load from a file via systemd credencials.
+
 ## Other Notable Changes {#sec-nixpkgs-release-26.05-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/logging/graylog.nix
+++ b/nixos/modules/services/logging/graylog.nix
@@ -7,20 +7,11 @@
 let
   cfg = config.services.graylog;
 
-  confFile = pkgs.writeText "graylog.conf" ''
-    is_master = ${lib.boolToString cfg.isMaster}
-    node_id_file = ${cfg.nodeIdFile}
-    password_secret = ${cfg.passwordSecret}
-    root_username = ${cfg.rootUsername}
-    root_password_sha2 = ${cfg.rootPasswordSha2}
-    elasticsearch_hosts = ${lib.concatStringsSep "," cfg.elasticsearchHosts}
-    message_journal_dir = ${cfg.messageJournalDir}
-    mongodb_uri = ${cfg.mongodbUri}
-    plugin_dir = /var/lib/graylog/plugins
-    data_dir = ${cfg.dataDir}
-
-    ${cfg.extraConfig}
-  '';
+  settings-ini = pkgs.writeText "graylog.conf" (
+    lib.generators.toINIWithGlobalSection { listsAsDuplicateKeys = true; } {
+      globalSection = cfg.settings;
+    }
+  );
 
   glPlugins = pkgs.buildEnv {
     name = "graylog-plugins";
@@ -28,123 +19,184 @@ let
   };
 
 in
-
 {
-  ###### interface
+  options.services.graylog = {
+    enable = lib.mkEnableOption "Graylog, a log management solution.";
+    package = lib.mkPackageOption pkgs "graylog" { };
 
-  options = {
+    enableLocalMongoDB = lib.mkEnableOption "a local MongoDB instance.";
 
-    services.graylog = {
+    settings = lib.mkOption {
+      default = { };
+      type = lib.types.submodule {
+        freeformType = lib.types.anything;
+        options = {
+          is_master = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Whether this is the master instance of your Graylog cluster.";
+          };
 
-      enable = lib.mkEnableOption "Graylog, a log management solution";
+          node_id_file = lib.mkOption {
+            type = lib.types.str;
+            default = "/var/lib/graylog/server/node-id";
+            description = "Path of the file containing the graylog node-id.";
+          };
 
-      package = lib.mkPackageOption pkgs "graylog" {
-        example = "graylog-6_0";
+          root_username = lib.mkOption {
+            type = lib.types.str;
+            default = "admin";
+            description = "Name of the default administrator user.";
+          };
+
+          message_journal_dir = lib.mkOption {
+            type = lib.types.str;
+            default = "/var/lib/graylog/data/journal";
+            description = ''
+              The directory which will be used to store the message journal.
+              The directory must be exclusively used by Graylog and must not contain
+              any other files than the ones created by Graylog itself.
+            '';
+          };
+
+          plugin_dir = lib.mkOption {
+            type = lib.types.str;
+            default = "/var/lib/graylog/plugins";
+            description = "Directory used to store Graylog server plugins.";
+          };
+
+          data_dir = lib.mkOption {
+            type = lib.types.str;
+            default = "/var/lib/graylog/data";
+            description = "Directory used to store Graylog server state.";
+          };
+
+          mongodb_uri = lib.mkOption {
+            type = lib.types.str;
+            default = "mongodb://127.0.0.1:27017/graylog";
+            description = ''
+              MongoDB connection string.
+              See http://docs.mongodb.org/manual/reference/connection-string/ for details.
+            '';
+          };
+
+        };
       };
-
-      user = lib.mkOption {
-        type = lib.types.str;
-        default = "graylog";
-        description = "User account under which graylog runs";
+      example = {
+        is_master = true;
+        http_bind_address = "127.0.0.1:9000";
+        http_external_uri = "http://127.0.0.1:9000/";
+        mongodb_uri = "mongodb://127.0.0.1:27017/graylog";
       };
+      description = ''
+        Configuration for Graylog, as a structured Nix attribute set.
 
-      isMaster = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = "Whether this is the master instance of your Graylog cluster";
-      };
+        If you specify settings here, they will be used as persistent
+        configuration and Graylog will retain the same configuration
+        across restarts.
 
-      nodeIdFile = lib.mkOption {
-        type = lib.types.str;
-        default = "/var/lib/graylog/server/node-id";
-        description = "Path of the file containing the graylog node-id";
-      };
-
-      passwordSecret = lib.mkOption {
-        type = lib.types.str;
-        description = ''
-          You MUST set a secret to secure/pepper the stored user passwords here. Use at least 64 characters.
-          Generate one by using for example: pwgen -N 1 -s 96
-        '';
-      };
-
-      rootUsername = lib.mkOption {
-        type = lib.types.str;
-        default = "admin";
-        description = "Name of the default administrator user";
-      };
-
-      rootPasswordSha2 = lib.mkOption {
-        type = lib.types.str;
-        example = "e3c652f0ba0b4801205814f8b6bc49672c4c74e25b497770bb89b22cdeb4e952";
-        description = ''
-          You MUST specify a hash password for the root user (which you only need to initially set up the
-          system and in case you lose connectivity to your authentication backend)
-          This password cannot be changed using the API or via the web interface. If you need to change it,
-          modify it here.
-          Create one by using for example: echo -n yourpassword | shasum -a 256
-          and use the resulting hash value as string for the option
-        '';
-      };
-
-      elasticsearchHosts = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        example = lib.literalExpression ''[ "http://node1:9200" "http://user:password@node2:19200" ]'';
-        description = "List of valid URIs of the http ports of your elastic nodes. If one or more of your elasticsearch hosts require authentication, include the credentials in each node URI that requires authentication";
-      };
-
-      dataDir = lib.mkOption {
-        type = lib.types.str;
-        default = "/var/lib/graylog/data";
-        description = "Directory used to store Graylog server state.";
-      };
-
-      messageJournalDir = lib.mkOption {
-        type = lib.types.str;
-        default = "/var/lib/graylog/data/journal";
-        description = "The directory which will be used to store the message journal. The directory must be exclusively used by Graylog and must not contain any other files than the ones created by Graylog itself";
-      };
-
-      mongodbUri = lib.mkOption {
-        type = lib.types.str;
-        default = "mongodb://localhost/graylog";
-        description = "MongoDB connection string. See http://docs.mongodb.org/manual/reference/connection-string/ for details";
-      };
-
-      extraConfig = lib.mkOption {
-        type = lib.types.lines;
-        default = "";
-        description = "Any other configuration options you might want to add";
-      };
-
-      plugins = lib.mkOption {
-        description = "Extra graylog plugins";
-        default = [ ];
-        type = lib.types.listOf lib.types.package;
-      };
-
+        For a complete list of available options, see:
+        https://go2docs.graylog.org/current/setting_up_graylog/server_configuration_settings_reference.htm
+      '';
     };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "graylog";
+      description = "User account under which graylog runs.";
+    };
+
+    passwordSecretFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        Path of the file containing the secret to secure/pepper the stored user passwords here.
+
+        You MUST set a secret here. Use at least 64 characters.
+        Generate one by using for example: pwgen -N 1 -s 96
+      '';
+    };
+
+    rootPasswordSha2File = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        Path of the file containing a hash password for the root user.
+
+        You MUST specify a hash password for the root user (which you only need
+        to initially set up the system and in case you lose connectivity to your
+        authentication backend). This password cannot be changed using the API
+        or via the web interface. If you need to change it, modify it here.
+
+        Create one by using for example: echo -n yourpassword | shasum -a 256
+        and use the resulting hash value as string for the option.
+      '';
+    };
+
+    elasticsearchHosts = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      example = lib.literalExpression ''[ "http://node1:9200" "http://user:password@node2:19200" ]'';
+      description = ''
+        List of valid URIs of the http ports of your elastic nodes. If one or more
+        of your elasticsearch hosts require authentication, include the credentials
+        in each node URI that requires authentication.
+      '';
+    };
+
+    plugins = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Extra graylog plugins.";
+    };
+
   };
 
-  ###### implementation
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "graylog" "isMaster" ]
+      [ "services" "graylog" "settings" "is_master" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "graylog" "nodeIdFile" ]
+      [ "services" "graylog" "settings" "node_id_file" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "graylog" "rootUsername" ]
+      [ "services" "graylog" "settings" "root_username" ]
+    )
+    (lib.mkRemovedOptionModule [
+      "services"
+      "graylog"
+      "passwordSecret"
+    ] "Please instead use `services.graylog.passwordSecretFile`")
+    (lib.mkRemovedOptionModule [
+      "services"
+      "graylog"
+      "rootPasswordSha2"
+    ] "Please instead use `services.graylog.rootPasswordSha2File`")
+    (lib.mkRenamedOptionModule
+      [ "services" "graylog" "dataDir" ]
+      [ "services" "graylog" "settings" "data_dir" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "graylog" "messageJournalDir" ]
+      [ "services" "graylog" "settings" "message_journal_dir" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "graylog" "mongodbUri" ]
+      [ "services" "graylog" "settings" "mongodb_uri" ]
+    )
+    (lib.mkRemovedOptionModule [
+      "services"
+      "graylog"
+      "extraConfig"
+    ] "Please instead use `services.graylog.settings`")
+  ];
 
   config = lib.mkIf cfg.enable {
+    services.graylog.settings.elasticsearch_hosts = lib.concatStringsSep "," cfg.elasticsearchHosts;
 
-    # Note: when changing the default, make it conditional on
-    # ‘system.stateVersion’ to maintain compatibility with existing
-    # systems!
-    services.graylog.package =
-      let
-        mkThrow = ver: throw "graylog-${ver} was removed, please upgrade your graylog version.";
-        base =
-          if lib.versionAtLeast config.system.stateVersion "25.05" then
-            pkgs.graylog-6_0
-          else if lib.versionAtLeast config.system.stateVersion "23.05" then
-            mkThrow "5_1"
-          else
-            mkThrow "3_3";
-      in
-      lib.mkDefault base;
+    services.mongodb = lib.mkIf cfg.enableLocalMongoDB {
+      enable = true;
+    };
 
     users.users = lib.mkIf (cfg.user == "graylog") {
       graylog = {
@@ -156,15 +208,14 @@ in
     users.groups = lib.mkIf (cfg.user == "graylog") { graylog = { }; };
 
     systemd.tmpfiles.rules = [
-      "d '${cfg.messageJournalDir}' - ${cfg.user} - - -"
+      "d '${cfg.settings.message_journal_dir}' - ${cfg.user} - - -"
     ];
 
     systemd.services.graylog = {
       description = "Graylog Server";
       wantedBy = [ "multi-user.target" ];
-      environment = {
-        GRAYLOG_CONF = "${confFile}";
-      };
+      after = [ "network.target" ] ++ lib.optionals cfg.enableLocalMongoDB [ "mongodb.service" ];
+      environment.GRAYLOG_CONF = "${settings-ini}";
       path = [
         pkgs.which
         pkgs.procps
@@ -173,8 +224,8 @@ in
         rm -rf /var/lib/graylog/plugins || true
         mkdir -p /var/lib/graylog/plugins -m 755
 
-        mkdir -p "$(dirname ${cfg.nodeIdFile})"
-        chown -R ${cfg.user} "$(dirname ${cfg.nodeIdFile})"
+        mkdir -p "$(dirname ${cfg.settings.node_id_file})"
+        chown -R ${cfg.user} "$(dirname ${cfg.settings.node_id_file})"
 
         for declarativeplugin in `ls ${glPlugins}/bin/`; do
           ln -sf ${glPlugins}/bin/$declarativeplugin /var/lib/graylog/plugins/$declarativeplugin
@@ -184,10 +235,21 @@ in
         done
       '';
       serviceConfig = {
+        LoadCredential = [
+          "passwordSecret:${cfg.passwordSecretFile}"
+          "rootSha2:${cfg.rootPasswordSha2File}"
+        ];
         User = "${cfg.user}";
         StateDirectory = "graylog";
-        ExecStart = "${cfg.package}/bin/graylogctl run";
       };
+      script = ''
+        set -eou pipefail
+        shopt -s inherit_errexit
+
+        GRAYLOG_PASSWORD_SECRET="$(<"$CREDENTIALS_DIRECTORY/passwordSecret")" \
+        GRAYLOG_ROOT_PASSWORD_SHA2="$(<"$CREDENTIALS_DIRECTORY/rootSha2")" \
+        ${cfg.package}/bin/graylogctl run
+      '';
     };
   };
 }

--- a/nixos/tests/graylog.nix
+++ b/nixos/tests/graylog.nix
@@ -1,7 +1,11 @@
-{ pkgs, lib, ... }:
+# Run this test with NIXPKGS_ALLOW_UNFREE=1
+{ lib, pkgs, ... }:
 {
   name = "graylog";
-  meta.maintainers = [ ];
+  meta.maintainers = with lib.maintainers; [
+    bbenno
+    robertjakub
+  ];
 
   nodes.machine =
     { pkgs, ... }:
@@ -9,27 +13,28 @@
       virtualisation.memorySize = 4096;
       virtualisation.diskSize = 1024 * 6;
 
-      services.mongodb.enable = true;
-      services.elasticsearch.enable = true;
-      services.elasticsearch.extraConf = ''
-        network.publish_host: 127.0.0.1
-        network.bind_host: 127.0.0.1
-      '';
+      # use community-edition for tests
+      services.mongodb.package = pkgs.mongodb-ce;
+
+      services.opensearch = {
+        enable = true;
+        extraJavaOptions = [ "-Djava.net.preferIPv4Stack=true" ];
+        settings.network.host = "127.0.0.1";
+      };
 
       services.graylog = {
         enable = true;
-        passwordSecret = "YGhZ59wXMrYOojx5xdgEpBpDw2N6FbhM4lTtaJ1KPxxmKrUvSlDbtWArwAWMQ5LKx1ojHEVrQrBMVRdXbRyZLqffoUzHfssc";
-        elasticsearchHosts = [ "http://localhost:9200" ];
-
-        # `echo -n "nixos" | shasum -a 256`
-        rootPasswordSha2 = "6ed332bcfa615381511d4d5ba44a293bb476f368f7e9e304f0dff50230d1a85b";
+        enableLocalMongoDB = true;
+        elasticsearchHosts = [ "http://127.0.0.1:9200" ];
+        passwordSecretFile = "/run/graylog-passwordsecret";
+        rootPasswordSha2File = "/run/graylog-rootpasswordsha2";
       };
 
       environment.systemPackages = [ pkgs.jq ];
 
       systemd.services.graylog.path = [ pkgs.netcat ];
       systemd.services.graylog.preStart = ''
-        until nc -z localhost 9200; do
+        until nc -z 127.0.0.1 9200; do
           sleep 2
         done
       '';
@@ -72,9 +77,15 @@
           facility = "Test";
         }
       );
+
+      passwordSecret = "YGhZ59wXMrYOojx5xdgEpBpDw2N6FbhM4lTtaJ1KPxxmKrUvSlDbtWArwAWMQ5LKx1ojHEVrQrBMVRdXbRyZLqffoUzHfssc";
+      # `echo -n "nixos" | shasum -a 256`
+      rootPasswordSha2 = "6ed332bcfa615381511d4d5ba44a293bb476f368f7e9e304f0dff50230d1a85b";
     in
     ''
       machine.start()
+      machine.execute("echo \"${passwordSecret}\" > /run/graylog-passwordsecret && chmod 400 /run/checkmate-passwordsecret")
+      machine.execute("echo \"${rootPasswordSha2}\" > /run/graylog-rootpasswordsha2 && chmod 400 /run/checkmate-rootpasswordsha2")
       machine.wait_for_unit("graylog.service")
 
       machine.wait_until_succeeds(
@@ -127,12 +138,14 @@
 
       machine.succeed(
           'test "$(curl -X GET '
-          + "-sSfL 'http://127.0.0.1:9000/api/search/universal/relative?query=*' "
+          + "-sSfL 'http://127.0.0.1:9000/api/search/universal/relative?query=*&range=300&fields=*' "
           + f"-u {session}:session "
           + "-H 'Accept: application/json' "
           + "-H 'Content-Type: application/json' "
           + "-H 'x-requested-by: cli'"
           + ' | jq \'.total_results\' | xargs echo)" = "1"'
       )
+
+      machine.shutdown()
     '';
 }

--- a/pkgs/tools/misc/graylog/7.0.nix
+++ b/pkgs/tools/misc/graylog/7.0.nix
@@ -1,0 +1,14 @@
+{ callPackage, lib, ... }:
+let
+  buildGraylog = callPackage ./graylog.nix { };
+in
+buildGraylog {
+  version = "7.0.5";
+  hash = "sha256-ipw8+zQThIiU6KX7ticQJqHFy7bK769DTNa2FIE/kUg=";
+  maintainers = with lib.maintainers; [
+    bbenno
+    etwas
+    robertjakub
+  ];
+  license = lib.licenses.sspl;
+}

--- a/pkgs/tools/misc/graylog/graylog.nix
+++ b/pkgs/tools/misc/graylog/graylog.nix
@@ -3,19 +3,19 @@
   stdenv,
   fetchurl,
   makeWrapper,
-  openjdk11_headless,
   openjdk17_headless,
-  systemd,
+  openjdk21_headless,
   nixosTests,
+  udev,
+  systemd,
 }:
-
 {
   version,
   hash,
   maintainers,
   license,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "graylog_${lib.versions.majorMinor version}";
   inherit version;
 
@@ -25,13 +25,19 @@ stdenv.mkDerivation rec {
   };
 
   dontBuild = true;
-
   nativeBuildInputs = [ makeWrapper ];
+
   makeWrapperArgs = [
     "--set-default"
     "JAVA_HOME"
-    "${if (lib.versionAtLeast version "5.0") then openjdk17_headless else openjdk11_headless}"
+    "${if (lib.versionAtLeast version "7.0") then openjdk21_headless else openjdk17_headless}"
+    "--set-default"
+    "JAVA_CMD"
+    "$JAVA_HOME/bin/java"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux) [
     "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ systemd ]}"
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ udev ]}"
   ];
 
   passthru.tests = { inherit (nixosTests) graylog; };
@@ -39,16 +45,11 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out
     cp -r {graylog.jar,bin,plugin} $out
-  ''
-  + lib.optionalString (lib.versionOlder version "4.3") ''
-    cp -r lib $out
-  ''
-  + ''
     wrapProgram $out/bin/graylogctl $makeWrapperArgs
   '';
 
   meta = {
-    description = "Open source log management solution";
+    description = "Self-Managed Log Management";
     homepage = "https://www.graylog.org/";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     inherit license;
@@ -56,4 +57,4 @@ stdenv.mkDerivation rec {
     mainProgram = "graylogctl";
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2506,17 +2506,17 @@ with pkgs;
 
   grails = callPackage ../development/web/grails { jdk = null; };
 
-  graylog-6_0 = callPackage ../tools/misc/graylog/6.0.nix { };
-
   inherit
     ({
-      graylog-6_1 = callPackage ../tools/misc/graylog/6.1.nix { };
+      graylog-7_0 = callPackage ../tools/misc/graylog/7.0.nix { };
     })
-    graylog-6_1
+    graylog-7_0
     ;
 
+  graylog = graylog-7_0;
+
   graylogPlugins = recurseIntoAttrs (
-    callPackage ../tools/misc/graylog/plugins.nix { graylogPackage = graylog-6_0; }
+    callPackage ../tools/misc/graylog/plugins.nix { graylogPackage = graylog; }
   );
 
   graphviz = callPackage ../tools/graphics/graphviz { };


### PR DESCRIPTION
Add Graylog 7.0 with its current version 7.0.5.

Changes are described in the [changelog](https://go2docs.graylog.org/current/changelogs/changelog.html#Graylog705).

Additionally, breaking changes are summarised in the: [migration guide](https://go2docs.graylog.org/current/upgrading_graylog/upgrade_to_graylog_7.0.htm)

The `services.graylog` module has been refactored with the following breaking changes:
-  The `services.graylog.extraConfig` option has been removed. Configuration should now be specified directly via `services.graylog.settings`.
- The `services.graylog.passwordSecret` option has been removed. Use `services.graylog.passwordSecretFile` to securely load from a file via systemd credentials.
- The `services.graylog.rootPasswordSha2` option has been removed. Use `services.graylog.rootPasswordSha2File` to securely load from a file via systemd credentials.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

CC: @bbenno @eetwas

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [X] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
