### PR TITLE
shairport-sync: fix configure flags, improve service definition

### DIFF
--- a/nixos/modules/services/networking/shairport-sync.nix
+++ b/nixos/modules/services/networking/shairport-sync.nix
@@ -157,16 +157,13 @@ in
       serviceConfig = {
         User = cfg.user;
         Group = cfg.group;
-        ExecStart = "${lib.getExe cfg.package} ${cfg.arguments}";
+        ExecStart = "${lib.getExe cfg.package} --configfile=${configFile} ${cfg.arguments}";
         Restart = "on-failure";
         RuntimeDirectory = "shairport-sync";
       };
     };
 
-    environment = {
-      systemPackages = [ cfg.package ];
-      etc."shairport-sync.conf".source = configFile;
-    };
+    environment.systemPackages = [ cfg.package ];
   };
 
 }

--- a/nixos/modules/services/networking/shairport-sync.nix
+++ b/nixos/modules/services/networking/shairport-sync.nix
@@ -38,13 +38,13 @@ in
       settings = mkOption {
         type = configFormat.type;
         default = {
-          general.output_backend = "pa";
+          general.output_backend = "pulseaudio";
           diagnostics.log_verbosity = 1;
         };
         example = {
           general = {
             name = "NixOS Shairport";
-            output_backend = "pw";
+            output_backend = "pipewire";
           };
           metadata = {
             enabled = "yes";
@@ -118,7 +118,7 @@ in
     services.avahi.publish.userServices = true;
 
     services.shairport-sync.settings = {
-      general.output_backend = lib.mkDefault "pa";
+      general.output_backend = lib.mkDefault "pulseaudio";
       diagnostics.log_verbosity = lib.mkDefault 1;
     };
 

--- a/pkgs/by-name/sh/shairport-sync/package.nix
+++ b/pkgs/by-name/sh/shairport-sync/package.nix
@@ -118,8 +118,8 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-stdout"
     "--with-avahi"
   ]
-  ++ optional enablePulse "--with-pa"
-  ++ optional enablePipewire "--with-pw"
+  ++ optional enablePulse "--with-pulseaudio"
+  ++ optional enablePipewire "--with-pipewire"
   ++ optional enableAlsa "--with-alsa"
   ++ optional enableSndio "--with-sndio"
   ++ optional enableAo "--with-ao"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

shairport-sync upstream renamed the `--with-` configure flags for pulseaudio and pipewire. This PR reflects that change. (Annoyingly, using the old, now unknown flags didn't cause a compile error, merely a warning.)

Additionally, it also make sure configuration reloading on config changes works properly by passing the config file as a service command line argument instead of merely placing it in `/etc`. 

I do have a few other doubts too, but haven't done anything about them:

 * Should `services.shairport-sync.enable` really put the executable in the system path? I don't see that it provides any kind of cli client functionality besides the service. 
 * Is it really worth keeping the `shairport-sync-airplay2` alias around? Running that requires `nqptp`, but that currently doesn't have a service module. There is a handful of users with [public configs](https://github.com/search?q=shairport-sync-airplay2%20path%3A*.nix&type=code).
 
 ---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
