### PR TITLE
nixtamal: split into two outputs (bin/lib)

### DIFF
--- a/pkgs/by-name/ni/nixtamal/package.nix
+++ b/pkgs/by-name/ni/nixtamal/package.nix
@@ -11,6 +11,7 @@
   nix-prefetch-fossil,
   nix-prefetch-git,
   nix-prefetch-pijul,
+  removeReferencesTo,
   testers,
   nixtamal,
 }:
@@ -31,6 +32,7 @@ ocamlPackages.buildDunePackage (finalAttrs: {
 
   nativeBuildInputs = [
     makeBinaryWrapper
+    removeReferencesTo
     # For manpages
     python3Packages.docutils
     python3Packages.pygments
@@ -40,11 +42,15 @@ ocamlPackages.buildDunePackage (finalAttrs: {
   ];
 
   buildInputs = with ocamlPackages; [
-    camomile
     cmdliner
+    fmt
+    ppx_deriving_qcheck
+  ];
+
+  propagatedBuildInputs = with ocamlPackages; [
+    camomile
     eio
     eio_main
-    fmt
     jingoo
     (jsont.override {
       withBrr = false;
@@ -53,7 +59,7 @@ ocamlPackages.buildDunePackage (finalAttrs: {
     kdl
     logs
     ppx_deriving
-    ppx_deriving_qcheck
+    qcheck-core
     saturn
     stdint
     uri
@@ -72,8 +78,20 @@ ocamlPackages.buildDunePackage (finalAttrs: {
 
   doCheck = true;
 
-  postInstall = ''
-    wrapProgram "$out/bin/nixtamal" --prefix PATH : ${
+  outputs = [
+    "bin"
+    "lib"
+    "out"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix="$bin" --libdir="$lib/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib" nixtamal
+    for dep in ${ocamlPackages.ocaml} ${ocamlPackages.camomile}
+    do
+        remove-references-to -t $dep $bin/bin/nixtamal
+    done
+    wrapProgram "$bin/bin/nixtamal" --prefix PATH : ${
       lib.makeBinPath [
         coreutils
         nix-prefetch-darcs
@@ -82,10 +100,11 @@ ocamlPackages.buildDunePackage (finalAttrs: {
         nix-prefetch-pijul
       ]
     }
+    runHook postInstall
   '';
 
   passthru.tests.version = testers.testVersion {
-    package = nixtamal;
+    package = nixtamal.bin;
     command = "${nixtamal.meta.mainProgram} --version";
   };
 


### PR DESCRIPTION
And remove references to OCaml from the bin/ output.

This should make the closure of the `nixtamal` binary (much) smaller.

This has not been thoroughly tested.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
