### PR TITLE
tailscale: 1.94.2 -> 1.96.2

### DIFF
--- a/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
+++ b/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
@@ -2,9 +2,10 @@
   lib,
   tailscale,
   buildGoModule,
+  go_1_26,
 }:
 
-buildGoModule {
+buildGoModule.override { go = go_1_26; } {
   pname = "tailscale-gitops-pusher";
   inherit (tailscale) version;
 

--- a/pkgs/by-name/ta/tailscale-nginx-auth/package.nix
+++ b/pkgs/by-name/ta/tailscale-nginx-auth/package.nix
@@ -2,10 +2,11 @@
   lib,
   stdenv,
   buildGoModule,
+  go_1_26,
   tailscale,
 }:
 
-buildGoModule {
+buildGoModule.override { go = go_1_26; } {
   pname = "tailscale-nginx-auth";
   inherit (tailscale) version src vendorHash;
 

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -3,6 +3,7 @@
   stdenv,
 
   buildGoModule,
+  go_1_26,
   fetchFromGitHub,
 
   makeWrapper,
@@ -22,9 +23,9 @@
   tailscale-nginx-auth,
 }:
 
-buildGoModule (finalAttrs: {
+buildGoModule.override { go = go_1_26; } (finalAttrs: {
   pname = "tailscale";
-  version = "1.94.2";
+  version = "1.96.2";
 
   outputs = [
     "out"
@@ -35,10 +36,10 @@ buildGoModule (finalAttrs: {
     owner = "tailscale";
     repo = "tailscale";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qjWVB8xWVgIVUgrf27F6hwiFIE+4ERXWeHv26ugg/x4=";
+    hash = "sha256-6taTRKYFxCNK7BUnNZ3lljqVS7AeYEfm46gmilf6eEk=";
   };
 
-  vendorHash = "sha256-WeMTOkERj4hvdg4yPaZ1gRgKnhRIBXX55kUVbX/k/xM=";
+  vendorHash = "sha256-rhuWEEN+CtumVxOw6Dy/IRxWIrZ2x6RJb6ULYwXCQc4=";
 
   nativeBuildInputs = [
     makeWrapper
@@ -91,11 +92,6 @@ buildGoModule (finalAttrs: {
     # subPackages above limits what is built to just what we
     # want but also limits the tests
     unset subPackages
-
-    # several tests hang, but keeping the file for tsnet/packet_filter_test.go
-    # packet_filter_test issue: https://github.com/tailscale/tailscale/issues/16051
-    substituteInPlace tsnet/tsnet_test.go \
-      --replace-fail 'func Test' 'func skippedTest'
   '';
 
   checkFlags =
@@ -133,9 +129,6 @@ buildGoModule (finalAttrs: {
         # not necessary and fails to match
         "TestSyncedToUpstream" # tempfork/acme
 
-        # flaky: https://github.com/tailscale/tailscale/issues/7030
-        "TestConcurrent"
-
         # flaky: https://github.com/tailscale/tailscale/issues/11762
         "TestTwoDevicePing"
 
@@ -144,7 +137,36 @@ buildGoModule (finalAttrs: {
         "TestTaildropIntegration_Fresh"
 
         # context deadline exceeded
-        "TestPacketFilterFromNetmap"
+        "TestPacketFilterFromNetmap" # tsnet
+
+        # tsnet tests that need a full tailscale server and hang in the sandbox
+        "TestListener_Server" # tsnet
+        "TestDialBlocks" # tsnet
+        "TestConn" # tsnet
+        "TestLoopbackLocalAPI" # tsnet
+        "TestLoopbackSOCKS5" # tsnet
+        "TestTailscaleIPs" # tsnet
+        "TestListenerCleanup" # tsnet
+        "TestStartStopStartGetsSameIP" # tsnet
+        "TestFunnel" # tsnet
+        "TestFunnelClose" # tsnet
+        "TestListenService" # tsnet
+        "TestListenerClose" # tsnet
+        "TestFallbackTCPHandler" # tsnet
+        "TestCapturePcap" # tsnet
+        "TestUDPConn" # tsnet
+        "TestUserMetricsByteCounters" # tsnet
+        "TestUserMetricsRouteGauges" # tsnet
+        "TestTUN" # tsnet
+        "TestTUNDNS" # tsnet
+        "TestListenPacket" # tsnet
+        "TestListenTCP" # tsnet
+        "TestListenTCPDualStack" # tsnet
+        "TestDialTCP" # tsnet
+        "TestDialUDP" # tsnet
+        "TestSelfDial" # tsnet
+        "TestListenUnspecifiedAddr" # tsnet
+        "TestListenMultipleEphemeralPorts" # tsnet
 
         # flaky: https://github.com/tailscale/tailscale/issues/15348
         "TestSafeFuncHappyPath"
@@ -155,9 +177,10 @@ buildGoModule (finalAttrs: {
         # Fails because we vendor dependencies
         "TestLicenseHeaders"
 
-        # Uses testing/synctest with gonotify.DirWatcher which spawns goroutines
-        # that block on inotify syscalls incompatible with synctest's bubble mechanism
+        # Uses testing/synctest which spawns goroutines that block on syscalls
+        # incompatible with synctest's bubble mechanism
         "TestDNSTrampleRecovery"
+        "TestOnPolicyChangeSkipsPreAuthConns" # ssh/tailssh
       ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         # syscall default route interface en0 differs from netstat


### PR DESCRIPTION
https://tailscale.com/changelog#client

- Override to go_1_26 (required by go.mod >= 1.26.1)
- Remove TestConcurrent skip (test no longer exists upstream)
- Add `TestOnPolicyChangeSkipsPreAuthConns` skip (synctest bubble issue)
- Replace blanket `substituteInPlace` on `tsnet/tsnet_test.go` with explicit skip list, allowing pure unit tests to actually run


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
