### PR TITLE
etesync-dav: fix web UI  for Radicale >= 3.6.0

### DIFF
--- a/pkgs/by-name/et/etesync-dav/radicale-3-6-compat.patch
+++ b/pkgs/by-name/et/etesync-dav/radicale-3-6-compat.patch
@@ -49,7 +49,7 @@ index 1ccc6dd..0f68561 100644
      def delete(self, href=None):
          """Delete an item.
 diff --git a/etesync_dav/radicale/web.py b/etesync_dav/radicale/web.py
-index 869624f..6b4c515 100644
+index 869624f..ff335a7 100644
 --- a/etesync_dav/radicale/web.py
 +++ b/etesync_dav/radicale/web.py
 @@ -12,6 +12,8 @@
@@ -61,7 +61,7 @@ index 869624f..6b4c515 100644
  from radicale import web
  
  from etesync_dav.mac_helpers import has_ssl
-@@ -31,6 +33,8 @@ class Web(web.BaseWeb):
+@@ -31,8 +33,10 @@ class Web(web.BaseWeb):
              environ["wsgi.url_scheme"] = "https"
          body = list(app(environ, start_response))[0]
          ret_response.append(body)
@@ -69,4 +69,31 @@ index 869624f..6b4c515 100644
 +            ret_response.append(None)  # xml_request field
          return tuple(ret_response)
  
-     def get(self, environ, base_prefix, path, user):
+-    def get(self, environ, base_prefix, path, user):
++    def get(self, environ, base_prefix, path, user, *args, **kwargs):
+         return self._call(environ, base_prefix, path, user)
+ 
+-    def post(self, environ, base_prefix, path, user):
++    def post(self, environ, base_prefix, path, user, *args, **kwargs):
+         return self._call(environ, base_prefix, path, user)
+diff --git a/etesync_dav/radicale_main/server.py b/etesync_dav/radicale_main/server.py
+index b593661..a258f7d 100644
+--- a/etesync_dav/radicale_main/server.py
++++ b/etesync_dav/radicale_main/server.py
+@@ -53,12 +53,12 @@ elif os.name == "nt":
+ 
+ 
+ class MyApplication(Application):
+-    def do_POST(self, environ, base_prefix, path, user):
++    def do_POST(self, environ, base_prefix, path, user, *args, **kwargs):
+         """Manage POST request."""
+         # Dispatch .web URL to web module
+         if path == "/.web" or path.startswith("/.web/"):
+-            return self._web.post(environ, base_prefix, path, user)
++            return self._web.post(environ, base_prefix, path, user, *args, **kwargs)
+ 
+-        return super().do_POST(environ, base_prefix, path, user)
++        return super().do_POST(environ, base_prefix, path, user, *args, **kwargs)
+ 
+ 
+ def format_address(address):


### PR DESCRIPTION
Spiritual successor to https://github.com/NixOS/nixpkgs/pull/494473. I hadn't tested login on the web ui manually, and tests don't seem to cover this specific functionality.

Radicale 3.6.0 added remote_host and remote_useragent positional arguments to all do_* methods. MyApplication.do_POST and Web.get/post must accept and forward these extra arguments.

Proposed for upstreaming in https://github.com/etesync/etesync-dav/pull/365


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
