### PR TITLE
ocamlformat: 0.28.1 → 0.29.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocamlformat/generic.nix
+++ b/pkgs/development/ocaml-modules/ocamlformat/generic.nix
@@ -1,7 +1,8 @@
 {
   lib,
+  ocaml,
   fetchurl,
-  version ? "0.28.1",
+  version ? if lib.versionAtLeast ocaml.version "4.14" then "0.29.0" else "0.28.1",
   astring,
   base,
   camlp-streams,
@@ -50,6 +51,7 @@ rec {
         "0.26.2" = "sha256-Lk9Za/eqNnqET+g7oPawvxSyplF53cCCNj/peT0DdcU=";
         "0.27.0" = "sha256-3b9ITAdtCPmUAO6Et5DsIx9cj8vV0zJKZADVOI6EbRU=";
         "0.28.1" = "sha256-cL2gN9C+2WHtkb21GYsu7vVCREdQqLAV2AzLlLP/Qfs=";
+        "0.29.0" = "sha256-2sd/CpV654K7S4abB7mAOocqNPjB6uiQG0LSG2I8nbU=";
       }
       ."${version}";
   };

--- a/pkgs/development/ocaml-modules/ocamlformat/ocamlformat-lib.nix
+++ b/pkgs/development/ocaml-modules/ocamlformat/ocamlformat-lib.nix
@@ -17,9 +17,6 @@ buildDunePackage {
   pname = "ocamlformat-lib";
   inherit src version;
 
-  minimalOCamlVersion = "4.08";
-  duneVersion = "3";
-
   nativeBuildInputs = [ menhir ];
 
   propagatedBuildInputs = library_deps;

--- a/pkgs/development/ocaml-modules/ocamlformat/ocamlformat-rpc-lib.nix
+++ b/pkgs/development/ocaml-modules/ocamlformat/ocamlformat-rpc-lib.nix
@@ -20,9 +20,6 @@ buildDunePackage {
   pname = "ocamlformat-rpc-lib";
   inherit src version;
 
-  minimalOCamlVersion = "4.08";
-  duneVersion = "3";
-
   propagatedBuildInputs = [
     csexp
     sexplib0

--- a/pkgs/development/ocaml-modules/ocamlformat/ocamlformat.nix
+++ b/pkgs/development/ocaml-modules/ocamlformat/ocamlformat.nix
@@ -17,8 +17,6 @@ buildDunePackage {
   pname = "ocamlformat";
   inherit src version;
 
-  minimalOCamlVersion = "4.08";
-
   nativeBuildInputs = if lib.versionAtLeast version "0.25.1" then [ ] else [ menhir ];
 
   buildInputs = [
@@ -43,6 +41,7 @@ buildDunePackage {
       || lib.versionAtLeast ocaml.version "5.1" && !lib.versionAtLeast version "0.25"
       || lib.versionAtLeast ocaml.version "5.2" && !lib.versionAtLeast version "0.26.2"
       || lib.versionAtLeast ocaml.version "5.3" && !lib.versionAtLeast version "0.27"
-      || lib.versionAtLeast ocaml.version "5.4" && !lib.versionAtLeast version "0.28";
+      || lib.versionAtLeast ocaml.version "5.4" && !lib.versionAtLeast version "0.28"
+      || lib.versionAtLeast version "0.29.0" && !lib.versionAtLeast ocaml.version "4.14";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4605,6 +4605,7 @@ with pkgs;
   inherit (ocamlPackages)
     ocamlformat # latest version
     ocamlformat_0_28_1
+    ocamlformat_0_29_0
     ;
 
   inherit (ocamlPackages) odig;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1513,6 +1513,7 @@ let
         ocamlformat_0_26_2 = ocamlformat.override { version = "0.26.2"; };
         ocamlformat_0_27_0 = ocamlformat.override { version = "0.27.0"; };
         ocamlformat_0_28_1 = ocamlformat.override { version = "0.28.1"; };
+        ocamlformat_0_29_0 = ocamlformat.override { version = "0.29.0"; };
 
         ocamlformat = callPackage ../development/ocaml-modules/ocamlformat/ocamlformat.nix { };
 


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
