### PR TITLE
cantarell-fonts: remove ad-hoc fix

### DIFF
--- a/pkgs/by-name/ca/cantarell-fonts/package.nix
+++ b/pkgs/by-name/ca/cantarell-fonts/package.nix
@@ -33,12 +33,6 @@ stdenv.mkDerivation rec {
     appstream-glib
   ];
 
-  # ad-hoc fix for https://github.com/NixOS/nixpkgs/issues/50855
-  # until we fix gettext's envHook
-  preBuild = ''
-    export GETTEXTDATADIRS="$GETTEXTDATADIRS_FOR_BUILD"
-  '';
-
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
   outputHash = "sha256-OjHj4h3n+/ozbrLaiH4bGppQ+2LA2RB/sZQVO9EPOEw=";


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/50855#issuecomment-1809263970


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I noticed the referenced issue is resolved so the fix no longer seems necessary.

Tested with the original steps to reproduce:

> Change the hash in pkgs/data/fonts/cantarell-fonts/default.nix and then:
> nix-build '<nixpkgs>' -A cantarell-fonts

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
