### PR TITLE
quake-shareware: init at 1.06

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2776,6 +2776,14 @@
     github = "axodentally";
     githubId = 24368475;
   };
+  axunes = {
+    name = "axunes";
+    email = "axunes@axunes.net";
+    matrix = "@axunes:matrix.org";
+    github = "axunes";
+    githubId = 55267708;
+    keys = [ { fingerprint = "024A A47E 55D7 FCF6 38BF  2189 46B4 2EE8 C118 DBE9"; } ];
+  };
   ayazhafiz = {
     email = "ayaz.hafiz.1@gmail.com";
     github = "hafiz";

--- a/pkgs/by-name/qu/quake-shareware/package.nix
+++ b/pkgs/by-name/qu/quake-shareware/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  libarchive,
+  fetchurl,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  name = "pak0.pak";
+  version = "1.06";
+
+  src = fetchurl {
+    url = "https://github.com/Jason2Brownlee/QuakeOfficialArchive/raw/main/bin/quake106.zip";
+    hash = "sha256-7GydNLGuAlKsAGYEW2YRp5GcKg14o6Ztk4eo9ZdVMjk=";
+    meta.license = {
+      url = "https://github.com/id-Software/Quake/raw/master/WinQuake/data/SLICNSE.TXT";
+      free = false;
+      redistributable = true;
+    };
+  };
+
+  nativeBuildInputs = [ libarchive ];
+
+  outputHash = "sha256-NanFXl5aKEoVmtKmLg6N7yPYKVYf4vVOtALbwKmpRq8=";
+
+  unpackPhase = ''
+    runHook preUnpack
+    bsdtar xf "$src" resource.1
+    bsdtar xf resource.1 ID1/PAK0.PAK
+    runHook postUnpack
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    cp ID1/PAK0.PAK "$out"
+    runHook postInstall
+  '';
+
+  # to be used in source port expressions
+  passthru.id1 = stdenvNoCC.mkDerivation {
+    pname = "quake-shareware-id1";
+    version = "1.06";
+
+    dontUnpack = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+      install -Dm644 ${finalAttrs.finalPackage} "$out/id1/pak0.pak"
+      runHook postInstall
+    '';
+
+    outputHashMode = "recursive";
+    outputHash = "sha256-jalaua2KY3J7ULVfPjHxKLvuUL3xyhwtEQfW3o1vqdc=";
+  };
+
+  meta = {
+    description = "Quake episode 1, shareware";
+    longDescription = ''
+      Original shareware distribution of Quake episode 1.
+      A Quake source port is required to play.
+      If you wish to use mods or the full version of the game,
+      you can symlink pak0.pak to your own quake folder.
+    '';
+    homepage = "https://bethesda.net/en/game/quake";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ axunes ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added a package that fetches from a well-established GitHub mirror the Quake shareware distribution, quake106.zip, and extracts pak0.pak from it to be added to the share/games/quake/id1 directory. pak0.pak is built as a separate derivation since unlike quake106.zip it is not redistributable, and so it can become a dependency of a source port. The version is set to 1.06 although as far as I know this is the only shareware release of Quake. quake106.zip is also available from other sources such as archive.org or any of the mirrors of ftp.idsoftware.com.

I was under the impression that quake106.zip would be cached by Hydra but now I'm not so sure. b43Firmware_\* seems to pull its src from cache.nixos.org but I don't know why. Examining the b43 firmware packages is what prompted me to make this pull request.

Also added myself as maintainer.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
