### PR TITLE
python3Packages.celery-types: fix build

### DIFF
--- a/pkgs/development/python-modules/celery-types/default.nix
+++ b/pkgs/development/python-modules/celery-types/default.nix
@@ -2,8 +2,8 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  poetry-core,
   typing-extensions,
+  uv-build,
 }:
 
 buildPythonPackage rec {
@@ -17,9 +17,14 @@ buildPythonPackage rec {
     hash = "sha256-yT+80LBKnpwvVdVUCspKoepMwGqHDAyN7lBi/dWWY/4=";
   };
 
-  nativeBuildInputs = [ poetry-core ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.9.18,<0.10.0" "uv_build"
+  '';
 
-  propagatedBuildInputs = [ typing-extensions ];
+  build-system = [ uv-build ];
+
+  dependencies = [ typing-extensions ];
 
   doCheck = false;
 


### PR DESCRIPTION
- python314Packages.celery-types
  - https://hydra.nixos.org/build/322445894
  - https://hydra.nixos.org/build/322445893
  - https://hydra.nixos.org/build/322445892
  - https://hydra.nixos.org/build/322445891
- python313Packages.celery-types
  - https://hydra.nixos.org/build/322406216
  - https://hydra.nixos.org/build/322406217
  - https://hydra.nixos.org/build/322406215
  - https://hydra.nixos.org/build/322406213

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
