### PR TITLE
libipt: 2.1.2 -> 2.2

### DIFF
--- a/pkgs/by-name/li/libipt/package.nix
+++ b/pkgs/by-name/li/libipt/package.nix
@@ -2,29 +2,20 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   freebsd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libipt";
-  version = "2.1.2";
+  version = "2.2";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "libipt";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-rO2Mf2/BfKlPh1wHe0qTuyQAyqpSB/j3Q+JWpNDyNm0=";
+    sha256 = "sha256-hSC00GbVllJStgt9iA9WT54U8NQRtgJHuyZyb5ougc8=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "libipt-fix-cmake-4.patch";
-      url = "https://github.com/intel/libipt/commit/fa7d42de25be526da532284cc8b771fdeb384f81.patch";
-      hash = "sha256-/jTyoGyKw29Nu27bAXmStpjOdTeGdQYpEX2rb29vSSQ=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = lib.optional stdenv.hostPlatform.isFreeBSD freebsd.libstdthreads;

--- a/pkgs/by-name/li/libipt/package.nix
+++ b/pkgs/by-name/li/libipt/package.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "intel";
     repo = "libipt";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-hSC00GbVllJStgt9iA9WT54U8NQRtgJHuyZyb5ougc8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hSC00GbVllJStgt9iA9WT54U8NQRtgJHuyZyb5ougc8=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -25,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
+    changelog = "https://github.com/intel/libipt/releases/tag/v${finalAttrs.version}";
     description = "Intel Processor Trace decoder library";
     homepage = "https://github.com/intel/libipt";
     license = lib.licenses.bsd3;


### PR DESCRIPTION
Changelogs:
- https://github.com/intel/libipt/releases/tag/v2.1.3 
- https://github.com/intel/libipt/releases/tag/v2.2

Diff: https://github.com/intel/libipt/compare/v2.1.2...v2.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
