### PR TITLE
coqPackages.CertiRocq: init at 0.9.1

### DIFF
--- a/pkgs/development/coq-modules/CertiRocq/default.nix
+++ b/pkgs/development/coq-modules/CertiRocq/default.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  pkgs,
+  pkg-config,
+  mkCoqDerivation,
+  coq,
+  wasmcert,
+  compcert,
+  metarocq-erasure-plugin,
+  metarocq-safechecker-plugin,
+  ExtLib,
+  version ? null,
+}:
+
+with lib;
+mkCoqDerivation {
+  pname = "CertiRocq";
+  owner = "CertiRocq";
+  repo = "certirocq";
+  opam-name = "rocq-certirocq";
+  mlPlugin = true;
+
+  inherit version;
+  defaultVersion =
+    let
+      case = coq: mr: out: {
+        cases = [
+          coq
+          mr
+        ];
+        inherit out;
+      };
+    in
+    lib.switch
+      [
+        coq.coq-version
+        metarocq-erasure-plugin.version
+      ]
+      [
+        (case "9.1" "1.5.1-9.1" "0.9.1+9.1")
+      ]
+      null;
+  release = {
+    "0.9.1+9.1".sha256 = "sha256-YsweBaoq8+QG63e7Llp/4bHldAFnSQSyMumJkb+Bsp0=";
+  };
+  releaseRev = v: "v${v}";
+
+  buildInputs = [
+    pkgs.clang
+  ];
+
+  propagatedBuildInputs = [
+    wasmcert
+    compcert
+    ExtLib
+    metarocq-erasure-plugin
+    metarocq-safechecker-plugin
+  ];
+
+  patchPhase = ''
+    patchShebangs ./configure.sh
+    patchShebangs ./clean_extraction.sh
+    patchShebangs ./make_plugin.sh
+  '';
+
+  configurePhase = ''
+    ./configure.sh local
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    make all
+    make plugins
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    OUTDIR=$out/lib/coq/${coq.coq-version}/user-contrib
+
+    DST=$OUTDIR/CertiRocq/Plugin/runtime make -C runtime install
+    COQLIBINSTALL=$OUTDIR make -C theories install
+    COQLIBINSTALL=$OUTDIR make -C libraries install
+    COQLIBINSTALL=$OUTDIR COQPLUGININSTALL=$OCAMLFIND_DESTDIR make -C plugin install
+    COQLIBINSTALL=$OUTDIR COQPLUGININSTALL=$OCAMLFIND_DESTDIR make -C cplugin install
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CertiRocq";
+    maintainers = with maintainers; [
+      womeier
+      _4ever2
+    ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -71,6 +71,7 @@ let
       category-theory = callPackage ../development/coq-modules/category-theory { };
       ceres = callPackage ../development/coq-modules/ceres { };
       ceres-bs = callPackage ../development/coq-modules/ceres-bs { };
+      CertiRocq = callPackage ../development/coq-modules/CertiRocq { };
       Cheerios = callPackage ../development/coq-modules/Cheerios { };
       coinduction = callPackage ../development/coq-modules/coinduction { };
       CoLoR = callPackage ../development/coq-modules/CoLoR (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
