### PR TITLE
prek: Declare runtime dependencies

### DIFF
--- a/pkgs/by-name/pr/prek/package.nix
+++ b/pkgs/by-name/pr/prek/package.nix
@@ -9,8 +9,14 @@
   python312,
   versionCheckHook,
   nix-update-script,
+  withPythonSupport ? false,
 }:
-
+let
+  pythonRuntimeDeps = [
+    python312
+    uv
+  ];
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "prek";
   version = "0.3.6";
@@ -30,9 +36,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeCheckInputs = [
     git
-    python312
-    uv
-  ];
+  ]
+  ++ pythonRuntimeDeps;
+
+  propagatedBuildInputs = [
+    git
+  ]
+  ++ lib.optionals withPythonSupport pythonRuntimeDeps;
 
   # many tests just do not work, as they require network access
   # best to disable all, as the upstream already tests everything


### PR DESCRIPTION
`prek` assumes that `git` is on the `PATH`.

`prek` will attempt to download `uv` if it's not on the `PATH`, but the
downloaded executable is not compatible with NixOS. `prek` also assumes
`python` is on the `PATH` when dealing with Python-based hooks. Because
of this I've bundled those under a `withPythonSupport` flag. This flag
defaults to `false` for compatibility with the original code, and to
keep the package the minimal size by default.

Closes <https://github.com/j178/prek/issues/1707>.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
