### PR TITLE
  alcarin-tengwar: init at 0.83

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10078,6 +10078,13 @@
     githubId = 11212268;
     name = "gruve-p";
   };
+  gs-101 = {
+    email = "gabrielsantosdesouza@disroot.org";
+    github = "gs-101";
+    githubId = 172639817;
+    keys = [ { fingerprint = "D1D3 37F6 CB32 02DC B9BA  337B F9D8 EABC F57E ED58"; } ];
+    name = "Gabriel Santos";
+  };
   gschwartz = {
     email = "gsch@pennmedicine.upenn.edu";
     github = "GregorySchwartz";

--- a/pkgs/by-name/al/alcarin-tengwar/package.nix
+++ b/pkgs/by-name/al/alcarin-tengwar/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  installFonts,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "alcarin-tengwar";
+  version = "0.83";
+
+  src = fetchFromGitHub {
+    owner = "Tosche";
+    repo = "Alcarin-Tengwar";
+    rev = "a4530d430ea01871b0b0a54d1de218d2ffde0ea5";
+    hash = "sha256-W1PJ2ABjtGUhWp6XBUq6Zox7uG81tMEs13GidfwgD6Q=";
+  };
+
+  nativeBuildInputs = [ installFonts ];
+
+  meta = {
+    description = "Typeface designed to provide Tengwar symbols";
+    homepage = "https://github.com/Tosche/Alcarin-Tengwar";
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ gs-101 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Add [Alcarin Tengwar](https://github.com/Tosche/Alcarin-Tengwar), a [Tengwar](https://en.wikipedia.org/wiki/Tengwar) typeface. I did this because I'm a [Guix](https://guix.gnu.org/) migrant, and this was the only package that was missing here. Also, I [packaged it there myself](https://codeberg.org/guix/guix/pulls/2850).

I took some [cascadia-code code](https://github.com/gs-101/nixpkgs/blob/master/pkgs/by-name/ca/cascadia-code/package.nix#L18-L34) for this.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. (crashed my notebook)
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
