### PR TITLE
blutter: init at 0-unstable-2026-03-17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30397,5 +30397,11 @@
     githubId = 59917878;
     name = "Mathias Zhang";
   };
+  huanghunr = {
+    email = "huanghunr@outlook.com";
+    github = "huanghunr";
+    githubId = 160948982;
+    name = "huanghunr";
+  };
   # keep-sorted end
 }

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10897,6 +10897,12 @@
     githubId = 60099368;
     name = "Rafael Kienitz";
   };
+  huanghunr = {
+    email = "huanghunr@outlook.com";
+    github = "huanghunr";
+    githubId = 160948982;
+    name = "huanghunr";
+  };
   huantian = {
     name = "David Li";
     email = "davidtianli@gmail.com";
@@ -30396,12 +30402,6 @@
     github = "zzzsyyy";
     githubId = 59917878;
     name = "Mathias Zhang";
-  };
-  huanghunr = {
-    email = "huanghunr@outlook.com";
-    github = "huanghunr";
-    githubId = 160948982;
-    name = "huanghunr";
   };
   # keep-sorted end
 }

--- a/pkgs/by-name/bl/blutter/package.nix
+++ b/pkgs/by-name/bl/blutter/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  python3,
+  runCommand,
+  git,
+  cmake,
+  ninja,
+  pkg-config,
+  gcc,
+  icu,
+  capstone,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "blutter";
+  version = "0-unstable-2026-03-17";
+
+  src = fetchFromGitHub {
+    owner = "worawit";
+    repo = "blutter";
+    rev = "129377f65dffecd59535eb35041de534c4dea2ea";
+    hash = "sha256-88ErOUjzXrUtxpK7wmoo2nhyByf5mU+f3BbScI3BsCA=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/blutter
+    cp -r . $out/share/blutter
+    chmod -R u+w $out/share/blutter
+
+    mkdir -p $out/bin
+    makeWrapper ${
+      python3.withPackages (
+        ps: with ps; [
+          pyelftools
+          requests
+        ]
+      )
+    }/bin/python $out/bin/blutter \
+      --add-flags "$out/share/blutter/blutter.py" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          git
+          cmake
+          ninja
+          pkg-config
+          gcc
+        ]
+      } \
+      --prefix PKG_CONFIG_PATH : ${
+        lib.makeSearchPathOutput "dev" "lib/pkgconfig" [
+          icu
+          capstone
+        ]
+      } \
+      --prefix CMAKE_PREFIX_PATH : ${
+        lib.makeSearchPath "" [
+          (lib.getDev icu)
+          (lib.getLib icu)
+          (lib.getDev capstone)
+          (lib.getLib capstone)
+        ]
+      } \
+      --prefix CMAKE_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          icu
+          capstone
+        ]
+      } \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          icu
+          capstone
+        ]
+      } \
+      --prefix CMAKE_INCLUDE_PATH : ${
+        lib.makeSearchPathOutput "dev" "include" [
+          icu
+          capstone
+        ]
+      } \
+      --set ICU_ROOT ${lib.getDev icu} \
+      --run 'export CPPFLAGS="-I${lib.getDev capstone}/include/capstone ''${CPPFLAGS:-}"' \
+      --run 'export CXXFLAGS="-I${lib.getDev capstone}/include/capstone ''${CXXFLAGS:-}"'
+
+    runHook postInstall
+  '';
+
+  passthru.tests.smoke = runCommand "blutter-smoke" { } ''
+    ${finalAttrs.finalPackage}/bin/blutter --help >/dev/null
+    touch $out
+  '';
+
+  meta = {
+    description = "Flutter Mobile Application Reverse Engineering Tool";
+    homepage = "https://github.com/worawit/blutter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ huanghunr ];
+    platforms = lib.platforms.linux;
+    mainProgram = "blutter";
+  };
+})

--- a/pkgs/by-name/bl/blutter/package.nix
+++ b/pkgs/by-name/bl/blutter/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  makeWrapper,
   python3,
   runCommand,
   git,
@@ -14,6 +13,38 @@
   capstone,
 }:
 
+let
+  pythonEnv = python3.withPackages (
+    ps: with ps; [
+      pyelftools
+      requests
+    ]
+  );
+
+  pkgConfigPath = lib.makeSearchPathOutput "dev" "lib/pkgconfig" [
+    icu
+    capstone
+  ];
+
+  cmakePrefixPath = lib.makeSearchPath "" [
+    (lib.getDev icu)
+    (lib.getLib icu)
+    (lib.getDev capstone)
+    (lib.getLib capstone)
+  ];
+
+  cmakeLibraryPath = lib.makeLibraryPath [
+    icu
+    capstone
+  ];
+
+  cmakeIncludePath = lib.makeSearchPathOutput "dev" "include" [
+    icu
+    capstone
+  ];
+
+  capstoneCompatInclude = "${lib.getDev capstone}/include/capstone";
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "blutter";
   version = "0-unstable-2026-03-17";
@@ -25,8 +56,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-88ErOUjzXrUtxpK7wmoo2nhyByf5mU+f3BbScI3BsCA=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-
   installPhase = ''
     runHook preInstall
 
@@ -35,64 +64,47 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     chmod -R u+w $out/share/blutter
 
     mkdir -p $out/bin
-    makeWrapper ${
-      python3.withPackages (
-        ps: with ps; [
-          pyelftools
-          requests
-        ]
-      )
-    }/bin/python $out/bin/blutter \
-      --add-flags "$out/share/blutter/blutter.py" \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          git
-          cmake
-          ninja
-          pkg-config
-          gcc
-        ]
-      } \
-      --prefix PKG_CONFIG_PATH : ${
-        lib.makeSearchPathOutput "dev" "lib/pkgconfig" [
-          icu
-          capstone
-        ]
-      } \
-      --prefix CMAKE_PREFIX_PATH : ${
-        lib.makeSearchPath "" [
-          (lib.getDev icu)
-          (lib.getLib icu)
-          (lib.getDev capstone)
-          (lib.getLib capstone)
-        ]
-      } \
-      --prefix CMAKE_LIBRARY_PATH : ${
-        lib.makeLibraryPath [
-          icu
-          capstone
-        ]
-      } \
-      --prefix LD_LIBRARY_PATH : ${
-        lib.makeLibraryPath [
-          icu
-          capstone
-        ]
-      } \
-      --prefix CMAKE_INCLUDE_PATH : ${
-        lib.makeSearchPathOutput "dev" "include" [
-          icu
-          capstone
-        ]
-      } \
-      --set ICU_ROOT ${lib.getDev icu} \
-      --run 'export CPPFLAGS="-I${lib.getDev capstone}/include/capstone ''${CPPFLAGS:-}"' \
-      --run 'export CXXFLAGS="-I${lib.getDev capstone}/include/capstone ''${CXXFLAGS:-}"'
+    cat > $out/bin/blutter <<'EOF'
+    #!${stdenvNoCC.shell}
+    set -euo pipefail
+
+    stateRoot="''${XDG_STATE_HOME:-$HOME/.local/state}/blutter"
+    workDir="$stateRoot/${finalAttrs.version}"
+
+    if [ ! -d "$workDir" ]; then
+      mkdir -p "$stateRoot"
+      cp -r "${placeholder "out"}/share/blutter" "$workDir"
+      chmod -R u+w "$workDir"
+    fi
+
+    export PATH="${
+      lib.makeBinPath [
+        git
+        cmake
+        ninja
+        pkg-config
+        gcc
+      ]
+    }:$PATH"
+    export PKG_CONFIG_PATH="${pkgConfigPath}''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+    export CMAKE_PREFIX_PATH="${cmakePrefixPath}''${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+    export CMAKE_LIBRARY_PATH="${cmakeLibraryPath}''${CMAKE_LIBRARY_PATH:+:$CMAKE_LIBRARY_PATH}"
+    export CMAKE_INCLUDE_PATH="${cmakeIncludePath}''${CMAKE_INCLUDE_PATH:+:$CMAKE_INCLUDE_PATH}"
+    export LD_LIBRARY_PATH="${cmakeLibraryPath}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    export ICU_ROOT="${lib.getDev icu}"
+    export CPPFLAGS="-I${capstoneCompatInclude} ''${CPPFLAGS:-}"
+    export CXXFLAGS="-I${capstoneCompatInclude} ''${CXXFLAGS:-}"
+
+    exec "${pythonEnv}/bin/python" "$workDir/blutter.py" "$@"
+    EOF
+    chmod +x $out/bin/blutter
 
     runHook postInstall
   '';
 
   passthru.tests.smoke = runCommand "blutter-smoke" { } ''
+    export HOME="$TMPDIR"
+    export XDG_STATE_HOME="$TMPDIR/.local/state"
     ${finalAttrs.finalPackage}/bin/blutter --help >/dev/null
     touch $out
   '';


### PR DESCRIPTION
Adds a new package: `blutter` (https://github.com/worawit/blutter), a Flutter reverse engineering tool.

The package installs a `blutter` wrapper around upstream `blutter.py` and exports the toolchain/runtime environment needed on Nix (cmake/ninja/gcc/pkg-config, ICU and capstone include/library paths).  

Because upstream writes build artifacts and fetched Dart SDK sources at runtime, the wrapper runs from a writable state directory under `~/.local/state/blutter/<version>`.

Also adds `huanghunr` to `maintainers/maintainer-list.nix` (in a separate commit).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.