### PR TITLE
haskell: Split GHC and Haskell libs into separate outputs

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -230,6 +230,10 @@
             ../../tools/haskell/hadrian/disable-hyperlinked-source-extra-args.patch
         )
       ]
+      # XXX this is only tested with GHC 9.10 currently
+      ++ lib.optionals (lib.versionAtLeast version "9.10") [
+        ./ghc_split.diff
+      ]
       ++ lib.optionals (lib.versionAtLeast version "9.8" && lib.versionOlder version "9.12") [
         (fetchpatch {
           name = "enable-ignore-build-platform-mismatch.patch";
@@ -608,7 +612,7 @@ stdenv.mkDerivation (
       ''
     )
     + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-      export NIX_LDFLAGS+=" -rpath $out/lib/ghc-${version}"
+      export NIX_LDFLAGS+=" -rpath $lib/lib/ghc-${version}"
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       export NIX_LDFLAGS+=" -no_dtrace_dof"
@@ -748,6 +752,7 @@ stdenv.mkDerivation (
       python3
       # Tool used to update GHC's settings file in postInstall
       bootPkgs.ghc-settings-edit
+      buildPackages.removeReferencesTo
     ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
       autoSignDarwinBinariesHook
@@ -826,6 +831,8 @@ stdenv.mkDerivation (
     outputs = [
       "out"
       "doc"
+      "lib"
+      "debug"
     ];
 
     # We need to configure the bindist *again* before installing
@@ -835,6 +842,38 @@ stdenv.mkDerivation (
     preInstall = ''
       pushd _build/bindist/*
 
+      # install RTS debug files to $debug, install other libs to $lib
+      pushd NIXOUT
+      find -type f,l -name '*_debug*.so' | \
+        while read file; do
+          targetdir="$debug/$(dirname "$file")"
+          mkdir -p "$targetdir"
+          mv "$file" -t "$targetdir"
+        done
+      mkdir $lib && cp -r * $lib/
+      popd
+
+      # fix RPATH to reference the .so libs in the nix store correctly
+      grep --binary -l -r /NIXOUT/ bin/ | while read file; do
+         mapfile -t -d : rpaths < <( patchelf --print-rpath "$file" )
+         suffix=""
+         for i in "''${!rpaths[@]}"; do
+            rpath="''${rpaths[i]}"
+            if [[ "$rpath" == */NIXOUT/* ]]; then
+               suffix="''${rpath#*/NIXOUT/}"
+               unset 'rpaths[i]'
+            fi
+         done
+         IFS=: newrpath="$lib/$suffix:''${rpaths[*]}"
+         echo "Set RPATH on $file" >&2
+         patchelf --set-rpath "$newrpath" "$file"
+      done
+
+      # fix package .conf files
+      pushd lib/package.conf.d
+      sed -i -e '/NIXOUT/{ p; s,[$]{pkgroot}/../lib/../NIXOUT/,'"$debug"'/,; }' rts-*.conf
+      substituteInPlace *.conf --replace-quiet ${"'$"}{pkgroot}/../lib/../NIXOUT/' "$lib/"
+      popd
     ''
     # the bindist configure script uses different env variables than the GHC configure script
     # see https://github.com/NixOS/nixpkgs/issues/267250 krank:ignore-line
@@ -845,12 +884,17 @@ stdenv.mkDerivation (
     ''
     # Replicate configurePhase
     + ''
-      $configureScript "''${configureFlags[@]}"
+      $configureScript "''${configureFlags[@]}" --libdir=$out/lib --libexecdir=$out/libexec
     '';
 
     postInstall = ''
       # leave bindist directory
       popd
+
+      find $lib -type f -exec remove-references-to -t $out '{}' +
+
+      # clean up: remove .copy files
+      find $out -type f -name '*.copy' -exec rm '{}' +
 
       settingsFile="$out/lib/${targetPrefix}${haskellCompilerName}/lib/settings"
 
@@ -900,6 +944,21 @@ stdenv.mkDerivation (
 
       # Install the bash completion file.
       install -Dm 644 utils/completion/ghc.bash $out/share/bash-completion/completions/${targetPrefix}ghc
+    '';
+
+    # this is weird. after the fixup phase (including patchELF) the binaries are broken
+    # (no version information available, symbol lookup error)
+    # the workaround is to add an arbitrary path to the RPATH and shrink the RPATH again.
+    postFixup = ''
+      find "$out/lib/${targetPrefix}${haskellCompilerName}/bin" -type f -executable | \
+        while read binary; do
+          if file "$binary" | grep -q "ELF"; then
+             echo "  Repairing: $(basename "$binary")"
+             p=$( patchelf --print-rpath "$binary" )
+             patchelf --set-rpath "$p:/fake/path" "$binary"
+             patchelf --shrink-rpath "$binary"
+          fi
+        done
     '';
 
     passthru = {

--- a/pkgs/development/compilers/ghc/ghc_split.diff
+++ b/pkgs/development/compilers/ghc/ghc_split.diff
@@ -1,0 +1,80 @@
+diff -ur -x '*.in' -x '*-nix' -x '*.py' -x '*lint' -x '*build-*' -x '*build' -x '*.sh' ghc-9.10.3-source/hadrian/src/Hadrian/BuildPath.hs ../ghc-9.10.3-source/hadrian/src/Hadrian/BuildPath.hs
+--- ghc-9.10.3-source/hadrian/src/Hadrian/BuildPath.hs	1970-01-01 00:00:01.000000000 +0000
++++ ../ghc-9.10.3-source/hadrian/src/Hadrian/BuildPath.hs	2026-03-25 13:07:18.095438381 +0000
+@@ -62,8 +62,9 @@
+     _ <- Parsec.string root *> Parsec.optional (Parsec.char '/')
+     stage <- parseStage
+     _ <- Parsec.char '/'
+-    regPath <- Parsec.string "lib/"
+-            <> Parsec.manyTill Parsec.anyChar (Parsec.try $ Parsec.string "/")
++    regPath <-
++      (Parsec.string "NIXOUT/" <> Parsec.many1 (Parsec.noneOf "/") <> Parsec.string "/" <> Parsec.string "lib/")
++      <|> (Parsec.string "lib/" <> Parsec.manyTill Parsec.anyChar (Parsec.try $ Parsec.string "/"))
+     a <- after
+     return (GhcPkgPath root stage regPath a)
+ 
+diff -ur -x '*.in' -x '*-nix' -x '*.py' -x '*lint' -x '*build-*' -x '*build' -x '*.sh' ghc-9.10.3-source/hadrian/src/Rules/BinaryDist.hs ../ghc-9.10.3-source/hadrian/src/Rules/BinaryDist.hs
+--- ghc-9.10.3-source/hadrian/src/Rules/BinaryDist.hs	1970-01-01 00:00:01.000000000 +0000
++++ ../ghc-9.10.3-source/hadrian/src/Rules/BinaryDist.hs	2026-03-26 12:16:56.432683646 +0000
+@@ -222,6 +222,7 @@
+                   IO.createFileLink version_prog versioned_runhaskell_path
+ 
+         copyDirectory (ghcBuildDir -/- "lib") bindistFilesDir
++        copyDirectory (ghcBuildDir -/- "NIXOUT") bindistFilesDir
+         copyDirectory (rtsIncludeDir)         bindistFilesDir
+         when windowsHost $ createGhcii (bindistFilesDir -/- "bin")
+ 
+@@ -548,4 +549,3 @@
+       [ "#!/bin/sh"
+       , "exec \"$(dirname \"$0\")\"/ghc --interactive \"$@\""
+       ]
+-
+diff -ur -x '*.in' -x '*-nix' -x '*.py' -x '*lint' -x '*build-*' -x '*build' -x '*.sh' ghc-9.10.3-source/hadrian/src/Rules/Library.hs ../ghc-9.10.3-source/hadrian/src/Rules/Library.hs
+--- ghc-9.10.3-source/hadrian/src/Rules/Library.hs	1970-01-01 00:00:01.000000000 +0000
++++ ../ghc-9.10.3-source/hadrian/src/Rules/Library.hs	2026-03-24 12:08:54.463849628 +0000
+@@ -25,16 +25,16 @@
+ libraryRules :: Rules ()
+ libraryRules = do
+     root <- buildRootRules
+-    root -/- "**/libHS*-*.dylib"       %> buildDynamicLib root "dylib"
+-    root -/- "**/libHS*-*.so"          %> buildDynamicLib root "so"
+-    root -/- "**/libHS*-*.dll"         %> buildDynamicLib root "dll"
++    root -/- "**/build/libHS*-*.dylib"       %> buildDynamicLib root "dylib"
++    root -/- "**/build/libHS*-*.so"          %> buildDynamicLib root "so"
++    root -/- "**/build/libHS*-*.dll"         %> buildDynamicLib root "dll"
+     root -/- "**/*.a"                  %> buildStaticLib  root
+     root -/- "**/stamp-*"              %> buildPackage root
+     priority 2 $ do
+-        root -/- "stage*/lib/**/libHS*-*.dylib" %> registerDynamicLib root "dylib"
+-        root -/- "stage*/lib/**/libHS*-*.so"    %> registerDynamicLib root "so"
+-        root -/- "stage*/lib/**/libHS*-*.dll"   %> registerDynamicLib root "dll"
+-        root -/- "stage*/lib/**/*.a"            %> registerStaticLib  root
++        root -/- "stage*/**/lib/**/libHS*-*.dylib" %> registerDynamicLib root "dylib"
++        root -/- "stage*/**/lib/**/libHS*-*.so"    %> registerDynamicLib root "so"
++        root -/- "stage*/**/lib/**/libHS*-*.dll"   %> registerDynamicLib root "dll"
++        root -/- "stage*/**/lib/**/*.a"            %> registerStaticLib  root
+         root -/- "**/HS*-*.o"   %> buildGhciLibO root
+         root -/- "**/HS*-*.p_o" %> buildGhciLibO root
+ 
+diff -ur -x '*.in' -x '*-nix' -x '*.py' -x '*lint' -x '*build-*' -x '*build' -x '*.sh' ghc-9.10.3-source/hadrian/src/Settings/Builders/Cabal.hs ../ghc-9.10.3-source/hadrian/src/Settings/Builders/Cabal.hs
+--- ghc-9.10.3-source/hadrian/src/Settings/Builders/Cabal.hs	1970-01-01 00:00:01.000000000 +0000
++++ ../ghc-9.10.3-source/hadrian/src/Settings/Builders/Cabal.hs	2026-03-26 13:06:50.455693077 +0000
+@@ -86,6 +86,7 @@
+   pkg       <- getPackage
+   package_id <- expr $ pkgUnitId stage pkg
+   let prefix = "${pkgroot}" ++ (if windowsHost then "" else "/..")
++      dynlibdir = "$libdir/../NIXOUT/$compiler/lib"
+   mconcat [ -- Don't strip libraries when cross compiling.
+             -- TODO: We need to set @--with-strip=(stripCmdPath :: Action FilePath)@,
+             -- and if it's @:@ disable stripping as well. As it is now, I believe
+@@ -103,6 +104,8 @@
+             , arg package_id
+             , arg "--prefix"
+             , arg prefix
++            , arg "--dynlibdir"
++            , arg dynlibdir
+ 
+             -- NB: this is valid only because Hadrian puts the @doc@ and
+             -- @libraries@ folders in the same relative position:
+Only in ../ghc-9.10.3-source/hadrian/src/Settings/Builders: Cabal.hs.orig
+Only in ../ghc-9.10.3-source/hadrian/src/Settings/Builders: Cabal.hs.rej

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -637,6 +637,7 @@ lib.fix (
       outputs = [
         "out"
       ]
+      ++ (optional isLibrary "dev")
       ++ (optional enableSeparateDataOutput "data")
       ++ (optional enableSeparateDocOutput "doc")
       ++ (optional enableSeparateBinOutput "bin")
@@ -888,8 +889,9 @@ lib.fix (
           # just the target specified; "install" will error here, since not all targets have been built.
           else
             ''
+              mkdir -p $out
               ${setupCommand} copy ${buildTarget}
-              local packageConfDir="$out/${ghcLibdir}/package.conf.d"
+              local packageConfDir="$dev/${ghcLibdir}/package.conf.d"
               local packageConfFile="$packageConfDir/${pname}-${version}.conf"
               mkdir -p "$packageConfDir"
               ${setupCommand} register --gen-pkg-config=$packageConfFile
@@ -918,10 +920,9 @@ lib.fix (
             cp -r dist/build/$exe/$exe.jsexe ${binDir}
           done
         ''}
-
         ${optionalString enableSeparateDocOutput ''
           for x in ${docdir "$doc"}"/html/src/"*.html; do
-            remove-references-to -t $out $x
+            remove-references-to -t $out ${optionalString isLibrary "-t $dev"} $x
           done
           mkdir -p $doc
         ''}

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -366,9 +366,12 @@ let
 
   defaultConfigureFlags = [
     "--verbose"
-    "--prefix=$out"
+    (if isLibrary then "--prefix=$dev" else "--prefix=$out")
     # Note: This must be kept in sync manually with mkGhcLibdir
     ("--libdir=\\$prefix/lib/\\$compiler" + lib.optionalString (ghc ? hadrian) "/lib")
+    (optionalString isLibrary (
+      "--dynlibdir=$out/lib/\\$compiler" + lib.optionalString (ghc ? hadrian) "/lib"
+    ))
     "--libsubdir=\\$abi/\\$libname"
     (optionalString enableSeparateDataOutput "--datadir=$data/share/${ghcNameWithPrefix}")
     (optionalString enableSeparateDocOutput "--docdir=${docdir "$doc"}")
@@ -925,7 +928,7 @@ lib.fix (
             remove-references-to -t $out ${optionalString isLibrary "-t $dev"} $x
           done
           mkdir -p $doc
-        ''}
+        ''}${optionalString isLibrary "find $out -type f -exec remove-references-to -t $dev '{}' +"}
         ${optionalString enableSeparateDataOutput "mkdir -p $data"}
 
         runHook postInstall

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -63,9 +63,10 @@ let
   docDir = "$out/share/doc/ghc/html";
   packageCfgDir = "${libDir}/package.conf.d";
   paths = lib.concatLists (
-    map (pkg: [ pkg ] ++ lib.optionals installDocumentation [ (lib.getOutput "doc" pkg) ]) (
-      lib.filter (x: x ? isHaskellLibrary) (lib.closePropagation packages)
-    )
+    map (
+      pkg:
+      [ (lib.getOutput "dev" pkg) ] ++ lib.optionals installDocumentation [ (lib.getOutput "doc" pkg) ]
+    ) (lib.filter (x: x ? isHaskellLibrary) (lib.closePropagation packages))
   );
   hasLibraries = lib.any (x: x.isHaskellLibrary) paths;
   # Clang is needed on Darwin for -fllvm to work.


### PR DESCRIPTION
We (https://github.com/MercuryTechnologies/) are using nixpkgs in a very large (~16k modules) Haskell code base. Currently we are migrating from Cabal to a scalable build system (buck2) which supports remote execution.

As you might imagine this poses a few challenges, for example we need to make all required nix dependencies available on the remote executor.

One possible way of doing that is to use a Docker image which is used by the remote system in order to run actions remotely.

We are looking into different alternative solutions as well, but in general we need to reduce the size of the runtime closure in order to reduce the overhead of downloading / handling gigabtyes of data.

For instance, one use case for remote execution is running tests. The tests are not build statically, but require dynamic Haskell libraries to run.

Including the required libraries in the Docker image using the dockerTools currently ways in at around 15 GiB.

Looking into the things included in the image, I noticed that haddock html files are part of it. The static archives are part of the image as well.

The reason the docs are included is that these are referenced from the package db file. So, as a first step I moved that out into the `dev` output. This reduces the size of the resulting Docker image to just under 10 GiB.

Eventually, I really would like to separate runtime and development dependencies for Haskell packages. I see that almost all Haskell binary is built statically, which is probably only done because using dynamic Haskell libraries would result in a huge runtime closure for those packages.

I'd like to propose to split Haskell packages (probably not just the libraries) into runtime dependencies and development dependencies for this reason.

This PR changes this for libraries:

`out` -- only contains the `.so`
`dev` -- contains `.hi`, `.hie`, `.a` and package config / db

GHC itself has been split up into these outputs:

`out` -- contains the GHC compiler, static libraries, .hi files and the package DB
`lib` -- contains only the shared libraries (minus debug, see below)
`debug` -- contains the debug versions of the RTS shared library

(I know, this is not very consistent, and I tried to use a `dev` output for GHC too but ran into issues due to some automatic configure flags being applied and things moving around)

I have build hlint with enableSharedExecutables and the closure size went down from 4.28 GiB to 3.08 GiB. This is still very large since it depends on the compiler package which ways in at around 2.94 GiB (including ghc-doc). I would like to split this package as well.

I also build amazonka-core which is a large Haskell library and has many dependencies, just to see that it works.

Splitting up those packages would have the benefit for us that we could track these in our buck2 build in a much more fine-grained manner.

Maybe this has been attempted before? I couldn't find anything related...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
