### PR TITLE
snmalloc: init at 0.7.4

### DIFF
--- a/pkgs/by-name/sn/snmalloc/package.nix
+++ b/pkgs/by-name/sn/snmalloc/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  clangStdenv,
+  fetchFromGitHub,
+  cmake,
+  nix-update-script,
+}:
+
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "snmalloc";
+  version = "0.7.4";
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "snmalloc";
+    tag = finalAttrs.version;
+    hash = "sha256-+UCqUrfvhnB4leiYCnGJ8ORfVkTaGimaErP56XCJ5PM=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Message passing based memory allocator";
+    homepage = "https://github.com/microsoft/snmalloc";
+    downloadPage = "https://github.com/microsoft/snmalloc/releases";
+    changelog = "https://github.com/microsoft/snmalloc/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ VZstless ];
+  };
+})


### PR DESCRIPTION
like mimalloc, this package only contains library, no binary is produced.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all libraries in `./result/lib/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
