### PR TITLE
zerobrew: init at 0.2.1

### DIFF
--- a/pkgs/by-name/ze/zerobrew/package.nix
+++ b/pkgs/by-name/ze/zerobrew/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  sqlite,
+  xz,
+  zstd,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zerobrew";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "lucasgelfond";
+    repo = "zerobrew";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qBbH4rdpRKYxkX58ljcQMxvo4BFDdTJpvVfjrb/z3fI=";
+  };
+
+  cargoHash = "sha256-vuen++jxNB4fjAR16MN14Z0eQ9ma/SLbGPjMC/7/Ovg=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    sqlite
+    xz
+    zstd
+  ];
+
+  env = {
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  meta = {
+    description = "5-20x faster experimental Homebrew alternative";
+    homepage = "https://github.com/lucasgelfond/zerobrew";
+    changelog = "https://github.com/lucasgelfond/zerobrew/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = with lib.licenses; [
+      bsd2
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ isabelroses ];
+    mainProgram = "zb";
+  };
+})


### PR DESCRIPTION
adds https://github.com/lucasgelfond/zerobrew/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
