### PR TITLE
python3Packages.argos-translate-files: 1.4.1 -> 1.4.4; modernize

### DIFF
--- a/pkgs/development/python-modules/argos-translate-files/default.nix
+++ b/pkgs/development/python-modules/argos-translate-files/default.nix
@@ -1,7 +1,8 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+  pytestCheckHook,
   writableTmpDirAsHomeHook,
   setuptools,
   lxml,
@@ -10,14 +11,16 @@
   translatehtml,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "argos-translate-files";
   version = "1.4.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-9ufNuExfyW3gr8+pIpp6Ie03e0hE4l3l3kk6EiVH0x8=";
+  src = fetchFromGitHub {
+    owner = "LibreTranslate";
+    repo = "argos-translate-files";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XCrABdyly249dpam0pSwTWHoli/uijoUYKaHQhCqB7Y=";
   };
 
   build-system = [ setuptools ];
@@ -29,14 +32,13 @@ buildPythonPackage rec {
     translatehtml
   ];
 
+  doCheck = true;
+
   nativeCheckInputs = [
+    pytestCheckHook
     # pythonImportsCheck needs a home dir for argostranslatefiles
     writableTmpDirAsHomeHook
   ];
-
-  postPatch = ''
-    ln -s */requires.txt requirements.txt
-  '';
 
   pythonImportsCheck = [ "argostranslatefiles" ];
 
@@ -46,4 +48,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ misuzu ];
   };
-}
+})

--- a/pkgs/development/python-modules/argos-translate-files/default.nix
+++ b/pkgs/development/python-modules/argos-translate-files/default.nix
@@ -13,17 +13,28 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "argos-translate-files";
-  version = "1.4.1";
+  version = "1.4.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "LibreTranslate";
     repo = "argos-translate-files";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XCrABdyly249dpam0pSwTWHoli/uijoUYKaHQhCqB7Y=";
+    hash = "sha256-6AxVBiK0g6ajstyCQZ9ExF9MRYSLd4Frw03N7c9bvuI=";
   };
 
   build-system = [ setuptools ];
+
+  pythonRelaxDeps = [ "beautifulsoup4" ];
+
+  # LibreTranslate has forked argos-translate [1] to fix some bugs and
+  # make stanza optional, but it's unclear what the future of this fork
+  # is.
+  #
+  # We'll stay on upstream argostranslate for now.
+  #
+  # [1]: https://github.com/Libretranslate/argos-translate/
+  pythonRemoveDeps = [ "argos-translate-lt" ];
 
   dependencies = [
     lxml


### PR DESCRIPTION
1. Modernize the package a bit by fetching from GitHub, removing the recursive attribute set, and enabling checks.
2. Update from 1.4.1 to 1.4.4 while keeping the current argostranslate (upstream) instead of the libretranslate form ([argos-translate-lt](https://github.com/argosopentech/argos-translate/compare/master...LibreTranslate:argos-translate:master)).

Also see https://community.libretranslate.com/t/whats-the-future-of-the-argos-translate-dependency-in-libretranslate/2156

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test