### PR TITLE
kdePackages.plasma-vault: don't hardcode fusermount path

### DIFF
--- a/pkgs/kde/plasma/plasma-vault/hardcode-paths.patch
+++ b/pkgs/kde/plasma/plasma-vault/hardcode-paths.patch
@@ -43,19 +43,6 @@ index b992f6f..eb828dd 100644
  }
  
  QString GocryptfsBackend::getConfigFilePath(const Device &device) const
-diff --git a/kded/engine/fusebackend_p.cpp b/kded/engine/fusebackend_p.cpp
-index 8763304..e6860d2 100644
---- a/kded/engine/fusebackend_p.cpp
-+++ b/kded/engine/fusebackend_p.cpp
-@@ -90,7 +90,7 @@ QProcess *FuseBackend::process(const QString &executable, const QStringList &arg
- 
- QProcess *FuseBackend::fusermount(const QStringList &arguments) const
- {
--    return process(fusermountExecutable, arguments, {});
-+    return process("@fusermount@", arguments, {});
- }
- 
- FutureResult<> FuseBackend::initialize(const QString &name, const Device &device, const MountPoint &mountPoint, const Vault::Payload &payload)
 diff --git a/kded/engine/vault.cpp b/kded/engine/vault.cpp
 index c101079..67c8a83 100644
 --- a/kded/engine/vault.cpp


### PR DESCRIPTION
We're not in a privileged context here, so we need to rely on fusermount's suid-ness to actually do the unmount.

Fixes #501493.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
