### PR TITLE
nixos/pam: rename updateWtmp to lastlog.enable, add silent option

### DIFF
--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -254,7 +254,7 @@ in
           startSession = true;
           allowNullPassword = true;
           showMotd = true;
-          updateWtmp = true;
+          lastlog.enable = true;
         };
         chpasswd.rootOK = true;
       };

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -137,6 +137,7 @@ let
       imports = [
         (lib.mkRenamedOptionModule [ "enableKwallet" ] [ "kwallet" "enable" ])
         (lib.mkRenamedOptionModule [ "u2fAuth" ] [ "u2f" "enable" ])
+        (lib.mkRenamedOptionModule [ "updateWtmp" ] [ "lastlog" "enable" ])
       ];
 
       options = {
@@ -583,10 +584,21 @@ let
           '';
         };
 
-        updateWtmp = lib.mkOption {
-          default = false;
-          type = lib.types.bool;
-          description = "Whether to update {file}`/var/log/wtmp`.";
+        lastlog = {
+          enable = lib.mkOption {
+            default = false;
+            type = lib.types.bool;
+            description = "Whether to update {file}`/var/log/wtmp`.";
+          };
+
+          silent = lib.mkOption {
+            default = true;
+            example = false;
+            type = lib.types.bool;
+            description = ''
+              Whether to suppress the message showing the last login date.
+            '';
+          };
         };
 
         logFailures = lib.mkOption {
@@ -1521,11 +1533,11 @@ let
               }
               {
                 name = "lastlog";
-                enable = cfg.updateWtmp;
+                enable = cfg.lastlog.enable;
                 control = "required";
                 modulePath = "${pkgs.util-linux.lastlog}/lib/security/pam_lastlog2.so";
                 settings = {
-                  silent = true;
+                  inherit (cfg.lastlog) silent;
                 };
               }
               # Work around https://github.com/systemd/systemd/issues/8598
@@ -2549,7 +2561,7 @@ in
     environment.etc = lib.mapAttrs' makePAMService enabledServices;
 
     systemd =
-      lib.mkIf (lib.any (service: service.updateWtmp) (lib.attrValues config.security.pam.services))
+      lib.mkIf (lib.any (service: service.lastlog.enable) (lib.attrValues config.security.pam.services))
         {
           tmpfiles.packages = [ pkgs.util-linux.lastlog ]; # /lib/tmpfiles.d/lastlog2-tmpfiles.conf
           services.lastlog2-import = {

--- a/nixos/tests/pam/pam-lastlog.nix
+++ b/nixos/tests/pam/pam-lastlog.nix
@@ -8,7 +8,7 @@
     {
       # we abuse run0 for a quick login as root as to not require setting up accounts and passwords
       security.pam.services.systemd-run0 = {
-        updateWtmp = true; # enable lastlog
+        lastlog.enable = true;
       };
     };
 

--- a/nixos/tests/pam/pam-lastlog.nix
+++ b/nixos/tests/pam/pam-lastlog.nix
@@ -6,10 +6,7 @@
   nodes.machine =
     { ... }:
     {
-      # we abuse run0 for a quick login as root as to not require setting up accounts and passwords
-      security.pam.services.systemd-run0 = {
-        lastlog.enable = true;
-      };
+      imports = [ ../common/user-account.nix ];
     };
 
   testScript = ''
@@ -23,8 +20,13 @@
 
     with subtest("Test lastlog entries are created by logins"):
       machine.wait_for_unit("multi-user.target")
-      machine.succeed("run0 --pty true") # perform full login
-      print(machine.succeed("lastlog2 --active --user root"))
+      machine.wait_until_tty_matches("1", "login: ")
+      machine.send_chars("alice\n")
+      machine.wait_until_tty_matches("1", "Password: ")
+      machine.send_chars("foobar\n")
+      machine.wait_until_succeeds("pgrep -u alice bash")
+      print(machine.succeed("lastlog2 --active --user alice"))
       machine.succeed("stat /var/lib/lastlog/lastlog2.db")
+      machine.send_chars("exit\n")
   '';
 }


### PR DESCRIPTION
Renames `updateWtmp` to `lastlog.enable` (so there's a place to put the `silent` option) and adds a switch to allow disabling the `silent` option (so you can show last login date when logging in on a TTY).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
