### PR TITLE
nixos-rebuild-ng: preserve SSH_AUTH_SOCK in subprocess environment

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -297,7 +297,7 @@ def _normalize_env(env: Mapping[str, EnvValue] | None) -> dict[str, EnvValue]:
     """
     Normalize env mapping, but preserve some environment variables by default.
     """
-    return {"PATH": PRESERVE_ENV, **(env or {})}
+    return {"PATH": PRESERVE_ENV, "SSH_AUTH_SOCK": PRESERVE_ENV, **(env or {})}
 
 
 def _resolve_env_local(env: dict[str, EnvValue]) -> dict[str, str]:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -27,6 +27,17 @@ def test_remote_shell_script() -> None:
     )
 
 
+def test_normalize_env_preserves_ssh_auth_sock() -> None:
+    """SSH_AUTH_SOCK must be preserved so that commands like nix-copy-closure
+    can use SSH agent forwarding for authentication."""
+    env = p._normalize_env(None)
+    assert env.get("SSH_AUTH_SOCK") is p.PRESERVE_ENV
+
+    # Explicit SSH_AUTH_SOCK value should not be overridden
+    env = p._normalize_env({"SSH_AUTH_SOCK": "/tmp/custom-agent"})
+    assert env["SSH_AUTH_SOCK"] == "/tmp/custom-agent"
+
+
 @patch.dict(p.os.environ, {"PATH": "/path/to/bin"}, clear=True)
 @patch("subprocess.run", autospec=True)
 def test_run_wrapper(mock_run: Any) -> None:
@@ -124,7 +135,7 @@ def test_run_wrapper(mock_run: Any) -> None:
             "--",
             "/bin/sh",
             "-c",
-            """'exec env -i PATH="${PATH-}" "$@"'""",
+            """'exec env -i PATH="${PATH-}" SSH_AUTH_SOCK="${SSH_AUTH_SOCK-}" "$@"'""",
             "sh",
             "test",
             "--with",
@@ -157,7 +168,7 @@ def test_run_wrapper(mock_run: Any) -> None:
             "--stdin",
             "/bin/sh",
             "-c",
-            """'exec env -i PATH="${PATH-}" FOO=bar "$@"'""",
+            """'exec env -i PATH="${PATH-}" SSH_AUTH_SOCK="${SSH_AUTH_SOCK-}" FOO=bar "$@"'""",
             "sh",
             "test",
             "--with",
@@ -289,7 +300,7 @@ def test_custom_sudo_args(mock_run: Any) -> None:
             "--args",
             "/bin/sh",
             "-c",
-            """'exec env -i PATH="${PATH-}" "$@"'""",
+            """'exec env -i PATH="${PATH-}" SSH_AUTH_SOCK="${SSH_AUTH_SOCK-}" "$@"'""",
             "sh",
             "test",
         ],


### PR DESCRIPTION
## Description

The recent environment refactoring in `nixos-rebuild-ng` introduced `_normalize_env` which constructs a minimal environment (only `PATH`) for `subprocess.run` calls. This strips `SSH_AUTH_SOCK` from the environment, breaking SSH agent forwarding when `nix-copy-closure` runs during remote deployments.

## The Problem

When deploying with `nixos-rebuild switch --target-host root@<host>`, the flow is:

1. SSH into the target machine (agent forwarding works via `-A`)
2. Build the system configuration locally
3. Run `nix-copy-closure --to root@<host>` to copy the closure

Step 3 fails because `nix-copy-closure` is executed via `run_wrapper` with an explicit `env={"NIX_SSHOPTS": "..."}`. This triggers `_normalize_env` → `_resolve_env_local` → `subprocess.run(env={"PATH": ..., "NIX_SSHOPTS": ...})`, which **does not include `SSH_AUTH_SOCK`**.

Without `SSH_AUTH_SOCK`, the SSH client inside `nix-copy-closure` cannot locate the forwarded agent socket, resulting in:

```
root@192.168.1.172: Permission denied (publickey,keyboard-interactive).
error: failed to start SSH connection to '192.168.1.172'
```

### Regression

The previous implementation used `os.environ | extra_env` which preserved the full environment. The refactored `_normalize_env` constructs a minimal env from scratch, inadvertently dropping `SSH_AUTH_SOCK`.

## The Fix

Add `SSH_AUTH_SOCK` to the set of environment variables preserved by default in `_normalize_env`, alongside `PATH`. This is consistent with the function's documented purpose of preserving variables that are needed for correct operation.

If `SSH_AUTH_SOCK` is not set in the current environment, it is simply omitted (the `PRESERVE_ENV` sentinel handles this gracefully).

## Testing

- Added `test_normalize_env_preserves_ssh_auth_sock` to verify `SSH_AUTH_SOCK` is preserved by default and that explicit values are not overridden
- Updated existing tests to reflect `SSH_AUTH_SOCK` in remote shell scripts

## Reproduction

```bash
# This fails — nix-copy-closure's SSH has no agent
ssh -A root@host 'env -i PATH="$PATH" NIX_SSHOPTS="-A" nix-copy-closure --to root@host /run/current-system'

# This works — SSH_AUTH_SOCK is preserved
ssh -A root@host 'env -i PATH="$PATH" NIX_SSHOPTS="-A" SSH_AUTH_SOCK="$SSH_AUTH_SOCK" nix-copy-closure --to root@host /run/current-system'
```