### PR TITLE
jenkins: 2.541.2 -> 2.541.3

### DIFF
--- a/nixos/modules/services/continuous-integration/jenkins/job-builder.nix
+++ b/nixos/modules/services/continuous-integration/jenkins/job-builder.nix
@@ -175,7 +175,7 @@ in
             (umask 0077; printf "${cfg.accessUser}:@password_placeholder@" >"$auth_file")
             "${pkgs.replace-secret}/bin/replace-secret" "@password_placeholder@" "$access_token_file" "$auth_file"
 
-            if ! "${pkgs.jenkins}/bin/jenkins-cli" -s "$jenkins_url" -auth "@$auth_file" reload-configuration; then
+            if ! "${pkgs.jenkins}/bin/jenkins-cli" -http -s "$jenkins_url" -auth "@$auth_file" reload-configuration; then
                 echo "error: failed to reload configuration"
                 exit 1
             fi

--- a/nixos/tests/jenkins-cli.nix
+++ b/nixos/tests/jenkins-cli.nix
@@ -25,7 +25,7 @@
     assert "http://0.0.0.0:8080" in machine.succeed("echo $JENKINS_URL")
 
     machine.succeed(
-        "jenkins-cli -auth admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword)"
+        "jenkins-cli -http -auth admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword)"
     )
   '';
 }

--- a/nixos/tests/jenkins.nix
+++ b/nixos/tests/jenkins.nix
@@ -118,7 +118,7 @@
           master.wait_until_succeeds("test -f ${jenkinsHome}/jobs/folder-1/jobs/job-2/config.xml")
 
           # Verify that jenkins also sees the jobs.
-          out = master.succeed("${pkgs.jenkins}/bin/jenkins-cli -s ${jenkinsUrl} -auth admin:$(cat ${jenkinsHome}/secrets/initialAdminPassword) list-jobs")
+          out = master.succeed("${pkgs.jenkins}/bin/jenkins-cli -http -s ${jenkinsUrl} -auth admin:$(cat ${jenkinsHome}/secrets/initialAdminPassword) list-jobs")
           jobs = [x.strip() for x in out.splitlines()]
           # Seeing jobs inside folders requires the Folders plugin
           # (https://plugins.jenkins.io/cloudbees-folder/), which we don't have
@@ -135,7 +135,7 @@
           master.wait_until_fails("test -f ${jenkinsHome}/jobs/folder-1/jobs/job-2/config.xml")
 
           # Verify that jenkins also sees the jobs as removed.
-          out = master.succeed("${pkgs.jenkins}/bin/jenkins-cli -s ${jenkinsUrl} -auth admin:$(cat ${jenkinsHome}/secrets/initialAdminPassword) list-jobs")
+          out = master.succeed("${pkgs.jenkins}/bin/jenkins-cli -http -s ${jenkinsUrl} -auth admin:$(cat ${jenkinsHome}/secrets/initialAdminPassword) list-jobs")
           jobs = [x.strip() for x in out.splitlines()]
           assert jobs == [], f"jobs != []: {jobs}"
     '';

--- a/pkgs/by-name/je/jenkins/package.nix
+++ b/pkgs/by-name/je/jenkins/package.nix
@@ -18,11 +18,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "jenkins";
-  version = "2.541.2";
+  version = "2.541.3";
 
   src = fetchurl {
     url = "https://get.jenkins.io/war-stable/${finalAttrs.version}/jenkins.war";
-    hash = "sha256-3J1TLlTUt+t9eO3NMheHbdSBG0nRo7ZuWZrUpkLVcZM=";
+    hash = "sha256-AACt36hyKWMWQTek4OYKvCJ9nWBxDE3rGUgfmnUc9RI=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
jenkins-cli requires the -http parameter now, otherwise it fails to
connect to Jenkins and the tests fail.

https://www.jenkins.io/changelog-stable/#v2.541.3

Security advisory: https://www.jenkins.io/security/advisory/2026-03-18/ (CVE-2026-33001, CVE-2026-33002, CVE-2026-33003, CVE-2026-33004)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
