### PR TITLE
cups-fuji-xerox-c525-a: init at 1.0-2_i386

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11553,6 +11553,12 @@
     githubId = 13622947;
     keys = [ { fingerprint = "1412 816B A9FA F62F D051 1975 D3E1 B013 B463 1293"; } ];
   };
+  isomorph70 = {
+    name = "Svend Haugaard Sørensen";
+    github = "Isomorph70";
+    githubId = 37809106;
+    email = "isomorph70+os@gmail.com";
+  };
   isotoxal = {
     name = "Abhinav Kuruvila Joseph";
     email = "abhinavkuruvila@proton.me";

--- a/pkgs/by-name/cu/cups-fuji-xerox-c525-a/package.nix
+++ b/pkgs/by-name/cu/cups-fuji-xerox-c525-a/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation {
     homepage = "https://archive.org/details/fuji-xerox-docuprint-c525-a-ap_1.0-2_i386";
     license = licenses.unfree; # Proprietary binary driver
     platforms = platforms.linux;
-    maintainers = [ isomorph70 ];
+    maintainers = [ lib.maintainers.isomorph70 ];
     broken = false; # Works on NixOS, with 32 bit libraries.
     # A flaw on Xerox 6525N, printing n copies results in n^2 copies being printed.
     priority = 4; # High priority for printer drivers

--- a/pkgs/by-name/cu/cups-fuji-xerox-c525-a/package.nix
+++ b/pkgs/by-name/cu/cups-fuji-xerox-c525-a/package.nix
@@ -1,0 +1,83 @@
+# cups-fuji-xerox-c525-a.nix
+{
+  stdenv,
+  fetchurl,
+  ghostscript,
+  pkgs,
+  makeWrapper,
+  patchelf,
+  dpkg,
+}:
+let
+  pname = "cups-fuji-xerox-c525-a";
+  driverName = "fuji-xerox-docuprint-c525-a-ap";
+  version = "1.0-2_i386"; # Updated from deb filename
+  deb = "${driverName}_${version}.deb";
+in
+stdenv.mkDerivation {
+  inherit
+    pname
+    driverName
+    version
+    deb
+    ;
+
+  src = fetchurl {
+    name = "${deb}";
+    url = "https://archive.org/download/${driverName}_${version}/${deb}";
+    sha256 = "058pbqqb7injbabv2g0wz2qsxscmk1ysryccnpcdgjnplh9m32pj";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    patchelf
+  ];
+  dontConfigure = true;
+  dontBuild = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg -x $src $out
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+      mv $out/usr/* $out/
+      rmdir $out/usr
+
+      substituteInPlace $out/share/cups/model/FujiXerox/en/FX_DocuPrint_C525_A_AP.ppd --replace-warn "/usr" "$out"
+      substituteInPlace $out/lib/cups/filter/FXM_PS2PM --replace-warn "/usr" "${ghostscript}"
+
+      # DYNAMICALLY find all ELF 32-bit executables in lib/cups/filter
+    mapfile -t filters < <(find $out/lib/cups/filter -type f -executable -exec sh -c ' file "$1" 2>/dev/null | grep -q "ELF 32-bit" && basename "$1" ' sh {} \;)
+
+    # echo "Found ELF 32-bit filters: ''${filters[*]}"
+
+    # Patch all ELF binaries
+      for f in "''${filters[@]}"; do
+        patchelf --set-interpreter ${pkgs.pkgsi686Linux.glibc}/lib/ld-linux.so.2 \
+        --set-rpath "${
+          pkgs.lib.makeLibraryPath (
+            with pkgs.pkgsi686Linux;
+            [
+              glibc
+              cups
+            ]
+          )
+        }" "$out/lib/cups/filter/$f"
+      done
+
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Fuji Xerox DocuPrint C525 A-AP CUPS driver, also work with Dell 1320c and Xerox Phaser 6125N";
+    homepage = "https://archive.org/details/fuji-xerox-docuprint-c525-a-ap_1.0-2_i386";
+    license = licenses.unfree; # Proprietary binary driver
+    platforms = platforms.linux;
+    maintainers = [ isomorph70 ];
+    broken = false; # Works on NixOS, with 32 bit libraries.
+    # A flaw on Xerox 6525N, printing n copies results in n^2 copies being printed.
+    priority = 4; # High priority for printer drivers
+  };
+}

--- a/pkgs/by-name/cu/cups-fuji-xerox-c525-a/package.nix
+++ b/pkgs/by-name/cu/cups-fuji-xerox-c525-a/package.nix
@@ -7,6 +7,7 @@
   makeWrapper,
   patchelf,
   dpkg,
+  lib,
 }:
 let
   pname = "cups-fuji-xerox-c525-a";
@@ -70,14 +71,13 @@ stdenv.mkDerivation {
 
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "Fuji Xerox DocuPrint C525 A-AP CUPS driver, also work with Dell 1320c and Xerox Phaser 6125N";
     homepage = "https://archive.org/details/fuji-xerox-docuprint-c525-a-ap_1.0-2_i386";
     license = licenses.unfree; # Proprietary binary driver
     platforms = platforms.linux;
-    maintainers = [ lib.maintainers.isomorph70 ];
+    maintainers = with maintainers; [ isomorph70 ];
     broken = false; # Works on NixOS, with 32 bit libraries.
     # A flaw on Xerox 6525N, printing n copies results in n^2 copies being printed.
-    priority = 4; # High priority for printer drivers
   };
 }


### PR DESCRIPTION
<!--
- Fuji Xerox DocuPrint C525 A-AP CUPS driver
- From official .deb via archive.org
- i686 filters with patchelf
- Tested: nix-build, NixOS services.printing, test page prints
- Also work with laser printer Dell 1320c and Xerox Phaser 6125N

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
