### PR TITLE
betterleaks: init at 1.1.1

### DIFF
--- a/pkgs/by-name/be/betterleaks/package.nix
+++ b/pkgs/by-name/be/betterleaks/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "betterleaks";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "betterleaks";
+    repo = "betterleaks";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PJGFvm+QoExUMliL6rvBAKKjt8Ce5VZfQxCYbpXUXfU=";
+  };
+
+  vendorHash = "sha256-lIblIctRnq//ic+most3g9Ff92XhfqbFfHrLdI0beQQ=";
+
+  ldflags = [
+    "-s"
+    "-X=github.com/betterleaks/betterleaks/version.Version=${finalAttrs.version}"
+  ];
+
+  subPackages = [
+    "."
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd betterleaks \
+      --bash <($out/bin/betterleaks completion bash) \
+      --fish <($out/bin/betterleaks completion fish) \
+      --zsh <($out/bin/betterleaks completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/betterleaks";
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Scan code for secrets";
+    homepage = "https://github.com/betterleaks/betterleaks";
+    changelog = "https://github.com/betterleaks/betterleaks/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    mainProgram = "betterleaks";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Looking at [these](https://github.com/gitleaks/gitleaks/issues/1274#issuecomment-3939279568) GitHub discussions, betterleaks is the successor to gitleaks.
They plan to develop betterleaks v2 instead of gitleaks v9.

I have removed two files from the current gitleaks package.

- remove $out/bin/config: https://github.com/NixOS/nixpkgs/pull/500477
- remove $out/etc/gitleaks.toml: https://github.com/NixOS/nixpkgs/pull/466763#discussion_r2942175664

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
