### PR TITLE
nix-prefetch-darcs: print status to stderr; fetchdarcs: --no-cache in sandbox

### DIFF
--- a/pkgs/build-support/fetchdarcs/builder.sh
+++ b/pkgs/build-support/fetchdarcs/builder.sh
@@ -20,7 +20,7 @@ set -o noglob
 success=
 for repository in $repositories; do
     echo "Trying to clone $repository $tagtext into $out …"
-    if darcs clone --lazy $tagflags "$repository" "$out"; then
+    if darcs clone --lazy --no-cache $tagflags "$repository" "$out"; then
         # remove metadata, because it can change
         rm -rf "$out/_darcs"
         success=1

--- a/pkgs/build-support/fetchdarcs/nix-prefetch-darcs
+++ b/pkgs/build-support/fetchdarcs/nix-prefetch-darcs
@@ -27,7 +27,7 @@ usage() {
 while [ $# -gt 0 ]; do
 	case "$1" in
 		--quiet)
-		  quiet=1; shift 1 ;;
+			quiet=1; shift 1 ;;
 		--name)
 			name="$2"; shift 2 ;;
 		--repo)
@@ -127,11 +127,7 @@ if [ -z "$final_path" ]; then
 
 	cd "$tmp_clone"
 	# Do not print Darcs progress to stdout (else stdout isn’t parsable JSON)
-	if [ -t 1 ]; then
-		darcs clone $clone_args "$repository" "$name" >/dev/tty
-	else
-		darcs clone $clone_args "$repository" "$name" >/dev/null
-	fi
+	darcs clone "$clone_args" "$repository" "$name" 1>&2
 	# Will put the current Darcs context into the store.
 	new_context="$tmp_clone/${name}-context.txt"
 	darcs log --repodir="$tmp_clone/$name" --context > "$new_context"


### PR DESCRIPTION
 • /dev/tty can’t be redirected & could be useful for debugging
 • Darcs will not be able to even reach the cache in the sandbox anyhow
 • also fix up 1 mismatching indentation

```console
$ result/bin/nix-prefetch-darcs https://darcs.toastal.in.th/pl-pretty | jq
Finished cloning.        
{
  "repository": "https://darcs.toastal.in.th/pl-pretty",
  "weak-hash": "57acac26c478f6c1b7e4a02ecc015df1c791c6dd",
  "context": "/nix/store/2025hvjcwbzfg31ij1h6lgspq28k7kq9-fetchdarcs-context.txt",
  "date": "2026-01-30T18:02:27Z",
  "path": "/nix/store/xx66jdkb0a9hrb8brnrps7kfqbz3dali-fetchdarcs",
  "sha256": "1cjhmpv02n7w0cnhc82kbi4slblj0hfjvazzdkz75m5rm0z2962f",
  "hash": "sha256-TpgkPqi51HL+bP+rLR0Eki6qSVxTIAYtA/xYAfatULI="
}
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.