### PR TITLE
python3Packages.supabase: 2.28.0 -> 2.28.3

### DIFF
--- a/pkgs/development/python-modules/postgrest/default.nix
+++ b/pkgs/development/python-modules/postgrest/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "postgrest";
-  version = "2.28.0";
+  version = "2.28.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${version}";
-    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
+    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
   };
 
   sourceRoot = "${src.name}/src/postgrest";

--- a/pkgs/development/python-modules/realtime/default.nix
+++ b/pkgs/development/python-modules/realtime/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "realtime";
-  version = "2.28.0";
+  version = "2.28.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${version}";
-    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
+    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
   };
 
   sourceRoot = "${src.name}/src/realtime";

--- a/pkgs/development/python-modules/storage3/default.nix
+++ b/pkgs/development/python-modules/storage3/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "storage3";
-  version = "2.28.0";
+  version = "2.28.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${version}";
-    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
+    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
   };
 
   sourceRoot = "${src.name}/src/storage";

--- a/pkgs/development/python-modules/supabase-auth/default.nix
+++ b/pkgs/development/python-modules/supabase-auth/default.nix
@@ -14,14 +14,14 @@
 }:
 buildPythonPackage rec {
   pname = "supabase-auth";
-  version = "2.28.0";
+  version = "2.28.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${version}";
-    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
+    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
   };
 
   sourceRoot = "${src.name}/src/auth";

--- a/pkgs/development/python-modules/supabase-functions/default.nix
+++ b/pkgs/development/python-modules/supabase-functions/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "supabase-functions";
-  version = "2.28.0";
+  version = "2.28.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${version}";
-    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
+    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
   };
 
   sourceRoot = "${src.name}/src/functions";

--- a/pkgs/development/python-modules/supabase/default.nix
+++ b/pkgs/development/python-modules/supabase/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "supabase";
-  version = "2.28.0";
+  version = "2.28.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "supabase-py";
     tag = "v${version}";
-    hash = "sha256-nK+IZRrKjNy84EC8krBvAZll5E0+jV3bLJh8qIVRElI=";
+    hash = "sha256-Ra7Ig9IMWouMIadx6mg/pe8GlgLCavR6OsPjqgySTCw=";
   };
 
   sourceRoot = "${src.name}/src/supabase";


### PR DESCRIPTION
Updates the Supabase Python client stack to **v2.28.3** (original pr was for v2.28.2)

Changelog:
- https://github.com/supabase/supabase-py/blob/v2.28.3/CHANGELOG.md
- https://github.com/supabase/supabase-py/releases/tag/v2.28.3

closes https://github.com/NixOS/nixpkgs/pull/499998

## Things done

- Built on platform:
  - [x] x86_64-linux (NixOS)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

  Commands run:
  - `nix build -L .#python3Packages.postgrest`
  - `nix build -L .#python3Packages.supabase`
  - `nix build -L .#python3Packages.realtime`
  - `nix build -L .#python3Packages.storage3`
  - `nix build -L .#python3Packages.supabase-auth`
  - `nix build -L .#python3Packages.supabase-functions`

- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.