### PR TITLE
odin: dev-2026-02 -> dev-2026-04

### DIFF
--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -13,13 +13,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "odin";
-  version = "dev-2026-02";
+  version = "dev-2026-04";
 
   src = fetchFromGitHub {
     owner = "odin-lang";
     repo = "Odin";
     tag = finalAttrs.version;
-    hash = "sha256-TiXHFFmXzSyENFeTtQoskGrU7oWAHXR7eGgne0w1vEE=";
+    hash = "sha256-vUQKXyVKZRLzAPeCileAOIfWXvKLrIjYIHXTdMGnG3k=";
   };
 
   patches = [
@@ -96,6 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "odin";
     maintainers = with lib.maintainers; [
       astavie
+      atomicptr
       diniamo
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/od/odin/system-raylib.patch
+++ b/pkgs/by-name/od/odin/system-raylib.patch
@@ -39,10 +39,10 @@ index 559437a60..cd31fbe43 100644
  RAYGUI_VERSION :: "4.0"
  
 diff --git a/vendor/raylib/raylib.odin b/vendor/raylib/raylib.odin
-index 02bb6deea..0df93009b 100644
+index b051f1885..9376dcc48 100644
 --- a/vendor/raylib/raylib.odin
 +++ b/vendor/raylib/raylib.odin
-@@ -99,42 +99,7 @@ MAX_TEXT_BUFFER_LENGTH :: #config(RAYLIB_MAX_TEXT_BUFFER_LENGTH, 1024)
+@@ -97,42 +97,7 @@ MAX_MATERIAL_MAPS      :: #config(RAYLIB_MAX_MATERIAL_MAPS, 12)
  
  #assert(size_of(rune) == size_of(c.int))
  
@@ -74,7 +74,7 @@ index 02bb6deea..0df93009b 100644
 -		"system:Cocoa.framework",
 -		"system:OpenGL.framework",
 -		"system:IOKit.framework",
--	} 
+-	}
 -} else when ODIN_ARCH == .wasm32 || ODIN_ARCH == .wasm64p32 {
 -	foreign import lib {
 -		RAYLIB_WASM_LIB,
@@ -87,21 +87,21 @@ index 02bb6deea..0df93009b 100644
  VERSION_MAJOR :: 5
  VERSION_MINOR :: 5
 diff --git a/vendor/raylib/rlgl/rlgl.odin b/vendor/raylib/rlgl/rlgl.odin
-index 6ac19695d..78a483a59 100644
+index 14a7cf5b0..a8e641220 100644
 --- a/vendor/raylib/rlgl/rlgl.odin
 +++ b/vendor/raylib/rlgl/rlgl.odin
-@@ -112,47 +112,12 @@ import rl "../."
+@@ -112,47 +112,7 @@ import rl "../."
  
  VERSION :: "5.0"
  
 -RAYLIB_SHARED :: #config(RAYLIB_SHARED, false)
 -RAYLIB_WASM_LIB :: #config(RAYLIB_WASM_LIB, "../wasm/libraylib.a")
 -
- // Note: We pull in the full raylib library. If you want a truly stand-alone rlgl, then:
- // - Compile a separate rlgl library and use that in the foreign import blocks below.
- // - Remove the `import rl "../."` line
- // - Copy the code from raylib.odin for any types we alias from that package (see PixelFormat etc)
- 
+-// Note: We pull in the full raylib library. If you want a truly stand-alone rlgl, then:
+-// - Compile a separate rlgl library and use that in the foreign import blocks below.
+-// - Remove the `import rl "../."` line
+-// - Copy the code from raylib.odin for any types we alias from that package (see PixelFormat etc)
+-
 -when ODIN_OS == .Windows {
 -	@(extra_linker_flags="/NODEFAULTLIB:" + ("msvcrt" when RAYLIB_SHARED else "libcmt"))
 -	foreign import lib {
@@ -139,3 +139,4 @@ index 6ac19695d..78a483a59 100644
  
  GRAPHICS_API_OPENGL_11  :: false
  GRAPHICS_API_OPENGL_21  :: true
+


### PR DESCRIPTION
## Things done

Fix the broken patch, update to dev-2026-04

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
