### PR TITLE
supertux: 0.6.3 -> 0.7.0

### DIFF
--- a/pkgs/by-name/su/supertux/package.nix
+++ b/pkgs/by-name/su/supertux/package.nix
@@ -19,47 +19,18 @@
   openal,
   libogg,
   libvorbis,
+  physfs,
+  fmt,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "supertux";
-  version = "0.6.3";
+  version = "0.7.0";
 
   src = fetchurl {
     url = "https://github.com/SuperTux/supertux/releases/download/v${finalAttrs.version}/SuperTux-v${finalAttrs.version}-Source.tar.gz";
-    sha256 = "1xkr3ka2sxp5s0spp84iv294i29s1vxqzazb6kmjc0n415h0x57p";
+    hash = "sha256-MvxbmbmZTtWOWDQdbyHekldks4ElbhCFkRNt5TvDHaU=";
   };
-
-  postPatch = ''
-    sed '1i#include <memory>' -i external/partio_zip/zip_manager.hpp # gcc12
-    # Fix build with cmake 4. Remove for version >= 0.6.4.
-    # See <https://github.com/SuperTux/supertux/pull/3093>
-    substituteInPlace CMakeLists.txt --replace-fail \
-      'cmake_minimum_required(VERSION 3.1)' \
-      'cmake_minimum_required(VERSION 4.0)'
-    substituteInPlace external/physfs/CMakeLists.txt --replace-fail \
-      'cmake_minimum_required(VERSION 2.8.12)' \
-      'cmake_minimum_required(VERSION 4.0)'
-    substituteInPlace external/sexp-cpp/CMakeLists.txt --replace-fail \
-      'cmake_minimum_required(VERSION 3.0)' \
-      'cmake_minimum_required(VERSION 4.0)'
-    substituteInPlace external/squirrel/CMakeLists.txt --replace-fail \
-      'cmake_minimum_required(VERSION 2.8)' \
-      'cmake_minimum_required(VERSION 4.0)'
-    substituteInPlace external/tinygettext/CMakeLists.txt --replace-fail \
-      'cmake_minimum_required(VERSION 2.4)' \
-      'cmake_minimum_required(VERSION 4.0)'
-    substituteInPlace external/SDL_ttf/CMakeLists.txt --replace-fail \
-      'cmake_minimum_required(VERSION 3.0)' \
-      'cmake_minimum_required(VERSION 4.0)'
-    substituteInPlace external/discord-sdk/CMakeLists.txt --replace-fail \
-      'cmake_minimum_required (VERSION 3.2.0)' \
-      'cmake_minimum_required (VERSION 4.0)'
-    # Fix build with boost 1.89.
-    substituteInPlace CMakeLists.txt --replace-fail \
-      'find_package(Boost REQUIRED COMPONENTS filesystem system date_time locale)' \
-      'find_package(Boost REQUIRED COMPONENTS filesystem date_time locale)'
-  '';
 
   nativeBuildInputs = [
     pkg-config
@@ -82,6 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
     openal
     libogg
     libvorbis
+    physfs
+    fmt
   ];
 
   cmakeFlags = [ "-DENABLE_BOOST_STATIC_LIBS=OFF" ];


### PR DESCRIPTION
- Resolves #500236

release notes: https://github.com/SuperTux/supertux/releases/tag/v0.7.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
