### PR TITLE
zabbix: Multiple versions

### DIFF
--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -1,7 +1,7 @@
 generic: {
   v74 = generic {
-    version = "7.4.7";
-    hash = "sha256-FsOZQv6yg9euoX6Ccfy0/9usBpkVYVjcs3IZZ095m9g=";
+    version = "7.4.8";
+    hash = "sha256-qbRStsV00igpziBpOhqpyriL8PWFt6oqajrUyxTdOxw=";
   };
   v70 = generic {
     version = "7.0.24";

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -4,8 +4,8 @@ generic: {
     hash = "sha256-FsOZQv6yg9euoX6Ccfy0/9usBpkVYVjcs3IZZ095m9g=";
   };
   v70 = generic {
-    version = "7.0.23";
-    hash = "sha256-Q+pfyx5dsl50vcg+qJNtebgJO2FK9OiJQXSFvHTwYeI=";
+    version = "7.0.24";
+    hash = "sha256-b4rpkLmyV2fk//vLXMfEVdZ04qOS3CFHhIil0cDn1Zc=";
   };
   v60 = generic {
     version = "6.0.45";

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -8,7 +8,7 @@ generic: {
     hash = "sha256-Q+pfyx5dsl50vcg+qJNtebgJO2FK9OiJQXSFvHTwYeI=";
   };
   v60 = generic {
-    version = "6.0.44";
-    hash = "sha256-TveW2ofMnm3PXUPwoklTPe48tI6dED/dAQKjwO2P4F4=";
+    version = "6.0.45";
+    hash = "sha256-duB2w2xDH9ZHEDh9iZ5Fr6RH0dI2lMCVvySA5dmSZcU=";
   };
 }


### PR DESCRIPTION
zabbix: 6.0.44 -> 6.0.45 https://www.zabbix.com/rn/rn6.0.45
zabbix70: 7.0.23 -> 7.0.24 https://www.zabbix.com/rn/rn7.0.24
zabbix74: 7.4.7 -> 7.4.8 https://www.zabbix.com/rn/rn7.4.8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
