### PR TITLE
wayback_machine_downloader: 2.3.1 -> 2.4.6, use StrawberryMaster fork

### DIFF
--- a/pkgs/by-name/wa/wayback_machine_downloader/Gemfile
+++ b/pkgs/by-name/wa/wayback_machine_downloader/Gemfile
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-gem 'wayback_machine_downloader'
+gem 'wayback_machine_downloader_straw'

--- a/pkgs/by-name/wa/wayback_machine_downloader/Gemfile.lock
+++ b/pkgs/by-name/wa/wayback_machine_downloader/Gemfile.lock
@@ -1,13 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    wayback_machine_downloader (2.3.1)
+    concurrent-ruby (1.3.6)
+    wayback_machine_downloader_straw (2.4.6)
+      concurrent-ruby (~> 1.3, >= 1.3.4)
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
-  wayback_machine_downloader
+  wayback_machine_downloader_straw
+
+CHECKSUMS
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  wayback_machine_downloader_straw (2.4.6) sha256=99fe45c4f702dc658a2f2f310171627730636c179160630cc5620a39dd8d004c
 
 BUNDLED WITH
-   2.6.9
+  4.0.3

--- a/pkgs/by-name/wa/wayback_machine_downloader/gemset.nix
+++ b/pkgs/by-name/wa/wayback_machine_downloader/gemset.nix
@@ -1,12 +1,23 @@
 {
-  wayback_machine_downloader = {
+  concurrent-ruby = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "170426sashqc2k2angg8d0bhs7spi1x1isv6cyk2hif0l6xxm3cm";
+      sha256 = "a1aDfh5+UpL5hk80tpxaLLx1wM9TOPHOmQPRD6di1as=";
       type = "gem";
     };
-    version = "2.3.1";
+    version = "1.3.6";
+  };
+  wayback_machine_downloader_straw = {
+    dependencies = [ "concurrent-ruby" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "mf5FxPcC3GWKLy8xAXFidzBjbBeRYGMMxWIKOd2NAEw=";
+      type = "gem";
+    };
+    version = "2.4.6";
   };
 }

--- a/pkgs/by-name/wa/wayback_machine_downloader/package.nix
+++ b/pkgs/by-name/wa/wayback_machine_downloader/package.nix
@@ -4,15 +4,15 @@
   bundlerUpdateScript,
 }:
 bundlerApp {
-  pname = "wayback_machine_downloader";
+  pname = "wayback_machine_downloader_straw";
   exes = [ "wayback_machine_downloader" ];
   gemdir = ./.;
 
-  passthru.updateScript = bundlerUpdateScript "wayback_machine_downloader";
+  passthru.updateScript = bundlerUpdateScript "wayback_machine_downloader_straw";
 
   meta = {
     description = "Download websites from the Internet Archive Wayback Machine";
-    homepage = "https://github.com/hartator/wayback-machine-downloader";
+    homepage = "https://github.com/StrawberryMaster/wayback-machine-downloader";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     mainProgram = "wayback_machine_downloader";


### PR DESCRIPTION
The old maintainer has not published in over 4 years. https://github.com/hartator/wayback-machine-downloader

The new fork is regularly maintained and has community support. https://github.com/StrawberryMaster/wayback-machine-downloader

Fixes #496416 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
