### PR TITLE
proton-pass-cli: fix never updated package

### DIFF
--- a/pkgs/by-name/pr/proton-pass-cli/package.nix
+++ b/pkgs/by-name/pr/proton-pass-cli/package.nix
@@ -37,9 +37,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  nativeCheckInputs = [
+  nativeInstallCheckInputs = [
     versionCheckHook
   ];
+  doInstallCheck = true;
   versionCheckProgram = "${placeholder "out"}/bin/pass-cli";
   versionCheckProgramArg = "--version";
 
@@ -71,13 +72,22 @@ stdenv.mkDerivation (finalAttrs: {
           common-updater-scripts
         ]
       }"
-      NEW_VERSION=$(curl --silent https://proton.me/download/pass-cli/versions.json | jq '.passCliVersions.version' --raw-output)
+      NEW_VERSION=$(curl --silent https://proton.me/download/pass-cli/versions.json \
+        | jq '.passCliVersions.version' --raw-output)
+
       if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
           echo "No update available."
           exit 0
       fi
+
+      PKG_FILE="pkgs/by-name/pr/proton-pass-cli/package.nix"
       for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
-        update-source-version "proton-pass-cli" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+        # After iter 1 the version field already equals $NEW_VERSION.
+        # Reset it so update-source-version detects a diff and re-prefetches.
+        sed -i "s|version = \"$NEW_VERSION\"|version = \"${finalAttrs.version}\"|" \
+          "$PKG_FILE"
+        update-source-version "proton-pass-cli" "$NEW_VERSION" \
+          --source-key="sources.$platform"
       done
     '';
   };


### PR DESCRIPTION
The proton-pass-cli package is never really updated. Although the updater correctly updates the version and the hashes, the real binary is never installed.

The installed should be "1.6.1", but `pass-cli -V` still outputs an old version (1.2.0 for me).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
