### PR TITLE
vcluster: add shell completion files

### DIFF
--- a/pkgs/by-name/vc/vcluster/package.nix
+++ b/pkgs/by-name/vc/vcluster/package.nix
@@ -6,6 +6,8 @@
   nix-update-script,
   testers,
   vcluster,
+  installShellFiles,
+  writableTmpDirAsHomeHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -20,6 +22,12 @@ buildGoModule (finalAttrs: {
   };
 
   vendorHash = null;
+
+  nativeBuildInputs = [
+    installShellFiles
+    # vcluster crashes, even on generating the completion script, if home is not writeable
+    writableTmpDirAsHomeHook
+  ];
 
   subPackages = [ "cmd/vclusterctl" ];
 
@@ -41,9 +49,16 @@ buildGoModule (finalAttrs: {
     runHook postInstall
   '';
 
+  postInstall = ''
+    installShellCompletion --cmd vcluster \
+      --bash <($out/bin/vcluster completion bash) \
+      --fish <($out/bin/vcluster completion fish) \
+      --zsh <($out/bin/vcluster completion zsh)
+  '';
+
   passthru.tests.version = testers.testVersion {
     package = vcluster;
-    command = "HOME=$(mktemp -d) vcluster --version";
+    command = "vcluster --version";
   };
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/vc/vcluster/package.nix
+++ b/pkgs/by-name/vc/vcluster/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   buildGoModule,
   fetchFromGitHub,
@@ -6,6 +7,8 @@
   nix-update-script,
   testers,
   vcluster,
+  installShellFiles,
+  writableTmpDirAsHomeHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -20,6 +23,12 @@ buildGoModule (finalAttrs: {
   };
 
   vendorHash = null;
+
+  nativeBuildInputs = [
+    installShellFiles
+    # vcluster crashes, even on generating the completion script, if home is not writeable
+    writableTmpDirAsHomeHook
+  ];
 
   subPackages = [ "cmd/vclusterctl" ];
 
@@ -39,6 +48,13 @@ buildGoModule (finalAttrs: {
     install -Dm755 $GOPATH/bin/vclusterctl $out/bin/vcluster
 
     runHook postInstall
+  '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd vcluster \
+      --bash <($out/bin/vcluster completion bash) \
+      --fish <($out/bin/vcluster completion fish) \
+      --zsh <($out/bin/vcluster completion zsh)
   '';
 
   passthru.tests.version = testers.testVersion {


### PR DESCRIPTION
Adding shellCompletionFiles in the same manner as any other go cli based on cobra.
Compare [kubectl](https://github.com/NixOS/nixpkgs/blob/b40629efe5d6ec48dd1efba650c797ddbd39ace0/pkgs/by-name/ku/kubectl/package.nix#L26)

## Things done

added shellCompletionFiles call to installPhase

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
