### PR TITLE
mcmojave-cursors: init at 0-unstable-2021-02-24

### DIFF
--- a/pkgs/by-name/mc/mcmojave-cursors/package.nix
+++ b/pkgs/by-name/mc/mcmojave-cursors/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fontconfig,
+  inkscape,
+  which,
+  writableTmpDirAsHomeHook,
+  xcursorgen,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "mcmojave-cursors";
+  version = "0-unstable-2021-02-24";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = "McMojave-cursors";
+    rev = "7d0bfc1f91028191cdc220b87fd335a235ee4439";
+    hash = "sha256-4YqSucpxA7jsuJ9aADjJfKRPgPR89oq2l0T1N28+GV0=";
+  };
+
+  strictDeps = true;
+
+  postPatch = ''
+    patchShebangs build.sh
+  '';
+
+  nativeBuildInputs = [
+    fontconfig
+    inkscape
+    which
+    writableTmpDirAsHomeHook
+    xcursorgen
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export FONTCONFIG_FILE="${fontconfig.out}/etc/fonts/fonts.conf"
+
+    rm -rf dist
+    ./build.sh
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -dm755 "$out/share/icons"
+    cp -a dist "$out/share/icons/McMojave-cursors"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "macOS Mojave-inspired X cursor theme";
+    homepage = "https://github.com/vinceliuice/McMojave-cursors";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ Zaczero ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
