### PR TITLE
actool: init at 1.3.0

### DIFF
--- a/pkgs/by-name/ac/actool/package.nix
+++ b/pkgs/by-name/ac/actool/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  icu,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "actool";
+  version = "1.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "viraptor";
+    repo = "actool";
+    tag = finalAttrs.version;
+    hash = "sha256-8v2P6Z1ZOP65M30+7dTtfXvD0dvaKYSLA9aaP2uzA7E=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    pillow
+    liblzfse
+    icu
+  ];
+
+  meta = {
+    description = "Apple's actool reimplementation";
+    homepage = "https://github.com/viraptor/actool";
+    license = [ lib.licenses.mit ];
+    mainProgram = "actool";
+    maintainers = [ lib.maintainers.viraptor ];
+  };
+})


### PR DESCRIPTION
Add an independent reimplementation of Apple's actool. Due to old version of available upstream actool, we're not able to compile some assets successfully anymore, like the ones in element-desktop and transmission.
This alternative supports some newer behaviours, but is nowhere close to complete yet.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
