### PR TITLE
[release-25.11] python3Packages.gradio: mark insecure

### DIFF
--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -379,5 +379,11 @@ buildPythonPackage rec {
     description = "Python library for easily interacting with trained machine learning models";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ pbsds ];
+    knownVulnerabilities = [
+      "gradio v5 is unmaintained, upgrade to v6 on nixos-unstable"
+      "CVE-2026-27167" # https://github.com/NixOS/nixpkgs/issues/496131
+      "CVE-2026-28416" # https://github.com/NixOS/nixpkgs/issues/496130
+      "CVE-2026-28415" # https://github.com/NixOS/nixpkgs/issues/496125
+    ];
   };
 }

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -380,7 +380,7 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ pbsds ];
     knownVulnerabilities = [
-      "gradio v5 is unmaintained, upgrade to v6 on nixos-unstable"
+      "gradio v5 is unmaintained, upgrade to v6 on nixos-unstable or on nixos-26.05"
       "CVE-2026-27167" # https://github.com/NixOS/nixpkgs/issues/496131
       "CVE-2026-28416" # https://github.com/NixOS/nixpkgs/issues/496130
       "CVE-2026-28415" # https://github.com/NixOS/nixpkgs/issues/496125


### PR DESCRIPTION
closes https://github.com/NixOS/nixpkgs/issues/496131
closes https://github.com/NixOS/nixpkgs/issues/496130
closes https://github.com/NixOS/nixpkgs/issues/496125


I initially backported gradio 6 to nixos-25.11 like so:

```
git cherry-pick -x 016457b94c62 # python3Packages.gradio: add updateScript
git cherry-pick -x 24146425a899 # python3Packages.gradio-client: modify updateScript
git cherry-pick -x 1379ae70af0d # python3Packages.gradio-client: 1.12.1 -> 2.0.1
git cherry-pick -x e434fb5db4e7 # python3Packages.gradio-pdf: 0.0.22 -> 0.0.23
git cherry-pick -x 9c931abdf4a5 # python3Packages.gradio: 5.49.1 -> 6.1.0
git cherry-pick -x 3ad9007b0555 # python3Packages.gradio: 6.1.0 -> 6.2.0
git cherry-pick -x 40e1fd425865 # python3Packages.gradio: clean up dependencies
git cherry-pick -x b1bbc0b32ad7 # python3Packages.gradio: 6.2.0 -> 6.3.0
git cherry-pick -x acdaa5ade3b8 # python3Packages.gradio: 6.3.0 -> 6.4.0
git cherry-pick -x 4016f1755a9c # python3Packages.gradio-client: fix tests
git cherry-pick -x b3662670f9e9 # python3Packages.gradio: 6.4.0 -> 6.5.1
git cherry-pick -x 2236517ed2c4 # python3Packages.gradio: 6.5.1 -> 6.8.0
git cherry-pick -x a9b9af1579fc # python3Packages.gradio-client: 2.0.1 -> 2.2.0
git cherry-pick -x 3e0ce62945bb # python3Packages.gradio-client: tether version to gradio
git cherry-pick -x 6d3864070f0a # python3Packages.gradio: 6.8.0 -> 6.9.0
```

but then i saw the [breaking changes](https://www.gradio.app/main/guides/gradio-6-migration-guide), and opted not to backport.




<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
