### PR TITLE
programs.nix-required-mounts.presets.zluda.enable: init

### DIFF
--- a/nixos/modules/programs/nix-required-mounts.nix
+++ b/nixos/modules/programs/nix-required-mounts.nix
@@ -67,6 +67,23 @@ let
     # TODO: Refactor `hardware.graphics` to ease referencing the closure
     # NOTE: A naive implementation may e.g. introduce a conditional infinite recursion (https://github.com/NixOS/nixpkgs/pull/488199)
     nvidia-gpu.unsafeFollowSymlinks = true;
+
+    zluda = {
+      onFeatures = [
+        "cuda"
+      ];
+      paths = [
+        pkgs.addDriverRunpath.driverLink
+        "/dev/dri"
+        "/dev/kfd"
+        "/sys/devices/virtual/kfd"
+        # As per https://www.kernel.org/doc/Documentation/admin-guide/devices.txt
+        # 226 is the major ID for "Direct Rendering Infrastructure (DRI)" devices
+        "/sys/dev/char/226:*"
+      ]
+      ++ config.hardware.graphics.extraPackages;
+      unsafeFollowSymlinks = true;
+    };
   };
 in
 {
@@ -82,6 +99,16 @@ in
       You may extend or override the exposed paths via the
       `programs.nix-required-mounts.allowedPatterns.nvidia-gpu.paths` option.
     '';
+
+    presets.zluda.enable = lib.mkEnableOption ''
+      Same as `programs.nix-required-mounts.presets.nvidia-gpu` but adds paths
+      to the sandbox that are needed for running CUDA applications on top of
+      the ZLUDA translation layer combined with AMD GPUs.
+
+      You may extend or override the exposed paths via the
+      `programs.nix-required-mounts.allowedPatterns.zluda.paths` option.
+    '';
+
     allowedPatterns =
       with lib.types;
       lib.mkOption {
@@ -120,6 +147,14 @@ in
         nix.settings.system-features = cfg.allowedPatterns.nvidia-gpu.onFeatures;
         programs.nix-required-mounts.allowedPatterns = {
           inherit (defaults) nvidia-gpu;
+        };
+      })
+      (lib.mkIf cfg.presets.zluda.enable {
+        hardware.graphics.enable = lib.mkDefault true;
+        hardware.amdgpu.zluda.enable = lib.mkDefault true;
+        nix.settings.system-features = cfg.allowedPatterns.zluda.onFeatures;
+        programs.nix-required-mounts.allowedPatterns = {
+          inherit (defaults) zluda;
         };
       })
     ]

--- a/nixos/modules/services/hardware/amdgpu.nix
+++ b/nixos/modules/services/hardware/amdgpu.nix
@@ -40,30 +40,41 @@ in
     };
 
     opencl.enable = lib.mkEnableOption "OpenCL support using ROCM runtime library";
+    zluda.enable = lib.mkEnableOption "CUDA support using ZLUDA runtime library";
+    zluda.package = lib.mkPackageOption pkgs "zluda" { };
   };
 
-  config = {
-    boot.kernelParams =
-      lib.optionals cfg.legacySupport.enable [
-        "amdgpu.si_support=1"
-        "amdgpu.cik_support=1"
-        "radeon.si_support=0"
-        "radeon.cik_support=0"
-      ]
-      ++ lib.optionals cfg.overdrive.enable [
-        "amdgpu.ppfeaturemask=${cfg.overdrive.ppfeaturemask}"
-      ];
+  config = lib.mkMerge [
+    {
+      boot.kernelParams =
+        lib.optionals cfg.legacySupport.enable [
+          "amdgpu.si_support=1"
+          "amdgpu.cik_support=1"
+          "radeon.si_support=0"
+          "radeon.cik_support=0"
+        ]
+        ++ lib.optionals cfg.overdrive.enable [
+          "amdgpu.ppfeaturemask=${cfg.overdrive.ppfeaturemask}"
+        ];
 
-    boot.initrd.kernelModules = lib.optionals cfg.initrd.enable [ "amdgpu" ];
-
-    hardware.graphics = lib.mkIf cfg.opencl.enable {
-      enable = lib.mkDefault true;
-      extraPackages = [
-        pkgs.rocmPackages.clr
-        pkgs.rocmPackages.clr.icd
-      ];
-    };
-  };
+      boot.initrd.kernelModules = lib.optionals cfg.initrd.enable [ "amdgpu" ];
+    }
+    (lib.mkIf cfg.opencl.enable {
+      hardware.graphics = {
+        enable = lib.mkDefault true;
+        extraPackages = [
+          pkgs.rocmPackages.clr
+          pkgs.rocmPackages.clr.icd
+        ];
+      };
+    })
+    (lib.mkIf cfg.zluda.enable {
+      hardware.graphics = {
+        enable = lib.mkDefault true;
+        extraPackages = [ cfg.zluda.package ];
+      };
+    })
+  ];
 
   meta = {
     maintainers = with lib.maintainers; [ johnrtitor ];


### PR DESCRIPTION
This profile is based on the PR https://github.com/NixOS/nixpkgs/pull/500971 and puts everything to use for AMD systems to run CUDA in the sandbox.

CC @kmein @jfly @SomeoneSerge 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
