### PR TITLE
kiwix-apple: init at 3.13.0

### DIFF
--- a/pkgs/by-name/ki/kiwix-apple/package.nix
+++ b/pkgs/by-name/ki/kiwix-apple/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeBinaryWrapper,
+  nix-update-script,
+  undmg,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "kiwix-apple";
+  version = "3.13.0";
+
+  src = fetchurl {
+    url = "https://download.kiwix.org/release/kiwix-macos/kiwix-macos_${finalAttrs.version}.dmg";
+    hash = "sha256-f9Un5ufiwwDiMesdw2dtnHWLM4ZtGMnFcGMuR3aIvHs=";
+  };
+
+  sourceRoot = ".";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    undmg
+  ];
+
+  postInstall = ''
+    mkdir -p $out/Applications
+    cp -r Kiwix.app $out/Applications
+    makeWrapper $out/Applications/Kiwix.app/Contents/MacOS/Kiwix $out/bin/${finalAttrs.meta.mainProgram}
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--url=https://github.com/kiwix/kiwix-apple"
+      "--version-regex=(.*\\..*\\..*)" # matches arbitrary tags otherwise
+    ];
+  };
+
+  meta = {
+    changelog = "https://github.com/kiwix/kiwix-apple/blob/${finalAttrs.version}/CHANGELOG.md";
+    description = "Offline reader for Web content";
+    downloadPage = "https://get.kiwix.org/en/solutions/applications/kiwix-reader/";
+    homepage = "https://get.kiwix.org/en/solutions/applications/";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "kiwix";
+    maintainers = with lib.maintainers; [ MysteryBlokHed ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Adds a package for the macOS version of the kiwix reader. The kiwix-desktop source code (used for the existing kiwix package) does not support macOS; a separate repository (<https://github.com/kiwix/kiwix-apple>) is used instead.

The package requires Xcode to build, so the release binary is sourced from a DMG file instead of building the package from source.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test