### PR TITLE
ibtool: init at 1.1.3

### DIFF
--- a/pkgs/by-name/ib/ibtool/package.nix
+++ b/pkgs/by-name/ib/ibtool/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  icu,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "ibtool";
+  version = "1.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "viraptor";
+    repo = "ibtool";
+    tag = finalAttrs.version;
+    hash = "sha256-O2CCuM34U5EbqgkFXs/vokM2Q1bv5mqBgFqfhDP463Y=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    lxml
+  ];
+
+  runtimeDependencies = [
+    icu
+  ];
+
+  meta = {
+    description = "Apple's ibtool reimplementation";
+    homepage = "https://github.com/viraptor/ibtool";
+    license = [ lib.licenses.mit ];
+    mainProgram = "ibtool";
+    maintainers = [ lib.maintainers.viraptor ];
+  };
+})


### PR DESCRIPTION
## Things done

Initial version of the Apple's ibtool reimplementation. Supports macos only, not ios and others.
Aims for the full compatibility, but is still in early stages. Compiles transmission and r-macgui successfully.

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
