### PR TITLE
onedriver: 0.14.0 -> 0.15.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15470,6 +15470,11 @@
     githubId = 516527;
     name = "Lukas Werling";
   };
+  lnk3 = {
+    github = "lnk3";
+    githubId = 23727619;
+    name = "Luca Ruperto";
+  };
   lnl7 = {
     email = "daiderd@gmail.com";
     github = "LnL7";

--- a/pkgs/by-name/on/onedriver/package.nix
+++ b/pkgs/by-name/on/onedriver/package.nix
@@ -13,18 +13,18 @@
 }:
 let
   pname = "onedriver";
-  version = "0.14.1";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "jstaf";
     repo = "onedriver";
     rev = "v${version}";
-    hash = "sha256-mA5otgqXQAw2UYUOJaC1zyJuzEu2OS/pxmjJnWsVdxs=";
+    hash = "sha256-DCxF52CtA9KAP+yz5Rgzc/nUAXtZwfYAVU7oHREJlRY=";
   };
 in
 buildGoModule {
   inherit pname version src;
-  vendorHash = "sha256-OOiiKtKb+BiFkoSBUQQfqm4dMfDW3Is+30Kwcdg8LNA=";
+  vendorHash = "sha256-Ifcmf9AtZnrjgTPQnof/ap0TY19zHVftm5N4JgvbAgs=";
 
   nativeBuildInputs = [
     pkg-config
@@ -51,19 +51,19 @@ buildGoModule {
     install -Dm644 ./pkg/resources/onedriver.png $out/share/icons/onedriver/onedriver.png
     install -Dm644 ./pkg/resources/onedriver-128.png $out/share/icons/onedriver/onedriver-128.png
 
-    install -Dm644 ./pkg/resources/onedriver.desktop $out/share/applications/onedriver.desktop
+    install -Dm644 ./pkg/resources/onedriver-launcher.desktop $out/share/applications/onedriver-launcher.desktop
     install -Dm644 ./pkg/resources/onedriver@.service $out/lib/systemd/user/onedriver@.service
 
     mkdir -p $out/share/man/man1
     installManPage ./pkg/resources/onedriver.1
 
-    substituteInPlace $out/share/applications/onedriver.desktop \
-      --replace "/usr/bin/onedriver-launcher" "$out/bin/onedriver-launcher" \
-      --replace "/usr/share/icons" "$out/share/icons"
+    substituteInPlace $out/share/applications/onedriver-launcher.desktop \
+      --replace-fail "/usr/bin/onedriver-launcher" "$out/bin/onedriver-launcher" \
+      --replace-fail "/usr/share/icons" "$out/share/icons"
 
     substituteInPlace $out/lib/systemd/user/onedriver@.service \
-      --replace "/usr/bin/onedriver" "$out/bin/onedriver" \
-      --replace "/usr/bin/fusermount" "${wrapperDir}/fusermount"
+      --replace-fail "/usr/bin/onedriver" "$out/bin/onedriver" \
+      --replace-fail "/usr/bin/fusermount" "${wrapperDir}/fusermount"
   '';
 
   meta = {
@@ -76,7 +76,10 @@ buildGoModule {
     '';
     inherit (src.meta) homepage;
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.massimogengarelli ];
+    maintainers = [
+      lib.maintainers.massimogengarelli
+      lib.maintainers.lnk3
+    ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Updated [onedriver](https://github.com/jstaf/onedriver) to new [release 0.15.0](https://github.com/jstaf/onedriver/releases/tag/v0.15.0)

The automatic update failed because the `onedriver.desktop` file is now removed (it happened [here](https://github.com/jstaf/onedriver/commit/4377d7562089b7725957e371671e86130322ff54)), and this was the failed build log:
https://nixpkgs-update-logs.nix-community.org/onedriver/2026-03-17.log

## Changelog:
- Slight refresh of the onedriver UI to look nicer.
- Fix an authentication bug (Microsoft changed the auth format and I was using a
regex to parse the token when I shouldn't have been).
- Update to webkit2gtk-4.1 (what all major distros are using now).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. **`onedriver --version` is now 0.15.0**
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
