### PR TITLE
goose-cli: 1.23.2 -> 1.28.0

### DIFF
--- a/pkgs/by-name/go/goose-cli/fetchers.nix
+++ b/pkgs/by-name/go/goose-cli/fetchers.nix
@@ -1,0 +1,21 @@
+# not a stable interface, do not reference outside the goose-cli package but make a
+# copy if you need
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+{
+  fetchLibrustyV8 =
+    args:
+    fetchurl {
+      name = "librusty_v8-${args.version}";
+      url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+      sha256 = args.shas.${stdenv.hostPlatform.system};
+      meta = {
+        inherit (args) version;
+        sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      };
+    };
+}

--- a/pkgs/by-name/go/goose-cli/librusty_v8.nix
+++ b/pkgs/by-name/go/goose-cli/librusty_v8.nix
@@ -1,0 +1,12 @@
+# auto-generated file -- DO NOT EDIT!
+{ fetchLibrustyV8 }:
+
+fetchLibrustyV8 {
+  version = "145.0.0"; # From source's Cargo.lock
+  shas = {
+    x86_64-linux = "sha256-chV1PAx40UH3Ute5k3lLrgfhih39Rm3KqE+mTna6ysE=";
+    aarch64-linux = "sha256-4IivYskhUSsMLZY97+g23UtUYh4p5jk7CzhMbMyqXyY=";
+    x86_64-darwin = "sha256-1jUuC+z7saQfPYILNyRJanD4+zOOhXU2ac/LFoytwho=";
+    aarch64-darwin = "sha256-yHa1eydVCrfYGgrZANbzgmmf25p7ui1VMas2A7BhG6k=";
+  };
+}

--- a/pkgs/by-name/go/goose-cli/package.nix
+++ b/pkgs/by-name/go/goose-cli/package.nix
@@ -1,17 +1,23 @@
 {
   lib,
   stdenv,
+  callPackage,
   fetchFromGitHub,
   fetchurl,
   rustPlatform,
+  cmake,
   dbus,
   libxcb,
   pkg-config,
   protobuf,
   openssl,
+  cacert,
   writableTmpDirAsHomeHook,
   nix-update-script,
   llvmPackages,
+  librusty_v8 ? callPackage ./librusty_v8.nix {
+    inherit (callPackage ./fetchers.nix { }) fetchLibrustyV8;
+  },
 }:
 
 let
@@ -28,16 +34,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "goose-cli";
-  version = "1.23.2";
+  version = "1.28.0";
 
   src = fetchFromGitHub {
     owner = "block";
     repo = "goose";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Zwb3y9XhtmKxJG6XOIHl49YVZMBsYtOPePM7heJfEvE=";
+    hash = "sha256-/1TtsnNiLoTkvyeFR282qSpo+Jt3pvFxduJ7lyzsTXI=";
   };
 
-  cargoHash = "sha256-G6Jok2OfSlOVlkF62gxivrKM0VlGqWFNdR0pQh79A0Q=";
+  cargoHash = "sha256-bhnbSjGqyWbQd5PjZ116JH91vjVy6R/+iBlNKL6debg=";
 
   cargoBuildFlags = [
     "--bin"
@@ -47,8 +53,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   nativeBuildInputs = [
+    cmake
     pkg-config
     protobuf
+    rustPlatform.bindgenHook
   ];
 
   buildInputs = [
@@ -57,7 +65,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ libxcb ];
 
-  env.LIBCLANG_PATH = "${lib.getLib llvmPackages.libclang}/lib";
+  env = {
+    LIBCLANG_PATH = "${lib.getLib llvmPackages.libclang}/lib";
+    RUSTY_V8_ARCHIVE = librusty_v8;
+  };
 
   preBuild = ''
     mkdir -p tokenizer_files/Xenova--gpt-4o tokenizer_files/Xenova--claude-tokenizer
@@ -65,7 +76,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ln -s ${claude-tokenizer} tokenizer_files/Xenova--claude-tokenizer/tokenizer.json
   '';
 
-  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    cacert
+  ];
 
   __darwinAllowLocalNetworking = true;
 
@@ -128,6 +142,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       cloudripper
       thardin
       brittonr
+      miniharinn
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };

--- a/pkgs/by-name/go/goose-cli/package.nix
+++ b/pkgs/by-name/go/goose-cli/package.nix
@@ -13,6 +13,7 @@
   openssl,
   cacert,
   writableTmpDirAsHomeHook,
+  versionCheckHook,
   nix-update-script,
   llvmPackages,
   librusty_v8 ? callPackage ./librusty_v8.nix {
@@ -130,6 +131,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=test_session_id_matches_across_calls"
     "--skip=test_session_id_propagation_to_llm"
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/go/goose-cli/package.nix
+++ b/pkgs/by-name/go/goose-cli/package.nix
@@ -16,9 +16,22 @@
   versionCheckHook,
   nix-update-script,
   llvmPackages,
+  makeWrapper,
   librusty_v8 ? callPackage ./librusty_v8.nix {
     inherit (callPackage ./fetchers.nix { }) fetchLibrustyV8;
   },
+
+  # Extension(s) Dependencies
+  python3,
+  bash,
+  # X11
+  xdotool,
+  wmctrl,
+  xclip,
+  xwininfo,
+  # Wayland
+  wtype,
+  wl-clipboard,
 }:
 
 let
@@ -58,6 +71,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pkg-config
     protobuf
     rustPlatform.bindgenHook
+    makeWrapper
   ];
 
   buildInputs = [
@@ -75,6 +89,28 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mkdir -p tokenizer_files/Xenova--gpt-4o tokenizer_files/Xenova--claude-tokenizer
     ln -s ${gpt-4o-tokenizer} tokenizer_files/Xenova--gpt-4o/tokenizer.json
     ln -s ${claude-tokenizer} tokenizer_files/Xenova--claude-tokenizer/tokenizer.json
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/goose \
+      --prefix PATH : ${
+        lib.makeBinPath (
+          [
+            bash
+            python3
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
+            # X11
+            xdotool
+            wmctrl
+            xclip
+            xwininfo
+            # Wayland
+            wtype
+            wl-clipboard
+          ]
+        )
+      }
   '';
 
   nativeCheckInputs = [

--- a/pkgs/by-name/go/goose-cli/package.nix
+++ b/pkgs/by-name/go/goose-cli/package.nix
@@ -123,6 +123,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=context_mgmt::auto_compact::tests::test_auto_compact_respects_config"
     "--skip=scheduler::tests::test_scheduled_session_has_schedule_id"
   ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # Broken on aarch64-linux: request capture races across session_id_propagation_test cases
+    "--skip=test_session_id_matches_across_calls"
+    "--skip=test_session_id_propagation_to_llm"
+  ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "--skip=logging::tests::test_log_file_name_no_session"
     "--skip=recipes::extract_from_cli::tests::test_extract_recipe_info_from_cli_basic"

--- a/pkgs/by-name/go/goose-cli/package.nix
+++ b/pkgs/by-name/go/goose-cli/package.nix
@@ -189,6 +189,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       thardin
       brittonr
       miniharinn
+      caniko
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };


### PR DESCRIPTION
Release: https://github.com/block/goose/releases/tag/v1.28.0
Diff: https://github.com/block/goose/compare/v1.23.2...v1.28.0

`goose-cli 1.28.0` now depends on rusty_v8, which required prefetching the `librusty_v8` archive to avoid netowrk access during build. Also add `cacert` to `nativeCheckInputs` as some test depends on it and add version check.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
