### PR TITLE
fastflix: init at 6.2.1

### DIFF
--- a/pkgs/by-name/fa/fastflix/package.nix
+++ b/pkgs/by-name/fa/fastflix/package.nix
@@ -1,0 +1,124 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  qt6,
+  ffmpeg,
+  mkvtoolnix,
+  tesseract,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "fastflix";
+  version = "6.2.1";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "cdgriffith";
+    repo = "FastFlix";
+    tag = version;
+    hash = "sha256-vlMS3Grqp6Ys1++711lwRuFC4LhcyrHtU/S3MGB4riY=";
+  };
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtwayland
+  ];
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = with python3Packages; [
+    babelfish
+    chardet
+    cleanit
+    colorama
+    coloredlogs
+    ffmpeg-normalize
+    iso639-lang
+    mistune
+    opencv-python
+    packaging
+    pathvalidate
+    pgsrip
+    platformdirs
+    psutil
+    pydantic
+    pyside6
+    pysrt
+    pytesseract
+    python-box
+    requests
+    reusables
+    ruamel-yaml
+    setuptools
+    trakit
+  ];
+
+  pythonRelaxDeps = [
+    "chardet"
+    "mistune"
+    "pathvalidate"
+    "platformdirs"
+    "psutil"
+    "pyside6"
+    "python-box"
+  ];
+
+  dontWrapQtApps = true;
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [
+      ffmpeg
+      mkvtoolnix
+      tesseract
+    ])
+  ];
+
+  # qtWrapperArgs only exists as a shell array, so it has to be appended here
+  # rather than spliced into makeWrapperArgs (which __structuredAttrs turns
+  # into a real array, suppressing word splitting and expansion).
+  preFixup = ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+    ffmpeg
+  ];
+
+  disabledTests = [
+    # requires network and asserts the checked-out version is newer than the
+    # latest upstream release, which can never hold for a tagged release
+    "test_version"
+  ];
+
+  # CI=true is upstream's own switch to skip the local-only integration
+  # encodes in tests/test_local_encode.py
+  preCheck = ''
+    export CI=true
+    export QT_QPA_PLATFORM=offscreen
+  '';
+
+  pythonImportsCheck = [ "fastflix" ];
+
+  meta = {
+    description = "Simple and friendly GUI for encoding videos";
+    homepage = "https://github.com/cdgriffith/FastFlix";
+    changelog = "https://github.com/cdgriffith/FastFlix/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sophronesis ];
+    platforms = lib.platforms.linux;
+    mainProgram = "fastflix";
+  };
+}

--- a/pkgs/development/python-modules/ffmpeg-normalize/default.nix
+++ b/pkgs/development/python-modules/ffmpeg-normalize/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  uv-build,
+  tqdm,
+  ffmpeg-progress-yield,
+  colorlog,
+  mutagen,
+  ffmpeg,
+  pytestCheckHook,
+  versionCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "ffmpeg-normalize";
+  version = "1.37.3";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "slhck";
+    repo = "ffmpeg-normalize";
+    tag = "v${version}";
+    hash = "sha256-KhkGBsuLMNtbo51M1ljIjn6OWSGQasEg2XoS1f1xpoo=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.8.14,<0.9.0" "uv_build"
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    tqdm
+    ffmpeg-progress-yield
+    colorlog
+    mutagen
+  ];
+
+  pythonRelaxDeps = [ "colorlog" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    ffmpeg
+  ];
+
+  # Tests require network access and specific ffmpeg features
+  doCheck = false;
+
+  pythonImportsCheck = [ "ffmpeg_normalize" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Normalize audio via ffmpeg";
+    homepage = "https://github.com/slhck/ffmpeg-normalize";
+    changelog = "https://github.com/slhck/ffmpeg-normalize/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "ffmpeg-normalize";
+    maintainers = with lib.maintainers; [ sophronesis ];
+  };
+}

--- a/pkgs/development/python-modules/iso639-lang/default.nix
+++ b/pkgs/development/python-modules/iso639-lang/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "iso639-lang";
+  version = "2.6.3";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "LBeaudoux";
+    repo = "iso639";
+    tag = "v${version}";
+    hash = "sha256-ORqSrf84b/ddpCUi9e43ur6C+XcJjQGM+fmJ8e/wFus=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "iso639" ];
+
+  meta = {
+    description = "Fast, comprehensive ISO 639 library for individual languages and language groups";
+    homepage = "https://github.com/LBeaudoux/iso639";
+    changelog = "https://github.com/LBeaudoux/iso639/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sophronesis ];
+  };
+}

--- a/pkgs/development/python-modules/pgsrip/default.nix
+++ b/pkgs/development/python-modules/pgsrip/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build dependencies
+  poetry-core,
+
+  # dependencies
+  babelfish,
+  cleanit,
+  click,
+  numpy,
+  opencv-python,
+  pysrt,
+  pytesseract,
+  setuptools,
+  trakit,
+}:
+
+buildPythonPackage rec {
+  pname = "pgsrip";
+  version = "0.1.12";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ratoaq2";
+    repo = "pgsrip";
+    tag = version;
+    hash = "sha256-8UzElhMdhjZERdogtAbkcfw67blk9lOTQ09vjF5SXm4=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    babelfish
+    cleanit
+    click
+    numpy
+    opencv-python
+    pysrt
+    pytesseract
+    setuptools
+    trakit
+  ];
+
+  pythonRelaxDeps = true;
+
+  # no tests in the tagged release (the test suite on main postdates 0.1.12)
+  doCheck = false;
+
+  pythonImportsCheck = [ "pgsrip" ];
+
+  meta = {
+    description = "Rip your PGS subtitles";
+    homepage = "https://github.com/ratoaq2/pgsrip";
+    changelog = "https://github.com/ratoaq2/pgsrip/releases/tag/${version}";
+    license = lib.licenses.mit;
+    mainProgram = "pgsrip";
+    maintainers = with lib.maintainers; [ sophronesis ];
+  };
+}

--- a/pkgs/development/python-modules/reusables/default.nix
+++ b/pkgs/development/python-modules/reusables/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  rarfile,
+  unar,
+}:
+
+buildPythonPackage rec {
+  pname = "reusables";
+  version = "1.0.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "cdgriffith";
+    repo = "Reusables";
+    tag = version;
+    hash = "sha256-l8nARlyLPMLZnIdV5IT2HeZ8duUA94cc2jWEVrBJ5wc=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    rarfile
+    # rarfile has no built-in extractor and expects unrar/unar/bsdtar/7z on
+    # PATH; unar is free and, unlike bsdtar, extracts the test fixture without
+    # CRC errors
+    unar
+  ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # binds a local TCP socket, which the darwin sandbox denies
+    "test_server_and_download"
+  ];
+
+  pythonImportsCheck = [ "reusables" ];
+
+  meta = {
+    description = "Commonly consumed code commodities for Python";
+    homepage = "https://github.com/cdgriffith/Reusables";
+    changelog = "https://github.com/cdgriffith/Reusables/blob/${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sophronesis ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5917,6 +5917,8 @@ self: super: with self; {
 
   ffcv = callPackage ../development/python-modules/ffcv { };
 
+  ffmpeg-normalize = callPackage ../development/python-modules/ffmpeg-normalize { };
+
   ffmpeg-progress-yield = callPackage ../development/python-modules/ffmpeg-progress-yield { };
 
   ffmpeg-python = callPackage ../development/python-modules/ffmpeg-python { };
@@ -8239,6 +8241,8 @@ self: super: with self; {
   iso3166 = callPackage ../development/python-modules/iso3166 { };
 
   iso4217 = callPackage ../development/python-modules/iso4217 { };
+
+  iso639-lang = callPackage ../development/python-modules/iso639-lang { };
 
   iso8601 = callPackage ../development/python-modules/iso8601 { };
 
@@ -13088,6 +13092,8 @@ self: super: with self; {
 
   pgspecial = callPackage ../development/python-modules/pgspecial { };
 
+  pgsrip = callPackage ../development/python-modules/pgsrip { };
+
   pgvector = callPackage ../development/python-modules/pgvector { };
 
   phart = callPackage ../development/python-modules/phart { };
@@ -17707,6 +17713,8 @@ self: super: with self; {
   retrying = callPackage ../development/python-modules/retrying { };
 
   returns = callPackage ../development/python-modules/returns { };
+
+  reusables = callPackage ../development/python-modules/reusables { };
 
   reuse = callPackage ../development/python-modules/reuse { };
 


### PR DESCRIPTION
FastFlix is a simple and friendly GUI for encoding videos. It supports H.264, HEVC, AV1, and more using FFmpeg, with both hardware and software encoders including NVIDIA NVEnc, AMD VCE, Intel QSV, and VAAPI.

Homepage: https://github.com/cdgriffith/FastFlix

Also adds required Python dependencies:
- `python3Packages.iso639-lang`: ISO 639 language codes library
- `python3Packages.reusables`: Python utility functions
- `python3Packages.ffmpeg-normalize`: Audio normalization via ffmpeg
- `python3Packages.pgsrip`: PGS subtitle ripper

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
