### PR TITLE
proxytunnel: init at 1.12.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15050,6 +15050,12 @@
     githubId = 31388299;
     name = "Leonardo Eugênio";
   };
+  lenianiva = {
+    name = "Leni Aniva";
+    email = "aniva@stanford.edu";
+    github = "lenianiva";
+    githubId = 107011294;
+  };
   lenivaya = {
     name = "Danylo Osipchuk";
     email = "danylo.osipchuk@proton.me";

--- a/pkgs/by-name/pr/proxytunnel/package.nix
+++ b/pkgs/by-name/pr/proxytunnel/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  openssl,
+  fetchFromGitHub,
+  versionCheckHook,
+  asciidoc,
+  xmlto,
+  docbook-xsl-nons,
+  docbook_xml_dtd_45,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "proxytunnel";
+  version = "1.12.3";
+
+  src = fetchFromGitHub {
+    owner = "proxytunnel";
+    repo = "proxytunnel";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+IRbL3VcnW+uYLIkwvaFJ8zBYbQAkqmzVluDsCrdURk=";
+  };
+
+  makeFlags = [ "prefix=${placeholder "out"}" ];
+  buildInputs = [ openssl ];
+  nativeBuildInputs = [
+    asciidoc
+    xmlto
+    docbook-xsl-nons
+    docbook_xml_dtd_45
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    mainProgram = "proxytunnel";
+    homepage = "http://proxytunnel.sf.net/";
+    description = "Stealth tunneling through HTTP(S) proxies";
+    platforms = lib.platforms.unix;
+    license = lib.licenses.gpl2Only;
+    changelog = "https://github.com/proxytunnel/proxytunnel/raw/${finalAttrs.src.tag}/CHANGES";
+    maintainers = with lib.maintainers; [
+      lenianiva
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Note that this package doesn't have tests: https://github.com/proxytunnel/proxytunnel

It is packaged in [Kali Linux](https://www.kali.org/tools/proxytunnel/) and [Debian](https://manpages.debian.org/testing/proxytunnel/proxytunnel.1).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
