### PR TITLE
gitbutler-cli: init at 0.19.7

### DIFF
--- a/pkgs/by-name/gi/gitbutler-cli/package.nix
+++ b/pkgs/by-name/gi/gitbutler-cli/package.nix
@@ -1,0 +1,88 @@
+{
+  cmake,
+  dbus,
+  git,
+  gitbutler,
+  lib,
+  libgit2,
+  makeWrapper,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gitbutler-cli";
+  version = gitbutler.version;
+
+  # Inherit source and cargo configuration from the gitbutler desktop app
+  inherit (gitbutler) src cargoHash;
+
+  # cargo-auditable fails because `but-db` uses `dep:tokio`
+  # The gitbutler desktop package avoids it by using cargo-tauri instead.
+  auditable = false;
+
+  cargoBuildFlags = [
+    "--package=but"
+    "--package=gitbutler-git"
+  ];
+
+  cargoTestFlags =
+    [
+      "--package=but"
+      "--"
+    ]
+    ++ lib.concatMap (test: [ "--skip=${test}" ]) gitbutler.skippedTests;
+
+  nativeBuildInputs = [
+    cmake # Required by `zlib-sys` crate
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libgit2
+    openssl
+  ]
+  ++ lib.optional stdenv.hostPlatform.isLinux dbus;
+
+  nativeCheckInputs = [ git ];
+
+  postInstall = ''
+    mkdir -p $out/libexec/gitbutler-cli
+    mv $out/bin/but $out/libexec/gitbutler-cli/but
+    mv $out/bin/gitbutler-git-askpass $out/libexec/gitbutler-cli/gitbutler-git-askpass
+    mv $out/bin/gitbutler-git-setsid $out/libexec/gitbutler-cli/gitbutler-git-setsid
+    makeWrapper $out/libexec/gitbutler-cli/but $out/bin/but
+  '';
+
+  env = {
+    RUSTFLAGS = "--cfg tokio_unstable";
+    OPENSSL_NO_VENDOR = true;
+    LIBGIT2_NO_VENDOR = 1;
+  };
+
+  passthru.updateScript = nix-update-script {
+    attrPath = "gitbutler";
+    extraArgs = [
+      "--version-regex"
+      "release/(.*)"
+    ];
+  };
+
+  meta = {
+    description = "Git client CLI tool for simultaneous branches on top of your existing workflow";
+    homepage = "https://gitbutler.com";
+    changelog = "https://github.com/gitbutlerapp/gitbutler/releases/tag/release/${finalAttrs.version}";
+    license = lib.licenses.fsl11Mit;
+    maintainers = with lib.maintainers; [
+      getchoo
+      techknowlogick
+      cholli
+    ];
+    mainProgram = "but";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/gi/gitbutler/package.nix
+++ b/pkgs/by-name/gi/gitbutler/package.nix
@@ -120,29 +120,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "but-cherry-apply"
     "but-worktrees"
   ]
-  ++ [
-    "--"
-  ]
-  # Skip these specific tests
-  ++ lib.concatMap (test: [ "--skip=${test}" ]) [
-    # These tests try connecting to a local address (192.0.2.1) and expect the
-    # connection to fail in a certain way. When run on macOS with a network
-    # sandbox (?) these tests fail while preparing the socket.
-    # https://github.com/NixOS/nixpkgs/pull/473706#issuecomment-3734337124
-    "test_is_network_error"
-    # assertion `left == right` failed: GIT_EDITOR should take precedence if git is executed correctly
-    #  left: "vi"
-    # right: "from-GIT_EDITOR"
-    "git_editor_takes_precedence"
-    # FLAKY (try again): child exited unsuccessfully: ExitStatus(unix_wait_status(10752))
-    "migrations_in_parallel_with_processes"
-    # Archive at 'tests/fixtures/generated-archives/[...].tar' not found [..] Error: No such file or directory (os error 2)
-    "merge_first_branch_into_gb_local_and_verify_rebase"
-    "json_output_with_dangling_commits"
-    "two_dangling_commits_different_branches"
-    # darwin: Error: timeout waiting for matching event
-    "track_directory_changes_after_rename"
-  ];
+  ++ [ "--" ]
+  ++ lib.concatMap (test: [ "--skip=${test}" ]) finalAttrs.passthru.skippedTests;
 
   env = {
     # Make sure `crates/gitbutler-tauri/inject-git-binaries.sh` can find our
@@ -156,7 +135,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # task tracing requires Tokio to be built with RUSTFLAGS="--cfg tokio_unstable"
     RUSTFLAGS = "--cfg tokio_unstable";
 
-    TUBRO_BINARY_PATH = lib.getExe turbo;
+    TURBO_BINARY_PATH = lib.getExe turbo;
     TURBO_TELEMETRY_DISABLED = 1;
 
     OPENSSL_NO_VENDOR = true;
@@ -185,6 +164,34 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
 
   passthru = {
+    inherit (finalAttrs) cargoHash;
+
+    # Shared skip list used by both the gitbutler desktop and gitbutler-cli test runs.
+    # cargo's --skip does substring matching, so prefixes like "tui::tests" cover whole modules.
+    skippedTests = [
+      # These tests try connecting to a local address (192.0.2.1) and expect the
+      # connection to fail in a certain way. When run on macOS with a network
+      # sandbox (?) these tests fail while preparing the socket.
+      # https://github.com/NixOS/nixpkgs/pull/473706#issuecomment-3734337124
+      "test_is_network_error"
+      # assertion `left == right` failed: GIT_EDITOR should take precedence if git is executed correctly
+      #  left: "vi"
+      # right: "from-GIT_EDITOR"
+      "git_editor_takes_precedence"
+      # FLAKY (try again): child exited unsuccessfully: ExitStatus(unix_wait_status(10752))
+      "migrations_in_parallel_with_processes"
+      # Archive at 'tests/fixtures/generated-archives/[...].tar' not found [..] Error: No such file or directory (os error 2)
+      "merge_first_branch_into_gb_local_and_verify_rebase"
+      "json_output_with_dangling_commits"
+      "two_dangling_commits_different_branches"
+      "new_from_project_handle_uses_repo_gitdir"
+      "new_from_project_handle_keeps_repo_cached"
+      # darwin: Error: timeout waiting for matching event
+      "track_directory_changes_after_rename"
+      # TUI snapshot tests require a real terminal; fail in the nix sandbox
+      "command::legacy::status::tui::tests"
+    ];
+
     updateScript = nix-update-script {
       extraArgs = [
         "--version-regex"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
