### PR TITLE
minimax-coding-plan-mcp: init at 0-unstable-2026-02-10

### DIFF
--- a/pkgs/by-name/mi/minimax-coding-plan-mcp/package.nix
+++ b/pkgs/by-name/mi/minimax-coding-plan-mcp/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "minimax-coding-plan-mcp";
+  version = "0-unstable-2026-02-10";
+
+  src = fetchFromGitHub {
+    owner = "MiniMax-AI";
+    repo = "MiniMax-Coding-Plan-MCP";
+    rev = "fbac3b3e56922a1249e00eebe07d9ee68f4768dc";
+    hash = "sha256-pxXeakBfn2FYAiznuJyBy58FkoV/Sx1zSYaSFDZUJX0=";
+  };
+
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    mcp
+    python-dotenv
+    requests
+  ];
+
+  pythonImportsCheck = [ "minimax_mcp" ];
+
+  meta = {
+    description = "MiniMax MCP server for coding-plan users with web search and image understanding";
+    homepage = "https://github.com/MiniMax-AI/MiniMax-Coding-Plan-MCP";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "minimax-coding-plan-mcp";
+  };
+})

--- a/pkgs/by-name/mi/minimax-coding-plan-mcp/package.nix
+++ b/pkgs/by-name/mi/minimax-coding-plan-mcp/package.nix
@@ -30,7 +30,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     description = "MiniMax MCP server for coding-plan users with web search and image understanding";
     homepage = "https://github.com/MiniMax-AI/MiniMax-Coding-Plan-MCP";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ superherointj ];
     mainProgram = "minimax-coding-plan-mcp";
   };
 })


### PR DESCRIPTION
minimax-coding-plan-mcp: init at 0-unstable-2026-02-10

Provides search capability and image recognition capabilities to AI Agents (OpenCode, etc.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test