### PR TITLE
fetchPnpmDeps: exclude links/ from checkedAt cleanup

### DIFF
--- a/pkgs/build-support/node/fetch-pnpm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-pnpm-deps/default.nix
@@ -138,7 +138,11 @@ in
 
             # Remove timestamp and sort the json files
             rm -rf $storePath/{v3,v10}/tmp
-            for f in $(find $storePath -name "*.json"); do
+            # Exclude links/ which contains actual npm package files (e.g.
+            # tsconfig.json with JSONC trailing commas/comments) that jq cannot
+            # parse as strict JSON. All other *.json files are pnpm metadata
+            # that may contain checkedAt timestamps.
+            for f in $(find $storePath -not -path "*/links/*" -name "*.json"); do
               jq --sort-keys "del(.. | .checkedAt?)" $f | sponge $f
             done
 


### PR DESCRIPTION
The `fixupPhase` ran `jq` over all `*.json` files in the pnpm store output, including the `links/` directory which contains actual npm package files. Many packages ship `tsconfig.json`, `.vscode/settings.json`, etc. using JSONC format — trailing commas and `//` comments — which `jq` rejects as invalid strict JSON, causing builds to fail:

```
jq: parse error: Invalid numeric literal at line N, column N
```

The `checkedAt` timestamp field we strip for reproducibility only appears in `index/` metadata files. Scoping the `find` to `*/index/*` is sufficient and avoids touching package source files in `links/`.

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test