### PR TITLE
python3Packages.etelemetry: fix build

### DIFF
--- a/pkgs/development/python-modules/etelemetry/default.nix
+++ b/pkgs/development/python-modules/etelemetry/default.nix
@@ -9,7 +9,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "etelemetry";
   version = "0.3.1";
   pyproject = true;
@@ -17,12 +17,12 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "sensein";
     repo = "etelemetry-client";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-UaE5JQhv2AtzXKY7YD2/g6Kj1igKhmnY3zlf1P9B/iQ=";
   };
 
   postPatch = ''
-    substituteInPlace setup.py --replace-fail "versioneer.get_version()" "'${version}'"
+    substituteInPlace setup.py --replace-fail "versioneer.get_version()" "'${finalAttrs.version}'"
   '';
 
   build-system = [
@@ -54,8 +54,8 @@ buildPythonPackage rec {
   meta = {
     description = "Lightweight python client to communicate with the etelemetry server";
     homepage = "https://github.com/sensein/etelemetry-client";
-    changelog = "https://github.com/sensein/etelemetry-client/releases/tag/v${version}";
+    changelog = "https://github.com/sensein/etelemetry-client/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/etelemetry/default.nix
+++ b/pkgs/development/python-modules/etelemetry/default.nix
@@ -43,6 +43,14 @@ buildPythonPackage rec {
     "etelemetry.config"
   ];
 
+  disabledTests = [
+    # RuntimeError: Connection to server could not be made
+    # due to external network access
+    "test_etrequest"
+    "test_get_project"
+    "test_check_available"
+  ];
+
   meta = {
     description = "Lightweight python client to communicate with the etelemetry server";
     homepage = "https://github.com/sensein/etelemetry-client";

--- a/pkgs/development/python-modules/niworkflows/default.nix
+++ b/pkgs/development/python-modules/niworkflows/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -27,6 +28,7 @@
   scipy,
   seaborn,
   svgutils,
+  sysctl,
   templateflow,
   traits,
   transforms3d,
@@ -89,6 +91,10 @@ buildPythonPackage (finalAttrs: {
     pytest-env
     pytestCheckHook
     writableTmpDirAsHomeHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Needed for tests that read the system memory usage on Darwin
+    sysctl
   ];
 
   enabledTestPaths = [ "niworkflows" ];


### PR DESCRIPTION
1. Disable tests that fail due to network access.
2. Migrate to `finalAttrs`
3. `python3Packages.niworkflows`: Disable tests that fail on Darwin when it tries to read system memory (even with the sandbox off)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
