### PR TITLE
dotnetCorePackages.fetchNupkg: neutralize avalonia.buildservices

### DIFF
--- a/pkgs/build-support/dotnet/fetch-nupkg/overrides.nix
+++ b/pkgs/build-support/dotnet/fetch-nupkg/overrides.nix
@@ -63,6 +63,15 @@
       }
     );
 
+  "Avalonia.BuildServices" =
+    package:
+    package.overrideAttrs (old: {
+      postPatch = ''
+        shopt -s extglob
+        rm -rf !(*.nuspec)
+      '';
+    });
+
   "SkiaSharp.NativeAssets.Linux" =
     package:
     package.overrideAttrs (

--- a/pkgs/by-name/kn/knossosnet/package.nix
+++ b/pkgs/by-name/kn/knossosnet/package.nix
@@ -31,10 +31,6 @@ buildDotnetModule rec {
 
   runtimeDeps = [ openal ];
 
-  env = {
-    AVALONIA_TELEMETRY_OPTOUT = "1";
-  };
-
   nativeBuildInputs = [ copyDesktopItems ];
 
   desktopItems = [

--- a/pkgs/by-name/li/libation/package.nix
+++ b/pkgs/by-name/li/libation/package.nix
@@ -27,8 +27,6 @@ buildDotnetModule rec {
 
   sourceRoot = "${src.name}/Source";
 
-  env.AVALONIA_TELEMETRY_OPTOUT = "1";
-
   dotnet-sdk = dotnetCorePackages.sdk_10_0_1xx;
 
   dotnet-runtime = dotnetCorePackages.runtime_10_0;

--- a/pkgs/by-name/ms/msbuild-structured-log-viewer/package.nix
+++ b/pkgs/by-name/ms/msbuild-structured-log-viewer/package.nix
@@ -23,8 +23,6 @@ buildDotnetModule (finalAttrs: {
     hash = "sha256-HTWPsVl/pMi+lMSax5JNtbPXHeqD8QxfvLp2bhVxfPs=";
   };
 
-  env.AVALONIA_TELEMETRY_OPTOUT = "1";
-
   dotnet-sdk = dotnetCorePackages.sdk_8_0;
   dotnet-runtime = dotnetCorePackages.runtime_8_0;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
