### PR TITLE
scx: split C and Rust versions, Rust 1.0.20 -> 1.1.0, C 1.0.20 -> unstable

### DIFF
--- a/nixos/modules/services/scheduling/scx.nix
+++ b/nixos/modules/services/scheduling/scx.nix
@@ -37,31 +37,7 @@ in
     };
 
     scheduler = lib.mkOption {
-      type = lib.types.enum [
-        "scx_beerland"
-        "scx_bpfland"
-        "scx_chaos"
-        "scx_cosmos"
-        "scx_central"
-        "scx_flash"
-        "scx_flatcg"
-        "scx_lavd"
-        "scx_layered"
-        "scx_mitosis"
-        "scx_nest"
-        "scx_p2dq"
-        "scx_pair"
-        "scx_prev"
-        "scx_qmap"
-        "scx_rlfifo"
-        "scx_rustland"
-        "scx_rusty"
-        "scx_sdt"
-        "scx_simple"
-        "scx_tickless"
-        "scx_userland"
-        "scx_wd40"
-      ];
+      type = lib.types.enum cfg.package.schedulers;
       default = "scx_rustland";
       example = "scx_bpfland";
       description = ''
@@ -125,5 +101,6 @@ in
 
   meta = {
     inherit (pkgs.scx.full.meta) maintainers;
+    buildDocsInSandbox = false;
   };
 }

--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -11,7 +11,7 @@
   libseccomp,
 }:
 
-llvmPackages.stdenv.mkDerivation {
+llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "scx_cscheds";
   version = "0-unstable-2026-01-13";
 
@@ -48,10 +48,35 @@ llvmPackages.stdenv.mkDerivation {
     "zerocallusedregs"
   ];
 
-  doCheck = true;
+  __structuredAttrs = true;
+  EXPECTED_SCHEDULERS = finalAttrs.passthru.schedulers;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    cd $out/bin
+    found=(scx_*)
+    if [[ "''${found[@]}" != "''${EXPECTED_SCHEDULERS[@]}" ]]; then
+      echo "List of available schedulers changed, expected: ''${EXPECTED_SCHEDULERS[@]}, found: ''${found[@]}"
+      exit 1
+    fi
+
+    runHook postInstallCheck
+  '';
 
   passthru = {
     inherit (scx.rustscheds.passthru) tests;
+    schedulers = [
+      "scx_central"
+      "scx_flatcg"
+      "scx_nest"
+      "scx_pair"
+      "scx_prev"
+      "scx_qmap"
+      "scx_simple"
+      "scx_userland"
+    ];
   };
 
   meta = scx.rustscheds.meta // {
@@ -68,4 +93,4 @@ llvmPackages.stdenv.mkDerivation {
     '';
     homepage = "https://github.com/sched-ext/scx/tree/main/scheds/c";
   };
-}
+})

--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -1,4 +1,5 @@
 {
+  fetchFromGitHub,
   llvmPackages,
   libbpf,
   pkg-config,
@@ -12,7 +13,14 @@
 
 llvmPackages.stdenv.mkDerivation {
   pname = "scx_cscheds";
-  inherit (scx.rustscheds) version src;
+  version = "0-unstable-2026-01-13";
+
+  src = fetchFromGitHub {
+    owner = "sched-ext";
+    repo = "scx-c-examples";
+    rev = "82c692afe32ed4e79fd047a93d3ff316bf399287";
+    hash = "sha256-buXwId/4TwDfo/5mApMAEWHri92bW9x3jLEE5rawS3w=";
+  };
 
   postPatch = ''
     substituteInPlace ./scheds/c/Makefile \
@@ -47,10 +55,11 @@ llvmPackages.stdenv.mkDerivation {
   };
 
   meta = scx.rustscheds.meta // {
-    description = "Sched-ext C userspace schedulers";
+    description = "Sched-ext C example schedulers";
     longDescription = ''
-      This includes C based schedulers such as scx_central, scx_flatcg,
-      scx_nest, scx_pair, scx_qmap, scx_simple, scx_userland.
+      This includes C based example schedulers such as scx_central, scx_flatcg,
+      scx_nest, scx_pair, scx_qmap, scx_simple, scx_userland. These are examples,
+      and generally not recommended for end users.
 
       ::: {.note}
       Sched-ext schedulers are only available on kernels version 6.12 or later.

--- a/pkgs/os-specific/linux/scx/scx_full.nix
+++ b/pkgs/os-specific/linux/scx/scx_full.nix
@@ -1,14 +1,19 @@
 {
-  lib,
+  buildEnv,
   scx,
 }:
-scx.cscheds.overrideAttrs (oldAttrs: {
+buildEnv {
   pname = "scx_full";
-  postInstall = (oldAttrs.postInstall or "") + ''
-    cp ${lib.getBin scx.rustscheds}/bin/* ${placeholder "out"}/bin/
-  '';
+  inherit (scx.rustscheds) version;
 
-  meta = oldAttrs.meta // {
+  paths = [
+    scx.cscheds
+    scx.rustscheds
+  ];
+
+  passthru.schedulers = scx.cscheds.schedulers ++ scx.rustscheds.schedulers;
+
+  meta = {
     description = "Sched-ext C and Rust userspace schedulers";
     longDescription = ''
       This includes C based schedulers such as scx_central, scx_flatcg,
@@ -22,4 +27,4 @@ scx.cscheds.overrideAttrs (oldAttrs: {
     '';
     homepage = "https://github.com/sched-ext/scx";
   };
-})
+}

--- a/pkgs/os-specific/linux/scx/scx_rustscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_rustscheds.nix
@@ -14,16 +14,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "scx_rustscheds";
-  version = "1.0.20";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "sched-ext";
     repo = "scx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MUWbNsxmbCRCOWB2dHpi5dEY2rNRrINxJSyl5SNSO9Y=";
+    hash = "sha256-kPOAiy2siIKZ6/zz43qPW7bp27T98MOhwmZMxpVpito=";
   };
 
-  cargoHash = "sha256-H58wschck+l41fQh9W5SNVb5g9lAnw90SOSd/RtGXyw=";
+  cargoHash = "sha256-nXiprz5ryGJeTy9nnKaLSKE0FSl17YE88xFt9bUTTL8=";
 
   nativeBuildInputs = [
     pkg-config
@@ -51,17 +51,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "zerocallusedregs"
   ];
 
-  doCheck = true;
-  checkFlags = [
-    "--skip=compat::tests::test_ksym_exists"
-    "--skip=compat::tests::test_read_enum"
-    "--skip=compat::tests::test_struct_has_field"
-    "--skip=cpumask"
-    "--skip=topology"
-    "--skip=proc_data::tests::test_thread_operations"
-    "--skip=json::tests::test_with_resources"
-    "--skip=json::tests::test_with_dir"
-  ];
+  # most of the tests rely on system CPU topology info,
+  # which is not available in the sandbox
+  doCheck = false;
 
   passthru.tests.basic = nixosTests.scx;
   passthru.updateScript = nix-update-script { };

--- a/pkgs/os-specific/linux/scx/scx_rustscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_rustscheds.nix
@@ -55,8 +55,48 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # which is not available in the sandbox
   doCheck = false;
 
+  # we don't need these
+  postInstall = ''
+    rm $out/bin/{scx_arena_selftests,vmlinux_docify,xtask}
+  '';
+
+  __structuredAttrs = true;
+  EXPECTED_SCHEDULERS = finalAttrs.passthru.schedulers;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    cd $out/bin
+    found=(scx_*)
+    if [[ "''${found[@]}" != "''${EXPECTED_SCHEDULERS[@]}" ]]; then
+      echo "List of available schedulers changed, expected: ''${EXPECTED_SCHEDULERS[@]}, found: ''${found[@]}"
+      exit 1
+    fi
+
+    runHook postInstallCheck
+  '';
+
   passthru.tests.basic = nixosTests.scx;
   passthru.updateScript = nix-update-script { };
+  passthru.schedulers = [
+    "scx_beerland"
+    "scx_bpfland"
+    "scx_cake"
+    "scx_chaos"
+    "scx_cosmos"
+    "scx_flash"
+    "scx_lavd"
+    "scx_layered"
+    "scx_mitosis"
+    "scx_p2dq"
+    "scx_pandemonium"
+    "scx_rlfifo"
+    "scx_rustland"
+    "scx_rusty"
+    "scx_tickless"
+    "scx_wd40"
+  ];
 
   meta = {
     description = "Sched-ext Rust userspace schedulers";


### PR DESCRIPTION
The C schedulers were moved into their own separate repo to clearly indicate that they're not to be used. We should probably deprecate those at some point.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
