### PR TITLE
devenv: 2.0.4 -> 2.0.5

### DIFF
--- a/pkgs/by-name/de/devenv/package.nix
+++ b/pkgs/by-name/de/devenv/package.nix
@@ -23,16 +23,16 @@
 }:
 
 let
-  version = "2.0.4";
+  version = "2.0.5";
   devenvNixVersion = "2.32";
-  devenvNixRev = "41eee9d3b1f611b1b90d51caa858b6d83834c44a";
+  devenvNixRev = "ef483d53f25990bf0b4fd39f5414f885977ebd85";
 
   nix_components =
     (nixVersions.nixComponents_git.overrideSource (fetchFromGitHub {
       owner = "cachix";
       repo = "nix";
       rev = devenvNixRev;
-      hash = "sha256-vtf03lfgQKNkPH9FdXdboBDS5DtFkXB8xRw5EBpuDas=";
+      hash = "sha256-eY8JFns4OeEidye8VIW68LSoykbPO0bQujvQVLLK7Qg=";
     })).overrideScope
       (
         finalScope: prevScope: {
@@ -48,10 +48,10 @@ rustPlatform.buildRustPackage {
     owner = "cachix";
     repo = "devenv";
     tag = "v${version}";
-    hash = "sha256-wPH6q2PSP64doUXHqdEAmY68X4IAeC2UjSIyqzoUYwE=";
+    hash = "sha256-8tO3NLG9Lc/NUee0Owcf/z63TNTrUcx7eVRxSb294rk=";
   };
 
-  cargoHash = "sha256-CzhdUrNAAhCVnXZCk06djnBv1cczhj7tIG/JRmaBX5c=";
+  cargoHash = "sha256-ecntFSPDWblllDtS/D086UKtQJG9La4TGEBhP3q0CfY=";
 
   env = {
     RUSTFLAGS = "--cfg tracing_unstable";


### PR DESCRIPTION
## Summary
- Update devenv from 2.0.4 to 2.0.5
- https://github.com/cachix/devenv/releases/tag/v2.0.5

## Test plan
- [x] Built on x86_64-linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)