### PR TITLE
chirpstack-gateway-mesh: init at 4.1.3

### DIFF
--- a/pkgs/by-name/ch/chirpstack-gateway-mesh/package.nix
+++ b/pkgs/by-name/ch/chirpstack-gateway-mesh/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+  protobuf,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "chirpstack-gateway-mesh";
+  version = "4.1.3";
+
+  src = fetchFromGitHub {
+    owner = "chirpstack";
+    repo = "chirpstack-gateway-mesh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-t4W2G8NzVvcGp6nmCn4Wt9OUR9c7yceKdhDFb/RAk20=";
+  };
+
+  cargoHash = "sha256-3292/Q9OCoxkIOgOwAle37Ltozt1CDGGeXw6lqT91kU=";
+
+  nativeBuildInputs = [ protobuf ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Turn LoRa gateways into relays for extending the range of LoRa networks";
+    homepage = "https://www.chirpstack.io";
+    changelog = "https://github.com/chirpstack/chirpstack-gateway-mesh/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.stv0g ];
+    platforms = lib.platforms.linux;
+    mainProgram = "chirpstack-gateway-mesh";
+  };
+})


### PR DESCRIPTION
ChirpStack Gateway Mesh is a software component that can turn a LoRa® gateway into a relay. This makes it possible to extend the LoRa coverage, without the need to connect each LoRa gateway to the internet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
