### PR TITLE
python3Packages.trio-websocket: disable flaky test on Darwin

### DIFF
--- a/pkgs/development/python-modules/trio-websocket/default.nix
+++ b/pkgs/development/python-modules/trio-websocket/default.nix
@@ -69,6 +69,6 @@ buildPythonPackage (finalAttrs: {
     description = "WebSocket client and server implementation for Python Trio";
     homepage = "https://github.com/HyperionGray/trio-websocket";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ sarahec ];
   };
 })

--- a/pkgs/development/python-modules/trio-websocket/default.nix
+++ b/pkgs/development/python-modules/trio-websocket/default.nix
@@ -11,7 +11,7 @@
   wsproto,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "trio-websocket";
   version = "0.12.2";
   pyproject = true;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "HyperionGray";
     repo = "trio-websocket";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-TGFf4WUeZDrjp/UiQ9O/GoaK5BRC2aaGZVPfqZ4Ip9I=";
   };
 
@@ -65,10 +65,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "trio_websocket" ];
 
   meta = {
-    changelog = "https://github.com/HyperionGray/trio-websocket/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/HyperionGray/trio-websocket/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "WebSocket client and server implementation for Python Trio";
     homepage = "https://github.com/HyperionGray/trio-websocket";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/trio-websocket/default.nix
+++ b/pkgs/development/python-modules/trio-websocket/default.nix
@@ -55,6 +55,9 @@ buildPythonPackage rec {
     "test_server_close_timeout"
     "test_server_handler_exit"
     "test_server_open_timeout"
+    # Race condition
+    # ValueError: Connection already closed
+    "test_open_websocket_internal_exc"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
1. Disabled test that can fail under load (on darwin) with a race condition. 
2. Migrated to finalAttrs
3. Added self as maintainer


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
