### PR TITLE
maintainers: remove eigengrau

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7626,12 +7626,6 @@
     githubId = 25820532;
     name = "Luca Schwan";
   };
-  eigengrau = {
-    email = "seb@schattenkopie.de";
-    name = "Sebastian Reuße";
-    github = "eigengrau";
-    githubId = 4939947;
-  };
   eikek = {
     email = "eike.kettner@posteo.de";
     github = "eikek";

--- a/pkgs/by-name/ba/ballerina/package.nix
+++ b/pkgs/by-name/ba/ballerina/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
     mainProgram = "bal";
     license = lib.licenses.asl20;
     platforms = openjdk.meta.platforms;
-    maintainers = with lib.maintainers; [ eigengrau ];
+    maintainers = [ ];
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
   };
 }

--- a/pkgs/by-name/fo/forge-mtg/package.nix
+++ b/pkgs/by-name/fo/forge-mtg/package.nix
@@ -140,7 +140,6 @@ maven.buildMavenPackage {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       dyegoaurelio
-      eigengrau
     ];
   };
 }

--- a/pkgs/by-name/ra/rabtap/package.nix
+++ b/pkgs/by-name/ra/rabtap/package.nix
@@ -25,6 +25,6 @@ buildGoModule (finalAttrs: {
     description = "RabbitMQ wire tap and swiss army knife";
     license = lib.licenses.gpl3Only;
     homepage = "https://github.com/jandelgado/rabtap";
-    maintainers = with lib.maintainers; [ eigengrau ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/x-/x-create-mouse-void/package.nix
+++ b/pkgs/by-name/x-/x-create-mouse-void/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "Creates an undecorated black window and prevents the mouse from entering that window";
     platforms = lib.platforms.unix;
     license = lib.licenses.unfreeRedistributable;
-    maintainers = with lib.maintainers; [ eigengrau ];
+    maintainers = [ ];
     mainProgram = "x-create-mouse-void";
   };
 }

--- a/pkgs/development/python-modules/pyisbn/default.nix
+++ b/pkgs/development/python-modules/pyisbn/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     description = "Python module for working with 10- and 13-digit ISBNs";
     homepage = "https://github.com/JNRowe/pyisbn";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ eigengrau ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [August 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aeigengrau)
- Hasn't created any PRs / Issues since [November 2024](https://github.com/NixOS/nixpkgs/issues?q=author%3Aeigengrau)
- About 49 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aeigengrau%20-commenter%3Aeigengrau%20-author%3Aeigengrau%20-reviewed-by%3Aeigengrau) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages 

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] ballerina
- [ ] rabtap
- [ ] x-create-mouse-void
- [ ] python3Packages.pyisbn