### PR TITLE
awscli2: 2.33.2 -> 2.34.24

### DIFF
--- a/pkgs/by-name/aw/awscli2/package.nix
+++ b/pkgs/by-name/aw/awscli2/package.nix
@@ -54,28 +54,29 @@ let
 in
 py.pkgs.buildPythonApplication rec {
   pname = "awscli2";
-  version = "2.33.2"; # N.B: if you change this, check if overrides are still up-to-date
+  version = "2.34.24"; # N.B: if you change this, check if overrides are still up-to-date
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-cli";
     tag = version;
-    hash = "sha256-dAtcYDdrZASrwBjQfnZ4DUR4F5WhY59/UX92QcILavs=";
+    hash = "sha256-PDoztQYKfH6FjdSyMQGsT8No3LB56naQ/AxTPN/dslQ=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail 'flit_core>=3.7.1,<3.9.1' 'flit_core>=3.7.1' \
+      --replace-fail 'flit_core>=3.7.1,<3.12.1' 'flit_core>=3.7.1' \
       --replace-fail 'awscrt==' 'awscrt>=' \
       --replace-fail 'distro>=1.5.0,<1.9.0' 'distro>=1.5.0' \
       --replace-fail 'docutils>=0.10,<0.20' 'docutils>=0.10' \
       --replace-fail 'prompt-toolkit>=3.0.24,<3.0.52' 'prompt-toolkit>=3.0.24' \
-      --replace-fail 'ruamel.yaml>=0.15.0,<=0.17.21' 'ruamel.yaml>=0.15.0' \
-      --replace-fail 'ruamel.yaml.clib>=0.2.0,<=0.2.12' 'ruamel.yaml.clib>=0.2.0'
+      --replace-fail 'ruamel_yaml>=0.15.0,<=0.19.1' 'ruamel_yaml>=0.15.0' \
+      --replace-fail 'ruamel_yaml_clib>=0.2.0,<=0.2.15' 'ruamel_yaml_clib>=0.2.0' \
+      --replace-fail 'wcwidth<0.3.0' 'wcwidth>=0.3.0'
 
     substituteInPlace requirements-base.txt \
-      --replace-fail "wheel==0.43.0" "wheel>=0.43.0"
+      --replace-fail "wheel==0.46.3" "wheel>=0.46.3"
 
     # Upstream needs pip to build and install dependencies and validates this
     # with a configure script, but we don't as we provide all of the packages

--- a/pkgs/development/python-modules/awscrt/default.nix
+++ b/pkgs/development/python-modules/awscrt/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "awscrt";
-  version = "0.31.1";
+  version = "0.31.3";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-q7ZHaNJb9WPajiFl1Hekkcuhi8IsTsjbesva6U5Z68Q=";
+    hash = "sha256-FswDgO7wc6Ljfv8BqY8/IQjq1tu0qRnUD2VtsNitS3E=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
https://github.com/aws/aws-cli/compare/2.33.2...2.34.24

- bump `python3Packages.awscrt` to meet dependency

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
