### PR TITLE
devpi-server: 6.19.1 -> 6.19.2

### DIFF
--- a/pkgs/by-name/de/devpi-server/unwrapped.nix
+++ b/pkgs/by-name/de/devpi-server/unwrapped.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
+  versionCheckHook,
 
   # build-system
   setuptools,
@@ -15,6 +16,7 @@
   httpx,
   itsdangerous,
   packaging,
+  packaging-legacy,
   passlib,
   platformdirs,
   pluggy,
@@ -27,7 +29,6 @@
   # tests
   beautifulsoup4,
   nginx,
-  packaging-legacy,
   pytest-asyncio,
   pytestCheckHook,
   webtest,
@@ -41,14 +42,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "devpi-server";
-  version = "6.19.1";
+  version = "6.19.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "devpi";
     repo = "devpi";
     tag = "server-${finalAttrs.version}";
-    hash = "sha256-YFY2iLnORzFxnfGYU2kCpJL8CZi+lALIkL1bRpfd4NE=";
+    hash = "sha256-rAku3oHcmzFNA/MP/64382gCTgqopwjjy4S4HTEFZiY=";
   };
 
   postPatch = ''
@@ -71,6 +72,7 @@ buildPythonPackage (finalAttrs: {
     httpx
     itsdangerous
     packaging
+    packaging-legacy
     passlib
     platformdirs
     pluggy
@@ -83,10 +85,11 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ passlib.optional-dependencies.argon2;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   nativeCheckInputs = [
     beautifulsoup4
     nginx
-    packaging-legacy
     pytest-asyncio
     pytestCheckHook
     webtest
@@ -141,5 +144,6 @@ buildPythonPackage (finalAttrs: {
       confus
       makefu
     ];
+    mainProgram = "devpi-server";
   };
 })


### PR DESCRIPTION
see  http://doc.devpi.net/

changelog: https://github.com/devpi/devpi/blob/server-6.19.2/server/CHANGELOG

Note: packaging-legacy needed as runtime dependency for package introspection

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc: @makefu 