### PR TITLE
go-csp-collector: 0.0.17-unstable-2025-11-24 -> 0.0.17

### DIFF
--- a/pkgs/by-name/go/go-csp-collector/package.nix
+++ b/pkgs/by-name/go/go-csp-collector/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  go_1_26,
   buildGoModule,
   fetchFromGitHub,
   versionCheckHook,
@@ -7,18 +8,18 @@
   nixosTests,
 }:
 
-buildGoModule (finalAttrs: {
+buildGoModule.override { go = go_1_26; } (finalAttrs: {
   pname = "go-csp-collector";
-  version = "0.0.17-unstable-2025-11-24";
+  version = "0.0.17";
 
   src = fetchFromGitHub {
     owner = "jacobbednarz";
     repo = "go-csp-collector";
-    rev = "c997e31172ed2d785fc960296b826a9587bd5de9";
-    hash = "sha256-ZfE8xa+og14dlUmvYfatecSdrhmuMbFFNTw5RZ3ZHXU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NuJM7MneCptlmX0NV7c/7T1E5xhzM8Z59xNwEEGVuHM=";
   };
 
-  vendorHash = "sha256-SrQahSHO5ZIkcLR3BR5CR5BTStW1pH1Ij1Eql0b3tuU=";
+  vendorHash = "sha256-YbpBZhXTlSEKkCRDzFeDWRT8HEsCG2905WVGjxvW6oY=";
 
   ldflags = [
     "-s"
@@ -45,7 +46,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "A content security policy violation collector written in Golang";
     homepage = "https://github.com/jacobbednarz/go-csp-collector";
-    changelog = "https://github.com/jacobbednarz/go-csp-collector/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/jacobbednarz/go-csp-collector/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     mainProgram = "go-csp-collector";
     maintainers = with lib.maintainers; [ stepbrobd ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/jacobbednarz/go-csp-collector/releases/tag/v0.0.17

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
