### PR TITLE
botan3: 3.10.0 -> 3.11.0

### DIFF
--- a/pkgs/by-name/bo/botan3/package.nix
+++ b/pkgs/by-name/bo/botan3/package.nix
@@ -18,6 +18,11 @@
 
   # build ESDM RNG plugin
   withEsdm ? false,
+  # build with jitterentropy RNG plugin,
+  # default disabled, health tests may fail without
+  # configuration of OSR and related parameters
+  # in jitterentropy
+  withJitterentropy ? false,
   # useful, but have to disable tests for now, as /dev/tpmrm0 is not accessible
   withTpm2 ? false,
   policy ? null,
@@ -55,7 +60,7 @@ let
       '';
 in
 stdenv.mkDerivation (finalAttrs: {
-  version = "3.10.0";
+  version = "3.11.0";
   pname = "botan";
 
   __structuredAttrs = true;
@@ -77,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "randombit";
     repo = "botan";
     tag = finalAttrs.version;
-    hash = "sha256-E4kKk4ry3SMn2DbnUTVx22lcAWDxxbo8DLyixjr/S6A=";
+    hash = "sha256-jjrO43SItFi+6FrU9B45Y1GK+6V5ZIgaYaMHkgRh4IE=";
   };
 
   nativeBuildInputs = [
@@ -92,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (stdenv.hostPlatform.isLinux && withTpm2) [
     tpm2-tss
   ]
-  ++ lib.optionals (!stdenv.hostPlatform.isMinGW) [
+  ++ lib.optionals (withJitterentropy && !stdenv.hostPlatform.isMinGW) [
     jitterentropy
   ]
   ++ lib.optionals (withEsdm && !stdenv.hostPlatform.isMinGW) [
@@ -129,7 +134,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (stdenv.hostPlatform.isLinux && withTpm2) [
     "--with-tpm2"
   ]
-  ++ lib.optionals (!stdenv.hostPlatform.isMinGW) [
+  ++ lib.optionals (withJitterentropy && !stdenv.hostPlatform.isMinGW) [
     "--enable-modules=jitter_rng"
   ]
   ++ lib.optionals (withEsdm && !stdenv.hostPlatform.isMinGW) [

--- a/pkgs/by-name/rn/rnp/0001-fix-build-with-Botan-3.11.patch
+++ b/pkgs/by-name/rn/rnp/0001-fix-build-with-Botan-3.11.patch
@@ -1,0 +1,25 @@
+From aa31e5d8af9295488bef3a559ec3756d5021501d Mon Sep 17 00:00:00 2001
+From: Markus Theil <markus.theil@secunet.com>
+Date: Mon, 16 Mar 2026 13:14:29 +0100
+Subject: [PATCH] fix build with Botan 3.11
+
+Signed-off-by: Markus Theil <markus.theil@secunet.com>
+---
+ src/lib/crypto/mem.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/lib/crypto/mem.cpp b/src/lib/crypto/mem.cpp
+index 94d90f54..dbd2a143 100644
+--- a/src/lib/crypto/mem.cpp
++++ b/src/lib/crypto/mem.cpp
+@@ -25,6 +25,7 @@
+  */
+ 
+ #include <cstdio>
++#include <cstring>
+ #include "mem.h"
+ #include "logging.h"
+ #include <botan/ffi.h>
+-- 
+2.53.0
+

--- a/pkgs/by-name/rn/rnp/package.nix
+++ b/pkgs/by-name/rn/rnp/package.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
+    # tracked at https://github.com/rnpgp/rnp/pull/2381
+    ./0001-fix-build-with-Botan-3.11.patch
   ];
 
   cmakeFlags = [

--- a/pkgs/development/python-modules/botan3/default.nix
+++ b/pkgs/development/python-modules/botan3/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
-  sourceRoot = "Botan-${version}/src/python";
+  sourceRoot = "source/src/python";
 
   postPatch = ''
     # remove again, when https://github.com/randombit/botan/pull/5040 got


### PR DESCRIPTION
Changelog:
https://botan.randombit.net/news.html#version-3-11-0-2026-03-15

Notable security fixes:
- Fix OCSP verification
- Fix concurrent access to (stateful) signature/KEM schemes like ML-KEM

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
