### PR TITLE
python3Packages.sphinx-markdown-builder: remove superfluous dependencies

### DIFF
--- a/pkgs/development/python-modules/sphinx-markdown-builder/default.nix
+++ b/pkgs/development/python-modules/sphinx-markdown-builder/default.nix
@@ -6,7 +6,6 @@
 
   # build system
   setuptools,
-  wheel,
 
   # deps
   docutils,
@@ -15,19 +14,7 @@
 
   # tests
   pytestCheckHook,
-
-  # optional deps
-  black,
-  bumpver,
-  coveralls,
-  flake8,
-  isort,
-  pip-tools,
-  pylint,
-  pytest,
-  pytest-cov,
   sphinxcontrib-httpdomain,
-  sphinxcontrib-plantuml,
 }:
 
 buildPythonPackage rec {
@@ -44,7 +31,6 @@ buildPythonPackage rec {
 
   build-system = [
     setuptools
-    wheel
   ];
 
   dependencies = [
@@ -53,34 +39,14 @@ buildPythonPackage rec {
     tabulate
   ];
 
-  optional-dependencies = {
-    dev = [
-      black
-      bumpver
-      coveralls
-      flake8
-      isort
-      pip-tools
-      pylint
-      pytest
-      pytest-cov
-      sphinx
-      sphinxcontrib-httpdomain
-      sphinxcontrib-plantuml
-    ];
-  };
-
   pythonImportsCheck = [
     "sphinx_markdown_builder"
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
+    sphinxcontrib-httpdomain
   ];
-
-  # NOTE: not sure why, but a `Missing dependencies: wheel` error happens when
-  # `black` is included here, with python3.13
-  checkInputs = lib.remove black optional-dependencies.dev;
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
