### PR TITLE
iperf2: fix iperf2 cross compilation

### DIFF
--- a/pkgs/by-name/ip/iperf2/package.nix
+++ b/pkgs/by-name/ip/iperf2/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  pkgsCross,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -18,16 +19,23 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [ "--enable-fastsampling" ];
 
+  makeFlags = [ "AR:=$(AR)" ];
+
   postInstall = ''
     mv $out/bin/iperf $out/bin/iperf2
     ln -s $out/bin/iperf2 $out/bin/iperf
   '';
+
+  passthru.tests = {
+    cross-aarch64 = pkgsCross.aarch64-multiplatform.iperf2;
+  };
 
   meta = {
     homepage = "https://sourceforge.net/projects/iperf/";
     description = "Tool to measure IP bandwidth using UDP or TCP";
     platforms = lib.platforms.unix;
     license = lib.licenses.mit;
+    mainProgram = "iperf2";
     maintainers = with lib.maintainers; [ randomizedcoder ];
 
     # prioritize iperf3

--- a/pkgs/tools/networking/iperf/2.nix
+++ b/pkgs/tools/networking/iperf/2.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [ "--enable-fastsampling" ];
 
+  makeFlags = [ "AR:=$(AR)" ];
+
   postInstall = ''
     mv $out/bin/iperf $out/bin/iperf2
     ln -s $out/bin/iperf2 $out/bin/iperf


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/206343 fixed cross compilation for iperf2, then https://github.com/NixOS/nixpkgs/commit/34ae57af26dfa8e97276a56b481fd838bf27c09e broke it again. This PR re-enables cross compilation for iperf2.

Ran `nix build .#pkgsCross.aarch64-multiplatform.iperf2` on my x86 machine to cross compile successfully.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
