### PR TITLE
nixos/pam: don't fall through to unix for failed systemd_home auth

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -807,7 +807,7 @@ let
               {
                 name = "systemd_home";
                 enable = config.services.homed.enable;
-                control = "sufficient";
+                control = "[success=done authtok_expired=bad new_authtok_reqd=bad maxtries=bad acct_expired=bad default=ignore]";
                 modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
               }
               # The required pam_unix.so module has to come after all the sufficient modules
@@ -1009,7 +1009,7 @@ let
                     {
                       name = "systemd_home-early";
                       enable = config.services.homed.enable;
-                      control = "optional";
+                      control = "[success=1 authtok_err=bad perm_denied=bad maxtries=bad default=ignore]";
                       modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
                     }
                     {
@@ -1107,7 +1107,7 @@ let
                 {
                   name = "systemd_home";
                   enable = config.services.homed.enable;
-                  control = "sufficient";
+                  control = "[success=done authtok_err=bad perm_denied=bad maxtries=bad default=ignore]";
                   modulePath = "${config.systemd.package}/lib/security/pam_systemd_home.so";
                 }
                 {


### PR DESCRIPTION
Following the [upstream example config][1], prevents fatal homed errors (e.g. wrong password for a homed user) from falling through to pam_unix, and also makes sure if homed succeeds, it skips pam_unix.

[1]: https://github.com/systemd/systemd/commit/9a4f9e84c4ba79f39c7f5ab4b4d1a099a7496d52


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
