### PR TITLE
servo: remove supinie from maintainers

### DIFF
--- a/pkgs/by-name/se/servo/package.nix
+++ b/pkgs/by-name/se/servo/package.nix
@@ -176,7 +176,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
       hexa
-      supinie
     ];
     teams = with lib.teams; [ ngi ];
     mainProgram = "servo";


### PR DESCRIPTION
<details>
    <summary>Original Content</summary>

## Reasons

- Last commented in [July 2025](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Asupinie)
- Hasn't created any PRs / Issues since [May 2025](https://github.com/NixOS/nixpkgs/issues?q=author%3Asupinie)
- About 53 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Asupinie%20-commenter%3Asupinie%20-author%3Asupinie%20-reviewed-by%3Asupinie) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages 

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] aerogramme
- [ ] cargo-preflight
</details>
