### PR TITLE
unigine-{tropics,sanctuary,superposition}: migrate to by-name, use multilib, modernize derivation

### DIFF
--- a/pkgs/by-name/un/unigine-sanctuary/package.nix
+++ b/pkgs/by-name/un/unigine-sanctuary/package.nix
@@ -1,22 +1,10 @@
 {
   lib,
-  stdenv,
   fetchurl,
-  makeWrapper,
-  autoPatchelfHook,
-  libx11,
-  libxext,
-  libxrandr,
-  libxinerama,
-  libglvnd,
-  openal,
-  glibc,
-  makeDesktopItem,
-  copyDesktopItems,
-  imagemagick,
-  liberation_ttf,
+  pkgsi686Linux,
 }:
-stdenv.mkDerivation rec {
+
+pkgsi686Linux.stdenv.mkDerivation rec {
   pname = "unigine-sanctuary";
   version = "2.3";
 
@@ -26,9 +14,9 @@ stdenv.mkDerivation rec {
   };
 
   libPath = lib.makeLibraryPath [
-    libglvnd
-    openal
-    glibc
+    pkgsi686Linux.libglvnd
+    pkgsi686Linux.openal
+    pkgsi686Linux.glibc
   ];
 
   installPhase = ''
@@ -47,7 +35,7 @@ stdenv.mkDerivation rec {
     convert -size 256x256 xc:Transparent -define gradient:center="128,128" -define gradient:vector="128,128 128,128" \
       -define gradient:radii="128,128" -fill radial-gradient:'rgb(164,0,0)-rgb(67,1,3)' \
       -draw "roundRectangle 0,0 256,256 50,50" ${pname}-${version}/icon.png
-    convert ${pname}-${version}/icon.png -size 181.991x181.991 -font ${liberation_ttf}/share/fonts/truetype/LiberationSans-Regular.ttf \
+    convert ${pname}-${version}/icon.png -size 181.991x181.991 -font ${pkgsi686Linux.liberation_ttf}/share/fonts/truetype/LiberationSans-Regular.ttf \
       -pointsize 181.991 -define gradient:center="128,128" -define gradient:vector="128,128 128,128" \
       -define gradient:radii="46.6974,46.6974" -fill radial-gradient:'rgb(249,197,46)-rgb(218,144,31)' \
       -stroke none -strokewidth 4.54977 -draw 'text 69.3061,194.247 "S"' ${pname}-${version}/icon.png
@@ -62,7 +50,7 @@ stdenv.mkDerivation rec {
   '';
 
   desktopItems = [
-    (makeDesktopItem {
+    (pkgsi686Linux.makeDesktopItem {
       name = "Sanctuary";
       exec = "Sanctuary";
       genericName = "A GPU Stress test tool from the UNIGINE";
@@ -72,18 +60,18 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    autoPatchelfHook
-    makeWrapper
-    imagemagick
-    copyDesktopItems
+    pkgsi686Linux.autoPatchelfHook
+    pkgsi686Linux.makeWrapper
+    pkgsi686Linux.imagemagick
+    pkgsi686Linux.copyDesktopItems
   ];
 
   buildInputs = [
-    stdenv.cc.cc
-    libx11
-    libxext
-    libxrandr
-    libxinerama
+    pkgsi686Linux.stdenv.cc.cc
+    pkgsi686Linux.libx11
+    pkgsi686Linux.libxext
+    pkgsi686Linux.libxrandr
+    pkgsi686Linux.libxinerama
   ];
 
   dontUnpack = true;

--- a/pkgs/by-name/un/unigine-sanctuary/package.nix
+++ b/pkgs/by-name/un/unigine-sanctuary/package.nix
@@ -4,13 +4,13 @@
   pkgsi686Linux,
 }:
 
-pkgsi686Linux.stdenv.mkDerivation rec {
+pkgsi686Linux.stdenv.mkDerivation (finalAttrs: {
   pname = "unigine-sanctuary";
   version = "2.3";
 
   src = fetchurl {
-    url = "https://assets.unigine.com/d/Unigine_Sanctuary-${version}.run";
-    sha256 = "sha256-KKi70ctkEm+tx0kjBMWVKMLDrJ1TsPH+CKLDMXA6OdU=";
+    url = "https://assets.unigine.com/d/Unigine_Sanctuary-${finalAttrs.version}.run";
+    hash = "sha256-KKi70ctkEm+tx0kjBMWVKMLDrJ1TsPH+CKLDMXA6OdU=";
   };
 
   libPath = lib.makeLibraryPath [
@@ -20,31 +20,31 @@ pkgsi686Linux.stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
-    bash $src --target ${pname}-${version}
+    bash $src --target unigine-sanctuary-${finalAttrs.version}
 
-    install -D -m 0755 ${pname}-${version}/bin/libUnigine_x86.so $out/lib/unigine/sanctuary/bin/libUnigine_x86.so
-    install -D -m 0755 ${pname}-${version}/bin/Sanctuary $out/lib/unigine/sanctuary/bin/Sanctuary
-    install -D -m 0755 ${pname}-${version}/1024x768_windowed.sh $out/bin/Sanctuary
+    install -D -m 0755 unigine-sanctuary-${finalAttrs.version}/bin/libUnigine_x86.so $out/lib/unigine/sanctuary/bin/libUnigine_x86.so
+    install -D -m 0755 unigine-sanctuary-${finalAttrs.version}/bin/Sanctuary $out/lib/unigine/sanctuary/bin/Sanctuary
+    install -D -m 0755 unigine-sanctuary-${finalAttrs.version}/1024x768_windowed.sh $out/bin/Sanctuary
 
-    cp -R ${pname}-${version}/data $out/lib/unigine/sanctuary
+    cp -R unigine-sanctuary-${finalAttrs.version}/data $out/lib/unigine/sanctuary
 
     wrapProgram $out/bin/Sanctuary \
-      --prefix LD_LIBRARY_PATH : ${libPath}:$out/lib/unigine/sanctuary/bin \
+      --prefix LD_LIBRARY_PATH : ${finalAttrs.libPath}:$out/lib/unigine/sanctuary/bin \
       --run "cd $out/lib/unigine/sanctuary"
 
     convert -size 256x256 xc:Transparent -define gradient:center="128,128" -define gradient:vector="128,128 128,128" \
       -define gradient:radii="128,128" -fill radial-gradient:'rgb(164,0,0)-rgb(67,1,3)' \
-      -draw "roundRectangle 0,0 256,256 50,50" ${pname}-${version}/icon.png
-    convert ${pname}-${version}/icon.png -size 181.991x181.991 -font ${pkgsi686Linux.liberation_ttf}/share/fonts/truetype/LiberationSans-Regular.ttf \
+      -draw "roundRectangle 0,0 256,256 50,50" unigine-sanctuary-${finalAttrs.version}/icon.png
+    convert unigine-sanctuary-${finalAttrs.version}/icon.png -size 181.991x181.991 -font ${pkgsi686Linux.liberation_ttf}/share/fonts/truetype/LiberationSans-Regular.ttf \
       -pointsize 181.991 -define gradient:center="128,128" -define gradient:vector="128,128 128,128" \
       -define gradient:radii="46.6974,46.6974" -fill radial-gradient:'rgb(249,197,46)-rgb(218,144,31)' \
-      -stroke none -strokewidth 4.54977 -draw 'text 69.3061,194.247 "S"' ${pname}-${version}/icon.png
+      -stroke none -strokewidth 4.54977 -draw 'text 69.3061,194.247 "S"' unigine-sanctuary-${finalAttrs.version}/icon.png
 
     for RES in 16 24 32 48 64 128 256; do
       mkdir -p $out/share/icons/hicolor/"$RES"x"$RES"/apps
-      convert ${pname}-${version}/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Sanctuary.png
+      convert unigine-sanctuary-${finalAttrs.version}/icon.png -resize "$RES"x"$RES" $out/share/icons/hicolor/"$RES"x"$RES"/apps/Sanctuary.png
     done
-    convert ${pname}-${version}/icon.png -resize 128x128 $out/share/icons/Sanctuary.png
+    convert unigine-sanctuary-${finalAttrs.version}/icon.png -resize 128x128 $out/share/icons/Sanctuary.png
 
     runHook postInstall
   '';
@@ -88,4 +88,4 @@ pkgsi686Linux.stdenv.mkDerivation rec {
     ];
     mainProgram = "Sanctuary";
   };
-}
+})

--- a/pkgs/by-name/un/unigine-tropics/package.nix
+++ b/pkgs/by-name/un/unigine-tropics/package.nix
@@ -3,16 +3,14 @@
   fetchurl,
   pkgsi686Linux,
 }:
-let
-  version = "1.3";
-in
-pkgsi686Linux.stdenv.mkDerivation {
+
+pkgsi686Linux.stdenv.mkDerivation (finalAttrs: {
   pname = "unigine-tropics";
-  inherit version;
+  version = "1.3";
 
   src = fetchurl {
-    url = "https://assets.unigine.com/d/Unigine_Tropics-${version}.run";
-    sha256 = "sha256-/eA1i42/PMcoBbUJIGS66j7QpZ13oPkOi1Y6Q27TikU=";
+    url = "https://assets.unigine.com/d/Unigine_Tropics-${finalAttrs.version}.run";
+    hash = "sha256-/eA1i42/PMcoBbUJIGS66j7QpZ13oPkOi1Y6Q27TikU=";
   };
 
   libPath = lib.makeLibraryPath [
@@ -86,4 +84,4 @@ pkgsi686Linux.stdenv.mkDerivation {
     ];
     mainProgram = "Tropics";
   };
-}
+})

--- a/pkgs/by-name/un/unigine-tropics/package.nix
+++ b/pkgs/by-name/un/unigine-tropics/package.nix
@@ -1,24 +1,12 @@
 {
   lib,
-  stdenv,
   fetchurl,
-  makeWrapper,
-  autoPatchelfHook,
-  libx11,
-  libxext,
-  libxrandr,
-  libxinerama,
-  libglvnd,
-  openal,
-  glibc,
-  makeDesktopItem,
-  copyDesktopItems,
-  imagemagick,
+  pkgsi686Linux,
 }:
 let
   version = "1.3";
 in
-stdenv.mkDerivation {
+pkgsi686Linux.stdenv.mkDerivation {
   pname = "unigine-tropics";
   inherit version;
 
@@ -28,9 +16,9 @@ stdenv.mkDerivation {
   };
 
   libPath = lib.makeLibraryPath [
-    libglvnd
-    openal
-    glibc
+    pkgsi686Linux.libglvnd
+    pkgsi686Linux.openal
+    pkgsi686Linux.glibc
   ];
 
   installPhase = ''
@@ -60,7 +48,7 @@ stdenv.mkDerivation {
   '';
 
   desktopItems = [
-    (makeDesktopItem {
+    (pkgsi686Linux.makeDesktopItem {
       name = "Tropics";
       exec = "Tropics";
       genericName = "A GPU Stress test tool from the UNIGINE";
@@ -70,18 +58,18 @@ stdenv.mkDerivation {
   ];
 
   nativeBuildInputs = [
-    autoPatchelfHook
-    makeWrapper
-    imagemagick
-    copyDesktopItems
+    pkgsi686Linux.autoPatchelfHook
+    pkgsi686Linux.makeWrapper
+    pkgsi686Linux.imagemagick
+    pkgsi686Linux.copyDesktopItems
   ];
 
   buildInputs = [
-    stdenv.cc.cc
-    libx11
-    libxext
-    libxrandr
-    libxinerama
+    pkgsi686Linux.stdenv.cc.cc
+    pkgsi686Linux.libx11
+    pkgsi686Linux.libxext
+    pkgsi686Linux.libxrandr
+    pkgsi686Linux.libxinerama
   ];
 
   dontUnpack = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9427,8 +9427,6 @@ with pkgs;
     }
   );
 
-  unigine-tropics = pkgsi686Linux.callPackage ../applications/graphics/unigine-tropics { };
-
   unigine-sanctuary = pkgsi686Linux.callPackage ../applications/graphics/unigine-sanctuary { };
 
   uuagc = haskell.lib.compose.justStaticExecutables haskellPackages.uuagc;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9427,8 +9427,6 @@ with pkgs;
     }
   );
 
-  unigine-sanctuary = pkgsi686Linux.callPackage ../applications/graphics/unigine-sanctuary { };
-
   uuagc = haskell.lib.compose.justStaticExecutables haskellPackages.uuagc;
 
   vim = vimUtils.makeCustomizable (


### PR DESCRIPTION
This pull request refactors and improves the packaging of several UNIGINE GPU benchmarking tools in Nixpkgs. The main changes involve moving the `unigine-tropics` and `unigine-superposition` packages to the `pkgs/by-name/un/` directory, updating their build logic to consistently use `pkgsi686Linux` dependencies, and introducing a new package for `unigine-sanctuary`. Additionally, references to the old package locations are removed from `all-packages.nix`.

**Packaging improvements and refactoring:**

* Moved `unigine-tropics` and `unigine-superposition` packages from `pkgs/applications/graphics/` to `pkgs/by-name/un/`, and updated their build scripts to use `pkgsi686Linux` consistently for all dependencies and build inputs.

* Added a new package definition for `unigine-sanctuary` at `pkgs/by-name/un/unigine-sanctuary/package.nix`, including all necessary build steps, dependency handling, icon generation, and desktop integration.

**Maintenance and cleanup:**

* Removed the old references to `unigine-tropics`, `unigine-sanctuary`, and `unigine-superposition` from `pkgs/top-level/all-packages.nix`, as these are now managed in the new location and structure.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
