### PR TITLE
oscgoesbrrr: init at 2.1.20

### DIFF
--- a/pkgs/by-name/os/oscgoesbrrr/10-hardcode-versions.patch
+++ b/pkgs/by-name/os/oscgoesbrrr/10-hardcode-versions.patch
@@ -1,0 +1,51 @@
+Author: lactose <mail@lactose.dev>
+
+Fix for hardcoded versions. Also fills in package version in package.json
+
+Index: OscGoesBrrr/.nvmrc
+===================================================================
+--- OscGoesBrrr.orig/.nvmrc
++++ OscGoesBrrr/.nvmrc
+@@ -1,1 +1,1 @@
+-24.14.0
++@NODE_VERSION@
+Index: OscGoesBrrr/package.json
+===================================================================
+--- OscGoesBrrr.orig/package.json
++++ OscGoesBrrr/package.json
+@@ -1,6 +1,6 @@
+ {
+   "name": "OscGoesBrrr",
+-  "version": "0.0.0-dev",
++  "version": "@OGB_VERSION@",
+   "type": "module",
+   "description": "Haptics for VRChat",
+   "author": {
+@@ -19,7 +19,7 @@
+   "repository": "https://github.com/OscToys/OscGoesBrrr",
+   "license": "CC BY-NC-SA 4.0",
+   "engines": {
+-    "node": "24.14.0"
++    "node": "@NODE_VERSION@"
+   },
+   "devDependencies": {
+     "@emotion/cache": "^11.14.0",
+@@ -108,5 +108,5 @@
+   "optionalDependencies": {
+     "native-reg": "^1.1.1"
+   },
+-  "packageManager": "pnpm@10.30.3"
++  "packageManager": "pnpm@@PNPM_VERSION@"
+ }
+Index: OscGoesBrr/pnpm-workspace.yaml
+===================================================================
+--- OscGoesBrrr.orig/pnpm-workspace.yaml
++++ OscGoesBrrr/pnpm-workspace.yaml
+@@ -1,5 +1,5 @@
+ onlyBuiltDependencies:
+   - electron
+ minimumReleaseAge: 10080
+-useNodeVersion: 24.14.0
++useNodeVersion: @NODE_VERSION@
+ engineStrict: true
+ 

--- a/pkgs/by-name/os/oscgoesbrrr/package.nix
+++ b/pkgs/by-name/os/oscgoesbrrr/package.nix
@@ -1,0 +1,124 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  copyDesktopItems,
+  makeDesktopItem,
+  makeWrapper,
+  replaceVars,
+  iconConvTools,
+  nodejs-slim_24,
+  pnpmConfigHook,
+  pnpm_10,
+  electron_41,
+  nix-update-script,
+}:
+let
+  nodejs-slim = nodejs-slim_24;
+  pnpm = pnpm_10.override { inherit nodejs-slim; };
+  electron = electron_41;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "oscgoesbrrr";
+  version = "2.1.20";
+
+  src = fetchFromGitHub {
+    owner = "OscToys";
+    repo = "OscGoesBrrr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aAA257kevw/dmfzKSyUk8VyClpZUvrEgAQsox3hjWgk=";
+  };
+
+  patches = [
+    (replaceVars ./10-hardcode-versions.patch {
+      OGB_VERSION = finalAttrs.version;
+      NODE_VERSION = nodejs-slim.version;
+      PNPM_VERSION = pnpm.version;
+    })
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    nodejs-slim
+    pnpmConfigHook
+    pnpm
+    makeWrapper
+    copyDesktopItems
+    iconConvTools
+  ];
+
+  buildInputs = [ electron ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    hash = "sha256-bUdHtHBDC/W1Gjp6By+5Q4d1+7THntLT7JszvbnP+HQ=";
+    fetcherVersion = 3;
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "oscgoesbrrr";
+      type = "Application";
+      desktopName = "OscGoesBrrr";
+      genericName = "VRChat OSC Haptics Dashboard";
+      exec = "OscGoesBrrr";
+      icon = "oscgoesbrrr";
+      comment = "Make haptics in real life go BRRR from VRChat";
+      categories = [ "Utility" ];
+      keywords = [
+        "OSC"
+        "OGB"
+        "VRChat"
+      ];
+    })
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # install electron bundle
+    mkdir -p $out/lib/OscGoesBrrr/app
+    cp app/main.bundle.js $out/lib/OscGoesBrrr/
+    cp app/preload.js app/*.html app/*.png app/*.ico $out/lib/OscGoesBrrr/app/
+    echo '{"name":"OscGoesBrrr","version":"${finalAttrs.version}","type": "module","main":"main.bundle.js"}' \
+      > $out/lib/OscGoesBrrr/package.json
+
+
+    # generate icons
+    icoFileToHiColorTheme src/icons/ogb-logo.ico oscgoesbrrr $out
+
+    # create electron wrapper application
+    mkdir -p $out/bin
+    makeWrapper ${electron}/bin/electron $out/bin/OscGoesBrrr \
+      --add-flags $out/lib/OscGoesBrrr
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Graphical OSC haptic control dashboard for VRChat";
+    longDescription = ''
+      OscGoesBrrr provides a bridge for VRChat SPS and TPS plugs and sockets to Intiface Central.
+      It also supports OSCQuery to allow other OSC applications to communicate to VRChat.
+    '';
+    homepage = "https://osc.toys";
+    changelog = "https://github.com/OscToys/OscGoesBrrr/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.cc-by-nc-sa-40;
+    maintainers = with lib.maintainers; [ lactose ];
+    mainProgram = "OscGoesBrrr";
+  };
+})


### PR DESCRIPTION
Adds [OscGoesBrrr](https://github.com/OscToys/OscGoesBrrr/), a popular haptic tool for VRChat. Builds off of previous work by @TheButlah. Also includes an update script.

I was not aware of the initial packaging effort while working on this, but my package is significantly different as upstream has gone through a major release since #447061. The aforementioned PR is currently for 1.42.0 and fails to build.

Closes #447061.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
