### PR TITLE
nixtamal: 1.1.4 → 1.1.5; multi-output derivation

### DIFF
--- a/pkgs/by-name/ni/nixtamal/package.nix
+++ b/pkgs/by-name/ni/nixtamal/package.nix
@@ -80,17 +80,32 @@ ocamlPackages.buildDunePackage (finalAttrs: {
 
   outputs = [
     "bin"
+    "data"
+    "doc"
     "lib"
+    "man"
     "out"
   ];
 
   installPhase = ''
     runHook preInstall
-    dune install --prefix="$bin" --libdir="$lib/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib" nixtamal
-    for dep in ${ocamlPackages.ocaml} ${ocamlPackages.camomile}
+
+    dune install \
+       -j "$NIX_BUILD_CORES" \
+       --cache="disabled" \
+       --prefix="$out" \
+       --bindir="$bin/bin" \
+       --datadir="$data/share" \
+       --docdir="$doc/share/doc" \
+       --mandir="$man/share/man" \
+       --libdir="$lib/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib" \
+       nixtamal
+
+    for dep in "${ocamlPackages.ocaml}" "${ocamlPackages.camomile}"
     do
-        remove-references-to -t $dep $bin/bin/nixtamal
+        remove-references-to -t "$dep" "$bin/bin/nixtamal"
     done
+
     wrapProgram "$bin/bin/nixtamal" --prefix PATH : ${
       lib.makeBinPath [
         coreutils
@@ -100,6 +115,7 @@ ocamlPackages.buildDunePackage (finalAttrs: {
         nix-prefetch-pijul
       ]
     }
+
     runHook postInstall
   '';
 
@@ -112,6 +128,12 @@ ocamlPackages.buildDunePackage (finalAttrs: {
     license = with lib.licenses; [ gpl3Plus ];
     platforms = lib.platforms.unix;
     mainProgram = "nixtamal";
+    outputsToInstall = [
+      "bin"
+      "data"
+      "doc"
+      "man"
+    ];
     homepage = "https://nixtamal.toast.al";
     changelog = "https://nixtamal.toast.al/changelog/";
     description = "Fulfilling input pinning for Nix";

--- a/pkgs/by-name/ni/nixtamal/package.nix
+++ b/pkgs/by-name/ni/nixtamal/package.nix
@@ -18,7 +18,7 @@
 
 ocamlPackages.buildDunePackage (finalAttrs: {
   pname = "nixtamal";
-  version = "1.1.4";
+  version = "1.1.5";
   release_year = 2026;
 
   minimalOCamlVersion = "5.3";
@@ -27,7 +27,7 @@ ocamlPackages.buildDunePackage (finalAttrs: {
     url = "https://darcs.toastal.in.th/nixtamal/stable/";
     mirrors = [ "https://smeder.ee/~toastal/nixtamal.darcs" ];
     rev = finalAttrs.version;
-    hash = "sha256-iLjVuNS0pgoWoXp/Yr6ovEazXqhe5bflqtuzFupxmw0=";
+    hash = "sha256-viMbqPq/XyvRt7AsVk/wT1hbWlZGXqiOfp4SccqyOI8=";
   };
 
   nativeBuildInputs = [
@@ -119,7 +119,8 @@ ocamlPackages.buildDunePackage (finalAttrs: {
       Nixtamal’s keys features
 
       • Automate the manual work of input pinning, allowing to lock & refresh inputs
-      • Declaritive KDL manifest file over imperative CLI flags
+      • Declarative KDL manifest file over imperative CLI flags
+      • diff/grep-friendly lockfile
       • Host, forge, VCS-agnostic
       • Choose eval time fetchers (builtins) or build time fetchers (Nixpkgs, default) — which opens up fetching Darcs, Pijul, & Fossil
       • Supports mirrors


### PR DESCRIPTION
Implements the `nixtamal.bin` & errors bubble up stderr, not stdout

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.