### PR TITLE
webeep-sync: init at 1.0.3-unstable-2024-04-30

### DIFF
--- a/pkgs/by-name/we/webeep-sync/package.nix
+++ b/pkgs/by-name/we/webeep-sync/package.nix
@@ -1,0 +1,125 @@
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+  pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  writableTmpDirAsHomeHook,
+  makeWrapper,
+  electron,
+  nodejs,
+  zip,
+  makeDesktopItem,
+  copyDesktopItems,
+  lib,
+  nix-update-script,
+  withDebug ? false,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "webeep-sync";
+  version = "1.0.3-unstable-2026-03-24";
+
+  src = fetchFromGitHub {
+    owner = "toto04";
+    repo = "webeep-sync";
+    rev = "eabae4471b32660358c8bf95a985473f145d160a";
+    hash = "sha256-wQUNhuhuARLJG0ZYRVpIAgUIbYDFTLC3sRH762HOmBY=";
+  };
+
+  nativeBuildInputs = [
+    pnpmConfigHook
+    pnpm_10
+    writableTmpDirAsHomeHook
+    makeWrapper
+    nodejs
+    zip
+    electron
+    copyDesktopItems
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-IuI1asHqq2n1/hqf1NlRUG5/GU7HTLKCjalNooyPcO4=";
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+  };
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
+  patches = [ ./workspace.patch ]; # TODO: waiting for PR https://github.com/toto04/webeep-sync/pull/138
+
+  preBuild = ''
+    # create the electron archive to be used by electron-packager
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    pushd electron-dist
+    zip -0Xqr ../electron.zip .
+    popd
+
+    rm -r electron-dist
+
+    # force @electron/packager to use our electron instead of downloading it
+    substituteInPlace node_modules/.pnpm/@electron+packager@*/node_modules/@electron/packager/dist/packager.js \
+      --replace-fail "await this.getElectronZipPath(downloadOpts)" "'$(pwd)/electron.zip'"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm config set node-linker hoisted
+    pnpm run package | cat
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ${lib.optionalString (!withDebug) ''
+      find -type f \( -name "*.ts" -o -name "*.map" \) -exec rm -rf {} +
+    ''}
+
+    rm -rf node_modules/.pnpm/{*electron*,*typescript*,prettier*,eslint*,@babel*,react-icons*}
+    # remove symlinks to the previously deleted packages
+    find node_modules packages/**/node_modules -xtype l -delete
+
+    mkdir -p $out/lib/node_modules/${finalAttrs.pname}
+    cp -r .webpack node_modules $out/lib/node_modules/${finalAttrs.pname}/
+
+    makeWrapper ${electron}/bin/electron $out/bin/${finalAttrs.pname} \
+      ${lib.optionalString withDebug ''--set NODE_OPTIONS "--enable-source-maps"''} \
+      --add-flags "$out/lib/node_modules/${finalAttrs.pname}/.webpack/x64/main/index.js" \
+      --add-flags "--user-data-dir=\$HOME/.config/${finalAttrs.pname}"
+
+    for size in 32 48 64 72 96 128 256; do
+      install -Dm644 static/icons/icon-$size"x"$size.png \
+        $out/share/icons/hicolor/$size"x"$size/apps/${finalAttrs.pname}.png
+    done
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = finalAttrs.pname;
+      exec = finalAttrs.pname;
+      icon = finalAttrs.pname; # Matches the PNG name we installed earlier
+      desktopName = "WeBeep Sync";
+      comment = finalAttrs.meta.description;
+      categories = [ "Education" ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Keep all your WeBeep files synced on your computer";
+    homepage = "https://github.com/toto04/webeep-sync";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.lnk3 ];
+    mainProgram = "webeep-sync";
+  };
+})

--- a/pkgs/by-name/we/webeep-sync/workspace.patch
+++ b/pkgs/by-name/we/webeep-sync/workspace.patch
@@ -1,0 +1,8 @@
+--- a/pnpm-workspace.yaml
++++ b/pnpm-workspace.yaml
+@@ -1,3 +1,5 @@
++packages:
++  - '.'
+ allowBuilds:
+   '@parcel/watcher': true
+   electron: true


### PR DESCRIPTION
[webeep-sync](https://github.com/toto04/webeep-sync) is an Electron-based desktop utility to fetch course files for [Politecnico di Milano](https://www.polimi.it/) university.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
