### PR TITLE
rustup: 1.28.2 -> 1.29.0

### DIFF
--- a/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
@@ -1,16 +1,16 @@
 diff --git a/src/dist/component/package.rs b/src/dist/component/package.rs
-index dfccc661..85233f3b 100644
+index dc545d4b62..4dd8ade86e 100644
 --- a/src/dist/component/package.rs
 +++ b/src/dist/component/package.rs
-@@ -113,6 +113,7 @@ impl Package for DirectoryPackage {
+@@ -130,6 +130,7 @@
                      } else {
                          builder.move_file(path.clone(), &src_path)?
                      }
 +                    nix_patchelf_if_needed(&target.prefix().path().join(path.clone()))
                  }
-                 "dir" => {
+                 ComponentPartKind::Dir => {
                      if self.copy {
-@@ -135,6 +136,176 @@ impl Package for DirectoryPackage {
+@@ -152,6 +153,176 @@
      }
  }
  
@@ -31,7 +31,7 @@ index dfccc661..85233f3b 100644
 +        .parent()
 +        .ok_or(anyhow!("failed to get parent directory"))?
 +        .with_file_name("nix-support");
-+    let mut file = std::fs::File::create(dest_lld_path)?;
++    let mut file = fs::File::create(dest_lld_path)?;
 +    ld_wrapper_path.push("ld-wrapper.sh");
 +
 +    let wrapped_script = format!(
@@ -184,6 +184,6 @@ index dfccc661..85233f3b 100644
 +    }
 +}
 +
- #[derive(Debug)]
- pub(crate) struct TarPackage<'a>(DirectoryPackage, temp::Dir<'a>);
- 
+ /// Handle the async result of io operations
+ /// Replaces op.result with Ok(())
+ fn filter_result(op: &mut CompletedIo) -> io::Result<()> {

--- a/pkgs/development/tools/rust/rustup/default.nix
+++ b/pkgs/development/tools/rust/rustup/default.nix
@@ -25,16 +25,16 @@ in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rustup";
-  version = "1.28.2";
+  version = "1.29.0";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "rustup";
     tag = finalAttrs.version;
-    hash = "sha256-iX5hEaQwCW9MuyafjXml8jV3EDnxRNUlOoy3Cur/Iyw=";
+    hash = "sha256-jbB0nmXtc95Ac+YfmyELh6n5OTRMmeDPT4OFIlJNrZc=";
   };
 
-  cargoHash = "sha256-KljaAzYHbny7KHOO51MotdmNpHCKWdt6kc/FIpFN6c0=";
+  cargoHash = "sha256-m/KoXNJh00zYKZo7MIJsBvo4zldfKdofrUh8AItJqXI=";
 
   nativeBuildInputs = [
     makeBinaryWrapper
@@ -78,9 +78,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # TODO: Investigate this.
   doCheck = !stdenv.hostPlatform.isDarwin;
   # Random failures when running tests in parallel.
-  preCheck = ''
-    export NIX_BUILD_CORES=1
-  '';
+  dontUseCargoParallelTests = true;
 
   # skip failing tests
   checkFlags = [
@@ -89,7 +87,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=suite::cli_exact::check_updates_some"
     "--skip=suite::cli_exact::check_updates_with_update"
     # rustup-init is not used in nix rustup
-    "--skip=suite::cli_ui::rustup_init_ui_doc_text_tests"
+    "--skip=suite::cli_rustup_init_ui"
+    # reaches out to the network to test TLS roots, which can't be done in the
+    # build sandbox
+    "--skip=suite::static_roots::store_static_roots"
   ];
 
   postInstall = ''


### PR DESCRIPTION
Release announcement: https://blog.rust-lang.org/2026/03/12/Rustup-1.29.0/
Changelog: https://github.com/rust-lang/rustup/blob/1.29.0/CHANGELOG.md

We also switch from `export NIX_BUILD_CORES=1` in `preCheck` to `dontUseCargoParallelTests`, to make compiling test crates slightly faster while still running them serially to avoid the failures that parallel tests originally caused. (The tests all happened to pass in parallel for me, but these things tend to be messy and load-sensitive so I don't want to cause regressions by removing it.)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
