### PR TITLE
rido: init at 0.7.0

### DIFF
--- a/pkgs/by-name/ri/rido/package.nix
+++ b/pkgs/by-name/ri/rido/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rido";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "lj3954";
+    repo = "rido";
+    rev = "a731341207d5886b43322a0f5b46692ad9a2a739";
+    hash = "sha256-VQldNVyDoKCqfUVjuhZj4dOcmxUSK446XtpgDg6G0CY=";
+  };
+
+  cargoHash = "sha256-2bfODjw+JHrX8kHvr09+DGV1Ntvt9aacSdyVZlvQc/g=";
+
+  meta = {
+    description = "Fetch valid URLs and checksums of Microsoft Operating Systems";
+    homepage = "https://github.com/lj3954/rido";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "rido";
+    maintainers = with lib.maintainers; [ stv0g ];
+  };
+})


### PR DESCRIPTION
https://github.com/lj3954/rido

Rido is a library crate which allows applications access to valid URLs and Checksums for various releases of Microsoft Windows. It is inspired by the [Mido](https://github.com/ElliotKillick/Mido) bash script and [Fido](https://github.com/pbatard/Fido) PowerShell script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
