### PR TITLE
delve: add shell completion files

### DIFF
--- a/pkgs/by-name/de/delve/package.nix
+++ b/pkgs/by-name/de/delve/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   stdenv,
   nix-update-script,
+  installShellFiles,
 }:
 
 buildGoModule (finalAttrs: {
@@ -22,6 +23,8 @@ buildGoModule (finalAttrs: {
   ];
 
   vendorHash = null;
+
+  nativeBuildInputs = [ installShellFiles ];
 
   subPackages = [ "cmd/dlv" ];
 
@@ -48,6 +51,11 @@ buildGoModule (finalAttrs: {
     # add symlink for vscode golang extension
     # https://github.com/golang/vscode-go/blob/master/docs/debugging.md#manually-installing-dlv-dap
     ln $out/bin/dlv $out/bin/dlv-dap
+
+    installShellCompletion --cmd dlv \
+      --bash <($out/bin/dlv completion bash) \
+      --fish <($out/bin/dlv completion fish) \
+      --zsh <($out/bin/dlv completion zsh)
   '';
 
   # delve doesn't support --version


### PR DESCRIPTION
Adding shellCompletionFiles in the same manner as any other go cli based on cobra.
Compare [kubectl](https://github.com/NixOS/nixpkgs/blob/b40629efe5d6ec48dd1efba650c797ddbd39ace0/pkgs/by-name/ku/kubectl/package.nix#L26)
Things done

added shellCompletionFiles call to installPhase

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
