### PR TITLE
security-ca: make ca bundle overrideable via internal option

### DIFF
--- a/nixos/modules/security/ca.nix
+++ b/nixos/modules/security/ca.nix
@@ -94,6 +94,11 @@ in
         (Read-only) the path to the final bundle of certificate authorities as a single file.
       '';
     };
+
+    security.pki.caBundlePackage = lib.mkOption {
+      type = lib.types.path;
+      internal = true;
+    };
   };
 
   config = lib.mkMerge [
@@ -111,7 +116,10 @@ in
       # P11-Kit trust source.
       environment.etc."ssl/trust-source".source = "${cacertPackage.p11kit}/etc/ssl/trust-source";
     })
-    { security.pki.caBundle = caBundle; }
+    {
+      security.pki.caBundlePackage = caBundle;
+      security.pki.caBundle = cfg.caBundlePackage;
+    }
   ];
 
 }


### PR DESCRIPTION
Added an internal option `security.pki.caBundlePackage` that allows to override the `security.pki.caBundle` option. This is so that the prior option still remains `readOnly` as it should be used that way 99% of the time while also allowing to override it when the user is 100% sure of what they're doing.

This would allow me to generate the bundle on activation time (or via systemd service but my usecase is activation time because I'm setting it from a `sops-nix` secret path) and set its path to the generated one for use in other modules.

I don't think this needs any further testing because it doesn't make any actual changes in any NixOS system config but I will test if requested.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
