### PR TITLE
Add rust-based minecraft proxies

### DIFF
--- a/pkgs/by-name/in/infrarust/package.nix
+++ b/pkgs/by-name/in/infrarust/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "infrarust";
+  version = "1.6.3";
+
+  src = fetchFromGitHub {
+    owner = "Shadowner";
+    repo = "Infrarust";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ntHWteA1UDpXJc7HfRAmLN3lLz2Tn+u6n53vJDv7IRQ=";
+  };
+
+  cargoHash = "sha256-a210tGEkDpleXrjtGv9YU/z/2K5Q9Tj80aMfUK4fbdA=";
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "High-Performance Minecraft Reverse Proxy in Rust";
+    homepage = "https://github.com/shadowner/infrarust";
+    changelog = "https://github.com/Shadowner/Infrarust/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ hustlerone ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I am adding both Infrarust and minecraft-rust-proxy. I have tested the former only (I will test the latter later).

This PR does not include modules. Therefore, I expect these to be used in flakes like nix-minecraft or by some bespoke module a user might be doing.

These rust-based proxies are quite different from Velocity (and similar ones). Their main strengths are complete transparency to the backend instances, allowing you to proxy most modded minecraft versions (specifically, those past 1.6 due to them specifying the desired host to be connecting to).

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
