### PR TITLE
stayrtr: 0.6.2 -> 0.6.4

### DIFF
--- a/pkgs/by-name/st/stayrtr/package.nix
+++ b/pkgs/by-name/st/stayrtr/package.nix
@@ -8,15 +8,15 @@
 
 buildGoModule (finalAttrs: {
   pname = "stayrtr";
-  version = "0.6.2";
+  version = "0.6.4";
 
   src = fetchFromGitHub {
     owner = "bgp";
     repo = "stayrtr";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-QdPp+AHOVn/L4lArhwUNNu3OP2ALEFzs/hVnfSxaEbg=";
+    hash = "sha256-7/n1rflDgJy2X/PTBTnxuxHMi1Kq/vwQQUepFb11EC0=";
   };
-  vendorHash = "sha256-m1CHpmTUQVkBjkjg2bjl9llU1Le1GLRKKLGT4h7MbnE=";
+  vendorHash = "sha256-ACfCBbW42tic/m86/pAUquqzK1k05VUtH61mRD4Hu+4=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


0.6.4: 
*    Move server metrics to its own package by @randomthingsandstuff in https://github.com/bgp/stayrtr/pull/159
*   Port PR#133 to new metrics structure by @randomthingsandstuff in https://github.com/bgp/stayrtr/pull/160
*    go fmt ci/cd check because this is annoying by @randomthingsandstuff in https://github.com/bgp/stayrtr/pull/161

0.6.3:
* feat: add http endpoint to view connected clients by @floatingstatic in https://github.com/bgp/stayrtr/pull/143
* Fix race sending error report before tcp connection closed by @floatingstatic in https://github.com/bgp/stayrtr/pull/142
* Update required go version in doc by @arjenz in https://github.com/bgp/stayrtr/pull/144
* Fix RPM packaging process by @kw4tts in https://github.com/bgp/stayrtr/pull/148
* Issue https://github.com/bgp/stayrtr/issues/145 fix: Avoid sending stale data, properly handle errRPKIJsonFileTooOld by @lukastribus in https://github.com/bgp/stayrtr/pull/146
* Added Environment variable for the --cache flag (STAYRTR_CACHE) by @tim427 in https://github.com/bgp/stayrtr/pull/130

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
