### PR TITLE
python3Packages.gephipy: init at 0.0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6408,6 +6408,11 @@
     githubId = 8864716;
     name = "Duarte David";
   };
+  demic-dev = {
+    name = "Michele De Cillis";
+    github = "demic-dev";
+    githubId = 59309595;
+  };
   demin-dmitriy = {
     email = "demindf@gmail.com";
     github = "demin-dmitriy";

--- a/pkgs/development/python-modules/gephipy/default.nix
+++ b/pkgs/development/python-modules/gephipy/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  pkgs,
+  buildPythonPackage,
+
+  fetchPypi,
+
+  jdk21_headless,
+  poetry-core,
+
+  jpype1,
+  networkx,
+}:
+let
+  gephi-toolkit = pkgs.fetchMavenArtifact {
+    groupId = "org.gephi";
+    artifactId = "gephi-toolkit";
+    version = "0.10.1";
+    classifier = "all";
+    hash = "sha256-Pk9f1sfR11weC/vq5CzFih0irnxdeTpJjmxYQvIr8Cc=";
+  };
+in
+buildPythonPackage (finalAttrs: {
+  pname = "gephipy";
+  version = "0.0.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = finalAttrs.pname;
+    version = finalAttrs.version;
+
+    hash = "sha256-r3hHcDEX17SNr9l4m9oEVXAky03wSGAbEznV6rPEMf0=";
+  };
+
+  build-system = [ poetry-core ];
+
+  buildInputs = [
+    jdk21_headless
+  ];
+
+  dependencies = [
+    networkx
+    jpype1
+  ];
+
+  pythonImportsCheck = [ "gephipy" ];
+
+  # during first use, they download the gephi .jar. applying a patch that links to the nix store
+  postPatch = ''
+    substituteInPlace gephipy/gephipy.py --replace-fail "jvm.start()" 'jvm.start(gephi_jar_path="${gephi-toolkit.passthru.jar}")'
+  '';
+
+  meta = {
+    description = "A wrapper of Gephi toolkit for Python";
+    homepage = "https://github.com/gephi/gephipy/";
+    maintainers = with lib.maintainers; [ demic-dev ];
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/development/python-modules/gephipy/default.nix
+++ b/pkgs/development/python-modules/gephipy/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  pkgs,
+  buildPythonPackage,
+
+  fetchPypi,
+
+  jdk21_headless,
+  poetry-core,
+
+  jpype1,
+  networkx,
+}:
+let
+  gephi-toolkit = pkgs.fetchMavenArtifact {
+    groupId = "org.gephi";
+    artifactId = "gephi-toolkit";
+    version = "0.10.1";
+    classifier = "all";
+    hash = "sha256-Pk9f1sfR11weC/vq5CzFih0irnxdeTpJjmxYQvIr8Cc=";
+  };
+in
+buildPythonPackage (finalAttrs: {
+  pname = "gephipy";
+  version = "0.0.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+
+    hash = "sha256-r3hHcDEX17SNr9l4m9oEVXAky03wSGAbEznV6rPEMf0=";
+  };
+
+  build-system = [ poetry-core ];
+
+  buildInputs = [
+    jdk21_headless
+  ];
+
+  dependencies = [
+    networkx
+    jpype1
+  ];
+
+  # Sdist on pypi doesn't include test/ folder. Therefore, I can't run tests.
+  # nativeCheckInputs = [ pytestCheckHook ];
+  # enabledTestPaths = [
+  #   "test/"
+  # ];
+
+  pythonImportsCheck = [ "gephipy" ];
+
+  # during first use, they download the gephi .jar. applying a patch that links to the nix store
+  postPatch = ''
+    substituteInPlace gephipy/gephipy.py --replace-fail "jvm.start()" 'jvm.start(gephi_jar_path="${gephi-toolkit.passthru.jar}")'
+  '';
+
+  meta = {
+    description = "Wrapper of Gephi toolkit for Python";
+    homepage = "https://github.com/gephi/gephipy/";
+    maintainers = with lib.maintainers; [ demic-dev ];
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6152,6 +6152,8 @@ self: super: with self; {
     pkgs.gepetto-viewer-corba.override { python3Packages = self; }
   );
 
+  gephipy = callPackage ../development/python-modules/gephipy { };
+
   gerbonara = callPackage ../development/python-modules/gerbonara { };
 
   get-video-properties = callPackage ../development/python-modules/get-video-properties { };


### PR DESCRIPTION
GephiPy is a Python library wrapper for Gephi, allowing to export graphs and networks in high resolutions and programmatically, useful if dealing with a lot of networks. 

Homepage: https://github.com/gephi/gephipy

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
