### PR TITLE
itgmania: add new package scope for themes, update to 1.2.1

### DIFF
--- a/pkgs/by-name/it/itgmania/package.nix
+++ b/pkgs/by-name/it/itgmania/package.nix
@@ -19,6 +19,7 @@
   udev,
   makeWrapper,
   makeDesktopItem,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -82,6 +83,8 @@ stdenv.mkDerivation (finalAttrs: {
       ];
     })
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://www.itgmania.com/";

--- a/pkgs/by-name/it/itgmania/package.nix
+++ b/pkgs/by-name/it/itgmania/package.nix
@@ -91,6 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       ftsimas
       maxwell-lt
+      ungeskriptet
     ];
     mainProgram = "itgmania";
   };

--- a/pkgs/by-name/it/itgmania/package.nix
+++ b/pkgs/by-name/it/itgmania/package.nix
@@ -1,101 +1,23 @@
 {
-  lib,
-  stdenv,
-  fetchFromGitHub,
-  cmake,
-  nasm,
-  pkg-config,
-  copyDesktopItems,
-  alsa-lib,
-  glew,
-  glib,
-  gtk3,
-  libmad,
-  libogg,
-  libpulseaudio,
-  libusb-compat-0_1,
-  libvorbis,
-  libxtst,
-  udev,
+  symlinkJoin,
   makeWrapper,
-  makeDesktopItem,
-  nix-update-script,
+  itgmaniaPackages,
+  extraPackages ? [ ],
 }:
+let
+  unwrapped = itgmaniaPackages.itgmania-unwrapped;
+in
+symlinkJoin {
+  inherit (unwrapped) pname version meta;
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "itgmania";
-  version = "1.2.0";
+  paths = [ unwrapped ] ++ extraPackages;
 
-  src = fetchFromGitHub {
-    owner = "itgmania";
-    repo = "itgmania";
-    tag = "v${finalAttrs.version}";
-    fetchSubmodules = true;
-    hash = "sha256-RkV/OIDudt2XemhaFRY7IA5o7Q2w+j01tauD7KpzYpA=";
-  };
+  nativeBuildInputs = [ makeWrapper ];
 
-  nativeBuildInputs = [
-    cmake
-    nasm
-    pkg-config
-    makeWrapper
-    copyDesktopItems
-  ];
-
-  buildInputs = [
-    alsa-lib
-    glew
-    glib
-    gtk3
-    libmad
-    libogg
-    libpulseaudio
-    libusb-compat-0_1
-    libvorbis
-    libxtst
-    udev
-  ];
-
-  cmakeFlags = lib.optionals (!stdenv.hostPlatform.isx86) [ "-DWITH_MINIMAID=off" ];
-
-  postInstall = ''
+  postBuild = ''
     makeWrapper $out/itgmania/itgmania $out/bin/itgmania \
       --chdir $out/itgmania
-
-    mkdir -p $out/share/icons/hicolor/scalable/apps/
-    ln -s $out/itgmania/Data/logo.svg $out/share/icons/hicolor/scalable/apps/itgmania.svg
   '';
 
-  desktopItems = [
-    (makeDesktopItem {
-      name = "itgmania";
-      desktopName = "ITGmania";
-      genericName = "Rhythm and dance game";
-      tryExec = "itgmania";
-      exec = "itgmania";
-      terminal = false;
-      icon = "itgmania";
-      type = "Application";
-      comment = "A cross-platform rhythm video game.";
-      categories = [
-        "Game"
-        "ArcadeGame"
-      ];
-    })
-  ];
-
-  passthru.updateScript = nix-update-script { };
-
-  meta = {
-    homepage = "https://www.itgmania.com/";
-    description = "Fork of StepMania 5.1, improved for the post-ITG community";
-    platforms = lib.platforms.linux;
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      ftsimas
-      maxwell-lt
-      ungeskriptet
-    ];
-    mainProgram = "itgmania";
-  };
-})
+  passthru.unwrapped = unwrapped;
+}

--- a/pkgs/by-name/it/itgmania/packages.nix
+++ b/pkgs/by-name/it/itgmania/packages.nix
@@ -1,0 +1,10 @@
+{ lib, newScope }:
+lib.makeScope newScope (self: {
+  itgmania-unwrapped = self.callPackage ./unwrapped.nix { };
+  # Themes
+  arrowcloud-theme = self.callPackage ./themes/arrowcloud-theme.nix { };
+  digital-dance = self.callPackage ./themes/digital-dance.nix { };
+  itg2-sm5 = self.callPackage ./themes/itg2-sm5.nix { };
+  itg3encore = self.callPackage ./themes/itg3encore.nix { };
+  zmod-simply-love = self.callPackage ./themes/zmod-simply-love.nix { };
+})

--- a/pkgs/by-name/it/itgmania/themes/arrowcloud-theme.nix
+++ b/pkgs/by-name/it/itgmania/themes/arrowcloud-theme.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "arrowcloud-theme";
+  version = "20260328";
+
+  src = fetchFromGitHub {
+    owner = "Arrow-Cloud";
+    repo = "theme";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9BND3IUIc5uMBxzw+Pn/59jBKBK/xGWrOIgcIYIQvgk=";
+  };
+
+  postInstall = ''
+    mkdir -p "$out/itgmania/Themes/Arrow Cloud"
+    mv * "$out/itgmania/Themes/Arrow Cloud"
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+
+  meta = {
+    description = "Arrow Cloud's fork of Zmod";
+    homepage = "https://github.com/Arrow-Cloud/theme";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+  };
+})

--- a/pkgs/by-name/it/itgmania/themes/digital-dance.nix
+++ b/pkgs/by-name/it/itgmania/themes/digital-dance.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenv,
+  fetchFromCodeberg,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "digital-dance";
+  version = "1.1.3-unstable-2026-04-19";
+
+  src = fetchFromCodeberg {
+    owner = "JNero";
+    repo = "Digital-Dance-ITGMania";
+    rev = "bfce7a6d719189a3eec1577b54256941e8d602a5";
+    hash = "sha256-yrXdU73Jokm+nMMi8mtxdEL5+xuFj4sHIW+/nulcJJI=";
+  };
+
+  postInstall = ''
+    mkdir -p "$out/itgmania/Themes/Digital Dance"
+    mv * "$out/itgmania/Themes/Digital Dance"
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Theme for ITGMania to (hopefully) utilize all of it's features and more";
+    homepage = "https://codeberg.org/JNero/Digital-Dance-ITGMania";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+  };
+})

--- a/pkgs/by-name/it/itgmania/themes/itg2-sm5.nix
+++ b/pkgs/by-name/it/itgmania/themes/itg2-sm5.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "itg2-sm5";
+  version = "1.1.0-unstable-2025-10-08";
+
+  src = fetchFromGitHub {
+    owner = "JoseVarelaP";
+    repo = "In-The-Groove2-SM5";
+    rev = "e25f1a44efa55cd2247891f40633403910b75d21";
+    hash = "sha256-FMyT7ZA/1cqiClXDvD7CmJlOFaaWnPLuOuei6fsbzg8=";
+  };
+
+  postInstall = ''
+    mkdir -p "$out/itgmania/Themes/ITG2-SM5"
+    mv * "$out/itgmania/Themes/ITG2-SM5"
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Semi-Conversion/Recreation of In The Groove 1 & 2 to StepMania 5";
+    homepage = "https://github.com/JoseVarelaP/In-The-Groove2-SM5";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+  };
+})

--- a/pkgs/by-name/it/itgmania/themes/itg3encore.nix
+++ b/pkgs/by-name/it/itgmania/themes/itg3encore.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "itg3encore";
+  version = "0-unstable-2026-04-21";
+
+  src = fetchFromGitHub {
+    owner = "DarkBahamut162";
+    repo = "itg3encore";
+    rev = "bb9e9bb9bfb09ba7df586d5b5cc1f4813bbea8e7";
+    hash = "sha256-dih1MeORhNgh3pV7eQLsbhnkiVIE7rQnIWWJFALHoG0=";
+  };
+
+  postInstall = ''
+    mkdir -p "$out/itgmania/Themes/ITG3Encore"
+    mv * "$out/itgmania/Themes/ITG3Encore"
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "An upgraded port of ITG3's Encore theme";
+    homepage = "https://github.com/DarkBahamut162/itg3encore";
+    # https://github.com/DarkBahamut162/itg3encore/issues/16
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+  };
+})

--- a/pkgs/by-name/it/itgmania/themes/zmod-simply-love.nix
+++ b/pkgs/by-name/it/itgmania/themes/zmod-simply-love.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zmod-simply-love";
+  version = "5.8.1-april";
+
+  src = fetchFromGitHub {
+    owner = "zarzob";
+    repo = "Simply-Love-SM5";
+    tag = finalAttrs.version;
+    hash = "sha256-4EkCR9M8xip2b8ddWyUIom2HM72Ba8KdVodIyc5h4p8=";
+  };
+
+  postInstall = ''
+    mkdir -p "$out/itgmania/Themes/Zmod Simply Love"
+    mv * "$out/itgmania/Themes/Zmod Simply Love"
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+
+  meta = {
+    description = "Zmod fork of Simply Love";
+    homepage = "https://github.com/zarzob/Simply-Love-SM5";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      maxwell-lt
+      ungeskriptet
+    ];
+  };
+})

--- a/pkgs/by-name/it/itgmania/unwrapped.nix
+++ b/pkgs/by-name/it/itgmania/unwrapped.nix
@@ -54,7 +54,11 @@ stdenv.mkDerivation (finalAttrs: {
     udev
   ];
 
-  cmakeFlags = lib.optionals (!stdenv.hostPlatform.isx86) [ "-DWITH_MINIMAID=off" ];
+  cmakeFlags = [
+    "-DWITH_FULL_RELEASE=on"
+    "-DWITH_NIGHTLY_RELEASE=off"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isx86) [ "-DWITH_MINIMAID=off" ];
 
   postInstall = ''
     mkdir -p $out/share/icons/hicolor/scalable/apps/

--- a/pkgs/by-name/it/itgmania/unwrapped.nix
+++ b/pkgs/by-name/it/itgmania/unwrapped.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  nasm,
+  pkg-config,
+  copyDesktopItems,
+  alsa-lib,
+  glew,
+  glib,
+  gtk3,
+  libmad,
+  libogg,
+  libpulseaudio,
+  libusb-compat-0_1,
+  libvorbis,
+  libxtst,
+  udev,
+  makeDesktopItem,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "itgmania";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "itgmania";
+    repo = "itgmania";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-RkV/OIDudt2XemhaFRY7IA5o7Q2w+j01tauD7KpzYpA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    nasm
+    pkg-config
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    alsa-lib
+    glew
+    glib
+    gtk3
+    libmad
+    libogg
+    libpulseaudio
+    libusb-compat-0_1
+    libvorbis
+    libxtst
+    udev
+  ];
+
+  cmakeFlags = lib.optionals (!stdenv.hostPlatform.isx86) [ "-DWITH_MINIMAID=off" ];
+
+  postInstall = ''
+    mkdir -p $out/share/icons/hicolor/scalable/apps/
+    ln -s $out/itgmania/Data/logo.svg $out/share/icons/hicolor/scalable/apps/itgmania.svg
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "itgmania";
+      desktopName = "ITGmania";
+      genericName = "Rhythm and dance game";
+      tryExec = "itgmania";
+      exec = "itgmania";
+      terminal = false;
+      icon = "itgmania";
+      type = "Application";
+      comment = "A cross-platform rhythm video game.";
+      categories = [
+        "Game"
+        "ArcadeGame"
+      ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://www.itgmania.com/";
+    description = "Fork of StepMania 5.1, improved for the post-ITG community";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      ftsimas
+      maxwell-lt
+      ungeskriptet
+    ];
+    mainProgram = "itgmania";
+  };
+})

--- a/pkgs/by-name/it/itgmania/unwrapped.nix
+++ b/pkgs/by-name/it/itgmania/unwrapped.nix
@@ -23,14 +23,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "itgmania";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "itgmania";
     repo = "itgmania";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-RkV/OIDudt2XemhaFRY7IA5o7Q2w+j01tauD7KpzYpA=";
+    hash = "sha256-bTABfTflWasuXvX+YPciUIICAFVROk/SgeClgrTUjkQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6642,6 +6642,8 @@ with pkgs;
     '';
   });
 
+  itgmaniaPackages = recurseIntoAttrs (callPackage ../by-name/it/itgmania/packages.nix { });
+
   itk_5_2 = callPackage ../development/libraries/itk/5.2.x.nix {
     enableRtk = false;
   };


### PR DESCRIPTION
These commits introduce a new package scope (`itgmaniaPackages`), which can be used to group together themes and other extensions for the game. To achieve configuring ITGmania declaratively, we can override the extraPackages argument of the ITGmania package using a list of packages. I had to wrap ITGmania with symlinkJoin to avoid rebuilding the entire package. 

Can be tested using
```
nix-shell -p 'with import (builtins.fetchTarball "https://github.com/ungeskriptet/nixpkgs/archive/itgmania-packages.tar.gz") { }; itgmania.override { extraPackages = with itgmaniaPackages; [ arrowcloud-theme itg2-sm5 itg3encore zmod-simply-love ]; }' --run 'itgmania'
```

@rehtlaw Are there any other themes or extensions I should package for ITGmania?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
