### PR TITLE
siomon: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24647,6 +24647,12 @@
     githubId = 16844216;
     name = "Phillip Seeber";
   };
+  sheevy = {
+    email = "mw.kubica@gmail.com";
+    github = "sheevy";
+    githubId = 1525683;
+    name = "Mateusz Kubica";
+  };
   sheganinans = {
     email = "sheganinans@gmail.com";
     github = "sheganinans";

--- a/pkgs/by-name/si/siomon/package.nix
+++ b/pkgs/by-name/si/siomon/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "siomon";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "level1techs";
+    repo = "siomon";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ox4J2YKTN2Hf51+gyl6TKiS/6HIMbgplwv73tVAHFd0=";
+  };
+
+  cargoHash = "sha256-PC8G/FQjIwdyUBtG6DBon/4ZseihrBUZ/L65Agh6hhY=";
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Hardware information and real-time sensor monitoring tool for Linux";
+    homepage = "https://github.com/level1techs/siomon";
+    changelog = "https://github.com/level1techs/siomon/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ sheevy ];
+    mainProgram = "sio";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR is the same as https://github.com/NixOS/nixpkgs/pull/499549 but the PR request comes from a branch in my `nixpkgs` fork.
----
New linux monitoring tool from Level1Tech.
Post announcing it: https://forum.level1techs.com/t/first-linux-weekly-stream-5-30pm-est/247201
Repo: https://github.com/level1techs/siomon
Crate (which I don't use): https://crates.io/crates/siomon

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
