### PR TITLE
python3Packages.zarr: remove useless optional-dependencies

### DIFF
--- a/pkgs/development/python-modules/zarr/default.nix
+++ b/pkgs/development/python-modules/zarr/default.nix
@@ -23,37 +23,17 @@
   cupy,
   # cli
   typer,
-  # test
-  pytestCheckHook,
-  pytest-asyncio,
-  pytest-cov,
-  pytest-accept ? null, # TODO: Package
+  # optional
   rich,
-  mypy,
-  numpydoc,
+  universal-pathlib,
+
+  # test
   hypothesis,
-  pytest-xdist,
+  numpydoc,
+  pytest-asyncio,
+  pytestCheckHook,
   tomlkit,
   uv,
-  # remote_tests
-  botocore,
-  s3fs,
-  moto,
-  requests,
-  # optional
-  universal-pathlib,
-  # docs
-  mkdocs-material,
-  mkdocs,
-  mkdocstrings,
-  mkdocstrings-python,
-  mike,
-  mkdocs-redirects,
-  markdown-exec ? null, # TODO: Package
-  griffe-inherited-docstrings ? null, # TODO: Package,
-  ruff,
-  towncrier,
-  astroid,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -94,67 +74,22 @@ buildPythonPackage (finalAttrs: {
       cli = [
         typer
       ];
-      # Development extras
-      test = [
-        #pytest
-        pytest-asyncio
-        pytest-cov
-        pytest-accept
-        rich
-        mypy
-        numpydoc
-        hypothesis
-        # From some reason the existence of pytest-xdist makes the tests fail
-        # depending on $NIX_BUILD_CORES
-        #pytest-xdist
-        packaging
-        tomlkit
-        uv
-      ];
-      remote_tests = [
-        botocore
-        s3fs
-        moto
-        requests
-      ]
-      ++ moto.optional-dependencies.server
-      ++ moto.optional-dependencies.s3;
       optional = [
         rich
         universal-pathlib
       ];
-      docs = [
-        # Doc building
-        mkdocs-material
-        mkdocs
-        mkdocstrings
-        mkdocstrings-python
-        mike
-        mkdocs-redirects
-        markdown-exec
-        griffe-inherited-docstrings
-        ruff
-        towncrier # Changelog generation
-        # Optional dependencies to run examples
-        rich
-        s3fs
-        astroid
-        #pytest
-      ]
-      ++ mkdocs-material.optional-dependencies.imaging
-      ++ lib.optionals (markdown-exec != null) markdown-exec.optional-dependencies.ansi
-      ++ numcodecs.optional-dependencies.msgpack;
     };
   };
 
   nativeCheckInputs = [
+    hypothesis
+    numpydoc
+    pytest-asyncio
     pytestCheckHook
+    tomlkit
+    uv
   ]
-  ++ finalAttrs.finalPackage.passthru.optional-dependencies.cli
-  # Not adding `passthru.optional-dependencies.remote{,_tests}` since the
-  # existence of these Python modules triggers tests that fail in the sandbox
-  # due to failed network requests.
-  ++ finalAttrs.finalPackage.passthru.optional-dependencies.test;
+  ++ finalAttrs.finalPackage.passthru.optional-dependencies.cli;
 
   disabledTestPaths = [
     # requires uv and then fails at setting up python envs


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
