### PR TITLE
profile-sync-daemon: 6.50 -> 7.00

### DIFF
--- a/pkgs/by-name/pr/profile-sync-daemon/package.nix
+++ b/pkgs/by-name/pr/profile-sync-daemon/package.nix
@@ -3,31 +3,63 @@
   stdenv,
   fetchFromGitHub,
   util-linux,
+  fuse-overlayfs,
+  runCommand,
+  writableTmpDirAsHomeHook,
+  makeWrapper,
   coreutils,
+  rsync,
+  kmod,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "profile-sync-daemon";
-  version = "6.50";
+  version = "7.00";
 
   src = fetchFromGitHub {
     owner = "graysky2";
     repo = "profile-sync-daemon";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Wb9YLxuu9i9s/Y6trz5NZDU9WRywe3138cp5Q2gWbxM=";
+    hash = "sha256-XlpKHU+TvTxDGvpfr4wRV4GsVyVmxEKQ7J4Ac2sqybo=";
   };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
 
   installPhase = ''
     PREFIX=\"\" DESTDIR=$out make install
     substituteInPlace $out/bin/profile-sync-daemon \
-      --replace "/usr/" "$out/" \
-      --replace "sudo " "/run/wrappers/bin/sudo "
+      --replace-fail "/usr/bin/fuse-overlayfs" "${fuse-overlayfs}/bin/fuse-overlayfs" \
+      --replace-fail "/usr/share/" "$out/share/" \
+      --replace-fail "sudo " "/run/wrappers/bin/sudo "
     # $HOME detection fails (and is unnecessary)
     sed -i '/^HOME/d' $out/bin/profile-sync-daemon
-    substituteInPlace $out/bin/psd-overlay-helper \
-      --replace "PATH=/usr/bin:/bin" "PATH=${util-linux.bin}/bin:${coreutils}/bin" \
-      --replace "sudo " "/run/wrappers/bin/sudo "
+    wrapProgram $out/bin/profile-sync-daemon \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          rsync
+          kmod
+        ]
+      }
   '';
+
+  passthru.tests.simple =
+    runCommand "profile-sync-daemon preview"
+      {
+        nativeBuildInputs = [
+          finalAttrs.finalPackage
+          writableTmpDirAsHomeHook
+        ];
+      }
+      ''
+        # The script tells you to modify your config and to run again.
+        profile-sync-daemon preview
+        profile-sync-daemon preview
+
+        touch $out
+      '';
 
   meta = {
     description = "Syncs browser profile dirs to RAM";


### PR DESCRIPTION
Updates the package, and adds fuse-overlayfs bin because upstream uses that now rather than old helper.

Resolves #500504 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
