### PR TITLE
Autoswitch virtualenv init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6971,6 +6971,12 @@
     githubId = 131907205;
     name = "David Thievon";
   };
+  dogethebeast = {
+    email = "ratiqnarwal@gmail.com";
+    github = "dogethebeast";
+    githubId = 60806265;
+    name = "Ratiq Narwal";
+  };
   dolphindalt = {
     email = "dolphindalt@gmail.com";
     github = "dolphindalt";

--- a/pkgs/by-name/au/autoswitch-virtualenv/package.nix
+++ b/pkgs/by-name/au/autoswitch-virtualenv/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkgs,
+  installShellFiles,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "autoswitch-virtualenv";
+  version = "3.9.0";
+
+  src = fetchFromGitHub {
+    owner = "MichaelAquilina";
+    repo = "zsh-autoswitch-virtualenv";
+    tag = finalAttrs.version;
+    hash = "sha256-j2YX+OcYbvS2G/KUNzcWbJepm9bZlegp1r8ZjcY6Nnw=";
+  };
+
+  dontBuild = true;
+  nativeBuildInputs = [ installShellFiles ];
+  installPhase = ''
+    install -Dm755 autoswitch_virtualenv.plugin.zsh $out/autoswitch-virtualenv.plugin.zsh
+  '';
+
+  postPatch = ''
+    substituteInPlace ./autoswitch_virtualenv.plugin.zsh \
+      --replace-fail "virtualenv" "${lib.getExe' pkgs.virtualenv "virtualenv"}" \
+      --replace-fail "/usr/bin/stat" "${lib.getExe' pkgs.coreutils "stat"}" \
+      --replace-fail "/bin/rm" "${lib.getExe' pkgs.coreutils "rm"}" \
+      --replace-fail "/bin/ls" "${lib.getExe' pkgs.coreutils "ls"}" \
+      --replace-fail "/bin/mkdir" "${lib.getExe' pkgs.coreutils "mkdir"}"
+  '';
+
+  meta = {
+    description = "ZSH plugin that switches python virtualenvs automatically as you move between directories";
+    homepage = "https://github.com/MichaelAquilina/zsh-autoswitch-virtualenv";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.dogethebeast ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
