### PR TITLE
python3Packages.{langchain,langgraph,langsmith}: version bump

### DIFF
--- a/pkgs/development/python-modules/langchain-anthropic/default.nix
+++ b/pkgs/development/python-modules/langchain-anthropic/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-anthropic";
-  version = "1.3.4";
+  version = "1.3.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-anthropic==${finalAttrs.version}";
-    hash = "sha256-8dGP26N2aheMTtI2wYMBVitlzrTsJZa5Zt5xVl+vqI4=";
+    hash = "sha256-R4X2WEU1I9HuuA9k4/6NrRMYuLjS6DQHQeP3xzp+Uso=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/partners/anthropic";

--- a/pkgs/development/python-modules/langchain-aws/default.nix
+++ b/pkgs/development/python-modules/langchain-aws/default.nix
@@ -8,13 +8,14 @@
 
   # dependencies
   boto3,
+  langchain,
   langchain-core,
   numpy,
   pydantic,
 
   # optional-dependencies
-  langchain-anthropic,
   anthropic,
+  langchain-anthropic,
 
   # tests
   langchain-tests,
@@ -28,14 +29,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-aws";
-  version = "1.3.1";
+  version = "1.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-aws";
     tag = "langchain-aws==${finalAttrs.version}";
-    hash = "sha256-hKMTzN2NVMSMCVsFroFFUM0embz8KHbDnmunwOb9ofw=";
+    hash = "sha256-1zeZsLff0dcn9rJZu6zR6l/oXvXPXNTqKo0Ma+cXafo=";
   };
 
   postPatch = ''
@@ -49,6 +50,7 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     boto3
+    langchain
     langchain-core
     numpy
     pydantic

--- a/pkgs/development/python-modules/langchain-classic/default.nix
+++ b/pkgs/development/python-modules/langchain-classic/default.nix
@@ -42,14 +42,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-classic";
-  version = "1.0.2";
+  version = "1.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-classic==${finalAttrs.version}";
-    hash = "sha256-NH2l2Htt5nAzzvwKUgQNwvQBLxZKhOLxnxthvK/Yh4I=";
+    hash = "sha256-vCYdBBN9vU8gWedCxKXnzLzZ5C7pYl3KyECBNAQggto=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/langchain";

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -36,14 +36,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-core";
-  version = "1.2.18";
+  version = "1.2.19";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-core==${finalAttrs.version}";
-    hash = "sha256-Mk9Kr12wclBw2Q1YeJMg1MBe5XD0q09P2fgKZam/cK0=";
+    hash = "sha256-qQ0bCg+ghb84tafyahMzA4GroLz8smGfwIUg2bHmY0w=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/core";

--- a/pkgs/development/python-modules/langchain-mistralai/default.nix
+++ b/pkgs/development/python-modules/langchain-mistralai/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-mistralai";
-  version = "1.1.1";
+  version = "1.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-mistralai==${version}";
-    hash = "sha256-cdUl6LusttH6c0tBvaxQR5UGHjwyubKELCDv61VQ6Qo=";
+    hash = "sha256-vCYdBBN9vU8gWedCxKXnzLzZ5C7pYl3KyECBNAQggto=";
   };
 
   sourceRoot = "${src.name}/libs/partners/mistralai";

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -46,14 +46,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain";
-  version = "1.2.10";
+  version = "1.2.12";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain==${finalAttrs.version}";
-    hash = "sha256-Icgka7z1wLuxEjUO5baxMya7KfltYsK8TXtCMg73E1Q=";
+    hash = "sha256-Z0noVsSu0OZchynlJSkIe0p076/0nay+1uS2ZXnztns=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/langchain_v1";

--- a/pkgs/development/python-modules/langgraph-cli/default.nix
+++ b/pkgs/development/python-modules/langgraph-cli/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langgraph-cli";
-  version = "0.4.17";
+  version = "0.4.18";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "cli==${finalAttrs.version}";
-    hash = "sha256-liyQPt0S2zfRSDZ0LYn1QmNrqyEUYiF6LL2pPt210j8=";
+    hash = "sha256-KhDvdy7iZtaSLRNdmdObv3KbUiOMkcHtCRZ3/13AQak=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/cli";

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -41,14 +41,14 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "langgraph";
-  version = "1.0.10";
+  version = "1.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = finalAttrs.version;
-    hash = "sha256-NJSmpVshj/x6ws+jFYXGarNKNztbk5OIIMA1neFOyIY=";
+    hash = "sha256-Dbzyp9Tl6VaLoWDnLk5UCiYnWFcZM3kljv8EdB1IEAI=";
   };
 
   postgresqlTestSetupPost = ''
@@ -135,6 +135,8 @@ buildPythonPackage (finalAttrs: {
     "tests/test_pregel_async.py"
     "tests/test_subgraph_persistence.py"
     "tests/test_subgraph_persistence_async.py"
+    "tests/test_time_travel.py"
+    "tests/test_time_travel_async.py"
   ];
 
   # Since `langgraph` is the only unprefixed package, we have to use an explicit match

--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -31,14 +31,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langsmith";
-  version = "0.7.14";
+  version = "0.7.18";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langsmith-sdk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uoWevYxIjslOKzsbVaYc3KZjpG9703S/ucVaCK85R5M=";
+    hash = "sha256-praKCpNzZ8e+QEU9Ji9ryspzIiF9X98rUOvMbwjMZho=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python";
@@ -93,9 +93,7 @@ buildPythonPackage (finalAttrs: {
     # due to circular import
     "tests/unit_tests/test_client.py"
     "tests/unit_tests/evaluation/test_runner.py"
-    # flaky time comparisons
-    # https://github.com/langchain-ai/langsmith-sdk/issues/2245
-    "tests/unit_tests/test_uuid_v7.py"
+
     # google-adk isn't packaged (and has an enormous number of dependencies)
     "tests/unit_tests/wrappers/test_google_adk.py"
   ];


### PR DESCRIPTION
Version updates via `update.nix`. Updating langgraph required updating langchain (which was missing a dependency) and it became worthwhile to update the whole cohort at once.

*  python3Packages.langsmith: 0.7.17 -> 0.7.18
*  python3Packages.langchain-mistralai: 1.1.1 -> 1.1.2
*  python3Packages.langchain-classic: 1.0.2 -> 1.0.3
*  python3Packages.langchain-anthropic: 1.3.4 -> 1.3.5
*  python3Packages.langchain-core: 1.2.18 -> 1.2.19
*  python3Packages.langchain-aws: 1.3.1 -> 1.4.0
*  python3Packages.langchain: 1.2.10 -> 1.2.12
*  python3Packages.langgraph: 1.0.10 -> 1.1.2
*  langgraph-cli: 0.4.17 -> 0.4.18


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
