### PR TITLE
vtk: propagate libxcursor

### DIFF
--- a/pkgs/by-name/f3/f3d/package.nix
+++ b/pkgs/by-name/f3/f3d/package.nix
@@ -9,7 +9,7 @@
   libxt,
   openusd,
   onetbb,
-  vtk,
+  vtk_9_6,
   autoPatchelfHook,
   python3Packages,
   opencascade-occt,
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    vtk
+    vtk_9_6
     opencascade-occt
     assimp
     fontconfig

--- a/pkgs/development/libraries/vtk/generic.nix
+++ b/pkgs/development/libraries/vtk/generic.nix
@@ -167,7 +167,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libxfixes
     libxrender
-    libxcursor
   ]
   ++ lib.optional withQt6 qt6.qttools
   ++ lib.optional mpiSupport mpi
@@ -217,9 +216,10 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libx11
+    libxcursor
     gl2ps
   ]
-  # create meta package providing dist-info for python3Pacakges.vtk that common cmake build does not do
+  # create meta package providing dist-info for python3Packages.vtk that common cmake build does not do
   ++ lib.optionals pythonSupport [
     (python3Packages.mkPythonMetaPackage {
       inherit (finalAttrs) pname version meta;


### PR DESCRIPTION
f3d: vtk_9_5 -> vtk_9_6

VTK 9.6 requires xcursor to be propagated otherwise depending packages can fail to build. `f3d`, which would otherwise fail to build against vtk_9_6, is added as an example here.

Currently this is a substantial rebuild due to propagation in VTK 9.5 as well which is not clearly necessary. We could conditionally propagate to avoid this mass rebuild at the cost of a bit of additional code complexity. It's also possible we find some more such packages.

@qbisi 

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
