### PR TITLE
typescript-go: update buildGoModule from 125 to 126, 0-unstable-2026-02-11 -> 0-unstable-2026-03-19

### DIFF
--- a/pkgs/by-name/ty/typescript-go/package.nix
+++ b/pkgs/by-name/ty/typescript-go/package.nix
@@ -16,11 +16,11 @@ buildGoModule {
     owner = "microsoft";
     repo = "typescript-go";
     rev = "737e16fee4eedc201b8c70109bef965b4c73c23c";
-    hash = "sha256-Il2UgZ1DX0ijKZLlMNOdywOANBl9x5WSLiQbp3gogBQ=";
+    hash = "sha256-YSg/stB9my8KAEOkS2hvlVJ56EFmHSpC492+AY5YmOE=";
     fetchSubmodules = false;
   };
 
-  vendorHash = "sha256-QNKXJ9HA8WlLlTxflLt0a/Y2Lt8NG1AnNmBOESYFyRI=";
+  vendorHash = "sha256-Il2UgZ1DX0ijKZLlMNOdywOANBl9x5WSLiQbp3gogBQ=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ty/typescript-go/package.nix
+++ b/pkgs/by-name/ty/typescript-go/package.nix
@@ -16,7 +16,7 @@ buildGoModule {
     owner = "microsoft";
     repo = "typescript-go";
     rev = "737e16fee4eedc201b8c70109bef965b4c73c23c";
-    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    hash = "sha256-YSg/stB9my8KAEOkS2hvlVJ56EFmHSpC492+AY5YmOE=";
     fetchSubmodules = false;
   };
 

--- a/pkgs/by-name/ty/typescript-go/package.nix
+++ b/pkgs/by-name/ty/typescript-go/package.nix
@@ -1,12 +1,12 @@
 {
   lib,
-  buildGo125Module,
+  buildGo126Module,
   fetchFromGitHub,
   nix-update-script,
 }:
 
 let
-  buildGoModule = buildGo125Module;
+  buildGoModule = buildGo126Module;
 in
 buildGoModule {
   pname = "typescript-go";

--- a/pkgs/by-name/ty/typescript-go/package.nix
+++ b/pkgs/by-name/ty/typescript-go/package.nix
@@ -10,13 +10,13 @@ let
 in
 buildGoModule {
   pname = "typescript-go";
-  version = "0-unstable-2026-02-11";
+  version = "0-unstable-2026-03-19";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "typescript-go";
-    rev = "08cb84c68ae83b9def5e0132e05362e5061342ab";
-    hash = "sha256-IvR7zHSl7kUmamQkGGrzdKJrdypnQe2a0X1YUyRYYTU=";
+    rev = "737e16fee4eedc201b8c70109bef965b4c73c23c";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
     fetchSubmodules = false;
   };
 

--- a/pkgs/by-name/ty/typescript-go/package.nix
+++ b/pkgs/by-name/ty/typescript-go/package.nix
@@ -16,7 +16,7 @@ buildGoModule {
     owner = "microsoft";
     repo = "typescript-go";
     rev = "737e16fee4eedc201b8c70109bef965b4c73c23c";
-    hash = "sha256-YSg/stB9my8KAEOkS2hvlVJ56EFmHSpC492+AY5YmOE=";
+    hash = "sha256-Il2UgZ1DX0ijKZLlMNOdywOANBl9x5WSLiQbp3gogBQ=";
     fetchSubmodules = false;
   };
 


### PR DESCRIPTION
Updated typescript-go to a newer commit and tested. [2026-02-11 -> 2026-03-19]
Had to bump the buildGoModule for the build to work as the minimum version required was bumped on their side.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.