### PR TITLE
metropolis: init at 0.1.0

### DIFF
--- a/pkgs/by-name/me/metropolis/package.nix
+++ b/pkgs/by-name/me/metropolis/package.nix
@@ -1,0 +1,43 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "metropolis";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "5c0";
+    repo = "metropolis";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Yps7PFxtR09rKwg5Gg12bsX7XISUZSSmPqK3mvxG1dI=";
+  };
+
+  cargoHash = "sha256-jtbxqw/T+kgD4Vbl2vT8HnkqdO2sMyL/6xugSYkXhIQ=";
+
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    description = "Cyberpunk system monitor";
+    longDescription = ''
+      "The year is 20XX. Your processes aren't just rows in a table.
+      They're the residents.  Your CPU isn't just silicon.  It's the
+      infrastructure.  And the city?  The city is breathing."
+
+      Metropolis is a high-performance, narrative-driven system
+      monitor built for the terminal.  It transcends traditional
+      hardware monitoring by transforming raw kernel metrics into a
+      living, breathing Cyberpunk Skyline.
+
+      Every flicker of a neon sign, every shuttle streaking across the
+      sky, and every drop of rain is a direct reflection of your
+      system's heartbeat.
+    '';
+    homepage = "https://github.com/5c0/metropolis";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "metropolis";
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
