### PR TITLE
gnome-manuals, goocanvas_{1,2,3}: fix updateScript attrPath

### DIFF
--- a/pkgs/by-name/gn/gnome-manuals/package.nix
+++ b/pkgs/by-name/gn/gnome-manuals/package.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = gnome.updateScript {
     packageName = "manuals";
+    attrPath = "gnome-manuals";
   };
 
   meta = {

--- a/pkgs/by-name/go/goocanvas_1/package.nix
+++ b/pkgs/by-name/go/goocanvas_1/package.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = gnome.updateScript {
+      attrPath = "goocanvas_${lib.versions.major finalAttrs.version}";
       packageName = "goocanvas";
       versionPolicy = "odd-unstable";
       freeze = true;

--- a/pkgs/by-name/go/goocanvas_2/package.nix
+++ b/pkgs/by-name/go/goocanvas_2/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = gnome.updateScript {
-      attrPath = "goocanvas${lib.versions.major finalAttrs.version}";
+      attrPath = "goocanvas_${lib.versions.major finalAttrs.version}";
       packageName = "goocanvas";
       versionPolicy = "odd-unstable";
       freeze = true;

--- a/pkgs/by-name/go/goocanvas_3/package.nix
+++ b/pkgs/by-name/go/goocanvas_3/package.nix
@@ -61,8 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = gnome.updateScript {
-      attrPath = "${finalAttrs.pname}_${lib.versions.major finalAttrs.version}";
-      packageName = finalAttrs.pname;
+      attrPath = "goocanvas_${lib.versions.major finalAttrs.version}";
+      packageName = "goocanvas";
       versionPolicy = "odd-unstable";
     };
   };

--- a/pkgs/by-name/go/goocanvas_3/package.nix
+++ b/pkgs/by-name/go/goocanvas_3/package.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = gnome.updateScript {
-      attrPath = "${finalAttrs.pname}${lib.versions.major finalAttrs.version}";
+      attrPath = "${finalAttrs.pname}_${lib.versions.major finalAttrs.version}";
       packageName = finalAttrs.pname;
       versionPolicy = "odd-unstable";
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

#480855 changed the name of the goocanvas packages without adjusting the updateScript's attrPath (cc @quantenzitrone)

#497761 added gnome-manuals but is missing the updateScript' attrPath to find this package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
