### PR TITLE
ob-xf: init at 1.0.3

### DIFF
--- a/pkgs/by-name/ob/ob-xf/package.nix
+++ b/pkgs/by-name/ob/ob-xf/package.nix
@@ -1,0 +1,99 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  freetype,
+  fontconfig,
+  libjack2,
+  libGL,
+  libx11,
+  libxcursor,
+  libxext,
+  libxinerama,
+  libxrandr,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ob-xf";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "surge-synthesizer";
+    repo = "OB-Xf";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-MeknY3jiUTcnX29AtdYNci4dAF1uFCZRpwrxEH3YEEM=";
+  };
+
+  postPatch = ''
+    # The build calls git at configure time to determine version info.
+    # Provide a static BUILD_VERSION file so git is not required.
+    cat > BUILD_VERSION <<EOF
+    SST_VERSION_INFO
+    5044e2e3
+    v${finalAttrs.version}
+    main
+    ${finalAttrs.version}
+    EOF
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = [
+    alsa-lib
+    freetype
+    fontconfig
+    libjack2
+    libGL
+    libx11
+    libxcursor
+    libxext
+    libxinerama
+    libxrandr
+  ];
+
+  enableParallelBuilding = true;
+
+  # JUCE dlopen's x11 at runtime, crashes without it
+  env.NIX_LDFLAGS = "-lX11";
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+
+  installPhase = ''
+    runHook preInstall
+
+    # Factory data (patches, themes) — provided by upstream's install() rule
+    cmake --install .
+
+    mkdir -p $out/lib/{vst3,lv2,clap}
+
+    cp -r OB-Xf_artefacts/Release/VST3/OB-Xf.vst3 $out/lib/vst3/
+    cp -r OB-Xf_artefacts/Release/LV2/OB-Xf.lv2 $out/lib/lv2/
+    cp -r OB-Xf_artefacts/Release/CLAP/OB-Xf.clap $out/lib/clap/
+
+    install -Dm755 OB-Xf_artefacts/Release/Standalone/OB-Xf $out/bin/OB-Xf
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Virtual analog synthesizer plug-in inspired by the Oberheim OB-X";
+    homepage = "https://surge-synth-team.org/ob-xf/";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ magnetophon ];
+    mainProgram = "OB-Xf";
+  };
+})


### PR DESCRIPTION
The latest new synth plugin by the Surge team.
https://github.com/surge-synthesizer/OB-Xf

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
