### PR TITLE
Linkml

### DIFF
--- a/pkgs/by-name/li/linkml/package.nix
+++ b/pkgs/by-name/li/linkml/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "linkml";
+  version = "1.10.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "linkml";
+    repo = "linkml";
+    rev = "v${version}";
+    hash = "sha256-9UFjro2z/LBOMS5RtrVmObvjBLtFPnqPLLYMdCV6gvg=";
+  };
+
+  # The installable application lives under packages/linkml and depends on the sibling packages/linkml_runtime.
+  # Pointing the build at the sub-package directly.
+  sourceRoot = "${src.name}/packages/linkml";
+
+  build-system = with python3Packages; [
+    hatchling
+    uv-dynamic-versioning
+    hatch-vcs
+  ];
+
+  # linkml-runtime is a sibling workspace package bundled in the same repo.
+  propagatedBuildInputs =
+    let
+      linkml-runtime = python3Packages.buildPythonPackage {
+        pname = "linkml-runtime";
+        inherit version src;
+        sourceRoot = "${src.name}/packages/linkml_runtime";
+        pyproject = true;
+        build-system = with python3Packages; [
+          hatchling
+          uv-dynamic-versioning
+          hatch-vcs
+        ];
+        propagatedBuildInputs = with python3Packages; [
+          click
+          curies
+          deprecated
+          hbreader
+          jsonasobj2
+          jsonschema
+          prefixcommons
+          prefixmaps
+          pydantic
+          pyyaml
+          rdflib
+          requests
+        ];
+        pythonImportsCheck = [ "linkml_runtime" ];
+      };
+    in
+    with python3Packages;
+    [
+      linkml-runtime
+      antlr4-python3-runtime
+      click
+      graphviz
+      hbreader
+      isodate
+      jinja2
+      jsonasobj2
+      jsonschema
+      openpyxl
+      parse
+      pydantic
+      pyyaml
+      rdflib
+      requests
+      typing-extensions
+    ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-snapshot
+  ];
+
+  pytestFlagsArray = [
+    "-m"
+    "not network and not slow and not docker and not kroki"
+  ];
+
+  pythonImportsCheck = [ "linkml" ];
+
+  meta = {
+    description = "Linked Data Modeling Language — schema tooling and code generators";
+    longDescription = ''
+      LinkML is a linked data modeling language following object-oriented and
+      ontological principles. Models are authored in YAML and can be converted
+      to JSON Schema, OWL, SHACL, ShEx, SQL DDL, Pydantic, and many other
+      formats via a rich set of bundled generators.
+    '';
+    homepage = "https://linkml.io/linkml";
+    changelog = "https://github.com/linkml/linkml/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    mainProgram = "gen-python";
+  };
+}

--- a/pkgs/by-name/li/linkml/package.nix
+++ b/pkgs/by-name/li/linkml/package.nix
@@ -41,13 +41,8 @@ python3Packages.buildPythonApplication rec {
         ];
         propagatedBuildInputs = with python3Packages; [
           click
-          curies
           deprecated
-          hbreader
-          jsonasobj2
           jsonschema
-          prefixcommons
-          prefixmaps
           pydantic
           pyyaml
           rdflib
@@ -62,10 +57,8 @@ python3Packages.buildPythonApplication rec {
       antlr4-python3-runtime
       click
       graphviz
-      hbreader
       isodate
       jinja2
-      jsonasobj2
       jsonschema
       openpyxl
       parse


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Draft PR for anyone who wanted to build on this, currently failing with:

```
 Checking runtime dependencies for linkml_runtime-1.10.0-py3-none-any.whl
       >   - curies not installed
       >   - hbreader not installed
       >   - json-flattener not installed
       >   - jsonasobj2 not installed
       >   - prefixcommons not installed
       >   - prefixmaps not installed
```

Which I can't find on nixpkgs.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
