### PR TITLE
tilemaker: 3.0.0 → 3.1.0

### DIFF
--- a/pkgs/by-name/ti/tilemaker/package.nix
+++ b/pkgs/by-name/ti/tilemaker/package.nix
@@ -3,9 +3,7 @@
   stdenv,
   fetchFromGitHub,
   buildPackages,
-  fetchpatch,
   cmake,
-  installShellFiles,
   boost,
   lua,
   protobuf_21,
@@ -13,27 +11,19 @@
   shapelib,
   sqlite,
   zlib,
-  testers,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tilemaker";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "systemed";
     repo = "tilemaker";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-rB5oP03yaIzklwkGsIeS9ELbHOY9AObwjRrK9HBQFI4=";
+    hash = "sha256-0reO4YYxbFM75CQrSLTybsb5g6PhJaShAtT+X3CaPfM=";
   };
-
-  patches = [
-    # fixes for Boost 1.86
-    (fetchpatch {
-      url = "https://github.com/systemed/tilemaker/commit/6509f0cf50943a90b36b5c6802118b72124b1e7a.patch";
-      hash = "sha256-C4aCUGTTUtY24oARihMnljjRbw80xRdMUyvu/b1Nsdw=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace src/options_parser.cpp \
@@ -43,10 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "default_value(\"static\")" "default_value(\"$out/share/tilemaker/static\")"
   '';
 
-  nativeBuildInputs = [
-    cmake
-    installShellFiles
-  ];
+  nativeBuildInputs = [ cmake ];
 
   buildInputs = [
     boost
@@ -65,15 +52,12 @@ stdenv.mkDerivation (finalAttrs: {
   env.NIX_CFLAGS_COMPILE = toString [ "-DTM_VERSION=${finalAttrs.version}" ];
 
   postInstall = ''
-    installManPage ../docs/man/tilemaker.1
     install -Dm644 ../resources/*.{json,lua} -t $out/share/tilemaker
     cp -r ../server/static $out/share/tilemaker
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-    command = "tilemaker --help";
-  };
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Make OpenStreetMap vector tiles without the stack";

--- a/pkgs/by-name/ti/tilemaker/package.nix
+++ b/pkgs/by-name/ti/tilemaker/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://tilemaker.org/";
     changelog = "https://github.com/systemed/tilemaker/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.free; # FTWPL
-    maintainers = with lib.maintainers; [ sikmir ];
+    teams = [ lib.teams.geospatial ];
     platforms = lib.platforms.unix;
     mainProgram = "tilemaker";
   };


### PR DESCRIPTION
https://github.com/systemed/tilemaker/releases/tag/v3.1.0

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
