### PR TITLE
zed-editor-fhs: fix Codex CLI library dependencies

### DIFF
--- a/pkgs/by-name/ze/zed-editor/package.nix
+++ b/pkgs/by-name/ze/zed-editor/package.nix
@@ -75,6 +75,9 @@ let
           glibc
           # required by at least https://github.com/zed-industries/package-version-server
           openssl
+          # required by at least the Codex CLI agent
+          libcap
+          zlib
         ])
         ++ additionalPkgs pkgs;
 


### PR DESCRIPTION
Trying to use the Codex CLI currently fails.

Looking at the logs in the console, we can see that the agent's binary is missing `libcap.so.2` and `libz.so.1`.

I never know what to choose between `libz` and `zlib` so I choose `zlib` here but I might be wrong.

With this patch, the agent launch correctly.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

@GaetanLepage @niklaskorz