### PR TITLE
zrythm: upgrade to KDE6 Package set, hardcode pname

### DIFF
--- a/pkgs/by-name/zr/zrythm/package.nix
+++ b/pkgs/by-name/zr/zrythm/package.nix
@@ -41,7 +41,7 @@
   ninja,
   pcre2,
   pkg-config,
-  plasma5Packages,
+  kdePackages,
   python3,
   rtaudio_6,
   rtmidi,
@@ -201,7 +201,7 @@ stdenv.mkDerivation (finalAttrs: {
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix GSETTINGS_SCHEMA_DIR : "$out/share/gsettings-schemas/${finalAttrs.pname}-${finalAttrs.version}/glib-2.0/schemas/"
-      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${plasma5Packages.breeze-icons}/share"
+      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${kdePackages.breeze-icons}/share"
     )
   '';
 

--- a/pkgs/by-name/zr/zrythm/package.nix
+++ b/pkgs/by-name/zr/zrythm/package.nix
@@ -200,7 +200,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preFixup = ''
     gappsWrapperArgs+=(
-      --prefix GSETTINGS_SCHEMA_DIR : "$out/share/gsettings-schemas/${finalAttrs.pname}-${finalAttrs.version}/glib-2.0/schemas/"
+      --prefix GSETTINGS_SCHEMA_DIR : "$out/share/gsettings-schemas/zrythm-${finalAttrs.version}/glib-2.0/schemas/"
       --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:${kdePackages.breeze-icons}/share"
     )
   '';


### PR DESCRIPTION
This pull request updates the `zrythm` package to use `kdePackages` instead of the deprecated `plasma5Packages` for KDE dependencies. It also updates references to KDE icons accordingly.

Dependency update:

* Replaced `plasma5Packages` with `kdePackages` in the list of dependencies and in the `preFixup` script, ensuring compatibility with newer KDE packaging standards.

Path updates:

* Updated the icon directory reference from `${plasma5Packages.breeze-icons}/share` to `${kdePackages.breeze-icons}/share` in the `preFixup` script.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
