### PR TITLE
codd: 0.1.6 -> 0.1.8

### DIFF
--- a/pkgs/by-name/co/codd/generated.nix
+++ b/pkgs/by-name/co/codd/generated.nix
@@ -41,7 +41,7 @@
 }:
 mkDerivation {
   pname = "codd";
-  version = "0.1.6";
+  version = "0.1.8";
   src = ./.;
   isLibrary = true;
   isExecutable = true;
@@ -72,6 +72,7 @@ mkDerivation {
     unliftio
     unliftio-core
     unordered-containers
+    uuid
     vector
   ];
   executableHaskellDepends = [

--- a/pkgs/by-name/co/codd/package.nix
+++ b/pkgs/by-name/co/codd/package.nix
@@ -14,18 +14,18 @@
 ##############
 
 let
-  # Haxl has relatively tight version requirements and is thus often marked as broken.
+  # Haxl has relatively tight version requirements and is often marked as broken.
   haxlJailbroken = haskell.lib.markUnbroken (haskell.lib.doJailbreak haskellPackages.haxl);
 
   generated = haskellPackages.callPackage ./generated.nix { haxl = haxlJailbroken; };
 
   derivationWithVersion = haskell.lib.compose.overrideCabal rec {
-    version = "0.1.6";
+    version = "0.1.8";
     src = fetchFromGitHub {
       owner = "mzabani";
       repo = "codd";
       tag = "v${version}";
-      hash = "sha256-KdZCL09TERy/PolQyYYykEbPtG5yhxrLZSSo9n6p2WE=";
+      hash = "sha256-7MKlR3oepOwlBwiEpzz3NFepEYGqROT5RrYoe/vvBKM=";
     };
 
     # We only run codd's tests that don't require postgresql nor strace. We need to support unix sockets in codd's test suite


### PR DESCRIPTION
Codd update, changelog at https://github.com/mzabani/codd/releases .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
