### PR TITLE
Remove use of `texlive.combine` in preparation for deprecation

### DIFF
--- a/pkgs/applications/graphics/inkscape/extensions.nix
+++ b/pkgs/applications/graphics/inkscape/extensions.nix
@@ -5,7 +5,7 @@
   runCommand,
   inkcut,
   callPackage,
-  texlive,
+  texliveBasic,
 }:
 
 {
@@ -51,7 +51,7 @@
   inkstitch = callPackage ./extensions/inkstitch { };
   silhouette = callPackage ./extensions/silhouette { };
   textext = callPackage ./extensions/textext {
-    pdflatex = texlive.combined.scheme-basic;
-    lualatex = texlive.combined.scheme-basic;
+    pdflatex = texliveBasic;
+    lualatex = texliveBasic;
   };
 }

--- a/pkgs/by-name/au/auto-multiple-choice/package.nix
+++ b/pkgs/by-name/au/auto-multiple-choice/package.nix
@@ -63,6 +63,13 @@ stdenv.mkDerivation (finalAttrs: {
   # There's only the Makefile
   dontConfigure = true;
 
+  outputs = [
+    "out"
+    "man"
+    "tex"
+    "texdoc"
+  ];
+
   makeFlags = [
     "PERLPATH=${perlWithPackages}/bin/perl"
     # We *need* to set DESTDIR as empty and use absolute paths below,
@@ -74,8 +81,8 @@ stdenv.mkDerivation (finalAttrs: {
     "BINDIR=${placeholder "out"}/bin"
     "PERLDIR=${placeholder "out"}/share/perl5"
     "MODSDIR=${placeholder "out"}/lib"
-    "TEXDIR=${placeholder "out"}/tex/latex/" # what texlive.combine expects
-    "TEXDOCDIR=${placeholder "out"}/share/doc/texmf/" # TODO where to put this?
+    "TEXDIR=${placeholder "tex"}/tex/latex/auto-multiple-choice/" # what texlive.withPackages expects
+    "TEXDOCDIR=${placeholder "texdoc"}/doc/latex/auto-multiple-choice/"
     "MAN1DIR=${placeholder "out"}/share/man/man1"
     "DESKTOPDIR=${placeholder "out"}/share/applications"
     "METAINFODIR=${placeholder "out"}/share/metainfo"
@@ -109,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
         netpbm
       ]
     } \
-    --set TEXINPUTS ".:$out/tex/latex:"
+    --set TEXINPUTS ".:$tex/tex/latex:"
   '';
 
   nativeBuildInputs = [
@@ -161,10 +168,7 @@ stdenv.mkDerivation (finalAttrs: {
       …
       environment.systemPackages = with pkgs; [
         auto-multiple-choice
-        (texlive.combine {
-          inherit (pkgs.texlive) scheme-full;
-          inherit auto-multiple-choice;
-        })
+        (texliveFull.withPackages (_: [auto-multiple-choice.tex]))
       ];
       </screen>
 

--- a/pkgs/by-name/ex/extractpdfmark/package.nix
+++ b/pkgs/by-name/ex/extractpdfmark/package.nix
@@ -6,7 +6,7 @@
   pkg-config,
   poppler,
   stdenv,
-  texlive,
+  texliveMinimal,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     ghostscript
-    texlive.combined.scheme-minimal
+    texliveMinimal
   ];
 
   meta = {

--- a/pkgs/development/python-modules/pylatex/default.nix
+++ b/pkgs/development/python-modules/pylatex/default.nix
@@ -7,7 +7,7 @@
   pytestCheckHook,
   matplotlib,
   quantities,
-  texlive,
+  texliveSmall,
 }:
 
 buildPythonPackage rec {
@@ -35,7 +35,12 @@ buildPythonPackage rec {
     pytestCheckHook
     matplotlib
     quantities
-    (texlive.combine { inherit (texlive) scheme-small lastpage collection-fontsrecommended; })
+    (texliveSmall.withPackages (
+      ps: with ps; [
+        lastpage
+        collection-fontsrecommended
+      ]
+    ))
   ];
 
   meta = {

--- a/pkgs/development/python-modules/pytikz-allefeld/default.nix
+++ b/pkgs/development/python-modules/pytikz-allefeld/default.nix
@@ -6,7 +6,7 @@
   pymupdf,
   numpy,
   ipython,
-  texlive,
+  texliveSmall,
 }:
 
 buildPythonPackage {
@@ -31,7 +31,7 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "tikz" ];
 
-  nativeCheckInputs = [ texlive.combined.scheme-small ];
+  nativeCheckInputs = [ texliveSmall ];
   checkPhase = ''
     runHook preCheck
     python -c 'if 1:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
As discussed on [NixOS discourse](https://discourse.nixos.org/t/how-and-when-to-deprecate-texlive-combine-looking-for-tex-live-reviewers/76121) there are plans to deprecate `texlive.combine`.
In preparation for that, this removes the use of `texlive.combine` and `texlive.combined`in all packages.

The biggest change is to `auto-multiple-choice`, which didn't properly work with the new `texlive.withPackages`.
I verified that I could build a LaTeX document using `\usepackage{automultiplechoice}` with `(texliveFull.withPackages (_: [auto-multiple-choice.tex]))` as now suggested in the description.
Maybe @thblt (as the maintainer) and @xworld21 (being more experienced with TeXLive packaging) should have a look at my changes here.

The current last use of `texlive.combine` is in `texFunctions.runLaTeX`, which currently seems to be broken, so we might want to consider deprecating it instead. (I haven't figured out how to unbreak it so far.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
