### PR TITLE
zyouz: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29895,6 +29895,12 @@
     githubId = 22890520;
     matrix = "@yusufraji49:matrix.org";
   };
+  yutaura = {
+    email = "yuuta3594@gmail.com";
+    github = "YutaUra";
+    githubId = 45471709;
+    name = "Yuta Ura";
+  };
   yvan-sraka = {
     email = "yvan@sraka.xyz";
     github = "yvan-sraka";

--- a/pkgs/by-name/zy/zyouz/package.nix
+++ b/pkgs/by-name/zy/zyouz/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zig,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zyouz";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "YutaUra";
+    repo = "zyouz";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-m8KTillhvWqIAACKL9k8iYVLyp9iXu5pl/AaCFvfuu8=";
+  };
+
+  nativeBuildInputs = [ zig ];
+
+  # Zig tests require a TTY, which is unavailable in the Nix sandbox
+  dontUseZigCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A terminal multiplexer driven by a static config file";
+    homepage = "https://github.com/YutaUra/zyouz";
+    changelog = "https://github.com/YutaUra/zyouz/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yutaura ];
+    mainProgram = "zyouz";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
https://github.com/YutaUra/zyouz

A terminal multiplexer driven by a static config file. Similar to tmux/zellij but configured entirely through a declarative ZON config — no runtime commands needed.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test