### PR TITLE
rvgl-launcher: init at 0.1.23.1030a4-rev1

### DIFF
--- a/pkgs/by-name/rv/rvgl-launcher/package.nix
+++ b/pkgs/by-name/rv/rvgl-launcher/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitLab,
+  copyDesktopItems,
+  makeDesktopItem,
+  buildFHSEnv,
+}:
+
+let
+  unwrapped = python3Packages.buildPythonApplication (finalAttrs: {
+    pname = "rvgl-launcher-unwrapped";
+    version = "0.1.23.1030a4";
+    pyproject = true;
+
+    src = fetchFromGitLab {
+      owner = "re-volt";
+      repo = "rvgl-launcher";
+      tag = finalAttrs.version;
+      hash = "sha256-F/NyRE81CgHkJx2Wf7cZ8r8s8d5Pzv/O2XlGvyX+1rk=";
+    };
+
+    build-system = with python3Packages; [ setuptools ];
+
+    dependencies = with python3Packages; [
+      wxpython
+      requests
+      appdirs
+      packaging
+    ];
+
+    postPatch = ''
+      substituteInPlace setup.py \
+        --replace-fail "'wx'" "'wxPython'"
+    '';
+
+    postInstall = ''
+      install -Dm755 rvgl_launcher.py $out/bin/rvgl-launcher
+      install -Dm644 icons/icon.png $out/share/pixmaps/rvgl-launcher.png
+    '';
+
+    nativeBuildInputs = [ copyDesktopItems ];
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "rvgl-launcher";
+        desktopName = "RVGL Launcher";
+        icon = "rvgl-launcher";
+        exec = "rvgl-launcher";
+        comment = "Launcher and package manager for RVGL";
+        categories = [ "Game" ];
+      })
+    ];
+
+    meta = {
+      description = "Launcher and package manager for RVGL";
+      longDescription = "RVGL Launcher is a cross-platform installer, launcher and package manager for RVGL";
+      homepage = "https://re-volt.gitlab.io/rvgl-launcher";
+      downloadPage = "https://gitlab.com/re-volt/rvgl-launcher";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [ andrewfield ];
+      mainProgram = "rvgl-launcher";
+      platforms = lib.platforms.linux;
+    };
+  });
+
+in
+buildFHSEnv {
+  name = "rvgl-launcher";
+  version = unwrapped.version;
+
+  runScript = "rvgl-launcher";
+
+  targetPkgs =
+    pkgs: with pkgs; [
+      unwrapped
+
+      p7zip
+
+      SDL2
+      SDL2_image
+      libvorbis
+      fluidsynth
+      gtk3
+    ];
+
+  passthru = {
+    unwrapped = unwrapped;
+  };
+
+  meta = unwrapped.meta;
+}

--- a/pkgs/by-name/rv/rvgl-launcher/package.nix
+++ b/pkgs/by-name/rv/rvgl-launcher/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitLab,
+  copyDesktopItems,
+  makeDesktopItem,
+  buildFHSEnv,
+}:
+
+let
+  unwrapped = python3Packages.buildPythonApplication (finalAttrs: {
+    pname = "rvgl-launcher-unwrapped";
+    version = "0.1.23.1030a4-rev1";
+    pyproject = true;
+
+    src = fetchFromGitLab {
+      owner = "re-volt";
+      repo = "rvgl-launcher";
+      tag = finalAttrs.version;
+      hash = "sha256-Xq8gFE8rWMwufvZL5ZaWXbQ/Ls6nPGgmU3PjzFeQOuM=";
+    };
+
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    build-system = with python3Packages; [ setuptools ];
+
+    dependencies = with python3Packages; [
+      wxpython
+      requests
+      appdirs
+      packaging
+    ];
+
+    postInstall = ''
+      install -Dm644 icons/icon.png $out/share/pixmaps/rvgl-launcher.png
+    '';
+
+    nativeBuildInputs = [ copyDesktopItems ];
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = "rvgl-launcher";
+        desktopName = "RVGL Launcher";
+        icon = "rvgl-launcher";
+        exec = "rvgl-launcher";
+        comment = "Launcher and package manager for RVGL";
+        categories = [ "Game" ];
+      })
+    ];
+
+    meta = {
+      description = "Launcher and package manager for RVGL";
+      longDescription = "RVGL Launcher is a cross-platform installer, launcher and package manager for RVGL";
+      homepage = "https://re-volt.gitlab.io/rvgl-launcher";
+      downloadPage = "https://gitlab.com/re-volt/rvgl-launcher";
+      license = lib.licenses.gpl3Only;
+      maintainers = with lib.maintainers; [ andrewfield ];
+      mainProgram = "rvgl-launcher";
+      platforms = lib.platforms.linux;
+    };
+  });
+
+in
+(buildFHSEnv {
+  # The launcher works well with the unwrapped section but the game itself when launched seems to require an FHS environment.
+  pname = "rvgl-launcher";
+  inherit (unwrapped) version meta;
+
+  runScript = "rvgl-launcher";
+
+  targetPkgs =
+    pkgs: with pkgs; [
+      unwrapped
+
+      p7zip # Only needed by the actual game when launched, to manage the RVGL packages the game itself uses.
+
+      SDL2
+      SDL2_image
+      libvorbis
+      fluidsynth
+      gtk3
+    ];
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications $out/share/pixmaps
+    ln -s ${unwrapped}/share/applications/rvgl-launcher.desktop $out/share/applications/rvgl-launcher.desktop
+    ln -s ${unwrapped}/share/pixmaps/rvgl-launcher.png $out/share/pixmaps/rvgl-launcher.png
+  '';
+
+  passthru = {
+    inherit unwrapped;
+  };
+}).overrideAttrs
+  (
+    finalAttrs: previousAttrs: {
+      strictDeps = true;
+      __structuredAttrs = true;
+    }
+  )


### PR DESCRIPTION
This pull request adds the launcher and package manager for RVGL, the port of the Re-Volt video game.

Parent homepage: https://re-volt.gitlab.io
Homepage: https://re-volt.gitlab.io/rvgl-launcher
Download page: https://gitlab.com/re-volt/rvgl-launcher
Related site: https://rvgl.org

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## Notes
 - I have only been able to test on GNU/Linux, I don't know if it works on Darwin. That is why the platforms listed only include GNU/Linux at the moment.
 - Tested with a keyboard and an Xbox controller and only offline so far.
 - The game itself runs perfectly well when launched, although the log gives the warning:
```
Error loading libFLAC.so.12: libFLAC.so.12: cannot open shared object file: No such file or directory
Error loading libFLAC.so.8: libFLAC.so.8: cannot open shared object file: No such file or directory 
```
I have been unable to solve this warning. Adding `flac` to the targetPkgs does not provide those old libraries and I know of no extra commands to try to patch/link the old libraries to the new ones. The upstream binary where the hard linking is made to those old libraries also appears unavailable.

 - The unwrapped section works well in a non-FHS environment but the game itself when launched seems to require an FHS environment which is why there is a wrapped and non-wrapped section. I hope I have written the recipe correctly to provide both parts.
  - The gtk3 package is not strictly needed in the target packages but it will write constant errors to the log without it.
  - The p7zip package in the target packages is only needed by the actual game when launched, to manage the RVGL packages the game itself uses.