### PR TITLE
python3Packages.hg-git: fix build failure

### DIFF
--- a/pkgs/development/python-modules/hg-git/default.nix
+++ b/pkgs/development/python-modules/hg-git/default.nix
@@ -29,6 +29,11 @@ buildPythonPackage rec {
     mercurial
   ];
 
+  # the dulwich version we are using is ahead of the one used upstream by hg-git.
+  # the build was failing because it could not import 'ANNOTATED_TAG_SUFFIX' from
+  # 'dulwich.refs'.
+  patches = [ ./dulwich_ANNOTATED_TAG_SUFFIX_renamed.patch ];
+
   pythonRelaxDeps = [ "dulwich" ];
 
   pythonImportsCheck = [ "hggit" ];

--- a/pkgs/development/python-modules/hg-git/dulwich_ANNOTATED_TAG_SUFFIX_renamed.patch
+++ b/pkgs/development/python-modules/hg-git/dulwich_ANNOTATED_TAG_SUFFIX_renamed.patch
@@ -1,0 +1,64 @@
+diff -r 1c168e428a22 hggit/git2hg.py
+--- a/hggit/git2hg.py	Mon Nov 18 20:33:10 2024 +0100
++++ b/hggit/git2hg.py	Fri Mar 20 01:49:29 2026 +0000
+@@ -5,8 +5,8 @@
+ 
+ from dulwich import config as dul_config
+ from dulwich.objects import Commit, Tag
++from dulwich.protocol import PEELED_TAG_SUFFIX
+ from dulwich.refs import (
+-    ANNOTATED_TAG_SUFFIX,
+     LOCAL_BRANCH_PREFIX,
+     LOCAL_TAG_PREFIX,
+ )
+@@ -306,7 +306,7 @@
+                     raise error.RepoLookupError(msg)
+     else:
+         for ref, sha in refs.items():
+-            if not ref.endswith(ANNOTATED_TAG_SUFFIX) and (
++            if not ref.endswith(PEELED_TAG_SUFFIX) and (
+                 ref.startswith(LOCAL_BRANCH_PREFIX)
+                 or ref.startswith(LOCAL_TAG_PREFIX)
+                 or ref == b'HEAD'
+diff -r 1c168e428a22 hggit/git_handler.py
+--- a/hggit/git_handler.py	Mon Nov 18 20:33:10 2024 +0100
++++ b/hggit/git_handler.py	Fri Mar 20 01:49:29 2026 +0000
+@@ -9,8 +9,8 @@
+ from dulwich.errors import HangupException, GitProtocolError, ApplyDeltaError
+ from dulwich.objects import Blob, Commit, Tag, Tree, parse_timezone
+ from dulwich.pack import apply_delta
++from dulwich.protocol import PEELED_TAG_SUFFIX
+ from dulwich.refs import (
+-    ANNOTATED_TAG_SUFFIX,
+     LOCAL_BRANCH_PREFIX,
+     LOCAL_TAG_PREFIX,
+ )
+@@ -1638,8 +1638,8 @@
+             # pull tags pointing to known revisions, including
+             # annotated tags
+             for ref, sha in refs.items():
+-                if ref.endswith(ANNOTATED_TAG_SUFFIX) and sha in self._map_git:
+-                    actual_ref = ref[: -len(ANNOTATED_TAG_SUFFIX)]
++                if ref.endswith(PEELED_TAG_SUFFIX) and sha in self._map_git:
++                    actual_ref = ref[: -len(PEELED_TAG_SUFFIX)]
+                     filteredrefs.setdefault(actual_ref, refs[actual_ref])
+ 
+             return [x for x in filteredrefs.values() if x not in self.git]
+@@ -1855,7 +1855,7 @@
+         repotags = self.repo.tags()
+         new_refs = {}
+         for k in refs:
+-            if k.endswith(ANNOTATED_TAG_SUFFIX) or not k.startswith(
++            if k.endswith(PEELED_TAG_SUFFIX) or not k.startswith(
+                 LOCAL_TAG_PREFIX
+             ):
+                 continue
+@@ -2036,7 +2036,7 @@
+ 
+         for ref_name, sha in refs.items():
+             if (
+-                ref_name.endswith(ANNOTATED_TAG_SUFFIX)
++                ref_name.endswith(PEELED_TAG_SUFFIX)
+                 or sha not in self.git.object_store
+             ):
+                 # the sha points to a peeled tag; we should either


### PR DESCRIPTION
the dulwich version we are using is ahead of the one used upstream by hg-git. the build was failing because it could not import 'ANNOTATED_TAG_SUFFIX' from 'dulwich.refs'.

- dulwich renamed `ANNOTATED_TAG_SUFFIX` to `PEELED_TAG_SUFFIX` in [2ef900fa](https://github.com/jelmer/dulwich/commit/2ef900fa)
- dulwich moved `PEELED_TAG_SUFFIX` to `dulwich.protocol` in [abdb24e2](https://github.com/jelmer/dulwich/commit/abdb24e2)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
