### PR TITLE
dotnetCorePackages.fetchNupkg: use patchcil in avalonia.x11 override and add more libs

### DIFF
--- a/pkgs/build-support/dotnet/auto-patchcil-hook/auto-patchcil.sh
+++ b/pkgs/build-support/dotnet/auto-patchcil-hook/auto-patchcil.sh
@@ -4,13 +4,13 @@
 declare -a autoPatchcilLibs
 declare -a extraAutoPatchcilLibs
 
-gatherLibraries() {
+gatherAutoPatchcilLibraries() {
     if [ -d "$1/lib" ]; then
         autoPatchcilLibs+=("$1/lib")
     fi
 }
 
-addEnvHooks "${targetOffset:?}" gatherLibraries
+addEnvHooks "${targetOffset:?}" gatherAutoPatchcilLibraries
 
 # Can be used to manually add additional directories with shared object files
 # to be included for the next autoPatchcil invocation.

--- a/pkgs/build-support/dotnet/auto-patchcil-hook/auto-patchcil.sh
+++ b/pkgs/build-support/dotnet/auto-patchcil-hook/auto-patchcil.sh
@@ -90,8 +90,11 @@ autoPatchcil() {
         --rid "$rid"
         "${ignoreMissingDepsArray[@]}"
         --paths "$@"
-        --libs "${autoPatchcilLibs[@]}"
     )
+
+    if (( ${#autoPatchcilLibs[@]} > 0 )); then
+        autoPatchcilFlags+=(--libs "${autoPatchcilLibs[@]}")
+    fi
 
     # shellcheck disable=SC2016
     echoCmd 'patchcil auto flags' "${autoPatchcilFlags[@]}"

--- a/pkgs/build-support/dotnet/fetch-nupkg/overrides.nix
+++ b/pkgs/build-support/dotnet/fetch-nupkg/overrides.nix
@@ -6,6 +6,13 @@
   libice,
   libsm,
   libx11,
+  libxcursor,
+  libxext,
+  libxi,
+  libxrandr,
+  gtk3,
+  libGL,
+  vulkan-loader,
   stdenv,
   writeText,
 }:
@@ -54,12 +61,25 @@
     package.overrideAttrs (
       old:
       lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
-        setupHook = writeText "setupHook.sh" ''
-          prependToVar dotnetRuntimeDeps \
-            "${lib.getLib libice}" \
-            "${lib.getLib libsm}" \
-            "${lib.getLib libx11}"
-        '';
+        nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [ dotnetCorePackages.autoPatchcilHook ];
+
+        buildInputs = old.buildInputs or [ ] ++ [
+          libice
+          libsm
+          libx11
+          libxcursor
+          libxext
+          libxi
+          libxrandr
+          gtk3
+          libGL
+          vulkan-loader
+        ];
+
+        autoPatchcilRuntimeId = dotnetCorePackages.systemToDotnetRid stdenv.hostPlatform.system;
+        autoPatchcilIgnoreMissingDeps = [
+          "libc"
+        ];
       }
     );
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
