### PR TITLE
devpi-client: 7.2.0 -> 7.2.1

### DIFF
--- a/pkgs/by-name/de/devpi-client/package.nix
+++ b/pkgs/by-name/de/devpi-client/package.nix
@@ -4,20 +4,23 @@
   git,
   glibcLocales,
   python3,
-  fetchPypi,
+  fetchFromGitHub,
   nix-update-script,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "devpi-client";
-  version = "7.2.0";
+  version = "7.2.1";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "devpi-client";
-    inherit (finalAttrs) version;
-    hash = "sha256-wUM2hFjDh4unvuah2bQY4uZZVxo4VmFPWNdriigmnXs=";
+  src = fetchFromGitHub {
+    owner = "devpi";
+    repo = "devpi";
+    tag = "client-${finalAttrs.version}";
+    hash = "sha256-rAku3oHcmzFNA/MP/64382gCTgqopwjjy4S4HTEFZiY=";
   };
+
+  sourceRoot = "${finalAttrs.src.name}/client";
 
   build-system = with python3.pkgs; [
     setuptools
@@ -34,6 +37,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     pkginfo
     pluggy
     platformdirs
+    requests
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
Updage devpi-client too for devpi-server (python packaging index)

Changelog:

> #### 7.2.1 (2026-03-17)
> 
> ##### Bug Fixes
> 
> - Work around missing support for metadata 2.4 in pkginfo with Python 3.7.
> 
> - The stored basic authentication credentials are now correctly applied to
>   HTTP API URLs containing a query string.
> 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
