### PR TITLE
gnomeExtensions.light-dict: manually pack adding OCR dependencies

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4457,6 +4457,12 @@
     githubId = 37775;
     name = "Kirill A. Korinsky";
   };
+  caterpillar = {
+    email = "w@caterpillar.ink";
+    github = "caterpillar-1";
+    githubId = 39209322;
+    name = "Caterpillar";
+  };
   cathalmullan = {
     email = "contact@cathal.dev";
     github = "CathalMullan";

--- a/pkgs/desktops/gnome/extensions/light-dict/default.nix
+++ b/pkgs/desktops/gnome/extensions/light-dict/default.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  replaceVars,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  python3, # src/ldocr.py
+  bash, # cli/*.sh
+  gobject-introspection, # src/ldocr.py
+  sassc, # res/style/meson.build, res/data/theme/meson.build
+  gjs, # res/data/scalable/status/meson.build
+  libsoup_3,
+  libxml2, # res/data/extension_gresource require xmllint
+  gettext, # cli/update-po.sh
+  curl, # cli/get-version.sh
+  glib, # meson.build
+}:
+
+let
+  python3-env =
+    python3.withPackages # src/ldocr.py
+      (
+        ps: with ps; [
+          # for OCR
+          opencv4
+          pytesseract
+          pygobject3
+        ]
+      );
+in
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-light-dict";
+  version = "49.0";
+
+  src = fetchFromGitHub {
+    owner = "tuberry";
+    repo = "light-dict";
+    rev = version;
+    sha256 = "sha256-+c5Mw9LfvPdxgeDk9Zoeh9YZvT+lnnKnRtQ0AUcJlrE=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    sassc
+    gjs
+    libsoup_3
+    libxml2
+    gettext
+    curl
+    glib
+  ];
+
+  patches = [
+    (replaceVars ./fix-paths.patch {
+      bash-path = lib.meta.getExe bash;
+      python-executable-path = lib.meta.getExe python3-env;
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "###gnome-shell-extensions-path###" "$out/share/gnome-shell/extensions/"
+  '';
+
+  configurePhase = ''
+    meson setup build
+  '';
+
+  buildPhase = ''
+    meson install -C build
+  '';
+
+  dontInstall = true;
+
+  buildInputs = [
+    gobject-introspection
+    python3-env
+  ];
+
+  passthru = {
+    extensionUuid = "light-dict@tuberry.github.io";
+    extensionPortalSlug = "light-dict";
+  };
+
+  meta = {
+    description = "Manipulate primary selections on the fly, typically used as Lightweight Dictionaries";
+    homepage = "https://github.com/tuberry/light-dict";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ caterpillar ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/desktops/gnome/extensions/light-dict/fix-paths.patch
+++ b/pkgs/desktops/gnome/extensions/light-dict/fix-paths.patch
@@ -1,0 +1,82 @@
+diff --git a/cli/_ldocr.sh b/cli/_ldocr.sh
+index a91ddaa..b5e11bf 100644
+--- a/cli/_ldocr.sh
++++ b/cli/_ldocr.sh
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!@bash-path@
+ # SPDX-FileCopyrightText: tuberry
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ 
+diff --git a/cli/get-version.sh b/cli/get-version.sh
+index 85755fb..10545a0 100755
+--- a/cli/get-version.sh
++++ b/cli/get-version.sh
+@@ -1,6 +1,5 @@
+-#!/bin/bash
++#!@bash-path@
+ # SPDX-FileCopyrightText: tuberry
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ 
+-RET=$(curl -sSf https://extensions.gnome.org/extension/"$EGO"/ | grep data-svm | sed -e 's/.*: //; s/}}"//') # | xargs -I{} expr {} + 1)
+-echo "${RET:?'ERROR: Failed to fetch version, build with -Dversion option to skip'}"
++echo 83
+diff --git a/cli/update-po.sh b/cli/update-po.sh
+index 1fdca32..8adaffd 100755
+--- a/cli/update-po.sh
++++ b/cli/update-po.sh
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!@bash-path@
+ # SPDX-FileCopyrightText: tuberry
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ 
+diff --git a/meson.build b/meson.build
+index 3063486..9c98f9f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -37,7 +37,7 @@ if(target == 'system')
+   schema_dir = datadir / 'glib-2.0' / 'schemas'
+   target_dir = datadir / 'gnome-shell' / 'extensions' / metadata['uuid']
+ else
+-  target_root = (target == 'local') ? fs.expanduser('~/.local/share/gnome-shell/extensions/') : meson.project_build_root()
++  target_root = '###gnome-shell-extensions-path###'
+   target_dir = target_root / metadata['uuid']
+   locale_dir = target_dir / 'locale'
+   schema_dir = target_dir / 'schemas'
+diff --git a/src/extension.js b/src/extension.js
+index 6af3e19..dd22b6f 100644
+--- a/src/extension.js
++++ b/src/extension.js
+@@ -276,7 +276,7 @@ class DictAct extends F.Mortal {
+         let ret = new F.Mortal();
+         this.$set.tie([
+             K.OCRP, [K.OCRS, null, x => this.$src.tray.hub?.$menu.ocr.choose(x)],
+-        ], ret, () => { ret.cmd = `python ${T.ROOT}/ldocr.py -m ${OCRModes[ret[K.OCRS]]} ${ret[K.OCRP]}`; }).tie([
++        ], ret, () => { ret.cmd = `@python-executable-path@ ${T.ROOT}/ldocr.py -m ${OCRModes[ret[K.OCRS]]} ${ret[K.OCRP]}`; }).tie([
+             [K.KEYS, x => !!x.length, x => ret.$src.keys.toggle(x)],
+             [K.DOCR, null, x => { ret.$src.dwell.toggle(x); this.$src.tray.hub?.$setDwell(x); }],
+         ], ret);
+diff --git a/src/ldocr.py b/src/ldocr.py
+index 80a38b9..7f34f7f 100644
+--- a/src/ldocr.py
++++ b/src/ldocr.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!@python-executable-path@
+ # SPDX-FileCopyrightText: tuberry
+ # SPDX-License-Identifier: GPL-3.0-or-later
+ # type: ignore
+diff --git a/src/prefs.js b/src/prefs.js
+index 8d87e4e..de4cae4 100644
+--- a/src/prefs.js
++++ b/src/prefs.js
+@@ -205,7 +205,7 @@ class PrefsBasic extends UI.Page {
+         let opencv = '<a href="https://github.com/opencv/opencv-python">opencv-python</a>',
+             tesseract = '<a href="https://github.com/madmaze/pytesseract">pytesseract</a>',
+             ocr = T.seq(new UI.Help()[$].set({popover: new Gtk.Popover()[$].connect('notify::visible', w => w.child?.select_region(-1, -1))}), // HACK: workaround for full selection on popup
+-                w => T.execute(`python ${T.ROOT}/ldocr.py -h`).then(x => w.setup(x, {selectable: true, cssClasses: ['ld-popover']})).catch(e => w.setup(e.message, null, true)));
++                w => T.execute(`@python-executable-path@ ${T.ROOT}/ldocr.py -h`).then(x => w.setup(x, {selectable: true, cssClasses: ['ld-popover']})).catch(e => w.setup(e.message, null, true)));
+         this.$add([null, [
+             [[_('Enable s_ystray'), _('Scroll to toggle the trigger style')], K.TRAY],
+             [[_('_Trigger style'), _('Passive means pressing Alt to trigger')], K.PSV, K.TRG],

--- a/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
+++ b/pkgs/desktops/gnome/extensions/manuallyPackaged.nix
@@ -23,4 +23,5 @@
   "window-corner-preview@fabiomereu.it" = callPackage ./window-corner-preview { };
   # Can be removed when https://github.com/oae/gnome-shell-pano/issues/271 resolved
   "pano@elhan.io" = callPackage ./pano { };
+  "light-dict@tuberry.github.io" = callPackage ./light-dict { };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Manually pack gnomeExtensions.light-dict

Light Dict depends on OpenCV and TesseractOCR.

This GNOME extension invokes custom python script, which has dependencies on OpenCV and TesseractOCR, via D-Bus (shell command) from JS. Patching python interpreter path in the command solves the problem.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. (`python` in the review enviroment is not the python executable used in the scripts, reviewers need to check shebang of `ldocr.py` and select the python executable manually)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (read the comment above)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
