### PR TITLE
kara: 0.8.0 -> 1.0.0

### DIFF
--- a/pkgs/by-name/ka/kara/package.nix
+++ b/pkgs/by-name/ka/kara/package.nix
@@ -2,29 +2,45 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  cmake,
   nix-update-script,
   kdePackages,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "kara";
-  version = "0.8.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "dhruv8sh";
     repo = "kara";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gdYwgHNnkvayd7GK9H8AZHeKL589hU6MN9DXiUkSU3A=";
+    hash = "sha256-nOMsR9bocDVwH1wB+tGu7y4hnvcAUVTNPXrAzcmws3w=";
   };
 
-  installPhase = ''
-    runHook preInstall
+  nativeBuildInputs = [
+    cmake
+    kdePackages.extra-cmake-modules
+  ];
 
-    mkdir -p $out/share/plasma/plasmoids/org.dhruv8sh.kara
-    cp metadata.json $out/share/plasma/plasmoids/org.dhruv8sh.kara
-    cp -r contents $out/share/plasma/plasmoids/org.dhruv8sh.kara
+  buildInputs = with kdePackages; [
+    qtbase
+    qtdeclarative
+    ki18n
+    kservice
+    kwindowsystem
+    libplasma
+    plasma-activities
+    kwin
+    plasma-workspace
+  ];
 
-    runHook postInstall
-  '';
+  strictDeps = true;
+
+  cmakeFlags = [
+    (lib.cmakeFeature "Qt6_DIR" "${kdePackages.qtbase}/lib/cmake/Qt6")
+  ];
+
+  dontWrapQtApps = true;
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Updated kara to the latest version, 1.0.0.

Changelog: https://github.com/dhruv8sh/kara/releases/tag/v1.0.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
