### PR TITLE
xprin: init at 0.2.0

### DIFF
--- a/pkgs/by-name/xp/xprin/package.nix
+++ b/pkgs/by-name/xp/xprin/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "xprin";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "crossplane-contrib";
+    repo = "xprin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5qRPzrMAW7gw5fv5rgR9hOrZreeWXj/UFyMQAzpCA0s=";
+  };
+
+  vendorHash = "sha256-mFICxQ0WHPFxHJ5wmElqcRMOvExKWmX2XXCRQCWbXoI=";
+
+  subPackages = [
+    "cmd/xprin"
+    "cmd/xprin-helpers"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/crossplane-contrib/xprin/internal/version.version=v${finalAttrs.version}"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Crossplane testing framework for render and schema validation";
+    homepage = "https://github.com/crossplane-contrib/xprin";
+    changelog = "https://github.com/crossplane-contrib/xprin/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      LorenzBischof
+    ];
+    mainProgram = "xprin";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Crossplane testing framework for render and schema validation

https://github.com/crossplane-contrib/xprin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
