### PR TITLE
minimax-mcp: init at 0-unstable-2026-03-19

### DIFF
--- a/pkgs/by-name/mi/minimax-mcp/package.nix
+++ b/pkgs/by-name/mi/minimax-mcp/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "minimax-mcp";
+  version = "0-unstable-2026-03-19";
+
+  src = fetchFromGitHub {
+    owner = "MiniMax-AI";
+    repo = "MiniMax-MCP";
+    rev = "1a53cf1";
+    hash = "sha256-pi9QMEdgJ5HYn7MNulsQ3kn93OtBGad8Ehojc8apAEs=";
+  };
+
+  pyproject = true;
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    mcp
+    fastapi
+    uvicorn
+    python-dotenv
+    pydantic
+    httpx
+    fuzzywuzzy
+    levenshtein
+    sounddevice
+    soundfile
+    requests
+  ];
+
+  pythonImportsCheck = [ "minimax_mcp" ];
+
+  dontCheckRuntimeDeps = true;
+
+  meta = {
+    description = "MiniMax MCP Server for text-to-speech, voice cloning, image and video generation";
+    longDescription = ''
+      A Model Context Protocol (MCP) server for MiniMax that enables
+      text-to-speech, voice cloning, image generation, and video generation
+      capabilities. Works with MCP clients like Claude Desktop, Cursor, and OpenCode.
+    '';
+    homepage = "https://github.com/MiniMax-AI/MiniMax-MCP";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "minimax-mcp";
+  };
+})

--- a/pkgs/by-name/mi/minimax-mcp/package.nix
+++ b/pkgs/by-name/mi/minimax-mcp/package.nix
@@ -45,7 +45,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     '';
     homepage = "https://github.com/MiniMax-AI/MiniMax-MCP";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ superherointj ];
     mainProgram = "minimax-mcp";
   };
 })


### PR DESCRIPTION
minimax-mcp: init at 0-unstable-2026-03-19

MiniMax MCP Server for text-to-speech, voice cloning, image and video generation

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
