### PR TITLE
libtas: 1.4.6 -> 1.4.7

### DIFF
--- a/pkgs/by-name/li/libtas/0001-remove-setcap-install-hook.patch
+++ b/pkgs/by-name/li/libtas/0001-remove-setcap-install-hook.patch
@@ -1,0 +1,22 @@
+From 89d1132e29925ee046ed84cfd46180b6a2bb0f3b Mon Sep 17 00:00:00 2001
+From: Michaili K <git@michaili.dev>
+Date: Mon, 16 Mar 2026 13:59:56 +0100
+Subject: [PATCH] remove setcap install hook
+
+---
+ src/program/Makefile.am | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/program/Makefile.am b/src/program/Makefile.am
+index e5d387bd..cd6e7d23 100644
+--- a/src/program/Makefile.am
++++ b/src/program/Makefile.am
+@@ -212,5 +212,3 @@ SUFFIXES = .h _moc.cpp
+ 
+ CLEANFILES = $(libTAS_MOCSOURCES)
+ 
+-install-exec-hook:
+-	if command -v setcap >/dev/null 2>&1; then setcap cap_checkpoint_restore+eip $(DESTDIR)$(bindir)/$(bin_PROGRAMS); fi
+-- 
+2.52.0
+

--- a/pkgs/by-name/li/libtas/package.nix
+++ b/pkgs/by-name/li/libtas/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchurl,
+  fetchpatch2,
   autoreconfHook,
   pkg-config,
   SDL2,
@@ -35,6 +36,11 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchurl {
       url = "https://github.com/clementgallet/libTAS/commit/779ff0fb0f3accfc62949680d85ecf96b28d18ef.patch";
       hash = "sha256-xAaTWIXt8FkMu6GE5mBWtLypROFZ1aEqmBTtG+6rTWk=";
+    })
+    # Fix build with gcc15
+    (fetchpatch2 {
+      url = "https://github.com/clementgallet/libTAS/commit/9699b158c522cf778bcdf626d0520fdd0a8b83aa.patch?full_index=1";
+      hash = "sha256-vM1f6rvKIFyzEGJ7k+b/Zp4gAv8u6mdDUD5evV+hCJU=";
     })
   ];
 

--- a/pkgs/by-name/li/libtas/package.nix
+++ b/pkgs/by-name/li/libtas/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchurl,
   fetchpatch2,
   autoreconfHook,
   pkg-config,
@@ -23,20 +22,15 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libtas";
-  version = "1.4.6";
+  version = "1.4.7";
 
   src = fetchFromGitHub {
     owner = "clementgallet";
     repo = "libTAS";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-/hyKJ8HGLN7hT+9If/lcp0C7GnhJMRpc7EKDgA1kQcI=";
+    hash = "sha256-TDFpLleY7+uBjcIqF9e7mA5eQN2s+U04qVQRvpfFfcQ=";
   };
   patches = [
-    # Fixes `undefined symbol: SDL_Log` errors
-    (fetchurl {
-      url = "https://github.com/clementgallet/libTAS/commit/779ff0fb0f3accfc62949680d85ecf96b28d18ef.patch";
-      hash = "sha256-xAaTWIXt8FkMu6GE5mBWtLypROFZ1aEqmBTtG+6rTWk=";
-    })
     # Fix build with gcc15
     (fetchpatch2 {
       url = "https://github.com/clementgallet/libTAS/commit/9699b158c522cf778bcdf626d0520fdd0a8b83aa.patch?full_index=1";

--- a/pkgs/by-name/li/libtas/package.nix
+++ b/pkgs/by-name/li/libtas/package.nix
@@ -10,6 +10,7 @@
   ffmpeg,
   lua5_4,
   qt5,
+  libxcb,
   libxi,
   file,
   binutils,
@@ -49,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     ffmpeg
     lua5_4
     qt5.qtbase
+    libxcb
   ];
 
   configureFlags = [

--- a/pkgs/by-name/li/libtas/package.nix
+++ b/pkgs/by-name/li/libtas/package.nix
@@ -11,6 +11,7 @@
   lua5_4,
   qt5,
   libxcb,
+  libcap,
   libxi,
   file,
   binutils,
@@ -37,6 +38,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/clementgallet/libTAS/commit/9699b158c522cf778bcdf626d0520fdd0a8b83aa.patch?full_index=1";
       hash = "sha256-vM1f6rvKIFyzEGJ7k+b/Zp4gAv8u6mdDUD5evV+hCJU=";
     })
+    # Capabilities cannot be set in Nix derivations,
+    # so the `setcap` invocation in the install hook must be removed.
+    ./0001-remove-setcap-install-hook.patch
   ];
 
   nativeBuildInputs = [
@@ -51,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     lua5_4
     qt5.qtbase
     libxcb
+    libcap
   ];
 
   configureFlags = [


### PR DESCRIPTION
Depends on #500370

Updates libTAS to [1.4.7](https://github.com/clementgallet/libTAS/releases/tag/v1.4.7) ([changelog](https://github.com/clementgallet/libTAS/blob/v1.4.7/CHANGELOG.md#147---2025-10-06)).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- c475eb18462ee831f1dbd91bd40500cd38b68524 bumps libTAS to 1.4.7
- 600f4f8e4313ef2594389986ed821e4dddebce82 adds libxcb as a new dependency
- e0038eae38f0354c2bb745b18698d8b7b2615912 adds libcap as a new dependency & removes the install hook trying to add `CAP_CHECKPOINT_RESTORE` capabilities to the binary.
  - while libTAS does still work without this capability, this is of course not ideal. I have some open questions/problems in [this review](https://github.com/NixOS/nixpkgs/pull/500402#discussion_r2940389721). Any answers/suggestions are welcome!

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
