### PR TITLE
sudoku: init at 1.6.1

### DIFF
--- a/pkgs/by-name/su/sudoku/package.nix
+++ b/pkgs/by-name/su/sudoku/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  blueprint-compiler,
+  desktop-file-utils,
+  fetchFromGitHub,
+  gtk4,
+  libadwaita,
+  meson,
+  ninja,
+  python3,
+  stdenv,
+  wrapGAppsHook4,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sudoku";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "sepehr-rs";
+    repo = "Sudoku";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xO/UlRGkfFwU8IGA5e5/wRHbWgMqXW/IDHL4GzwFDjk=";
+  };
+
+  nativeBuildInputs = [
+    blueprint-compiler
+    desktop-file-utils
+    meson
+    ninja
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    (python3.withPackages (
+      ps: with ps; [
+        pygobject3
+        sudoku-engine
+      ]
+    ))
+  ];
+
+  meta = {
+    description = "A modern Sudoku app built with Python, GTK4 and libadwaita";
+    changelog = "https://github.com/sepehr-rs/Sudoku/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/sepehr-rs/Sudoku";
+    license = lib.licenses.gpl3Plus;
+    teams = [ lib.teams.gnome-circle ];
+    mainProgram = "sudokugame";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/sudoku-engine/default.nix
+++ b/pkgs/development/python-modules/sudoku-engine/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  wheel,
+}:
+
+buildPythonPackage rec {
+  pname = "sudoku-engine";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "sudoku_engine";
+    inherit version;
+    hash = "sha256-5SjxeztClL/jL3bhCG1LoXyv0Op2DuA22qDKzX2Xa0M=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  pythonImportsCheck = [
+    "sudoku"
+  ];
+
+  meta = {
+    description = "A simple Python package that generates and solves m x n Sudoku puzzles";
+    homepage = "https://pypi.org/project/sudoku-engine/";
+    teams = [ lib.teams.gnome-circle ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18691,6 +18691,8 @@ self: super: with self; {
 
   sudachipy = callPackage ../development/python-modules/sudachipy { };
 
+  sudoku-engine = callPackage ../development/python-modules/sudoku-engine { };
+
   suds = callPackage ../development/python-modules/suds { };
 
   suds-community = callPackage ../development/python-modules/suds-community { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [Sudoku](https://apps.gnome.org/Sudoku/), a GNOME Circle app for playing games of Sudoku.
Also adds [sudoku-engine](https://pypi.org/project/sudoku-engine/), a Python library from the same developer used as the backend for the app.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
