### PR TITLE
electron{,-bin,-chromedriver}: 38 -> 41

### DIFF
--- a/pkgs/by-name/lo/logseq/bump-better-sqlite3.patch
+++ b/pkgs/by-name/lo/logseq/bump-better-sqlite3.patch
@@ -1,5 +1,18 @@
+diff --git a/resources/package.json b/resources/package.json
+index de39ccc..d42b7fb 100644
+--- a/resources/package.json
++++ b/resources/package.json
+@@ -25,7 +25,7 @@
+     "@logseq/rsapi": "0.0.92",
+     "@sentry/electron": "2.5.1",
+     "abort-controller": "3.0.0",
+-    "better-sqlite3": "12.4.1",
++    "better-sqlite3": "12.8.0",
+     "chokidar": "^3.5.1",
+     "command-exists": "1.2.9",
+     "diff-match-patch": "1.0.5",
 diff --git a/static/yarn.lock b/static/yarn.lock
-index 36b4476..0e7c5ee 100644
+index 36b4476..4738ef9 100644
 --- a/static/yarn.lock
 +++ b/static/yarn.lock
 @@ -1444,11 +1444,6 @@ ansi-regex@^5.0.1:
@@ -26,6 +39,21 @@ index 36b4476..0e7c5ee 100644
  anymatch@~3.1.2:
    version "3.1.3"
    resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
+@@ -1653,10 +1643,10 @@ baseline-browser-mapping@^2.8.25:
+   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.28.tgz#9ef511f5a7c19d74a94cafcbf951608398e9bdb3"
+   integrity sha512-gYjt7OIqdM0PcttNYP2aVrr2G0bMALkBaoehD4BuRGjAOtipg0b6wHg1yNL+s5zSnLZZrGHOw4IrND8CD+3oIQ==
+ 
+-better-sqlite3@12.4.1:
+-  version "12.4.1"
+-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.4.1.tgz#f78df6c80530d1a0b750b538033e6199b7d30d26"
+-  integrity sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==
++better-sqlite3@12.8.0:
++  version "12.8.0"
++  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.8.0.tgz#ec9ccd4a426a35f3b9355c147af6c92a6ddd6862"
++  integrity sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==
+   dependencies:
+     bindings "^1.5.0"
+     prebuild-install "^7.1.1"
 @@ -3081,11 +3071,6 @@ get-caller-file@^2.0.5:
    resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
    integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -54,7 +54,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     ./electron-forge-package-instead-of-make.patch
     ./electron-forge-disable-signing.patch
-    ./fix-yarn-lock.patch
+
+    # bumps better-sqlite3 to work with electron 39+
+    # also fixes outdated yarn.lock
+    ./bump-better-sqlite3.patch
   ];
 
   mavenRepo = stdenv.mkDerivation {
@@ -109,7 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
     name = "logseq-${finalAttrs.version}-yarn-deps-static-resources";
     inherit (finalAttrs) src patches;
     postPatch = "cd ./static";
-    hash = "sha256-zAGEQlOqKfPDrIoZQUnjBifgdYDYRsiHH7PUNrd0u+8=";
+    hash = "sha256-5DBVlCWlUXYvo0bJWQwvSNMW4P9E8kjE9RQe9/ViJM0=";
   };
 
   yarnOfflineCacheAmplify = fetchYarnDeps {

--- a/pkgs/by-name/sp/splayer/package.nix
+++ b/pkgs/by-name/sp/splayer/package.nix
@@ -21,6 +21,7 @@
 }:
 let
   electron = electron_39;
+  pnpm = pnpm_10_29_2;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "splayer";
@@ -40,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
       version
       src
       ;
-    pnpm = pnpm_10_29_2;
+    inherit pnpm;
     fetcherVersion = 2;
     hash = "sha256-PTfZopse+9RS7qh0miLu3duYlWDfifZS254tZKqgxKk=";
   };
@@ -56,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm_10_29_2
+    pnpm
     nodejs
     rustPlatform.cargoSetupHook
     cargo

--- a/pkgs/by-name/sp/splayer/package.nix
+++ b/pkgs/by-name/sp/splayer/package.nix
@@ -6,7 +6,7 @@
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
-  electron,
+  electron_39,
   rustPlatform,
   cargo,
   rustc,
@@ -19,6 +19,9 @@
   nix-update-script,
   removeReferencesTo,
 }:
+let
+  electron = electron_39;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "splayer";
   version = "3.0.0";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5460,9 +5460,9 @@ with pkgs;
     electron_40
     electron_41
     ;
-  electron = electron_38;
-  electron-bin = electron_38-bin;
-  electron-chromedriver = electron-chromedriver_38;
+  electron = electron_41;
+  electron-bin = electron_41-bin;
+  electron-chromedriver = electron-chromedriver_41;
 
   autoconf = callPackage ../development/tools/misc/autoconf { };
   autoconf269 = callPackage ../development/tools/misc/autoconf/2.69.nix { };


### PR DESCRIPTION
The default electron version is marked as insecure since https://github.com/NixOS/nixpkgs/pull/501574.

Previous: https://github.com/NixOS/nixpkgs/pull/445470
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I'm currently running nixpkgs-review.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
