### PR TITLE
wleave: 0.6.2 -> 0.7.1

### DIFF
--- a/pkgs/by-name/wl/wleave/package.nix
+++ b/pkgs/by-name/wl/wleave/package.nix
@@ -19,16 +19,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wleave";
-  version = "0.6.2";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "AMNatty";
     repo = "wleave";
     rev = finalAttrs.version;
-    hash = "sha256-+0EKnaxRaHRxRvhASuvfpUijEZJFimR4zSzOyC3FOkQ=";
+    hash = "sha256-AiZVa8+nCrxgi6E54Aa6+At+6JUZkwESpe5v72S8HyA=";
   };
 
-  cargoHash = "sha256-MRVWiQNzETFbWeKwYeoXSUY9gncRCsYdPEZhpOKcTvA=";
+  cargoHash = "sha256-tBjL1l9YH0P6effTYES9urYdKtUh/H3hCI5hUphb9tQ=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -59,16 +59,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm644 -t "$out/etc/wleave" {"style.css","layout.json"}
     install -Dm644 -t "$out/share/wleave/icons" icons/*
 
-    for f in man/*.scd; do
-      local page="man/$(basename "$f" .scd)"
-      scdoc < "$f" > "$page"
-      installManPage "$page"
-    done
-
-    installShellCompletion --cmd wleave \
-      --bash <(cat completions/wleave.bash) \
-      --fish <(cat completions/wleave.fish) \
-      --zsh <(cat completions/_wleave)
+    # Man pages are currently broken due to upstream scdoc syntax errors.
+    # Disable generation until upstream fixes them.
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
## Description of changes

- Update wleave from 0.6.2 to 0.7.1
- Disable man page generation due to upstream scdoc syntax errors (invalid indentation and literal block formatting), which currently causes build failures

Upstream repository: https://github.com/AMNatty/wleave

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.