### PR TITLE
[25.11] capnproto: backport security fixes

### DIFF
--- a/pkgs/by-name/ca/capnproto/package.nix
+++ b/pkgs/by-name/ca/capnproto/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   clangStdenv,
   fetchFromGitHub,
+  fetchpatch2,
   cmake,
   openssl,
   zlib,
@@ -48,6 +49,16 @@ clangStdenv.mkDerivation rec {
     ./fix-libucontext.patch
     # https://github.com/capnproto/capnproto/pull/2410
     ./fix-libatomic.patch
+    # Fix buffer overrun in async readMessage()
+    (fetchpatch2 {
+      url = "https://github.com/capnproto/capnproto/commit/28731820130b3b06a658fa061cfc40a3917bceaa.patch?full_index=1";
+      hash = "sha256-3weH0+ZjmVnUmnaCD3X5u6AykfUdKAFgXxHfzRRTksM=";
+    })
+    # Fix HTTP body size integer overflow bugs
+    (fetchpatch2 {
+      url = "https://github.com/capnproto/capnproto/commit/2744b3c012b4aa3c31cefb61ec656829fa5c0e36.patch?full_index=1";
+      hash = "sha256-OVuphM8w80mS4cgXr14kfuPrflACK/BkZdDySCNWat8=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Not-cherry-picked-because: although the update containing these patches is a minor one, it has other changes that would require regeneration of the generated capnproto code, breaking the using program until this is done.

See: #485054

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
