### PR TITLE
[Backport release-25.11] adguardhome: 0.107.71 -> 0.107.73

### DIFF
--- a/pkgs/by-name/ad/adguardhome/package.nix
+++ b/pkgs/by-name/ad/adguardhome/package.nix
@@ -9,15 +9,15 @@
 
 buildGoModule (finalAttrs: {
   pname = "adguardhome";
-  version = "0.107.71";
+  version = "0.107.73";
   src = fetchFromGitHub {
     owner = "AdguardTeam";
     repo = "AdGuardHome";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uyDmS/C1nd0DEHy91tMw/2W5Rih/0j59yxGCwTjFjPc=";
+    hash = "sha256-WsZDwbcF0epmsz/lP2QMcf8CnvCCoc+Z2LQaecB01WU=";
   };
 
-  vendorHash = "sha256-KSDvI7SljFUZSUFytT1U76HzQydv3rNsOmDMKCXDl6M=";
+  vendorHash = "sha256-od20SYVMiLmfOpstuKdc99bA3HWcAaXwcLS0tiGlWog=";
 
   dashboard = buildNpmPackage {
     inherit (finalAttrs) src version;
@@ -25,7 +25,7 @@ buildGoModule (finalAttrs: {
     postPatch = ''
       cd client
     '';
-    npmDepsHash = "sha256-AYm4ZgTsPJ6aNL7fo9DJqC0yq9i1mJghO7zWWC1X9eA=";
+    npmDepsHash = "sha256-HPWe8ZZKtToUk5CCLeEwwBBK8hEYMjgGQz3hIfFkZz4=";
     npmBuildScript = "build-prod";
     postBuild = ''
       mkdir -p $out/build/
@@ -45,7 +45,7 @@ buildGoModule (finalAttrs: {
 
   passthru = {
     updateScript = ./update.sh;
-    schema_version = 32;
+    schema_version = 33;
     tests.adguardhome = nixosTests.adguardhome;
     tests.version = testers.testVersion {
       package = finalAttrs.finalPackage;

--- a/pkgs/by-name/ad/adguardhome/update.sh
+++ b/pkgs/by-name/ad/adguardhome/update.sh
@@ -1,5 +1,5 @@
-#! /usr/bin/env nix-shell
-#! nix-shell -i bash -p curl gnugrep jq nix-prefetch nix-update
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -I nixpkgs=. -i bash -p bash cacert common-updater-scripts curl gnugrep jq nix nix-prefetch nix-update
 
 # This file is based on /pkgs/servers/gotify/update.sh
 
@@ -13,7 +13,7 @@ version=$(jq -r '.tag_name' <<<"$latest_release")
 echo "got version $version"
 
 schema_version=$(curl --silent "https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/${version}/internal/configmigrate/configmigrate.go" \
-    | grep -Po '(?<=const LastSchemaVersion uint = )[[:digit:]]+$')
+  | grep -Po '(?<=const LastSchemaVersion uint = )[[:digit:]]+$')
 
 echo "got schema_version $schema_version"
 

--- a/pkgs/by-name/ad/adguardhome/update.sh
+++ b/pkgs/by-name/ad/adguardhome/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure -I nixpkgs=. -i bash -p bash cacert common-updater-scripts curl gnugrep jq nix nix-prefetch nix-update
+#!nix-shell --pure -I nixpkgs=. -i bash -p bash cacert common-updater-scripts curl git gnugrep jq nix nix-prefetch nix-update
 
 # This file is based on /pkgs/servers/gotify/update.sh
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Backport of #498634 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
