### PR TITLE
firewall-iptables: drop old OUTPUT rules after reload

### DIFF
--- a/nixos/modules/services/networking/firewall-iptables.nix
+++ b/nixos/modules/services/networking/firewall-iptables.nix
@@ -273,8 +273,32 @@ let
 
     ${cfg.extraStopCommands}
 
+    N_OUTPUT_RULES="$(iptables --list OUTPUT --line-number | tail -1 | cut -d' ' -f1)"
+    ${lib.optionalString config.networking.enableIPv6 ''
+      N_OUTPUT_RULES_IPv6="$(ip6tables --list OUTPUT --line-number | tail -1 | cut -d' ' -f1)"
+    ''}
+
     if ${startScript}; then
       ip46tables -D INPUT -j nixos-drop 2>/dev/null || true
+
+      # Do not clear OUTPUT rules to avoid dropping connections,
+      # instead drop the old rules after reload. Rules are dropped
+      # in reverse order in order to preserve fallthrough behaviour
+      # while rules are being dropped.
+
+      if [[ "$N_OUTPUT_RULES" != "num" ]]; then # Catch case when chain is empty
+        for i in $(seq $N_OUTPUT_RULES -1 1); do
+          iptables -D OUTPUT $i
+        done
+      fi
+
+    ${lib.optionalString config.networking.enableIPv6 ''
+      if [[ "$N_OUTPUT_RULES_IPv6" != "num" ]]; then # Catch case when chain is empty
+        for i in $(seq $N_OUTPUT_RULES_IPv6 -1 1); do
+          ip6tables -D OUTPUT $i
+        done
+      fi
+    ''}
     else
       echo "Failed to reload firewall... Stopping"
       ${stopScript}
@@ -345,7 +369,11 @@ in
       ];
       conflicts = [ "shutdown.target" ];
 
-      path = [ cfg.package ] ++ cfg.extraPackages;
+      path = [
+        pkgs.coreutils
+        cfg.package
+      ]
+      ++ cfg.extraPackages;
 
       # FIXME: this module may also try to load kernel modules, but
       # containers don't have CAP_SYS_MODULE.  So the host system had


### PR DESCRIPTION
Otherwise old OUTPUT rules are just appended to on a switch.

We've been testing this in production at Arista since October of last year: https://github.com/awakesecurity/nixpkgs/pull/268

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
