### PR TITLE
ceph: dashboard integration tests

### DIFF
--- a/nixos/modules/services/network-filesystems/ceph.nix
+++ b/nixos/modules/services/network-filesystems/ceph.nix
@@ -61,6 +61,7 @@ let
           5;
       startLimitIntervalSec = 60 * 30; # 30 mins
 
+      path = [ ceph.out ];
       serviceConfig = {
         LimitNOFILE = 1048576;
         LimitNPROC = 1048576;

--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -43,6 +43,7 @@ let
     { pkgs, ... }:
     {
       virtualisation = {
+        memorySize = 2048;
         emptyDiskImages = [
           20480
           20480
@@ -91,6 +92,10 @@ let
           cfg.osd1.name
           cfg.osd2.name
         ];
+      };
+      rgw = {
+        enable = true;
+        daemons = [ cfg.monA.name ];
       };
     };
   };
@@ -196,6 +201,16 @@ let
         "ceph osd pool delete single-node-other-test single-node-other-test --yes-i-really-really-mean-it",
     )
 
+    # Bootstrap RGW
+    monA.succeed(
+        "sudo -u ceph mkdir -p /var/lib/ceph/radosgw/ceph-${cfg.monA.name}",
+        "ceph auth get-or-create client.${cfg.monA.name} osd 'allow rwx' mon 'allow rw' > /var/lib/ceph/radosgw/ceph-${cfg.monA.name}/keyring",
+        "chown ceph:ceph /var/lib/ceph/radosgw/ceph-${cfg.monA.name}/keyring",
+        "systemctl start ceph-rgw-${cfg.monA.name}",
+    )
+    monA.wait_for_unit("ceph-rgw-${cfg.monA.name}")
+    monA.wait_for_open_port(7480)
+
     # Shut down ceph by stopping ceph.target.
     monA.succeed("systemctl stop ceph.target")
 
@@ -206,6 +221,7 @@ let
     monA.wait_for_unit("ceph-osd-${cfg.osd0.name}")
     monA.wait_for_unit("ceph-osd-${cfg.osd1.name}")
     monA.wait_for_unit("ceph-osd-${cfg.osd2.name}")
+    monA.wait_for_unit("ceph-rgw-${cfg.monA.name}")
 
     # Ensure the cluster comes back up again
     monA.succeed("ceph -s | grep 'mon: 1 daemons'")
@@ -229,6 +245,7 @@ let
     monA.succeed(
         "echo 'foo bar baz qux' > /tmp/dashboard_pw",
         "ceph dashboard ac-user-create admin -i /tmp/dashboard_pw administrator",
+        "ceph dashboard set-rgw-credentials",
     )
 
     # Get dashboard auth token
@@ -243,6 +260,12 @@ let
         f"curl --fail -s -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Authorization: Bearer {token}' http://localhost:8080/api/health/minimal",
     ))
     assert health["health"]["status"] == "HEALTH_OK"
+
+    # List daemons via REST API
+    rgw_daemons = json.loads(monA.succeed(
+        f"curl --fail -s -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Authorization: Bearer {token}' http://localhost:8080/api/rgw/daemon",
+    ))
+    assert rgw_daemons[0]["id"] == "a"
   '';
 in
 {

--- a/nixos/tests/ceph-single-node.nix
+++ b/nixos/tests/ceph-single-node.nix
@@ -100,6 +100,8 @@ let
   # For other ways to deploy a ceph cluster, look at the documentation at
   # https://docs.ceph.com/docs/master/
   testScript = ''
+    import json
+
     start_all()
 
     monA.wait_for_unit("network.target")
@@ -222,6 +224,25 @@ let
     monA.wait_for_open_port(8080)
     monA.wait_until_succeeds("curl -q --fail http://localhost:8080")
     monA.wait_until_succeeds("ceph -s | grep 'HEALTH_OK'")
+
+    # Initialize dashboard creds
+    monA.succeed(
+        "echo 'foo bar baz qux' > /tmp/dashboard_pw",
+        "ceph dashboard ac-user-create admin -i /tmp/dashboard_pw administrator",
+    )
+
+    # Get dashboard auth token
+    auth_payload = json.dumps({"username": "admin", "password": "foo bar baz qux"})
+    auth_response = json.loads(monA.succeed(
+        f"curl --fail -s -X POST -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Content-Type: application/json' -d '{auth_payload}' http://localhost:8080/api/auth",
+    ))
+    token = auth_response["token"]
+
+    # Check cluster health via dashboard API
+    health = json.loads(monA.succeed(
+        f"curl --fail -s -H 'Accept: application/vnd.ceph.api.v1.0+json' -H 'Authorization: Bearer {token}' http://localhost:8080/api/health/minimal",
+    ))
+    assert health["health"]["status"] == "HEALTH_OK"
   '';
 in
 {


### PR DESCRIPTION
Hey nixpkgs ceph team, I wanted to see if I could help contribute to the ceph 20 upgrade effort. I know there were some concerns about keeping ceph-mgr modules like dashboard working through the python incompatible changes. The current integration test suite doesn't exercise code like the dashboard so I thought adding some additional coverage there could be helpful.

The ceph dashboard ui itself is built on top of the [ceph resful api](https://docs.ceph.com/en/squid/mgr/ceph_api/) (which is different than the now deprecated [restful module](https://docs.ceph.com/en/squid/mgr/restful/)). So hitting it makes for a good way to see if the dashboard components are all working correctly. I did actually uncover a bug where ceph-mgr expects radosgw-admin in its path. I have a quick fix to ensure ceph bin is in the systemd unit path, but I feel like this would be better patched in a ceph-mgr wrapper maybe. It seems like there are similar issues in #494583 needing a wrapper for python3 discovery.

This branch merge base is currently before the major python changes so I can confirm these pass on 19.x, pre-20.x changes.

I'm not sure when it makes sense for this change to be ready. Maybe after #494583 is sorted out?

CC @benaryorg @nh2 @James-1701 @limwa 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
