### PR TITLE
[Backport release-25.11] telegram-desktop: 6.4.1 -> 6.6.2, _64gram: 1.1.93 -> 1.1.94

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/default.nix
@@ -9,9 +9,6 @@
   qtsvg,
   qtwayland,
   kimageformats,
-  libavif,
-  libheif,
-  libjxl,
   wrapGAppsHook3,
   wrapQtAppsHook,
   geoclue2,
@@ -40,11 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     kimageformats
     qtwayland
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    libavif
-    libheif
-    libjxl
   ]
   ++ lib.optionals withWebkit [
     glib-networking

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/tg_owt.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/tg_owt.nix
@@ -33,13 +33,13 @@
 
 stdenv.mkDerivation {
   pname = "tg_owt";
-  version = "0-unstable-2025-06-02";
+  version = "0-unstable-2025-12-12";
 
   src = fetchFromGitHub {
     owner = "desktop-app";
     repo = "tg_owt";
-    rev = "62321fd7128ab2650b459d4195781af8185e46b5";
-    hash = "sha256-l6EdHJLd42TU+4pLakdU3a5PLVxrxjta0CSRy5hVBFU=";
+    rev = "d888bc3f79b4aa80333d8903410fa439db5f6696";
+    hash = "sha256-ZiZ0HD4UNPJj1ZtoGroJRQBYeL/nwpp4B9GtXFcCA7M=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
@@ -42,14 +42,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "telegram-desktop-unwrapped";
-  version = "6.4.1";
+  version = "6.5.1";
 
   src = fetchFromGitHub {
     owner = "telegramdesktop";
     repo = "tdesktop";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-jmUj0kTyok5CsOe/to6bTN3jH/RMF7jE+AnFJi2nW90=";
+    hash = "sha256-y2sf2wDJ6dYxRdDLKIr78z9tPBIoh2WICg4zJBmb85Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
@@ -28,6 +28,9 @@
   microsoft-gsl,
   boost,
   ada,
+  libavif,
+  libheif,
+  libjxl,
   libicns,
   apple-sdk_15,
   nix-update-script,
@@ -90,6 +93,9 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     apple-sdk_15
     libicns
+    libavif
+    libheif
+    libjxl
   ];
 
   dontWrapQtApps = true;

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
@@ -45,14 +45,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "telegram-desktop-unwrapped";
-  version = "6.6.1";
+  version = "6.6.2";
 
   src = fetchFromGitHub {
     owner = "telegramdesktop";
     repo = "tdesktop";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-qFKOY+SS5aQcZhIP2MChDy8gRK7ynKAXCm3Ifzub41w=";
+    hash = "sha256-sMg7h+he+mlqTu8wSLAsSJzCmwTX3t+suTEY77RH+aI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/unwrapped.nix
@@ -45,14 +45,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "telegram-desktop-unwrapped";
-  version = "6.5.1";
+  version = "6.6.1";
 
   src = fetchFromGitHub {
     owner = "telegramdesktop";
     repo = "tdesktop";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-y2sf2wDJ6dYxRdDLKIr78z9tPBIoh2WICg4zJBmb85Q=";
+    hash = "sha256-qFKOY+SS5aQcZhIP2MChDy8gRK7ynKAXCm3Ifzub41w=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/_6/_64gram/package.nix
+++ b/pkgs/by-name/_6/_64gram/package.nix
@@ -10,13 +10,13 @@ telegram-desktop.override {
   inherit withWebkit;
   unwrapped = telegram-desktop.unwrapped.overrideAttrs (old: rec {
     pname = "64gram-unwrapped";
-    version = "1.1.93";
+    version = "1.1.94";
 
     src = fetchFromGitHub {
       owner = "TDesktop-x64";
       repo = "tdesktop";
       tag = "v${version}";
-      hash = "sha256-AwzTmEaN6MsJNq1W+cyAbg+QkYrPaV2LXmt3NzKc/vQ=";
+      hash = "sha256-pMcG0B3YxrvvaLsC2yWJsm9wHpv5+xLtp+wQhRtJ38Q=";
       fetchSubmodules = true;
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
