### PR TITLE
consumo: init at 0.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9486,6 +9486,13 @@
     githubId = 16470252;
     name = "Gemini Lasswell";
   };
+  gbr-ufs = {
+    email = "gabriel.santosdesouza@dcomp.ufs.br";
+    github = "gbr-ufs";
+    githubId = 211904116;
+    keys = [ { fingerprint = "6A38 69D1 3C11 18A3 B80E  60DC 34BF 0A88 061E 363F"; } ];
+    name = "Gabriel Santos de Souza";
+  };
   gbtb = {
     email = "goodbetterthebeast3@gmail.com";
     github = "gbtb";

--- a/pkgs/by-name/co/consumo/package.nix
+++ b/pkgs/by-name/co/consumo/package.nix
@@ -1,0 +1,63 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "consumo";
+  version = "0.13.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "gbr-ufs";
+    repo = "consumo";
+    tag = finalAttrs.version;
+    hash = "sha256-qVvXD7JaaCwVL9WV6SeIN2j5HLEotYEi+X6cYUJxL0Q=";
+  };
+
+  build-system = [ python3Packages.uv-build ];
+
+  dependencies = with python3Packages; [
+    av
+    beautifulsoup4
+    brotli
+    lxml
+    pydantic
+    pymupdf
+    python-magic
+    trafilatura
+    typer
+    yt-dlp
+    zstandard
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  /*
+    False positive from pythonRuntimeDepsCheckHook:
+      - "bs4" is the import name for beautifulsoup4 (not the PyPI
+        package name)
+  */
+  pythonRemoveDeps = [
+    "bs4"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    changelog = "https://github.com/gbr-ufs/consumo/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Content consumption analyzer CLI";
+    homepage = "https://gbr-ufs.github.io/consumo/";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "consumo";
+    maintainers = with lib.maintainers; [ gbr-ufs ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3180,6 +3180,8 @@ self: super: with self; {
 
   consul = callPackage ../development/python-modules/consul { };
 
+  consumo = toPythonModule (pkgs.consumo.override { python3Packages = self; });
+
   container-inspector = callPackage ../development/python-modules/container-inspector { };
 
   contexter = callPackage ../development/python-modules/contexter { };


### PR DESCRIPTION
[consumo](https://gbr-ufs.github.io/consumo/) is a CLI I wrote to measure the time it would take to consume a piece of media based on [the Medium formula](https://mediumcourse.com/how-is-medium-article-read-time-calculated/).

It's not perfect yet, but I think that [dogfooding](https://en.wikipedia.org/wiki/Eating_your_own_dog_food) it by having it as a package will help me clean up the rough edges.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
