### PR TITLE
obdautodoctor: init at 5.1.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15073,6 +15073,12 @@
     name = "leo60228";
     keys = [ { fingerprint = "5BE4 98D5 1C24 2CCD C21A  4604 AC6F 4BA0 78E6 7833"; } ];
   };
+  leoflo = {
+    email = "noreply@leoflo.me";
+    github = "le0flo";
+    githubId = 128467278;
+    name = "Leonardo";
+  };
   leona = {
     email = "nix@leona.is";
     github = "leona-ya";

--- a/pkgs/by-name/ob/obdautodoctor/package.nix
+++ b/pkgs/by-name/ob/obdautodoctor/package.nix
@@ -1,0 +1,70 @@
+{
+  stdenv,
+  lib,
+  fetchzip,
+  autoPatchelfHook,
+  copyDesktopItems,
+  makeDesktopItem,
+  kdePackages,
+  bluez,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "obdautodoctor";
+  version = "5.1.8";
+
+  src = fetchzip {
+    url = "https://cdn2.obdautodoctor.com/release/obd-auto-doctor_${finalAttrs.version}_amd64.tar.gz";
+    hash = "sha256-3qht1G2Qi+IhL/x9MMEAwM0exCav5iKtnZXTl6cwx3E=";
+  };
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+    kdePackages.qtbase
+    bluez
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    kdePackages.wrapQtAppsHook
+    copyDesktopItems
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D obdautodoctor $out/bin/obdautodoctor
+    install -D obdautodoctor.png $out/share/icons/hicolor/128x128/apps/obdautodoctor.png
+
+    install -D license.txt $out/share/licenses/obdautodoctor/license.txt
+    install -D lgpl-3.0.txt $out/share/licenses/obdautodoctor/lgpl-3.0.txt
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "obdautodoctor";
+      desktopName = "OBD Auto Doctor";
+      comment = "OBD Car Diagnostics Software";
+      icon = "obdautodoctor";
+      exec = "obdautodoctor";
+      terminal = false;
+      categories = [
+        "Qt"
+        "Utility"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "Diagnose problems, reset the Check Engine Light, and monitor your car's performance with ease";
+    homepage = "https://www.obdautodoctor.com/";
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ leoflo ];
+  };
+})


### PR DESCRIPTION
This is a package for a car diagnostic software. It offers a linux build but it didn't have a package on the nixpkgs repo, so I built my own and used it a bit.

I have a flake that can already be installed to try this package but I wanted it to be a part of the official nixpkgs repo.

It is proprietary software so I expect to need to change some things in the meta (maybe, i don't know).
It's also my first official package contribution so anything I could've done better to package the software properly is (obviously) accepted.

This is the link to the projects homepage: https://www.obdautodoctor.com/

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
