### PR TITLE
obs-studio-plugins.obs-midi-mg: init at 3.1.4

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -54,6 +54,8 @@
 
   obs-media-controls = qt6Packages.callPackage ./obs-media-controls { };
 
+  obs-midi-mg = qt6Packages.callPackage ./obs-midi-mg.nix { };
+
   obs-move-transition = callPackage ./obs-move-transition.nix { };
 
   obs-multi-rtmp = qt6Packages.callPackage ./obs-multi-rtmp { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-midi-mg.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-midi-mg.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  obs-studio,
+  cmake,
+  libremidi,
+  pkg-config,
+  qtbase,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "obs-midi-mg";
+  version = "3.1.4";
+
+  src = fetchFromGitHub {
+    owner = "nhielost";
+    repo = "obs-midi-mg";
+    tag = finalAttrs.version;
+    hash = "sha256-enWqdEUIzGE9QWK8+u6hKIXmORZXhzK0pbYza6R7SFA=";
+  };
+
+  buildInputs = [
+    obs-studio
+    libremidi
+    qtbase
+  ];
+
+  env.QTDIR = qtbase.dev;
+
+  dontWrapQtApps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  postUnpack = ''
+    cp -r ${libremidi.src}/* $sourceRoot/deps/libremidi
+    chmod -R +w $sourceRoot/deps/libremidi
+  '';
+
+  postInstall = ''
+    rm -rf "$out/obs-plugins" "$out/data"
+  '';
+
+  cmakeFlags = [
+    # PipeWire support currently disabled in libremidi dependency.
+    # see https://github.com/NixOS/nixpkgs/pull/374469
+    (lib.cmakeBool "LIBREMIDI_NO_PIPEWIRE" true)
+    (lib.cmakeBool "ENABLE_QT" true)
+  ];
+
+  meta = {
+    description = "Allows MIDI devices to interact with OBS Studio";
+    homepage = "https://github.com/nhielost/obs-midi-mg";
+    changelog = "https://github.com/nhielost/obs-midi-mg/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ matthiabeyer ];
+    inherit (obs-studio.meta) platforms;
+  };
+})


### PR DESCRIPTION
This is WIP because it does not build yet.

@PatrickDaG this seems to be a plugin that works with advanced-scene-switcher, which you maintain. Maybe you have an idea here?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
