### PR TITLE
importNpmLock: handle commit in resolved git url

### DIFF
--- a/pkgs/build-support/node/import-npm-lock/default.nix
+++ b/pkgs/build-support/node/import-npm-lock/default.nix
@@ -52,9 +52,17 @@ let
                 // fetcherOpts
               ))
             else if lib.hasPrefix "git" module.resolved then
+              let
+                url = elemAt mUrl 1;
+                urlParts = lib.splitString "#" url;
+                commit = if builtins.length urlParts == 2 then elemAt urlParts 1 else null;
+              in
               (fetchGit (
                 {
-                  url = module.resolved;
+                  url = "${scheme}://${elemAt urlParts 0}";
+                }
+                // lib.optionalAttrs (commit != null) {
+                  rev = commit;
                 }
                 // fetcherOpts
               ))


### PR DESCRIPTION
npm's locking process resolves Git dependencies to a given commit, separated by a `#`. Before this change, any encounter of these URLs would cause `fetchGit` to fail, as they're not valid repo URLs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
