### PR TITLE
linux_libre: remove cruft

### DIFF
--- a/nixos/tests/kernel-generic/default.nix
+++ b/nixos/tests/kernel-generic/default.nix
@@ -84,7 +84,6 @@ let
       linux_rt_5_15
       linux_rt_6_1
       linux_rt_6_6
-      linux_libre
 
       linux_testing
       ;

--- a/pkgs/os-specific/linux/amdgpu-i2c/default.nix
+++ b/pkgs/os-specific/linux/amdgpu-i2c/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/twifty/amd-gpu-i2c";
     downloadPage = "https://github.com/twifty/amd-gpu-i2c";
     description = "Exposes i2c interface to set colors on AMD GPUs";
-    broken = kernel.kernelOlder "6.1.0" || kernel.isLibre;
+    broken = kernel.kernelOlder "6.1.0";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ thardin ];

--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -77,7 +77,6 @@ lib.makeOverridable (
 
     # for module compatibility
     isZen ? false,
-    isLibre ? false,
     isHardened ? false,
 
     # Whether to utilize the controversial import-from-derivation feature to parse the config
@@ -526,7 +525,6 @@ lib.makeOverridable (
       inherit
         isZen
         isHardened
-        isLibre
         withRust
         ;
       isXen = lib.warn "The isXen attribute is deprecated. All Nixpkgs kernels that support it now have Xen enabled." true;

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -75,7 +75,6 @@ lib.makeOverridable (
 
     isLTS ? false,
     isZen ? false,
-    isLibre ? false,
     isHardened ? false,
 
     # easy overrides to stdenv.hostPlatform.linux-kernel members
@@ -317,7 +316,6 @@ lib.makeOverridable (
             isLTS
             isZen
             isHardened
-            isLibre
             ;
           isXen = lib.warn "The isXen attribute is deprecated. All Nixpkgs kernels that support it now have Xen enabled." true;
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -329,7 +329,6 @@ in
           isLTS
           isZen
           isHardened
-          isLibre
           ;
         inherit (kernel) kernelOlder kernelAtLeast;
         kernelModuleMakeFlags = self.kernel.commonMakeFlags ++ [


### PR DESCRIPTION
follow up from https://github.com/NixOS/nixpkgs/commit/545a975d7e225d6315080aee7e82cee5a133fb51


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
