### PR TITLE
jemalloc,clightning,objfw,ulogd: remove unnecessary `autogen` dependency

### DIFF
--- a/pkgs/by-name/cl/clightning/package.nix
+++ b/pkgs/by-name/cl/clightning/package.nix
@@ -5,7 +5,6 @@
   darwin,
   fetchurl,
   autoconf,
-  autogen,
   automake,
   gettext,
   libtool,
@@ -41,7 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
   # option to libtool, also we have to add the modified gsed package.
   nativeBuildInputs = [
     autoconf
-    autogen
     automake
     gettext
     libtool

--- a/pkgs/by-name/je/jemalloc/package.nix
+++ b/pkgs/by-name/je/jemalloc/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch,
-  autogen,
   autoconf,
   automake,
   # By default, jemalloc puts a je_ prefix onto all its symbols on OSX, which
@@ -57,7 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    autogen
     autoconf
     automake
   ];

--- a/pkgs/by-name/ob/objfw/package.nix
+++ b/pkgs/by-name/ob/objfw/package.nix
@@ -1,6 +1,5 @@
 {
   autoconf,
-  autogen,
   automake,
   clangStdenv,
   fetchfossil,
@@ -21,7 +20,6 @@ clangStdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     automake
-    autogen
     autoconf
   ];
 

--- a/pkgs/by-name/ul/ulogd/package.nix
+++ b/pkgs/by-name/ul/ulogd/package.nix
@@ -9,7 +9,6 @@
   libnfnetlink,
   automake,
   autoconf,
-  autogen,
   libtool,
   libpq,
   libmysqlclient,
@@ -70,7 +69,6 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     automake
     autoconf
-    autogen
     libtool
     linuxdoc-tools
   ];


### PR DESCRIPTION
This PR removes the GNU AutoGen (`autogen`) package from `nativeBuildInputs` in 4 packages that don't actually use it. These packages have `autogen.sh` scripts that are standard autotools bootstrap wrappers (typically they call `autoconf`, `aclocal`, `autoheader`), and are not GNU AutoGen template processors.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (for `ulogd`)
  - [x] [Package tests] at `passthru.tests`. (for `objfw` and `ulogd`)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
