### PR TITLE
coconut: add missing dependency

### DIFF
--- a/pkgs/development/python-modules/coconut/default.nix
+++ b/pkgs/development/python-modules/coconut/default.nix
@@ -14,6 +14,7 @@
   prompt-toolkit,
   setuptools,
   tkinter,
+  tstr,
   watchdog,
 }:
 
@@ -42,6 +43,7 @@ buildPythonPackage rec {
     pygments
     prompt-toolkit
     setuptools
+    tstr
     watchdog
   ];
 

--- a/pkgs/development/python-modules/tstr/default.nix
+++ b/pkgs/development/python-modules/tstr/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pytestCheckHook,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "tstr";
+  version = "0.4.0.post1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ilotoki0804";
+    repo = "tstr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0IWisLpgJETGCBk1cqOnmlf1yvpNUajEiY+Qn2gxH0w=";
+  };
+
+  build-system = [ hatchling ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  pythonImportsCheck = [ "tstr" ];
+
+  meta = {
+    description = "Backports of various template string utilities";
+    license = [ lib.licenses.asl20 ];
+    maintainers = with lib.maintainers; [ sigmanificient ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19691,6 +19691,8 @@ self: super: with self; {
 
   tsplib95 = callPackage ../development/python-modules/tsplib95 { };
 
+  tstr = callPackage ../development/python-modules/tstr { };
+
   tt-flash = callPackage ../development/python-modules/tt-flash { };
 
   tt-tools-common = callPackage ../development/python-modules/tt-tools-common { };


### PR DESCRIPTION
- https://hydra.nixos.org/build/323311831
- https://hydra.nixos.org/build/323311833
- https://hydra.nixos.org/build/323311834
- https://hydra.nixos.org/build/323311835

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
