### PR TITLE
nixos/wivrn: add option for Steam support and fix wayvr 

### DIFF
--- a/nixos/modules/services/video/wivrn.nix
+++ b/nixos/modules/services/video/wivrn.nix
@@ -106,6 +106,10 @@ in
       };
 
       steam = {
+        enable = lib.mkEnableOption "Steam support" // {
+          default = true;
+        };
+
         importOXRRuntimes = mkEnableOption ''
           Sets `PRESSURE_VESSEL_IMPORT_OPENXR_1_RUNTIMES` system-wide to allow Steam to automatically discover the WiVRn server.
 
@@ -211,12 +215,12 @@ in
               }
           );
           # Needs Steam in the PATH to allow launching games from the headset
-          path = [ cfg.steam.package ];
+          path = mkIf cfg.steam.enable [ cfg.steam.package ];
           wantedBy = mkIf cfg.autoStart [ "default.target" ];
           restartTriggers = [
             cfg.package
-            cfg.steam.package
-          ];
+          ]
+          ++ lib.optionals cfg.steam.enable [ cfg.steam.package ];
         };
       };
     };

--- a/pkgs/by-name/wa/wayvr/package.nix
+++ b/pkgs/by-name/wa/wayvr/package.nix
@@ -75,6 +75,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ]
   ++ lib.optionals withOpenVR [ "openvr" ];
 
+  postInstall = ''
+    install -D wayvr/wayvr.desktop -t $out/share/applications
+    install -D wayvr/wayvr.svg -t $out/share/icons/hicolor/scalable/apps
+  '';
+
   passthru = {
     tests.testVersion = testers.testVersion { package = wayvr; };
 


### PR DESCRIPTION
Add a new `services.wivrn.steam.enable` option to let the user enable or
disable Steam support. This option is enabled by default to not break
existing setups.

Also install the desktop file for the wayvr package, since it doesn't show up in the WiVRn menu without it. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
