### PR TITLE
workmux: init at 0.1.138

### DIFF
--- a/pkgs/by-name/wo/workmux/package.nix
+++ b/pkgs/by-name/wo/workmux/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  installShellFiles,
+  git,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "workmux";
+  version = "0.1.138";
+
+  src = fetchFromGitHub {
+    owner = "raine";
+    repo = "workmux";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FOKbfRmFTvK2exQfy+5DHHdlCwtsZuueZrcPNvHSncI=";
+  };
+
+  cargoHash = "sha256-Mil5l/VZLTQmhDGEXCTFNH1L4mGjt1wOLV11h2mn8pY=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    git
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    export HOME=$TMPDIR
+    installShellCompletion --cmd workmux \
+      --bash <($out/bin/workmux completions bash) \
+      --fish <($out/bin/workmux completions fish) \
+      --zsh <($out/bin/workmux completions zsh)
+  '';
+
+  meta = {
+    description = "Orchestrate git worktrees and terminal multiplexer windows as isolated development environments";
+    homepage = "https://github.com/raine/workmux";
+    changelog = "https://github.com/raine/workmux/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ cpcloud ];
+    mainProgram = "workmux";
+  };
+})


### PR DESCRIPTION
[workmux](https://github.com/raine/workmux) is a workflow tool that orchestrates git worktrees and terminal multiplexer windows (tmux, WezTerm, kitty, or Zellij) as isolated development environments.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)