### PR TITLE
neovim dont wrap lua path

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -252,6 +252,11 @@
 
 - `wrapNeovimUnstable` now sets provider-related configuration in its generated config rather than as wrapper arguments. It should not affect configuration unless you set `wrapRc` to false or are using the `legacyWrapper`.
 
+- neovim lua dependencies are now set in the generated init.lua instead of
+  modifying LUA_PATH in the wrapper. Commands run pre-vimrc via `nvim --cmd
+  "require'LUA_MODULE'"` may
+  not find their lua dependencies anymore. Use `nvim -c "lua require'LUA_MODULE'"` instead to run these commands after loading `init.lua`.
+
 - We now use the upstream wrapper script for Gradle, supporting both the `JAVA_HOME` and `GRADLE_OPTS` environment variables.
 
 - the `autossh-ng` NixOS module was introduced as a simpler alternative to the existing `autossh` module.

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -415,7 +415,7 @@ pkgs.lib.recurseIntoAttrs rec {
   # check that bringing in one plugin with lua deps makes those deps visible from wrapper
   # for instance luasnip has a dependency on jsregexp
   can_require_transitive_deps = runTest nvim-with-luasnip ''
-    ${nvim-with-luasnip}/bin/nvim -i NONE --cmd "lua require'jsregexp'" -e +quitall!
+    ${nvim-with-luasnip}/bin/nvim -i NONE -c "lua require'jsregexp'" -e +quitall!
   '';
 
   inherit nvim_with_rocks_nvim;

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -107,9 +107,11 @@ let
         packpathDirs.myNeovimPackages = vimPackageInfo.vimPackage;
         finalPackdir = neovimUtils.packDir packpathDirs;
 
+        luaDeps = extraLuaPackages lua.pkgs ++ vimPackageInfo.luaDependencies;
+
         luaPathLuaRc =
           let
-            luaEnv = lua.withPackages (lp: extraLuaPackages lp ++ vimPackageInfo.luaDependencies);
+            luaEnv = lua.withPackages (_: luaDeps);
 
             # getLuaPath / getLuaCPath are not interpreter dependant at the moment and might thus cause
             # errors between luajit/Puc lua
@@ -122,7 +124,7 @@ let
           '';
 
         rcContent = lib.concatStringsSep "\n" (
-          lib.optional (extraLuaPackages lua.pkgs != [ ]) luaPathLuaRc
+          lib.optional (luaDeps != [ ]) luaPathLuaRc
           ++ [ providerLuaRc ]
           ++ lib.optional (luaRcContent != "") luaRcContent
           ++ lib.optional (neovimRcContent' != "") ''
@@ -327,16 +329,7 @@ let
             rm $out/bin/nvim
             touch $out/rplugin.vim
 
-            echo "Looking for lua dependencies..."
-            source ${lua}/nix-support/utils.sh
-
-            _addToLuaPath "${finalPackdir}"
-
-            echo "LUA_PATH towards the end of packdir: $LUA_PATH"
-
-            makeWrapper ${lib.escapeShellArgs finalMakeWrapperArgs} ${wrapperArgsStr} \
-                --prefix LUA_PATH ';' "$LUA_PATH" \
-                --prefix LUA_CPATH ';' "$LUA_CPATH"
+            makeWrapper ${lib.escapeShellArgs finalMakeWrapperArgs} ${wrapperArgsStr}
           '';
 
         buildPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Depends on https://github.com/NixOS/nixpkgs/pull/500415.
Pass on dependencies in generated configuration rather than via a wrapping argument so we can do without the wrapping.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
