### PR TITLE
atuin: add nushell-integration test

### DIFF
--- a/pkgs/by-name/at/atuin/package.nix
+++ b/pkgs/by-name/at/atuin/package.nix
@@ -4,8 +4,11 @@
   fetchFromGitHub,
   installShellFiles,
   rustPlatform,
+  runCommandLocal,
   nixosTests,
   nix-update-script,
+  nushell,
+  atuin,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -57,6 +60,21 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     tests = {
       inherit (nixosTests) atuin;
+      nushell-integration =
+        runCommandLocal "test-${atuin.name}-nushell-integration"
+          {
+            nativeBuildInputs = [
+              nushell
+              atuin
+            ];
+            meta.platforms = nushell.meta.platforms;
+          }
+          ''
+            export HOME="$NIX_BUILD_ROOT"
+            mkdir $out
+            nu -c "atuin init nu | save atuin.nu"
+            nu -c "source atuin.nu"
+          '';
     };
     updateScript = nix-update-script { };
   };

--- a/pkgs/by-name/at/atuin/package.nix
+++ b/pkgs/by-name/at/atuin/package.nix
@@ -4,8 +4,11 @@
   fetchFromGitHub,
   installShellFiles,
   rustPlatform,
+  runCommandLocal,
   nixosTests,
   nix-update-script,
+  nushell,
+  atuin,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -59,6 +62,21 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     tests = {
       inherit (nixosTests) atuin atuin-programs;
+      nushell-integration =
+        runCommandLocal "test-${atuin.name}-nushell-integration"
+          {
+            nativeBuildInputs = [
+              nushell
+              atuin
+            ];
+            meta.platforms = nushell.meta.platforms;
+          }
+          ''
+            export HOME="$NIX_BUILD_ROOT"
+            mkdir $out
+            nu -c "atuin init nu | save atuin.nu"
+            nu -c "source atuin.nu"
+          '';
     };
     updateScript = nix-update-script { };
   };


### PR DESCRIPTION
A follow-up to #381384.
This PR adds a `passtru.tests.nushell-integration` for `atuin`.
The goal is to catch incompatibilities caused by the fact that nushell releases breaking changes frequently.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @SuperSandro2000 @sciencentistguy @r-vdp
