### PR TITLE
buildDotnetModule: disallow using SelfContained on solutions

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -77,7 +77,7 @@ let
       # The type of build to perform. This is passed to `dotnet` with the `--configuration` flag. Possible values are `Release`, `Debug`, etc.
       buildType ? "Release",
       # If set to true, builds the application as a self-contained - removing the runtime dependency on dotnet
-      selfContainedBuild ? false,
+      selfContainedBuild ? null,
       # Whether to use an alternative wrapper, that executes the application DLL using the dotnet runtime from the user environment. `dotnet-runtime` is provided as a default in case no .NET is installed
       # This is useful for .NET tools and applications that may need to run under different .NET runtimes
       useDotnetFromEnv ? false,

--- a/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
+++ b/pkgs/build-support/dotnet/build-dotnet-module/hook/dotnet-hook.sh
@@ -115,6 +115,11 @@ dotnetBuildPhase() {
     local useRuntime=
     _dotnetIsSolution "$projectFile" || useRuntime=1
 
+    if [[ -v dotnetSelfContainedBuild && -z "${useRuntime:-}" ]]; then
+      echo "Building a solution with selfContainedBuild specified is not supported"
+      exit 1
+    fi
+
     for runtimeId in "${runtimeIds[@]}"; do
       local runtimeIdFlags=()
       if [[ -n $useRuntime ]]; then
@@ -197,6 +202,11 @@ dotnetCheckPhase() {
   for projectFile in "${testProjectFiles[@]-${projectFiles[@]}}"; do
     local useRuntime=
     _dotnetIsSolution "$projectFile" || useRuntime=1
+
+    if [[ -v dotnetSelfContainedBuild && -z "${useRuntime:-}" ]]; then
+      echo "Building a solution with selfContainedBuild specified is not supported"
+      exit 1
+    fi
 
     for runtimeId in "${runtimeIds[@]}"; do
       local runtimeIdFlags=()
@@ -369,6 +379,11 @@ dotnetInstallPhase() {
     local useRuntime=
     _dotnetIsSolution "$projectFile" || useRuntime=1
 
+    if [[ -v dotnetSelfContainedBuild && -z "${useRuntime:-}" ]]; then
+      echo "Building a solution with selfContainedBuild specified is not supported"
+      exit 1
+    fi
+
     for runtimeId in "${runtimeIds[@]}"; do
       local runtimeIdFlags=()
       if [[ -n $useRuntime ]]; then
@@ -395,6 +410,11 @@ dotnetInstallPhase() {
 
     local useRuntime=
     _dotnetIsSolution "$projectFile" || useRuntime=1
+
+    if [[ -v dotnetSelfContainedBuild && -z "${useRuntime:-}" ]]; then
+      echo "Building a solution with selfContainedBuild specified is not supported"
+      exit 1
+    fi
 
     for runtimeId in "${runtimeIds[@]}"; do
       local runtimeIdFlags=()

--- a/pkgs/by-name/ar/archisteamfarm/package.nix
+++ b/pkgs/by-name/ar/archisteamfarm/package.nix
@@ -44,8 +44,6 @@ buildDotnetModule rec {
   executable = "ArchiSteamFarm";
   installPath = "${placeholder "out"}/lib/ArchiSteamFarm";
 
-  enableParallelBuilding = false;
-
   useAppHost = false;
   dotnetFlags = [
     # useAppHost doesn't explicitly disable this

--- a/pkgs/by-name/au/audiothekar/package.nix
+++ b/pkgs/by-name/au/audiothekar/package.nix
@@ -20,11 +20,6 @@ buildDotnetModule rec {
 
   projectFile = "Audiothekar.sln";
 
-  # > Unable to use package assets cache due to I/O error. This can occur when
-  # > the same project is built more than once in parallel. Performance may be
-  # > degraded, but the build result will not be impacted.
-  enableParallelBuilding = false;
-
   doCheck = false;
 
   nugetDeps = ./deps.json;

--- a/pkgs/by-name/bo/boogie/package.nix
+++ b/pkgs/by-name/bo/boogie/package.nix
@@ -22,9 +22,6 @@ buildDotnetModule rec {
   projectFile = [ "Source/Boogie.sln" ];
   nugetDeps = ./deps.json;
 
-  # [...]Microsoft.NET.Publish.targets(248,5): error MSB3021: Unable to copy file "[...]/NUnit3.TestAdapter.pdb" to "[...]/NUnit3.TestAdapter.pdb". Access to the path '[...]/NUnit3.TestAdapter.pdb' is denied. [[...]/ExecutionEngineTests.csproj]
-  enableParallelBuilding = false;
-
   executables = [ "BoogieDriver" ];
 
   makeWrapperArgs = [

--- a/pkgs/by-name/du/duplicati/package.nix
+++ b/pkgs/by-name/du/duplicati/package.nix
@@ -75,8 +75,6 @@ buildDotnetModule rec {
   dotnet-sdk = dotnetCorePackages.sdk_8_0;
   dotnet-runtime = dotnetCorePackages.aspnetcore_8_0;
 
-  enableParallelBuilding = false;
-
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
   buildInputs = [

--- a/pkgs/by-name/ev/everest/package.nix
+++ b/pkgs/by-name/ev/everest/package.nix
@@ -67,9 +67,6 @@ buildDotnetModule {
   # Needed for ILAsm projects: https://github.com/NixOS/nixpkgs/issues/370754#issuecomment-2571475814
   linkNugetPackages = true;
 
-  # Microsoft.NET.Sdk complains: The process cannot access the file xxx because it is being used by another process.
-  enableParallelBuilding = false;
-
   preBuild = ''
     # See .azure-pipelines/prebuild.ps1
     sed -i 's|0\.0\.0-dev|1.${version}.0-nixos-${lib.substring 0 5 rev}|' Celeste.Mod.mm/Mod/Everest/Everest.cs

--- a/pkgs/by-name/kn/knossosnet/package.nix
+++ b/pkgs/by-name/kn/knossosnet/package.nix
@@ -26,9 +26,6 @@ buildDotnetModule rec {
   nugetDeps = ./deps.json;
   executables = [ "Knossos.NET" ];
 
-  # IO errors in build due to solution building race
-  enableParallelBuilding = false;
-
   runtimeDeps = [ openal ];
 
   env = {

--- a/pkgs/by-name/n-/n-m3u8dl-re/package.nix
+++ b/pkgs/by-name/n-/n-m3u8dl-re/package.nix
@@ -19,11 +19,6 @@ buildDotnetModule (finalAttrs: {
     ./publish-fix.patch
   ];
 
-  # from openutau/default.nix
-  # [...]/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(248,5): error MSB4018: The "GenerateDepsFile" task failed unexpectedly. [[...]/N_m3u8DL-RE.Common.csproj]
-  # [...]/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(248,5): error MSB4018: System.IO.IOException: The process cannot access the file '[...]/N_m3u8DL-RE.Common.deps.json' because it is being used by another process. [[...]/N_m3u8DL-RE.Common.csproj]
-  enableParallelBuilding = false;
-
   projectFile = "src/N_m3u8DL-RE.sln";
   nugetDeps = ./deps.json;
 

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -34,8 +34,6 @@ buildDotnetModule (finalAttrs: {
 
   gameHashes = callPackage ./game-hashes { };
 
-  enableParallelBuilding = false;
-
   # If the whole solution is published, there seems to be a race condition where
   # it will sometimes publish the wrong version of a dependent assembly, for
   # example: Microsoft.Extensions.Hosting.dll 6.0.0 instead of 8.0.0.

--- a/pkgs/by-name/op/openutau/package.nix
+++ b/pkgs/by-name/op/openutau/package.nix
@@ -45,10 +45,6 @@ buildDotnetModule rec {
   dotnet-sdk = dotnetCorePackages.sdk_8_0;
   dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
-  # [...]/Microsoft.NET.Sdk.targets(157,5): error MSB4018: The "GenerateDepsFile" task failed unexpectedly. [[...]/OpenUtau.Core.csproj]
-  # [...]/Microsoft.NET.Sdk.targets(157,5): error MSB4018: System.IO.IOException: The process cannot access the file '[...]/OpenUtau.Core.deps.json' because it is being used by another process. [[...]/OpenUtau.Core.csproj]
-  enableParallelBuilding = false;
-
   projectFile = "OpenUtau.sln";
   nugetDeps = ./deps.json;
 

--- a/pkgs/by-name/re/renode/package.nix
+++ b/pkgs/by-name/re/renode/package.nix
@@ -116,8 +116,6 @@ buildDotnetModule rec {
 
   dontUseCmakeConfigure = true;
 
-  enableParallelBuilding = false;
-
   preBuild = ''
     mkdir -p lib/resources
     ln -s ${resources}/* lib/resources/

--- a/pkgs/by-name/ry/ryubing/package.nix
+++ b/pkgs/by-name/ry/ryubing/package.nix
@@ -51,8 +51,6 @@ buildDotnetModule rec {
       darwin.sigtool
     ];
 
-  enableParallelBuilding = false;
-
   dotnet-sdk = dotnetCorePackages.sdk_9_0;
   dotnet-runtime = dotnetCorePackages.runtime_9_0;
 

--- a/pkgs/by-name/tk/tkmm/package.nix
+++ b/pkgs/by-name/tk/tkmm/package.nix
@@ -58,7 +58,6 @@ buildDotnetModule (finalAttrs: {
     libxrandr
   ];
 
-  enableParallelBuilding = false;
   dotnetFlags = [
     ''-p:DefineConstants="READONLY_FS"''
   ];

--- a/pkgs/games/openra/build-engine.nix
+++ b/pkgs/games/openra/build-engine.nix
@@ -56,9 +56,6 @@ buildDotnetModule {
 
   dontDotnetFixup = true;
 
-  # Microsoft.NET.Publish.targets(248,5): error MSB3021: Unable to copy file "[...]/Newtonsoft.Json.dll" to "[...]/Newtonsoft.Json.dll". Access to the path '[...]Newtonsoft.Json.dll' is denied. [/build/source/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj]
-  enableParallelBuilding = false;
-
   preBuild = ''
     make VERSION=${engine.build}-${version} version
   '';


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/493140#discussion_r2943197059

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
