### PR TITLE
eclipses: fix update script to handle new download page format

### DIFF
--- a/pkgs/applications/editors/eclipse/update.sh
+++ b/pkgs/applications/editors/eclipse/update.sh
@@ -1,31 +1,31 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i bash --pure -p curl cacert libxml2 yq nix jq
-#! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/3c7487575d9445185249a159046cc02ff364bff8.tar.gz
+#! nix-shell -i bash --pure -p curl cacert nix jq
+#! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/5b2c2d84341b2afb5647081c1386a80d7a8d8605.tar.gz
 #                                                                ^
 #                                                                |
-#                   nixos-unstable ~ 2023-07-06 -----------------/
+#                   nixos-unstable ~ 2026-03-16 -----------------/
 
 set -o errexit
 set -o nounset
 
 # scrape the downloads page for release info
 
-curl -s -o eclipse-dl.html https://download.eclipse.org/eclipse/downloads/
-trap "rm eclipse-dl.html" EXIT
+curl -s -O https://download.eclipse.org/eclipse/downloads/data.json
+trap "rm data.json" EXIT
 
 dlquery() {
-    q=$1
-    xmllint --html eclipse-dl.html --xmlout 2>/dev/null | xq -r ".html.body.main.div.table[3].tr[1].td[0].a${q}";
+    q="$1"
+    cat data.json | jq -r ".releases[0] | $q";
 }
 
 # extract release info from download page HTML
 
-platform_major=$(dlquery '."#text" | split(".") | .[0]' -r);
-platform_minor=$(dlquery '."#text" | split(".") | .[1]' -r);
+platform_major=$(dlquery '.label | split(".") | .[0]');
+platform_minor=$(dlquery '.label | split(".") | .[1]');
 
-year=$(dlquery '."@href" | split("/") | .[] | select(. | startswith("R")) | split("-") | .[2] | .[0:4]')
-buildmonth=$(dlquery '."@href" | split("/") | .[] | select(. | startswith("R")) | split("-") | .[2] | .[4:6]')
-builddaytime=$(dlquery '."@href" | split("/") | .[] | select(. | startswith("R")) | split("-") | .[2] | .[6:12]')
+year=$(dlquery '.path | split("/") | .[] | select(. | startswith("R")) | split("-") | .[2] | .[0:4]')
+buildmonth=$(dlquery '.path | split("/") | .[] | select(. | startswith("R")) | split("-") | .[2] | .[4:6]')
+builddaytime=$(dlquery '.path | split("/") | .[] | select(. | startswith("R")) | split("-") | .[2] | .[6:12]')
 timestamp="${year}${buildmonth}${builddaytime}";
 
 # account for possible release-month vs. build-month mismatches


### PR DESCRIPTION
there is now a convenient data.json that makes scraping much easier

This worked locally to produce an updated to 4.39 (2026-03), but I'd like to let the update machinery run it to make sure it works, rather than creating the PR for it manually.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
