### PR TITLE
python3Packages.mkdocs-simple-blog: fix build

### DIFF
--- a/pkgs/development/python-modules/mkdocs-simple-blog/default.nix
+++ b/pkgs/development/python-modules/mkdocs-simple-blog/default.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   mkdocs,
   poetry-core,
+  pytestCheckHook,
+  pytest-cov-stub,
 }:
 buildPythonPackage rec {
   pname = "mkdocs-simple-blog";
@@ -23,8 +25,10 @@ buildPythonPackage rec {
     mkdocs
   ];
 
-  # This package has no tests
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
 
   pythonImportsCheck = [ "mkdocs_simple_blog" ];
 

--- a/pkgs/development/python-modules/mkdocs-simple-blog/default.nix
+++ b/pkgs/development/python-modules/mkdocs-simple-blog/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   mkdocs,
-  setuptools,
+  poetry-core,
 }:
 buildPythonPackage rec {
   pname = "mkdocs-simple-blog";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     hash = "sha256-1RzorEsGXA8mRzMSS9S5vbPqJXK0vPMlRixo+Yrq27U=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [ poetry-core ];
 
   dependencies = [
     mkdocs


### PR DESCRIPTION
- python313Packages.mkdocs-simple-blog
  - https://hydra.nixos.org/build/322418979
  - https://hydra.nixos.org/build/322418973
  - https://hydra.nixos.org/build/322418974
  - https://hydra.nixos.org/build/322418969
- python314Packages.mkdocs-simple-blog
  - https://hydra.nixos.org/build/322458138			
  - https://hydra.nixos.org/build/322458133
  - https://hydra.nixos.org/build/322458136
  - https://hydra.nixos.org/build/322458132

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
