### PR TITLE
jellyseerr: rename jellyseerr to seerr

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -226,6 +226,8 @@
 
 - `services.taskchampion-sync-server` module have been added an option `services.taskchampion-sync-server.dynamicUser` to use systemd's DynamicUser feature. This is enabled by default when stateVersion is at least 26.05, and disabled otherwise. If you need this feature, you need to set `services.taskchampion-sync-server.dynamicUser` to `true` and migrate `/var/lib/taskchampion-sync-server` to `/var/lib/private/taskchampion-sync-server`.
 
+- Package `jellyseerr` has been renamed to `seerr` following the upstream rename.
+
 - The default packages in `services.jenkins.packages` have been dropped, since not every Jenkins installation needs any package at all. It's more reasonable to leave it empty and let users configure what they need.
 
 ## Other Notable Changes {#sec-nixpkgs-release-26.05-notable-changes}

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8508,6 +8508,12 @@
     githubId = 88741530;
     name = "Fabian Rigoll";
   };
+  fallenbagel = {
+    name = "fallenbagel";
+    github = "fallenbagel";
+    githubId = 98979876;
+    email = "hello@fallenbagel.com";
+  };
   famfo = {
     name = "famfo";
     email = "famfo+nixpkgs@famfo.xyz";

--- a/nixos/doc/manual/release-notes/rl-2305.section.md
+++ b/nixos/doc/manual/release-notes/rl-2305.section.md
@@ -105,7 +105,7 @@ In addition to numerous new and updated packages, this release has the following
 
 - [vmalert](https://victoriametrics.com/), an alerting engine for VictoriaMetrics. Available as [services.vmalert.instances](#opt-services.vmalert.instances._name_.enable).
 
-- [jellyseerr](https://github.com/Fallenbagel/jellyseerr), a web-based requests manager for Jellyfin, forked from Overseerr. Available as [services.jellyseerr](#opt-services.jellyseerr.enable).
+- [jellyseerr](https://github.com/Fallenbagel/jellyseerr), a web-based requests manager for Jellyfin, forked from Overseerr. Available as `services.jellyseerr`.
 
 - [kavita](https://kavitareader.com), a self-hosted digital library. Available as [services.kavita](options.html#opt-services.kavita.enable).
 

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -211,7 +211,10 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `geph` package's built-in GUI `geph5-client-gui` has been [removed](https://github.com/geph-official/geph5/commit/f2221fb8386312daf2cef05483ebb353ff48bdb4) by the upstream. All users who wish to continue using the GUI should install the `gephgui-wry`, which is consistent with the official release version.
 
-- `services.jellyseerr` has been renamed to `services.seerr` following the upstream changes. Service name changed accordingly.
+- `services.jellyseerr` has been renamed to `services.seerr` following the upstream changes. Notable breaking changes:
+  - systemd service name changed accordingly.
+  - Default config directory moved from `/var/lib/jellyseerr/config` to `/var/lib/seerr/`.
+    - If `stateVersion` is older than `26.05`, the module fall backs to the legacy path value.
 
 - `services.vikunja` has been updated to Vikunja [v1.0.0](https://vikunja.io/changelog/whats-new-in-vikunja-1.0.0/), which introduces multiple breaking changes.
   Notable breaking changes:

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -211,6 +211,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `geph` package's built-in GUI `geph5-client-gui` has been [removed](https://github.com/geph-official/geph5/commit/f2221fb8386312daf2cef05483ebb353ff48bdb4) by the upstream. All users who wish to continue using the GUI should install the `gephgui-wry`, which is consistent with the official release version.
 
+- `services.jellyseerr` has been renamed to `services.seerr` following the upstream changes. Service name changed accordingly.
+
 - `services.vikunja` has been updated to Vikunja [v1.0.0](https://vikunja.io/changelog/whats-new-in-vikunja-1.0.0/), which introduces multiple breaking changes.
   Notable breaking changes:
   - CORS is enabled by default. The module now sets

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -884,7 +884,6 @@
   ./services/misc/irkerd.nix
   ./services/misc/jackett.nix
   ./services/misc/jellyfin.nix
-  ./services/misc/jellyseerr.nix
   ./services/misc/kiwix-serve.nix
   ./services/misc/klipper.nix
   ./services/misc/languagetool.nix
@@ -950,6 +949,7 @@
   ./services/misc/rumno.nix
   ./services/misc/safeeyes.nix
   ./services/misc/sdrplay.nix
+  ./services/misc/seerr.nix
   ./services/misc/servarr/lidarr.nix
   ./services/misc/servarr/prowlarr.nix
   ./services/misc/servarr/radarr.nix

--- a/nixos/modules/services/misc/jellyseerr.nix
+++ b/nixos/modules/services/misc/jellyseerr.nix
@@ -12,7 +12,7 @@ in
 
   options.services.jellyseerr = {
     enable = lib.mkEnableOption "Jellyseerr, a requests manager for Jellyfin";
-    package = lib.mkPackageOption pkgs "jellyseerr" { };
+    package = lib.mkPackageOption pkgs "seerr" { };
 
     openFirewall = lib.mkOption {
       type = lib.types.bool;

--- a/nixos/modules/services/misc/seerr.nix
+++ b/nixos/modules/services/misc/seerr.nix
@@ -12,7 +12,10 @@ in
     (lib.mkRenamedOptionModule [ "services" "jellyseerr" ] [ "services" "seerr" ])
   ];
 
-  meta.maintainers = [ lib.maintainers.camillemndn ];
+  meta.maintainers = with lib.maintainers; [
+    camillemndn
+    fallenbagel
+  ];
 
   options.services.seerr = {
     enable = lib.mkEnableOption "Seerr, a requests manager for Jellyfin";

--- a/nixos/modules/services/misc/seerr.nix
+++ b/nixos/modules/services/misc/seerr.nix
@@ -6,6 +6,9 @@
 }:
 let
   cfg = config.services.seerr;
+  # 26.05 introduced a breaking change which is guarded behind stateVersion to avoid
+  # breaking users.
+  useNewConfigLocation = lib.versionAtLeast config.system.stateVersion "26.05";
 in
 {
   imports = [
@@ -35,7 +38,7 @@ in
 
     configDir = lib.mkOption {
       type = lib.types.path;
-      default = "/var/lib/jellyseerr/config";
+      default = if useNewConfigLocation then "/var/lib/seerr/" else "/var/lib/jellyseerr/config";
       description = "Config data directory";
     };
   };
@@ -51,7 +54,8 @@ in
       };
       serviceConfig = {
         Type = "exec";
-        StateDirectory = "jellyseerr";
+        # Note: this should be a parent of configDir.
+        StateDirectory = if useNewConfigLocation then "seerr" else "jellyseerr";
         DynamicUser = true;
         ExecStart = lib.getExe cfg.package;
         Restart = "on-failure";

--- a/nixos/modules/services/misc/seerr.nix
+++ b/nixos/modules/services/misc/seerr.nix
@@ -5,25 +5,29 @@
   ...
 }:
 let
-  cfg = config.services.jellyseerr;
+  cfg = config.services.seerr;
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule [ "services" "jellyseerr" ] [ "services" "seerr" ])
+  ];
+
   meta.maintainers = [ lib.maintainers.camillemndn ];
 
-  options.services.jellyseerr = {
-    enable = lib.mkEnableOption "Jellyseerr, a requests manager for Jellyfin";
+  options.services.seerr = {
+    enable = lib.mkEnableOption "Seerr, a requests manager for Jellyfin";
     package = lib.mkPackageOption pkgs "seerr" { };
 
     openFirewall = lib.mkOption {
       type = lib.types.bool;
       default = false;
-      description = "Open port in the firewall for the Jellyseerr web interface.";
+      description = "Open port in the firewall for the Seerr web interface.";
     };
 
     port = lib.mkOption {
       type = lib.types.port;
       default = 5055;
-      description = "The port which the Jellyseerr web UI should listen to.";
+      description = "The port which the Seerr web UI should listen to.";
     };
 
     configDir = lib.mkOption {
@@ -34,8 +38,8 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.services.jellyseerr = {
-      description = "Jellyseerr, a requests manager for Jellyfin";
+    systemd.services.seerr = {
+      description = "Seerr, a requests manager for Jellyfin";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       environment = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -793,7 +793,6 @@ in
   isso = runTest ./isso.nix;
   jackett = runTest ./jackett.nix;
   jellyfin = runTest ./jellyfin.nix;
-  jellyseerr = runTest ./jellyseerr.nix;
   jenkins = runTest ./jenkins.nix;
   jenkins-cli = runTest ./jenkins-cli.nix;
   jibri = runTest ./jibri.nix;
@@ -1451,6 +1450,7 @@ in
   sdl3 = runTest ./sdl3.nix;
   searx = runTest ./searx.nix;
   seatd = runTest ./seatd.nix;
+  seerr = runTest ./seerr.nix;
   send = runTest ./send.nix;
   service-runner = runTest ./service-runner.nix;
   servo = runTest ./servo.nix;

--- a/nixos/tests/seerr.nix
+++ b/nixos/tests/seerr.nix
@@ -1,17 +1,17 @@
 { lib, ... }:
 {
-  name = "jellyseerr";
+  name = "seerr";
   meta.maintainers = with lib.maintainers; [ matteopacini ];
 
   nodes.machine =
     { pkgs, ... }:
     {
-      services.jellyseerr.enable = true;
+      services.seerr.enable = true;
     };
 
   testScript = ''
     machine.start()
-    machine.wait_for_unit("jellyseerr.service")
+    machine.wait_for_unit("seerr.service")
     machine.wait_for_open_port(5055)
     machine.succeed("curl --fail http://localhost:5055/")
   '';

--- a/nixos/tests/seerr.nix
+++ b/nixos/tests/seerr.nix
@@ -1,7 +1,10 @@
 { lib, ... }:
 {
   name = "seerr";
-  meta.maintainers = with lib.maintainers; [ matteopacini ];
+  meta.maintainers = with lib.maintainers; [
+    matteopacini
+    fallenbagel
+  ];
 
   nodes.machine =
     { pkgs, ... }:

--- a/pkgs/by-name/se/seerr/package.nix
+++ b/pkgs/by-name/se/seerr/package.nix
@@ -1,8 +1,8 @@
 {
   lib,
-  pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
+  pnpm_10,
   fetchFromGitHub,
   stdenv,
   makeWrapper,
@@ -16,24 +16,24 @@
 
 let
   nodejs = nodejs_22;
-  pnpm = pnpm_9.override { inherit nodejs; };
+  pnpm = pnpm_10.override { inherit nodejs; };
 in
 stdenv.mkDerivation (finalAttrs: {
-  pname = "jellyseerr";
-  version = "2.7.3";
+  pname = "seerr";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
-    owner = "Fallenbagel";
-    repo = "jellyseerr";
+    owner = "seerr-team";
+    repo = "seerr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-a3lhQ33Zb+vSu1sQjuqO3bITiQEIOVyFTecmJAhJROU=";
+    hash = "sha256-POmxXuuxATWyNLnKKNO7W3BZ1WL0t0/0IoOpzqKs4oQ=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-kCM6oNfBlVsjItzBDxSbeLu0+53I5XzxcerpCTEvZ0M=";
+    hash = "sha256-p45B6hp0BsSCAeOL7miVzVMG84UW24uUf2OpbH+xQuw=";
   };
 
   buildInputs = [ sqlite ];
@@ -71,34 +71,29 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
     mkdir -p $out/share
-    cp -r -t $out/share .next node_modules dist public package.json jellyseerr-api.yml
+    cp -r -t $out/share .next node_modules dist public package.json seerr-api.yml
     runHook postInstall
   '';
 
   postInstall = ''
     mkdir -p $out/bin
-    makeWrapper '${nodejs}/bin/node' "$out/bin/jellyseerr" \
+    makeWrapper '${nodejs}/bin/node' "$out/bin/seerr" \
       --add-flags "$out/share/dist/index.js" \
       --chdir "$out/share" \
       --set NODE_ENV production
   '';
 
   passthru = {
-    inherit (nixosTests) jellyseerr;
+    inherit (nixosTests) seerr;
     updateScript = nix-update-script { };
   };
 
   meta = {
-    description = "Fork of overseerr for jellyfin support";
-    homepage = "https://github.com/Fallenbagel/jellyseerr";
-    longDescription = ''
-      Jellyseerr is a free and open source software application for managing
-      requests for your media library. It is a a fork of Overseerr built to
-      bring support for Jellyfin & Emby media servers!
-    '';
+    description = "Open-source media request and discovery manager for Jellyfin, Plex, and Emby";
+    homepage = "https://github.com/seerr-team/seerr";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.camillemndn ];
+    maintainers = with lib.maintainers; [ camillemndn ];
     platforms = lib.platforms.linux;
-    mainProgram = "jellyseerr";
+    mainProgram = "seerr";
   };
 })

--- a/pkgs/by-name/se/seerr/package.nix
+++ b/pkgs/by-name/se/seerr/package.nix
@@ -92,7 +92,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open-source media request and discovery manager for Jellyfin, Plex, and Emby";
     homepage = "https://github.com/seerr-team/seerr";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ camillemndn ];
+    maintainers = with lib.maintainers; [
+      camillemndn
+      fallenbagel
+    ];
     platforms = lib.platforms.linux;
     mainProgram = "seerr";
   };

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -953,6 +953,7 @@ mapAliases {
   jdk24 = throw "OpenJDK 24 was removed as it has reached its end of life"; # Added 2025-10-04
   jdk24_headless = throw "OpenJDK 24 was removed as it has reached its end of life"; # Added 2025-10-04
   jellyfin-media-player = jellyfin-desktop; # Added 2025-12-14
+  jellyseerr = warnAlias "'jellyseerr' has been renamed to 'seerr'" seerr; # Added 2026-03-17
   jesec-rtorrent = throw "'jesec-rtorrent' has been removed due to lack of maintenance upstream."; # Added 2025-11-20
   jhentai = throw "'jhentai' has been removed, as it is unmaintained"; # Added 2026-01-25
   jikespg = throw "'jikespg' has been removed due to lack of maintenance upstream."; # Added 2025-06-10


### PR DESCRIPTION
Follow-up on https://github.com/NixOS/nixpkgs/pull/450093 -- rebase and address review comments
## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
