### PR TITLE
python3Packages.sphinxcontrib-spelling: fix build

### DIFF
--- a/pkgs/development/python-modules/sphinxcontrib-spelling/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-spelling/default.nix
@@ -4,8 +4,8 @@
   fetchFromGitHub,
   sphinx,
   pyenchant,
-  setuptools,
-  setuptools-scm,
+  hatchling,
+  hatch-vcs,
   wheel,
 }:
 
@@ -22,8 +22,8 @@ buildPythonPackage rec {
   };
 
   nativeBuildInputs = [
-    setuptools
-    setuptools-scm
+    hatchling
+    hatch-vcs
     wheel
   ];
 


### PR DESCRIPTION
- python313Packages.sphinxcontrib-spelling
  - https://hydra.nixos.org/build/322434060						
  - https://hydra.nixos.org/build/322434059
  - https://hydra.nixos.org/build/322434056
  - https://hydra.nixos.org/build/322434057
- python314Packages.sphinxcontrib-spelling
  - https://hydra.nixos.org/build/322472882						
  - https://hydra.nixos.org/build/322472878
  - https://hydra.nixos.org/build/322472887
  - https://hydra.nixos.org/build/322474294

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test