### PR TITLE
burpsuite: 2026.1.2 -> 2026.3

### DIFF
--- a/pkgs/by-name/bu/burpsuite/package.nix
+++ b/pkgs/by-name/bu/burpsuite/package.nix
@@ -9,20 +9,20 @@
 }:
 
 let
-  version = "2026.1.2";
+  version = "2026.3";
 
   product =
     if proEdition then
       {
         productName = "pro";
         productDesktop = "Burp Suite Professional Edition";
-        hash = "sha256-KF6VOXO3IKsysA3SBJJzL+G2yQEVpCQKL6IMYQhYFMc=";
+        hash = "sha256-iGSXyF6Jh3eSuokzu8DNK6wIUw7a0px/Hg5QwzgMQY4=";
       }
     else
       {
         productName = "community";
         productDesktop = "Burp Suite Community Edition";
-        hash = "sha256-5LNzF68VhGdWttzZCkw/Ign4x6V4EhU/EHMddeSVirk=";
+        hash = "sha256-kr4Fa6NjaCiN6ulwr+HR6KN/DpYWFlzwnyO4E34x4yY=";
       };
 
   src = fetchurl {

--- a/pkgs/by-name/bu/burpsuite/update.sh
+++ b/pkgs/by-name/bu/burpsuite/update.sh
@@ -9,7 +9,7 @@ curl -s 'https://portswigger.net/burp/releases/data' | jq -r '
       [ .ResultSet.Results[]
         | select((.categories|sort) == (["Professional","Community"]|sort))
         | .builds[]
-        | select(.ProductPlatform == "Jar")
+        | select(.BuildCategoryPlatform == "Jar")
       ] as $all
       | ($all | max_by( (.Version // "") | split(".") | map(tonumber? // 0) ) | .Version) as $v
       | $all | map(select(.Version == $v))
@@ -17,8 +17,8 @@ curl -s 'https://portswigger.net/burp/releases/data' | jq -r '
 
 version=$(jq -r '.[0].Version' latest.json)
 
-comm_hex=$(jq -r '.[] | select(.ProductId=="community") .Sha256Checksum' latest.json)
-pro_hex=$(jq -r '.[] | select(.ProductId=="pro") .Sha256Checksum' latest.json)
+comm_hex=$(jq -r '.[] | select(.BuildCategoryId=="community") .Sha256Checksum' latest.json)
+pro_hex=$(jq -r '.[] | select(.BuildCategoryId=="pro") .Sha256Checksum' latest.json)
 
 comm_sri="sha256-$(printf %s "$comm_hex" | xxd -r -p | base64 -w0)"
 pro_sri="sha256-$(printf %s "$pro_hex" | xxd -r -p | base64 -w0)"


### PR DESCRIPTION
Updated Burp Suite from 2026.1.2 to 2026.3.
Fixed `update.sh` script to handle upstream JSON changes.
Changelog: https://portswigger.net/burp/releases

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
