### PR TITLE
hubstaff: fix missing desktop icon

### DIFF
--- a/pkgs/by-name/hu/hubstaff/package.nix
+++ b/pkgs/by-name/hu/hubstaff/package.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation {
       name = "netsoft-com.netsoft.hubstaff";
       desktopName = "Hubstaff";
       exec = "HubstaffClient";
-      icon = "hubstaff";
+      icon = "hubstaff-color";
       comment = "Time tracking software";
       categories = [
         "Office"
@@ -119,6 +119,13 @@ stdenv.mkDerivation {
 
     # Why is this needed? SEGV otherwise.
     ln -s $opt/data/resources $opt/x86_64/resources
+
+    # Link icons to the standard directory
+    for dir in $opt/data/resources/hicolor/[0-9]*x[0-9]*; do
+      size=$(basename "$dir")
+      mkdir -p $out/share/icons/hicolor/$size/apps
+      ln -s $dir/apps/hubstaff-color.png $out/share/icons/hicolor/$size/apps/hubstaff-color.png
+    done
     runHook postInstall
   '';
 


### PR DESCRIPTION
- Symlinked the `hubstaff-color.png` files directly into `$out/share/icons/hicolor/` for all provided resolutions, so desktop environments can properly locate the application icon.                                                                                                                                                             
- Updated the `icon` attribute in `makeDesktopItem` from `hubstaff` to `hubstaff-color` to accurately match the filenames provided in the package. 

Tested successfully for NixOS stable Cinnamon

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @michalrus