### PR TITLE
hevel: init at 0-unstable-2026-03-15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22896,6 +22896,13 @@
     githubId = 61013287;
     name = "Ricardo Steijn";
   };
+  ricardomaps = {
+    email = "ricardomapurungajunior@gmail.com";
+    github = "ricardomaps";
+    githubId = 49507078;
+    name = "Ricardo Mapurunga Junior";
+    matrix = "@ricmaps:matrix.org";
+  };
   richar = {
     github = "ri-char";
     githubId = 17962023;

--- a/pkgs/by-name/he/hevel/package.nix
+++ b/pkgs/by-name/he/hevel/package.nix
@@ -1,0 +1,78 @@
+{
+  fetchFromSourcehut,
+  fontconfig,
+  lib,
+  libdrm,
+  libinput,
+  libxcb-wm,
+  libxkbcommon,
+  neuswc,
+  neuwld,
+  nix-update-script,
+  pixman,
+  pkg-config,
+  stdenv,
+  wayland,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hevel";
+  version = "0-unstable-2026-03-15";
+
+  src = fetchFromSourcehut {
+    owner = "~dlm";
+    repo = "hevel";
+    rev = "cce195a2176163f099ed95c9bf7020033bdbbac9";
+    hash = "sha256-9B180ebZzOtv9eEICVpYSo558T0/UYEVELFztPzOX4o=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    fontconfig
+    libdrm
+    libinput
+    libxcb-wm
+    libxkbcommon
+    neuswc
+    neuwld
+    pixman
+    wayland
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Scrollable, floating window manager for Wayland";
+    longDescription = ''
+      "Make the user interface invisible"
+
+      hevel is a scrollable, floating window manager for Wayland that
+      uses mouse chords for all commands.
+
+      Its design is inspired by ideas from Rob Pike's 1988 paper,
+      "Window Systems Should be Transparent", taken to their logical
+      extremes.  In this sense, hevel is a modernization of
+      mouse-driven Unix and Plan 9 window systems such as mux, 8½, and
+      rio.
+
+      Unlike those systems, hevel has no menus and is not limited to a
+      single screen of space.  Instead, the desktop is an infinite
+      plane: windows can be created anywhere, and the view can be
+      freely scrolled thru (vertically, or in all axis).
+    '';
+    homepage = "https://git.sr.ht/~dlm/hevel";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [
+      ricardomaps
+      yiyu
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/he/hevel/package.nix
+++ b/pkgs/by-name/he/hevel/package.nix
@@ -1,0 +1,76 @@
+{
+  fetchFromSourcehut,
+  lib,
+  libxkbcommon,
+  neuswc,
+  nix-update-script,
+  pkg-config,
+  stdenv,
+  wayland,
+  writeText,
+  conf ? null,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hevel";
+  version = "0-unstable-2026-05-07";
+
+  src = fetchFromSourcehut {
+    owner = "~dlm";
+    repo = "hevel";
+    rev = "7ef61a5c0d4012417443734919ac723635cd5464";
+    hash = "sha256-ad4euUV+jJYG58aO9tfKyCq8sznDf2tHj7RmORqnP1o=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libxkbcommon
+    neuswc
+    wayland
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  postPatch =
+    let
+      configFile =
+        if lib.isDerivation conf || builtins.isPath conf then conf else writeText "config.h" conf;
+    in
+    lib.optionalString (conf != null) "cp {configFile} config.h";
+
+  meta = {
+    description = "Scrollable, floating window manager for Wayland";
+    longDescription = ''
+      "Make the user interface invisible"
+
+      hevel is a scrollable, floating window manager for Wayland that
+      uses mouse chords for all commands.
+
+      Its design is inspired by ideas from Rob Pike's 1988 paper,
+      "Window Systems Should be Transparent", taken to their logical
+      extremes.  In this sense, hevel is a modernization of
+      mouse-driven Unix and Plan 9 window systems such as mux, 8½, and
+      rio.
+
+      Unlike those systems, hevel has no menus and is not limited to a
+      single screen of space.  Instead, the desktop is an infinite
+      plane: windows can be created anywhere, and the view can be
+      freely scrolled thru (vertically, or in all axis).
+    '';
+    homepage = "https://git.sr.ht/~dlm/hevel";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [
+      ricardomaps
+      yiyu
+    ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ne/neuswc/package.nix
+++ b/pkgs/by-name/ne/neuswc/package.nix
@@ -1,0 +1,84 @@
+{
+  fetchFromSourcehut,
+  fontconfig,
+  lib,
+  libdrm,
+  libinput,
+  libxcb-util,
+  libxcb-wm,
+  libxkbcommon,
+  meson,
+  neuwld,
+  ninja,
+  nix-update-script,
+  pixman,
+  pkg-config,
+  stdenv,
+  udev,
+  udevSupport ? true,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  xwayland,
+  xwaylandSupport ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "neuswc";
+  version = "0-unstable-2026-03-19";
+
+  src = fetchFromSourcehut {
+    owner = "~shrub900";
+    repo = "neuswc";
+    rev = "8a2d575859ae683ed7dc695b31c3c1dfa104242a";
+    hash = "sha256-MJNoodnZGys+jTHP6QMLC1xViyfskZN2473uXyd2pYQ=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    fontconfig
+    libdrm
+    libxkbcommon
+    neuwld
+    pixman
+    wayland
+    wayland-protocols
+    wayland-scanner
+    xwayland
+  ]
+  ++ lib.optionals udevSupport [
+    libinput
+    udev
+  ]
+  ++ lib.optionals xwaylandSupport [
+    xwayland
+    libxcb-util
+    libxcb-wm
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = ''
+      Fork of [swc](https://github.com/michaelforney/swc/) for [hevel
+      window
+      manager](https://git.sr.ht/~shrub900/neuswc/tree/main/hevel.derivelinux.org).
+    '';
+    homepage = "https://git.sr.ht/~shrub900/neuswc";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      ricardomaps
+      yiyu
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/ne/neuswc/package.nix
+++ b/pkgs/by-name/ne/neuswc/package.nix
@@ -1,0 +1,98 @@
+{
+  fetchFromSourcehut,
+  fontconfig,
+  lib,
+  libdrm,
+  libinput,
+  libxcb,
+  libxcb-wm,
+  libxkbcommon,
+  meson,
+  neuwld,
+  ninja,
+  nix-update-script,
+  pixman,
+  pkg-config,
+  stdenv,
+  udev,
+  udevSupport ? stdenv.hostPlatform.isLinux,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  xwayland,
+  xwaylandSupport ? true,
+  videoBackend ? "drm",
+}:
+
+assert lib.assertOneOf "videoBackend" videoBackend [
+  "drm"
+  "fb"
+];
+assert lib.assertMsg (
+  xwaylandSupport -> videoBackend == "drm"
+) "Enable the DRM video backend to use XWayland.";
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "neuswc";
+  version = "0-unstable-2026-09-04";
+
+  src = fetchFromSourcehut {
+    owner = "~shrub900";
+    repo = "neuswc";
+    rev = "35d8564f9c4105df3e6f8f16ee323a55b3e027e6";
+    hash = "sha256-ZMaqyXMsYnYjZkJr475RR6w2wlaJuK+QV94SRbaL2vc=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    fontconfig
+    libxkbcommon
+    (neuwld.override { drmSupport = videoBackend == "drm"; })
+    pixman
+    wayland
+    wayland-protocols
+  ]
+  ++ lib.optionals udevSupport [
+    libinput
+    udev
+  ]
+  ++ lib.optionals xwaylandSupport [
+    xwayland
+    libxcb
+    libxcb-wm
+  ]
+  ++ lib.optional (videoBackend == "drm") libdrm;
+
+  mesonFlags = [
+    (lib.mesonEnable "xwayland" xwaylandSupport)
+    (lib.mesonOption "video" videoBackend)
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = ''
+      Fork of [swc](https://github.com/michaelforney/swc/) for [hevel
+      window
+      manager](https://git.sr.ht/~shrub900/neuswc/tree/main/hevel.derivelinux.org).
+    '';
+    homepage = "https://git.sr.ht/~shrub900/neuswc";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      ricardomaps
+      yiyu
+    ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ne/neuwld/package.nix
+++ b/pkgs/by-name/ne/neuwld/package.nix
@@ -1,0 +1,59 @@
+{
+  doxygen,
+  fetchFromSourcehut,
+  fontconfig,
+  lib,
+  libdrm,
+  meson,
+  ninja,
+  nix-update-script,
+  pixman,
+  pkg-config,
+  stdenv,
+  wayland,
+  wayland-scanner,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "neuwld";
+  version = "0-unstable-2026-03-18";
+
+  src = fetchFromSourcehut {
+    owner = "~shrub900";
+    repo = "neuwld";
+    rev = "6446a28168045efffa8ccd3de0b6eb3599fb5339";
+    hash = "sha256-rP03qodS9zUKJ6WPxPlu/sn+yRWc6jssa10mVPEjodc=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    doxygen
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    fontconfig
+    libdrm
+    pixman
+    wayland
+    wayland-scanner
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Drawing library that targets Wayland";
+    homepage = "https://git.sr.ht/~shrub900/neuwld";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      ricardomaps
+      yiyu
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/ne/neuwld/package.nix
+++ b/pkgs/by-name/ne/neuwld/package.nix
@@ -1,0 +1,71 @@
+{
+  doxygen,
+  fetchFromSourcehut,
+  fontconfig,
+  lib,
+  freetype,
+  libdrm,
+  meson,
+  ninja,
+  nix-update-script,
+  pixman,
+  pkg-config,
+  stdenv,
+  wayland,
+  wayland-scanner,
+  drmSupport ? true,
+  waylandSupport ? true,
+  documentationSupport ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "neuwld";
+  version = "0-unstable-2026-08-13";
+
+  src = fetchFromSourcehut {
+    owner = "~shrub900";
+    repo = "neuwld";
+    rev = "554f827cadfdfcc276c709dbffa3b2b04c70cf7c";
+    hash = "sha256-KAK4/TpNekaonN0yxi4/5mRdZL1uxYdGmwl41FRH5wU=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ]
+  ++ lib.optional (waylandSupport && drmSupport) wayland-scanner
+  ++ lib.optional documentationSupport doxygen;
+
+  buildInputs = [
+    fontconfig
+    pixman
+    freetype
+  ]
+  ++ lib.optional drmSupport libdrm
+  ++ lib.optional waylandSupport wayland;
+
+  mesonFlags = [
+    (lib.mesonEnable "wayland" waylandSupport)
+    (lib.mesonEnable "drm" drmSupport)
+    (lib.mesonEnable "doxygen" documentationSupport)
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Drawing library that targets Wayland";
+    homepage = "https://git.sr.ht/~shrub900/neuwld";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      ricardomaps
+      yiyu
+    ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
