### PR TITLE
newsflash: 4.2.1 -> 5.0.0

### DIFF
--- a/pkgs/by-name/ne/newsflash/package.nix
+++ b/pkgs/by-name/ne/newsflash/package.nix
@@ -14,6 +14,7 @@
   gdk-pixbuf,
   clapper-unwrapped,
   gtk4,
+  gtksourceview5,
   libadwaita,
   libxml2,
   openssl,
@@ -27,18 +28,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "newsflash";
-  version = "4.2.1";
+  version = "5.0.0";
 
   src = fetchFromGitLab {
     owner = "news-flash";
     repo = "news_flash_gtk";
     tag = "v.${finalAttrs.version}";
-    hash = "sha256-me9/2sA1Thne10+JrSMvicDRxXuevCnM8Tb+kwXzNDI=";
+    hash = "sha256-y03N4Gqc8zmfT/zBQWyQ8Kptmwrw48PpurZCQ6Fxmm8=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-cgu1zP85UCb/6gYNcj/khc6u1kSwX0UZ2oIjM2UUBOA=";
+    hash = "sha256-Wij+RPtzaSqT4iwrRdqFjZd8kAfBbOGl4cPgrtBUOFI=";
   };
 
   postPatch = ''
@@ -70,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     clapper-unwrapped
     gtk4
+    gtksourceview5
     libadwaita
     libxml2
     openssl


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://gitlab.com/news-flash/news_flash_gtk/-/releases/v.5.0.0

without `gtksourceview5`, the build failed:

<details>
<summary>nix log</summary>

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/50ql78128a2m6fd1m85fnmk94yspngjy-source
source root is source
Executing cargoSetupPostUnpackHook
Finished cargoSetupPostUnpackHook
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
patching script interpreter paths in build-aux/cargo.sh
find: 'build-aux/cargo.sh': No such file or directory
Executing cargoSetupPostPatchHook
Validating consistency between /build/source/Cargo.lock and /build/newsflash-5.0.0-vendor/Cargo.lock
Finished cargoSetupPostPatchHook
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
mesonConfigurePhase flags: --prefix=/nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0 --libdir=/nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/lib --libexecdir=/nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5
.0.0/libexec --bindir=/nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/bin --sbindir=/nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/sbin --includedir=/nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/inc
lude --mandir=/nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/share/man --infodir=/nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/share/info --localedir=/nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/
share/locale -Dauto_features=enabled -Dwrap_mode=nodownload --buildtype=plain
The Meson build system
Version: 1.10.1
Source dir: /build/source
Build dir: /build/source/build
Build type: native build
Project name: newsflash
Project version: 5.0.0
Rust compiler for the host machine: rustc -C linker=gcc (rustc 1.93.0 "1.93.0")
Rust linker for the host machine: gcc ld.bfd 2.44
Host machine cpu family: x86_64
Host machine cpu: x86_64
Found pkg-config: YES (/nix/store/1nv3i8mpypy3d516f4pd95m0w72r73jy-pkg-config-wrapper-0.29.2/bin/pkg-config) 0.29.2
Run-time dependency glib-2.0 found: YES 2.86.3
Run-time dependency gio-2.0 found: YES 2.86.3
Run-time dependency gtk4 found: YES 4.20.3
Run-time dependency libadwaita-1 found: YES 1.8.4
Run-time dependency webkitgtk-6.0 found: YES 2.50.6
Program cargo found: YES (/nix/store/p96faw8wiwi10cy94hr42gzmiapv15fm-cargo-1.93.0/bin/cargo)
Program glib-compile-resources found: YES (/nix/store/jhb15l57qmqxck5ddd1dh2ys729vc8gb-glib-2.86.3-dev/bin/glib-compile-resources)
Program glib-compile-schemas found: YES (/nix/store/jhb15l57qmqxck5ddd1dh2ys729vc8gb-glib-2.86.3-dev/bin/glib-compile-schemas)
Program cargo-vendor found: NO
Configuring io.gitlab.news_flash.NewsFlash.desktop.in using configuration
Program msgfmt found: YES (/nix/store/md592gfars4m9madyrpj9yrq5jhckgjf-gettext-0.26/bin/msgfmt)
Program desktop-file-validate found: YES (/nix/store/pqn5nik8xrxkmvhpm2v6h2fh9mw5pkvr-desktop-file-utils-0.28/bin/desktop-file-validate)
Configuring io.gitlab.news_flash.NewsFlash.appdata.xml.in using configuration
data/meson.build:31: WARNING: The variable(s) 'jangernert' in the input file 'data/io.gitlab.news_flash.NewsFlash.appdata.xml.in.in' are not present in the given configuration data.
Program appstreamcli found: NO
Configuring io.gitlab.news_flash.NewsFlash.service using configuration
Program msginit found: YES (/nix/store/md592gfars4m9madyrpj9yrq5jhckgjf-gettext-0.26/bin/msginit)
Program msgmerge found: YES (/nix/store/md592gfars4m9madyrpj9yrq5jhckgjf-gettext-0.26/bin/msgmerge)
Program xgettext found: YES (/nix/store/md592gfars4m9madyrpj9yrq5jhckgjf-gettext-0.26/bin/xgettext)
Configuring config.rs using configuration
Message: Building in release mode
Program gtk4-update-icon-cache found: YES (/nix/store/r5ifa1m0sqa6ny76jgglds7gr540837m-gtk4-4.20.3/bin/gtk4-update-icon-cache)
Program update-desktop-database found: YES (/nix/store/pqn5nik8xrxkmvhpm2v6h2fh9mw5pkvr-desktop-file-utils-0.28/bin/update-desktop-database)
Build targets in project: 42

newsflash 5.0.0

  User defined options
    auto_features: enabled
    bindir       : /nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/bin
    buildtype    : plain
    includedir   : /nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/include
    infodir      : /nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/share/info
    libdir       : /nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/lib
    libexecdir   : /nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/libexec
    localedir    : /nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/share/locale
    mandir       : /nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/share/man
    prefix       : /nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0
    sbindir      : /nix/store/clbdgfmh9m4hg3f5jw9im8zyc9ksspbm-newsflash-5.0.0/sbin
    wrap_mode    : nodownload

Found ninja-1.13.2 at /nix/store/4siii6hvzs9ymbq37k04vcpx6xnybz21-ninja-1.13.2/bin/ninja
mesonConfigurePhase: enabled\ parallel\ building
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
build flags: -j16
[1/39] Building translation po/be/LC_MESSAGES/newsflash-be.mo
[2/39] Building translation po/bg/LC_MESSAGES/newsflash-bg.mo
[3/39] Building translation po/eu/LC_MESSAGES/newsflash-eu.mo
[4/39] Building translation po/ca/LC_MESSAGES/newsflash-ca.mo
[5/39] Building translation po/cs/LC_MESSAGES/newsflash-cs.mo
[6/39] Building translation po/ar/LC_MESSAGES/newsflash-ar.mo
[7/39] Building translation po/bn/LC_MESSAGES/newsflash-bn.mo
[8/39] Building translation po/de_DE/LC_MESSAGES/newsflash-de_DE.mo
[9/39] Building translation po/es/LC_MESSAGES/newsflash-es.mo
[10/39] Building translation po/et/LC_MESSAGES/newsflash-et.mo
[11/39] Building translation po/fa/LC_MESSAGES/newsflash-fa.mo
[12/39] Building translation po/gl/LC_MESSAGES/newsflash-gl.mo
[13/39] Building translation po/hi/LC_MESSAGES/newsflash-hi.mo
[14/39] Building translation po/fi/LC_MESSAGES/newsflash-fi.mo
[15/39] Building translation po/he/LC_MESSAGES/newsflash-he.mo
[16/39] Building translation po/hr/LC_MESSAGES/newsflash-hr.mo
[17/39] Building translation po/fr/LC_MESSAGES/newsflash-fr.mo
[18/39] Building translation po/hu/LC_MESSAGES/newsflash-hu.mo
[19/39] Building translation po/kab/LC_MESSAGES/newsflash-kab.mo
[20/39] Building translation po/ia/LC_MESSAGES/newsflash-ia.mo
[21/39] Building translation po/it/LC_MESSAGES/newsflash-it.mo
[22/39] Building translation po/ja/LC_MESSAGES/newsflash-ja.mo
[23/39] Building translation po/ko/LC_MESSAGES/newsflash-ko.mo
[23/39] Generating src/cargo-build with a custom command
   Compiling proc-macro2 v1.0.106
   Compiling quote v1.0.45
   Compiling unicode-ident v1.0.24
   Compiling libc v0.2.183
   Compiling cfg-if v1.0.4
   Compiling pkg-config v0.3.32
   Compiling serde_core v1.0.228
   Compiling smallvec v1.15.1
   Compiling heck v0.5.0
   Compiling winnow v0.7.15
   Compiling memchr v2.8.0
   Compiling target-lexicon v0.13.3
   Compiling version-compare v0.2.1
   Compiling bitflags v2.11.0
   Compiling pin-project-lite v0.2.17
   Compiling version_check v0.9.5
   Compiling itoa v1.0.17
   Compiling siphasher v1.0.2
   Compiling serde v1.0.228
   Compiling futures-core v0.3.32
   Compiling autocfg v1.5.0
   Compiling parking_lot_core v0.9.12
   Compiling futures-io v0.3.32
   Compiling portable-atomic v1.13.1
   Compiling slab v0.4.12
   Compiling scopeguard v1.2.0
   Compiling log v0.4.29
   Compiling critical-section v1.2.0
   Compiling futures-sink v0.3.32
   Compiling lock_api v0.4.14
   Compiling crossbeam-utils v0.8.21
   Compiling shlex v1.3.0
   Compiling stable_deref_trait v1.2.1
   Compiling thiserror v2.0.18
   Compiling futures-channel v0.3.32
   Compiling futures-task v0.3.32
   Compiling allocator-api2 v0.2.21
   Compiling find-msvc-tools v0.1.9
   Compiling cfg-expr v0.20.7
   Compiling percent-encoding v2.3.2
   Compiling num-traits v0.2.19
   Compiling phf_shared v0.13.1
   Compiling zmij v1.0.21
   Compiling hashbrown v0.16.1
   Compiling syn v2.0.117
   Compiling toml_parser v1.0.9+spec-1.1.0
   Compiling serde_json v1.0.149
   Compiling jobserver v0.1.34
   Compiling typenum v1.19.0
   Compiling fastrand v2.3.0
   Compiling simd-adler32 v0.3.8
   Compiling bytes v1.11.1
   Compiling errno v0.3.14
   Compiling once_cell v1.21.3
   Compiling cc v1.2.56
   Compiling parking_lot v0.12.5
   Compiling signal-hook-registry v1.4.8
   Compiling phf_generator v0.13.1
   Compiling generic-array v0.14.7
   Compiling crc32fast v1.5.0
   Compiling adler2 v2.0.1
   Compiling zerocopy v0.8.42
   Compiling ryu v1.0.23
   Compiling rand_core v0.6.4
   Compiling miniz_oxide v0.8.9
   Compiling parking v2.2.1
   Compiling concurrent-queue v2.5.0
   Compiling socket2 v0.6.3
   Compiling rand v0.8.5
   Compiling toml_datetime v0.7.5+spec-1.1.0
   Compiling serde_spanned v1.0.4
   Compiling mio v1.1.1
   Compiling phf_shared v0.11.3
   Compiling vcpkg v0.2.15
   Compiling syn v1.0.109
   Compiling toml v0.9.12+spec-1.1.0
   Compiling tracing-core v0.1.36
   Compiling crossbeam-epoch v0.9.18
   Compiling flate2 v1.1.9
   Compiling phf_generator v0.11.3
   Compiling litemap v0.8.1
   Compiling writeable v0.6.2
   Compiling num-integer v0.1.46
   Compiling icu_normalizer_data v2.1.1
   Compiling icu_properties_data v2.1.2
   Compiling getrandom v0.3.4
   Compiling equivalent v1.0.2
   Compiling cmake v0.1.57
   Compiling fs_extra v1.3.0
   Compiling system-deps v7.0.7
   Compiling num-bigint v0.4.6
   Compiling dunce v1.0.5
   Compiling rustc-hash v2.1.1
   Compiling event-listener v5.4.1
   Compiling either v1.15.0
   Compiling aws-lc-sys v0.38.0
   Compiling new_debug_unreachable v1.0.6
   Compiling getrandom v0.4.2
   Compiling indexmap v2.13.0
   Compiling atomic-waker v1.1.2
   Compiling event-listener-strategy v0.5.4
   Compiling openssl-sys v0.9.111
   Compiling http v1.4.0
   Compiling utf8_iter v1.0.4
   Compiling static_assertions v1.1.0
   Compiling aws-lc-rs v1.16.1
   Compiling zeroize v1.8.2
   Compiling form_urlencoded v1.2.2
   Compiling rustversion v1.0.22
   Compiling uuid v1.22.0
   Compiling owo-colors v4.3.0
   Compiling unic-common v0.9.0
   Compiling glib-sys v0.22.0
   Compiling gobject-sys v0.22.0
   Compiling gio-sys v0.22.0
   Compiling unic-ucd-version v0.9.0
   Compiling pango-sys v0.22.0
   Compiling http-body v1.0.1
   Compiling synstructure v0.13.2
   Compiling gdk-pixbuf-sys v0.22.0
   Compiling cairo-sys-rs v0.22.0
   Compiling rustls-pki-types v1.14.0
   Compiling httparse v1.10.1
   Compiling base64 v0.22.1
   Compiling alloc-no-stdlib v2.0.4
   Compiling time-core v0.1.8
   Compiling powerfmt v0.2.0
   Compiling tinyvec_macros v0.1.1
   Compiling precomputed-hash v0.1.1
   Compiling unicode-linebreak v0.1.5
   Compiling unicode-width v0.2.2
   Compiling unic-char-range v0.9.0
   Compiling num-conv v0.2.0
   Compiling smawk v0.3.2
   Compiling unic-char-property v0.9.0
   Compiling time-macros v0.2.27
   Compiling deranged v0.5.8
   Compiling tinyvec v1.10.0
   Compiling textwrap v0.16.2
   Compiling alloc-stdlib v0.2.2
   Compiling async-lock v3.4.2
   Compiling rand_core v0.9.5
   Compiling phf_codegen v0.11.3
   Compiling foreign-types-shared v0.1.1
   Compiling ipnet v2.12.0
   Compiling fnv v1.0.7
   Compiling unicode-segmentation v1.12.0
   Compiling try-lock v0.2.5
   Compiling rustls v0.23.37
   Compiling openssl v0.10.75
   Compiling tower-service v0.3.3
   Compiling openssl-probe v0.2.1
   Compiling serde_derive v1.0.228
   Compiling thiserror-impl v2.0.18
   Compiling futures-macro v0.3.32
   Compiling zerofrom-derive v0.1.6
   Compiling yoke-derive v0.8.1
   Compiling zerovec-derive v0.11.2
   Compiling displaydoc v0.2.5
   Compiling zerocopy-derive v0.8.42
   Compiling tokio-macros v2.6.1
   Compiling tracing-attributes v0.1.31
   Compiling phf_macros v0.13.1
   Compiling glib-macros v0.22.2
   Compiling futures-util v0.3.32
   Compiling oxc-miette-derive v2.7.0
   Compiling untrusted v0.9.0
   Compiling tokio v1.50.0
   Compiling time v0.3.47
   Compiling phf_macros v0.11.3
   Compiling async-trait v0.1.89
   Compiling openssl-macros v0.1.1
   Compiling zerofrom v0.1.6
   Compiling yoke v0.8.1
   Compiling zerovec v0.11.5
   Compiling zerotrie v0.2.3
   Compiling tracing v0.1.44
   Compiling castaway v0.2.4
   Compiling phf v0.13.1
   Compiling want v0.3.1
   Compiling foreign-types v0.3.2
   Compiling brotli-decompressor v5.0.0
   Compiling gdk4-sys v0.11.0
   Compiling tinystr v0.8.2
   Compiling potential_utf v0.1.4
   Compiling oxc-miette v2.7.0
   Compiling icu_locale_core v2.1.1
   Compiling icu_collections v2.1.1
   Compiling bumpalo v3.19.0
   Compiling native-tls v0.2.18
   Compiling oxc_data_structures v0.95.0
   Compiling dtoa v1.0.11
   Compiling pin-utils v0.1.0
   Compiling toml_datetime v1.0.0+spec-1.1.0
   Compiling subtle v2.6.1
   Compiling data-encoding v2.10.0
   Compiling toml_edit v0.25.4+spec-1.1.0
   Compiling futures-executor v0.3.32
   Compiling icu_provider v2.1.1
   Compiling oxc_allocator v0.95.0
   Compiling dtoa-short v0.3.5
   Compiling brotli v8.0.2
   Compiling icu_properties v2.1.2
   Compiling icu_normalizer v2.1.1
   Compiling oxc_ast_macros v0.95.0
   Compiling glib v0.22.2
   Compiling phf v0.11.3
   Compiling compact_str v0.9.0
   Compiling cssparser-macros v0.6.1
   Compiling idna_adapter v1.2.1
   Compiling idna v1.1.0
   Compiling ppv-lite86 v0.2.21
   Compiling graphene-sys v0.22.0
   Compiling rand_chacha v0.9.0
   Compiling url v2.5.8
   Compiling itertools v0.14.0
   Compiling rand v0.9.2
   Compiling tokio-util v0.7.18
   Compiling cookie v0.18.1
   Compiling encoding_rs v0.8.35
   Compiling compression-core v0.4.31
   Compiling cow-utils v0.1.3
   Compiling unicase v2.9.0
   Compiling oxc_estree v0.95.0
   Compiling oxc_span v0.95.0
   Compiling mime_guess v2.0.5
   Compiling proc-macro-crate v3.5.0
   Compiling h2 v0.4.13
   Compiling compression-codecs v0.4.37
   Compiling enum-as-inner v0.6.1
   Compiling crypto-common v0.1.7
   Compiling http-body-util v0.1.3
   Compiling gtk4-sys v0.11.0
   Compiling crossbeam-channel v0.5.15
   Compiling sync_wrapper v1.0.2
   Compiling psl-types v2.0.11
   Compiling litrs v1.0.0
   Compiling rayon-core v1.13.0
   Compiling arrayvec v0.7.6
   Compiling nonmax v0.5.5
   Compiling unicode-id-start v1.4.0
   Compiling tower-layer v0.3.3
   Compiling tagptr v0.2.0
   Compiling hickory-proto v0.25.2
   Compiling oxc_index v4.1.0
   Compiling tower v0.5.3
   Compiling document-features v0.2.12
   Compiling moka v0.12.14
   Compiling publicsuffix v2.3.0
   Compiling async-compression v0.4.41
   Compiling tokio-native-tls v0.3.1
   Compiling rustls-native-certs v0.8.3
   Compiling gsk4-sys v0.11.0
   Compiling crossbeam-deque v0.8.6
   Compiling aho-corasick v1.1.4
   Compiling resolv-conf v0.7.6
   Compiling libm v0.2.16
   Compiling hyper v1.8.1
   Compiling iri-string v0.7.10
   Compiling dragonbox_ecma v0.0.5
   Compiling mime v0.3.17
   Compiling oxc_syntax v0.95.0
   Compiling cookie_store v0.22.1
   Compiling hickory-resolver v0.25.2
   Compiling gio v0.22.2
   Compiling hyper-util v0.1.20
   Compiling tower-http v0.6.8
   Compiling hyper-tls v0.6.0
   Compiling oxc_diagnostics v0.95.0
   Compiling serde_urlencoded v0.7.1
   Compiling bytemuck v1.25.0
   Compiling oxc_regular_expression v0.95.0
   Compiling equator-macro v0.4.2
   Compiling num-rational v0.4.2
   Compiling phf_codegen v0.13.1
   Compiling iana-time-zone v0.1.65
   Compiling glob v0.3.3
   Compiling ident_case v1.0.1
   Compiling strsim v0.11.1
   Compiling regex-syntax v0.8.10
   Compiling equator v0.4.2
   Compiling clang-sys v1.8.1
   Compiling darling_core v0.21.3
   Compiling chrono v0.4.44
   Compiling oxc_ast v0.95.0
   Compiling rayon v1.11.0
   Compiling block-buffer v0.10.4
   Compiling anyhow v1.0.102
   Compiling utf-8 v0.7.6
   Compiling semver v1.0.27
   Compiling lazy_static v1.5.0
   Compiling regex-automata v0.4.14
   Compiling digest v0.10.7
   Compiling rustc_version v0.4.1
   Compiling aligned-vec v0.6.4
   Compiling cairo-rs v0.22.0
   Compiling enumflags2_derive v0.7.12
   Compiling darling_macro v0.21.3
   Compiling memoffset v0.9.1
   Compiling minimal-lexical v0.2.1
   Compiling matches v0.1.10
   Compiling pastey v0.1.1
   Compiling nom v7.1.3
   Compiling darling v0.21.3
   Compiling field-offset v0.3.6
   Compiling v_frame v0.3.9
   Compiling libloading v0.8.9
   Compiling zvariant_utils v3.3.0
   Compiling gstreamer-sys v0.25.0
   Compiling string_cache_codegen v0.6.1
   Compiling oxc_ecmascript v0.95.0
   Compiling as-slice v0.2.1
   Compiling ahash v0.7.8
   Compiling bindgen v0.72.1
   Compiling rustix v1.1.4
   Compiling cpufeatures v0.2.17
   Compiling av-scenechange v0.14.1
   Compiling quick-error v2.0.1
   Compiling built v0.8.0
   Compiling paste v1.0.15
   Compiling option-ext v0.2.0
   Compiling regex v1.12.3
   Compiling dirs-sys v0.5.0
   Compiling aligned v0.4.3
   Compiling web_atoms v0.2.3
   Compiling zvariant_derive v5.10.0
   Compiling cexpr v0.6.0
   Compiling rav1e v0.8.1
   Compiling oxc_ast_visit v0.95.0
   Compiling futures-lite v2.6.1
   Compiling graphene-rs v0.22.0
   Compiling arg_enum_proc_macro v0.3.4
   Compiling profiling-procmacros v1.0.17
   Compiling itertools v0.13.0
   Compiling block-padding v0.3.3
   Compiling string_cache_codegen v0.5.4
   Compiling fdeflate v0.3.7
   Compiling getrandom v0.2.17
   Compiling nom v8.0.0
   Compiling core2 v0.4.0
   Compiling slotmap v1.1.1
   Compiling self_cell v1.2.2
   Compiling linux-raw-sys v0.12.1
   Compiling weezl v0.1.12
   Compiling same-file v1.0.6
   Compiling y4m v0.8.0
   Compiling sha2 v0.10.9
   Compiling walkdir v2.5.0
   Compiling oxc_semantic v0.95.0
   Compiling web_atoms v0.1.3
   Compiling bitstream-io v4.9.0
   Compiling png v0.18.1
   Compiling profiling v1.0.17
   Compiling inout v0.1.4
   Compiling dirs v6.0.0
   Compiling maybe-rayon v0.1.1
   Compiling core_maths v0.1.1
   Compiling rgb v0.8.53
   Compiling gtk4-macros v0.11.0
   Compiling gdk-pixbuf v0.22.0
   Compiling pango v0.22.0
   Compiling half v2.7.1
   Compiling av1-grain v0.2.5
   Compiling cobs v0.3.0
   Compiling ptr_meta_derive v0.1.4
   Compiling num-derive v0.4.2
   Compiling fax_derive v0.2.0
   Compiling string_cache v0.9.0
   Compiling clapper-player-sys v0.10.1
   Compiling simd_helpers v0.1.0
   Compiling servo_arc v0.4.3
   Compiling async-io v2.6.0
   Compiling ahash v0.8.12
   Compiling outref v0.1.0
   Compiling rkyv v0.7.46
   Compiling float-cmp v0.9.0
   Compiling zune-core v0.4.12
   Compiling imgref v1.12.0
   Compiling oxc_sourcemap v6.0.2
   Compiling color_quant v1.1.0
   Compiling byteorder-lite v0.1.0
   Compiling outref v0.5.2
   Compiling noop_proc_macro v0.3.0
   Compiling vsimd v0.8.0
   Compiling zune-core v0.5.1
   Compiling mac v0.1.1
   Compiling gdk4 v0.11.0
   Compiling image-webp v0.2.4
   Compiling futf v0.1.5
   Compiling zune-jpeg v0.5.12
   Compiling loop9 v0.1.5
   Compiling polling v3.11.0
   Compiling base64-simd v0.8.0
   Compiling gif v0.14.1
   Compiling zune-jpeg v0.4.21
   Compiling strict-num v0.1.1
   Compiling simd-abstraction v0.7.1
   Compiling libxml v0.3.8
   Compiling fax v0.2.6
   Compiling ptr_meta v0.1.4
   Compiling postcard v1.1.3
   Compiling ttf-parser v0.25.1
   Compiling shellexpand v3.1.2
   Compiling cipher v0.4.4
   Compiling hashbrown v0.12.3
   Compiling rust-embed-utils v8.11.0
   Compiling enumflags2 v0.7.12
   Compiling tendril v0.5.0
   Compiling selectors v0.35.0
   Compiling avif-serialize v0.8.8
   Compiling cssparser v0.33.0
   Compiling string_cache v0.8.9
   Compiling rkyv_derive v0.7.46
   Compiling derive_more-impl v2.1.1
   Compiling parcel_selectors v0.28.2
   Compiling libsqlite3-sys v0.35.0
   Compiling zune-inflate v0.2.54
   Compiling gsk4 v0.11.0
   Compiling bigdecimal v0.4.10
   Compiling lebe v0.5.3
   Compiling async-task v4.7.1
   Compiling arrayref v0.3.9
   Compiling pxfm v0.1.28
   Compiling diesel_derives v2.3.7
   Compiling json-escape-simd v3.0.1
   Compiling jetscii v0.5.3
   Compiling bit_field v0.10.3
   Compiling pastey v0.2.1
   Compiling roxmltree v0.20.0
   Compiling endi v1.1.1
   Compiling seahash v4.1.0
   Compiling zvariant v5.10.0
   Compiling convert_case v0.6.0
   Compiling fontconfig-parser v0.5.8
   Compiling option-operations v0.6.1
   Compiling exr v1.74.0
   Compiling gtk4 v0.11.0
   Compiling moxcms v0.7.11
   Compiling ravif v0.12.0
   Compiling derive_more v2.1.1
   Compiling minify-html-common v0.0.3
   Compiling tiny-skia-path v0.12.0
   Compiling markup5ever v0.38.0
   Compiling rust-embed-impl v8.11.0
   Compiling oxc-browserslist v2.3.1
   Compiling tiff v0.10.3
   Compiling base64-simd v0.7.0
   Compiling tendril v0.4.3
   Compiling dsl_auto_type v0.2.0
   Compiling data-url v0.1.1
   Compiling qoi v0.4.1
   Compiling kurbo v0.13.0
   Compiling cssparser v0.36.0
   Compiling const-str-proc-macro v0.3.2
   Compiling serde_repr v0.1.20
   Compiling diesel_table_macro_syntax v0.3.0
   Compiling unic-ucd-hangul v0.9.0
   Compiling gdk4-wayland-sys v0.11.0
   Compiling clapper-player-gtk-sys v0.10.1
   Compiling libadwaita-sys v0.9.1
   Compiling sourceview5-sys v0.11.0
   Compiling async-channel v2.5.0
   Compiling kstring v2.0.2
   Compiling itertools v0.10.5
   Compiling scheduled-thread-pool v0.2.7
   Compiling memmap2 v0.9.10
   Compiling seq-macro v0.3.6
   Compiling entities v1.0.1
   Compiling temp-dir v0.1.16
   Compiling unicode-properties v0.1.4
   Compiling vlq v0.5.1
   Compiling unicode-bidi-mirroring v0.4.0
   Compiling crc-catalog v2.4.0
   Compiling muldiv v1.0.1
   Compiling unicode-ccc v0.4.0
   Compiling unicode-script v0.5.8
   Compiling thiserror v1.0.69
   Compiling hashbrown v0.14.5
   Compiling oxc_parser v0.95.0
   Compiling rustybuzz v0.20.1
   Compiling gstreamer v0.25.1
   Compiling crc v3.4.0
   Compiling parcel_sourcemap v2.1.1
   Compiling dashmap v5.5.3
   Compiling gettext-sys v0.26.0
   Compiling escaper v0.1.1
   Compiling fontdb v0.23.0
   Compiling r2d2 v0.8.10
warning: sourceview5-sys@0.11.0: 
error: failed to run custom build command for `sourceview5-sys v0.11.0`

Caused by:
  process didn't exit successfully: `/build/source/build/src/release/build/sourceview5-sys-476c9475e5eb5075/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=/build/newsflash-5.0.0-vendor/sourceview5-sys-0.11.0/Cargo.toml
  cargo:rerun-if-env-changed=GTKSOURCEVIEW_5_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  cargo:warning=
  pkg-config exited with status code 1
  > PKG_CONFIG_PATH=/nix/store/w08vddbwik5kws16wzf542r81rnkdsy1-gobject-introspection-1.86.0-dev/lib/pkgconfig:/nix/store/xff3v3hj0slzkxhksrsrscva5scf35an-libffi-3.5.2-dev/lib/pkgconfig:/nix/store/jhb15l57qmqxck5ddd1dh2ys729vc8gb-glib-2.
86.3-dev/lib/pkgconfig:/nix/store/87y9237m9c9m9mxk9ajwdfmn78vz6w2y-zlib-1.3.1-dev/share/pkgconfig:/nix/store/27l45fx07bp8cf1xxh0fp2v38cxhn4rq-librsvg-2.61.3-dev/lib/pkgconfig:/nix/store/bfbb982lzrfzbvs5v9jwlnz0rbjvl8i9-gdk-pixbuf-2.44.5-
dev/lib/pkgconfig:/nix/store/1pvh13dxm69x8m5hycd30yq4jk6kkbfz-libtiff-4.7.1-dev/lib/pkgconfig:/nix/store/lnz9kvncmkpq7wpzd6jgjs3zwzl9mhgr-libjpeg-turbo-3.1.3-dev/lib/pkgconfig:/nix/store/678ygbangkyc4yb5xm7qb4psfpk3vw4c-libpng-apng-1.6.5
5-dev/lib/pkgconfig:/nix/store/2pfjag759wflbzpvginva62kkn215c2j-cairo-1.18.4-dev/lib/pkgconfig:/nix/store/n1dpdbrj2s14l02b822jql8kc238zxh7-fontconfig-2.17.1-dev/lib/pkgconfig:/nix/store/374f5mfap8y7i6rzc3qnq249ym1nxfdq-freetype-2.13.3-de
v/lib/pkgconfig:/nix/store/f2zvkh7iizs8y2r443kv9c2vk4h2y90m-bzip2-1.0.8-dev/lib/pkgconfig:/nix/store/m8x59ybbd4hycpswc27vj7hjyng7q7w6-brotli-1.2.0-dev/lib/pkgconfig:/nix/store/s60msvirzaknyjgpsc8yyld1qg5i3hn5-pixman-0.46.4/lib/pkgconfig:
/nix/store/7cxd1fc7plwpfr1k4l9d58xv46dingpw-libxext-1.3.7-dev/lib/pkgconfig:/nix/store/qh282gd7s1vyn3f6k0p5vxax579spbw6-xorgproto-2025.1/share/pkgconfig:/nix/store/zbhrpx2wh8cvs8k638lgrnvgjfkyn92v-libxau-1.0.12-dev/lib/pkgconfig:/nix/sto
re/xr8bh0qk2d1jj3yvi2k8flhdal3svy0q-libxrender-0.9.12-dev/lib/pkgconfig:/nix/store/hppiap02zqbx9d3bh0xpzbmnp5ai2d11-libx11-1.8.12-dev/lib/pkgconfig:/nix/store/lhzl3z3rgn2zif730ww2fyb1d8gfrnk1-libxcb-1.17.0-dev/lib/pkgconfig:/nix/store/hy
r351vhs5lcz1vkk59kmnjn5svsj58g-gtk4-4.20.3-dev/lib/pkgconfig:/nix/store/6fa65y6dr51a8q7dmnnq2y3gsws76bpz-graphene-1.10.8-dev/lib/pkgconfig:/nix/store/99l5iv6m6qzhq6mgfsn3zl74hil4wady-pango-1.57.0-dev/lib/pkgconfig:/nix/store/x6y6khsf313j
6sa6pjcv9ar0k4rkdph1-harfbuzz-12.3.0-dev/lib/pkgconfig:/nix/store/xcv4ngdj8sn0p7mnps6ldvgwzipnqs77-graphite2-1.3.14-dev/lib/pkgconfig:/nix/store/4jbj6hzq9lhpjbg5h5mcvdlwzw67rxxh-libxft-2.3.9-dev/lib/pkgconfig:/nix/store/blr5zdnxfckm1690c
dx6anmh3s17sx5p-wayland-1.24.0-dev/lib/pkgconfig:/nix/store/5vq341gkk6ydjw8zkxskg9kzq2j71zpk-vulkan-loader-1.4.341.0-dev/lib/pkgconfig:/nix/store/v5s2sldwj887dm1cn928fzrpnb84pkf8-gsettings-desktop-schemas-49.1/share/pkgconfig:/nix/store/
3bwv9cp1cyairvzam8sv11b40s3pkjgz-clapper-unwrapped-0.10.0-dev/lib/pkgconfig:/nix/store/1w56nlmr8z01lmfr95vhvm8x7srv0z3q-libadwaita-1.8.4-dev/lib/pkgconfig:/nix/store/1f6917ky6w2gghw63myngxr2zq2zh8rm-libxml2-2.15.1-dev/lib/pkgconfig:/nix/
store/1p14m1hrdkykyxs0l6wg7y29ahppcnsr-openssl-3.6.1-dev/lib/pkgconfig:/nix/store/5j4mx4vckmmms2spy8x8kqjxcb12kpf5-sqlite-3.51.2-dev/lib/pkgconfig:/nix/store/jg2mxa0pcfpn5hfspkwxxf9fjiwadc2n-webkitgtk-2.50.6+abi=6.0-dev/lib/pkgconfig:/ni
x/store/517bxhhsv1w1fs2sxxzr9amzh4pai514-libsoup-3.6.5-dev/lib/pkgconfig:/nix/store/qiaidadvd1a38qw4nsr4xyp1wp6hk334-gstreamer-1.26.5-dev/lib/pkgconfig:/nix/store/fx219anq9yrb8i61l8jmpskh15hzmipk-gst-plugins-base-1.26.5-dev/lib/pkgconfig
:/nix/store/6g92fqnx6cwza2243r78p7rqmay8ssik-libdrm-2.4.131-dev/lib/pkgconfig:/nix/store/zsq24l3yixlczn85h344fqglx10byyh4-gst-plugins-bad-1.26.5-dev/lib/pkgconfig PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags gtksourceview-
5 'gtksourceview-5 >= 5.17'

  The system library `gtksourceview-5` required by crate `sourceview5-sys` was not found.
  The file `gtksourceview-5.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
  PKG_CONFIG_PATH contains the following:
      - /nix/store/w08vddbwik5kws16wzf542r81rnkdsy1-gobject-introspection-1.86.0-dev/lib/pkgconfig
      - /nix/store/xff3v3hj0slzkxhksrsrscva5scf35an-libffi-3.5.2-dev/lib/pkgconfig
      - /nix/store/jhb15l57qmqxck5ddd1dh2ys729vc8gb-glib-2.86.3-dev/lib/pkgconfig
      - /nix/store/87y9237m9c9m9mxk9ajwdfmn78vz6w2y-zlib-1.3.1-dev/share/pkgconfig
      - /nix/store/27l45fx07bp8cf1xxh0fp2v38cxhn4rq-librsvg-2.61.3-dev/lib/pkgconfig
      - /nix/store/bfbb982lzrfzbvs5v9jwlnz0rbjvl8i9-gdk-pixbuf-2.44.5-dev/lib/pkgconfig
      - /nix/store/1pvh13dxm69x8m5hycd30yq4jk6kkbfz-libtiff-4.7.1-dev/lib/pkgconfig
      - /nix/store/lnz9kvncmkpq7wpzd6jgjs3zwzl9mhgr-libjpeg-turbo-3.1.3-dev/lib/pkgconfig
      - /nix/store/678ygbangkyc4yb5xm7qb4psfpk3vw4c-libpng-apng-1.6.55-dev/lib/pkgconfig
      - /nix/store/2pfjag759wflbzpvginva62kkn215c2j-cairo-1.18.4-dev/lib/pkgconfig
      - /nix/store/n1dpdbrj2s14l02b822jql8kc238zxh7-fontconfig-2.17.1-dev/lib/pkgconfig
      - /nix/store/374f5mfap8y7i6rzc3qnq249ym1nxfdq-freetype-2.13.3-dev/lib/pkgconfig
      - /nix/store/f2zvkh7iizs8y2r443kv9c2vk4h2y90m-bzip2-1.0.8-dev/lib/pkgconfig
      - /nix/store/m8x59ybbd4hycpswc27vj7hjyng7q7w6-brotli-1.2.0-dev/lib/pkgconfig
      - /nix/store/s60msvirzaknyjgpsc8yyld1qg5i3hn5-pixman-0.46.4/lib/pkgconfig
      - /nix/store/7cxd1fc7plwpfr1k4l9d58xv46dingpw-libxext-1.3.7-dev/lib/pkgconfig
      - /nix/store/qh282gd7s1vyn3f6k0p5vxax579spbw6-xorgproto-2025.1/share/pkgconfig
      - /nix/store/zbhrpx2wh8cvs8k638lgrnvgjfkyn92v-libxau-1.0.12-dev/lib/pkgconfig
      - /nix/store/xr8bh0qk2d1jj3yvi2k8flhdal3svy0q-libxrender-0.9.12-dev/lib/pkgconfig
      - /nix/store/hppiap02zqbx9d3bh0xpzbmnp5ai2d11-libx11-1.8.12-dev/lib/pkgconfig
      - /nix/store/lhzl3z3rgn2zif730ww2fyb1d8gfrnk1-libxcb-1.17.0-dev/lib/pkgconfig
      - /nix/store/hyr351vhs5lcz1vkk59kmnjn5svsj58g-gtk4-4.20.3-dev/lib/pkgconfig
      - /nix/store/6fa65y6dr51a8q7dmnnq2y3gsws76bpz-graphene-1.10.8-dev/lib/pkgconfig
      - /nix/store/99l5iv6m6qzhq6mgfsn3zl74hil4wady-pango-1.57.0-dev/lib/pkgconfig
      - /nix/store/x6y6khsf313j6sa6pjcv9ar0k4rkdph1-harfbuzz-12.3.0-dev/lib/pkgconfig
      - /nix/store/xcv4ngdj8sn0p7mnps6ldvgwzipnqs77-graphite2-1.3.14-dev/lib/pkgconfig
      - /nix/store/4jbj6hzq9lhpjbg5h5mcvdlwzw67rxxh-libxft-2.3.9-dev/lib/pkgconfig
      - /nix/store/blr5zdnxfckm1690cdx6anmh3s17sx5p-wayland-1.24.0-dev/lib/pkgconfig
      - /nix/store/5vq341gkk6ydjw8zkxskg9kzq2j71zpk-vulkan-loader-1.4.341.0-dev/lib/pkgconfig
      - /nix/store/v5s2sldwj887dm1cn928fzrpnb84pkf8-gsettings-desktop-schemas-49.1/share/pkgconfig
      - /nix/store/3bwv9cp1cyairvzam8sv11b40s3pkjgz-clapper-unwrapped-0.10.0-dev/lib/pkgconfig
      - /nix/store/1w56nlmr8z01lmfr95vhvm8x7srv0z3q-libadwaita-1.8.4-dev/lib/pkgconfig
      - /nix/store/1f6917ky6w2gghw63myngxr2zq2zh8rm-libxml2-2.15.1-dev/lib/pkgconfig
      - /nix/store/1p14m1hrdkykyxs0l6wg7y29ahppcnsr-openssl-3.6.1-dev/lib/pkgconfig
      - /nix/store/5j4mx4vckmmms2spy8x8kqjxcb12kpf5-sqlite-3.51.2-dev/lib/pkgconfig
      - /nix/store/jg2mxa0pcfpn5hfspkwxxf9fjiwadc2n-webkitgtk-2.50.6+abi=6.0-dev/lib/pkgconfig
      - /nix/store/517bxhhsv1w1fs2sxxzr9amzh4pai514-libsoup-3.6.5-dev/lib/pkgconfig
      - /nix/store/qiaidadvd1a38qw4nsr4xyp1wp6hk334-gstreamer-1.26.5-dev/lib/pkgconfig
      - /nix/store/fx219anq9yrb8i61l8jmpskh15hzmipk-gst-plugins-base-1.26.5-dev/lib/pkgconfig
      - /nix/store/6g92fqnx6cwza2243r78p7rqmay8ssik-libdrm-2.4.131-dev/lib/pkgconfig
      - /nix/store/zsq24l3yixlczn85h344fqglx10byyh4-gst-plugins-bad-1.26.5-dev/lib/pkgconfig

  HINT: you may need to install a package such as gtksourceview-5, gtksourceview-5-dev or gtksourceview-5-devel.

warning: build failed, waiting for other jobs to finish...
[38/39] Merging translations for data/io.gitlab.news_flash.NewsFlash.appdata.xml
FAILED: [code=101] src/io.gitlab.news_flash.NewsFlash 
/nix/store/hlxw2q9qansq7bn52xvlb5badw3z1v8s-coreutils-9.10/bin/env CARGO_HOME=/build/source/build/cargo-home /nix/store/p96faw8wiwi10cy94hr42gzmiapv15fm-cargo-1.93.0/bin/cargo build --manifest-path /build/source/Cargo.toml --target-dir /
build/source/build/src --jobs 16 --release && cp src/x86_64-unknown-linux-gnu/release/news_flash_gtk src/io.gitlab.news_flash.NewsFlash
ninja: build stopped: subcommand failed.
```

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
