### PR TITLE
context7-mcp: init at 2.1.4

### DIFF
--- a/pkgs/by-name/co/context7-mcp/package.nix
+++ b/pkgs/by-name/co/context7-mcp/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  nix-update-script,
+
+  nodejs,
+  pnpm,
+  pnpmConfigHook,
+  fetchPnpmDeps,
+}:
+let
+  tag-prefix = "@upstash/context7-mcp";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "context7-mcp";
+  version = "2.1.4";
+
+  src = fetchFromGitHub {
+    owner = "upstash";
+    repo = "context7";
+    tag = "${tag-prefix}@${finalAttrs.version}";
+    hash = "sha256-bQXmKY4I5k5uaQ2FVEOPkym5X3mR87nALf3+jqJjJjE=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm
+    pnpmConfigHook
+    makeWrapper
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 3;
+    hash = "sha256-EjEdbPKXJbxaDBuAg/j+BSjI/W3HdsqbtDky0TPUB88=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter ${tag-prefix} build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    pnpm --filter ${tag-prefix} \
+         --offline \
+         --config.inject-workspace-packages=true \
+         deploy $out/lib/context7
+
+    mkdir -p $out/bin
+    makeWrapper ${nodejs}/bin/node $out/bin/context7-mcp \
+      --add-flags "$out/lib/context7/dist/index.js"
+
+    cp -r $src/skills $out
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    echo "Executing custom version check for MCP stdio server..."
+
+    output=$(< /dev/null $out/bin/context7-mcp 2>&1 || true)
+
+    if echo "$output" | grep -Fq "v${finalAttrs.version}"; then
+      echo "versionCheckPhase: found version v${finalAttrs.version}"
+    else
+      echo "versionCheckPhase: failed to find version v${finalAttrs.version}"
+      echo "Output was:"
+      echo "$output"
+      exit 1
+    fi
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex '${tag-prefix}@(.*)'" ];
+  };
+
+  meta = {
+    description = "MCP Server for up-to-date code documentation for LLMs and AI code editors";
+    homepage = "https://context7.com/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ arunoruto ];
+    mainProgram = "context7-mcp";
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+})


### PR DESCRIPTION
MCP Server for up-to-date code documentation for LLMs and AI code editors.

Building on darwin kinda worked: the building process never finished, but I got a binary in the end (I could search up in /nix/store). It would be really helpful if someone could try it out too!

Main differences compared to #476304:
- Only build the mcp component instead of the whole project
  - Use the tag prefix variable in the build phase
- Add more platforms
- Copy the `skills` folder in the output to be used by agents in the future!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
