### PR TITLE
nixos/pocket-id: fix force close on shutdown

### DIFF
--- a/nixos/modules/services/security/pocket-id.nix
+++ b/nixos/modules/services/security/pocket-id.nix
@@ -213,15 +213,16 @@ in
           settingsFile
         ];
 
+        script = ''
+          ${exportAllCredentials cfg.credentials}
+          exec ${getExe cfg.package}
+        '';
+
         serviceConfig = {
           Type = "simple";
           User = cfg.user;
           Group = cfg.group;
           WorkingDirectory = cfg.dataDir;
-          ExecStart = pkgs.writeShellScript "pocket-id-start" ''
-            ${exportAllCredentials cfg.credentials}
-            ${getExe cfg.package}
-          '';
           Restart = "always";
           RestartSec = 1;
           EnvironmentFile = [


### PR DESCRIPTION
Resolve https://github.com/pocket-id/pocket-id/issues/1383

Previously, the service's `ExecStart` used a shell script wrapper without `exec`. As a result, `pocket-id` ran as a child process of the shell. During service shutdown, systemd sends SIGTERM to the entire cgroup, causing `pocket-id` to receive the signal twice and triggering a forced shutdown instead of a graceful exit.

previous:
```
pocket-id-start[809]: Mar 18 11:12:17 INF Received interrupt signal. Shutting down… app=pocket-id version=2.4.0
pocket-id-start[809]: Mar 18 11:12:17 ERR Job failed with error app=pocket-id version=2.4.0 name=SendHeartbeat id=aa500005-a6ef-40f2-ae1b-f6e7e961f3d6 error="heartbeat request failed: context canceled"
pocket-id-start[809]: Mar 18 11:12:17 WRN Received a second interrupt signal. Forcing an immediate shutdown. app=pocket-id version=2.4.0
```

Context: 
  - https://github.com/NixOS/nixpkgs/pull/497937
  - https://github.com/pocket-id/pocket-id/issues/1383

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
