### PR TITLE
opentxl: use generated code as src instead of repo

### DIFF
--- a/pkgs/by-name/op/opentxl/package.nix
+++ b/pkgs/by-name/op/opentxl/package.nix
@@ -2,44 +2,38 @@
   lib,
   stdenv,
   callPackage,
-  fetchFromGitHub,
+  fetchurl,
   nix-update-script,
-  turingplus,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "opentxl";
   version = "11.3.7";
 
-  src = fetchFromGitHub {
-    owner = "CordyJ";
-    repo = "OpenTxl";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-Gh0OEZ5pGhbxDIKYuBLdzUV7Ezn+7elm146ccpJ5bn8=";
+  # The code generation part of the upstream build system relies on an x86-only binary,
+  # so the generated code is fetched from the GitHub release instead
+  src = fetchurl {
+    url = "https://github.com/CordyJ/OpenTxl/releases/download/v${finalAttrs.version}/OpenTxl-${finalAttrs.version}-csrc.tar.gz";
+    hash = "sha256-qIvxQqo1yCVJImjUvNNinzhoywVgaq9s0E+Ab+QStc0=";
   };
-
-  nativeBuildInputs = [ turingplus ];
 
   # Using -std=gnu89 to prevent errors that occur with default args
   env.NIX_CFLAGS_COMPILE = "-std=gnu89 -Wno-int-conversion";
 
   postPatch = ''
-    # Replace hardcoded /bin/rm in various files
-    find . -type f -exec sed -i 's#/bin/rm#rm#g' {} +
+    # Replace hardcoded FHS paths in various files
+    find . -type f -exec sed -i \
+      -e 's#/bin/mv#mv#g' \
+      -e 's#/bin/rm#rm#g' \
+      -e "s#/usr/local/bin#$out/bin#g" \
+      -e "s#/usr/local/lib/txl#$out/lib#g" \
+      {} +
 
     # Replace hardcoded gcc references
-    substituteInPlace src/scripts/c/unix/{txlc,txl2c} \
+    substituteInPlace scripts/unix/{txlc,txl2c} \
       --replace-fail gcc '${stdenv.cc}/bin/cc'
-
-    # Replace hardcoded FHS paths
-    substituteInPlace src/scripts/c/unix/* src/scripts/t/* \
-      --replace-fail '/usr/local/bin' "$out/bin" \
-      --replace-fail '/usr/local/lib/txl' "$out/lib"
   '';
 
-  # Generate source files and enter directory
   preBuild = ''
-    make csrc
-    cd csrc
     makeFlagsArray+=(
       CC="$CC"
       LD="$CC"
@@ -64,10 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Open-source compiler for the Txl language";
     mainProgram = "txl";
-    platforms = [
-      "x86_64-linux"
-      "x86_64-darwin"
-    ];
+    platforms = lib.platforms.unix;
     homepage = "https://github.com/CordyJ/OpenTxl";
     downloadPage = "https://github.com/CordyJ/OpenTxl/releases";
     changelog = "https://github.com/CordyJ/OpenTxl/releases/tag/v${finalAttrs.version}";


### PR DESCRIPTION
Previously, the derivation for this package would clone the source repo and run a codegen tool as part of the build process. However, the codegen tool only supports x86 architectures, while the emitted C is platform-agnostic. This PR allows the package to build on more platforms by instead fetching just the generated source .tar.gz from GitHub releases.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test