### PR TITLE
nixos/keycloak: use unix socket auth for locally created postgresql databases

### DIFF
--- a/nixos/modules/services/web-apps/keycloak.md
+++ b/nixos/modules/services/web-apps/keycloak.md
@@ -28,9 +28,13 @@ Keycloak can be used with either PostgreSQL, MariaDB or
 MySQL. Which one is used can be
 configured in [](#opt-services.keycloak.database.type). The selected
 database will automatically be enabled and a database and role
-created unless [](#opt-services.keycloak.database.host) is changed
-from its default of `localhost` or
-[](#opt-services.keycloak.database.createLocally) is set to `false`.
+created when [](#opt-services.keycloak.database.createLocally) is
+`true` (the default).
+
+For PostgreSQL, locally created databases use Unix socket
+authentication (peer auth), so no password is required. For
+MySQL/MariaDB, local database creation additionally requires
+[](#opt-services.keycloak.database.host) to be `localhost`.
 
 External database access can also be configured by setting
 [](#opt-services.keycloak.database.host),
@@ -43,11 +47,8 @@ and allow the configured database user full access to it.
 
 [](#opt-services.keycloak.database.passwordFile)
 must be set to the path to a file containing the password used
-to log in to the database. If [](#opt-services.keycloak.database.host)
-and [](#opt-services.keycloak.database.createLocally)
-are kept at their defaults, the database role
-`keycloak` with that password is provisioned
-on the local database instance.
+to log in to the database, unless using Unix socket
+authentication (PostgreSQL only).
 
 ::: {.warning}
 The path should be provided as a string, not a Nix path, since Nix
@@ -57,19 +58,21 @@ paths are copied into the world readable Nix store.
 ## Unix socket authentication {#module-services-keycloak-unix-socket}
 
 For PostgreSQL, Keycloak can connect via Unix socket using peer
-authentication, avoiding the need for a database password.
+authentication, avoiding the need for a database password. The
+required `junixsocket` plugins are added automatically.
 
-To use Unix sockets, set [](#opt-services.keycloak.database.host)
-to the PostgreSQL socket directory (e.g., `/run/postgresql`) and
-add the required junixsocket plugins:
+When [](#opt-services.keycloak.database.createLocally) is enabled
+(the default) with PostgreSQL, Unix socket authentication is used
+automatically.
+
+To use Unix sockets with an externally managed database, set
+[](#opt-services.keycloak.database.host) to the PostgreSQL socket
+directory:
 ```nix
 {
   services.keycloak = {
+    database.createLocally = false;
     database.host = "/run/postgresql";
-    plugins = with pkgs.keycloak.plugins; [
-      junixsocket-common
-      junixsocket-native-common
-    ];
   };
 }
 ```
@@ -159,7 +162,6 @@ A basic configuration with some custom settings could look like this:
     initialAdminPassword = "e6Wcm0RrtegMEHl"; # change on first login
     sslCertificate = "/run/keys/ssl_cert";
     sslCertificateKey = "/run/keys/ssl_key";
-    database.passwordFile = "/run/keys/db_password";
   };
 }
 ```

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -170,8 +170,11 @@ in
 
             For PostgreSQL, this can also be a path to a Unix socket
             directory (e.g., `/run/postgresql`) to use peer authentication.
-            This requires adding `junixsocket-common` and `junixsocket-native-common`
-            to [](#opt-services.keycloak.plugins).
+            The required `junixsocket` plugins are added automatically.
+
+            When [](#opt-services.keycloak.database.createLocally) is enabled
+            with PostgreSQL, this option is ignored and Unix socket auth is
+            used automatically.
           '';
         };
 
@@ -224,8 +227,12 @@ in
           description = ''
             Whether a database should be automatically created on the
             local host. Set this to false if you plan on provisioning a
-            local database yourself. This has no effect if
-            services.keycloak.database.host is customized.
+            local database yourself.
+
+            For PostgreSQL, the local database uses Unix socket
+            authentication (peer auth), so no password is required.
+            For MySQL/MariaDB, this has no effect if
+            [](#opt-services.keycloak.database.host) is customized.
           '';
         };
 
@@ -265,8 +272,10 @@ in
           description = ''
             The path to a file containing the database password.
 
-            Not required when using Unix socket authentication (peer auth)
-            by setting `host` to a socket path like `/run/postgresql`.
+            Not required when using Unix socket authentication (peer auth),
+            either via [](#opt-services.keycloak.database.createLocally) with
+            PostgreSQL or by setting [](#opt-services.keycloak.database.host)
+            to a socket path.
           '';
         };
       };
@@ -436,16 +445,17 @@ in
 
   config =
     let
-      # We only want to create a database if we're actually going to
-      # connect to it.
-      databaseActuallyCreateLocally = cfg.database.createLocally && cfg.database.host == "localhost";
-      createLocalPostgreSQL = databaseActuallyCreateLocally && cfg.database.type == "postgresql";
+      createLocalPostgreSQL = cfg.database.createLocally && cfg.database.type == "postgresql";
       createLocalMySQL =
-        databaseActuallyCreateLocally
+        cfg.database.createLocally
+        && cfg.database.host == "localhost"
         && elem cfg.database.type [
           "mysql"
           "mariadb"
         ];
+      databaseActuallyCreateLocally = createLocalPostgreSQL || createLocalMySQL;
+      useUnixSocket =
+        createLocalPostgreSQL || (cfg.database.type == "postgresql" && hasPrefix "/" cfg.database.host);
 
       mySqlCaKeystore = pkgs.runCommand "mysql-ca-keystore" { } ''
         ${pkgs.jre}/bin/keytool -importcert -trustcacerts -alias MySQLCACert -file ${cfg.database.caCert} -keystore $out -storepass notsosecretpassword -noprompt
@@ -518,7 +528,14 @@ in
           ++ (with cfg.package.plugins; [
             quarkus-systemd-notify
             quarkus-systemd-notify-deployment
-          ]);
+          ])
+          ++ optionals useUnixSocket (
+            with cfg.package.plugins;
+            [
+              junixsocket-common
+              junixsocket-native-common
+            ]
+          );
       };
     in
     mkIf cfg.enable {
@@ -564,10 +581,11 @@ in
           '';
         }
         {
-          assertion = cfg.database.passwordFile != null || hasPrefix "/" cfg.database.host;
+          assertion = cfg.database.passwordFile != null || useUnixSocket;
           message = ''
             services.keycloak.database.passwordFile must be set unless using
-            Unix socket authentication (host starting with /).
+            Unix socket authentication via a locally created PostgreSQL database
+            or by setting host to a socket path.
           '';
         }
       ];
@@ -604,8 +622,8 @@ in
           dbProps = if cfg.database.type == "postgresql" then postgresParams else mariadbParams;
 
           # Unix socket connection requires junixsocket library and special JDBC URL
-          isUnixSocket = hasPrefix "/" cfg.database.host;
-          unixSocketUrl = "jdbc:postgresql://localhost/${dbName}?socketFactory=org.newsclub.net.unix.AFUNIXSocketFactory$FactoryArg&socketFactoryArg=${cfg.database.host}/.s.PGSQL.${toString cfg.database.port}&sslMode=disable";
+          socketDir = if createLocalPostgreSQL then "/run/postgresql" else cfg.database.host;
+          unixSocketUrl = "jdbc:postgresql://localhost/${dbName}?socketFactory=org.newsclub.net.unix.AFUNIXSocketFactory$FactoryArg&socketFactoryArg=${socketDir}/.s.PGSQL.${toString cfg.database.port}&sslMode=disable";
         in
         mkMerge [
           {
@@ -615,10 +633,10 @@ in
               _secret = cfg.database.passwordFile;
             };
           }
-          (mkIf isUnixSocket {
+          (mkIf useUnixSocket {
             db-url = unixSocketUrl;
           })
-          (mkIf (!isUnixSocket) {
+          (mkIf (!useUnixSocket) {
             db-url-host = cfg.database.host;
             db-url-port = toString cfg.database.port;
             db-url-database = dbName;
@@ -641,24 +659,12 @@ in
           RemainAfterExit = true;
           User = "postgres";
           Group = "postgres";
-          LoadCredential = [ "db_password:${cfg.database.passwordFile}" ];
         };
         script = ''
           set -o errexit -o pipefail -o nounset -o errtrace
           shopt -s inherit_errexit
 
-          create_role="$(mktemp)"
-          trap 'rm -f "$create_role"' EXIT
-
-          # Read the password from the credentials directory and
-          # escape any single quotes by adding additional single
-          # quotes after them, following the rules laid out here:
-          # https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS
-          db_password="$(<"$CREDENTIALS_DIRECTORY/db_password")"
-          db_password="''${db_password//\'/\'\'}"
-
-          echo "CREATE ROLE keycloak WITH LOGIN PASSWORD '$db_password' CREATEDB" > "$create_role"
-          psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='keycloak'" | grep -q 1 || psql -tA --file="$create_role"
+          psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='keycloak'" | grep -q 1 || psql -tAc "CREATE ROLE keycloak WITH LOGIN"
           psql -tAc "SELECT 1 FROM pg_database WHERE datname = 'keycloak'" | grep -q 1 || psql -tAc 'CREATE DATABASE "keycloak" OWNER "keycloak"'
         '';
         enableStrictShellChecks = true;


### PR DESCRIPTION
- Fixes #479508. `createLocalPostgreSQL` no longer checks `host == "localhost"`, so `host = "/run/postgresql"` with `createLocally = true` now creates the database
- Fixes #479948. When `createLocally = true` with PostgreSQL, the module automatically uses Unix socket peer auth, auto-adds `junixsocket` plugins, and the init script creates the role without a password.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test