### PR TITLE
graylog(6_1, 6_0): mark for removal using meta.problems

### DIFF
--- a/pkgs/tools/misc/graylog/6.1.nix
+++ b/pkgs/tools/misc/graylog/6.1.nix
@@ -1,3 +1,4 @@
+# TODO: remove this version after 26.05
 { callPackage, lib, ... }:
 let
   buildGraylog = callPackage ./graylog.nix { };

--- a/pkgs/tools/misc/graylog/graylog.nix
+++ b/pkgs/tools/misc/graylog/graylog.nix
@@ -54,6 +54,10 @@ stdenv.mkDerivation rec {
     inherit license;
     inherit maintainers;
     mainProgram = "graylogctl";
+    # TODO: remove this after 26.05
+    problems = lib.optionalAttrs (lib.versions.majorMinor version <= "6.1") {
+      removal.message = "This package has been marked for removal in 26.11, Please consider upgrading to 7.0 or later to continue using this package after 26.11";
+    };
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
See
https://go2docs.graylog.org/current/setting_up_graylog/supported_versions.htm for more info.

Ref: https://github.com/NixOS/nixpkgs/issues/499333#issuecomment-4088153675


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
