### PR TITLE
gnubg: 1.07.001 -> 1.08.003

### DIFF
--- a/pkgs/by-name/gn/gnubg/package.nix
+++ b/pkgs/by-name/gn/gnubg/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   pkg-config,
+  flex,
   glib,
   python3,
   gtk2,
@@ -13,17 +14,18 @@
 
 stdenv.mkDerivation rec {
   pname = "gnubg";
-  version = "1.07.001";
+  version = "1.08.003";
 
   src = fetchurl {
     url = "mirror://gnu/gnubg/gnubg-release-${version}-sources.tar.gz";
-    hash = "sha256-cjmXKUGcrZ8RLDBmoS0AANpFCkVq3XsJTYkVUGnWgh4=";
+    hash = "sha256-b32WmxPP/3hvupD/jMXl1WS5f08Kppr+Tzg48YxEWXk=";
   };
 
   nativeBuildInputs = [
     copyDesktopItems
     pkg-config
     python3
+    flex
     glib
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://cgit.git.savannah.gnu.org/cgit/gnubg.git/tree/ChangeLog

Along with just being a version bump, the current version of gnubg that's on `nixos-unstable` was failing for me with:

```
> In file included from external_l.l:24:
> external_y.y:115:14: error: two or more data types in declaration specifiers
>   115 |     gboolean bool;
>       |              ^~~~
> external_y.y:115:18: warning: declaration does not declare anything
>   115 |     gboolean bool;
>       |                  ^
> external_l.l: In function 'ext_lex':
> external_l.l:78:13: error: expected identifier before 'bool'
>    78 | <*>(yes|on|true){EOT}   {   yylval->bool = 1;
>       |             ^~~~
> external_l.l:81:13: error: expected identifier before 'bool'
>    81 | <*>(no|off|false){EOT}  {   yylval->bool = 0;
>       |             ^~~~
> make[2]: *** [Makefile:974: external_l.o] Error 1
```

Searching for issues with "two or more data types in declaration specifiers" in this repository showed that it might be because I'm using gcc15. After updating gnubg, I no longer see this issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
