### PR TITLE
maintainers: remove fabiangd

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8476,12 +8476,6 @@
     githubId = 116184;
     keys = [ { fingerprint = "2F6C 930F D3C4 7E38 6AFA  4EB4 E23C D2DD 36A4 397F"; } ];
   };
-  fabiangd = {
-    email = "fabian.g.droege@gmail.com";
-    name = "Fabian G. Dröge";
-    github = "FabianGD";
-    githubId = 40316600;
-  };
   fabianhauser = {
     email = "fabian.nixos@fh2.ch";
     github = "fabianhauser";

--- a/pkgs/by-name/fp/fprettify/package.nix
+++ b/pkgs/by-name/fp/fprettify/package.nix
@@ -33,6 +33,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     mainProgram = "fprettify";
     homepage = "https://pypi.org/project/fprettify/";
     license = with lib.licenses; [ gpl3Only ];
-    maintainers = with lib.maintainers; [ fabiangd ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/hy/hyper/package.nix
+++ b/pkgs/by-name/hy/hyper/package.nix
@@ -112,7 +112,6 @@ stdenv.mkDerivation rec {
     homepage = "https://hyper.is/";
     maintainers = with lib.maintainers; [
       puffnfresh
-      fabiangd
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.mit;

--- a/pkgs/by-name/py/pylint-exit/package.nix
+++ b/pkgs/by-name/py/pylint-exit/package.nix
@@ -37,6 +37,6 @@ buildPythonApplication rec {
     description = "Utility to handle pylint exit codes in an OS-friendly way";
     license = lib.licenses.mit;
     homepage = "https://github.com/jongracecox/pylint-exit";
-    maintainers = [ lib.maintainers.fabiangd ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/anybadge/default.nix
+++ b/pkgs/development/python-modules/anybadge/default.nix
@@ -57,6 +57,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/jongracecox/anybadge";
     changelog = "https://github.com/jongracecox/anybadge/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ fabiangd ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ipympl/default.nix
+++ b/pkgs/development/python-modules/ipympl/default.nix
@@ -82,7 +82,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/matplotlib/jupyter-matplotlib";
     maintainers = with lib.maintainers; [
       jluttine
-      fabiangd
     ];
     license = lib.licenses.bsd3;
   };

--- a/pkgs/development/python-modules/qutip/default.nix
+++ b/pkgs/development/python-modules/qutip/default.nix
@@ -96,7 +96,7 @@ buildPythonPackage rec {
     homepage = "https://qutip.org/";
     changelog = "https://github.com/qutip/qutip/releases/tag/${src.tag}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fabiangd ];
+    maintainers = [ ];
     badPlatforms = [
       # Tests fail at ~80%
       # ../tests/test_animation.py::test_result_state Fatal Python error: Aborted


### PR DESCRIPTION
- Last commented in [2022](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Afabiangd)
- Hasn't created any PRs / Issues since [2022](https://github.com/NixOS/nixpkgs/issues?q=author%3Afabiangd)
- About 40 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Afabiangd%20-commenter%3Afabiangd%20-author%3Afabiangd%20-reviewed-by%3Afabiangd) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
