### PR TITLE
ogre-next: add darwin support

### DIFF
--- a/pkgs/by-name/og/ogre-next/package.nix
+++ b/pkgs/by-name/og/ogre-next/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch2,
+  testers,
 
   cmake,
   ninja,
@@ -75,11 +76,22 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "OGRE_CONFIG_ENABLE_STBI" true)
   ];
 
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+    versionCheck = true;
+  };
+
   meta = {
     description = "3D Object-Oriented Graphics Rendering Engine";
     homepage = "https://www.ogre3d.org/";
     maintainers = with lib.maintainers; [
       marcin-serwin
+    ];
+    pkgConfigModules = [
+      "OGRE"
+      "OGRE-Hlms"
+      "OGRE-MeshLodGenerator"
+      "OGRE-Overlay"
     ];
     platforms = lib.platforms.linux;
     license = lib.licenses.mit;

--- a/pkgs/by-name/og/ogre-next/package.nix
+++ b/pkgs/by-name/og/ogre-next/package.nix
@@ -22,6 +22,7 @@
   openvr,
   rapidjson,
   zziplib,
+  apple-sdk_15,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "ogre-next";
@@ -42,6 +43,35 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  postPatch = ''
+    # OgreMain/CMakeLists.txt has a macOS post-build block that uses `ditto`
+    # (a macOS system tool unavailable in the Nix sandbox) to copy headers
+    # into an Ogre.framework bundle. This block runs unconditionally on
+    # non-iOS macOS — it is not gated by OGRE_BUILD_LIBS_AS_FRAMEWORKS.
+    # Wrap it in a framework guard so it is skipped when frameworks are
+    # disabled, avoiding the missing `ditto` and the unnecessary framework
+    # directory structure.
+    substituteInPlace OgreMain/CMakeLists.txt \
+      --replace-fail \
+        'set(OGRE_OSX_BUILD_CONFIGURATION "$(PLATFORM_NAME)/$(CONFIGURATION)")' \
+        'if (OGRE_BUILD_LIBS_AS_FRAMEWORKS)
+    set(OGRE_OSX_BUILD_CONFIGURATION "$(PLATFORM_NAME)/$(CONFIGURATION)")' \
+      --replace-fail \
+        'ogre_config_framework(''${OGRE_NEXT}Main)' \
+        'endif ()
+    ogre_config_framework(''${OGRE_NEXT}Main)'
+
+    # Remove Xcode-centric CMAKE_OSX_SYSROOT and CMAKE_OSX_ARCHITECTURES overrides.
+    # Nix stdenv already sets these correctly via apple-sdk.
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'set(XCODE_ATTRIBUTE_SDKROOT macosx)' "" \
+      --replace-fail 'set(CMAKE_OSX_SYSROOT macosx)' "" \
+      --replace-fail \
+        'execute_process(COMMAND xcodebuild -version -sdk "''${XCODE_ATTRIBUTE_SDKROOT}" Path | head -n 1 OUTPUT_VARIABLE CMAKE_OSX_SYSROOT)' "" \
+      --replace-fail \
+        'string(REGEX REPLACE "(\r?\n)+$" "" CMAKE_OSX_SYSROOT "''${CMAKE_OSX_SYSROOT}")' ""
+  '';
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -54,7 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
     zziplib
     zlib
     tinyxml
-    openvr
     rapidjson
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
@@ -64,7 +93,11 @@ stdenv.mkDerivation (finalAttrs: {
     libxrandr
     libxt
     libxcb
-  ];
+    # openvr is broken on darwin
+    openvr
+  ]
+  # apple-sdk_15 provides Metal, Cocoa, and OpenGL frameworks
+  ++ lib.optional stdenv.hostPlatform.isDarwin apple-sdk_15;
 
   # TODO: Figure out Vulkan plugin deps
 
@@ -74,6 +107,19 @@ stdenv.mkDerivation (finalAttrs: {
     # Use STB instead of freeimage since the latter is marked as insecure
     (lib.cmakeBool "OGRE_CONFIG_ENABLE_FREEIMAGE" false)
     (lib.cmakeBool "OGRE_CONFIG_ENABLE_STBI" true)
+
+    # Framework bundles are incompatible with the Nix store
+    (lib.cmakeBool "OGRE_BUILD_LIBS_AS_FRAMEWORKS" false)
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # GL3Plus requires Khronos headers not available on darwin; Metal is the
+    # primary render system on macOS
+    (lib.cmakeBool "OGRE_BUILD_RENDERSYSTEM_GL3PLUS" false)
+  ]
+  # Both NEON and SSE2 SIMD cause build failures on aarch64
+  ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+    (lib.cmakeBool "OGRE_SIMD_NEON" false)
+    (lib.cmakeBool "OGRE_SIMD_SSE2" false)
   ];
 
   passthru.tests.pkg-config = testers.hasPkgConfigModules {
@@ -93,10 +139,7 @@ stdenv.mkDerivation (finalAttrs: {
       "OGRE-MeshLodGenerator"
       "OGRE-Overlay"
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     license = lib.licenses.mit;
-
-    # build problems around NEON intrinsics
-    broken = stdenv.hostPlatform.isAarch64;
   };
 })


### PR DESCRIPTION
This PR adds darwin support to ogre-next and also fixes the issue that made this broken on aarch64. This change is being made so that ogre-next can be used as a unix dependency of gz-sim (to be added in a later PR) and is one of two PRs required to support adding gz-sim (the other is #500349).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
