### PR TITLE
nixos/tests/systemd-homed: fix firstboot prompt flow

### DIFF
--- a/nixos/tests/systemd-homed.nix
+++ b/nixos/tests/systemd-homed.nix
@@ -46,27 +46,25 @@ in
 
     with subtest("create systemd-homed user on first boot prompt"):
       machine.wait_for_unit("systemd-homed.service")
-      machine.wait_until_tty_matches("1", "-- Press any key to proceed --")
-      machine.send_chars(" ")
-      machine.wait_until_tty_matches("1", "Please enter user name")
+      machine.wait_until_tty_matches("1", "Please enter user name to create")
       machine.send_chars("${username}\n")
-      machine.wait_until_tty_matches("1", "Please enter an auxiliary group")
-      machine.send_chars("wheel\n")
-      machine.wait_until_tty_matches("1", "Please enter an auxiliary group")
-      machine.send_chars("\n")
-      machine.wait_until_tty_matches("1", "Please enter the shell to use")
-      machine.send_chars("/bin/sh\n")
-      machine.wait_until_tty_matches("1", "Please enter new password")
+      machine.wait_until_tty_matches("1", "Please enter new password for user ${username}:")
       machine.send_chars("${initialPassword}\n")
       machine.wait_until_tty_matches("1", "(repeat)")
       machine.send_chars("${initialPassword}\n")
+      machine.wait_for_unit("systemd-homed-firstboot.service")
+
+    # The firstboot wizard doesn't prompt for groups; add wheel here so the
+    # later sudo subtest works. Leaving the shell unset also exercises the
+    # NixOS default-user-shell meson option.
+    machine.succeed("homectl update ${username} --offline -G wheel")
 
     with subtest("login as homed user"):
       machine.wait_until_tty_matches("1", "login: ")
       machine.send_chars("${username}\n")
       machine.wait_until_tty_matches("1", "Password: ")
       machine.send_chars("${initialPassword}\n")
-      machine.wait_until_succeeds("pgrep -u ${username} -t tty1 sh")
+      machine.wait_until_succeeds("pgrep -u ${username} -t tty1 bash")
       machine.send_chars("whoami > /tmp/2\n")
       machine.wait_for_file("/tmp/2")
       assert "${username}" in machine.succeed("cat /tmp/2")
@@ -122,11 +120,11 @@ in
       sshClient.send_chars("ssh -o StrictHostKeyChecking=no -i /tmp/id_ed25519 ${username}@machine\n")
       sshClient.wait_until_tty_matches("1", "Please enter password for user")
       sshClient.send_chars("${newPassword}\n")
-      machine.wait_until_succeeds("pgrep -u ${username} sh")
+      machine.wait_until_succeeds("pgrep -u ${username} bash")
       sshClient.send_chars("whoami > /tmp/5\n")
       machine.wait_for_file("/tmp/5")
       assert "${username}" in machine.succeed("cat /tmp/5")
       sshClient.send_chars("exit\n") # ssh
-      sshClient.send_chars("exit\n") # sh
+      sshClient.send_chars("exit\n") # bash
   '';
 }


### PR DESCRIPTION
The test has been broken since the 258.3 → 259 bump. v259 removed the "Press any key to proceed" gate and changed the firstboot unit to pass `--prompt-shell=no --prompt-groups=no`, so the shell and group prompts the test waits for never appear.

- Update to the current prompt sequence (username, password, repeat)
- Pass `--chrome=no` so the ANSI scroll-region setup does not interfere with `/dev/vcs` reads
- Add wheel membership and shell via `homectl update` afterwards since the wizard no longer prompts for them

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
