### PR TITLE
tree-sitter-grammars.tree-sitter-just: update upstream; 2025-01-05 -> 2026-03-15

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
@@ -1330,7 +1330,7 @@
 
   just = {
     version = "0-unstable-2025-01-05";
-    url = "github:IndianBoy42/tree-sitter-just";
+    url = "github:casey/tree-sitter-just";
     rev = "bb0c898a80644de438e6efe5d88d30bf092935cd";
     hash = "sha256-FwEuH/2R745jsuFaVGNeUTv65xW+MPjbcakRNcAWfZU=";
     meta = {

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
@@ -1335,6 +1335,9 @@
     hash = "sha256-YV+vab/QqGHVPV1e3wjd0w1nFskJEIU4ukq/yIlojk0=";
     meta = {
       license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [
+        Stebalien
+      ];
     };
   };
 

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
@@ -1329,10 +1329,10 @@
   };
 
   just = {
-    version = "0-unstable-2025-01-05";
+    version = "0-unstable-2026-03-15";
     url = "github:casey/tree-sitter-just";
-    rev = "bb0c898a80644de438e6efe5d88d30bf092935cd";
-    hash = "sha256-FwEuH/2R745jsuFaVGNeUTv65xW+MPjbcakRNcAWfZU=";
+    rev = "d9da862c156020c1a83d3c6ccdda32be6d8a5d4a";
+    hash = "sha256-YV+vab/QqGHVPV1e3wjd0w1nFskJEIU4ukq/yIlojk0=";
     meta = {
       license = lib.licenses.asl20;
     };


### PR DESCRIPTION
The author of just (casey) took over maintenance.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test