### PR TITLE
python3Packages.arviz-base: remove superfluous optional-dependencies

### DIFF
--- a/pkgs/development/python-modules/arviz-base/default.nix
+++ b/pkgs/development/python-modules/arviz-base/default.nix
@@ -12,25 +12,8 @@
   xarray,
 
   # optional-dependencies
-  black,
-  build,
-  isort,
-  mypy,
-  pre-commit,
-  cloudpickle,
   h5netcdf,
-  jupyter-sphinx,
-  myst-nb,
-  myst-parser,
-  numpydoc,
-  sphinx,
-  sphinx-book-theme,
-  sphinx-copybutton,
-  sphinx-design,
   netcdf4,
-  pytest,
-  pytest-cov,
-  scipy,
   zarr,
 
   # tests
@@ -61,40 +44,11 @@ buildPythonPackage (finalAttrs: {
   ];
 
   optional-dependencies = {
-    check = [
-      black
-      build
-      # docstub
-      isort
-      mypy
-      pre-commit
-    ];
-    ci = [
-      cloudpickle
-      pre-commit
-    ];
-    doc = [
-      h5netcdf
-      jupyter-sphinx
-      myst-nb
-      myst-parser
-      numpydoc
-      sphinx
-      sphinx-book-theme
-      sphinx-copybutton
-      sphinx-design
-    ];
     h5netcdf = [
       h5netcdf
     ];
     netcdf4 = [
       netcdf4
-    ];
-    test = [
-      pytest
-      pytest-cov
-      scipy
-      xarray
     ];
     zarr = [
       zarr


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
