### PR TITLE
scoop: init at 0.6.59

### DIFF
--- a/pkgs/by-name/sc/scoop/package.nix
+++ b/pkgs/by-name/sc/scoop/package.nix
@@ -1,0 +1,96 @@
+{
+  # eval deps
+  buildNpmPackage,
+  fetchpatch,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+
+  # runtime deps
+  certificate-ripper,
+  nodejs_20,
+  playwright-driver,
+  playwright-test,
+  yt-dlp,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "scoop";
+  version = "0.6.59";
+
+  src = fetchFromGitHub {
+    owner = "harvard-lil";
+    repo = "scoop";
+    tag = finalAttrs.version;
+    hash = "sha256-KcoTl2ehla6ALLrpAyfOqDioP5s3CGVfVhsj3Fbq6/Y=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/harvard-lil/scoop/pull/414/commits/4dc4ee6d4e6c3fa89cf5ec4c685178f1927ffa1f.patch";
+      hash = "sha256-zV7axS3zlD/hWwgZHTOkMLVak71giWy+J0iwZ3eSKL4=";
+    })
+  ];
+
+  # scoop doesn't work on node 22+ https://github.com/harvard-lil/portal/issues/12
+  nodejs = nodejs_20;
+
+  npmDepsHash = "sha256-lx+MxV8JDArDMQ0OV4eDXOTzd7xRfvvpAGJp+jPQPgs=";
+
+  env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+
+  dontNpmBuild = true;
+
+  postInstall = ''
+    scoop_npm_dir="$out/lib/node_modules/@harvard-lil/scoop"
+    ln -s /tmp "$scoop_npm_dir"/tmp
+
+    (
+      cd -- "$scoop_npm_dir/node_modules"
+      rm -rf playwright playwright-core
+      ln -s ${playwright-test}/lib/node_modules/playwright
+      ln -s ${playwright-test}/lib/node_modules/playwright-core
+    )
+
+    # reimplementing what scoop does in $src/postinstall.sh
+    exe_dir="$scoop_npm_dir/executables"
+    mkdir -p "$exe_dir"
+    ln -s ${lib.getExe yt-dlp} "$exe_dir"/yt-dlp
+    ln -s ${lib.getExe certificate-ripper} "$exe_dir"/crip
+  '';
+
+  makeWrapperArgs = [
+    "--set-default"
+    "PLAYWRIGHT_BROWSERS_PATH"
+    playwright-driver.browsers
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "High fidelity, browser-based, web archiving capture engine for witnessing the web";
+    homepage = "https://github.com/harvard-lil/scoop";
+    changelog = "https://github.com/harvard-lil/scoop/releases/tag/${finalAttrs.version}";
+    license = with lib.licenses; [
+      # from `find . -name 'package.json' -print0 | xargs -0 jq '.license' -r | sort -u` in the source dir after npm install
+      bsd0
+      agpl3Plus
+      asl20
+      blueOak100
+      bsd2
+      bsd3
+      isc
+      mit
+      zlib
+      psfl
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      # we don't know whats in those npm deps without digging
+      binaryBytecode
+      binaryNativeCode
+    ];
+    maintainers = [ lib.maintainers.shelvacu ];
+    mainProgram = "scoop";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Scoop is a tool for archiving websites into WACZ files

https://github.com/harvard-lil/scoop

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
