### PR TITLE
pulsar: 1.131.1 -> 1.131.2

### DIFF
--- a/pkgs/by-name/pu/pulsar/package.nix
+++ b/pkgs/by-name/pu/pulsar/package.nix
@@ -259,10 +259,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = writeShellScript "update-pulsar" ''
     set -euo pipefail
-    PATH="${lib.getBin curl}:$PATH"
-    PATH="${lib.getBin jq}:$PATH"
-    PATH="${lib.getBin coreutils}:$PATH"
-    PATH="${lib.getBin nix-update}:$PATH"
+    export PATH="${
+      lib.makeBinPath [
+        coreutils
+        curl
+        jq
+        nix-update
+      ]
+    }"
     version="$(curl https://api.github.com/repos/pulsar-edit/pulsar/releases/latest | jq ".tag_name" -r | tr -d 'v')"
     nix-update pkgsCross.gnu64.pulsar --version "$version"
     nix-update pkgsCross.aarch64-multiplatform.pulsar --version skip

--- a/pkgs/by-name/pu/pulsar/package.nix
+++ b/pkgs/by-name/pu/pulsar/package.nix
@@ -89,7 +89,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pulsar";
-  version = "1.131.1";
+  version = "1.131.2";
 
   src =
     finalAttrs.passthru.srcs.${stdenv.hostPlatform.system}
@@ -98,11 +98,11 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.srcs = {
     x86_64-linux = fetchurl {
       url = "https://github.com/pulsar-edit/pulsar/releases/download/v${finalAttrs.version}/Linux.pulsar-${finalAttrs.version}.tar.gz";
-      hash = "sha256-Is+KAnPuHUrj87KFTjB/v/LMDflq4LbX3VP8Cv7/CNQ=";
+      hash = "sha256-9KziiAKvfzh1yERPRakMCuQmW0ZlUQiaNFI2plWgb/c=";
     };
     aarch64-linux = fetchurl {
       url = "https://github.com/pulsar-edit/pulsar/releases/download/v${finalAttrs.version}/ARM.Linux.pulsar-${finalAttrs.version}-arm64.tar.gz";
-      hash = "sha256-P2ZBV9Al6xw347yUs3BOWnwJGWegRh52oygLFgjoBcw=";
+      hash = "sha256-0AG87yQfg/osTtCBV10/X/4MXkWxD7lkDXcyFIGKvEs=";
     };
   };
 


### PR DESCRIPTION
Changelog: https://github.com/pulsar-edit/pulsar/blob/v1.131.2/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
