### PR TITLE
cc-switch-cli: init at 5.0.1

### DIFF
--- a/pkgs/by-name/cc/cc-switch-cli/package.nix
+++ b/pkgs/by-name/cc/cc-switch-cli/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  stdenv,
+  installShellFiles,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cc-switch-cli";
+  version = "5.0.1";
+
+  src = fetchFromGitHub {
+    owner = "SaladDay";
+    repo = "cc-switch-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JwtgT8cP+i7hsaB13o0PTDZJWvC3os1zWagMqmbffXk=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src-tauri";
+
+  cargoHash = "sha256-m70IR0IFUj8C48WcHgdCCtPwW/8KOxeDIqgG1bIcOpo=";
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd cc-switch \
+      --bash <($out/bin/cc-switch completions bash) \
+      --fish <($out/bin/cc-switch completions fish) \
+      --zsh <($out/bin/cc-switch completions zsh)
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  # rusqlite uses the "bundled" feature which compiles SQLite from source,
+  # so no system sqlite dependency is needed.
+
+  checkFlags = [
+    # Requires access to the system hostname, unavailable in the Nix build sandbox.
+    "--skip=detect_system_device_name_returns_some"
+    # Requires binding a network port, unavailable in the Nix build sandbox.
+    "--skip=reloading_app_state_does_not_recover_an_active_takeover_session"
+    # Invokes the install.sh script which downloads binaries from GitHub.
+    "--skip=install_script"
+  ];
+
+  meta = {
+    description = "Cross-platform CLI management tool for Claude Code, Codex, Gemini, and OpenCode";
+    homepage = "https://github.com/SaladDay/cc-switch-cli";
+    changelog = "https://github.com/SaladDay/cc-switch-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bryango ];
+    mainProgram = "cc-switch";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
cc-switch-cli is a cross-platform CLI management tool for coding agents (including Claude Code, Codex, Gemini, and OpenCode). It is designed to be fully compatible with the popular GUI tool cc-switch. See:
- CLI: https://github.com/SaladDay/cc-switch-cli
- GUI: https://github.com/farion1231/cc-switch
- GUI: https://github.com/NixOS/nixpkgs/pull/474728

Note that the -cli variant packaged here is _not_ created by the same author of the GUI app, but is endorsed by them [here on X](https://x.com/Jason_Young1231/status/2032348666804215946).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
