### PR TITLE
ntpd-rs: cleanup, fetch upstream certificates patch

### DIFF
--- a/pkgs/by-name/nt/ntpd-rs/package.nix
+++ b/pkgs/by-name/nt/ntpd-rs/package.nix
@@ -1,5 +1,6 @@
 {
   fetchFromGitHub,
+  fetchpatch2,
   installShellFiles,
   lib,
   nix-update-script,
@@ -28,26 +29,22 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pandoc
   ];
 
-  # These fail based on timestamp issues with bundled certificates
-  # See https://github.com/NixOS/nixpkgs/issues/497682 & https://github.com/pendulum-project/ntpd-rs/pull/2133
+  # https://github.com/pendulum-project/ntpd-rs/issues/2152
   checkFlags = [
-    "--skip=daemon::keyexchange::tests::key_exchange_connection_limiter"
-    "--skip=daemon::keyexchange::tests::key_exchange_roundtrip_with_port_server"
     "--skip=daemon::ntp_source::tests::test_deny_stops_poll"
     "--skip=daemon::ntp_source::tests::test_timeroundtrip"
     "--skip=daemon::server::tests::test_server_serves"
-    "--skip=nts::tests::test_key_exchange_roundtrip_no_cookies"
-    "--skip=nts::tests::test_keyexchange_fixed_key_no_permission"
-    "--skip=nts::tests::test_keyexchange_roundtrip_fixed_key"
-    "--skip=nts::tests::test_keyexchange_roundtrip_fixed_key_keep_alive"
-    "--skip=nts::tests::test_keyexchange_roundtrip_fixed_key_no_permit"
-    "--skip=nts::tests::test_keyexchange_roundtrip_no_proto_overlap"
-    "--skip=nts::tests::test_keyexchange_roundtrip_no_upgrade_possible"
-    "--skip=nts::tests::test_keyexchange_roundtrip_supports"
-    "--skip=nts::tests::test_keyexchange_roundtrip_upgrading"
-    "--skip=nts::tests::test_keyexchange_roundtrip_v4"
-    "--skip=nts::tests::test_keyexchange_roundtrip_v5"
-    "--skip=nts::tests::test_keyexchange_supports_no_permission"
+  ];
+
+  # These fail based on timestamp issues with bundled certificates.
+  # See https://github.com/NixOS/nixpkgs/issues/497682 &
+  # https://github.com/pendulum-project/ntpd-rs/pull/2133
+  # Remove after ntpd-rs > 1.7.1
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/pendulum-project/ntpd-rs/commit/1df0cc959248612faf705f2fd69f53057fd0372e.patch";
+      hash = "sha256-2Yicq8P4TQJbhOSOVOXGmVAWEJdsDdaXKiQX40Z/oZY=";
+    })
   ];
 
   postPatch = ''
@@ -79,7 +76,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    changelog = "https://github.com/pendulum-project/ntpd-rs/blob/v${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/pendulum-project/ntpd-rs/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Full-featured implementation of the Network Time Protocol";
     homepage = "https://tweedegolf.nl/en/pendulum";
     license = with lib.licenses; [

--- a/pkgs/by-name/nt/ntpd-rs/package.nix
+++ b/pkgs/by-name/nt/ntpd-rs/package.nix
@@ -1,14 +1,13 @@
 {
-  lib,
-  stdenv,
-  rustPlatform,
   fetchFromGitHub,
-  ntpd-rs,
   installShellFiles,
-  pandoc,
-  nixosTests,
+  lib,
   nix-update-script,
-  testers,
+  nixosTests,
+  pandoc,
+  rustPlatform,
+  stdenvNoCC,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -25,8 +24,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-DXAy/K70sNhVOjDOd6G/juE7JgmewPzGHZDeXAOZ1+s=";
 
   nativeBuildInputs = [
-    pandoc
     installShellFiles
+    pandoc
   ];
 
   # These fail based on timestamp issues with bundled certificates
@@ -53,7 +52,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postPatch = ''
     substituteInPlace utils/generate-man.sh \
-      --replace-fail 'utils/pandoc.sh' 'pandoc'
+      --replace-fail 'utils/pandoc.sh' '${lib.getExe pandoc}'
   '';
 
   postBuild = ''
@@ -61,41 +60,38 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   postInstall = ''
-    install -Dm444 -t $out/lib/systemd/system docs/examples/conf/{ntpd-rs,ntpd-rs-metrics}.service
     installManPage docs/precompiled/man/{ntp.toml.5,ntp-ctl.8,ntp-daemon.8,ntp-metrics-exporter.8}
+    install -Dm444 docs/examples/conf/{ntpd-rs,ntpd-rs-metrics}.service \
+      --target-directory="$out"/lib/systemd/system
   '';
 
   outputs = [
-    "out"
     "man"
+    "out"
   ];
 
-  passthru = {
-    tests = {
-      nixos = lib.optionalAttrs stdenv.hostPlatform.isLinux nixosTests.ntpd-rs;
-      version = testers.testVersion {
-        package = ntpd-rs;
-        inherit (finalAttrs) version;
-      };
-    };
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
+  passthru = {
+    tests.nixos = lib.optionalAttrs stdenvNoCC.hostPlatform.isLinux nixosTests.ntpd-rs;
     updateScript = nix-update-script { };
   };
 
   meta = {
+    changelog = "https://github.com/pendulum-project/ntpd-rs/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "Full-featured implementation of the Network Time Protocol";
     homepage = "https://tweedegolf.nl/en/pendulum";
-    changelog = "https://github.com/pendulum-project/ntpd-rs/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
-      mit # or
-      asl20
+      asl20 # OR
+      mit
     ];
+    mainProgram = "ntp-ctl";
     maintainers = with lib.maintainers; [
       fpletz
       getchoo
     ];
-    mainProgram = "ntp-ctl";
     # note: Undefined symbols for architecture x86_64: "_ntp_adjtime"
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;
+    broken = with stdenvNoCC.hostPlatform; (isDarwin && isx86_64);
   };
 })


### PR DESCRIPTION
Resolves #497682

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
