### PR TITLE
octavePackages.buildOctavePackage: fix package test behavior for XFAILs

### DIFF
--- a/pkgs/development/interpreters/octave/run-pkg-test.nix
+++ b/pkgs/development/interpreters/octave/run-pkg-test.nix
@@ -17,7 +17,7 @@ runCommand "${package.name}-pkg-test"
   }
   ''
     { octave-cli --eval 'pkg test ${package.pname}' || touch FAILED_ERRCODE; } \
-      |& tee >( grep --quiet '^Failure Summary:$' && touch FAILED_OUTPUT || : ; cat >/dev/null )
+      |& tee >( grep --quiet -P '^\s*FAIL\s*[1-9]\d*$' && touch FAILED_OUTPUT || : ; cat >/dev/null )
     if [[ -f FAILED_ERRCODE ]]; then
       echo >&2 "octave-cli returned with non-zero exit code."
       false


### PR DESCRIPTION
I have never used octave, so, um, please check me carefully :).

- **octavePackages.buildOctavePackage: do not fail passthru.tests for XFAILing tests**
  The Failure Summary can be produced when all tests either pass or XFAIL. In this case, the package's testsuite should succeed. We will now match on a non-zero number of packages that fail.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
