### PR TITLE
triton-llvm: Set LLVM_TOOL_LLVM_DRIVER_BUILD=ON to use a single symlinked binary

### DIFF
--- a/pkgs/by-name/tr/triton-llvm/package.nix
+++ b/pkgs/by-name/tr/triton-llvm/package.nix
@@ -128,6 +128,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "LLVM_INCLUDE_DOCS" (buildDocs || buildMan))
     (lib.cmakeBool "MLIR_INCLUDE_DOCS" (buildDocs || buildMan))
     (lib.cmakeBool "LLVM_BUILD_DOCS" (buildDocs || buildMan))
+    # It's tempting to set BUILD_SHARED_LIBS, which saves far more space
+    # but currently segfaults in keras's test suite. More work needed.
+    (lib.cmakeBool "LLVM_TOOL_LLVM_DRIVER_BUILD" true) # Save space by using busybox style tool binary
     # Way too slow, only uses one core
     # (lib.cmakeBool "LLVM_ENABLE_DOXYGEN" (buildDocs || buildMan))
     (lib.cmakeBool "LLVM_ENABLE_SPHINX" (buildDocs || buildMan))


### PR DESCRIPTION
Save space by using busybox style tool binary
It's tempting to set BUILD_SHARED_LIBS, which saves far more space but currently segfaults in keras's test suite. More work needed. See 8106d8a6055c6c00452bf001f27ae376c2dd2503 (#500596) and subsequent revert (#501146)

This only gets us ≈500MiB of headroom, sadly, but I'd like to land *some* fix soon to save aarch64 users from painful ML ecosystem builds.

```
$ nix path-info -h --size {.,github:nixos/nixpkgs/master}#triton-llvm.out
/nix/store/589lw45zwk68fvdbp0bl6gb0s7hiw9p9-triton-llvm-22.0.0-unstable-2025-09-26         3.9 GiB
/nix/store/nfy3bwdpja8fhps21dhicw020ih3p8ls-triton-llvm-22.0.0-unstable-2025-09-26         3.5 GiB
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
