### PR TITLE
zotero-mcp-server: init at 0.6.2

### DIFF
--- a/pkgs/by-name/zo/zotero-mcp-server/package.nix
+++ b/pkgs/by-name/zo/zotero-mcp-server/package.nix
@@ -1,0 +1,116 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchurl,
+  python3Packages,
+  versionCheckHook,
+  stdenv,
+}:
+
+let
+  # tiktoken lazily downloads the cl100k_base encoding on first use; pre-seed its
+  # cache so the test suite is hermetic (the build sandbox has no network).
+  cl100kCacheKey = "9b5ad71b2ce5302211f9c61530b329a4922fc6a4";
+  tiktokenCl100k = fetchurl {
+    url = "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken";
+    hash = "sha256-Ijkht27pm96ZW3/3OFE+7xAPtR0YyTWXoRO8/+hlsqc=";
+  };
+in
+python3Packages.buildPythonApplication (finalAttrs: {
+  # We use PyPI name here to avoid conflict with the `zotero-mcp` package
+  pname = "zotero-mcp-server";
+  version = "0.6.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "54yyyu";
+    repo = "zotero-mcp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zTZ40MxZGkmxL5WzALogJ9828rz5fHkTAyDdcLfpva8=";
+  };
+
+  build-system = with python3Packages; [
+    hatchling
+  ];
+
+  dependencies = with python3Packages; [
+    bibtexparser
+    fastmcp
+    markitdown
+    mcp
+    pydantic
+    python-dotenv
+    pyzotero
+    requests
+    unidecode
+  ];
+
+  optional-dependencies = with python3Packages; {
+    semantic = [
+      chromadb
+      google-genai
+      openai
+      sentence-transformers
+      tiktoken
+    ];
+    pdf = [
+      ebooklib
+      pymupdf
+    ];
+    scite = [
+      requests
+    ];
+  };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
+  __darwinAllowLocalNetworking = true;
+
+  # semantic + pdf extras are needed at check time: chroma_client raises
+  # ImportError without chromadb, and several test modules import
+  # zotero_mcp.semantic_search unguarded. Mirrors upstream [dev] = [all].
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-timeout
+    chromadb
+    google-genai
+    openai
+    sentence-transformers
+    tiktoken
+    ebooklib
+    pymupdf
+  ];
+  doCheck = true;
+
+  # Keep the suite hermetic under the build sandbox: give pytest a writable HOME
+  # (the default /homeless-shelter is read-only) and point tiktoken at the cache.
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    export TIKTOKEN_CACHE_DIR=$(mktemp -d)
+    ln -s ${tiktokenCl100k} "$TIKTOKEN_CACHE_DIR"/${cl100kCacheKey}
+  '';
+
+  # Exercises a real PDF download (it deliberately bypasses the SSRF guard).
+  disabledTests = [ "test_cascade_order" ];
+
+  pythonImportsCheck = [ "zotero_mcp" ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Model Context Protocol server for Zotero";
+    homepage = "https://github.com/54yyyu/zotero-mcp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      yzx9
+    ];
+    platforms = with lib.platforms; linux ++ darwin;
+    # Error: terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
+    broken = with stdenv.hostPlatform; (isLinux && isAarch64) || (isDarwin && isx86_64);
+    mainProgram = "zotero-mcp";
+  };
+})


### PR DESCRIPTION
~~- python3Packages.pyzotero: init at 1.11.0~~
- zotero-mcp: init at 0.6.4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
