### PR TITLE
python3Packages.openapi-core: 0.22.0 -> 0.23.0

### DIFF
--- a/pkgs/development/python-modules/jsonschema-path/default.nix
+++ b/pkgs/development/python-modules/jsonschema-path/default.nix
@@ -13,21 +13,19 @@
 
 buildPythonPackage rec {
   pname = "jsonschema-path";
-  version = "0.3.4";
+  version = "0.4.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "p1c2u";
     repo = "jsonschema-path";
     tag = version;
-    hash = "sha256-rCepDnVAOEsokKjWCuqDYbGIq6/wn4rsQRx5dXTUsYo=";
+    hash = "sha256-xDNWQddw4ftq762EPvTjyXUEsyRfgs2ffeKVgbWVUs4=";
   };
 
   build-system = [ poetry-core ];
 
-  pythonRelaxDeps = [ "referencing" ];
-
-  propagatedBuildInputs = [
+  dependencies = [
     pathable
     pyyaml
     referencing

--- a/pkgs/development/python-modules/openapi-core/default.nix
+++ b/pkgs/development/python-modules/openapi-core/default.nix
@@ -30,14 +30,14 @@
 
 buildPythonPackage rec {
   pname = "openapi-core";
-  version = "0.22.0";
+  version = "0.23.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "p1c2u";
     repo = "openapi-core";
     tag = version;
-    hash = "sha256-fdONzFde9k2NAd5Rd8vTLt/lQX72JdNSFJhPVWryRQw=";
+    hash = "sha256-3Q0Cr9GfDNL+uA5oV20V2OMewTU9yRI0/WmXLW+nuzo=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/openapi-schema-validator/default.nix
+++ b/pkgs/development/python-modules/openapi-schema-validator/default.nix
@@ -6,10 +6,16 @@
   # build-system
   poetry-core,
 
-  # propagates
+  # dependencies
   jsonschema,
   jsonschema-specifications,
+  pydantic,
+  pydantic-settings,
+  referencing,
   rfc3339-validator,
+
+  # optional-dependencies
+  regress,
 
   # tests
   pytestCheckHook,
@@ -18,41 +24,41 @@
 
 buildPythonPackage rec {
   pname = "openapi-schema-validator";
-  version = "0.6.3";
+  version = "0.8.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "p1c2u";
     repo = "openapi-schema-validator";
     tag = version;
-    hash = "sha256-1Y049W4TbqvKZRwnvPVwyLq6CH6NQDrEfJknuMn8dGo=";
+    hash = "sha256-XOtSnlJJGEa6pOQDHTFRF0zqNxJIB2VlZvFv5kxwUIM=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     jsonschema
     jsonschema-specifications
+    pydantic
+    pydantic-settings
+    referencing
     rfc3339-validator
   ];
+
+  optional-dependencies = {
+    ecma-regex = [ regress ];
+  };
 
   nativeCheckInputs = [
     pytestCheckHook
     pytest-cov-stub
   ];
 
-  disabledTests = [
-    # https://github.com/python-openapi/openapi-schema-validator/issues/153
-    "test_array_prefixitems_invalid"
-  ];
-
-  pytestFlags = [ "-vvv" ];
-
   pythonImportsCheck = [ "openapi_schema_validator" ];
 
   meta = {
     changelog = "https://github.com/python-openapi/openapi-schema-validator/releases/tag/${src.tag}";
-    description = "Validates OpenAPI schema against the OpenAPI Schema Specification v3.0";
+    description = "Validates OpenAPI schema against the OpenAPI Schema Specification v3.0 and v3.1";
     homepage = "https://github.com/python-openapi/openapi-schema-validator";
     license = lib.licenses.bsd3;
     maintainers = [ ];

--- a/pkgs/development/python-modules/openapi-spec-validator/default.nix
+++ b/pkgs/development/python-modules/openapi-spec-validator/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "openapi-spec-validator";
-  version = "0.7.2";
+  version = "0.8.4";
   pyproject = true;
 
   # no tests via pypi sdist
@@ -27,12 +27,16 @@ buildPythonPackage rec {
     owner = "python-openapi";
     repo = "openapi-spec-validator";
     tag = version;
-    hash = "sha256-APEx7+vc824DLmdzLvhfFVrcjPxVwwUwxkh19gjXEvc=";
+    hash = "sha256-KY9mDnF/R2UO8WZ0WyBzpZQsVBxzxnTK6zyqvUb+hVw=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
-  propagatedBuildInputs = [
+  pythonRelaxDeps = [
+    "jsonschema"
+  ];
+
+  dependencies = [
     jsonschema
     jsonschema-path
     lazy-object-proxy

--- a/pkgs/development/python-modules/pathable/default.nix
+++ b/pkgs/development/python-modules/pathable/default.nix
@@ -9,17 +9,17 @@
 
 buildPythonPackage rec {
   pname = "pathable";
-  version = "0.4.4";
+  version = "0.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "p1c2u";
     repo = "pathable";
     tag = version;
-    hash = "sha256-nN5jpI0Zi5ofdSuN9QbTHDXPmQRq9KAn8SoHuNDpZaw=";
+    hash = "sha256-D3TYVMcKXPA6fmy2JND5o8ja3Rk8Ne17Sxm4+fLw3Dw=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
   nativeCheckInputs = [
     pytestCheckHook


### PR DESCRIPTION
Diff: https://github.com/p1c2u/openapi-core/compare/0.22.0...0.23.0

Changelog: https://github.com/python-openapi/openapi-core/releases/tag/0.23.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
