### PR TITLE
home-assistant: pin python-roborock to 4.15.0 for 2026.2.x compatibility

### DIFF
--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -160,6 +160,29 @@ let
         };
       });
 
+      # Pinned due to API changes in python-roborock >= 4.16.0 that require
+      # home-assistant >= 2026.3.0 (fan_power_options renamed to fan_speed_options)
+      python-roborock = super.python-roborock.overridePythonAttrs (oldAttrs: rec {
+        version = "4.15.0";
+        src = fetchFromGitHub {
+          inherit (oldAttrs.src) owner repo;
+          tag = "v${version}";
+          hash = "sha256-M1LAAQRzJkVQKHin/SUEEVVgFKFCbYbZ2NZ8vSwT+1Y=";
+        };
+        dependencies = (lib.filter (dep: (dep.pname or "") != "pyrate-limiter") (oldAttrs.dependencies or [ ])) ++ [
+          (super.pyrate-limiter.overridePythonAttrs (old: rec {
+            version = "3.9.0";
+            src = fetchFromGitHub {
+              owner = "vutran1710";
+              repo = "PyrateLimiter";
+              tag = "v${version}";
+              hash = "sha256-CAN3OWxXQaAzrh2q6z0OxPs4i02L/g2ISYFdUMHsHpg=";
+            };
+            build-system = [ self.poetry-core ];
+          }))
+        ];
+      });
+
       py-madvr2 = super.py-madvr2.overridePythonAttrs (oldAttrs: rec {
         version = "1.6.40";
         src = fetchFromGitHub {


### PR DESCRIPTION
## Motivation

Resolves #500395

`python-roborock` was updated to 4.17.1 in #495067, which introduced breaking API changes (`fan_power_options` renamed to `fan_speed_options`). This causes the roborock vacuum component in home-assistant 2026.2.3 to crash with:

```
AttributeError: 'StatusTrait' object has no attribute 'fan_power_options'. Did you mean: 'fan_speed_options'?
```

The fix in upstream home-assistant is in 2026.3.0, but nixpkgs currently ships 2026.2.3.

## Changes

- Pins `python-roborock` to 4.15.0 (last version compatible with home-assistant 2026.2.x) in the home-assistant package overrides
- Pins `pyrate-limiter` to 3.9.0 for this override, since `python-roborock` 4.15.0 requires `pyrate-limiter >=3.7.0,<4` while nixpkgs ships 4.0.2

This override can be removed once home-assistant is updated to 2026.3.x.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @fabaff