### PR TITLE
rocmPackages.composable_kernel: adjust split, fix MIOPEN_REQ_LIBS_ONLY exclusions

### DIFF
--- a/pkgs/development/rocm-modules/composable_kernel/base.nix
+++ b/pkgs/development/rocm-modules/composable_kernel/base.nix
@@ -127,6 +127,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Hacky fix for failure for some targets when all targets are selected out
     # for a non-optional at link time kernel
     ./fix-empty-offload-targets.diff
+    # Replace the broad MIOPEN_REQ_LIBS_ONLY "conv" str filter with correct allowlist
+    # to avoid building kernels that are never used by MIOpen despite
+    # MIOPEN_REQ_LIBS_ONLY being set
+    ./miopen-req-libs-only-allowlist.patch
   ];
 
   postPatch =

--- a/pkgs/development/rocm-modules/composable_kernel/default.nix
+++ b/pkgs/development/rocm-modules/composable_kernel/default.nix
@@ -43,33 +43,59 @@ let
         "gfx950"
       ];
     };
-    grouped_conv_bwd = {
+    grouped_conv_bwd1 = {
       targets = [
-        "device_grouped_conv1d_bwd_weight_instance"
         "device_grouped_conv2d_bwd_data_instance"
+      ];
+    };
+    grouped_conv_bwd2 = {
+      targets = [
         "device_grouped_conv2d_bwd_weight_instance"
       ];
     };
-    grouped_conv_fwd = {
+    grouped_conv_bwd3 = {
+      enabled = !miOpenReqLibsOnly;
       targets = [
-        "device_grouped_conv1d_fwd_instance"
+        "device_grouped_conv1d_bwd_weight_instance"
+      ];
+    };
+    grouped_conv_fwd1 = {
+      targets = [
         "device_grouped_conv2d_fwd_instance"
-        "device_grouped_conv2d_fwd_bias_bnorm_clamp_instance"
+      ];
+    };
+    grouped_conv_fwd2 = {
+      targets = [
         "device_grouped_conv2d_fwd_bias_clamp_instance"
         "device_grouped_conv2d_fwd_clamp_instance"
+      ];
+    };
+    grouped_conv_fwd3 = {
+      enabled = !miOpenReqLibsOnly;
+      targets = [
+        "device_grouped_conv1d_fwd_instance"
+        "device_grouped_conv2d_fwd_bias_bnorm_clamp_instance"
         "device_grouped_conv2d_fwd_dynamic_op_instance"
       ];
     };
     grouped_conv_bwd_3d1 = {
       targets = [
         "device_grouped_conv3d_bwd_data_instance"
-        "device_grouped_conv3d_bwd_data_bilinear_instance"
-        "device_grouped_conv3d_bwd_data_scale_instance"
       ];
     };
     grouped_conv_bwd_3d2 = {
       targets = [
+        "device_grouped_conv3d_bwd_data_bilinear_instance"
+        "device_grouped_conv3d_bwd_data_scale_instance"
+      ];
+    };
+    grouped_conv_bwd_3d3 = {
+      targets = [
         "device_grouped_conv3d_bwd_weight_instance"
+      ];
+    };
+    grouped_conv_bwd_3d4 = {
+      targets = [
         "device_grouped_conv3d_bwd_weight_bilinear_instance"
         "device_grouped_conv3d_bwd_weight_scale_instance"
       ];
@@ -77,25 +103,35 @@ let
     grouped_conv_fwd_3d1 = {
       targets = [
         "device_grouped_conv3d_fwd_instance"
-        "device_grouped_conv3d_fwd_clamp_instance"
-        "device_grouped_conv3d_fwd_bias_bnorm_clamp_instance"
-        "device_grouped_conv3d_fwd_bias_clamp_instance"
-        "device_grouped_conv3d_fwd_bilinear_instance"
-        "device_grouped_conv3d_fwd_convinvscale_instance"
-        "device_grouped_conv3d_fwd_convscale_instance"
-        "device_grouped_conv3d_fwd_convscale_add_instance"
       ];
     };
     grouped_conv_fwd_3d2 = {
       targets = [
-        "device_grouped_conv3d_fwd_convscale_relu_instance"
-        "device_grouped_conv3d_fwd_dynamic_op_instance"
+        "device_grouped_conv3d_fwd_bias_clamp_instance"
+      ];
+    };
+    grouped_conv_fwd_3d3 = {
+      targets = [
+        "device_grouped_conv3d_fwd_bilinear_instance"
+        "device_grouped_conv3d_fwd_clamp_instance"
         "device_grouped_conv3d_fwd_scale_instance"
-        "device_grouped_conv3d_fwd_scaleadd_ab_instance"
         "device_grouped_conv3d_fwd_scaleadd_scaleadd_relu_instance"
       ];
     };
+    grouped_conv_fwd_3d4 = {
+      enabled = !miOpenReqLibsOnly;
+      targets = [
+        "device_grouped_conv3d_fwd_bias_bnorm_clamp_instance"
+        "device_grouped_conv3d_fwd_convinvscale_instance"
+        "device_grouped_conv3d_fwd_convscale_instance"
+        "device_grouped_conv3d_fwd_convscale_add_instance"
+        "device_grouped_conv3d_fwd_convscale_relu_instance"
+        "device_grouped_conv3d_fwd_dynamic_op_instance"
+        "device_grouped_conv3d_fwd_scaleadd_ab_instance"
+      ];
+    };
     grouped_conv_fwd_nd = {
+      enabled = !miOpenReqLibsOnly;
       targets = [
         "device_grouped_convnd_bwd_weight_instance"
       ];
@@ -169,12 +205,17 @@ let
     };
     conv = {
       targets = [
-        "device_conv1d_bwd_data_instance"
         "device_conv2d_bwd_data_instance"
         "device_conv2d_fwd_instance"
         "device_conv2d_fwd_bias_relu_instance"
-        "device_conv2d_fwd_bias_relu_add_instance"
         "device_conv3d_bwd_data_instance"
+      ];
+    };
+    conv2 = {
+      enabled = !miOpenReqLibsOnly;
+      targets = [
+        "device_conv1d_bwd_data_instance"
+        "device_conv2d_fwd_bias_relu_add_instance"
       ];
     };
     pool = {
@@ -188,6 +229,7 @@ let
       ];
     };
     other0 = {
+      enabled = !miOpenReqLibsOnly;
       targets = [
         "device_quantization_instance"
       ];

--- a/pkgs/development/rocm-modules/composable_kernel/miopen-req-libs-only-allowlist.patch
+++ b/pkgs/development/rocm-modules/composable_kernel/miopen-req-libs-only-allowlist.patch
@@ -1,0 +1,49 @@
+diff --git a/library/src/tensor_operation_instance/gpu/CMakeLists.txt b/library/src/tensor_operation_instance/gpu/CMakeLists.txt
+index 172f6681b8..826b6bf50b 100644
+--- a/library/src/tensor_operation_instance/gpu/CMakeLists.txt
++++ b/library/src/tensor_operation_instance/gpu/CMakeLists.txt
+@@ -321,8 +321,42 @@ FOREACH(subdir_path ${dir_list})
+         endif()
+ 
+         if(MIOPEN_REQ_LIBS_ONLY)
+-            message(STATUS "Removing all sources that are not required for MIOpen")
+-            if(NOT "${cmake_instance}" MATCHES "conv")
++            get_filename_component(_subdir_name ${subdir_path} NAME)
++            # Allowlist of instance directories used by MIOpen.
++            # MIOpen links device_conv_operations; traced from includes
++            # in MIOpen solver source (implicitgemm_ck_util.hpp,
++            # conv_hip_implicit_gemm_*_xdlops.cpp, conv_ck_igemm_*_fused.cpp).
++            set(_miopen_required_subdirs
++                # non-grouped conv (convolution_forward.hpp, convolution_backward_data.hpp)
++                conv2d_fwd
++                conv2d_fwd_bias_relu
++                conv2d_bwd_data
++                conv3d_bwd_data
++                # 2D grouped conv (grouped_convolution_forward.hpp, _backward_data.hpp, _backward_weight.hpp)
++                grouped_conv2d_fwd
++                grouped_conv2d_bwd_data
++                grouped_conv2d_bwd_weight
++                # 2D grouped fused (grouped_convolution_forward_clamp.hpp, _bias_clamp.hpp)
++                grouped_conv2d_fwd_clamp
++                grouped_conv2d_fwd_bias_clamp
++                # 3D grouped conv (same headers as 2D, NumDimSpatial=3 branches)
++                grouped_conv3d_fwd
++                grouped_conv3d_bwd_data
++                grouped_conv3d_bwd_weight
++                # 3D grouped fused (grouped_convolution_forward_{bilinear,scale,clamp,bias_clamp,scaleadd_scaleadd_relu}.hpp)
++                grouped_conv3d_fwd_bilinear
++                grouped_conv3d_fwd_scale
++                grouped_conv3d_fwd_clamp
++                grouped_conv3d_fwd_bias_clamp
++                grouped_conv3d_fwd_scaleadd_scaleadd_relu
++                # 3D grouped bwd fused (grouped_convolution_backward_data_{bilinear,scale}.hpp)
++                grouped_conv3d_bwd_data_bilinear
++                grouped_conv3d_bwd_data_scale
++                # 3D grouped wrw fused (grouped_convolution_backward_weight_{bilinear,scale}.hpp)
++                grouped_conv3d_bwd_weight_bilinear
++                grouped_conv3d_bwd_weight_scale
++            )
++            if(NOT _subdir_name IN_LIST _miopen_required_subdirs)
+                 set(add_inst 0)
+             endif()
+         endif()


### PR DESCRIPTION
MIOPEN_REQ_LIBS_ONLY was incorrectly including unused kernels due to a str 'conv' match hitting various unneeded instances.

Not turning into upstream PR, CK is in plans to migrate to header-only usage soon™ so would be pointless churn.

The new split makes the time per shard much more even for grouped conv ops:

```
┏━ Dependency Graph:
┃    ┌─ ✔ composable_kernel-conv-7.2.0 on [3] ⏱ 4m18s
┃    ├─ ✔ composable_kernel-grouped_conv_bwd_3d2-7.2.0 on [3] ⏱ 34m34s
┃    ├─ ✔ composable_kernel-grouped_conv_bwd2-7.2.0 on [3] ⏱ 48m26s
┃    ├─ ✔ composable_kernel-grouped_conv_bwd_3d4-7.2.0 on [2] ⏱ 56m22s
┃    ├─ ✔ composable_kernel-grouped_conv_fwd2-7.2.0 ⏱ 58m44s
┃    ├─ ✔ composable_kernel-grouped_conv_bwd_3d3-7.2.0 on [2] ⏱ 1h2m12s
┃    ├─ ✔ composable_kernel-grouped_conv_bwd1-7.2.0 on [2] ⏱ 1h4m52s
┃    ├─ ✔ composable_kernel-grouped_conv_bwd_3d1-7.2.0 on [2] ⏱ 1h8m11s
┃    ├─ ✔ composable_kernel-grouped_conv_fwd_3d1-7.2.0 on [3] ⏱ 1h18m29s
┃    ├─ ✔ composable_kernel-grouped_conv_fwd1-7.2.0 ⏱ 1h24m17s
┃    ├─ ✔ composable_kernel-grouped_conv_fwd_3d2-7.2.0 on [3] ⏱ 50m30s
┃    ├─ ✔ composable_kernel-grouped_conv_fwd_3d3-7.2.0 on [3] ⏱ 41m31s
┃ ┌─ ✔ composable_kernel-7.2.0 on [1] ⏱ 41s
┃ ✔ review-shell 
```

Sadly, fwd1 is an outlier with a single instance and can't be trivially split further but it's still an improvement.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
