### PR TITLE
crowdsec-firewall-bouncer: fix "error while reading yaml file"

### DIFF
--- a/nixos/modules/services/security/crowdsec-firewall-bouncer.nix
+++ b/nixos/modules/services/security/crowdsec-firewall-bouncer.nix
@@ -231,7 +231,8 @@ in
           after = [ "crowdsec.service" ];
           wants = after;
           script = ''
-            cscli=${lib.getExe' config.services.crowdsec.package "cscli"}
+            # Need to use a `cscli` wrapper which sets `--config` to correct path.
+            cscli=/run/current-system/sw/bin/cscli
             if $cscli bouncers list --output json | ${lib.getExe pkgs.jq} -e -- ${lib.escapeShellArg "any(.[]; .name == \"${cfg.registerBouncer.bouncerName}\")"} >/dev/null; then
               # Bouncer already registered. Verify the API key is still present
               if [ ! -f ${apiKeyFile} ]; then


### PR DESCRIPTION
This reverts 84fa356 which introduced a regression. Not using a wrapper script results in `cscli` trying to use a default config in `/etc/crowdsec/config.yaml` and fail.

```
mar 16 21:53:56 vps crowdsec-firewall-bouncer-register-start[3659707]: Error: while reading yaml file: open /etc/crowdsec/config.yaml: no such file or directory
mar 16 21:53:56 vps crowdsec-firewall-bouncer-register-start[3659718]: Error: while reading yaml file: open /etc/crowdsec/config.yaml: no such file or directory
```

In https://github.com/NixOS/nixpkgs/pull/476312 @nicomem said:

> I referenced the cscli in /run/current-system/sw/bin to use the wrapper that the crowdsec module creates ([see here](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/security/crowdsec.nix#L511)).
> But in our case, we need nothing that the wrapper does, so directly using the package's cscli seems indeed better 👍

but that doesn't seem to be true.

FYI @gaelj 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
