### PR TITLE
coolercontrol: 3.1.1 -> 4.1.0

### DIFF
--- a/pkgs/applications/system/coolercontrol/coolercontrol-ui-data.nix
+++ b/pkgs/applications/system/coolercontrol/coolercontrol-ui-data.nix
@@ -12,7 +12,7 @@ buildNpmPackage {
   sourceRoot = "${src.name}/coolercontrol-ui";
 
   npmDepsFetcherVersion = 2;
-  npmDepsHash = "sha256-NmTNaHm7NGkNWnNbTfLC9/3cSJRR+ir1YS+ot4MJNog=";
+  npmDepsHash = "sha256-AzRw6DuloOFC7VN7yM9czqxosfVIoXAltv2xHUxac7k=";
 
   postBuild = ''
     cp -r dist $out

--- a/pkgs/applications/system/coolercontrol/coolercontrol-ui-data.nix
+++ b/pkgs/applications/system/coolercontrol/coolercontrol-ui-data.nix
@@ -11,7 +11,8 @@ buildNpmPackage {
   inherit version src;
   sourceRoot = "${src.name}/coolercontrol-ui";
 
-  npmDepsHash = "sha256-crkAK9k7wwbjiAQGBK584/29Zi0TZlljuASdvni8RkQ=";
+  npmDepsFetcherVersion = 2;
+  npmDepsHash = "sha256-NmTNaHm7NGkNWnNbTfLC9/3cSJRR+ir1YS+ot4MJNog=";
 
   postBuild = ''
     cp -r dist $out

--- a/pkgs/applications/system/coolercontrol/coolercontrold.nix
+++ b/pkgs/applications/system/coolercontrol/coolercontrold.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage {
   inherit version src;
   sourceRoot = "${src.name}/coolercontrold";
 
-  cargoHash = "sha256-i6QYJ2kVXpYVbGyY/5EeGbCVCkxLeqf1mgvrXKRdup0=";
+  cargoHash = "sha256-rFwbHsGkKLD9UgkdTbxMIjARmU0Ewal1NIwlbzRL/vc=";
 
   buildInputs = [ libdrm ];
 
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage {
       --replace-fail 'Command::new("sh")' 'Command::new("${runtimeShell}")'
 
     # This is supposed to be a "nix-compatible file path", but there is nothing that actually does the substitution
-    substituteInPlace ../../coolercontrold-${version}-vendor/pciid-parser-*/src/lib.rs \
+    substituteInPlace daemon/src/repositories/hwmon/pci_ids.rs \
       --replace-fail '@hwdata@' '${hwdata}'
   '';
 

--- a/pkgs/applications/system/coolercontrol/coolercontrold.nix
+++ b/pkgs/applications/system/coolercontrol/coolercontrold.nix
@@ -1,6 +1,7 @@
 {
   rustPlatform,
   testers,
+  hwdata,
   libdrm,
   coolercontrol,
   runtimeShell,
@@ -21,7 +22,7 @@ rustPlatform.buildRustPackage {
   inherit version src;
   sourceRoot = "${src.name}/coolercontrold";
 
-  cargoHash = "sha256-5YYodScAAs6ERVbj+irvyNS9IOkVaBHR4DCXTrrtyVI=";
+  cargoHash = "sha256-i6QYJ2kVXpYVbGyY/5EeGbCVCkxLeqf1mgvrXKRdup0=";
 
   buildInputs = [ libdrm ];
 
@@ -39,8 +40,12 @@ rustPlatform.buildRustPackage {
     cp -R ${coolercontrol.coolercontrol-ui-data}/* resources/app/
 
     # Hardcode a shell
-    substituteInPlace src/repositories/utils.rs \
+    substituteInPlace daemon/src/repositories/utils.rs \
       --replace-fail 'Command::new("sh")' 'Command::new("${runtimeShell}")'
+
+    # This is supposed to be a "nix-compatible file path", but there is nothing that actually does the substitution
+    substituteInPlace ../../coolercontrold-${version}-vendor/pciid-parser-*/src/lib.rs \
+      --replace-fail '@hwdata@' '${hwdata}'
   '';
 
   postInstall = ''

--- a/pkgs/applications/system/coolercontrol/default.nix
+++ b/pkgs/applications/system/coolercontrol/default.nix
@@ -5,13 +5,13 @@
 }:
 
 let
-  version = "4.0.1";
+  version = "4.1.0";
 
   src = fetchFromGitLab {
     owner = "coolercontrol";
     repo = "coolercontrol";
     tag = version;
-    hash = "sha256-X8KEZARksSwmFEKnGnwZk9aQ0ND6fOsSelCIWPkEjN8=";
+    hash = "sha256-v1enPMezagA3gcYD5EbC1ecTOXEsMLRGWIKzgDxzRWg=";
   };
 
   meta = {

--- a/pkgs/applications/system/coolercontrol/default.nix
+++ b/pkgs/applications/system/coolercontrol/default.nix
@@ -5,13 +5,13 @@
 }:
 
 let
-  version = "3.1.1";
+  version = "4.0.1";
 
   src = fetchFromGitLab {
     owner = "coolercontrol";
     repo = "coolercontrol";
-    rev = version;
-    hash = "sha256-ocGW55z/cbO7uXWxiHoE798hN56fLlSgmZkO507eruY=";
+    tag = version;
+    hash = "sha256-X8KEZARksSwmFEKnGnwZk9aQ0ND6fOsSelCIWPkEjN8=";
   };
 
   meta = {


### PR DESCRIPTION
Packages build. Not integration-tested yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
