### PR TITLE
ntpd-rs: fix build on darwin

### DIFF
--- a/pkgs/by-name/nt/ntpd-rs/package.nix
+++ b/pkgs/by-name/nt/ntpd-rs/package.nix
@@ -29,6 +29,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installShellFiles
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   # These fail based on timestamp issues with bundled certificates
   # See https://github.com/NixOS/nixpkgs/issues/497682 & https://github.com/pendulum-project/ntpd-rs/pull/2133
   checkFlags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

darwin build still fails even after #500583 

related: https://github.com/NixOS/nixpkgs/issues/497682

```
ntpd-rs> failures:
ntpd-rs>
ntpd-rs> ---- daemon::ntp_source::tests::test_poll_sends_state_update_and_packet stdout ----
ntpd-rs>
ntpd-rs> thread 'daemon::ntp_source::tests::test_poll_sends_state_update_and_packet' (1871395) panicked at ntpd/src/daemon/ntp_source.rs:601:10:
ntpd-rs> called `Result::unwrap()` on an `Err` value: Os { code: 1, kind: PermissionDenied, message: "Operation not permitted" }
ntpd-rs> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
ntpd-rs>
ntpd-rs>
ntpd-rs> failures:
ntpd-rs>     daemon::ntp_source::tests::test_poll_sends_state_update_and_packet
ntpd-rs>
ntpd-rs> test result: FAILED. 57 passed; 1 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.01s
ntpd-rs>
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
