### PR TITLE
agent-browser: init at 0.20.11

### DIFF
--- a/pkgs/by-name/ag/agent-browser/package.nix
+++ b/pkgs/by-name/ag/agent-browser/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "agent-browser";
+  version = "0.20.11";
+
+  src = fetchFromGitHub {
+    owner = "vercel-labs";
+    repo = "agent-browser";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-erjY+FWrDzw1Aj4SpsJdhHnbKF06CH0NFfggRVJDbYA=";
+  };
+
+  sourceRoot = "source/cli";
+
+  cargoHash = "sha256-NKRznFnroy1QuRecUaAqpCngvFKP7wLdy0wVFrYYI+c=";
+
+  # Tests require env vars and filesystem access unavailable in the sandbox
+  doCheck = false;
+
+  meta = {
+    description = "Fast browser automation CLI for AI agents";
+    homepage = "https://github.com/vercel-labs/agent-browser";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ domenkozar ];
+    mainProgram = "agent-browser";
+  };
+})


### PR DESCRIPTION
https://github.com/vercel-labs/agent-browser/releases/tag/v0.20.11

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
