### PR TITLE
rescript-language-server, vscode-extensions.chenglou92.rescript-vscode: 1.62.0 -> 1.72.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/default.nix
@@ -5,7 +5,7 @@
   callPackage,
 }:
 let
-  extVersion = "1.62.0";
+  extVersion = "1.72.0";
   rescript-editor-analysis = callPackage ./rescript-editor-analysis.nix { };
 
   # Ensure the versions match
@@ -30,7 +30,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     name = "rescript-vscode";
     publisher = "chenglou92";
     inherit version;
-    hash = "sha256-yUAhysTM9FXo9ZAzrto+tnjnofIUEQAGBg3tjIainrY=";
+    hash = "sha256-2fN8bq6X1Lm9/5+wNMzL8I0bUVMFetXDWVObUJeVYbU=";
   };
 
   # For rescript-language-server

--- a/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/rescript-editor-analysis.nix
+++ b/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/rescript-editor-analysis.nix
@@ -7,7 +7,7 @@
 
 ocamlPackages.buildDunePackage (finalAttrs: {
   pname = "analysis";
-  version = "1.62.0";
+  version = "1.72.0";
 
   minimalOCamlVersion = "4.10";
 
@@ -15,7 +15,7 @@ ocamlPackages.buildDunePackage (finalAttrs: {
     owner = "rescript-lang";
     repo = "rescript-vscode";
     tag = finalAttrs.version;
-    hash = "sha256-Tox5Qq0Kpqikac90sQww2cGr9RHlXnVy7GMnRA18CoA=";
+    hash = "sha256-bGCQ/HC6ItQMR0v0wLsF9pNX/Y1sBnp7E+Am0flWhGk=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/re/rescript-language-server/package.nix
+++ b/pkgs/by-name/re/rescript-language-server/package.nix
@@ -29,7 +29,8 @@ buildNpmPackage (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/server";
 
-  npmDepsHash = "sha256-Qi41qDJ0WR0QWw7guhuz1imT51SqI7mORGjNbmZWnio";
+  npmDepsFetcherVersion = 2;
+  npmDepsHash = "sha256-BUR/gln9yyKGa05FvxOF6vIcCz8BCQWGr/fzfmOPdj0=";
 
   strictDeps = true;
   nativeBuildInputs = [ esbuild ];
@@ -39,7 +40,7 @@ buildNpmPackage (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    # https://github.com/rescript-lang/rescript-vscode/blob/1.62.0/package.json#L252
+    # https://github.com/rescript-lang/rescript-vscode/blob/1.72.0/package.json#L286
     esbuild src/cli.ts --bundle --sourcemap --outfile=out/cli.js --format=cjs --platform=node --loader:.node=file --minify
 
     runHook postBuild


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
