### PR TITLE
ntpd-rs: skip tests depending on timestamped certs

### DIFF
--- a/pkgs/by-name/nt/ntpd-rs/package.nix
+++ b/pkgs/by-name/nt/ntpd-rs/package.nix
@@ -29,6 +29,28 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installShellFiles
   ];
 
+  # These fail based on timestamp issues with bundled certificates
+  # See https://github.com/NixOS/nixpkgs/issues/497682 & https://github.com/pendulum-project/ntpd-rs/pull/2133
+  checkFlags = [
+    "--skip=daemon::keyexchange::tests::key_exchange_connection_limiter"
+    "--skip=daemon::keyexchange::tests::key_exchange_roundtrip_with_port_server"
+    "--skip=daemon::ntp_source::tests::test_deny_stops_poll"
+    "--skip=daemon::ntp_source::tests::test_timeroundtrip"
+    "--skip=daemon::server::tests::test_server_serves"
+    "--skip=nts::tests::test_key_exchange_roundtrip_no_cookies"
+    "--skip=nts::tests::test_keyexchange_fixed_key_no_permission"
+    "--skip=nts::tests::test_keyexchange_roundtrip_fixed_key"
+    "--skip=nts::tests::test_keyexchange_roundtrip_fixed_key_keep_alive"
+    "--skip=nts::tests::test_keyexchange_roundtrip_fixed_key_no_permit"
+    "--skip=nts::tests::test_keyexchange_roundtrip_no_proto_overlap"
+    "--skip=nts::tests::test_keyexchange_roundtrip_no_upgrade_possible"
+    "--skip=nts::tests::test_keyexchange_roundtrip_supports"
+    "--skip=nts::tests::test_keyexchange_roundtrip_upgrading"
+    "--skip=nts::tests::test_keyexchange_roundtrip_v4"
+    "--skip=nts::tests::test_keyexchange_roundtrip_v5"
+    "--skip=nts::tests::test_keyexchange_supports_no_permission"
+  ];
+
   postPatch = ''
     substituteInPlace utils/generate-man.sh \
       --replace-fail 'utils/pandoc.sh' 'pandoc'


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/497682
Supersedes https://github.com/NixOS/nixpkgs/pull/500513

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
