### PR TITLE
godot-mcp: init at 0-unstable-2026-01-30

### DIFF
--- a/pkgs/by-name/go/godot-mcp/package.nix
+++ b/pkgs/by-name/go/godot-mcp/package.nix
@@ -38,7 +38,7 @@ buildNpmPackage {
     mainProgram = "godot-mcp";
     homepage = "https://github.com/Coding-Solo/godot-mcp";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ superherointj ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/go/godot-mcp/package.nix
+++ b/pkgs/by-name/go/godot-mcp/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage {
+  pname = "godot-mcp";
+  version = "0-unstable-2026-01-30";
+
+  src = fetchFromGitHub {
+    owner = "Coding-Solo";
+    repo = "godot-mcp";
+    rev = "f341234dfe44613e1d48fe4fbc8bfb9bf2e8e9eb";
+    hash = "sha256-cUGaO+6zP+3oUuB4Ni1HfBkb7QVxk9tznUkoxfQqH+s=";
+  };
+
+  npmDepsHash = "sha256-9F2QW8+IQiL+qZ4EXSq1pgk3DMmES8aAP3CAwL+fDfc=";
+
+  npmInstallFlags = [
+    "--ignore-scripts"
+  ];
+
+  npmBuildFlags = [
+    "run"
+    "build"
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "MCP server for interfacing with Godot game engine";
+    longDescription = ''
+      A Model Context Protocol (MCP) server for interacting with the Godot
+      game engine. Enables AI assistants to launch the Godot editor, run
+      projects, capture debug output, and control project execution.
+    '';
+    mainProgram = "godot-mcp";
+    homepage = "https://github.com/Coding-Solo/godot-mcp";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A new Model Context Protocol (MCP) server for interacting with the Godot game engine. Enables AI assistants to launch the Godot editor, run projects, capture debug output, and control project execution.

Homepage: https://github.com/Coding-Solo/godot-mcp

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
