### PR TITLE
nh-unwrapped: fix postInstall cleanup

### DIFF
--- a/pkgs/by-name/nh/nh-unwrapped/package.nix
+++ b/pkgs/by-name/nh/nh-unwrapped/package.nix
@@ -71,27 +71,34 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
-    # Run both shell completion and manpage generation tasks. Unlike the
-    # fine-grained variants, the 'dist' command doesn't allow specifying the
-    # path but that's fine, because we can simply install them from the implicit
-    # output directories.
-    $out/bin/xtask dist
+  postInstall =
+    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+      let
+        emulator = stdenv.hostPlatform.emulator buildPackages;
+      in
+      ''
+        # Run both shell completion and manpage generation tasks. Unlike the
+        # fine-grained variants, the 'dist' command doesn't allow specifying the
+        # path but that's fine, because we can simply install them from the implicit
+        # output directories.
+        ${emulator} $out/bin/xtask dist
 
-    # The dist task above should've created
-    #  1. Shell completions in comp/
-    #  2. The NH manpage (nh.1) in man/
-    # Let's install those.
-    # The important thing to note here is that installShellCompletion cannot
-    # actually load *all* shell completions we generate with 'xtask dist'.
-    # Elvish, for example isn't supported. So we have to be very explicit
-    # about what we're installing, or this will fail.
-    installShellCompletion --cmd ${finalAttrs.meta.mainProgram} ./comp/*.{bash,fish,zsh,nu}
-    installManPage ./man/nh.1
-
-    # Avoid populating PATH with an 'xtask' cmd
-    rm $out/bin/xtask
-  '';
+        # The dist task above should've created
+        #  1. Shell completions in comp/
+        #  2. The NH manpage (nh.1) in man/
+        # Let's install those.
+        # The important thing to note here is that installShellCompletion cannot
+        # actually load *all* shell completions we generate with 'xtask dist'.
+        # Elvish, for example isn't supported. So we have to be very explicit
+        # about what we're installing, or this will fail.
+        installShellCompletion --cmd ${finalAttrs.meta.mainProgram} ./comp/*.{bash,fish,zsh,nu}
+        installManPage ./man/nh.1
+      ''
+    )
+    + ''
+      # Avoid populating PATH with an 'xtask' cmd
+      rm $out/bin/xtask
+    '';
 
   cargoHash = "sha256-BLv69rL5L84wNTMiKHbSumFU4jVQqAiI1pS5oNLY9yE=";
 


### PR DESCRIPTION
brings back use of the emulator lost in the 4.2.0 -> 4.3.0 transition

makes deletion of xtask unconditional

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
