### PR TITLE
witr: 0.3.0 -> 0.3.1

### DIFF
--- a/pkgs/by-name/wi/witr/package.nix
+++ b/pkgs/by-name/wi/witr/package.nix
@@ -6,13 +6,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "witr";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "pranshuparmar";
     repo = "witr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HMaFus6sT2+lUauXsADKnCSeQZFEWNUmfRfgYkT3CJY=";
+    hash = "sha256-kjWhSRPU4OwRi4Azs7Ql//aMOhHU9Aya2EDcpNwOr6E=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -27,12 +27,12 @@ buildGoModule (finalAttrs: {
   vendorHash = null;
 
   ldflags = [
-    "-X main.version=v${finalAttrs.version}"
+    "-X github.com/pranshuparmar/witr/internal/version.Version=v${finalAttrs.version}"
   ];
 
   preBuild = ''
-    ldflags+=" -X=main.commit=$(cat COMMIT)"
-    ldflags+=" -X=main.buildDate=$(cat SOURCE_DATE_EPOCH)"
+    ldflags+=" -X=github.com/pranshuparmar/witr/internal/version.Commit=$(cat COMMIT)"
+    ldflags+=" -X=github.com/pranshuparmar/witr/internal/version.BuildDate=$(cat SOURCE_DATE_EPOCH)"
   '';
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
https://github.com/pranshuparmar/witr/releases/tag/v0.3.1
like #500993, but the ldflag names needed to be updated
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
