### PR TITLE
fantasque-sans-mono: use installFonts hook

### DIFF
--- a/pkgs/by-name/fa/fantasque-sans-mono/package.nix
+++ b/pkgs/by-name/fa/fantasque-sans-mono/package.nix
@@ -2,23 +2,31 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "fantasque-sans-mono";
   version = "1.8.0";
 
+  outputs = [
+    "out"
+    "webfont"
+    "doc"
+  ];
+
   src = fetchzip {
-    url = "https://github.com/belluzj/fantasque-sans/releases/download/v${version}/FantasqueSansMono-Normal.zip";
+    url = "https://github.com/belluzj/fantasque-sans/releases/download/v${finalAttrs.version}/FantasqueSansMono-Normal.zip";
     stripRoot = false;
     hash = "sha256-MNXZoDPi24xXHXGVADH16a3vZmFhwX0Htz02+46hWFc=";
   };
 
+  nativeBuildInputs = [ installFonts ];
+
   installPhase = ''
     runHook preInstall
 
-    install -Dm644 OTF/*.otf -t $out/share/fonts/opentype
-    install -Dm644 README.md -t $out/share/doc/${pname}-${version}
+    install -m644 -Dt $doc/share/doc/${finalAttrs.pname}-${finalAttrs.version} {*.md,*.txt}
 
     runHook postInstall
   '';
@@ -30,4 +38,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.rycee ];
   };
-}
+})


### PR DESCRIPTION
As per Issue [#495640](https://github.com/NixOS/nixpkgs/issues/495640), updated fantasque-sans-mono to use the new installFonts hook. Pleasant side effect of this is that now .otf, .ttf, .woff, and .woff2 fonts are installed instead of just .otf fonts. Besides this the documentation now includes CHANGELOG.md and LICENSE.txt in addition to README.md which was previously included. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.