### PR TITLE
opencode-claude-auth: init at 0.5.5

### DIFF
--- a/pkgs/by-name/op/opencode-claude-auth/package.nix
+++ b/pkgs/by-name/op/opencode-claude-auth/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "opencode-claude-auth";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "griffinmartin";
+    repo = "opencode-claude-auth";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ntqMpyXOyOvtZVbe5nZmQ3COxW3kM7IG8CCUbGWYYEk=";
+  };
+
+  npmDepsHash = "sha256-j4h/PUVWcgW9XRnaUqpMSdfb9TZtQfp1cOfxwG4FX5A=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "OpenCode plugin that uses your existing Claude Code credentials";
+    homepage = "https://github.com/griffinmartin/opencode-claude-auth";
+    changelog = "https://github.com/griffinmartin/opencode-claude-auth/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [opencode-claude-auth](https://github.com/griffinmartin/opencode-claude-auth).

Context: https://github.com/anomalyco/opencode/pull/18186

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
