### PR TITLE
lix: don't include `builtinDeps` as a bash variable

### DIFF
--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -124,6 +124,38 @@ let
       ''
         substitute $inputPath $out --replace-fail @deps@ "$(cat ${deps})"
       '';
+
+  # dep closure for builtin builders in meson array form for immediate use
+  builtinDeps =
+    finalAttrs:
+    if stdenv.hostPlatform.isStatic then
+      builtins.toFile "lix-static-dep-closure" "[]"
+    else
+      runCommand "lix-builtin-dep-closure"
+        {
+          closure = closureInfo {
+            # closureInfo does not work all that well for things like lowdown,
+            # where it finds only -out but not -lib. we'll take -out and -lib,
+            # ignoring -bin, -man, -dev, etc. and hope that'll be good enough.
+            rootPaths = lib.flatten (
+              map
+                (drv: [
+                  (drv.out or [ ])
+                  (drv.lib or [ ])
+                ])
+                (
+                  lib.subtractLists finalAttrs.disallowedReferences (
+                    finalAttrs.buildInputs ++ finalAttrs.propagatedBuildInputs
+                  )
+                )
+            );
+          };
+        }
+        ''
+          closure=($(cat $closure/store-paths))
+          closure="$(printf ", '%s'" "''${closure[@]}")"
+          printf "[%s]" "''${closure:2}" >$out
+        '';
 in
 # gcc miscompiles coroutines at least until 13.2, possibly longer
 # do not remove this check unless you are sure you (or your users) will not report bugs to Lix upstream about GCC miscompilations.
@@ -155,37 +187,6 @@ stdenv.mkDerivation (finalAttrs: {
     stdenv.cc.cc.stdenv.cc.cc
   ];
   __structuredAttrs = true;
-
-  # dep closure for builtin builders in meson array form for immediate use
-  builtinDeps =
-    if stdenv.hostPlatform.isStatic then
-      builtins.toFile "lix-static-dep-closure" "[]"
-    else
-      runCommand "lix-builtin-dep-closure"
-        {
-          closure = closureInfo {
-            # closureInfo does not work all that well for things like lowdown,
-            # where it finds only -out but not -lib. we'll take -out and -lib,
-            # ignoring -bin, -man, -dev, etc. and hope that'll be good enough.
-            rootPaths = lib.flatten (
-              map
-                (drv: [
-                  (drv.out or [ ])
-                  (drv.lib or [ ])
-                ])
-                (
-                  lib.subtractLists finalAttrs.disallowedReferences (
-                    finalAttrs.buildInputs ++ finalAttrs.propagatedBuildInputs
-                  )
-                )
-            );
-          };
-        }
-        ''
-          closure=($(cat $closure/store-paths))
-          closure="$(printf ", '%s'" "''${closure[@]}")"
-          printf "[%s]" "''${closure:2}" >$out
-        '';
 
   # We only include CMake so that Meson can locate toml11, which only ships CMake dependency metadata.
   dontUseCmakeConfigure = true;
@@ -373,7 +374,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (lib.versionAtLeast version "2.95") [
     "--${
       if stdenv.hostPlatform != stdenv.buildPlatform then "cross" else "native"
-    }-file=${mesonCrossFile finalAttrs.builtinDeps}"
+    }-file=${mesonCrossFile (builtinDeps finalAttrs)}"
   ];
 
   ninjaFlags = [ "-v" ];


### PR DESCRIPTION
This was causing Lix versions that don't use the dep closure to pull it in anyways.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
