### PR TITLE
radicle-node{,-unstable}: 1.7.0 -> 1.7.1

### DIFF
--- a/nixos/tests/radicle.nix
+++ b/nixos/tests/radicle.nix
@@ -188,7 +188,7 @@ in
         )
       with subtest("bob can sync bob's repository from the seed"):
         bob.succeed(
-          "cd /tmp/repo && rad sync --fetch --seed ${seed-nid}",
+          "cd /tmp/repo && rad sync --seed ${seed-nid}",
           "cd /tmp/repo && git pull"
         )
         assert bob.succeed("cat /tmp/repo/testfile") == "hello bob\n"

--- a/pkgs/by-name/ra/radicle-node/package.nix
+++ b/pkgs/by-name/ra/radicle-node/package.nix
@@ -160,6 +160,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       Repositories are replicated across peers in a decentralized manner, and users are in full control of their data and workflow.
     '';
     homepage = "https://radicle.xyz";
+    changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/tree/CHANGELOG.md";
     license = with lib.licenses; [
       asl20
       mit

--- a/pkgs/by-name/ra/radicle-node/package.nix
+++ b/pkgs/by-name/ra/radicle-node/package.nix
@@ -15,9 +15,9 @@
   xdg-utils,
   versionCheckHook,
 
-  version ? "1.7.0",
-  srcHash ? "sha256-8/+ximoCPfNQJ/1APb0d5Z8kfWTI3SoN0RX9qrLP52o=",
-  cargoHash ? "sha256-xo8bH7f5MrUzoLat67rxiWMA24AnCngUkWWt402XAMQ=",
+  version ? "1.7.1",
+  srcHash ? "sha256-MPanUDVKol7mWVJDrGoGUkKqmcje+MsiK0WfqXQ27iI=",
+  cargoHash ? "sha256-Lru4ps9FYi03NVtRLtwZX9jhozAvBDsJ72ihdIpQcQ8=",
   updateScript ? ./update.sh,
 }:
 

--- a/pkgs/by-name/ra/radicle-node/unstable.nix
+++ b/pkgs/by-name/ra/radicle-node/unstable.nix
@@ -1,8 +1,8 @@
 { radicle-node }:
 
 radicle-node.override {
-  version = "1.7.0";
-  srcHash = "sha256-8/+ximoCPfNQJ/1APb0d5Z8kfWTI3SoN0RX9qrLP52o=";
-  cargoHash = "sha256-xo8bH7f5MrUzoLat67rxiWMA24AnCngUkWWt402XAMQ=";
+  version = "1.7.1";
+  srcHash = "sha256-MPanUDVKol7mWVJDrGoGUkKqmcje+MsiK0WfqXQ27iI=";
+  cargoHash = "sha256-Lru4ps9FYi03NVtRLtwZX9jhozAvBDsJ72ihdIpQcQ8=";
   updateScript = ./update-unstable.sh;
 }


### PR DESCRIPTION
Changelog: https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z3gqcJUoA1n9HaHKufZs5FCSGazv5/tree/CHANGELOG.md

nixpkgs-review-gha run: https://github.com/Defelo/nixpkgs-review-gha/actions/runs/23317797090

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
