### PR TITLE
openra: add aarch64-linux support

### DIFF
--- a/pkgs/games/openra/build-engine.nix
+++ b/pkgs/games/openra/build-engine.nix
@@ -100,7 +100,10 @@ buildDotnetModule {
     homepage = "https://www.openra.net/";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.mdarocha ];
-    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    platforms = [ 
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     mainProgram = "openra-ra";
   };
 }

--- a/pkgs/games/openra/build-engine.nix
+++ b/pkgs/games/openra/build-engine.nix
@@ -100,7 +100,7 @@ buildDotnetModule {
     homepage = "https://www.openra.net/";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.mdarocha ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
     mainProgram = "openra-ra";
   };
 }


### PR DESCRIPTION
This was tested with `NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-shell -p openra --impure` on an aarch64-linux machine and it works fine, totally playable. I think we can add the platform.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
