### PR TITLE
musescore-evolution: 3.7.0-unstable-2026-03-03 -> musescore-evolution: 3.7.0-unstable-2026-03-11

### DIFF
--- a/pkgs/by-name/mu/musescore-evolution/package.nix
+++ b/pkgs/by-name/mu/musescore-evolution/package.nix
@@ -22,26 +22,21 @@
   libopus,
   tinyxml-2,
   qt5, # Needed for musescore 3.X
-  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "musescore-evolution";
-  version = "3.7.0-unstable-2026-03-03";
+  version = "3.7.0-unstable-2026-03-11";
 
   src = fetchFromGitHub {
     owner = "Jojo-Schmitz";
     repo = "MuseScore";
-    rev = "67504236fa073783f6616545185ec8bde6c22647";
-    hash = "sha256-QUUvUkdrJ4iL6cgDob+PdVRZp44kzHeoOi2N0Xb51To=";
+    rev = "2713642a8a0378f6d6465bbf6fdc74aaa21b4c85";
+    hash = "sha256-FQiAcb9vihdyQt2tZHMLMBp72e/i5xieVoQMVh5BrP4=";
   };
 
   patches = [
     ./musescore-evolution-pch-fix.patch
-    (fetchpatch {
-      url = "https://github.com/Jojo-Schmitz/MuseScore/commit/bbaa38ba2babb339043f87d50cec3240ca49fe0b.patch";
-      hash = "sha256-TbbrBo4uWCHeAs0Er3eYL+i0JWafI0zhetLpFjN0xg8=";
-    })
   ];
 
   # From top-level CMakeLists.txt:


### PR DESCRIPTION
Update package and remove patch (fixed in upstream MuseScore Evolution now).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
