### PR TITLE
google-clasp: 3.2.0 -> 3.3.0

### DIFF
--- a/pkgs/by-name/go/google-clasp/package.nix
+++ b/pkgs/by-name/go/google-clasp/package.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage rec {
   pname = "clasp";
-  version = "3.2.0";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "clasp";
     tag = "v${version}";
-    hash = "sha256-JLfkGxUHvde5RXlIWH+raBvTwqvpHOR/ul4yArLFj28=";
+    hash = "sha256-6HHkGcWzzrfIjQUPycSkF4pM/vrOo9rvWUnhHrA4LJ8=";
   };
 
-  npmDepsHash = "sha256-dT0HA21wvU+wP5/9juMYinY60Fq5ngWl5dgj0JJi9hM=";
+  npmDepsHash = "sha256-zQt+diejFiG1oEkXxN5/X9rh33wHenk+iWeHsack/kY=";
 
   # `npm run build` tries installing clasp globally
   npmBuildScript = [ "compile" ];


### PR DESCRIPTION
Diff: https://github.com/google/clasp/compare/v3.2.0...v3.3.0

Changelog: https://github.com/google/clasp/releases/tag/v3.3.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
