### PR TITLE
python3Packages.teltasync: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13693,6 +13693,13 @@
     github = "karaolidis";
     githubId = 46189100;
   };
+  karlbeecken = {
+    name = "Karl Beecken";
+    email = "karl@beecken.berlin";
+    github = "karlbeecken";
+    githubId = 32744028;
+    keys = [ { fingerprint = "7577 13A4 9609 0C2F 51C4  018C B5C8 89A2 F195 28F6"; } ];
+  };
   KarlJoad = {
     email = "karl@hallsby.com";
     github = "KarlJoad";

--- a/pkgs/development/python-modules/teltasync/default.nix
+++ b/pkgs/development/python-modules/teltasync/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromCodeberg,
+  aiohttp,
+  pydantic,
+  uv-build,
+  pytestCheckHook,
+  pytest-asyncio,
+  syrupy,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "teltasync";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromCodeberg {
+    owner = "dmho";
+    repo = "teltasync";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-skTJyWkDplgGJ5al6YMVnFAo1Js1yc5ViKUiPm9hhJg=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.10.2,<0.11.0" "uv_build"
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    aiohttp
+    pydantic
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    syrupy
+  ];
+
+  pythonImportsCheck = [ "teltasync" ];
+
+  meta = {
+    description = "Async, typed API client for Teltonika routers, built for Home Assistant";
+    homepage = "https://codeberg.org/dmho/teltasync";
+    changelog = "https://codeberg.org/dmho/teltasync/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.karlbeecken ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -6184,7 +6184,8 @@
       ];
     "teltonika" =
       ps: with ps; [
-      ]; # missing inputs: teltasync
+        teltasync
+      ];
     "temper" =
       ps: with ps; [
         temperusb
@@ -8124,6 +8125,7 @@
     "telegram"
     "telegram_bot"
     "tellduslive"
+    "teltonika"
     "temper"
     "template"
     "tesla_fleet"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18944,6 +18944,8 @@ self: super: with self; {
 
   tellduslive = callPackage ../development/python-modules/tellduslive { };
 
+  teltasync = callPackage ../development/python-modules/teltasync { };
+
   temescal = callPackage ../development/python-modules/temescal { };
 
   temperusb = callPackage ../development/python-modules/temperusb { };


### PR DESCRIPTION
- https://pypi.org/project/teltasync/
- https://codeberg.org/dmho/teltasync
- https://www.home-assistant.io/integrations/teltonika/



## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
