### PR TITLE
python3Packages.devpi-web: 5.0.1 -> 5.0.2

### DIFF
--- a/pkgs/development/python-modules/devpi-web/default.nix
+++ b/pkgs/development/python-modules/devpi-web/default.nix
@@ -28,14 +28,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "devpi-web";
-  version = "5.0.1";
+  version = "5.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "devpi";
     repo = "devpi";
     tag = "web-${finalAttrs.version}";
-    hash = "sha256-p52uwkXeCPPsnD9BLfqEa8NK4bAfIdpYIzdNgmwucms=";
+    hash = "sha256-rAku3oHcmzFNA/MP/64382gCTgqopwjjy4S4HTEFZiY=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/web";

--- a/pkgs/development/python-modules/devpi-web/default.nix
+++ b/pkgs/development/python-modules/devpi-web/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   gitUpdater,
@@ -68,6 +69,11 @@ buildPythonPackage (finalAttrs: {
     pytest-cov-stub
     packaging-legacy
     webtest
+  ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # https://github.com/devpi/devpi/issues/1114
+    "test_dont_index_deleted_mirror"
   ];
 
   pythonImportsCheck = [ "devpi_web" ];


### PR DESCRIPTION
update devpi-web plugin for devpi-server

------

Changelog:

> #### 5.0.2 (2026-03-17)
> 
> ##### Bug Fixes
> 
> - Prevent double indexing work on first start of freshly initialized/imported instance.
> 
> - Optimize preparation of mirror project data for indexing.
> 
> - Consistently use offline mode when indexing. This especially helps performance on startup.
> 
> - Skip redirect if an installer is detected which is configured without ``+simple`` in the URL.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
