### PR TITLE
transmission_4-{mac,qt,qt5}: enable mac gui

### DIFF
--- a/pkgs/applications/networking/p2p/transmission/0001-Skip-bundle-fixup.patch
+++ b/pkgs/applications/networking/p2p/transmission/0001-Skip-bundle-fixup.patch
@@ -1,0 +1,61 @@
+From a8122a78c496f09711e81c669ca3ee44c8df79f9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Stanis=C5=82aw=20Pitucha?= <stan.pitucha@envato.com>
+Date: Fri, 27 Mar 2026 08:58:08 +1100
+Subject: [PATCH] Skip fixup; it's unnecessary for nixpkgs
+
+---
+ cmake/TrMacros.cmake | 38 --------------------------------------
+ 1 file changed, 38 deletions(-)
+
+diff --git a/cmake/TrMacros.cmake b/cmake/TrMacros.cmake
+index 2efa8767c..cc17a47a5 100644
+--- a/cmake/TrMacros.cmake
++++ b/cmake/TrMacros.cmake
+@@ -376,44 +376,6 @@ function(tr_select_library LIBNAMES FUNCNAME DIRS OVAR)
+ endfunction()
+ 
+ function(tr_fixup_bundle_item BUNDLE_DIR BUNDLE_ITEMS DEP_DIRS)
+-    while(BUNDLE_ITEMS)
+-        list(GET BUNDLE_ITEMS 0 ITEM)
+-        list(REMOVE_AT BUNDLE_ITEMS 0)
+-
+-        set(ITEM_FULL_BUNDLE_PATH "${BUNDLE_DIR}/${ITEM}")
+-        get_filename_component(ITEM_FULL_BUNDLE_DIR "${ITEM_FULL_BUNDLE_PATH}" PATH)
+-
+-        unset(ITEM_DEPS)
+-        get_prerequisites("${ITEM_FULL_BUNDLE_PATH}" ITEM_DEPS 1 0 "${ITEM_FULL_BUNDLE_PATH}" "${DEP_DIRS}")
+-
+-        foreach(DEP IN LISTS ITEM_DEPS)
+-            gp_resolve_item("${ITEM_FULL_BUNDLE_PATH}" "${DEP}" "${ITEM_FULL_BUNDLE_DIR}" "${DEP_DIRS}" DEP_FULL_PATH)
+-
+-            if(DEP_FULL_PATH MATCHES "[.]dylib$")
+-                get_filename_component(DEP_NAME "${DEP_FULL_PATH}" NAME)
+-                file(COPY "${DEP_FULL_PATH}" DESTINATION "${BUNDLE_DIR}/Contents/MacOS/")
+-                set(DEP_BUNDLE_PATH "Contents/MacOS/${DEP_NAME}")
+-            elseif(DEP_FULL_PATH MATCHES "^(.+)/(([^/]+[.]framework)/.+)$")
+-                set(DEP_NAME "${CMAKE_MATCH_2}")
+-                file(
+-                    COPY "${CMAKE_MATCH_1}/${CMAKE_MATCH_3}"
+-                    DESTINATION "${BUNDLE_DIR}/Contents/Frameworks/"
+-                    PATTERN "Headers" EXCLUDE)
+-                set(DEP_BUNDLE_PATH "Contents/Frameworks/${DEP_NAME}")
+-            else()
+-                message(FATAL_ERROR "Don't know how to fixup '${DEP_FULL_PATH}'")
+-            endif()
+-
+-            execute_process(COMMAND install_name_tool -change "${DEP}" "@rpath/${DEP_NAME}" "${ITEM_FULL_BUNDLE_PATH}")
+-
+-            set(DEP_FULL_BUNDLE_PATH "${BUNDLE_DIR}/${DEP_BUNDLE_PATH}")
+-            execute_process(COMMAND chmod u+w "${DEP_FULL_BUNDLE_PATH}")
+-            execute_process(COMMAND install_name_tool -id "@rpath/${DEP_NAME}" "${DEP_FULL_BUNDLE_PATH}")
+-
+-            list(REMOVE_ITEM BUNDLE_ITEMS "${DEP_BUNDLE_PATH}")
+-            list(APPEND BUNDLE_ITEMS "${DEP_BUNDLE_PATH}")
+-        endforeach()
+-    endwhile()
+ endfunction()
+ 
+ function(tr_glib_compile_resources TGT NAME INPUT_DIR INPUT_FILE OUTPUT_FILE_BASE)
+-- 
+2.51.2
+

--- a/pkgs/applications/networking/p2p/transmission/4.nix
+++ b/pkgs/applications/networking/p2p/transmission/4.nix
@@ -24,7 +24,6 @@
   miniupnpc,
   dht,
   libnatpmp,
-  libiconv,
   # Build options
   enableGTK3 ? false,
   gtkmm3,
@@ -32,6 +31,7 @@
   wrapGAppsHook3,
   enableQt5 ? false,
   enableQt6 ? false,
+  enableMac ? false,
   qt5,
   qt6Packages,
   nixosTests,
@@ -40,10 +40,14 @@
   enableCli ? true,
   installLib ? false,
   apparmorRulesFromClosure,
+  ibtool,
+  actool,
+  coreutils,
+  makeWrapper,
 }:
 
 let
-  inherit (lib) cmakeBool optionals;
+  inherit (lib) cmakeBool optionals optionalString;
 
   apparmorRules = apparmorRulesFromClosure { name = "transmission-daemon"; } (
     [
@@ -74,16 +78,29 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  patches = [
+    ./0001-Skip-bundle-fixup.patch
+  ];
+
   outputs = [
     "out"
+  ]
+  ++ optionals stdenv.hostPlatform.isLinux [
     "apparmor"
   ];
+
+  # Remove once https://github.com/NixOS/nixpkgs/pull/508307 lands
+  # Stop clang trying to write in $HOME
+  env.CLANG_MODULE_CACHE_PATH = "/tmp/clang_module_cache";
 
   cmakeFlags = [
     (cmakeBool "ENABLE_CLI" enableCli)
     (cmakeBool "ENABLE_DAEMON" enableDaemon)
     (cmakeBool "ENABLE_GTK" enableGTK3)
-    (cmakeBool "ENABLE_MAC" false) # requires xcodebuild
+    (cmakeBool "ENABLE_MAC" enableMac)
     (cmakeBool "ENABLE_QT" (enableQt5 || enableQt6))
     (cmakeBool "INSTALL_LIB" installLib)
     (cmakeBool "RUN_CLANG_TIDY" false)
@@ -91,6 +108,9 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals stdenv.hostPlatform.isDarwin [
     # Transmission sets this to 10.13 if not explicitly specified, see https://github.com/transmission/transmission/blob/0be7091eb12f4eb55f6690f313ef70a66795ee72/CMakeLists.txt#L7-L16.
     "-DCMAKE_OSX_DEPLOYMENT_TARGET=${stdenv.hostPlatform.darwinMinVersion}"
+    # we don't have a compatible-enough signing tool right now
+    "-DCODESIGN_EXECUTABLE=${lib.getExe' coreutils "true"}"
+    "-DACTOOL_EXECUTABLE=${lib.getExe actool}"
   ];
 
   postPatch = ''
@@ -112,6 +132,12 @@ stdenv.mkDerivation (finalAttrs: {
     # Upstream uses different config file name.
     substituteInPlace CMakeLists.txt \
       --replace-fail 'find_package(UtfCpp)' 'find_package(utf8cpp)'
+  ''
+  + optionalString (stdenv.hostPlatform.isDarwin && (enableQt5 || enableQt6)) ''
+    substituteInPlace qt/CMakeLists.txt \
+      --replace-fail \
+        'transmission::qt_impl)' \
+        'transmission::qt_impl "-framework AppKit" "-framework CoreGraphics")'
   '';
 
   nativeBuildInputs = [
@@ -121,7 +147,12 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ optionals enableGTK3 [ wrapGAppsHook3 ]
   ++ optionals enableQt5 [ qt5.wrapQtAppsHook ]
-  ++ optionals enableQt6 [ qt6Packages.wrapQtAppsHook ];
+  ++ optionals enableQt6 [ qt6Packages.wrapQtAppsHook ]
+  ++ optionals enableMac [
+    ibtool
+    actool
+    makeWrapper
+  ];
 
   buildInputs = [
     curl
@@ -164,29 +195,33 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals enableSystemd [ systemd ]
   ++ optionals stdenv.hostPlatform.isLinux [ inotify-tools ];
 
-  postInstall = ''
-    mkdir $apparmor
-    cat >$apparmor/bin.transmission-daemon <<EOF
-    abi <abi/4.0>,
-    include <tunables/global>
-    profile $out/bin/transmission-daemon {
-      include <abstractions/base>
-      include <abstractions/nameservice>
-      include <abstractions/ssl_certs>
-      include "${apparmorRules}"
-      @{PROC}/sys/kernel/random/uuid r,
-      @{PROC}/sys/vm/overcommit_memory r,
-      @{PROC}/@{pid}/environ r,
-      @{PROC}/@{pid}/mounts r,
-      /tmp/tr_session_id_* rwk,
+  postInstall =
+    optionalString stdenv.hostPlatform.isLinux ''
+      mkdir $apparmor
+      cat >$apparmor/bin.transmission-daemon <<EOF
+      abi <abi/4.0>,
+      include <tunables/global>
+      profile $out/bin/transmission-daemon {
+        include <abstractions/base>
+        include <abstractions/nameservice>
+        include <abstractions/ssl_certs>
+        include "${apparmorRules}"
+        @{PROC}/sys/kernel/random/uuid r,
+        @{PROC}/sys/vm/overcommit_memory r,
+        @{PROC}/@{pid}/environ r,
+        @{PROC}/@{pid}/mounts r,
+        /tmp/tr_session_id_* rwk,
 
-      $out/share/transmission/public_html/** r,
+        $out/share/transmission/public_html/** r,
 
-      include if exists <local/bin.transmission-daemon>
-    }
-    EOF
-    install -Dm0444 -t $out/share/icons ../icons/hicolor_apps_scalable_transmission.svg
-  '';
+        include if exists <local/bin.transmission-daemon>
+      }
+      EOF
+      install -Dm0444 -t $out/share/icons ../icons/hicolor_apps_scalable_transmission.svg
+    ''
+    + optionalString enableMac ''
+      makeWrapper $out/Applications/Transmission.app/Contents/MacOS/Transmission $out/bin/transmission-mac
+    '';
 
   passthru.tests = {
     apparmor = nixosTests.transmission_4; # starts the service with apparmor enabled
@@ -200,6 +235,8 @@ stdenv.mkDerivation (finalAttrs: {
         "transmission-qt"
       else if enableGTK3 then
         "transmission-gtk"
+      else if enableMac then
+        "transmission-mac"
       else
         "transmission-cli";
     longDescription = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10617,6 +10617,7 @@ with pkgs;
   transmission_4-qt5 = transmission_4.override { enableQt5 = true; };
   transmission_4-qt6 = transmission_4.override { enableQt6 = true; };
   transmission_4-qt = transmission_4-qt5;
+  transmission_4-mac = transmission_4.override { enableMac = true; };
 
   tinywl = callPackage ../applications/window-managers/tinywl {
     wlroots = wlroots_0_20;


### PR DESCRIPTION
## Things done

Build with custom reimplemented ibtool and actool. This allows us to enable the native GUI on darwin.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
