### PR TITLE
dotenvx: 1.51.1 -> 1.57.2

### DIFF
--- a/pkgs/by-name/do/dotenvx/package.nix
+++ b/pkgs/by-name/do/dotenvx/package.nix
@@ -8,16 +8,16 @@
 
 buildNpmPackage rec {
   pname = "dotenvx";
-  version = "1.51.4";
+  version = "1.57.2";
 
   src = fetchFromGitHub {
     owner = "dotenvx";
     repo = "dotenvx";
     tag = "v${version}";
-    hash = "sha256-+tPN1ZLYWJ0WHQN7uRYMK13XTTEJy63gOpetiQZjtqY=";
+    hash = "sha256-OJYE1oK2AJV1zHh1eIx1pdH5N9PQN9n559B+qk2BcXo=";
   };
 
-  npmDepsHash = "sha256-K75er2hcfWiWDlKAU9BWyZ/peO9LoB5DLBz9vIBnn10=";
+  npmDepsHash = "sha256-sCwQ43CC9N9FLI7gHY3n80Tjg+lKKc0bqDcw7r2ZC10=";
 
   dontNpmBuild = true;
 
@@ -30,11 +30,14 @@ buildNpmPackage rec {
   };
 
   meta = {
-    description = "Better dotenv–from the creator of `dotenv";
+    description = "Better dotenv–from the creator of `dotenv`";
     homepage = "https://github.com/dotenvx/dotenvx";
     changelog = "https://github.com/dotenvx/dotenvx/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ natsukium ];
+    maintainers = with lib.maintainers; [
+      natsukium
+      kaynetik
+    ];
     mainProgram = "dotenvx";
   };
 }


### PR DESCRIPTION
<s>The upstream `package-lock.json` in every recent dotenvx release has `minipass-fetch@3.0.5` declaring `encoding@^0.1.13` as an `optionalDependencies` entry - but the encoding package was never actually resolved and added to the lock file's packages section. Newer npm (v10+) enforces strict lockfile consistency in `npm ci` and rejects this with `EUSAGE: Missing: encoding@ from lock file`. This happens before any installation even begins, so flags like `--legacy-peer-deps` or `--omit=optional` don't help.

The fix pattern (used by several packages I observed, like jsonld-cli, hyperbeam, intelephense): ship a vendored/patched package-lock.json alongside package.nix and substitute it via postPatch.</s>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
