### PR TITLE
cool-retro-term: 1.2.0 -> 2.0.0-beta1

### DIFF
--- a/pkgs/by-name/co/cool-retro-term/package.nix
+++ b/pkgs/by-name/co/cool-retro-term/package.nix
@@ -1,41 +1,48 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
-  libsForQt5,
+  fetchgit,
+  qt6,
   nixosTests,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.2.0";
+  version = "2.0.0-beta1";
   pname = "cool-retro-term";
 
-  src = fetchFromGitHub {
-    owner = "Swordfish90";
-    repo = "cool-retro-term";
-    tag = finalAttrs.version;
-    hash = "sha256-PewHLVmo+RTBHIQ/y2FBkgXsIvujYd7u56JdFC10B4c=";
+  src = fetchgit {
+    url = "https://github.com/Swordfish90/cool-retro-term";
+    rev = "4c11f0800ba0ad3d32dd76179b58cf9ea1def412";
+    fetchSubmodules = true;
+    hash = "sha256-zr/10rBRJ40EmX1wTB9QZuQAljPHoWCDPiS2/6GVfVs=";
   };
 
-  patchPhase = ''
-    sed -i -e '/qmltermwidget/d' cool-retro-term.pro
-  '';
-
   buildInputs = [
-    libsForQt5.qtbase
-    libsForQt5.qmltermwidget
-    libsForQt5.qtquickcontrols2
-    libsForQt5.qtgraphicaleffects
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtsvg
+    qt6.qt5compat
   ];
 
   nativeBuildInputs = [
-    libsForQt5.qmake
-    libsForQt5.wrapQtAppsHook
+    qt6.qmake
+    qt6.wrapQtAppsHook
   ];
 
   installFlags = [ "INSTALL_ROOT=$(out)" ];
 
+  qtWrapperArgs = [
+    "--prefix NIXPKGS_QT6_QML_IMPORT_PATH : ${placeholder "out"}/lib/qt-6/qml"
+  ];
+
   preFixup = ''
+    if [ -d $out/nix/store ]; then
+      find $out/nix/store -name "QMLTermWidget" -type d | while read src; do
+        mkdir -p $out/lib/qt-6/qml
+        cp -r "$src" $out/lib/qt-6/qml/
+      done
+      rm -rf $out/nix/store
+    fi
+
     mv $out/usr/share $out/share
     mv $out/usr/bin $out/bin
     rmdir $out/usr


### PR DESCRIPTION
cool-retro-term: 1.2.0 -> 2.0.0-beta1

Upstream has released 2.0.0-beta1 which migrates from Qt5 to Qt6 and
replaces the external qmltermwidget dependency with an in-tree fork as
a git submodule. See upstream changelog:
https://github.com/Swordfish90/cool-retro-term/releases/tag/2.0.0-beta1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.