### PR TITLE
nextpnr: 0.9-unstable-2026-02-08 -> 0.10

### DIFF
--- a/pkgs/by-name/ne/nextpnr/package.nix
+++ b/pkgs/by-name/ne/nextpnr/package.nix
@@ -22,11 +22,6 @@ let
     enablePython = true;
   };
 
-  pname = "nextpnr";
-
-  # Version 0.9 was patched (c7cfb) for Boost 1.87+ compatibility (boost system)
-  version = "0.9-unstable-2026-02-08";
-
   prjbeyond_src = fetchFromGitHub {
     owner = "YosysHQ-GmbH";
     repo = "prjbeyond-db";
@@ -35,65 +30,67 @@ let
   };
 in
 
-stdenv.mkDerivation rec {
-  inherit pname version;
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nextpnr";
+  version = "0.10";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "nextpnr";
-    rev = "35f14336c042a9aa86cc66221434262fbb02034e";
-    hash = "sha256-5Fn/Y+pjhnGFcZsCN7XZN0nPB9u/BIr+lxgrCC5pnpE=";
+    tag = "nextpnr-${finalAttrs.version}";
     fetchSubmodules = true;
+    hash = "sha256-goHHEvkBw+9s3RHGfQtRaueXRBnoI14TmfGmb+1WPAY=";
   };
+
+  # Don't use #embed macro for chipdb binary embeddings - otherwise getting spurious type narrowing errors.
+  # Maybe related to: https://github.com/llvm/llvm-project/issues/119256
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "check_cxx_compiler_hash_embed(HAS_HASH_EMBED CXX_FLAGS_HASH_EMBED)" ""
+  '';
 
   nativeBuildInputs = [
     cmake
     python3
   ]
-  ++ (lib.optional enableGui wrapQtAppsHook);
+  ++ lib.optionals enableGui [
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
     boostPython
     eigen
     python3Packages.apycula
   ]
-  ++ (lib.optional enableGui qtbase)
-  ++ (lib.optional stdenv.cc.isClang llvmPackages.openmp);
+  ++ lib.optionals enableGui [
+    qtbase
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
+  ];
 
-  cmakeFlags =
-    let
-      # Use the commit hash for the internal versioning
-      rev = src.rev;
-      versionStr = if (lib.hasPrefix "nextpnr-" rev) then rev else "nextpnr-${lib.substring 0 7 rev}";
-    in
-    [
-      "-DCURRENT_GIT_VERSION=${versionStr}"
-      "-DARCH=generic;ice40;ecp5;himbaechel"
-      "-DBUILD_TESTS=ON"
-      "-DICESTORM_INSTALL_PREFIX=${icestorm}"
-      "-DTRELLIS_INSTALL_PREFIX=${trellis}"
-      "-DTRELLIS_LIBDIR=${trellis}/lib/trellis"
-      "-DGOWIN_BBA_EXECUTABLE=${python3Packages.apycula}/bin/gowin_bba"
-      "-DUSE_OPENMP=ON"
+  cmakeFlags = [
+    (lib.cmakeFeature "CURRENT_GIT_VERSION" finalAttrs.src.tag)
+    (lib.cmakeFeature "ARCH" "generic;ice40;ecp5;himbaechel")
+    (lib.cmakeBool "BUILD_TESTS" true)
+    (lib.cmakeFeature "ICESTORM_INSTALL_PREFIX" icestorm.outPath)
+    (lib.cmakeFeature "TRELLIS_INSTALL_PREFIX" trellis.outPath)
+    (lib.cmakeFeature "TRELLIS_LIBDIR" "${lib.getLib trellis}/lib/trellis")
+    (lib.cmakeFeature "GOWIN_BBA_EXECUTABLE" (lib.getExe' python3Packages.apycula "gowin_bba"))
+    (lib.cmakeBool "USE_OPENMP" true)
 
-      # gatemate excluded due to non-reproducible build https://github.com/YosysHQ/prjpeppercorn/issues/9
-      # xilinx excluded due to needing vivado https://github.com/f4pga/prjxray?tab=readme-ov-file#step-1
-      "-DHIMBAECHEL_UARCH=example;gowin;ng-ultra"
+    # gatemate excluded due to non-reproducible build https://github.com/YosysHQ/prjpeppercorn/issues/9
+    # xilinx excluded due to needing vivado https://github.com/f4pga/prjxray?tab=readme-ov-file#step-1
+    (lib.cmakeFeature "HIMBAECHEL_UARCH" "example;gowin;ng-ultra")
 
-      "-DHIMBAECHEL_GOWIN_DEVICES=all"
-      "-DHIMBAECHEL_PRJBEYOND_DB=${prjbeyond_src}"
-      # https://github.com/YosysHQ/nextpnr/issues/1578
-      # `Compatibility with CMake < 3.5 has been removed from CMake.`
-      "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
-    ]
-    ++ (lib.optional enableGui "-DBUILD_GUI=ON");
+    (lib.cmakeFeature "HIMBAECHEL_GOWIN_DEVICES" "all")
+    (lib.cmakeFeature "HIMBAECHEL_PRJBEYOND_DB" prjbeyond_src.outPath)
+    # https://github.com/YosysHQ/nextpnr/issues/1578
+    # `Compatibility with CMake < 3.5 has been removed from CMake.`
+    # "CMAKE_POLICY_VERSION_MINIMUM=3.5"
 
-  postPatch = ''
-    # Don't use #embed macro for chipdb binary embeddings - otherwise getting spurious type narrowing errors.
-    # Maybe related to: https://github.com/llvm/llvm-project/issues/119256
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "check_cxx_compiler_hash_embed(HAS_HASH_EMBED CXX_FLAGS_HASH_EMBED)" ""
-  '';
+    (lib.cmakeBool "BUILD_GUI" enableGui)
+  ];
 
   doCheck = true;
 
@@ -109,8 +106,9 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Place and route tool for FPGAs";
     homepage = "https://github.com/yosyshq/nextpnr";
+    changelog = "https://github.com/YosysHQ/nextpnr/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.isc;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ thoughtpolice ];
   };
-}
+})

--- a/pkgs/development/python-modules/apycula/default.nix
+++ b/pkgs/development/python-modules/apycula/default.nix
@@ -1,24 +1,35 @@
 {
   lib,
   buildPythonPackage,
-  crc,
   fetchPypi,
+
+  # build-system
   setuptools-scm,
+
+  # dependencies
+  fastcrc,
+  msgspec,
+  numpy,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "apycula";
-  version = "0.29";
+  version = "0.31";
   pyproject = true;
 
+  # The Pypi archive contains necessary files generated with proprietary tools.
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-awhGSmGQDQ0Pi+4y9KoR1Yw6UZjM/CTxAV0jdfen6Qw=";
+    hash = "sha256-77pr4HbS2adFeEI3Q3KzcCfJMi4UomOtKnuGAxobxF0=";
   };
 
   build-system = [ setuptools-scm ];
 
-  dependencies = [ crc ];
+  dependencies = [
+    fastcrc
+    msgspec
+    numpy
+  ];
 
   # Tests require a physical FPGA
   doCheck = false;


### PR DESCRIPTION
## Things done

Includes an update to apycula since that is required. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
