### PR TITLE
launchnext: 2.3.0 -> 2.4.0

### DIFF
--- a/pkgs/by-name/la/launchnext/package.nix
+++ b/pkgs/by-name/la/launchnext/package.nix
@@ -6,11 +6,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "launchnext";
-  version = "2.3.0";
+  version = "2.4.0";
 
   src = fetchzip {
     url = "https://github.com/RoversX/LaunchNext/releases/download/${finalAttrs.version}/LaunchNext${finalAttrs.version}.zip";
-    hash = "sha256-gdfSkBWLXd1N17ruVlRs77q3VMX2nfmAYitPOVnDe3k=";
+    hash = "sha256-o52vYFr2j3AtFOpTyZ4jBnPhpfRGjyBXp5ZM4hlXqvU=";
     stripRoot = false;
   };
 


### PR DESCRIPTION
bump LaunchNext to 2.4.0

<https://github.com/RoversX/LaunchNext/releases/tag/2.4.0>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
