### PR TITLE
python3Packages.django-rq: 3.2.2 -> 4.0.1

### DIFF
--- a/pkgs/development/python-modules/django-rq/default.nix
+++ b/pkgs/development/python-modules/django-rq/default.nix
@@ -8,23 +8,22 @@
   redis,
   rq,
   prometheus-client,
-  sentry-sdk,
   pytest-django,
   pytestCheckHook,
   pyyaml,
   redisTestHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "django-rq";
-  version = "3.2.2";
+  version = "4.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rq";
     repo = "django-rq";
-    tag = "v${version}";
-    hash = "sha256-vKvEFySTgIWqe6RYnl3POtjCEbCJZsRKL2KcRs9bv30=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7V3kZVK9YsJDYrME4LHc1+U2lk1qBJU8Vza7o3JzuU0=";
   };
 
   build-system = [ hatchling ];
@@ -37,10 +36,7 @@ buildPythonPackage rec {
 
   optional-dependencies = {
     prometheus = [ prometheus-client ];
-    sentry = [ sentry-sdk ];
   };
-
-  pythonImportsCheck = [ "django_rq" ];
 
   # redis hook does not support darwin
   doCheck = !stdenv.hostPlatform.isDarwin;
@@ -51,7 +47,7 @@ buildPythonPackage rec {
     pyyaml
     redisTestHook
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.finalPackage.optional-dependencies;
 
   preCheck = ''
     export DJANGO_SETTINGS_MODULE=tests.settings
@@ -60,8 +56,8 @@ buildPythonPackage rec {
   meta = {
     description = "Simple app that provides django integration for RQ (Redis Queue)";
     homepage = "https://github.com/rq/django-rq";
-    changelog = "https://github.com/rq/django-rq/releases/tag/${src.tag}";
+    changelog = "https://github.com/rq/django-rq/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hexa ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/rq/django-rq/releases/tag/v4
https://github.com/rq/django-rq/releases/tag/v4.0.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
