### PR TITLE
agent-of-empires: init at 0.16.1

### DIFF
--- a/pkgs/by-name/ag/agent-of-empires/package.nix
+++ b/pkgs/by-name/ag/agent-of-empires/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  pkg-config,
+  cmake,
+  git,
+  openssl,
+  zlib,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "agent-of-empires";
+  version = "0.16.1";
+
+  src = fetchFromGitHub {
+    owner = "njbrake";
+    repo = "agent-of-empires";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MSvvGYvSi0dc7CAUI9ComAerptq8uEdE//3f03tC7S0=";
+  };
+
+  cargoHash = "sha256-wW8mnEUJ3LyzkeBFP3qdfwpuPsqIZmLOxi/lGIj5On8=";
+
+  cargoBuildFlags = [ "--package" "agent-of-empires" ];
+  cargoTestFlags = [ "--package" "agent-of-empires" ];
+
+  env.OPENSSL_NO_VENDOR = 1;
+
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+    cmake
+  ];
+
+  buildInputs = [
+    openssl
+    zlib
+  ];
+
+  nativeCheckInputs = [
+    git
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd aoe \
+      --bash <($out/bin/aoe completion bash) \
+      --fish <($out/bin/aoe completion fish) \
+      --zsh <($out/bin/aoe completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal session manager for AI coding agents";
+    homepage = "https://github.com/njbrake/agent-of-empires";
+    changelog = "https://github.com/njbrake/agent-of-empires/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ cpcloud ];
+    mainProgram = "aoe";
+  };
+})


### PR DESCRIPTION
[Agent of Empires](https://github.com/njbrake/agent-of-empires) is a terminal session manager for AI coding agents built on tmux. It lets users run multiple AI agents in parallel across different branches of a codebase, each in its own isolated session with optional Docker sandboxing. It provides both a TUI dashboard and a CLI for creating, monitoring, and managing agent sessions.

Supported AI tools include Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, and Pi.dev.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)