### PR TITLE
cudaPackages.cuda_cccl: patch to fix torch build on cuda>=13.0

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda_cccl.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_cccl.nix
@@ -23,6 +23,13 @@ buildRedist {
     rmdir -v "$PWD/include/cccl"
   '';
 
+  # NVIDIA, in their wisdom, expect CCCL to be a directory inside include.
+  # https://github.com/NVIDIA/cutlass/blob/087c84df83d254b5fb295a7a408f1a1d554085cf/CMakeLists.txt#L773
+  postInstall = lib.optionalString (cudaAtLeast "13.0") ''
+    nixLog "creating alias for ''${!outputInclude:?}/include/cccl"
+    ln -srv "''${!outputInclude:?}/include" "''${!outputInclude:?}/include/cccl"
+  '';
+
   meta = {
     description = "Building blocks that make it easier to write safe and efficient CUDA C++ code";
     longDescription = ''

--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -248,6 +248,7 @@ let
       && !(builtins.elem cudaPackages.cudaMajorVersion [
         "11"
         "12"
+        "13"
       ]);
     "MPI cudatoolkit does not match cudaPackages.cudatoolkit" =
       MPISupport && cudaSupport && (mpi.cudatoolkit != cudaPackages.cudatoolkit);


### PR DESCRIPTION
## Things done

This fixes the PyTorch build when using `cudaPackages`>=13.0.

Thanks to @ConnorBaker for [the fix](https://github.com/ConnorBaker/blender-temp/blob/7132a52cd929b764e83dc97fb0596b8caae58c95/overlay.nix#L35-L42).

cc @NixOS/cuda-maintainers

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
