### PR TITLE
amnezia-vpn: fix missing system tray and window icons

### DIFF
--- a/pkgs/by-name/am/amnezia-vpn/package.nix
+++ b/pkgs/by-name/am/amnezia-vpn/package.nix
@@ -109,6 +109,13 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "int nVersion = 1;" "int nVersion = 0;"
     substituteInPlace client/ui/qautostart.cpp \
       --replace-fail "/usr/share/pixmaps/AmneziaVPN.png" "AmneziaVPN"
+    # https://github.com/amnezia-vpn/amnezia-client/pull/2372
+    substituteInPlace client/ui/systemtray_notificationhandler.cpp \
+      --replace-fail 'm_systemTrayIcon.show();' ''' \
+      --replace-fail 'setTrayState(Vpn::ConnectionState::Disconnected);' 'setTrayState(Vpn::ConnectionState::Disconnected); m_systemTrayIcon.show();'
+    substituteInPlace client/main.cpp \
+      --replace-fail '#include "version.h"' $'#include "version.h"\n#include <QIcon>' \
+      --replace-fail 'app.setApplicationDisplayName(APPLICATION_NAME);' $'app.setApplicationDisplayName(APPLICATION_NAME);\n    app.setWindowIcon(QIcon::fromTheme("AmneziaVPN"));'
     substituteInPlace deploy/installer/config/AmneziaVPN.desktop.in \
       --replace-fail "/usr/share/pixmaps/AmneziaVPN.png" "$out/share/icons/hicolor/512x512/apps/AmneziaVPN.png"
     substituteInPlace deploy/data/linux/AmneziaVPN.service \


### PR DESCRIPTION
Fixed missing system tray and window icons, tested on Plasma

- Defer `QSystemTrayIcon::show()` until after the icon is set, so Plasma registers the tray item with a valid icon
- Add `setWindowIcon(QIcon::fromTheme("AmneziaVPN"))` to display the app icon in the taskbar


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
