### PR TITLE
[Backport release-25.11] guitarix: move to by-name and refactor

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1570,6 +1570,13 @@
     githubId = 754494;
     name = "Anders Asheim Hennum";
   };
+  anderscs = {
+    email = "anders@sorby.xyz";
+    github = "anderssorby";
+    githubId = 6331075;
+    matrix = "@anders:sorby.xyz";
+    name = "Anders C. Sørby";
+  };
   andershus = {
     email = "anders.husebo@eviny.no";
     github = "andershus";

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -44,14 +44,14 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "guitarix";
-  version = "0.46.0";
+  version = "0.47.0";
 
   src = fetchFromGitHub {
     owner = "brummer10";
     repo = "guitarix";
     rev = "V${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-AftC6fQEDzG/3C/83YbK/++bRgP7vPD0E2X6KEWpowc=";
+    hash = "sha256-YQqcpdehfC9UE1OowC1/YUw2eWgbLWMbAJ3V5tVmtiU=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/trunk";

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -135,6 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       lord-valen
+      anderscs
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/gu/guitarix/package.nix
+++ b/pkgs/by-name/gu/guitarix/package.nix
@@ -8,7 +8,7 @@
   curl,
   eigen,
   faust,
-  fftw,
+  fftwSinglePrec,
   gettext,
   glib,
   glib-networking,
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     eigen
     faust
-    fftw
+    fftwSinglePrec
     glib
     glib-networking.out
     glibmm

--- a/pkgs/by-name/gu/guitarix/package.nix
+++ b/pkgs/by-name/gu/guitarix/package.nix
@@ -8,6 +8,7 @@
   curl,
   eigen,
   faust,
+  fetchpatch2,
   fftwSinglePrec,
   gettext,
   glib,
@@ -108,6 +109,21 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional withLiblo liblo
   ++ lib.optional withZitaConvolver zita-convolver
   ++ lib.optional withZitaResampler zita-resampler;
+
+  patchFlags = [ "-p2" ];
+  patches = [
+    # Remove the mandatory check for `boost_system` which was removed in boost 1.89
+    (fetchpatch2 {
+      name = "make-boost-system-stub-optional.patch";
+      url = "https://github.com/brummer10/guitarix/compare/v0.47.0..187670358ffc47a0fa09e140586b2e88dfdcf043.patch?full_index=1";
+      hash = "sha256-9Z0sAM/oTm3ejv9chDbXEpkjNvlX/SN+k48XaJTqdy0=";
+      includes = [
+        "trunk/waf"
+        "*/wscript"
+        "trunk/waftools/*.py"
+      ];
+    })
+  ];
 
   # There are many bad shebangs which can fail builds.
   # See `https://github.com/brummer10/guitarix/issues/246`.

--- a/pkgs/by-name/gu/guitarix/package.nix
+++ b/pkgs/by-name/gu/guitarix/package.nix
@@ -42,6 +42,7 @@
     else
       false,
   enableNSM ? true, # Enables NSM support
+  enableSse ? stdenv.hostPlatform.isx86, # Enables support for SSE CPU extensions
   optimizationSupport ? null,
   withAvahi ? true,
   withBluez ? stdenv.hostPlatform.isLinux,
@@ -66,12 +67,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/trunk";
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     gettext
     hicolor-icon-theme
     intltool
     pkg-config
     python3
+    sassc
     wafHook
     wrapGAppsHook3
   ]
@@ -98,7 +102,6 @@ stdenv.mkDerivation (finalAttrs: {
     lilv
     lrdf
     lv2
-    sassc
   ]
   ++ lib.optional withAvahi avahi
   ++ lib.optional withBluez bluez
@@ -124,6 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional (!enableFaust) "--no-faust"
   ++ lib.optional (!enableNSM) "--no-nsm"
   ++ lib.optional enableOptimization "--optimization"
+  ++ lib.optional (!enableSse) "--disable-sse"
   ++ lib.optional (!withAvahi) "--no-avahi"
   ++ lib.optional (!withBluez) "--no-bluez"
   ++ lib.optional (!withZitaConvolver) "--includeconvolver"

--- a/pkgs/by-name/gu/guitarix/package.nix
+++ b/pkgs/by-name/gu/guitarix/package.nix
@@ -13,14 +13,14 @@
   glib,
   glib-networking,
   glibmm,
-  adwaita-icon-theme,
-  gsettings-desktop-schemas,
+  gperf,
   gtk3,
   gtkmm3,
   hicolor-icon-theme,
   intltool,
   ladspaH,
   libjack2,
+  liblo,
   libsndfile,
   lilv,
   lrdf,
@@ -28,19 +28,29 @@
   pkg-config,
   python3,
   sassc,
-  serd,
-  sord,
-  sratom,
   wafHook,
+  which,
   wrapGAppsHook3,
   zita-convolver,
   zita-resampler,
-  optimizationSupport ? false, # Enable support for native CPU extensions
+
+  enableFaust ? false, # Transpiles Faust DSP code to C++
+  enableGperf ? false, # Regenerates gperf files
+  enableOptimization ? # Enables support for native CPU extensions
+    if optimizationSupport != null then
+      lib.warn "`optimizationSupport` is deprecated in guitarix; use `enableOptimization` instead." optimizationSupport
+    else
+      false,
+  enableNSM ? true, # Enables NSM support
+  optimizationSupport ? null,
+  withAvahi ? true,
+  withBluez ? stdenv.hostPlatform.isLinux,
+  withLiblo ? enableNSM,
+  withZitaConvolver ? true,
+  withZitaResampler ? true,
 }:
 
-let
-  inherit (lib) optional;
-in
+assert enableNSM -> withLiblo;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "guitarix";
@@ -49,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "brummer10";
     repo = "guitarix";
-    rev = "V${finalAttrs.version}";
+    tag = "V${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-YQqcpdehfC9UE1OowC1/YUw2eWgbLWMbAJ3V5tVmtiU=";
   };
@@ -64,21 +74,22 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     wafHook
     wrapGAppsHook3
-  ];
+  ]
+  ++ lib.optionals enableFaust [
+    faust
+    which
+  ]
+  ++ lib.optional enableGperf gperf;
 
   buildInputs = [
-    avahi
-    bluez
     boost
     curl
     eigen
-    faust
     fftwSinglePrec
+    gettext
     glib
     glib-networking.out
     glibmm
-    adwaita-icon-theme
-    gsettings-desktop-schemas
     gtk3
     gtkmm3
     ladspaH
@@ -88,12 +99,18 @@ stdenv.mkDerivation (finalAttrs: {
     lrdf
     lv2
     sassc
-    serd
-    sord
-    sratom
-    zita-convolver
-    zita-resampler
-  ];
+  ]
+  ++ lib.optional withAvahi avahi
+  ++ lib.optional withBluez bluez
+  ++ lib.optional withLiblo liblo
+  ++ lib.optional withZitaConvolver zita-convolver
+  ++ lib.optional withZitaResampler zita-resampler;
+
+  # There are many bad shebangs which can fail builds.
+  # See `https://github.com/brummer10/guitarix/issues/246`.
+  postPatch = ''
+    patchShebangs --build tools/**
+  '';
 
   wafConfigureFlags = [
     "--no-font-cache-update"
@@ -102,34 +119,33 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-nls"
     "--install-roboto-font"
   ]
-  ++ optional optimizationSupport "--optimization";
-
-  env.NIX_CFLAGS_COMPILE = toString [ "-fpermissive" ];
+  # Use explicit flags to guarantee correct configuration
+  ++ lib.optional enableFaust "--faust" # Force waf to use the provided faust
+  ++ lib.optional (!enableFaust) "--no-faust"
+  ++ lib.optional (!enableNSM) "--no-nsm"
+  ++ lib.optional enableOptimization "--optimization"
+  ++ lib.optional (!withAvahi) "--no-avahi"
+  ++ lib.optional (!withBluez) "--no-bluez"
+  ++ lib.optional (!withZitaConvolver) "--includeconvolver"
+  ++ lib.optional (!withZitaResampler) "--includeresampler";
 
   meta = {
     description = "Virtual guitar amplifier for Linux running with JACK";
     mainProgram = "guitarix";
     longDescription = ''
-        guitarix is a virtual guitar amplifier for Linux running with
-      JACK (Jack Audio Connection Kit). It is free as in speech and
-      free as in beer. Its free sourcecode allows to build it for
-      other UNIX-like systems also, namely for BSD and for MacOSX.
+      Guitarix takes the signal from your guitar as any real amp would do: as a
+      mono-signal from your sound card. Your tone is processed by a main amp and
+      a rack-section. Both can be routed separately and deliver a processed
+      stereo-signal via JACK. You may fill the rack with effects from more than
+      25 built-in modules spanning from a simple noise-gate to brain-slashing
+      modulation-fx like flanger, phaser or auto-wah. Your signal is processed
+      with minimum latency. On a properly set-up Linux-system you do not need to
+      wait for more than 10 milliseconds for your playing to be delivered,
+      processed by guitarix.
 
-        It takes the signal from your guitar as any real amp would do:
-      as a mono-signal from your sound card. Your tone is processed by
-      a main amp and a rack-section. Both can be routed separately and
-      deliver a processed stereo-signal via JACK. You may fill the
-      rack with effects from more than 25 built-in modules spanning
-      from a simple noise-gate to brain-slashing modulation-fx like
-      flanger, phaser or auto-wah. Your signal is processed with
-      minimum latency. On any properly set-up Linux-system you do not
-      need to wait for more than 10 milli-seconds for your playing to
-      be delivered, processed by guitarix.
-
-        guitarix offers the range of sounds you would expect from a
-      full-featured universal guitar-amp. You can get crisp
-      clean-sounds, nice overdrive, fat distortion and a diversity of
-      crazy sounds never heard before.
+      Guitarix offers the range of sounds you would expect from a full-featured
+      universal guitar-amp. You can get crisp clean-sounds, nice overdrive, fat
+      distortion and a diversity of crazy sounds never heard before.
     '';
     homepage = "https://github.com/brummer10/guitarix";
     license = lib.licenses.gpl3Plus;
@@ -137,6 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
       lord-valen
       anderscs
     ];
+    # TODO: This potentially also works on darwin and BSD.
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10957,10 +10957,6 @@ with pkgs;
     pulseaudioSupport = false;
   };
 
-  guitarix = callPackage ../applications/audio/guitarix {
-    fftw = fftwSinglePrec;
-  };
-
   welle-io = qt6Packages.callPackage ../applications/radio/welle-io { };
 
   wireshark = qt6Packages.callPackage ../applications/networking/sniffers/wireshark {


### PR DESCRIPTION
Backports #470920.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
