### PR TITLE
slobdict: 1.0.0 -> 1.2.0

### DIFF
--- a/pkgs/by-name/sl/slobdict/package.nix
+++ b/pkgs/by-name/sl/slobdict/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   blueprint-compiler,
   meson,
   ninja,
@@ -17,7 +18,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "slobdict";
-  version = "1.0.0";
+  version = "1.2.0";
 
   pyproject = false; # built with meson
 
@@ -25,11 +26,12 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "MuntashirAkon";
     repo = "SlobDict";
     tag = finalAttrs.version;
-    hash = "sha256-V6EmEpxUMZUN9lHSNs4nZBZI2QNxUUWWODukm01lYxY=";
+    hash = "sha256-4u0VqaPDpyflWkN119IOVqKxpsskou3ou1dqpuRSaHI=";
   };
 
   nativeBuildInputs = [
     blueprint-compiler
+    glib
     gobject-introspection
     meson
     ninja
@@ -62,13 +64,28 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pymorphy3
     # python-romkan-ng not packaged
     xxhash
+
+    # Deps for cli mode
+    pygments
+    rich
+    premailer
+    cssutils
+    markdownify
   ];
 
   # Prevent double wrapping, let the Python wrapper use the args in preFixup.
   dontWrapGApps = true;
 
+  postBuild = ''
+    glib-compile-schemas --strict ../gnome-extension/slobdict@muntashir.dev/schemas
+  '';
+
   postInstall = ''
     chmod +x $out/bin/slobdict
+
+    mkdir -p $out/share/gnome-shell/extensions/slobdict@muntashir.dev
+    cp -r ../gnome-extension/slobdict@muntashir.dev/schemas $out/share/gnome-shell/extensions/slobdict@muntashir.dev
+    cp ../gnome-extension/slobdict@muntashir.dev/{extension.js,metadata.json} $out/share/gnome-shell/extensions/slobdict@muntashir.dev
   '';
 
   preFixup = ''
@@ -76,6 +93,11 @@ python3Packages.buildPythonApplication (finalAttrs: {
   '';
 
   strictDeps = true;
+
+  passthru = {
+    extensionPortalSlug = "slobdict";
+    extensionUuid = "slobdict@muntashir.dev";
+  };
 
   meta = {
     homepage = "https://github.com/MuntashirAkon/SlobDict";

--- a/pkgs/development/python-modules/premailer/default.nix
+++ b/pkgs/development/python-modules/premailer/default.nix
@@ -1,0 +1,44 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  lxml,
+  cssselect,
+  cssutils,
+  requests,
+  cachetools,
+  lib,
+}:
+
+buildPythonPackage {
+  pname = "premailer";
+  version = "3.10.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "peterbe";
+    repo = "premailer";
+    rev = "f4ded0b9701c4985e7ff5c5beda83324c264ea62";
+    hash = "sha256-8ALdpR3aIDg0wP+JYCPY1f7mEJgdJm8xlLlgGpa0Sa4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    lxml
+    cssselect
+    cssutils
+    requests
+    cachetools
+  ];
+
+  pythonImportsCheck = [ "premailer" ];
+
+  meta = {
+    changelog = "https://github.com/peterbe/premailer/blob/master/CHANGES.rst";
+    description = "Turns CSS blocks into style attributes";
+    homepage = "https://github.com/peterbe/premailer";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.linsui ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12785,6 +12785,8 @@ self: super: with self; {
 
   preggy = callPackage ../development/python-modules/preggy { };
 
+  premailer = callPackage ../development/python-modules/premailer { };
+
   preprocess-cancellation = callPackage ../development/python-modules/preprocess-cancellation { };
 
   presenterm-export = callPackage ../development/python-modules/presenterm-export { };


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/pull/500861

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
