### PR TITLE
pre-commit: fix meta hooks on non-NixOS Nix installs

### DIFF
--- a/pkgs/by-name/pr/pre-commit/meta-hooks-pythonpath.patch
+++ b/pkgs/by-name/pr/pre-commit/meta-hooks-pythonpath.patch
@@ -1,0 +1,11 @@
+diff --git a/pre_commit/clientlib.py b/pre_commit/clientlib.py
+--- a/pre_commit/clientlib.py
++++ b/pre_commit/clientlib.py
+@@ -349,7 +349,8 @@ def _entry(modname: str) -> str:
+     """the hook `entry` is passed through `shlex.split()` by the command
+     runner, so to prevent issues with spaces and backslashes (on Windows)
+     it must be quoted here.
+     """
+-    return f'{shlex.quote(sys.executable)} -m pre_commit.meta_hooks.{modname}'
++    pythonpath = ':'.join(sys.path)
++    return f'env PYTHONPATH={shlex.quote(pythonpath)} {shlex.quote(sys.executable)} -m pre_commit.meta_hooks.{modname}'

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -40,6 +40,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     ./languages-use-the-hardcoded-path-to-python-binaries.patch
     ./hook-tmpl.patch
     ./pygrep-pythonpath.patch
+    ./meta-hooks-pythonpath.patch
   ];
 
   build-system = with python3Packages; [


### PR DESCRIPTION
## Summary

When running `pre-commit run --all-files` with `repo: meta` hooks
(`check-hooks-apply`, `check-useless-excludes`) on a non-NixOS Nix install
(e.g. home-manager), the following error occurs:

```
/nix/store/.../python3.13: Error while finding module specification for
'pre_commit.meta_hooks.check_hooks_apply'
(ModuleNotFoundError: No module named 'pre_commit')
```

## Root Cause

`_entry()` in `pre_commit/clientlib.py` builds the shell command for meta hooks
using the bare `sys.executable` path. On Nix, the pre-commit binary is a wrapper
that injects dependencies via `site.addsitedir()`. Subprocesses spawned directly
via `sys.executable` bypass these injections, so `import pre_commit` fails.

## Fix

Apply the same fix already used for the `pygrep` language in
`pygrep-pythonpath.patch`: pass `PYTHONPATH` from `sys.path` to the subprocess.

Because the meta hook entry is a plain string processed via `shlex.split()`, the
`PYTHONPATH` is prepended using `env PYTHONPATH=...` rather than passed as a
keyword argument to `xargs`.

## Testing

The patch was verified locally by overriding `pre-commit` via `overrideAttrs` in
a home-manager config. All nixpkgs tests pass with the patch applied (715 passed,
1 skipped, 3 xfailed — identical to unpatched).

## Checklist

- [x] Tested the change by building locally and running the test suite
- [x] Minimal change — mirrors the existing `pygrep-pythonpath.patch` precedent