### PR TITLE
lib/systems: fix `qemuArch` for `aarch64_be`

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -319,7 +319,7 @@ let
           if final.isAarch32 then
             "arm"
           else if final.isAarch64 then
-            "aarch64"
+            "aarch64${optionalString final.isBigEndian "_be"}"
           else if final.isS390 && !final.isS390x then
             null
           else if final.isx86_64 then


### PR DESCRIPTION
`qemuArch` returned "aarch64" for both LE and BE, causing binfmt to
register `qemu-aarch64` for `aarch64_be` binaries. QEMU ships separate
`qemu-aarch64` and `qemu-aarch64_be` binaries, so the wrong interpreter
was used, failing with "Invalid ELF image for this architecture".

Since QEMU distinguishes endianness in the binary name, this adds the
"_be" suffix via `isBigEndian`, which is similar to the approach MIPS 
uses a few lines below.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
