### PR TITLE
appwrite-cli: init at 15.0.0 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17598,6 +17598,12 @@
     githubId = 14096356;
     name = "Michael McLeod";
   };
+  mikeee = {
+    email = "hey@mike.ee";
+    github = "mikeee";
+    githubId = 19765254;
+    name = "Mike";
+  };
   mikefaille = {
     email = "michael@faille.io";
     github = "mikefaille";

--- a/pkgs/by-name/ap/appwrite-cli/package.nix
+++ b/pkgs/by-name/ap/appwrite-cli/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "appwrite-cli";
+  version = "15.0.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "appwrite";
+    repo = "sdk-for-cli";
+    tag = finalAttrs.version;
+    hash = "sha256-fjR6TWKi3lSnZL52tPwrFZ/PYNknQyrfScWsvgAUaas=";
+  };
+
+  npmDepsHash = "sha256-8H0wv6rveRUDIBY6BGc6VuAtEvmjOfX/ODB8P7nozaY=";
+
+  meta = {
+    description = "Official Appwrite CLI";
+    homepage = "https://appwrite.io";
+    changelog = "https://github.com/appwrite/sdk-for-cli/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    mainProgram = "appwrite";
+    maintainers = with lib.maintainers; [ mikeee ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds the appwrite-cli

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
