### PR TITLE
gexiv2: 0.14.6 → 0.16.0

### DIFF
--- a/pkgs/by-name/ge/gexiv2/package.nix
+++ b/pkgs/by-name/ge/gexiv2/package.nix
@@ -11,15 +11,13 @@
   gnome,
   gobject-introspection,
   vala,
-  gtk-doc,
-  docbook-xsl-nons,
-  docbook_xml_dtd_43,
+  gi-docgen,
   python3,
 }:
 
 stdenv.mkDerivation rec {
   pname = "gexiv2";
-  version = "0.14.6";
+  version = "0.16.0";
 
   outputs = [
     "out"
@@ -29,7 +27,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gexiv2/${lib.versions.majorMinor version}/gexiv2-${version}.tar.xz";
-    sha256 = "YGwoqq57Hz71yOq+Xn3/18WhyGbSW3Zx+4R/4oenK4s=";
+    sha256 = "2W+JXyRTn5ZvV3srskia6E+CMpcKjQwGTkoAdHSne7s=";
   };
 
   nativeBuildInputs = [
@@ -38,9 +36,7 @@ stdenv.mkDerivation rec {
     pkg-config
     gobject-introspection
     vala
-    gtk-doc
-    docbook-xsl-nons
-    docbook_xml_dtd_43
+    gi-docgen
     (python3.pythonOnBuildForHost.withPackages (ps: [ ps.pygobject3 ]))
   ]
   ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
@@ -64,7 +60,7 @@ stdenv.mkDerivation rec {
 
   preCheck =
     let
-      libSuffix = if stdenv.hostPlatform.isDarwin then "2.dylib" else "so.2";
+      libName = if stdenv.hostPlatform.isDarwin then "libgexiv2-0.16.4.dylib" else "libgexiv2-0.16.so.4";
     in
     ''
       # Our gobject-introspection patches make the shared library paths absolute
@@ -72,8 +68,14 @@ stdenv.mkDerivation rec {
       # though, so we need to replace the absolute path with a local one during build.
       # We are using a symlink that will be overridden during installation.
       mkdir -p $out/lib
-      ln -s $PWD/gexiv2/libgexiv2.${libSuffix} $out/lib/libgexiv2.${libSuffix}
+      ln -s $PWD/gexiv2/${libName} $out/lib/${libName}
+      export GI_TYPELIB_PATH=$PWD/gexiv2
     '';
+
+  postFixup = ''
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
+  '';
 
   passthru = {
     updateScript = gnome.updateScript {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Upstream changelog: https://gitlab.gnome.org/GNOME/gexiv2/-/blob/main/CHANGES

- switched doc toolchain from `gtk-doc`/`docbook-xsl-nons`/`docbook_xml_dtd_43` to `gi-docgen`
- fixed library symlink name in `preCheck` to match new SONAME (`libgexiv2-0.16.so.4`)
- added `GI_TYPELIB_PATH` export in `preCheck`                                    
- added `postFixup` to correctly place docs into `$devdoc`

Indirectly verified through nautilus 50.0 build on x86_64-linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
