### PR TITLE
nixos/pam: add motd files and directories options

### DIFF
--- a/nixos/modules/programs/rust-motd.nix
+++ b/nixos/modules/programs/rust-motd.nix
@@ -151,7 +151,7 @@ in
       timerConfig.OnCalendar = cfg.refreshInterval;
     };
 
-    security.pam.services.sshd.showMotd = lib.mkIf cfg.enableMotdInSSHD true;
+    security.pam.services.sshd.motd.enable = lib.mkIf cfg.enableMotdInSSHD true;
     users.motdFile = lib.mkIf cfg.enableMotdInSSHD "/var/lib/rust-motd/motd";
 
     programs.rust-motd.settings.global.show_legacy_warning = false;

--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -253,7 +253,7 @@ in
         login = {
           startSession = true;
           allowNullPassword = true;
-          showMotd = true;
+          motd.enable = true;
           updateWtmp = true;
         };
         chpasswd.rootOK = true;

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -135,6 +135,7 @@ let
 
       imports = [
         (lib.mkRenamedOptionModule [ "enableKwallet" ] [ "kwallet" "enable" ])
+        (lib.mkRenamedOptionModule [ "showMotd" ] [ "motd" "enable" ])
       ];
 
       options = {
@@ -521,10 +522,49 @@ let
           '';
         };
 
-        showMotd = lib.mkOption {
-          default = false;
-          type = lib.types.bool;
-          description = "Whether to show the message of the day.";
+        motd = {
+          enable = lib.mkOption {
+            default = false;
+            type = lib.types.bool;
+            description = "Whether to show the message of the day.";
+          };
+
+          files = lib.mkOption {
+            default = [ (lib.defaultTo "/etc/motd" motd) ];
+            defaultText = lib.literalMD ''
+              `users.motd` or `users.motdFile` if defined, otherwise `"/etc/motd"`
+            '';
+            type = lib.types.listOf lib.types.path;
+            example = [
+              "/run/motd"
+              "/etc/motd"
+            ];
+            description = ''
+              List of files to try when showing the message of the day. Each
+              file will be tried in order (from first to last), and only the
+              first file that was read successfully will be shown.
+            '';
+          };
+
+          directories = lib.mkOption {
+            default = [ "/etc/motd.d" ];
+            type = lib.types.listOf lib.types.path;
+            example = [
+              "/run/motd.d"
+              "/etc/motd.d"
+            ];
+            description = ''
+              List of directories that contain message of the day snippets that
+              will be shown after the main message of the day.
+
+              Files are read in lexicographic order by name. Moreover, the
+              files are filtered by reading them with the credentials of the
+              target user authenticating on the system.
+
+              Files in directories that appear earlier in the list override
+              files with the same name in directories later in the list.
+            '';
+          };
         };
 
         makeHomeDir = lib.mkOption {
@@ -1461,11 +1501,12 @@ let
               }
               {
                 name = "motd";
-                enable = cfg.showMotd && (config.users.motd != "" || config.users.motdFile != null);
+                enable = cfg.motd.enable;
                 control = "optional";
                 modulePath = "${package}/lib/security/pam_motd.so";
                 settings = {
-                  inherit motd;
+                  motd = lib.concatStringsSep ":" cfg.motd.files;
+                  motd_dir = lib.concatStringsSep ":" cfg.motd.directories;
                 };
               }
               {

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -816,7 +816,7 @@ in
 
       security.pam.services.sshd = lib.mkIf (cfg.settings.UsePAM == true) {
         startSession = true;
-        showMotd = true;
+        motd.enable = true;
         unixAuth = if cfg.settings.PasswordAuthentication == true then true else false;
       };
 


### PR DESCRIPTION
Renames `showMotd` to `motd.enable` and adds `motd.files` and `motd.directories` for `pam_motd` to allow setting a list of files/directories to search per-service instead of always being hardcoded to `users.motd`/`users.motdFile`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
