### PR TITLE
monkeys-audio: add an updater script, drop `-std=` override

### DIFF
--- a/pkgs/by-name/mo/monkeys-audio/package.nix
+++ b/pkgs/by-name/mo/monkeys-audio/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchzip,
   cmake,
+  writeScript,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -15,14 +16,23 @@ stdenv.mkDerivation (finalAttrs: {
     stripRoot = false;
   };
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    # Otherwise, >> related build errors are encountered
-    "-std=c++11"
-  ];
-
   nativeBuildInputs = [
     cmake
   ];
+
+  passthru = {
+    updateScript = writeScript "update-monkeys-audio" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl pcre common-updater-scripts
+
+      set -eu -o pipefail
+
+      # Expect the text in format of "Monkey's Audio 12.58 SDK"'.
+      newVersion="$(curl -s https://monkeysaudio.com/developers.html |
+        pcregrep -o1 "Monkey's Audio ([0-9.]+) SDK")"
+      update-source-version ${finalAttrs.pname} "$newVersion"
+    '';
+  };
 
   meta = {
     description = "APE codec and decompressor";


### PR DESCRIPTION
Changes: https://monkeysaudio.com/versionhistory.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
