### PR TITLE
python3Packages.garth: 0.6.3 -> 0.7.9

### DIFF
--- a/pkgs/development/python-modules/garth/default.nix
+++ b/pkgs/development/python-modules/garth/default.nix
@@ -4,21 +4,23 @@
   fetchPypi,
   freezegun,
   hatchling,
+  logfire,
+  pydantic-settings,
   pydantic,
   pytest-vcr,
   pytestCheckHook,
-  requests,
   requests-oauthlib,
+  requests,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "garth";
-  version = "0.6.3";
+  version = "0.7.9";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-UZ1LUylEY4ZSu3QO5E3PNuHSNDIa7PCF7dfxqB6mb2k=";
+    hash = "sha256-vLNoLl6Z5w7n6u//desPqtgRCqEx66T/EiLXcFDN6Z4=";
   };
 
   pythonRelaxDeps = [ "requests-oauthlib" ];
@@ -26,7 +28,9 @@ buildPythonPackage (finalAttrs: {
   build-system = [ hatchling ];
 
   dependencies = [
+    logfire
     pydantic
+    pydantic-settings
     requests
     requests-oauthlib
   ];


### PR DESCRIPTION
Changelog: https://github.com/matin/garth/releases/tag/0.7.9


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
