### PR TITLE
arc_unpacker: fix build with boost 1.89

### DIFF
--- a/pkgs/by-name/ar/arc_unpacker/package.nix
+++ b/pkgs/by-name/ar/arc_unpacker/package.nix
@@ -41,6 +41,11 @@ stdenv.mkDerivation {
     substituteInPlace CMakeLists.txt --replace-fail \
       'cmake_minimum_required(VERSION 2.8.8)' \
       'cmake_minimum_required(VERSION 3.10)'
+
+    # boost 1.89 no longer provides boost_system as a separate CMake component
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'find_package(Boost COMPONENTS filesystem system REQUIRED)' \
+      'find_package(Boost COMPONENTS filesystem REQUIRED)'
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

Ref #485826

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
