### PR TITLE
python3Packages.latex2mathml: 3.78.1 -> 3.79.0, use finalAttrs

### DIFF
--- a/pkgs/development/python-modules/latex2mathml/default.nix
+++ b/pkgs/development/python-modules/latex2mathml/default.nix
@@ -2,26 +2,26 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  poetry-core,
+  hatchling,
   pytestCheckHook,
   pytest-cov-stub,
   multidict,
   xmljson,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "latex2mathml";
-  version = "3.78.1";
+  version = "3.79.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "roniemartinez";
     repo = "latex2mathml";
-    tag = version;
-    hash = "sha256-VhBq6KSiomFPue9yzYhU68gH+MkHovVi8VEEFi3yUZ8=";
+    tag = finalAttrs.version;
+    hash = "sha256-/ixS6TlovxOZgBqDq1t6KzcG6EKBSYwf3c+drHjQec4=";
   };
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -35,9 +35,9 @@ buildPythonPackage rec {
   meta = {
     description = "Pure Python library for LaTeX to MathML conversion";
     homepage = "https://github.com/roniemartinez/latex2mathml";
-    changelog = "https://github.com/roniemartinez/latex2mathml/releases/tag/${src.tag}";
+    changelog = "https://github.com/roniemartinez/latex2mathml/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     mainProgram = "latex2mathml";
     maintainers = with lib.maintainers; [ sfrijters ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/roniemartinez/latex2mathml/compare/3.78.1...3.79.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
