### PR TITLE
python3Packages.django-dbbackup: init at 5.2.0

### DIFF
--- a/pkgs/development/python-modules/django-dbbackup/default.nix
+++ b/pkgs/development/python-modules/django-dbbackup/default.nix
@@ -1,0 +1,56 @@
+{
+  buildPythonPackage,
+  django,
+  fetchFromGitHub,
+  gnupg,
+  lib,
+  psycopg2,
+  pytestCheckHook,
+  python-dotenv,
+  python-gnupg,
+  testfixtures,
+  writableTmpDirAsHomeHook,
+  hatchling,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "django-dbbackup";
+  version = "5.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Archmonger";
+    repo = "django-dbbackup";
+    tag = finalAttrs.version;
+    hash = "sha256-fl4ezDLHO6KwLfX5KMK9uMonONJCCDLyZUj9KMRZsGc=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    django
+  ];
+
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE=tests.settings
+  '';
+
+  pythonImportsCheck = [ "dbbackup" ];
+
+  nativeCheckInputs = [
+    gnupg
+    python-gnupg
+    psycopg2
+    pytestCheckHook
+    python-dotenv
+    testfixtures
+    writableTmpDirAsHomeHook
+  ];
+
+  meta = {
+    description = "Management commands to help backup and restore your project database and media files";
+    homepage = "https://github.com/Archmonger/django-dbbackup";
+    changelog = "https://github.com/Archmonger/django-dbbackup/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ kurogeek ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4160,6 +4160,8 @@ self: super: with self; {
 
   django-currentuser = callPackage ../development/python-modules/django-currentuser { };
 
+  django-dbbackup = callPackage ../development/python-modules/django-dbbackup { };
+
   django-debug-toolbar = callPackage ../development/python-modules/django-debug-toolbar { };
 
   django-dynamic-preferences =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
