### PR TITLE
windsend-rs: 1.5.5 -> 1.7.1

### DIFF
--- a/pkgs/by-name/wi/windsend-rs/package.nix
+++ b/pkgs/by-name/wi/windsend-rs/package.nix
@@ -17,16 +17,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "windsend-rs";
-  version = "1.5.5";
+  version = "1.7.1";
 
   src = fetchFromGitHub {
     owner = "doraemonkeys";
     repo = "WindSend";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-u82VmMuc7+tbc1Qgs5lbyFlNTauJm6E9KFXPHBdTryA=";
+    hash = "sha256-r3D6Uj8buMceqXov6An+OxgOTcNFrX5PwxhphtbeUv0=";
   };
 
-  cargoHash = "sha256-dn6O2cCOPInktrKrcZBwN2FwmKUjm3crCL6yhIPQj/Y=";
+  cargoHash = "sha256-uRL9cnvEZzaO/Qewl8Nm1LZlidCLLDC/RDY2j5byMnE=";
 
   sourceRoot = "${finalAttrs.src.name}/windSend-rs";
 
@@ -42,6 +42,21 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
     wayland
     xdotool
+  ];
+
+  checkFlags = [
+    # need x11 server
+    "--skip=route::sync_session::tests::idle_transport_sends_single_heartbeat_probe"
+    "--skip=route::sync_session::tests::out_of_order_event_is_rejected_with_protocol_close"
+    "--skip=route::sync_session::tests::peer_close_releases_session_instead_of_detaching"
+    "--skip=route::sync_session::tests::resume_after_disconnect_replays_detached_queue"
+    "--skip=route::sync_session::tests::slow_partial_inbound_frame_does_not_trip_peer_silence_timeout"
+    "--skip=sync::clipboard_event_hub::tests::remote_applies_update_baseline_without_fan_out"
+    "--skip=sync::clipboard_event_hub::tests::semantic_duplicates_are_not_fanned_out_twice"
+    "--skip=sync::session_registry::tests::detached_session_keeps_fan_out_queue_until_ttl_expires"
+    "--skip=sync::session_registry::tests::resume_attach_rejects_expired_sessions"
+    "--skip=sync::session_registry::tests::resume_attach_rotates_token_bumps_generation_and_applies_resume_ack"
+    "--skip=sync::session_registry::tests::start_attach_rejects_duplicate_session_ids"
   ];
 
   desktopItems = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/doraemonkeys/WindSend/releases/tag/v1.7.1
https://github.com/doraemonkeys/WindSend/compare/v1.5.5...v1.7.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
