### PR TITLE
ocamlPackages.landmarks-ppx: unbreak

### DIFF
--- a/pkgs/development/ocaml-modules/landmarks-ppx/default.nix
+++ b/pkgs/development/ocaml-modules/landmarks-ppx/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildDunePackage,
+  fetchpatch,
   ocaml,
   landmarks,
   ppxlib,
@@ -10,6 +11,11 @@ buildDunePackage {
   pname = "landmarks-ppx";
 
   inherit (landmarks) src version;
+
+  patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
+    url = "https://github.com/LexiFi/landmarks/commit/367c229e3275a83f81343ba116374bb68abc9d83.patch";
+    hash = "sha256-Qxue+++sNV6EHJGX1mbIeY2E2D5NuFpmIIBkTyvGvo8=";
+  });
 
   buildInputs = [ ppxlib ];
   propagatedBuildInputs = [ landmarks ];
@@ -22,6 +28,5 @@ buildDunePackage {
       Automatically or semi-automatically instrument your code using
       landmarks library.
     '';
-    broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 }


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
