### PR TITLE
subtui: init at 2.12.2

### DIFF
--- a/pkgs/by-name/su/subtui/package.nix
+++ b/pkgs/by-name/su/subtui/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  mpv,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule (finalAttrs: {
+  pname = "subtui";
+  version = "2.11.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "MattiaPun";
+    repo = "subtui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-b8p1JBA5cdbDAD8BXJnvptWpuC6oQ+aZZVt6nnKUPFM=";
+  };
+
+  vendorHash = "sha256-LSEp0NaNsdnpDZTDUvpK5L7yPlqt3/W4jI9OOnvo7Lc=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${finalAttrs.version}"
+    "-X main.commit=${finalAttrs.src.rev}"
+  ];
+
+  buildInputs = [ mpv ];
+
+  meta = {
+    description = "Lightweight Subsonic TUI music player built in Go with scrobbling support";
+    homepage = "https://github.com/MattiaPun/SubTUI";
+    license = lib.licenses.mit;
+    changelog = "https://github.com/MattiaPun/SubTUI/releases/tag/v${finalAttrs.version}";
+    mainProgram = "SubTUI";
+    maintainers = with lib.maintainers; [ artur-sannikov ];
+  };
+})


### PR DESCRIPTION
https://github.com/MattiaPun/SubTUI

A lightweight Subsonic TUI music player built in Go with scrobbling support. 

## Things done

I tested basic functionality of playing music on my Navidrome server. Seems fine, but I only have mp3s and flac files, no special formats.

I checked this file for reference: https://github.com/suzana2314/nix-config/blob/cc06e89373aa7114316e366633ffd62c2204a247/pkgs/subtui/default.nix

`nativeInstallCheckInputs` fails because `-v` returns `Version: dev | Commit: none`.

I'm also not sure about the necessity of this step

```nix
  postFixup = ''
    wrapProgram $out/bin/SubTUI \
      --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.mpv ]}
  '';
```

because `buildInputs = [ pkgs.mpv ];` works fine and it makes mpv available for `subtui` AFAIK.

`ldflags` come from the SubTUI's flake.nix: https://github.com/MattiaPun/SubTUI/blob/main/flake.nix.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
