### PR TITLE
opencloud: 5.1.0 -> 5.2.0

### DIFF
--- a/nixos/tests/opencloud.nix
+++ b/nixos/tests/opencloud.nix
@@ -41,7 +41,7 @@ let
         driver.find_element(By.ID, 'oc-login-password').send_keys(password)
         wait.until(EC.visibility_of_element_located((By.XPATH, '//button[@type="submit"]')))
         driver.find_element(By.XPATH, '//button[@type="submit"]').click()
-        wait.until(EC.visibility_of_element_located((By.ID, 'new-file-menu-btn')))
+        wait.until(EC.visibility_of_element_located((By.ID, 'app-floating-action-button-com-github-opencloud-eu-web-files-floating-action-button')))
         wait.until(EC.title_contains("Personal"))
       '';
 in

--- a/pkgs/by-name/op/opencloud/idp-web.nix
+++ b/pkgs/by-name/op/opencloud/idp-web.nix
@@ -2,9 +2,7 @@
   stdenvNoCC,
   lib,
   opencloud,
-  applyPatches,
-  fetchpatch,
-  pnpm_10,
+  pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -12,33 +10,22 @@
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencloud-idp-web";
 
-  inherit (opencloud) version;
-
-  src = applyPatches {
-    src = opencloud.src;
-    patches = [
-      # Fixes broken kopano tarball, remove in next version
-      (fetchpatch {
-        url = "https://github.com/opencloud-eu/opencloud/commit/212846f2f4e23e89ed675e5a689d87ba1de55b70.patch";
-        hash = "sha256-i+fkWTY4nrZ5fVGlQhhamxy9yrBL9OtDdm7CfV13oak=";
-      })
-    ];
-  };
+  inherit (opencloud) src version;
 
   pnpmRoot = "services/idp";
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10;
+    pnpm = pnpm_9;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.pnpmRoot}";
     fetcherVersion = 3;
-    hash = "sha256-W5odz//dONpBg4eRQQoVrBMVsEQVkkP89hzMdIXxG7w=";
+    hash = "sha256-AAAzo//YG5X2531C3vEhsLHRYJilRcomT5uTBSmzNmQ=";
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_10
+    pnpm_9
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/op/opencloud/package.nix
+++ b/pkgs/by-name/op/opencloud/package.nix
@@ -28,13 +28,13 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "opencloud";
-  version = "5.1.0";
+  version = "5.2.0";
 
   src = fetchFromGitHub {
     owner = "opencloud-eu";
     repo = "opencloud";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LZoQKXHDHHNLmu7FflQMCFUPlGS8eG7kZr8dmFku8Sk=";
+    hash = "sha256-lycqekiYAkNABl8144W8ZdUjAruc5OKp6c3FUSrLvOw=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/op/opencloud/web.nix
+++ b/pkgs/by-name/op/opencloud/web.nix
@@ -10,20 +10,20 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencloud-web";
-  version = "5.1.0";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "opencloud-eu";
     repo = "web";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Xx/uDn4m7Uu+4GMNB9vqsT+CozXhEo+2YGRMaMrjldM=";
+    hash = "sha256-eHu12DcP2LFJaRBX6WEieucS0HkSi231ZtUSZlunCuo=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-tPU16r0hc0DYwGnvnukivUz3a+Bz6urUZPtokN/lbuA=";
+    hash = "sha256-YOu0a/mR4PiRQx03BkPQbZgGQzgqXHy9DDihm8aD3wc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Also update all the other bits.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
