### PR TITLE
beszel-agent: add dataDir option

### DIFF
--- a/nixos/modules/services/monitoring/beszel-agent.nix
+++ b/nixos/modules/services/monitoring/beszel-agent.nix
@@ -16,6 +16,11 @@ in
   options.services.beszel.agent = {
     enable = lib.mkEnableOption "beszel agent";
     package = lib.mkPackageOption pkgs "beszel" { };
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/beszel-agent";
+      description = "Data directory of beszel-agent.";
+    };
     openFirewall = (lib.mkEnableOption "") // {
       description = "Whether to open the firewall port (default 45876).";
     };
@@ -126,7 +131,7 @@ in
 
       environment = lib.mapAttrs (
         _: value: if lib.isBool value then (lib.boolToString value) else value
-      ) cfg.environment;
+      ) (cfg.environment // { DATA_DIR = cfg.dataDir; });
 
       path =
         cfg.extraPath
@@ -147,6 +152,7 @@ in
         '';
 
         EnvironmentFile = cfg.environmentFile;
+        StateDirectory = baseNameOf cfg.dataDir;
 
         # adds ability to monitor docker/podman containers
         SupplementaryGroups =


### PR DESCRIPTION
### Description

Adds a `dataDir` option to the `beszel-agent` NixOS module, allowing users
to configure a custom data directory. Defaults to `/var/lib/beszel-agent` which is
the default location:
https://github.com/henrygd/beszel/blob/e4e0affbc18b7df639fa2425251fe4484db4066a/agent/data_dir.go#L32

### Motivation

Without this option, there is no way to declaratively configure where
beszel-agent stores its data, and `DATA_DIR` cannot be set.

### Changes

- `nixos/modules/services/monitoring/beszel-agent.nix`: add `dataDir` option

### Testing

Tested on NixOS with a local deployment.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
