### PR TITLE
sshsrv: init at 1.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21869,6 +21869,13 @@
     githubId = 478606;
     name = "Valentin Robert";
   };
+  ptman = {
+    name = "Paul Tötterman";
+    github = "ptman";
+    githubId = 24669;
+    email = "ptman+nixpkgs@ptman.name";
+    matrix = "@ptman:kapsi.fi";
+  };
   ptrhlm = {
     email = "ptrhlm0@gmail.com";
     github = "ptrhlm";

--- a/pkgs/by-name/ss/sshsrv/package.nix
+++ b/pkgs/by-name/ss/sshsrv/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "sshsrv";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "Crosse";
+    repo = "sshsrv";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-lNt5ftvhNYGeFo0w4Pzj3o3EXzTAVAOPdSGXNSQY9aw=";
+  };
+
+  vendorHash = "sha256-snqiThNkQfNJGbpFnOf4ab8oRFzW1NAChFmALUTCzEY=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "Connect to SSH servers using DNS SRV records";
+    homepage = "https://github.com/Crosse/sshsrv";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ ptman ];
+    mainProgram = "sshsrv";
+  };
+})


### PR DESCRIPTION
Add the tool [sshsrv](https://github.com/Crosse/sshsrv)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.