### PR TITLE
astro-language-server: include ts-plugin in package output

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9890,6 +9890,12 @@
     name = "Adrian Groh";
     keys = [ { fingerprint = "62BD BF30 83E9 7076 9665 B60B 3AA3 153E 98B0 D771"; } ];
   };
+  god464 = {
+    github = "god464";
+    githubId = 36400459;
+    name = "god464";
+    keys = [ { fingerprint = "089E 1560 7145 FE93 2C00  2942 D7A7 2706 FC8D E569"; } ];
+  };
   goertzenator = {
     email = "daniel.goertzen@gmail.com";
     github = "goertzenator";

--- a/pkgs/by-name/as/astro-language-server/package.nix
+++ b/pkgs/by-name/as/astro-language-server/package.nix
@@ -88,7 +88,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/withastro/astro/tree/main/packages/language-tools";
     changelog = "https://github.com/withastro/astro/blob/%40astrojs/language-server%40${finalAttrs.version}/packages/language-tools/language-server/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ miniharinn ];
+    maintainers = with lib.maintainers; [
+      miniharinn
+      god464
+    ];
     mainProgram = "astro-ls";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/as/astro-language-server/package.nix
+++ b/pkgs/by-name/as/astro-language-server/package.nix
@@ -20,7 +20,10 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   # https://pnpm.io/filtering#--filter-package_name-1
-  pnpmWorkspaces = [ "@astrojs/language-server..." ];
+  pnpmWorkspaces = [
+    "@astrojs/language-server..."
+    "@astrojs/ts-plugin"
+  ];
   prePnpmInstall = ''
     pnpm config set dedupe-peer-dependents false
     pnpm approve-builds @emmetio/css-parser
@@ -36,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_10;
     fetcherVersion = 2;
-    hash = "sha256-QJSFRJ3U7M0B7ukiU+BYY2KdrcNUpyiOcGA7G3xja3I=";
+    hash = "sha256-+5S/VuZjP6LoWUPKF1NMhw317AFAJUgaY7/Tq0ZKouw=";
   };
 
   nativeBuildInputs = [
@@ -50,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    pnpm --filter "@astrojs/language-server..." build
+    pnpm --filter "@astrojs/language-server..." --filter "@astrojs/ts-plugin" build
 
     runHook postBuild
   '';
@@ -63,11 +66,10 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm install --offline --prod --filter="@astrojs/language-server..."
     mkdir -p $out/{bin,lib/node_modules/astro-language-server/packages/language-tools}
     cp -r ./node_modules $out/lib/node_modules/astro-language-server
-    cp -r packages/language-tools/{language-server,yaml2ts} $out/lib/node_modules/astro-language-server/packages/language-tools/
+    cp -r packages/language-tools/{language-server,yaml2ts,ts-plugin} $out/lib/node_modules/astro-language-server/packages/language-tools/
     pushd $out/lib/node_modules/astro-language-server/node_modules
-    rm -rf {./,.pnpm/node_modules/}astro-{scripts,benchmark}
+    rm -rf {./,.pnpm/node_modules/}astro-{scripts,benchmark} .pnpm/node_modules/@astrojs/ts-plugin
     popd
-
     ln -s $out/lib/node_modules/astro-language-server/packages/language-tools/language-server/bin/nodeServer.js $out/bin/astro-ls
 
     runHook postInstall


### PR DESCRIPTION
This change adds the `ts-plugin` package. The package helps editors like Neovim correctly register the astro extension for `ts_ls`/`vtsls`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
