### PR TITLE
appendOverlays: preserve splicing on empty overlay list

### DIFF
--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -64,4 +64,22 @@ lib.recurseIntoAttrs {
     assert lib.all (p: p.stdenv.buildPlatform == p.stdenv.hostPlatform) pkgsLocal;
     assert lib.all (p: p.stdenv.buildPlatform != p.stdenv.hostPlatform) pkgsCross;
     pkgs.emptyFile;
+
+  # appendOverlays must preserve splicing so that cross-compilation
+  # works in NixOS modules (which go through appendOverlays via nixpkgs.nix).
+  appendOverlaysPreservesSplicing =
+    let
+      cross = nixpkgsFun {
+        localSystem = {
+          system = "x86_64-linux";
+        };
+        crossSystem = {
+          system = "aarch64-linux";
+        };
+      };
+      appended = cross.appendOverlays [ ];
+    in
+    assert cross.makeWrapper ? __spliced;
+    assert appended.makeWrapper ? __spliced;
+    pkgs.emptyFile;
 }

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -264,7 +264,10 @@ let
     # in one go when calling Nixpkgs, for performance and simplicity.
     appendOverlays =
       extraOverlays:
-      if extraOverlays == [ ] then self else nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
+      if extraOverlays == [ ] then
+        self.__splicedPackages
+      else
+        nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
 
     # NOTE: each call to extend causes a full nixpkgs rebuild, adding ~130MB
     #       of allocations. DO NOT USE THIS IN NIXPKGS.


### PR DESCRIPTION
## Summary

- `appendOverlays []` returned `self` (the unspliced inner fixpoint), while `import nixpkgs {}` returns `pkgs.__splicedPackages` (the spliced version via `booter.nix`). This caused packages to lose their `__spliced` attribute after passing through `appendOverlays`, breaking cross-compilation in NixOS modules.
- The NixOS `nixpkgs.nix` module calls `cfg.pkgs.appendOverlays cfg.overlays`, and when no overlays are defined, the empty-list short-circuit returned unspliced packages. This meant `nativeBuildInputs = [ pkgs.makeWrapper ]` in NixOS modules would evaluate the host-platform `makeWrapper` (which throws in cross context) instead of being spliced to `buildPackages.makeWrapper`.
- Fix: return `self.__splicedPackages` instead of `self` for the empty-list case.
- Add a test in `tests.top-level` that asserts `appendOverlays []` preserves `__spliced` on cross packages.

## Context

When evaluating NixOS modules with cross-compiled nixpkgs (e.g., `nixpkgs.pkgs = import nixpkgs { system = "x86_64-linux"; crossSystem = "aarch64-linux"; }`), any module using `pkgs.makeWrapper` (or similar spliced packages) in `nativeBuildInputs` would fail with:

```
error: makeWrapper/makeShellWrapper must be in nativeBuildInputs
```

This affected at least `borgbackup`, `mopidy`, `osquery`, `ldap`, `xl2tpd`, `apcupsd`, `knot`, `dgraph`, and many more NixOS modules.

## Test plan

- [x] `tests.top-level.appendOverlaysPreservesSplicing` passes with fix, fails without
- [x] borgbackup NixOS module evaluates with cross nixpkgs
- [x] mopidy NixOS module evaluates with cross nixpkgs