### PR TITLE
cwal: 0.5.0 -> 0.7.0

### DIFF
--- a/pkgs/by-name/cw/cwal/package.nix
+++ b/pkgs/by-name/cw/cwal/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cwal";
-  version = "0.5.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "nitinbhat972";
     repo = "cwal";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ky7ng6yxa8aMKRjjSHzWU6UC4QfeOdS+/rQ3eA/wRPE=";
+    hash = "sha256-2COw5YBa16XzB4h5dfTLDF6LYjb10UC3+hCgTavnnVo=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Updated `cwal`: `0.5.0` -> `0.7.0`

Release: https://github.com/nitinbhat972/cwal/releases/tag/v0.7.0
Diff: https://github.com/nitinbhat972/cwal/compare/v0.5.0...v0.7.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.