### PR TITLE
openclaw: add shell completions

### DIFF
--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenvNoCC,
+  buildPackages,
   fetchFromGitHub,
   fetchPnpmDeps,
   pnpmConfigHook,
@@ -10,6 +11,7 @@
   versionCheckHook,
   nix-update-script,
   rolldown,
+  installShellFiles,
   version ? "2026.3.12",
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -39,6 +41,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     pnpm_10
     nodejs_22
     makeWrapper
+    installShellFiles
   ];
 
   preBuild = ''
@@ -81,6 +84,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  postInstall = lib.optionalString (stdenvNoCC.hostPlatform.emulatorAvailable buildPackages) (
+    let
+      emulator = stdenvNoCC.hostPlatform.emulator buildPackages;
+    in
+    ''
+      installShellCompletion --cmd openclaw \
+        --bash <(${emulator} $out/bin/openclaw completion --shell bash) \
+        --fish <(${emulator} $out/bin/openclaw completion --shell fish) \
+        --zsh <(${emulator} $out/bin/openclaw completion --shell zsh)
+    ''
+  );
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;


### PR DESCRIPTION
adds shell completions to openclaw package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
