### PR TITLE
babashka-unwrapped: 1.12.214 -> 1.12.217

### DIFF
--- a/pkgs/development/interpreters/babashka/clojure-tools.nix
+++ b/pkgs/development/interpreters/babashka/clojure-tools.nix
@@ -7,10 +7,10 @@
 }:
 clojure.overrideAttrs (previousAttrs: {
   pname = "babashka-clojure-tools";
-  version = "1.12.4.1582";
+  version = "1.12.4.1597";
 
   src = fetchurl {
     url = previousAttrs.src.url;
-    hash = "sha256-/Vhk8ivy7DAxH5zjyvPTF5ngTWU7ZX7NtPCDb+ly/yE=";
+    hash = "sha256-DgEvXVExaexDTLoonh/fVS5nHjgekL6BlFYLM9X6wkM=";
   };
 })

--- a/pkgs/development/interpreters/babashka/default.nix
+++ b/pkgs/development/interpreters/babashka/default.nix
@@ -106,6 +106,7 @@ buildGraalvmNativeImage (finalAttrs: {
     maintainers = with lib.maintainers; [
       bandresen
       bhougland
+      deejayem
       DerGuteMoritz
       jlesquembre
     ];

--- a/pkgs/development/interpreters/babashka/default.nix
+++ b/pkgs/development/interpreters/babashka/default.nix
@@ -8,11 +8,11 @@
 
 buildGraalvmNativeImage (finalAttrs: {
   pname = "babashka-unwrapped";
-  version = "1.12.214";
+  version = "1.12.217";
 
   src = fetchurl {
     url = "https://github.com/babashka/babashka/releases/download/v${finalAttrs.version}/babashka-${finalAttrs.version}-standalone.jar";
-    sha256 = "sha256-Z1LdHKxF9xCb7iqe4YRtJSqZdkdiP0xudcgQjOkna08=";
+    sha256 = "sha256-5Nnzx2chre+h0SnM5spwiR9r4gjlyfc2FbgYa0spM34=";
   };
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
Update babashka to the latest version (1.12.217).

There's been a r-ryantm PR open to bump to 1.12.216 for a month (https://github.com/NixOS/nixpkgs/pull/492589), and none of the current maintainers have reviewed it, so I've added myself to the list, so that we can get these merged more quickly in the future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
