### PR TITLE
nixos/pihole-ftl: fix setup script to add allow and block lists

### DIFF
--- a/nixos/modules/services/networking/pihole-ftl-setup-script.nix
+++ b/nixos/modules/services/networking/pihole-ftl-setup-script.nix
@@ -41,7 +41,8 @@ in
     local payload="$1"
 
     echo "Adding list: $payload"
-    local result=$(PostFTLData "lists" "$payload")
+    local type=$($jq -r '.type' <<< "$payload")
+    local result=$(PostFTLData "lists?type=$type" "$payload")
 
     local error="$($jq '.error' <<< "$result")"
     if [[ "$error" != "null" ]]; then


### PR DESCRIPTION
There was a change at some point that requires you to pass the type of list to the API via a query parameter. This modifies that, and was verified by setting up the service and checking pihole-ftl-setup.service logs.

Resolves: #500852, although depends on #498231 to actually get `pihole-web` and `pihole-ftl` working together.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
