### PR TITLE
asahi-*, tiny-dfr: add update script and update all

### DIFF
--- a/pkgs/by-name/as/asahi-bless/package.nix
+++ b/pkgs/by-name/as/asahi-bless/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchCrate,
   rustPlatform,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -15,6 +16,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-nfSJ9RkzFAWlxlfoUKk8ZmIXDJXoSyHCGgRgMy9FDkw=";
   cargoDepsName = finalAttrs.pname;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Tool to select active boot partition on ARM Macs";

--- a/pkgs/by-name/as/asahi-bless/package.nix
+++ b/pkgs/by-name/as/asahi-bless/package.nix
@@ -7,14 +7,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "asahi-bless";
-  version = "0.4.1";
+  version = "0.4.3";
 
   src = fetchCrate {
     inherit (finalAttrs) pname version;
-    hash = "sha256-SNaA+CEuCBwo4c54qWGs5AdkBYb9IWY1cQ0dRd/noe8=";
+    hash = "sha256-JBd1YPTJ2ZqcGZ+FTGR2hqXWYd+kJ/0snWrn4uEpXWg=";
   };
 
-  cargoHash = "sha256-nfSJ9RkzFAWlxlfoUKk8ZmIXDJXoSyHCGgRgMy9FDkw=";
+  cargoHash = "sha256-DN5PRUO0M0/ExIkuR+Iwk3SW1jzIaFnzvLOBuFoJ360=";
   cargoDepsName = finalAttrs.pname;
 
   passthru = {

--- a/pkgs/by-name/as/asahi-btsync/package.nix
+++ b/pkgs/by-name/as/asahi-btsync/package.nix
@@ -3,19 +3,24 @@
   fetchCrate,
   rustPlatform,
   nix-update-script,
+  pkg-config,
+  dbus,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "asahi-btsync";
-  version = "0.2.0";
+  version = "0.2.5";
 
   src = fetchCrate {
     inherit (finalAttrs) pname version;
-    hash = "sha256-jp05WcwY1cWh4mBQj+3jRCZoG32OhDvTB84hOAGemX8=";
+    hash = "sha256-lAfbr2D6dITdlFCbz++OVz2SxYGapiZtrNjeBruBDJ8=";
   };
 
-  cargoHash = "sha256-gGWhi0T7xDIsbzfw/KL3TSneLvQaiz/2xbpHeZt1i3I=";
+  cargoHash = "sha256-80B47vRUgb+QWYoxqPWk1gCdWFM5bIxq0tR5FpssRQ4=";
   cargoDepsName = finalAttrs.pname;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dbus ];
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/as/asahi-btsync/package.nix
+++ b/pkgs/by-name/as/asahi-btsync/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchCrate,
   rustPlatform,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -15,6 +16,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-gGWhi0T7xDIsbzfw/KL3TSneLvQaiz/2xbpHeZt1i3I=";
   cargoDepsName = finalAttrs.pname;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Tool to sync Bluetooth pairing keys with macos on ARM Macs";

--- a/pkgs/by-name/as/asahi-fwextract/package.nix
+++ b/pkgs/by-name/as/asahi-fwextract/package.nix
@@ -10,14 +10,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "asahi-fwextract";
-  version = "0.7.9";
+  version = "0.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "AsahiLinux";
     repo = "asahi-installer";
     tag = "v${version}";
-    hash = "sha256-vbhepoZ52k5tW2Gd7tfQTZ5CLqzhV7dUcVh6+AYwECk=";
+    hash = "sha256-UMzmQ3buXousCR8t0eSf6m+OTvqp3mEQ73aZ9UznuOI=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/as/asahi-nvram/package.nix
+++ b/pkgs/by-name/as/asahi-nvram/package.nix
@@ -7,14 +7,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "asahi-nvram";
-  version = "0.2.3";
+  version = "0.2.4";
 
   src = fetchCrate {
     inherit (finalAttrs) pname version;
-    hash = "sha256-zfUvPHAPrYhzgeiirGuqZaWnLBH0PHsqOUy2e972bWM=";
+    hash = "sha256-wRlKTMzckygRkZoAT3ZDYnAF3owWEziAGNl4jteCf+A=";
   };
 
-  cargoHash = "sha256-NW/puo/Xoum7DjSQjBgilQcKbY3mAfVgXxUK6+1H1JI=";
+  cargoHash = "sha256-Syc4QgKUJM37FW3JQqVNN9WEMFwCSoo/BaI55k2HFRY=";
   cargoDepsName = finalAttrs.pname;
 
   passthru = {

--- a/pkgs/by-name/as/asahi-nvram/package.nix
+++ b/pkgs/by-name/as/asahi-nvram/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchCrate,
   rustPlatform,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -15,6 +16,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-NW/puo/Xoum7DjSQjBgilQcKbY3mAfVgXxUK6+1H1JI=";
   cargoDepsName = finalAttrs.pname;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Tool to read and write nvram variables on ARM Macs";

--- a/pkgs/by-name/as/asahi-wifisync/package.nix
+++ b/pkgs/by-name/as/asahi-wifisync/package.nix
@@ -7,14 +7,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "asahi-wifisync";
-  version = "0.2.0";
+  version = "0.2.3";
 
   src = fetchCrate {
     inherit (finalAttrs) pname version;
-    hash = "sha256-wKd6rUUnegvl6cHODVQlllaOXuAGlmwx9gr73I/2l/c=";
+    hash = "sha256-YO7Yq3S7F7WuW79MR1wrViw3tTBZi8XIsXrd4f0xCzs=";
   };
 
-  cargoHash = "sha256-ZxgRxQyDID3mBpr8dhHScctk14Pm9V51Gn24d24JyVk=";
+  cargoHash = "sha256-cfgsY34wFeBTy0CYwVRZN22Ndifn6ZPs2t6f8DS3S2k=";
   cargoDepsName = finalAttrs.pname;
 
   passthru = {

--- a/pkgs/by-name/as/asahi-wifisync/package.nix
+++ b/pkgs/by-name/as/asahi-wifisync/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchCrate,
   rustPlatform,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -15,6 +16,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-ZxgRxQyDID3mBpr8dhHScctk14Pm9V51Gn24d24JyVk=";
   cargoDepsName = finalAttrs.pname;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Tool to sync Wifi passwords with macos on ARM Macs";

--- a/pkgs/by-name/ti/tiny-dfr/package.nix
+++ b/pkgs/by-name/ti/tiny-dfr/package.nix
@@ -12,6 +12,7 @@
   pango,
   udev,
   udevCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -54,6 +55,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     homepage = "https://github.com/AsahiLinux/tiny-dfr";

--- a/pkgs/by-name/ti/tiny-dfr/package.nix
+++ b/pkgs/by-name/ti/tiny-dfr/package.nix
@@ -17,16 +17,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tiny-dfr";
-  version = "0.3.5";
+  version = "0.3.7";
 
   src = fetchFromGitHub {
     owner = "AsahiLinux";
     repo = "tiny-dfr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-G4OeYZH3VF6fKWxHYLTmwzQmQ4JupgYNH/6aJSgINvg=";
+    hash = "sha256-NwZ/uhVyI3NeI5CUsM42HUu6SpG0Lh8Mj66RY+ZuqBM=";
   };
 
-  cargoHash = "sha256-/PtoAc2ZNJfW5gegcFQAAlEmjSMysZ+QebVfHtW35Nk=";
+  cargoHash = "sha256-k9mXEKn+LqFJraLm2ahGGAbVUNeNPnEwt1wGEOXeSrc=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds the `nix-update-script` as update scripts for all the asahi packages, as they are all rust, and the default update script doesn't properly update derivations made with `rustPlatform.buildRustPackage`. Updated packages include:
```
asahi-bless: 0.4.1 -> 0.4.3
asahi-btsync: 0.2.0 -> 0.2.5
asahi-fwexxtract: 0.7.9 -> 0.8.0
asahi-nvram: 0.2.3 -> 0.2.4
asahi-wifisync: 0.2.0 -> 0.2.3
tiny-dfr: 0.3.5 -> 0.3.7
```

supercedes #471579 and #487402. I have built all the packages on my mac, but don't have wifi or bluetooth working yet so can't really test them. Nor do I have a touchbar for `tiny-dfr`. Would really appreciate someone else testing the updates.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
