### PR TITLE
duckdb: 1.4.4 -> 1.5.0

### DIFF
--- a/pkgs/by-name/du/duckdb/versions.json
+++ b/pkgs/by-name/du/duckdb/versions.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.4.4",
-  "rev": "6ddac802ffa9bcfbcc3f5f0d71de5dff9b0bc250",
-  "hash": "sha256-h9Mldv29u47DnFOCN28HBHWz8daFGE/Nj1JcnNhhQ5Q=",
-  "python_hash": "sha256-860KbaM7Ojp4Qwm5x5WPQg176XKOYayk8pLVaUAuC4M="
+  "version": "1.5.0",
+  "rev": "3a3967aa8190d0a2d1931d4ca4f5d920760030b4",
+  "hash": "sha256-nTtLs3we5LVV1yBRWqJJDCBVxA+TPKwW+t/5oONUSS4=",
+  "python_hash": "sha256-zQM5I61GBzEM3Hm0J/ZFxE9jzLq78poTf3kcSS0MaFw="
 }


### PR DESCRIPTION
  https://github.com/duckdb/duckdb/releases/tag/v1.5.0


Updating to duckdb v1.5.0 (https://duckdb.org/2026/03/09/announcing-duckdb-150)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
