### PR TITLE
kodi: inherit underlying kodi's `meta` when wrapping

### DIFF
--- a/pkgs/applications/video/kodi/wrapper.nix
+++ b/pkgs/applications/video/kodi/wrapper.nix
@@ -50,4 +50,8 @@ buildEnv {
         }"
     done
   '';
+
+  meta = {
+    inherit (kodi.meta) mainProgram;
+  };
 }


### PR DESCRIPTION
kodi has a mainProgram:

```
nix-repl> kodi.meta.mainProgram
"kodi"
```

But when wrapping it, we'd lose its mainProgram:

```
nix-repl> (kodi.withPackages (_: [])).meta.mainProgram
error:
       … while evaluating the attribute 'meta.mainProgram'
       ...

       error: attribute 'mainProgram' missing
       at «string»:1:1:
            1| (kodi.withPackages (_: [])).meta.mainProgram
             | ^
```

This fixes that. Please let me know if there's a better pattern to follow for inheriting meta information when wrapping. I intentionally didn't inherit the full `meta` attribute as it has some other information (such as `position`) that I think are better *not* inherited.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
