### PR TITLE
netbird-dashboard: fix SPA routing by falling back to index.html

### DIFF
--- a/nixos/modules/services/networking/netbird/dashboard.nix
+++ b/nixos/modules/services/networking/netbird/dashboard.nix
@@ -171,7 +171,7 @@ in
         root = cfg.finalDrv;
 
         locations = {
-          "/".tryFiles = "$uri $uri.html $uri/ =404";
+          "/".tryFiles = "$uri $uri/ /index.html";
 
           "= /404.html".extraConfig = ''
             internal;


### PR DESCRIPTION
## Motivation for this change

The NetBird dashboard is a Single Page Application (SPA). Currently, the `nixos/netbird-dashboard` module configures Nginx without a fallback to `index.html`. 

Because of this, when users attempt to authenticate using an IDP (like Keycloak or PocketID), the IDP redirects back to the dashboard at routes like `/auth` or `/silent-auth`. Nginx intercepts these, fails to find a matching file, and returns a 404 instead of letting the SPA handle the routing. 

This change updates the default Nginx `tryFiles` configuration to `"$uri $uri/ /index.html"`, which properly routes these requests to the frontend app. 

* **Upstream Issue:** [netbirdio/netbird#4978](https://github.com/netbirdio/netbird/issues/4978)
* **Related Upstream Dashboard PRs:** [netbirdio/dashboard#398](https://github.com/netbirdio/dashboard/pull/398), [netbirdio/dashboard#496](https://github.com/netbirdio/dashboard/pull/496)

I'll run more tests when I can.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
