### PR TITLE
python3Packages.mqtt2influxdb: fix build

### DIFF
--- a/pkgs/development/python-modules/mqtt2influxdb/default.nix
+++ b/pkgs/development/python-modules/mqtt2influxdb/default.nix
@@ -10,7 +10,10 @@
   pycron,
   pytestCheckHook,
   schema,
-  setuptools,
+  hatchling,
+  click,
+  influxdb3-python,
+  pydantic,
 }:
 
 buildPythonPackage rec {
@@ -25,12 +28,7 @@ buildPythonPackage rec {
     hash = "sha256-DS1k3JcTUK0yXRkJSFMeIZHSXpiIgSXJPZb3+72Wqko=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "find_version('mqtt2influxdb', '__init__.py')," "'${version}',"
-  '';
-
-  build-system = [ setuptools ];
+  build-system = [ hatchling ];
 
   dependencies = [
     influxdb
@@ -40,13 +38,14 @@ buildPythonPackage rec {
     pyaml
     pycron
     schema
+    click
+    influxdb3-python
+    pydantic
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "mqtt2influxdb" ];
-
-  enabledTestPaths = [ "tests/test.py" ];
 
   meta = {
     description = "Flexible MQTT to InfluxDB Bridge";


### PR DESCRIPTION
- python313Packages.mqtt2influxdb
  - https://hydra.nixos.org/build/322419409
  - https://hydra.nixos.org/build/322419402
- python314Packages.mqtt2influxdb
  - https://hydra.nixos.org/build/322458553
  - https://hydra.nixos.org/build/322458543

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
