### PR TITLE
justx: init at 0.5.2

### DIFF
--- a/pkgs/by-name/ju/justx/package.nix
+++ b/pkgs/by-name/ju/justx/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  just,
+  makeWrapper,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "justx";
+  version = "0.5.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "fpgmaas";
+    repo = "justx";
+    tag = finalAttrs.version;
+    hash = "sha256-eSV959rMcxiLBYoVRsF6XIf4ktZZOVm2oi6etBqJJxo=";
+  };
+
+  pythonRelaxDeps = [
+    "rich"
+    "textual"
+  ];
+
+  build-system = [
+    python3Packages.hatchling
+  ];
+
+  dependencies = with python3Packages; [
+    click
+    pydantic
+    questionary
+    rich
+    textual
+  ];
+
+  pythonImportsCheck = [
+    "justx"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Version in pyproject.toml does that match the release tag version.
+  # Remove this patch once they are fixed in the project to be in sync.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'version = "0.0.1"' 'version = "${finalAttrs.version}"'
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  postFixup = ''
+    wrapProgram "$out/bin/justx" \
+      --prefix PATH : "${lib.makeBinPath [ just ]}"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI command launcher built on top of just";
+    homepage = "https://fpgmaas.github.io/justx/";
+    downloadPage = "https://github.com/fpgmaas/justx";
+    changelog = "https://github.com/fpgmaas/justx/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    mainProgram = "justx";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

~`versionCheckHook` is not added as `justx --version` outputs `0.0.1` and not `0.5.2`~

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
