### PR TITLE
python3Packages.sphinxext-rediraffe: fix build

### DIFF
--- a/pkgs/development/python-modules/sphinxext-rediraffe/default.nix
+++ b/pkgs/development/python-modules/sphinxext-rediraffe/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   sphinx,
-  setuptools,
+  flit-core,
 }:
 
 buildPythonPackage rec {
@@ -18,15 +18,7 @@ buildPythonPackage rec {
     hash = "sha256-OW+MNQbPfJa8+jcpWZxTKD+EAv1gyo5tmcYAGba4u3c=";
   };
 
-  postPatch = ''
-    # Fixes "packaging.version.InvalidVersion: Invalid version: 'main'"
-    substituteInPlace setup.py \
-      --replace-fail 'version = "main"' 'version = "${version}"'
-  '';
-
-  build-system = [
-    setuptools
-  ];
+  build-system = [ flit-core ];
 
   dependencies = [
     sphinx


### PR DESCRIPTION
- python313Packages.sphinxext-rediraffe:
  - https://hydra.nixos.org/build/322434087
  - https://hydra.nixos.org/build/322434085
  - https://hydra.nixos.org/build/322434086
  - https://hydra.nixos.org/build/322434084
- python314Packages.sphinxext-rediraffe:
  - https://hydra.nixos.org/build/322472908
  - https://hydra.nixos.org/build/322472907
  - https://hydra.nixos.org/build/322472909
  - https://hydra.nixos.org/build/322472906

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
