### PR TITLE
python3Packages.django-markdownify: init at 0.9.6

### DIFF
--- a/pkgs/development/python-modules/django-markdownify/default.nix
+++ b/pkgs/development/python-modules/django-markdownify/default.nix
@@ -1,0 +1,58 @@
+{
+  buildPythonPackage,
+  django,
+  fetchFromGitHub,
+  lib,
+  pytest-django,
+  pytestCheckHook,
+  setuptools,
+  markdown,
+  bleach,
+  tinycss2,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "django-markdownify";
+  version = "0.9.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "erwinmatijsen";
+    repo = "django-markdownify";
+    tag = finalAttrs.version;
+    hash = "sha256-L/N0jjxBz7aQletOg+qairgq4utifPz4oqjT9AcljLI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    django
+    markdown
+    bleach
+  ]
+  ++ bleach.optional-dependencies.css;
+
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE=markdownify.checks
+  '';
+
+  nativeCheckInputs = [
+    tinycss2
+    pytest-django
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "markdownify" ];
+
+  disabledTests = [
+    # Test settings didn't setup DjangoTemplates
+    "test_markdownify_nodelist"
+  ];
+
+  meta = {
+    description = "Markdown template filter for Django";
+    homepage = "https://github.com/erwinmatijsen/django-markdownify";
+    changelog = "https://github.com/erwinmatijsen/django-markdownify/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kurogeek ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4244,6 +4244,8 @@ self: super: with self; {
 
   django-maintenance-mode = callPackage ../development/python-modules/django-maintenance-mode { };
 
+  django-markdownify = callPackage ../development/python-modules/django-markdownify { };
+
   django-markdownx = callPackage ../development/python-modules/django-markdownx { };
 
   django-markup = callPackage ../development/python-modules/django-markup { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
