### PR TITLE
node2nix: fix build

### DIFF
--- a/pkgs/development/node-packages/node-env.nix
+++ b/pkgs/development/node-packages/node-env.nix
@@ -547,6 +547,7 @@ let
           python
           nodejs
         ]
+        ++ lib.optional (nodejs ? npm) nodejs.npm
         ++ lib.optional (stdenv.hostPlatform.isLinux) pkgs.util-linux
         ++ lib.optional (stdenv.hostPlatform.isDarwin) libtool
         ++ buildInputs;
@@ -669,6 +670,7 @@ let
           python
           nodejs
         ]
+        ++ lib.optional (nodejs ? npm) nodejs.npm
         ++ lib.optional (stdenv.hostPlatform.isLinux) pkgs.util-linux
         ++ lib.optional (stdenv.hostPlatform.isDarwin) libtool
         ++ buildInputs;
@@ -768,6 +770,7 @@ let
           python
           nodejs
         ]
+        ++ lib.optional (nodejs ? npm) nodejs.npm
         ++ lib.optional (stdenv.hostPlatform.isLinux) pkgs.util-linux
         ++ buildInputs;
         buildCommand = ''


### PR DESCRIPTION
Since 7459fe949f29 (nodejs: make nodejs_* depend on nodejs-slim_*), `npm` was split into a separate output on `nodejs-slim`. The `passthru.pkgs` in `nodejs.nix` passes `nodejs = self` (slim) to `node-env.nix`, so `npm` was absent from `buildInputs`, causing "npm: command not found" during builds.

Fix by adding `nodejs.npm` to `buildInputs` when the attribute exists.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
