### PR TITLE
zxtune: unbreak build

### DIFF
--- a/pkgs/by-name/zx/zxtune/package.nix
+++ b/pkgs/by-name/zx/zxtune/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchFromBitbucket,
+  fetchpatch2,
+  dos2unix,
   nix-update-script,
   boost,
   zlib,
@@ -77,7 +79,22 @@ stdenv.mkDerivation rec {
 
   buildInputs = staticBuildInputs ++ dlopenBuildInputs;
 
+  prePatch = ''
+    # update-vgm.patch : Hunk #1 FAILED at 18 (different line endings)
+    find 3rdparty/vgm/ -type f -exec ${dos2unix}/bin/dos2unix {} \;
+  '';
   patches = [
+    # fix https://hydra.nixos.org/build/317966891
+    (fetchpatch2 {
+      name = "xmp-fix-for-gcc-15.patch";
+      url = "https://github.com/vitamin-caig/zxtune/commit/7f853a38924f78a25b86ac674b41e2f0fd2524a5.patch?full_index=1";
+      hash = "sha256-F6gD+w4lFymSRHXgDngYX/dZI26f7onOmYFlHkPKms8=";
+    })
+    (fetchpatch2 {
+      name = "update-vgm.patch";
+      url = "https://github.com/vitamin-caig/zxtune/commit/31e3ff7a8d13b72e6f72caecd15ae87cefca0465.patch?full_index=1";
+      hash = "sha256-uEa2LY/r/jVWHHEpFtsQba66YdIjA82fDlm+StKp/EI=";
+    })
     ./disable_updates.patch
   ];
 

--- a/pkgs/by-name/zx/zxtune/package.nix
+++ b/pkgs/by-name/zx/zxtune/package.nix
@@ -193,7 +193,10 @@ stdenv.mkDerivation rec {
     # zxtune supports mac and windows, but more work will be needed to
     # integrate with the custom make system (see platformName above)
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ EBADBEEF ];
+    maintainers = with lib.maintainers; [
+      pbsds
+      EBADBEEF
+    ];
     mainProgram = if withQt then "zxtune-qt" else "zxtune123";
   };
 }


### PR DESCRIPTION
- **zxtune: unbreak build**
- **zxtune: add pbsds to maintainers**

fixes https://hydra.nixos.org/build/317966891

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
