### PR TITLE
qbittorrent: add password file option to webui

### DIFF
--- a/nixos/modules/services/torrent/qbittorrent.nix
+++ b/nixos/modules/services/torrent/qbittorrent.nix
@@ -54,6 +54,45 @@ let
         mkKeyValueDefault { } sep k v;
   };
   configFile = pkgs.writeText "qBittorrent.conf" (gendeepINI cfg.serverConfig);
+
+  pbkdf2Script = pkgs.writers.writePython3 "qbittorrent-pbkdf2" { } ''
+    import base64
+    import configparser
+    import hashlib
+    import os
+    import sys
+
+    password_file = sys.argv[1]
+    config_file = sys.argv[2]
+
+    with open(password_file) as f:
+        password = f.read().rstrip('\n')
+
+    if not password:
+        print("Error: password file is empty", file=sys.stderr)
+        sys.exit(1)
+
+    salt = os.urandom(16)
+    dk = hashlib.pbkdf2_hmac(
+        'sha512', password.encode('utf-8'), salt, 100000, dklen=64
+    )
+    salt_b64 = base64.b64encode(salt).decode()
+    dk_b64 = base64.b64encode(dk).decode()
+    pbkdf2 = f"@ByteArray({salt_b64}:{dk_b64})"
+
+    config = configparser.RawConfigParser()
+    config.optionxform = str
+    config.read(config_file)
+
+    if not config.has_section('Preferences'):
+        config.add_section('Preferences')
+    config.set('Preferences', 'WebUI\\Password_PBKDF2', pbkdf2)
+
+    with open(config_file, 'w') as f:
+        config.write(f, space_around_delimiters=False)
+  '';
+
+  configPath = "${cfg.profileDir}/qBittorrent/config/qBittorrent.conf";
 in
 {
   options.services.qbittorrent = {
@@ -131,6 +170,16 @@ in
       '';
     };
 
+    webuiPasswordFile = mkOption {
+      type = nullOr path;
+      default = null;
+      description = ''
+        Path to a file containing the plaintext WebUI password.
+        The password is hashed using PBKDF2-HMAC-SHA512 and injected
+        into the config at service startup.
+      '';
+    };
+
     extraArgs = mkOption {
       type = listOf str;
       default = [ ];
@@ -167,15 +216,21 @@ in
         wantedBy = [ "multi-user.target" ];
         restartTriggers = optionals (cfg.serverConfig != { }) [ configFile ];
 
+        # qBittorrent expects a writable config file, so copy the generated
+        # config into the profile before startup and optionally inject the
+        # hashed WebUI password.
+        preStart = mkIf (cfg.serverConfig != { } || cfg.webuiPasswordFile != null) ''
+          ${pkgs.coreutils}/bin/install -Dm600 ${configFile} "${configPath}"
+
+          ${lib.optionalString (cfg.webuiPasswordFile != null) ''
+            ${pbkdf2Script} "$CREDENTIALS_DIRECTORY/webui-password" "${configPath}"
+          ''}
+        '';
+
         serviceConfig = {
           Type = "simple";
           User = cfg.user;
           Group = cfg.group;
-
-          # the config file has to be writable, so we have to do this weird dance
-          ExecStartPre = lib.mkIf (cfg.serverConfig != { }) ''
-            ${pkgs.coreutils}/bin/install -Dm600 ${configFile} "${cfg.profileDir}/qBittorrent/config/qBittorrent.conf"
-          '';
 
           ExecStart = utils.escapeSystemdExecArgs (
             [
@@ -186,6 +241,9 @@ in
             ++ optionals (cfg.torrentingPort != null) [ "--torrenting-port=${toString cfg.torrentingPort}" ]
             ++ cfg.extraArgs
           );
+          LoadCredential = mkIf (cfg.webuiPasswordFile != null) [
+            "webui-password:${cfg.webuiPasswordFile}"
+          ];
           TimeoutStopSec = 1800;
 
           # https://github.com/qbittorrent/qBittorrent/pull/6806#discussion_r121478661

--- a/nixos/tests/qbittorrent.nix
+++ b/nixos/tests/qbittorrent.nix
@@ -37,6 +37,18 @@
           serverConfig.Preferences.WebUI.Port = "8181";
         };
       };
+
+      specialisation.passwordFile.configuration = {
+        services.qbittorrent = {
+          enable = true;
+          webuiPort = null;
+          webuiPasswordFile = "/run/secrets/qbittorrent-password";
+          serverConfig.Preferences.WebUI = {
+            Username = "user";
+            Port = "8181";
+          };
+        };
+      };
     };
     # Seperate vm because it's not possible to reboot into a specialisation with
     # switch-to-configuration: https://github.com/NixOS/nixpkgs/issues/82851
@@ -76,6 +88,7 @@
       portChange = "${simpleSpecPath}/portChange";
       openPorts = "${simpleSpecPath}/openPorts";
       serverConfig = "${simpleSpecPath}/serverConfig";
+      passwordFile = "${simpleSpecPath}/passwordFile";
       serverConfigChange = "${declarativeSpecPath}/serverConfigChange";
     in
     ''
@@ -189,5 +202,50 @@
       with subtest("changes in serverConfig are applied correctly"):
           declarative.succeed("${serverConfigChange}/bin/switch-to-configuration test")
           test_webui(declarative, 7171)
+
+
+      # Password file tests
+
+      with subtest("webuiPasswordFile injects password at startup"):
+          # Create the password file and remove any existing config to test
+          # the "no prior config" case
+          simple.succeed("mkdir -p /run/secrets")
+          simple.succeed("echo -n adminadmin > /run/secrets/qbittorrent-password")
+          simple.succeed("rm -rf /var/lib/qBittorrent/qBittorrent/config/qBittorrent.conf")
+
+          simple.succeed("${passwordFile}/bin/switch-to-configuration test")
+          test_webui(simple, 8181)
+
+          # Verify authentication works with the injected password
+          qb_url = "http://localhost:8181"
+          api_url = f"{qb_url}/api/v2"
+          result = simple.succeed(
+              f'curl --header "Referer: {qb_url}" '
+              f'--data "username=user&password=adminadmin" '
+              f'{api_url}/auth/login'
+          )
+          assert "Ok" in result, f"Login failed, got: {result}"
+
+      with subtest("webuiPasswordFile rejects empty password files"):
+          simple.succeed(": > /run/secrets/qbittorrent-password")
+          simple.succeed("rm -f /var/lib/qBittorrent/qBittorrent/config/qBittorrent.conf")
+
+          simple.succeed("${passwordFile}/bin/switch-to-configuration test")
+          simple.fail("systemctl restart qbittorrent.service")
+          simple.succeed("systemctl is-failed qbittorrent.service")
+          simple.succeed(
+              "journalctl -u qbittorrent.service -b --no-pager | grep -F 'Error: password file is empty'"
+          )
+
+      with subtest("webuiPasswordFile fails clearly when the password file is missing"):
+          simple.succeed("systemctl reset-failed qbittorrent.service")
+          simple.succeed("rm -f /run/secrets/qbittorrent-password")
+          simple.succeed("rm -f /var/lib/qBittorrent/qBittorrent/config/qBittorrent.conf")
+
+          simple.fail("${passwordFile}/bin/switch-to-configuration test")
+          simple.succeed("systemctl is-failed qbittorrent.service")
+          simple.succeed(
+              "journalctl -u qbittorrent.service -b --no-pager | grep -E 'Failed to set up credentials|Failed at step CREDENTIALS|No such file or directory'"
+          )
     '';
 }


### PR DESCRIPTION
Add a `webuiPasswordFile` option that accepts a path to a file containing the plaintext WebUI password. At service startup, the password is hashed using PBKDF2-HMAC-SHA512 and injected into the qBittorrent config file using Python's configparser.

This is useful with secret management tools like sops-nix.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
