### PR TITLE
mgccli: init at 0.61.2

### DIFF
--- a/pkgs/by-name/mg/mgccli/package.nix
+++ b/pkgs/by-name/mg/mgccli/package.nix
@@ -1,0 +1,55 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  runCommand,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mgc";
+  version = "0.61.2";
+
+  src = fetchFromGitHub {
+    owner = "MagaluCloud";
+    repo = "magalu";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-quDsKFpGbTjtuez4PbdxLtWfBzflxfrfa8gbrxRj9zs=";
+  };
+
+  modRoot = "./mgc/cli";
+
+  proxyVendor = true;
+  vendorHash = "sha256-4DkEG7hCcSRmKsOrURql9jq8jGxzc/gVGxCyUBsA0F8=";
+
+  tags = [ "embed" ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "main.RawVersion=v${finalAttrs.version}"
+  ];
+  subPackages = [ "." ];
+
+  postInstall = ''
+    mv $out/bin/cli $out/bin/mgc
+  '';
+
+  passthru.tests = {
+    simple = runCommand "${finalAttrs.pname}-test" { } ''
+      ${finalAttrs.finalPackage}/bin/mgc --version
+      touch $out
+    '';
+  };
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = with lib; {
+    description = "Interact with Magalu Cloud (MGC) services through the command line";
+    license = licenses.gpl3Plus;
+    homepage = "https://github.com/MagaluCloud/mgccli";
+    mainProgram = "mgc";
+    maintainers = with maintainers; [ fabiob ];
+  };
+})


### PR DESCRIPTION
This PR adds a new package for the Magalu Cloud Command-Line Interface (`mgccli`).

Magalu Cloud is a cloud provider in Brazil. The CLI is documented at https://docs.magalu.cloud/docs/devops-tools/cli-mgc/overview .

The previous PR #474912 was accidentally closed.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
