### PR TITLE
nixos/zfs: Add services.zfs.ddtprune module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -219,6 +219,11 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- The ZFS module now supports periodic pruning of the deduplication table (DDT) via
+  [services.zfs.ddtprune](#opt-services.zfs.ddtprune). Per-pool pruning can be configured
+  using either an age threshold (`days`) or a percentage of entries to remove (`percentage`),
+  scheduled via a systemd timer.
+
 - [hardware.xpadneo](#opt-hardware.xpadneo.enable) now supports configuring kernel module parameters via a freeform [settings](#opt-hardware.xpadneo.settings) option, with convenience options for [rumble attenuation](#opt-hardware.xpadneo.rumbleAttenuation) and [controller quirks](#opt-hardware.xpadneo.quirks).
 
 - Wine has been updated to the 11.0 branch. Please check the [upstream announcement](https://gitlab.winehq.org/wine/wine/-/releases/wine-11.0) for more details.

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -17,6 +17,7 @@ let
   cfgSnapFlags = cfgSnapshots.flags;
   cfgScrub = config.services.zfs.autoScrub;
   cfgTrim = config.services.zfs.trim;
+  cfgDdtprune = config.services.zfs.ddtprune;
   cfgZED = config.services.zfs.zed;
 
   selectModulePackage = package: config.boot.kernelPackages.${package.kernelModuleAttribute};
@@ -592,6 +593,84 @@ in
       };
     };
 
+    services.zfs.ddtprune = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options = {
+            enable = lib.mkEnableOption "periodic pruning of the ZFS deduplication table (DDT) for this pool";
+
+            days = lib.mkOption {
+              type = lib.types.nullOr lib.types.ints.positive;
+              default = null;
+              example = 30;
+              description = ''
+                Prune DDT entries older than the specified number of days.
+                Mutually exclusive with {option}`percentage`.
+
+                See {manpage}`zpool-ddtprune(8)` for details.
+              '';
+            };
+
+            percentage = lib.mkOption {
+              type = lib.types.nullOr (lib.types.ints.between 1 100);
+              default = null;
+              example = 25;
+              description = ''
+                Prune the specified percentage of DDT entries, selecting the oldest first.
+                Mutually exclusive with {option}`days`.
+
+                See {manpage}`zpool-ddtprune(8)` for details.
+              '';
+            };
+
+            interval = lib.mkOption {
+              default = "monthly";
+              type = lib.types.str;
+              example = "weekly";
+              description = ''
+                How often to prune the deduplication table.
+                The format is described in
+                {manpage}`systemd.time(7)`.
+              '';
+            };
+
+            randomizedDelaySec = lib.mkOption {
+              default = "6h";
+              type = lib.types.str;
+              example = "12h";
+              description = ''
+                Add a randomized delay before each DDT prune.
+                The delay will be chosen between zero and this value.
+                This value must be a time span in the format specified by
+                {manpage}`systemd.time(7)`.
+              '';
+            };
+          };
+        }
+      );
+      default = { };
+      example = lib.literalExpression ''
+        {
+          rpool = {
+            enable = true;
+            days = 30;
+            interval = "weekly";
+          };
+          tank = {
+            enable = true;
+            percentage = 10;
+          };
+        }
+      '';
+      description = ''
+        Per-pool configuration for periodic pruning of the ZFS deduplication
+        data table (DDT) using {manpage}`zpool-ddtprune(8)`.
+
+        Each attribute name is a pool name, and creates a
+        `zfs-ddtprune@«pool»` systemd timer/service pair.
+      '';
+    };
+
     services.zfs.expandOnBoot = lib.mkOption {
       type = lib.types.either (lib.types.enum [
         "disabled"
@@ -1100,5 +1179,46 @@ in
         RandomizedDelaySec = cfgTrim.randomizedDelaySec;
       };
     })
+
+    (
+      let
+        enabledDdtprunePools = lib.filterAttrs (_: cfg: cfg.enable) cfgDdtprune;
+      in
+      lib.mkIf (cfgZfs.enabled && enabledDdtprunePools != { }) {
+        assertions = lib.mapAttrsToList (pool: cfg: {
+          assertion = (cfg.days != null) != (cfg.percentage != null);
+          message = "services.zfs.ddtprune.${pool}: exactly one of `days` or `percentage` must be set.";
+        }) enabledDdtprunePools;
+
+        systemd.services = lib.mapAttrs' (
+          pool: cfg:
+          lib.nameValuePair "zfs-ddtprune@${pool}" {
+            description = "ZFS DDT prune for pool ${pool}";
+            after = [ "zfs-import.target" ];
+            serviceConfig = {
+              Type = "oneshot";
+            };
+            script = ''
+              ${cfgZfs.package}/bin/zpool ddtprune ${
+                if cfg.days != null then "-d ${toString cfg.days}" else "-p ${toString cfg.percentage}"
+              } ${lib.escapeShellArg pool}
+            '';
+          }
+        ) enabledDdtprunePools;
+
+        systemd.timers = lib.mapAttrs' (
+          pool: cfg:
+          lib.nameValuePair "zfs-ddtprune@${pool}" {
+            wantedBy = [ "timers.target" ];
+            after = [ "multi-user.target" ];
+            timerConfig = {
+              OnCalendar = cfg.interval;
+              Persistent = lib.mkDefault "yes";
+              RandomizedDelaySec = cfg.randomizedDelaySec;
+            };
+          }
+        ) enabledDdtprunePools;
+      }
+    )
   ];
 }


### PR DESCRIPTION
Adds support for periodic pruning of the ZFS deduplication table (DDT) via `zpool ddtprune`. The new `services.zfs.ddtprune` option is an attrset keyed by pool name, allowing per-pool configuration of either age-based (`days`) or percentage-based (`percentage`) pruning, scheduled via a systemd timer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
