### PR TITLE
Revert "triton-llvm: build with BUILD_SHARED_LIBS to reduce output size"

### DIFF
--- a/pkgs/by-name/tr/triton-llvm/package.nix
+++ b/pkgs/by-name/tr/triton-llvm/package.nix
@@ -128,7 +128,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "LLVM_INCLUDE_DOCS" (buildDocs || buildMan))
     (lib.cmakeBool "MLIR_INCLUDE_DOCS" (buildDocs || buildMan))
     (lib.cmakeBool "LLVM_BUILD_DOCS" (buildDocs || buildMan))
-    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
     # Way too slow, only uses one core
     # (lib.cmakeBool "LLVM_ENABLE_DOXYGEN" (buildDocs || buildMan))
     (lib.cmakeBool "LLVM_ENABLE_SPHINX" (buildDocs || buildMan))


### PR DESCRIPTION
Reverts NixOS/nixpkgs#500596

This broke `python3Packages.keras` (tests segfault).
Can you have a quick look into it @LunNova please?

_Originally posted by @GaetanLepage in https://github.com/NixOS/nixpkgs/issues/500596#issuecomment-4085504512_

Unlikely to be quick to work out so revert, investigate, reland / replace later.