### PR TITLE
openimagedenoise: fix cuda cmake patch

### DIFF
--- a/pkgs/by-name/op/openimagedenoise/cuda.patch
+++ b/pkgs/by-name/op/openimagedenoise/cuda.patch
@@ -1,21 +1,16 @@
-Remove upstream workarounds for CMake "limitations" that do not appear to exist
-in nixpkgs build environment, but rather break the build, presumably because
-CMAKE_INSTALL_{BIN,LIB}DIR is an absolute path in our build so
-CMAKE_INSTALL_PREFIX has no effect.
-
 diff --git a/devices/CMakeLists.txt b/devices/CMakeLists.txt
-index d5111cd..43986ad 100644
+index a0ea112..4d03b4f 100644
 --- a/devices/CMakeLists.txt
 +++ b/devices/CMakeLists.txt
-@@ -53,7 +53,6 @@ if(OIDN_DEVICE_CUDA)
-       -DCMAKE_CXX_COMPILER:FILEPATH=${_host_compiler}
-       -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_TOOLCHAIN_FILE}
-       -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
--      -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/cuda/preinstall
-       -DCMAKE_INSTALL_BINDIR:PATH=${CMAKE_INSTALL_BINDIR}
-       -DCMAKE_INSTALL_LIBDIR:PATH=${CMAKE_INSTALL_LIBDIR}
-       -DCUDAToolkit_ROOT:PATH=${CUDAToolkit_ROOT}
-@@ -69,14 +68,6 @@ if(OIDN_DEVICE_CUDA)
+@@ -47,7 +47,6 @@ if(OIDN_DEVICE_CUDA)
+     -DCMAKE_CXX_COMPILER:FILEPATH=${_host_compiler}
+     -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_TOOLCHAIN_FILE}
+     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+-    -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/cuda/preinstall
+     -DCMAKE_INSTALL_BINDIR:PATH=${CMAKE_INSTALL_BINDIR}
+     -DCMAKE_INSTALL_LIBDIR:PATH=${CMAKE_INSTALL_LIBDIR}
+     -DOIDN_ROOT_BINARY_DIR:PATH=${OIDN_ROOT_BINARY_DIR}
+@@ -78,14 +77,6 @@ if(OIDN_DEVICE_CUDA)
      DEPENDS
        OpenImageDenoise_core
    )
@@ -30,3 +25,10 @@ index d5111cd..43986ad 100644
  endif()
  
  if(OIDN_DEVICE_HIP)
+@@ -186,4 +177,4 @@ endif()
+ 
+ if(OIDN_DEVICE_METAL)
+   add_subdirectory(metal)
+-endif()
+\ No newline at end of file
++endif()

--- a/pkgs/by-name/op/openimagedenoise/package.nix
+++ b/pkgs/by-name/op/openimagedenoise/package.nix
@@ -19,10 +19,14 @@ stdenv.mkDerivation (finalAttrs: {
   # The release tarballs include pretrained weights, which would otherwise need to be fetched with git-lfs
   src = fetchzip {
     url = "https://github.com/RenderKit/oidn/releases/download/v${finalAttrs.version}/oidn-${finalAttrs.version}.src.tar.gz";
-    sha256 = "sha256-SM0Bn4qgeqRJAXr2MMjNjfWJVTcciERZxMHiyx4Z1hA=";
+    hash = "sha256-SM0Bn4qgeqRJAXr2MMjNjfWJVTcciERZxMHiyx4Z1hA=";
   };
 
-  patches = lib.optional cudaSupport ./cuda.patch;
+  strictDeps = true;
+
+  patches = lib.optionals cudaSupport [
+    ./cuda.patch
+  ];
 
   postPatch = ''
     # fix build failure with GCC14
@@ -35,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     ispc
   ]
-  ++ lib.optional cudaSupport cudaPackages.cuda_nvcc
+  ++ lib.optionals cudaSupport [ cudaPackages.cuda_nvcc ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcodebuild ];
 
   buildInputs = [
@@ -49,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "OIDN_DEVICE_CUDA" cudaSupport)
-    (lib.cmakeFeature "TBB_INCLUDE_DIR" "${onetbb.dev}/include")
+    (lib.cmakeFeature "TBB_INCLUDE_DIR" "${lib.getDev onetbb}/include")
     (lib.cmakeFeature "TBB_ROOT" "${onetbb}")
   ];
 


### PR DESCRIPTION
## Things done

Hydra failure: https://hydra.nixos-cuda.org/build/261424

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
