### PR TITLE
mixing-station: init at 2.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14353,6 +14353,12 @@
     githubId = 659440;
     name = "Kornelijus";
   };
+  korny666 = {
+    email = "korny@publicgrave.de";
+    github = "korny666";
+    githubId = 12656521;
+    name = "Korny";
+  };
   koschi13 = {
     email = "maximilian.konter@protonmail.com";
     github = "koschi13";

--- a/pkgs/by-name/mi/mixing-station/package.nix
+++ b/pkgs/by-name/mi/mixing-station/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.8.0";
 
   src = fetchzip {
-    url = "https://mixingstation.app/backend/api/web/download/update/mixing-station-pc/release";
+    url = "https://mixingstation.app/backend/api/web/download/archive/mixing-station-pc/update/${finalAttrs.version}";
     name = "mixing-station-${finalAttrs.version}.zip";
     extension = "zip";
     hash = "sha256-AGmBCkaYt3kZv/XuR9fkeEVryFw6t/p1CHVirNp+81s=";
@@ -34,7 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     makeWrapper
-    unzip
   ];
 
   dontBuild = true;

--- a/pkgs/by-name/mi/mixing-station/package.nix
+++ b/pkgs/by-name/mi/mixing-station/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  makeWrapper,
+  unzip,
+  jre,
+  libGL,
+  libglvnd,
+  libx11,
+  libxext,
+  libxcursor,
+  libxrandr,
+  libxi,
+  libxxf86vm,
+  libxinerama,
+  libpulseaudio,
+  udev,
+  zenity,
+  yad,
+  which,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mixing-station";
+  version = "2.8.0";
+
+  src = fetchzip {
+    url = "https://mixingstation.app/backend/api/web/download/update/mixing-station-pc/release";
+    name = "mixing-station-${finalAttrs.version}.zip";
+    extension = "zip";
+    hash = "sha256-AGmBCkaYt3kZv/XuR9fkeEVryFw6t/p1CHVirNp+81s=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    unzip
+  ];
+
+  dontBuild = true;
+
+  installPhase =
+    let
+      runtimeLibs = lib.makeLibraryPath [
+        libGL
+        libglvnd
+        libx11
+        libxext
+        libxcursor
+        libxrandr
+        libxi
+        libxxf86vm
+        libxinerama
+        libpulseaudio
+        udev
+      ];
+      dialogTools = [
+        zenity
+        yad
+        which
+      ];
+    in
+    ''
+      runHook preInstall
+      install -Dm644 mixing-station-desktop.jar \
+        "$out/share/mixing-station/mixing-station-desktop.jar"
+      makeWrapper "${jre}/bin/java" "$out/bin/mixing-station" \
+            --add-flags "-Dawt.useSystemAAFontSettings=gasp" \
+            --add-flags "-jar $out/share/mixing-station/mixing-station-desktop.jar" \
+            --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+            --prefix LD_LIBRARY_PATH : "/run/opengl-driver/lib" \
+            --suffix PATH : "${lib.makeBinPath dialogTools}"
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "Remote control app for digital audio mixers (XAir, X32, dLive, etc.)";
+    homepage = "https://mixingstation.app";
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "mixing-station";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ korny666 ];
+  };
+})


### PR DESCRIPTION
## Description

Add [Mixing Station](https://mixingstation.app), a proprietary remote control app for digital audio mixers (Behringer XAir/X32, Allen & Heath dLive/SQ, Yamaha, Midas, etc.).

The package fetches the upstream JAR from the vendor's download API and wraps it with the nixpkgs JRE. OpenGL/GLX libraries are provided via `LD_LIBRARY_PATH` (including `/run/opengl-driver/lib` for proprietary NVIDIA drivers). Dialog tools (`zenity`, `yad`) are added as fallback for `tinyfiledialogs` support.

Note: The download URL is versionless (always "latest"), so hash and version require manual maintenance on updates.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.