### PR TITLE
samloader-rs: init at 1.1.0

### DIFF
--- a/pkgs/by-name/sa/samloader-rs/package.nix
+++ b/pkgs/by-name/sa/samloader-rs/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  perl,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "samloader-rs";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "topjohnwu";
+    repo = "samloader-rs";
+    tag = finalAttrs.version;
+    hash = "sha256-LgN/vGfb5hdy9/YH4x3+vFUjH97omGu2iNtkDJRMmsk=";
+  };
+
+  cargoHash = "sha256-o0+Kb8teYhuhvl8U6FiAq8Z6vd4IWA8k4Z104Z9BkMw=";
+
+  nativeBuildInputs = [ perl ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Download firmware for Samsung devices";
+    homepage = "https://github.com/topjohnwu/samloader-rs";
+    changelog = "https://github.com/topjohnwu/samloader-rs/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "samloader";
+  };
+})


### PR DESCRIPTION
Add samloader-rs, a program for downloading firmware for Samsung devices.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
