### PR TITLE
libvarlink: 24 -> 24.0.1

### DIFF
--- a/pkgs/by-name/li/libvarlink/package.nix
+++ b/pkgs/by-name/li/libvarlink/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libvarlink";
-  version = "24";
+  version = "24.0.1";
 
   src = fetchFromGitHub {
     owner = "varlink";
     repo = "libvarlink";
-    rev = finalAttrs.version;
-    sha256 = "sha256-/BWbbDFLxa1da5ewrt3DG/+096dZ+s6p8VdcRGDiEiU=";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-MO5wfmPAm90AD+Y+vYqZynB4A18/XtJ1cys+lIIwbTY=";
   };
 
   nativeBuildInputs = [
@@ -33,6 +33,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace 'assert(setlocale(LC_NUMERIC, "de_DE.UTF-8") != 0);' ""
 
     patchShebangs lib/test-symbols.sh varlink-wrapper.py
+
+    # They forgot to update the version
+    substituteInPlace meson.build \
+      --replace-fail "24.0.0" "${finalAttrs.version}"
   '';
 
   doCheck = true;


### PR DESCRIPTION
Diff: https://www.github.com/varlink/libvarlink/compare/24...v24.0.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
