### PR TITLE
python3Packages.tld: 0.13.1 -> 0.13.2

### DIFF
--- a/pkgs/development/python-modules/tld/default.nix
+++ b/pkgs/development/python-modules/tld/default.nix
@@ -6,26 +6,30 @@
   fetchPypi,
   pytestCheckHook,
   pytest-cov-stub,
+  setuptools,
+  setuptools-scm,
 }:
 
 buildPythonPackage rec {
   pname = "tld";
-  version = "0.13.1";
-  format = "setuptools";
+  version = "0.13.2";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-dewAk2y89WT2c2HEFxM2NEC2xO8PDBWStbD75ywXo1A=";
+    hash = "sha256-2YP6krnXF0AHQvyoROKdXhgnEHnHvPq/ZtAbObShQ0U=";
   };
 
-  nativeCheckInputs = [
-    pytestCheckHook
-    pytest-cov-stub
+  build-system = [
+    setuptools
+    setuptools-scm
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
     factory-boy
     faker
+    pytest-cov-stub
+    pytestCheckHook
   ];
 
   doCheck = false; # missing pytest-codeblock
@@ -41,7 +45,6 @@ buildPythonPackage rec {
 
   meta = {
     description = "Extracts the top level domain (TLD) from the URL given";
-    mainProgram = "update-tld-names";
     homepage = "https://github.com/barseghyanartur/tld";
     changelog = "https://github.com/barseghyanartur/tld/blob/${version}/CHANGELOG.rst";
     # https://github.com/barseghyanartur/tld/blob/master/README.rst#license
@@ -52,5 +55,6 @@ buildPythonPackage rec {
       gpl2Only
     ];
     maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "update-tld-names";
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/barseghyanartur/tld/blob/0.13.2/CHANGELOG.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
