### PR TITLE
python3Packages.ppf-datamatrix: init at 0.2

### DIFF
--- a/pkgs/development/python-modules/ppf-datamatrix/default.nix
+++ b/pkgs/development/python-modules/ppf-datamatrix/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  setuptools-scm,
+  fetchFromGitHub,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ppf-datamatrix";
+  version = "0.2";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "adrianschlatter";
+    repo = "ppf.datamatrix";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-g6KTUUYDXUlFmV0Rg3Mp23huAb+j+LTWrvY8wuYB90g=";
+  };
+
+  build-system = [ setuptools-scm ];
+
+  pythonImportsCheck = [ "ppf.datamatrix" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Pure-python package to generate data matrix codes";
+    homepage = "https://github.com/adrianschlatter/ppf.datamatrix";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kurogeek ];
+    changelog = "https://github.com/adrianschlatter/ppf.datamatrix/releases/tag/v${finalAttrs.src.tag}";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12727,6 +12727,8 @@ self: super: with self; {
 
   ppdeep = callPackage ../development/python-modules/ppdeep { };
 
+  ppf-datamatrix = callPackage ../development/python-modules/ppf-datamatrix { };
+
   ppft = callPackage ../development/python-modules/ppft { };
 
   ppk2-api = callPackage ../development/python-modules/ppk2-api { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
