### PR TITLE
odin: build box2d vendor package (#373413)

### DIFF
--- a/pkgs/by-name/od/odin/box2d-no-network.patch
+++ b/pkgs/by-name/od/odin/box2d-no-network.patch
@@ -1,0 +1,21 @@
+diff --git a/vendor/box2d/build_box2d.sh b/vendor/box2d/build_box2d.sh
+index 8d2a7c0..32edb9e 100755
+--- a/vendor/box2d/build_box2d.sh
++++ b/vendor/box2d/build_box2d.sh
+@@ -2,7 +2,6 @@
+ set -eu
+ 
+-VERSION="3.1.1"
+-RELEASE="https://github.com/erincatto/box2d/archive/refs/tags/v$VERSION.tar.gz"
++VERSION="${BOX2D_VERSION:?}"
+ 
+ cd "$(dirname "$0")"
+ 
+@@ -9,2 +9,6 @@
+-curl -O -L "$RELEASE"
++if [[ -z "${BOX2D_TARBALL:-}" ]]; then
++	printf '%s\n' "BOX2D_TARBALL is required" >&2
++	exit 1
++fi
++cp "$BOX2D_TARBALL" "v$VERSION.tar.gz"
+ tar -xzvf "v$VERSION.tar.gz"

--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -2,14 +2,26 @@
   lib,
   llvmPackages_18,
   fetchFromGitHub,
+  fetchurl,
   makeBinaryWrapper,
   which,
+  cmake,
   nix-update-script,
+  enableBox2d ? true,
 }:
 
 let
   llvmPackages = llvmPackages_18;
   inherit (llvmPackages) stdenv;
+  box2dVersion = "3.1.1";
+  box2dTarball =
+    if enableBox2d then
+      fetchurl {
+        url = "https://github.com/erincatto/box2d/archive/refs/tags/v${box2dVersion}.tar.gz";
+        hash = "sha256-+275FLUPQxLX2SGmAOq8EjGLs8VaC4wLkGCPpEiO8uQ=";
+      }
+    else
+      null;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "odin";
@@ -29,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     # available on Nix based systems. Instead, use the "system" Raylib version,
     # which can be provided by a pure Nix expression, for example in a shell.
     ./system-raylib.patch
+    ./box2d-no-network.patch
   ];
 
   postPatch = ''
@@ -53,6 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeBinaryWrapper
     which
+    cmake
   ];
 
   installPhase = ''
@@ -81,6 +95,9 @@ stdenv.mkDerivation (finalAttrs: {
     make -C "$out/share/vendor/cgltf/src/"
     make -C "$out/share/vendor/stb/src/"
     make -C "$out/share/vendor/miniaudio/src/"
+    if [ "${lib.boolToString enableBox2d}" = "true" ]; then
+      BOX2D_TARBALL=${box2dTarball} BOX2D_VERSION=${box2dVersion} bash $out/share/vendor/box2d/build_box2d.sh
+    fi
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Things done

~~This PR builds on top of https://github.com/NixOS/nixpkgs/pull/501374~~

The box2d vendor package downloads its own version of box2d, this patches the build script to handle the management of the box2d source via nix and makes building so it optional. Resolves #373413

With this patch applied I can successfully build this demo project https://github.com/atomicptr/odin-raylib-box2d which was impossible previously

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
