### PR TITLE
audiosource: 1.4 -> 1.5

### DIFF
--- a/pkgs/by-name/au/audiosource/adb-args-fix.patch
+++ b/pkgs/by-name/au/audiosource/adb-args-fix.patch
@@ -1,0 +1,16 @@
+diff --git a/audiosource b/audiosource
+index e2f034c..b6efc34 100755
+--- a/audiosource
++++ b/audiosource
+@@ -82,9 +82,9 @@ install() {
+ 
+ 	echo '[+] Installing Audio Source'
+ 
+-	adb install -rtg "$AUDIOSOURCE_APK" || {
++	adb install -r -t -g "$AUDIOSOURCE_APK" || {
+ 		adb uninstall "$AUDIOSOURCE_PKG"
+-		adb install -tg "$AUDIOSOURCE_APK"
++		adb install -t -g "$AUDIOSOURCE_APK"
+ 	}
+ }
+ 

--- a/pkgs/by-name/au/audiosource/package.nix
+++ b/pkgs/by-name/au/audiosource/package.nix
@@ -13,18 +13,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "audiosource";
-  version = "1.4";
+  version = "1.5";
 
   src = fetchFromGitHub {
     owner = "gdzx";
     repo = "audiosource";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SlX8gjs7X5jfoeU6pyk4n8f6oMJgneGVt0pmFs48+mQ=";
+    hash = "sha256-npN7V1svKaxCfsZBvmfm7T/UJsAQ4hQM3RN+tpK5cms=";
   };
 
   patches = [
-    # Removes build-related logic from the script that is unused in the package and fixes a small bug with adb args on new Android versions
-    ./unused-logic-removal-and-args-fix.patch
+    # Removes build-related logic from the script that is unused in the package
+    ./unused-logic-removal.patch
+    # Fixes a small bug with adb args on new Android versions
+    ./adb-args-fix.patch
   ];
 
   postPatch = ''
@@ -62,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.apk = fetchurl {
     url = "https://github.com/gdzx/audiosource/releases/download/v${finalAttrs.version}/audiosource.apk";
-    hash = "sha256-vDIF+NZ3JgTT67Dem4qeajWsA5m/MFt2nRDpWUqC9aU=";
+    hash = "sha256:cd48532829f41060d3c9909daa5563a669394eb9dd00baf303b6db1b5b2db1fa";
   };
 
   meta = {

--- a/pkgs/by-name/au/audiosource/unused-logic-removal.patch
+++ b/pkgs/by-name/au/audiosource/unused-logic-removal.patch
@@ -1,5 +1,5 @@
 diff --git a/audiosource b/audiosource
-index b06127a..0bccddf 100755
+index e2f034c..787076e 100755
 --- a/audiosource
 +++ b/audiosource
 @@ -2,15 +2,7 @@
@@ -16,18 +16,25 @@ index b06127a..0bccddf 100755
 -
 -AUDIOSOURCE_APK=${AUDIOSOURCE_APK:-"$AUDIOSOURCE_DEFAULT_APK"}
 +AUDIOSOURCE_APK=${AUDIOSOURCE_APK:-"@apkPath@"}
+ AUDIOSOURCE_PKG='fr.dzx.audiosource'
  ANDROID_SERIAL=${ANDROID_SERIAL:-}
  
- PYSOCAT="$(cat <<EOF
-@@ -81,22 +73,12 @@ install() {
+@@ -57,14 +49,6 @@ if __name__ == '__main__':
+ EOF
+ )"
  
- 	echo '[+] Installing Audio Source'
- 
--	adb install -rtg "$AUDIOSOURCE_APK" || {
-+	adb install -r -t -g "$AUDIOSOURCE_APK" || {
- 		adb uninstall fr.dzx.audiosource
--		adb install -tg "$AUDIOSOURCE_APK"
-+		adb install -t -g "$AUDIOSOURCE_APK"
+-build() {
+-	if [ "$AUDIOSOURCE_PROFILE" = 'release' ]; then
+-		./gradlew assembleRelease
+-	else
+-		./gradlew assembleDebug
+-	fi
+-}
+-
+ install() {
+ 	if ! command -v adb &> /dev/null; then
+ 		echo "Error: adb not found"
+@@ -88,16 +72,6 @@ install() {
  	}
  }
  
@@ -44,7 +51,7 @@ index b06127a..0bccddf 100755
  _unload() {
  	for id in `pactl list modules short | sed -n "/module-pipe-source\tsource_name=$AUDIOSOURCE_NAME/p" | cut -f1`; do
  		pactl unload-module "$id"
-@@ -146,7 +128,7 @@ volume() {
+@@ -189,7 +163,7 @@ volume() {
  
  main_help() {
  	cat <<-EOF
@@ -53,15 +60,15 @@ index b06127a..0bccddf 100755
  
  		Options:
  
-@@ -154,15 +136,13 @@ main_help() {
+@@ -197,7 +171,6 @@ main_help() {
  
  		Commands:
  
--		   build         Build Audio Source APK (default: debug)
--		   install       Install Audio Source to Android device (default: debug)
-+		   install       Install Audio Source to Android device
- 		   run           Run Audio Source and start forwarding
- 		   volume LEVEL  Set volume to LEVEL (for example, 250%)
+-		   build         Build Audio Source APK
+ 		   install       Install Audio Source to Android device
+ 		   run [-r]      Run Audio Source and start forwarding
+ 		                 (-r will automatically restart)
+@@ -205,8 +178,7 @@ main_help() {
  
  		Environment:
  
@@ -71,7 +78,7 @@ index b06127a..0bccddf 100755
  		   AUDIOSOURCE_NAME     Name of the PulseAudio source (default: android-<serial-hash>)
  		   ANDROID_SERIAL       Device serial number to connect to (default: unset)
  	EOF
-@@ -200,7 +180,7 @@ main() {
+@@ -244,7 +216,7 @@ main() {
  	shift
  
  	case "$cmd" in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/gdzx/audiosource/releases/tag/v1.5

I've also split the patch to the original script into two parts to make things slightly cleaner and filenames shorter.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
