### PR TITLE
python3Packages.djangorestframework-stubs: fix build

### DIFF
--- a/pkgs/development/python-modules/djangorestframework-stubs/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-stubs/default.nix
@@ -10,7 +10,7 @@
   pytestCheckHook,
   requests,
   types-pyyaml,
-  setuptools,
+  uv-build,
   types-markdown,
   types-requests,
   typing-extensions,
@@ -30,10 +30,10 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "<79.0.0" ""
+      --replace-fail "uv_build>=0.8.19,<0.10.0" "uv_build"
   '';
 
-  build-system = [ setuptools ];
+  build-system = [ uv-build ];
 
   dependencies = [
     django-stubs


### PR DESCRIPTION
- python313Packages.djangorestframework-stubs:
  - https://hydra.nixos.org/build/322982284
  - https://hydra.nixos.org/build/322982283
  - https://hydra.nixos.org/build/322982285
  - https://hydra.nixos.org/build/322982282
- python314Packages.djangorestframework-stubs:
  - https://hydra.nixos.org/build/322982694
  - https://hydra.nixos.org/build/322982691
  - https://hydra.nixos.org/build/322982692
  - https://hydra.nixos.org/build/322982693

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
