### PR TITLE
python3Packages.django-flags: init at 5.2.0

### DIFF
--- a/pkgs/development/python-modules/django-flags/default.nix
+++ b/pkgs/development/python-modules/django-flags/default.nix
@@ -1,0 +1,52 @@
+{
+  buildPythonPackage,
+  django,
+  django-debug-toolbar,
+  fetchFromGitHub,
+  jinja2,
+  lib,
+  pytest-django,
+  pytestCheckHook,
+  setuptools-scm,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "django-flags";
+  version = "5.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cfpb";
+    repo = "django-flags";
+    tag = finalAttrs.version;
+    hash = "sha256-4UOueNXfDouTqpLpG391zcGHTTJ8GfznYmEl33YKdv8=";
+  };
+
+  build-system = [
+    setuptools-scm
+  ];
+
+  dependencies = [
+    django
+  ];
+
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE=flags.tests.settings
+  '';
+
+  pythonImportsCheck = [ "flags" ];
+
+  nativeCheckInputs = [
+    django-debug-toolbar
+    jinja2
+    pytest-django
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Feature flags for Django projects";
+    homepage = "https://github.com/cfpb/django-flags";
+    changelog = "https://github.com/cfpb/django-flags/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ kurogeek ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4182,6 +4182,8 @@ self: super: with self; {
 
   django-filter = callPackage ../development/python-modules/django-filter { };
 
+  django-flags = callPackage ../development/python-modules/django-flags { };
+
   django-formset-js-improved =
     callPackage ../development/python-modules/django-formset-js-improved
       { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
