### PR TITLE
azure-devops-mcp: init at 2.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13149,6 +13149,11 @@
     githubId = 3170771;
     name = "Jo Vandeginste";
   };
+  Jozef833 = {
+    github = "Jozef833";
+    githubId = 172046463;
+    name = "Jozef833";
+  };
   jpagex = {
     name = "Jérémy Pagé";
     email = "contact@jeremypage.me";

--- a/pkgs/by-name/az/azure-devops-mcp/package.nix
+++ b/pkgs/by-name/az/azure-devops-mcp/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+buildNpmPackage rec {
+  pname = "azure-devops-mcp";
+  version = "2.5.0";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "azure-devops-mcp";
+    tag = "v${version}";
+    hash = "sha256-tIIPKjxAp5+rnl+WCfGaSlMt71A+v2Saq/E+pinBJqU=";
+  };
+
+  npmDepsHash = "sha256-I8eCzTXjOw+91aOTcO5L5Ha4s59E2oJ69jpl+8aZij8=";
+
+  npmBuildScript = "build";
+
+  meta = {
+    description = "MCP server for Azure DevOps";
+    homepage = "https://github.com/microsoft/azure-devops-mcp";
+    license = lib.licenses.mit;
+    mainProgram = "mcp-server-azuredevops";
+    maintainers = with lib.maintainers; [ Jozef833 ];
+  };
+}


### PR DESCRIPTION
Add [azure-devops-mcp](https://github.com/microsoft/azure-devops-mcp).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test