### PR TITLE
neovimUtils.makeVimPackageInfo: add lua dependencies

### DIFF
--- a/pkgs/applications/editors/neovim/module.nix
+++ b/pkgs/applications/editors/neovim/module.nix
@@ -93,6 +93,14 @@ in
       '';
     };
 
+    luaDependencies = lib.mkOption {
+      readOnly = true;
+      type = lib.types.listOf (lib.types.nullOr lib.types.package);
+      example = lib.literalExpression "[ (lp: [ lp.mpack ]) ]";
+      description = ''
+        Lua dependencies required by the plugins.
+      '';
+    };
   };
 
   config =
@@ -122,5 +130,11 @@ in
       ) [ ] pluginsNormalized;
 
       pluginPython3Packages = map (plugin: plugin.python3Dependencies or (_: [ ])) pluginsNormalized;
+
+      luaDependencies =
+        let
+          op = acc: p: acc ++ (p.plugin.requiredLuaModules or [ ]);
+        in
+        lib.foldl' op [ ] pluginsNormalized;
     };
 }

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -112,6 +112,7 @@ let
         runtimeDeps
         pluginAdvisedLua
         pluginPython3Packages
+        luaDependencies
         ;
 
       # A Vim "package", see ':h packages'

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -109,7 +109,7 @@ let
 
         luaPathLuaRc =
           let
-            luaEnv = lua.withPackages extraLuaPackages;
+            luaEnv = lua.withPackages (lp: extraLuaPackages lp ++ vimPackageInfo.luaDependencies);
 
             # getLuaPath / getLuaCPath are not interpreter dependant at the moment and might thus cause
             # errors between luajit/Puc lua


### PR DESCRIPTION
Neovim currently resolves its lua dependencies at buildtime in the wrapper, which causes some trouble as it's difficult to debug or replicate  the result outside the nixpkgs wrapper.
This change makes lua dependencies available at evaltime. We can thus build a luaEnv to avoid building a long LUA_PATH which can help with runtime perf.
The drawback is that we now need to engrave in nix the default LUA_PATH for the various lua interpreters. This is what I tried to avoid at first but this proves annoying.
As far as neovim is concerned, we only care about the lua 5.1 and luajit interpreters whose defaults only slightly differ for cpath IIRC. So it should mostly transparent except for one or two plugins in which case we can adapt the lua code.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
