### PR TITLE
nixos/scx: double quoting fix

### DIFF
--- a/nixos/modules/services/scheduling/scx.nix
+++ b/nixos/modules/services/scheduling/scx.nix
@@ -71,11 +71,11 @@ in
     };
 
     extraArgs = lib.mkOption {
-      type = lib.types.listOf lib.types.singleLineStr;
+      type = lib.types.listOf lib.types.str;
       default = [ ];
       example = [
-        "--slice-us 5000"
         "--verbose"
+        "--slice-us 5000"
       ];
       description = ''
         Parameters passed to the chosen scheduler at runtime.
@@ -107,9 +107,10 @@ in
         '';
         Restart = "on-failure";
       };
+
       environment = {
         SCX_SCHEDULER = cfg.scheduler;
-        SCX_FLAGS = lib.escapeShellArgs cfg.extraArgs;
+        SCX_FLAGS = lib.concatStringsSep " " cfg.extraArgs;
       };
 
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
`lib.concatStringsSep` prevents double quoting which lead to #500842
tested - `lib.concatStringsSep` not causing double quoting; (my issuecomments: https://github.com/NixOS/nixpkgs/issues/500842#issuecomment-4078382197 and https://github.com/NixOS/nixpkgs/issues/500842#issuecomment-4078407026)

and moved `"--verbose"` up, just for convenience 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
