### PR TITLE
libretranslate: 1.9.0 -> 1.9.5; modernize

### DIFF
--- a/pkgs/development/python-modules/argos-translate-files/default.nix
+++ b/pkgs/development/python-modules/argos-translate-files/default.nix
@@ -1,7 +1,8 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+  pytestCheckHook,
   writableTmpDirAsHomeHook,
   setuptools,
   lxml,
@@ -10,14 +11,16 @@
   translatehtml,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "argos-translate-files";
   version = "1.4.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-9ufNuExfyW3gr8+pIpp6Ie03e0hE4l3l3kk6EiVH0x8=";
+  src = fetchFromGitHub {
+    owner = "LibreTranslate";
+    repo = "argos-translate-files";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XCrABdyly249dpam0pSwTWHoli/uijoUYKaHQhCqB7Y=";
   };
 
   build-system = [ setuptools ];
@@ -29,14 +32,13 @@ buildPythonPackage rec {
     translatehtml
   ];
 
+  doCheck = true;
+
   nativeCheckInputs = [
+    pytestCheckHook
     # pythonImportsCheck needs a home dir for argostranslatefiles
     writableTmpDirAsHomeHook
   ];
-
-  postPatch = ''
-    ln -s */requires.txt requirements.txt
-  '';
 
   pythonImportsCheck = [ "argostranslatefiles" ];
 
@@ -46,4 +48,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ misuzu ];
   };
-}
+})

--- a/pkgs/development/python-modules/argos-translate-files/default.nix
+++ b/pkgs/development/python-modules/argos-translate-files/default.nix
@@ -13,17 +13,28 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "argos-translate-files";
-  version = "1.4.1";
+  version = "1.4.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "LibreTranslate";
     repo = "argos-translate-files";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XCrABdyly249dpam0pSwTWHoli/uijoUYKaHQhCqB7Y=";
+    hash = "sha256-6AxVBiK0g6ajstyCQZ9ExF9MRYSLd4Frw03N7c9bvuI=";
   };
 
   build-system = [ setuptools ];
+
+  pythonRelaxDeps = [ "beautifulsoup4" ];
+
+  # LibreTranslate has forked argos-translate [1] to fix some bugs and
+  # make stanza optional, but it's unclear what the future of this fork
+  # is.
+  #
+  # We'll stay on upstream argostranslate for now.
+  #
+  # [1]: https://github.com/Libretranslate/argos-translate/
+  pythonRemoveDeps = [ "argos-translate-lt" ];
 
   dependencies = [
     lxml

--- a/pkgs/development/python-modules/libretranslate/default.nix
+++ b/pkgs/development/python-modules/libretranslate/default.nix
@@ -3,7 +3,7 @@
   pkgs,
   buildPythonPackage,
   fetchFromGitHub,
-  pytestCheckHook,
+  writableTmpDirAsHomeHook,
   runCommand,
   hatchling,
   argostranslate,
@@ -32,7 +32,7 @@
   lndir,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "libretranslate";
   version = "1.9.0";
   pyproject = true;
@@ -40,8 +40,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "LibreTranslate";
     repo = "LibreTranslate";
-    tag = "v${version}";
     hash = "sha256-bBs7gG42H4MNca5RUiedKNQkLjKpBm2SbPMRyh2gh6c=";
+    tag = "v${finalAttrs.version}";
   };
 
   build-system = [
@@ -80,13 +80,8 @@ buildPythonPackage rec {
     ln -s $out/${python.sitePackages}/libretranslate/static $out/share/libretranslate/static
   '';
 
-  doCheck = false; # needs network access
-
-  nativeCheckInputs = [ pytestCheckHook ];
-
-  # required for import check to work (argostranslate)
-  env.HOME = "/tmp";
-
+  # needed to import the argostranslate module
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
   pythonImportsCheck = [ "libretranslate" ];
 
   passthru = {
@@ -112,8 +107,8 @@ buildPythonPackage rec {
   meta = {
     description = "Free and Open Source Machine Translation API. Self-hosted, no limits, no ties to proprietary services";
     homepage = "https://libretranslate.com";
-    changelog = "https://github.com/LibreTranslate/LibreTranslate/releases/tag/${src.tag}";
+    changelog = "https://github.com/LibreTranslate/LibreTranslate/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ misuzu ];
   };
-}
+})

--- a/pkgs/development/python-modules/libretranslate/default.nix
+++ b/pkgs/development/python-modules/libretranslate/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "libretranslate";
-  version = "1.9.0";
+  version = "1.9.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "LibreTranslate";
     repo = "LibreTranslate";
-    hash = "sha256-bBs7gG42H4MNca5RUiedKNQkLjKpBm2SbPMRyh2gh6c=";
     tag = "v${finalAttrs.version}";
+    hash = "sha256-VcMo1GX+ituQOW8Dpt0ABJG5fsJbFuxAPmi59Byg5ww=";
   };
 
   build-system = [
@@ -49,6 +49,14 @@ buildPythonPackage (finalAttrs: {
   ];
 
   pythonRelaxDeps = true;
+
+  # LibreTranslate has forked argos-translate [1] to fix some bugs and make stanza optional, but it's
+  # unclear what the future of this fork is.
+  #
+  # We'll stay on upstream argostranslate for now.
+  #
+  # [1]: https://github.com/Libretranslate/argos-translate/
+  pythonRemoveDeps = [ "argos-translate-lt" ];
 
   dependencies = [
     argostranslate


### PR DESCRIPTION
1. Modernize argos-translate-files the package a bit by fetching from GitHub, removing the recursive attribute set, and enabling checks.
1. Modernize libretranslate a by removing the recursive attribute set and using `writableTmpDirAsHomeHook`. I've also removed the `pytestCheckHook` and re-enabled `doCheck` because the test suite requires network access but checks need to be enabled for `writableTmpDirAsHomeHook` (specifically, for `nativeCheckInputs` to do anything).
3. Update  argos-translate-files from 1.4.1 to 1.4.4.
5. Update from 1.9.0 to 1.9.5.

I've kept keeping the dependency on argostranslate (upstream) instead of the libretranslate version ([argos-translate-lt](https://github.com/argosopentech/argos-translate/compare/master...LibreTranslate:argos-translate:master)). [According to upstream](https://community.libretranslate.com/t/whats-the-future-of-the-argos-translate-dependency-in-libretranslate/2156), this is a temporary fork.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
