### PR TITLE
nixos/systemd-boot: set strict error handling in installer script

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -102,6 +102,7 @@ let
 
   finalSystemdBootBuilder = pkgs.writeScript "install-systemd-boot.sh" ''
     #!${pkgs.runtimeShell}
+    set -euo pipefail
     ${systemdBootBuilder}/bin/systemd-boot "$@"
     ${cfg.extraInstallCommands}
   '';


### PR DESCRIPTION
Previously, if `boot.loader.systemd-boot.extraInstallCommands` was non-empty, errors from `systemdBootBuilder` would be ignored. If `/boot` was too small to install every boot entry, the `OSError: [Errno 28] No space left on device:` python error would be present in stdout/stdeer but the return code would still indicate success. 

## Things done

Manually tested on x86 hardware, `switch-to-configuration boot` now exists with non-zero exit code and `Failed to install bootloader` message if any failures occur in `install-systemd-boot.sh`.