### PR TITLE
nixos/jenkins: Drop default packages from `package` option

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -221,6 +221,8 @@
 
 - `services.taskchampion-sync-server` module have been added an option `services.taskchampion-sync-server.dynamicUser` to use systemd's DynamicUser feature. This is enabled by default when stateVersion is at least 26.05, and disabled otherwise. If you need this feature, you need to set `services.taskchampion-sync-server.dynamicUser` to `true` and migrate `/var/lib/taskchampion-sync-server` to `/var/lib/private/taskchampion-sync-server`.
 
+- The default packages in `services.jenkins.packages` have been dropped, since not every Jenkins installation needs any package at all. It's more reasonable to leave it empty and let users configure what they need.
+
 ## Other Notable Changes {#sec-nixpkgs-release-26.05-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/continuous-integration/jenkins/default.nix
+++ b/nixos/modules/services/continuous-integration/jenkins/default.nix
@@ -86,14 +86,16 @@ in
       javaPackage = lib.mkPackageOption pkgs "jdk25" { };
 
       packages = lib.mkOption {
-        default = [
-          pkgs.stdenv
-          pkgs.git
-          pkgs.jdk25
-          config.programs.ssh.package
-          pkgs.nix
-        ];
-        defaultText = lib.literalExpression "[ pkgs.stdenv pkgs.git pkgs.jdk17 config.programs.ssh.package pkgs.nix ]";
+        default = [ ];
+        example = lib.literalExpression ''
+          [
+            pkgs.stdenv
+            pkgs.git
+            pkgs.jdk25
+            config.programs.ssh.package
+            pkgs.nix
+          ]
+        '';
         type = lib.types.listOf lib.types.package;
         description = ''
           Packages to add to PATH for the jenkins process.


### PR DESCRIPTION
Not every Jenkins installation needs any package included in PATH. Drop the packages from `services.jenkins.packages` and leave the decision up to the user instead.

Add a release note to 26.05 in order to notify users.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
