### PR TITLE
[25.11] grocy: 4.5.0 -> 4.6.0

### DIFF
--- a/nixos/modules/services/web-apps/grocy.nix
+++ b/nixos/modules/services/web-apps/grocy.nix
@@ -79,22 +79,39 @@ in
 
       culture = mkOption {
         type = types.enum [
-          "de"
-          "en"
+          "bg_BG"
+          "ca"
+          "cs"
           "da"
+          "de"
+          "el_GR"
+          "en"
           "en_GB"
           "es"
+          "et_EE"
+          "fi"
           "fr"
+          "he_IL"
           "hu"
           "it"
+          "ja"
+          "ko_KR"
+          "lt"
           "nl"
           "no"
           "pl"
           "pt_BR"
+          "pt_PT"
+          "ro_RO"
           "ru"
           "sk_SK"
+          "sl"
           "sv_SE"
+          "ta"
           "tr"
+          "uk"
+          "zh_CN"
+          "zh_TW"
         ];
         default = "en";
         description = ''
@@ -119,6 +136,37 @@ in
           '';
         };
       };
+
+      entryPage = mkOption {
+        # https://github.com/grocy/grocy/blob/v4.6.0/config-dist.php#L75-L78
+        type = types.enum [
+          "stock"
+          "shoppinglist"
+          "recipes"
+          "chores"
+          "tasks"
+          "batteries"
+          "equipment"
+          "calendar"
+          "mealplan"
+        ];
+        default = "stock";
+        description = ''
+          Specify an custom homepage if desired.
+        '';
+      };
+    };
+
+    extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        These lines go at the end of config.php verbatim.
+      '';
+      example = ''
+        Setting('FEATURE_FLAG_RECIPES', false);
+        Setting('FEATURE_FLAG_STOCK_PRODUCT_FREEZING', false);
+      '';
     };
   };
 
@@ -129,6 +177,8 @@ in
       Setting('CURRENCY', '${cfg.settings.currency}');
       Setting('CALENDAR_FIRST_DAY_OF_WEEK', '${toString cfg.settings.calendar.firstDayOfWeek}');
       Setting('CALENDAR_SHOW_WEEK_OF_YEAR', ${boolToString cfg.settings.calendar.showWeekNumber});
+      Setting('ENTRY_PAGE', '${cfg.settings.entryPage}');
+      ${cfg.extraConfig}
     '';
 
     users.users.grocy = {

--- a/nixos/modules/services/web-apps/grocy.nix
+++ b/nixos/modules/services/web-apps/grocy.nix
@@ -149,11 +149,8 @@ in
       user = "grocy";
       group = "nginx";
 
-      # PHP 8.1 and 8.2 are the only version which are supported/tested by upstream:
-      # https://github.com/grocy/grocy/blob/v4.0.2/README.md#platform-support
-      phpPackage = pkgs.php82;
-
       inherit (cfg.phpfpm) settings;
+      inherit (cfg.package.passthru) phpPackage;
 
       phpEnv = {
         GROCY_CONFIG_FILE = "/etc/grocy/config.php";

--- a/pkgs/by-name/gr/grocy/0001-Define-configs-with-env-vars.patch
+++ b/pkgs/by-name/gr/grocy/0001-Define-configs-with-env-vars.patch
@@ -1,6 +1,6 @@
-From b1df18da8735ed8c043e5e63753a6524cce620e1 Mon Sep 17 00:00:00 2001
+From 4c9e6a687162729f96a2de428aa19058c04efe2b Mon Sep 17 00:00:00 2001
 From: Chris Moultrie <tebriel@frodux.in>
-Date: Tue, 4 Mar 2025 08:20:58 -0500
+Date: Sat, 7 Mar 2026 10:51:40 -0500
 Subject: [PATCH 1/2] Define configs with env vars
 
 ---
@@ -12,19 +12,19 @@ Subject: [PATCH 1/2] Define configs with env vars
  5 files changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/app.php b/app.php
-index 9cdd14e5..c0b30b6e 100644
+index 9224796a..da5c2357 100644
 --- a/app.php
 +++ b/app.php
-@@ -12,7 +12,7 @@ use Slim\Views\Blade;
+@@ -12,7 +12,7 @@ use Slim\Factory\AppFactory;
  require_once __DIR__ . '/packages/autoload.php';
  
  // Load config files
 -require_once GROCY_DATAPATH . '/config.php';
 +require_once getenv('GROCY_CONFIG_FILE');
  require_once __DIR__ . '/config-dist.php'; // For not in own config defined values we use the default ones
- require_once __DIR__ . '/helpers/ConfigurationValidator.php';
  
-@@ -52,7 +52,7 @@ catch (EInvalidConfig $ex)
+ // Error reporting definitions
+@@ -51,7 +51,7 @@ catch (\Grocy\Helpers\EInvalidConfig $ex)
  }
  
  // Create data/viewcache folder if it doesn't exist
@@ -33,16 +33,16 @@ index 9cdd14e5..c0b30b6e 100644
  if (!file_exists($viewcachePath))
  {
  	mkdir($viewcachePath);
-@@ -85,7 +85,7 @@ $app = AppFactory::create();
+@@ -84,7 +84,7 @@ $app = AppFactory::create();
  $container = $app->getContainer();
  $container->set('view', function (Container $container)
  {
--	return new Blade(__DIR__ . '/views', GROCY_DATAPATH . '/viewcache');
-+	return new Blade(__DIR__ . '/views', getenv('GROCY_CACHE_DIR'));
+-	return new SlimBladeView(__DIR__ . '/views', GROCY_DATAPATH . '/viewcache');
++	return new SlimBladeView(__DIR__ . '/views', getenv('GROCY_CACHE_DIR'));
  });
  
  $container->set('UrlManager', function (Container $container)
-@@ -127,7 +127,7 @@ $errorMiddleware->setDefaultErrorHandler(
+@@ -126,7 +126,7 @@ $errorMiddleware->setDefaultErrorHandler(
  
  $app->add(new CorsMiddleware($app->getResponseFactory()));
  
@@ -65,7 +65,7 @@ index 5941e348..9283ba93 100644
  			$htmlPurifierConfig->set('Attr.EnableID', true);
  			$htmlPurifierConfig->set('HTML.SafeIframe', true);
 diff --git a/services/DatabaseService.php b/services/DatabaseService.php
-index c5914e49..c249a3bf 100644
+index 0b6672fb..94bb9412 100644
 --- a/services/DatabaseService.php
 +++ b/services/DatabaseService.php
 @@ -145,6 +145,6 @@ class DatabaseService
@@ -90,10 +90,10 @@ index 113a6478..61568bc6 100644
  		{
  			mkdir($this->StoragePath);
 diff --git a/services/StockService.php b/services/StockService.php
-index 2261db4e..cd438942 100644
+index da27dacc..ffe714ec 100644
 --- a/services/StockService.php
 +++ b/services/StockService.php
-@@ -1752,7 +1752,7 @@ class StockService extends BaseService
+@@ -1784,7 +1784,7 @@ class StockService extends BaseService
  
  		// User plugins take precedence
  		$standardPluginPath = __DIR__ . "/../plugins/$pluginName.php";
@@ -103,5 +103,5 @@ index 2261db4e..cd438942 100644
  		{
  			require_once $userPluginPath;
 -- 
-2.47.2
+2.51.2
 

--- a/pkgs/by-name/gr/grocy/0002-Remove-check-for-config-file-as-it-s-stored-in-etc-g.patch
+++ b/pkgs/by-name/gr/grocy/0002-Remove-check-for-config-file-as-it-s-stored-in-etc-g.patch
@@ -1,6 +1,6 @@
-From f397d6e82d73761358d815a5ba880a05e7e281c3 Mon Sep 17 00:00:00 2001
+From ecb28fe2fc0527957c41651cd53e7af4b3cc9047 Mon Sep 17 00:00:00 2001
 From: Chris Moultrie <tebriel@frodux.in>
-Date: Tue, 4 Mar 2025 08:21:28 -0500
+Date: Sat, 7 Mar 2026 10:52:29 -0500
 Subject: [PATCH 2/2] Remove check for config-file as it's stored in /etc/grocy
 
 ---
@@ -8,10 +8,10 @@ Subject: [PATCH 2/2] Remove check for config-file as it's stored in /etc/grocy
  1 file changed, 1 deletion(-)
 
 diff --git a/helpers/PrerequisiteChecker.php b/helpers/PrerequisiteChecker.php
-index 8e12a5c5..37b433db 100644
+index dbc9c138..cd7d2526 100644
 --- a/helpers/PrerequisiteChecker.php
 +++ b/helpers/PrerequisiteChecker.php
-@@ -18,7 +18,6 @@ class PrerequisiteChecker
+@@ -20,7 +20,6 @@ class PrerequisiteChecker
  	public function checkRequirements()
  	{
  		self::checkForPhpVersion();
@@ -20,5 +20,5 @@ index 8e12a5c5..37b433db 100644
  		self::checkForComposer();
  		self::checkForPhpExtensions();
 -- 
-2.47.2
+2.51.2
 

--- a/pkgs/by-name/gr/grocy/package.nix
+++ b/pkgs/by-name/gr/grocy/package.nix
@@ -2,28 +2,30 @@
   lib,
   fetchFromGitHub,
   fetchYarnDeps,
-  php,
+  php85,
   yarn,
   fixup-yarn-lock,
   nixosTests,
 }:
-
+let
+  php = php85;
+in
 php.buildComposerProject2 (finalAttrs: {
   pname = "grocy";
-  version = "4.5.0";
+  version = "4.6.0";
 
   src = fetchFromGitHub {
     owner = "grocy";
     repo = "grocy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MnN6TIkNZWT+pAQf0+z5l3hj/7K/d3BfI7VAaUEKG8s=";
+    hash = "sha256-qdN+stXuwChv6IaFSX2SrSdej7Id/M0UaO2cggAvWdc=";
   };
 
-  vendorHash = "sha256-6vWV8+4tETUFBLeEoG7d8lHKILXvM7ezWbDiG11GA/s=";
+  vendorHash = "sha256-3f7me/YG2lt7fhkgXO1+0SXO+1IK+Fdb3/gywWyaxVg=";
 
   offlineCache = fetchYarnDeps {
     yarnLock = finalAttrs.src + "/yarn.lock";
-    hash = "sha256-Q+9hUxIfNrfdok39h04rz5I63RxOJ0qk3XlwvD1TcqI=";
+    hash = "sha256-48+u0NYZZiYvP2ADAkRdL079wmjWMHwPHi8rlDP41Eo=";
   };
 
   nativeBuildInputs = [
@@ -58,7 +60,10 @@ php.buildComposerProject2 (finalAttrs: {
     rm -r $out/share
   '';
 
-  passthru.tests = { inherit (nixosTests) grocy; };
+  passthru = {
+    phpPackage = php;
+    tests = { inherit (nixosTests) grocy; };
+  };
 
   meta = {
     license = lib.licenses.mit;


### PR DESCRIPTION
Backport of:
- https://github.com/NixOS/nixpkgs/pull/497612

Composer hash is different because the fetcher has changed in nixpkgs unstable and has not been backported.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test