### PR TITLE
yaziPlugins: update on 2026-03-19

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/compress/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/compress/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "compress.yazi";
-  version = "25.12.29-unstable-2026-01-24";
+  version = "25.12.29-unstable-2026-03-15";
 
   src = fetchFromGitHub {
     owner = "KKV9";
     repo = "compress.yazi";
-    rev = "cb6e8ec0141915dc319ccd6b904dcd2f03502576";
-    hash = "sha256-D/EpcRDIc3toeyjHqi+vGw0v9B22HVvKJua5EVEAc0U=";
+    rev = "46a6b9f02ff2f8aced466a1f01a3fe241f1cd45f";
+    hash = "sha256-Mby185FCJY6nqHcHDQu+D5SLk+wGcyeUHK8yAvrd4TM=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/lazygit/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/lazygit/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "lazygit.yazi";
-  version = "0-unstable-2025-12-31";
+  version = "0-unstable-2026-03-12";
 
   src = fetchFromGitHub {
     owner = "Lil-Dank";
     repo = "lazygit.yazi";
-    rev = "0e56060192d1ccd307664bf93b3d0beb1efe528e";
-    hash = "sha256-LcEpzSf0E43hnhOxJ/EHNJRk3Au5hcgRZ2Kj412Ykew=";
+    rev = "8c4086c813c5856ab9571ae9142ed7d40ed3211e";
+    hash = "sha256-YpRWnR5fEXzHY9yBFNKy1NvTzHa8B1UhS2Qrfe9+Tpg=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "26.1.22-unstable-2026-03-08";
+  version = "26.1.22-unstable-2026-03-17";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "6fbed8d3b34e2f72a52a481ea1461db112ea835d";
-    hash = "sha256-wmUseJ1li+J3euxtYtImIQ/NmbyAp8HhRZscC7Pib9s=";
+    rev = "26a75daabe768347d45aa65be4c75cfb15772ef2";
+    hash = "sha256-tE/ov1lF/bxxVCH00dXuWcjyjYkNpqeiMb0eIZ8Nwj4=";
   };
 
   meta = {


### PR DESCRIPTION
- compress: 25.12.29-unstable-2026-01-24 → 25.12.29-unstable-2026-03-15
  Compare: https://github.com/KKV9/compress.yazi/compare/cb6e8ec0141915dc319ccd6b904dcd2f03502576...46a6b9f02ff2f8aced466a1f01a3fe241f1cd45f
- lazygit: 0-unstable-2025-12-31 → 0-unstable-2026-03-12
  Compare: https://github.com/Lil-Dank/lazygit.yazi/compare/0e56060192d1ccd307664bf93b3d0beb1efe528e...8c4086c813c5856ab9571ae9142ed7d40ed3211e
- mediainfo: 26.1.22-unstable-2026-03-08 → 26.1.22-unstable-2026-03-17
  Compare: https://github.com/boydaihungst/mediainfo.yazi/compare/6fbed8d3b34e2f72a52a481ea1461db112ea835d...26a75daabe768347d45aa65be4c75cfb15772ef2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
