### PR TITLE
serial-studio: 3.1.10-unstable-2025-12-12 → 3.2.4

### DIFF
--- a/pkgs/by-name/se/serial-studio/0001-CMake-Deploy-Fix.patch
+++ b/pkgs/by-name/se/serial-studio/0001-CMake-Deploy-Fix.patch
@@ -1,11 +1,11 @@
-diff --git a/app/CMakeLists.txt b/app/CMakeLists.txt
-index e69150cd..c4ce7975 100644
---- a/app/CMakeLists.txt
-+++ b/app/CMakeLists.txt
-@@ -392,17 +392,6 @@
-   set(deploy_tool_options_arg "-force-openssl --release --no-translations")
+diff --git i/app/CMakeLists.txt w/app/CMakeLists.txt
+index 1ab415ea..23792435 100644
+--- i/app/CMakeLists.txt
++++ w/app/CMakeLists.txt
+@@ -872,17 +872,6 @@ elseif(WIN32)
+   set(deploy_tool_options_arg "-force-openssl --release --no-translations --no-compiler-runtime")
  endif()
-
+ 
 -qt_generate_deploy_qml_app_script(
 -  TARGET ${PROJECT_EXECUTABLE}
 -  OUTPUT_SCRIPT deploy_script
@@ -17,9 +17,6 @@ index e69150cd..c4ce7975 100644
 -
 -install(SCRIPT ${deploy_script})
 -
- #-------------------------------------------------------------------------------
- # Packaging
- #-------------------------------------------------------------------------------
--- 
-2.47.2
-
+ #---------------------------------------------------------------------------------------------------
+ # CPack installer/package generation
+ #---------------------------------------------------------------------------------------------------

--- a/pkgs/by-name/se/serial-studio/package.nix
+++ b/pkgs/by-name/se/serial-studio/package.nix
@@ -4,29 +4,34 @@
   fetchFromGitHub,
   cmake,
   qt6,
+  expat,
+  zlib,
   pkg-config,
+  wrapGAppsHook3,
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "serial-studio";
-  version = "3.1.10-unstable-2025-12-12";
+  version = "3.2.4";
 
   src = fetchFromGitHub {
     owner = "Serial-Studio";
     repo = "Serial-Studio";
-    rev = "b2e8b5430da59969dd697636677873f3f6c10c7c";
-    hash = "sha256-O/KAYKpVGn2Q0CPaReh564P5l+ilHuQYRJ4w5aFKZmg=";
-    fetchSubmodules = true;
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KY7ePFeO29jKnaFbP5IJo1Z/OqldTvmZUGuzZ+yqyK8=";
   };
 
   nativeBuildInputs = [
     cmake
     qt6.wrapQtAppsHook
     pkg-config
+    wrapGAppsHook3 # required for FileChooser
   ];
 
   buildInputs = [
+    expat
+    zlib
     qt6.qtbase
     qt6.qtdeclarative
     qt6.qtsvg
@@ -39,12 +44,23 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qt5compat
   ];
 
+  cmakeFlags = [
+    (lib.cmakeBool "USE_SYSTEM_ZLIB" true)
+    (lib.cmakeBool "USE_SYSTEM_EXPAT" true)
+  ];
+
   patches = [ ./0001-CMake-Deploy-Fix.patch ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/{Applications,bin}
     mv $out/Serial-Studio-GPL3.app $out/Applications
-    ln --symbolic $out/Applications/Serial-Studio-GPL3.app/Contents/MacOS/Serial-Studio-GPL3 $out/bin/serial-studio
+    ln -s $out/Applications/Serial-Studio-GPL3.app/Contents/MacOS/Serial-Studio-GPL3 $out/bin/serial-studio-gpl3
+  '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
   passthru.updateScript = nix-update-script {
@@ -53,8 +69,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Multi-purpose serial data visualization & processing program";
-    mainProgram = "serial-studio";
-    homepage = "https://serial-studio.github.io/";
+    mainProgram = "serial-studio-gpl3";
+    homepage = "https://serial-studio.com/";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ sikmir ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
https://github.com/Serial-Studio/Serial-Studio/releases

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
