### PR TITLE
avy: fix build with cmake4

### DIFF
--- a/pkgs/by-name/av/avy/package.nix
+++ b/pkgs/by-name/av/avy/package.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
     boost.out
     boost.dev
   ];
+
   env.NIX_CFLAGS_COMPILE = toString (
     [ "-Wno-narrowing" ]
     # Squelch endless stream of warnings on same few things
@@ -40,6 +41,13 @@ stdenv.mkDerivation {
     substituteInPlace abc/src/bdd/dsd/dsd.h --replace \
                '((Child = Dsd_NodeReadDec(Node,Index))>=0);' \
                '((intptr_t)(Child = Dsd_NodeReadDec(Node,Index))>=0);'
+
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required (VERSION 3.5.1)" "cmake_minimum_required (VERSION 3.10)"
+    substituteInPlace abc/CMakeLists.txt \
+      --replace-fail "cmake_minimum_required (VERSION 2.8.6)" "cmake_minimum_required (VERSION 3.10)"
+    substituteInPlace {avy,muser2,glucose,minisat}/CMakeLists.txt \
+      --replace-fail "cmake_minimum_required(VERSION 2.8.6)" "cmake_minimum_required (VERSION 3.10)"
 
     patch -p1 -d minisat -i ${./minisat-fenv.patch}
     patch -p1 -d glucose -i ${./glucose-fenv.patch}


### PR DESCRIPTION
There are multiple broken subprojects so used CMAKE_POLICY_VERSION_MINIMUM for a simple fix.
Ref #445447

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
