### PR TITLE
betterleaks: init at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13637,6 +13637,12 @@
     githubId = 87115;
     name = "Wael Nasreddine";
   };
+  kallevmercury = {
+    email = "kallev@mercury.com";
+    github = "kallevmercury";
+    githubId = 164934876;
+    name = "Kalle Virtaneva";
+  };
   kalebpace = {
     email = "kaleb.pace@pm.me";
     matrix = "@kalebpace:matrix.org";

--- a/pkgs/by-name/be/betterleaks/package.nix
+++ b/pkgs/by-name/be/betterleaks/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  versionCheckHook,
+  gitMinimal,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "betterleaks";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "betterleaks";
+    repo = "betterleaks";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PJGFvm+QoExUMliL6rvBAKKjt8Ce5VZfQxCYbpXUXfU=";
+  };
+
+  vendorHash = "sha256-lIblIctRnq//ic+most3g9Ff92XhfqbFfHrLdI0beQQ=";
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/betterleaks/betterleaks/version.Version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    versionCheckHook
+  ];
+
+  nativeCheckInputs = [ gitMinimal ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd betterleaks \
+      --bash <($out/bin/betterleaks completion bash) \
+      --fish <($out/bin/betterleaks completion fish) \
+      --zsh <($out/bin/betterleaks completion zsh)
+  '';
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Scan git repos (or files) for secrets";
+    longDescription = ''
+      Betterleaks is a secrets scanner that detects passwords, API keys, and
+      tokens in git repositories and files. It is a drop-in replacement for
+      gitleaks, built by the same authors with improved performance and
+      additional detection features.
+    '';
+    homepage = "https://github.com/betterleaks/betterleaks";
+    changelog = "https://github.com/betterleaks/betterleaks/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kallevmercury ];
+    mainProgram = "betterleaks";
+  };
+})


### PR DESCRIPTION
## Description

Add [betterleaks](https://github.com/betterleaks/betterleaks), a secrets scanner that detects passwords, API keys, and tokens in git repositories and files. It is a drop-in replacement for gitleaks, built by the same authors with improved performance and additional detection features.

## Things done

- [x] Built on platform(s)
  - [x] `aarch64-darwin`
- [x] Tested basic functionality of binary
- [x] `meta.mainProgram` is set
- [x] `passthru.updateScript` is set to `nix-update-script`
- [x] `doInstallCheck = true` with `versionCheckHook`

## Notes

- Uses `subPackages = ["."]` to avoid building an unrelated `config` utility from the source tree (same issue applies to gitleaks).