### PR TITLE
python3Packages.lox: fix build

### DIFF
--- a/pkgs/development/python-modules/lox/default.nix
+++ b/pkgs/development/python-modules/lox/default.nix
@@ -26,11 +26,6 @@ buildPythonPackage rec {
 
   dependencies = [ pathos ];
 
-  # setup.py requires pytest-runner for setuptools, which is wrong
-  postPatch = ''
-    substituteInPlace setup.py --replace-fail '"pytest-runner",' ""
-  '';
-
   pythonImportsCheck = [ "lox" ];
 
   disabledTests = [


### PR DESCRIPTION
- python313Packages.lox:
  - https://hydra.nixos.org/build/322417803
  - https://hydra.nixos.org/build/322417798
  - https://hydra.nixos.org/build/322417802
  - https://hydra.nixos.org/build/322417800
- python314Packages.lox
  - https://hydra.nixos.org/build/322456992
  - https://hydra.nixos.org/build/322456987
  - https://hydra.nixos.org/build/322456990
  - https://hydra.nixos.org/build/322456983


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
