### PR TITLE
nixos/actkbd: switch to Type=exec rather than forking

### DIFF
--- a/nixos/modules/services/hardware/actkbd.nix
+++ b/nixos/modules/services/hardware/actkbd.nix
@@ -139,7 +139,7 @@ in
       };
       serviceConfig = {
         Type = "exec";
-        ExecStart = "${pkgs.actkbd}/bin/actkbd -c ${configFile} -d %I";
+        ExecStart = "${pkgs.actkbd}/bin/actkbd --config ${configFile} --device %I";
       };
     };
 

--- a/nixos/modules/services/hardware/actkbd.nix
+++ b/nixos/modules/services/hardware/actkbd.nix
@@ -138,8 +138,8 @@ in
         ConditionPathExists = "%I";
       };
       serviceConfig = {
-        Type = "forking";
-        ExecStart = "${pkgs.actkbd}/bin/actkbd -D -c ${configFile} -d %I";
+        Type = "exec";
+        ExecStart = "${pkgs.actkbd}/bin/actkbd -c ${configFile} -d %I";
       };
     };
 


### PR DESCRIPTION
I read [the original PR](https://github.com/NixOS/nixpkgs/pull/7486) where this service was introduced, and I don't see why we chose `Type=forking`

Type=forking is best avoided if possible. I noticed this because the daemon's stdout/stderr was being blackholed (which is now no longer the case). I'm sure there are other reasons to avoid it too.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
