### PR TITLE
amiberry: 5.7.4 -> 8.1.5

### DIFF
--- a/pkgs/by-name/am/amiberry/package.nix
+++ b/pkgs/by-name/am/amiberry/package.nix
@@ -2,111 +2,56 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
-  copyDesktopItems,
-  makeWrapper,
+  curl,
+  enet,
   flac,
+  libGL,
   libmpeg2,
   libmpg123,
+  libpcap,
   libpng,
   libserialport,
+  nlohmann_json,
   portmidi,
-  SDL2,
-  SDL2_image,
-  SDL2_ttf,
-  makeDesktopItem,
+  sdl3,
+  sdl3-image,
+  zstd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "amiberry";
-  version = "5.7.4";
+  version = "8.1.5";
 
   src = fetchFromGitHub {
     owner = "BlitterStudio";
     repo = "amiberry";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EOoVJYefX2pQ2Zz9bLD1RS47u/+7ZWTMwZYha0juF64=";
+    hash = "sha256-udSMQxpELpk3Shu3+weHA9S0i/WMdVnrOuLGZ0whEEI=";
   };
-
-  patches = [
-    # cmake-4 support
-    (fetchpatch {
-      name = "cmake-4.patch";
-      url = "https://github.com/BlitterStudio/amiberry/commit/dbd85a37147603875b9ca51a9409c65a26c0d60a.patch?full_index=1";
-      hash = "sha256-w8Z9yhNafbXWv3nV8GDNpks2R1+M12uG1mWWrwVaEUk=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
-    copyDesktopItems
-    makeWrapper
   ];
 
   buildInputs = [
+    curl
+    enet
     flac
+    libGL
     libmpeg2
     libmpg123
+    libpcap
     libpng
     libserialport
+    nlohmann_json
     portmidi
-    SDL2
-    SDL2_image
-    SDL2_ttf
+    sdl3
+    sdl3-image
+    zstd
   ];
 
   enableParallelBuilding = true;
-
-  # Amiberry has traditionally behaved as a "Portable" app, meaning that it was designed to expect everything
-  # under the same directory. This is not compatible with Nix package conventions.
-  # The Amiberry behavior has changed since versions 5.7.4 and 6.3.4 (see
-  # https://github.com/BlitterStudio/amiberry/wiki/FAQ#q-where-does-amiberry-look-for-its-files-can-i-change-that
-  # for more information), however this is still not compatible with Nix packaging. The AMIBERRY_DATA_DIR can go
-  # in the nix store but the Amiberry configuration files must be stored in a user writable location.
-  # Fortunately Amiberry provides environment variables for specifying these locations which we can supply with the
-  # wrapper script below.
-  # One more caveat: Amiberry expects the configuration files path (AMIBERRY_HOME_DIR) to exist, otherwise it will
-  # fall back to behaving like a "Portable" app. The wrapper below ensures that the AMIBERRY_HOME_DIR path exists,
-  # preventing that fallback.
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    cp amiberry $out/bin/
-    cp -r abr data $out/
-    install -Dm444 data/amiberry.png $out/share/icons/hicolor/256x256/apps/amiberry.png
-    wrapProgram $out/bin/amiberry \
-      --set-default AMIBERRY_DATA_DIR $out \
-      --run 'AMIBERRY_HOME_DIR="$HOME/.amiberry"' \
-      --run 'mkdir -p \
-        $AMIBERRY_HOME_DIR/kickstarts \
-        $AMIBERRY_HOME_DIR/conf \
-        $AMIBERRY_HOME_DIR/nvram \
-        $AMIBERRY_HOME_DIR/plugins \
-        $AMIBERRY_HOME_DIR/screenshots \
-        $AMIBERRY_HOME_DIR/savestates \
-        $AMIBERRY_HOME_DIR/controllers \
-        $AMIBERRY_HOME_DIR/whdboot \
-        $AMIBERRY_HOME_DIR/lha \
-        $AMIBERRY_HOME_DIR/floppies \
-        $AMIBERRY_HOME_DIR/cdroms \
-        $AMIBERRY_HOME_DIR/harddrives'
-    runHook postInstall
-  '';
-
-  desktopItems = [
-    (makeDesktopItem {
-      name = "amiberry";
-      desktopName = "Amiberry";
-      exec = "amiberry";
-      comment = "Amiga emulator";
-      icon = "amiberry";
-      categories = [
-        "System"
-        "Emulator"
-      ];
-    })
-  ];
 
   meta = {
     homepage = "https://github.com/BlitterStudio/amiberry";


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324205526
- Diff: https://github.com/BlitterStudio/amiberry/compare/v5.7.4...v8.1.5
- Last release note: https://github.com/BlitterStudio/amiberry/releases/tag/v8.1.5

Fixes #380650 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
