### PR TITLE
tronbyt-server: init at 2.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14827,6 +14827,12 @@
       }
     ];
   };
+  laksith19 = {
+    email = "nixpkgs@laksith19.net";
+    github = "laksith19";
+    githubId = 78128865;
+    name = "Laksith Prabu";
+  };
   lamarios = {
     matrix = "@lamarios:matrix.org";
     github = "lamarios";

--- a/pkgs/by-name/tr/tronbyt-server/package.nix
+++ b/pkgs/by-name/tr/tronbyt-server/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoLatestModule,
+  libwebp,
+  nix-update-script,
+}:
+buildGoLatestModule (finalAttrs: {
+  pname = "tronbyt-server";
+  version = "2.2.3";
+  buildInputs = [ libwebp ];
+  postInstall = ''
+    mv $out/bin/server $out/bin/tronbyt-server
+  '';
+  ldflags = [
+    "-X 'tronbyt-server/internal/version.Version=v${finalAttrs.version}'"
+    "-X 'tronbyt-server/internal/version.Commit=v${finalAttrs.version}'"
+  ];
+  subPackages = [ "cmd/server" ];
+  src = fetchFromGitHub {
+    owner = "tronbyt";
+    repo = "server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uAOwI553F3YzJk7rwoZec/F2kD29kvcL5t44eORyFJw=";
+  };
+  vendorHash = "sha256-+/JPI6RqxfSbR9SIQuEvMMc2k8gSVZvMIlU/MnC2WmA=";
+
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    description = "Tronbyt server -- an alternate self hosted server for Tidbyt compatible devices";
+    license = lib.licenses.asl20;
+    homepage = "https://github.com/tronbyt/server";
+    maintainers = [ lib.maintainers.laksith19 ];
+    mainProgram = "tronbyt-server";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Add [tronbyt-server](https://github.com/tronbyt/server) to pkgs.

## Things done



- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
