### PR TITLE
lmstudio: 0.4.6.1 -> 0.4.7.4

### DIFF
--- a/pkgs/by-name/lm/lmstudio/package.nix
+++ b/pkgs/by-name/lm/lmstudio/package.nix
@@ -7,12 +7,12 @@
 let
   pname = "lmstudio";
 
-  version_aarch64-linux = "0.4.5-2";
-  hash_aarch64-linux = "sha256-BeF9FNMde9RW2icdq07zkWQafge7ViWKvR+xupRIdjE=";
-  version_aarch64-darwin = "0.4.6-1";
-  hash_aarch64-darwin = "sha256-CpeBUXpBAOJPEZAb3neY5pWRSGNcy4Usgsm6qyI5PVA=";
-  version_x86_64-linux = "0.4.6-1";
-  hash_x86_64-linux = "sha256-FHZ64zmnqHrQyX4ift/lVUzW+HiCVkXpWVa4hkssX/k=";
+  version_aarch64-linux = "0.4.7-4";
+  hash_aarch64-linux = "sha256-4gGg8CULPhAw1ZytaHmJNBqNyVVNO2LV+tm3AUi2sJo=";
+  version_aarch64-darwin = "0.4.7-4";
+  hash_aarch64-darwin = "sha256-V0m5oK+HCBaZPr6tAJVa98jb3IEPWs6ccAa/1GXsgy8=";
+  version_x86_64-linux = "0.4.7-4";
+  hash_x86_64-linux = "sha256-2dSgBr2B+PIUi/YCBmXDWXQWEEId6Qymh1JQuAPG/xU=";
 
   meta = {
     description = "LM Studio is an easy to use desktop app for experimenting with local and open-source Large Language Models (LLMs)";

--- a/pkgs/by-name/lm/lmstudio/update.sh
+++ b/pkgs/by-name/lm/lmstudio/update.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-for system in "aarch64-darwin darwin/arm64" "x86_64-linux linux/x64"; do
+for system in "aarch64-darwin darwin/arm64" "x86_64-linux linux/x64" "aarch64-linux linux/arm64"; do
   # shellcheck disable=SC2086
   set -- ${system} # split string into variables $1 and $2
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Changelog.](https://lmstudio.ai/changelog/lmstudio-v0.4.7)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
