### PR TITLE
irpf: 2025-1.7 -> 2026-1.0

### DIFF
--- a/pkgs/by-name/ir/irpf/package.nix
+++ b/pkgs/by-name/ir/irpf/package.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   fetchzip,
   copyDesktopItems,
-  jdk11,
+  jdk17,
   makeDesktopItem,
   makeWrapper,
   unzip,
@@ -11,10 +11,16 @@
   imagemagick,
   writeScript,
 }:
+let
+  # The officially recommended version is Java 17
+  java = jdk17;
 
+  # It's not clear yet if this version follows the app version, further updates will probably solve this question
+  pgd-updater-version = "1.0.0";
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "irpf";
-  version = "2025-1.7";
+  version = "2026-1.0";
 
   # https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/download/pgd/dirpf
   # Para outros sistemas operacionais -> Multi
@@ -24,18 +30,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     in
     fetchzip {
       url = "https://downloadirpf.receita.fazenda.gov.br/irpf/${year}/irpf/arquivos/IRPF${finalAttrs.version}.zip";
-      hash = "sha256-VLB/Ni+sZ0Xugh3v7vb4rqTlAZz3eHU33lbljCX3Yic=";
+      hash = "sha256-hePdoDbFPOMjdSzsJqZWyFhHX138bMuocwCNpdOEkKA=";
     };
-
-  passthru.updateScript = writeScript "update-irpf" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl pup common-updater-scripts
-
-    set -eu -o pipefail
-    #parses the html with the install links for the containers that contain the instalation files of type 'file archive, gets the version number of each version, and sorts to get the latest one on the website
-    version="$(curl -s https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/download/pgd/dirpf | pup '.rfb_container .rfb_ositem:parent-of(.fa-file-archive) attr{href}' | grep -oP "IRPF\K(\d+)-[\d.]+\d" | sort -r |  head -1)"
-    update-source-version irpf "$version"
-  '';
 
   nativeBuildInputs = [
     unzip
@@ -63,10 +59,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     cp --no-preserve=mode -r help lib lib-modulos "$BASEDIR"
 
-    install -Dm644 irpf.jar Leia-me.htm offline.png online.png pgd-updater.jar "$BASEDIR"
+    install -Dm644 irpf.jar Leia-me.htm offline.png online.png pgd-updater-${pgd-updater-version}.jar "$BASEDIR"
 
     # make xdg-open overrideable at runtime
-    makeWrapper ${jdk11}/bin/java $out/bin/irpf \
+    makeWrapper ${lib.getExe java} $out/bin/irpf \
       --add-flags "-Dawt.useSystemAAFontSettings=gasp" \
       --add-flags "-Dswing.aatext=true" \
       --add-flags "-jar $BASEDIR/irpf.jar" \
@@ -78,7 +74,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     unzip -jp lib/ppgd-icones-4.0.jar icones/rfb64.png | magick - -background none -gravity center -extent 96x96 $out/share/icons/hicolor/96x96/apps/rfb.png
     unzip -jp lib/ppgd-icones-4.0.jar icones/rfb48.png | magick - -background none -gravity center -extent 72x72 $out/share/icons/hicolor/72x72/apps/rfb.png
     unzip -j lib/ppgd-icones-4.0.jar icones/rfb.png -d $out/share/icons/hicolor/32x32/apps
+
     runHook postInstall
+  '';
+
+  passthru.updateScript = writeScript "update-irpf" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl pup common-updater-scripts
+
+    set -eu -o pipefail
+    #parses the html with the install links for the containers that contain the instalation files of type 'file archive, gets the version number of each version, and sorts to get the latest one on the website
+    version="$(curl -s https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/download/pgd/dirpf | pup '.rfb_container .rfb_ositem:parent-of(.fa-file-archive) attr{href}' | grep -oP "IRPF\K(\d+)-[\d.]+\d" | sort -r |  head -1)"
+    update-source-version irpf "$version"
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tax season is upon us.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
