### PR TITLE
sdl3: Use dlopen ELF notes

### DIFF
--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -6,6 +6,7 @@
   cmake,
   dbus,
   fetchFromGitHub,
+  autoPatchelfHook,
   ibusMinimal,
   installShellFiles,
   libGL,
@@ -97,20 +98,6 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail '"zenity"' '"${lib.getExe zenity}"'
       substituteInPlace src/dialog/unix/SDL_zenitydialog.c \
         --replace-fail '"zenity"' '"${lib.getExe zenity}"'
-    ''
-    # https://github.com/libsdl-org/SDL/issues/14805
-    + lib.optionalString vulkanSupport ''
-      substituteInPlace src/video/x11/SDL_x11vulkan.c \
-                        src/video/wayland/SDL_waylandvulkan.c \
-                        src/video/offscreen/SDL_offscreenvulkan.c \
-                        src/video/kmsdrm/SDL_kmsdrmvulkan.c \
-                        src/video/vivante/SDL_vivantevulkan.c \
-                        src/video/android/SDL_androidvulkan.c \
-        --replace-fail 'libvulkan.so' '${lib.getLib vulkan-loader}/lib/libvulkan.so'
-    ''
-    + lib.optionalString x11Support ''
-      substituteInPlace src/video/x11/SDL_x11vulkan.c \
-        --replace-fail 'libX11-xcb.so' '${lib.getLib libx11}/lib/libX11-xcb.so'
     '';
 
   strictDeps = true;
@@ -119,8 +106,15 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     validatePkgConfig
+    autoPatchelfHook
   ]
   ++ lib.optional waylandSupport wayland-scanner;
+
+  autoPatchelfFlags = [ "--keep-libc" ];
+  autoPatchelfIgnoreMissingDeps = [
+    "libGLES_CM.so.1"
+    "libsteam_api.so"
+  ];
 
   buildInputs =
     lib.optionals libusbSupport [


### PR DESCRIPTION
Use the same trick we do in systemd to satisfy dlopen dependencies automatically. This way we don't have to do things like patch in libraries' full paths, and it works for all dependencies in `buildInputs` instead of just the ones we rememebered to check. For instance, we're now picking up the dependencies necessary for it to `dlopen` `libudev` and `libdbus-1`, which are both recommended dependencies.

```
$ readelf -n libSDL3.so.0.4.0

Displaying notes found in: .note.gnu.property
  Owner                Data size        Description
  GNU                  0x00000020       NT_GNU_PROPERTY_TYPE_0
      Properties: x86 feature used: x86, MMX, XMM, YMM
        x86 ISA used: x86-64-baseline, x86-64-v2, x86-64-v3

Displaying notes found in: .note.dlopen
  Owner                Data size        Description
  FDO                  0x00000077       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"egl-ogl-es","description":"Support for OpenGL ES","priority":"suggested","soname":["libGLESv1_CM.so.1"]}]
  FDO                  0x00000076       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"egl-es-pvr","description":"Support for EGL ES PVR","priority":"suggested","soname":["libGLES_CM.so.1"]}]
  FDO                  0x0000006f       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"egl-es2","description":"Support for EGL ES2","priority":"suggested","soname":["libGLESv2.so.2"]}]
  FDO                  0x00000068       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"egl-egl","description":"Support for EGL","priority":"suggested","soname":["libEGL.so.1"]}]
  FDO                  0x0000007e       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"egl-opengl","description":"Support for OpenGL","priority":"suggested","soname":["libGL.so.1","libOpenGL.so.0"]}]
  FDO                  0x00000079       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"x11-vulkan","description":"Support for vulkan on X11","priority":"suggested","soname":["libX11-xcb.so.1"]}]
  FDO                  0x00000078       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"x11-vulkan","description":"Support for vulkan on X11","priority":"suggested","soname":["libvulkan.so.1"]}]
  FDO                  0x0000007e       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"kmsdrm-vulkan","description":"Support for Vulkan on KMSDRM","priority":"suggested","soname":["libvulkan.so.1"]}]
  FDO                  0x00000088       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"wayland-vulkan","description":"Support for Vulkan on wayland backend","priority":"suggested","soname":["libvulkan.so.1"]}]
  FDO                  0x00000078       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"core-libdbus","description":"Support for D-Bus IPC","priority":"recommended","soname":["libdbus-1.so.3"]}]
  FDO                  0x000000a0       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"events-udev","description":"Support for events through libudev","priority":"recommended","soname":["libudev.so.1","libudev.so.1","libudev.so.0"]}]
  FDO                  0x00000081       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"storage-steam","description":"Support for Steam user storage","priority":"suggested","soname":["libsteam_api.so"]}]
  FDO                  0x00000081       FDO_DLOPEN_METADATA
    Dlopen Metadata: [{"feature":"offscreen-vulkan","description":"Support for offscreen Vulkan","priority":"suggested","soname":["libvulkan.so.1"]}]
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
