### PR TITLE
libtar: fix cross-compilation by removing hardcoded strip from install

### DIFF
--- a/pkgs/by-name/li/libtar/package.nix
+++ b/pkgs/by-name/li/libtar/package.nix
@@ -49,6 +49,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ autoreconfHook ];
 
+  # libtar/Makefile.in hardcodes `INSTALL_PROGRAM = @INSTALL_PROGRAM@ -s`,
+  # which runs bare `strip` during `make install`. This fails in cross builds
+  # where only the prefixed strip (e.g. aarch64-unknown-linux-gnu-strip) is
+  # available. Nix's fixup phase handles stripping with the correct tool, so
+  # just remove the flag.
+  postPatch = ''
+    substituteInPlace libtar/Makefile.in \
+      --replace-fail '@INSTALL_PROGRAM@ -s' '@INSTALL_PROGRAM@'
+  '';
+
   meta = {
     description = "C library for manipulating POSIX tar files";
     mainProgram = "libtar";


### PR DESCRIPTION
[libtar/Makefile.in](https://repo.or.cz/libtar.git/blob/HEAD:/libtar/Makefile.in) hardcodes `INSTALL_PROGRAM = @INSTALL_PROGRAM@ -s`, which runs bare `strip` during `make install`. This fails in cross builds where only the target-prefixed strip is available in PATH.

Nix's fixup phase already handles stripping with the correct tool, so the flag is redundant even for native builds.

To see how it fails, try to build `pkgsLLVM.libtar` on master.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
