### PR TITLE
ardopc: fix build with gcc 15

### DIFF
--- a/pkgs/by-name/ar/ardopc/package.nix
+++ b/pkgs/by-name/ar/ardopc/package.nix
@@ -22,6 +22,20 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/ARDOPC";
 
+  postPatch = ''
+    substituteInPlace pktSession.c \
+      --replace-fail 'VOID L2SENDCOMMAND();' 'VOID L2SENDCOMMAND(struct _LINKTABLE * LINK, int CMD);' \
+      --replace-fail 'VOID CONNECTFAILED();' 'VOID CONNECTFAILED(struct _LINKTABLE * LINK);'
+    substituteInPlace ARDOPC.h \
+      --replace-fail 'BOOL CheckForPktData();' 'BOOL CheckForPktData(int Channel);'
+    substituteInPlace ALSASound.c \
+      --replace-fail 'void InitSound(BOOL Quiet)' 'void InitSound()'
+    substituteInPlace ARQ.c \
+      --replace-fail 'SendData(FALSE);' 'SendData();'
+    substituteInPlace Modulate.c \
+      --replace-fail 'SoundFlush(Number);' 'SoundFlush();'
+  '';
+
   nativeBuildInputs = [
     makeWrapper
     pkg-config


### PR DESCRIPTION
## Things done

Ref #475479

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
