### PR TITLE
global: fix build with GCC 15

### DIFF
--- a/pkgs/by-name/gl/global/package.nix
+++ b/pkgs/by-name/gl/global/package.nix
@@ -1,5 +1,6 @@
 {
   fetchurl,
+  fetchpatch2,
   lib,
   stdenv,
   libtool,
@@ -23,6 +24,15 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://gnu/global/global-${finalAttrs.version}.tar.gz";
     hash = "sha256-9uf9C2iu0pLoW7aGYWuvZVHVyUJK3N3KEdgIujGMsyA=";
   };
+
+  patches = [
+    # Fix for GCC 15 / C23, which interprets empty function parameter lists as
+    # having no parameters instead of an unspecified signature.
+    (fetchpatch2 {
+      url = "https://src.fedoraproject.org/rpms/global/raw/5a1ababa270e571f3133c03edcdb0e65f95e763f/f/libdb-dbpanic-function-pointers.patch";
+      hash = "sha256-o8u90h8ufF0Yr049fR9iMba+xq1tHXeiPdrHFSZMir0=";
+    })
+  ];
 
   nativeBuildInputs = [
     libtool


### PR DESCRIPTION
Closes #496198. Part of #475479.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
