### PR TITLE
Fix tray icon context menu of Qt 5 apps on KDE

### DIFF
--- a/pkgs/by-name/li/libdbusmenu-qt5/package.nix
+++ b/pkgs/by-name/li/libdbusmenu-qt5/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  cmake,
+  libsForQt5,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libdbusmenu-qt5";
+  version = "0.9.3+16";
+
+  src = fetchgit {
+    url = "https://git.launchpad.net/ubuntu/+source/libdbusmenu-qt";
+    rev = "import/${version}.04.20160218-1";
+    hash = "sha256-nXZv1m/dQv8vt+xPS7WTC8nKfbEJ45WtZ8vVBencPg0=";
+  };
+
+  buildInputs = [ libsForQt5.qtbase ];
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DWITH_DOC=OFF"
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
+
+  dontWrapQtApps = true;
+
+  meta = {
+    homepage = "https://launchpad.net/libdbusmenu-qt";
+    description = "Provides a Qt implementation of the DBusMenu spec";
+    maintainers = [ lib.maintainers.ttuegel ];
+    inherit (libsForQt5.qtbase.meta) platforms;
+    license = lib.licenses.lgpl2;
+  };
+}

--- a/pkgs/development/libraries/kde-frameworks/knotifications.nix
+++ b/pkgs/development/libraries/kde-frameworks/knotifications.nix
@@ -11,6 +11,7 @@
   qttools,
   qtx11extras,
   qtmacextras,
+  libdbusmenu-qt5,
 }:
 
 mkDerivation {
@@ -26,6 +27,7 @@ mkDerivation {
     kwindowsystem
     phonon
     qtx11extras
+    libdbusmenu-qt5
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     qtmacextras


### PR DESCRIPTION
libdbusmenu-qt is required for tray icon context menu support of libsForQt5.knotifications. Otherwise tray icons of Qt 5 apps on KDE will show an empty context menu. The package was dropped in #443745 so I added it back.

I encountered this problem and tested the fix on a somewhat weird setup: niri + waybar + plasma-integration + QT_QPA_PLATFORMTHEME=kde (to get KDE look-and-feel for Qt apps), but I expect the same applies to a normal KDE environment.

One can test this change with KeePassXC, which has a tray icon that can be enabled in settings, and is unfortunately still on Qt 5.

Before: 
<img width="70" height="32" alt="image" src="https://github.com/user-attachments/assets/2b772f7d-4295-4e9d-aa60-8777564f34d8" />

After:
<img width="264" height="96" alt="image" src="https://github.com/user-attachments/assets/8388be99-a145-4b49-b96b-36a1513f2874" />

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
