### PR TITLE
qogir-icon-theme: 2025-02-15 -> 0-unstable-2025-11-04

### DIFF
--- a/pkgs/by-name/qo/qogir-icon-theme/2026-03-20-missing-icons.patch
+++ b/pkgs/by-name/qo/qogir-icon-theme/2026-03-20-missing-icons.patch
@@ -1,0 +1,16 @@
+diff --git a/src/symbolic/status/audio-input-microphone-symbolic.svg b/src/symbolic/status/audio-input-microphone-symbolic.svg
+new file mode 120000
+index 00000000..87887c28
+--- /dev/null
++++ b/src/symbolic/status/audio-input-microphone-symbolic.svg
+@@ -0,0 +1 @@
++../devices/audio-input-microphone-symbolic.svg
+\ No newline at end of file
+diff --git a/src/symbolic/status/microphone-sensitivity-muted-symbolic.svg b/src/symbolic/status/microphone-sensitivity-muted-symbolic.svg
+new file mode 120000
+index 00000000..0f3dee8d
+--- /dev/null
++++ b/src/symbolic/status/microphone-sensitivity-muted-symbolic.svg
+@@ -0,0 +1 @@
++../../24/panel/microphone-sensitivity-muted-symbolic.svg
+\ No newline at end of file

--- a/pkgs/by-name/qo/qogir-icon-theme/package.nix
+++ b/pkgs/by-name/qo/qogir-icon-theme/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  gitUpdater,
+  unstableGitUpdater,
   gtk3,
   hicolor-icon-theme,
   jdupes,
@@ -21,15 +21,15 @@ lib.checkListOfEnum "${pname}: color variants" [ "standard" "dark" "all" ] color
   themeVariants
 
   stdenvNoCC.mkDerivation
-  rec {
+  {
     inherit pname;
-    version = "2025-02-15";
+    version = "0-unstable-2025-11-04";
 
     src = fetchFromGitHub {
       owner = "vinceliuice";
       repo = "qogir-icon-theme";
-      rev = version;
-      hash = "sha256-Eh4TWoFfArFmpM/9tkrf2sChQ0zzOZJE9pElchu8DCM=";
+      rev = "c633057ba0d27a504b3255144071c9691ed0264a";
+      hash = "sha256-VJHhyKk1f/25CNkqNM7+WQqQRdqBNgWD3XrJ+whOcd0=";
     };
 
     nativeBuildInputs = [
@@ -44,6 +44,10 @@ lib.checkListOfEnum "${pname}: color variants" [ "standard" "dark" "all" ] color
     # These fixup steps are slow and unnecessary.
     dontPatchELF = true;
     dontRewriteSymlinks = true;
+
+    patches = [
+      ./2026-03-20-missing-icons.patch
+    ];
 
     postPatch = ''
       patchShebangs install.sh
@@ -64,7 +68,7 @@ lib.checkListOfEnum "${pname}: color variants" [ "standard" "dark" "all" ] color
       runHook postInstall
     '';
 
-    passthru.updateScript = gitUpdater { };
+    passthru.updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
 
     meta = {
       description = "Flat colorful design icon theme";


### PR DESCRIPTION
## Things done

Since 2025-02-15 there have been [commits](https://github.com/vinceliuice/Qogir-icon-theme/compare/2025-02-15..master), but no new releases, hence the switch to the `0-unstable-<date>` scheme, similar to [qogir-kde](https://github.com/NixOS/nixpkgs/blob/8782ca90fbe694361313f528b0761a7c20475a63/pkgs/by-name/qo/qogir-kde/package.nix).

Also, there's an [upstream issue](https://github.com/vinceliuice/Qogir-icon-theme/issues/170) with missing icons. I added a patch.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
