### PR TITLE
nixos/tuxbox: init tuxbox

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1599,6 +1599,15 @@
   "module-security-acme-reload-dependencies": [
     "index.html#module-security-acme-reload-dependencies"
   ],
+  "module-programs-tuxbox": [
+    "index.html#module-programs-tuxbox"
+  ],
+  "module-programs-tuxbox-groups": [
+    "index.html#module-programs-tuxbox-groups"
+  ],
+  "module-programs-tuxbox-profile-switching": [
+    "index.html#module-programs-tuxbox-profile-switching"
+  ],
   "module-programs-zsh-ohmyzsh": [
     "index.html#module-programs-zsh-ohmyzsh"
   ],

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -54,6 +54,10 @@
 
 - [Dunst](https://github.com/dunst-project/dunst), a lightweight and customizable notification daemon. Available as [services.dunst](#opt-services.dunst.enable).
 
+- [TuxBox](https://github.com/AndyCappDev/tuxbox), a Linux driver for all TourBox models - Native
+  feel with USB, Bluetooth, haptics and graphical configuration GUI. Available as
+  [programs.tuxbox](#opt-programs.tuxbox.enable).
+
 - [cocoon](https://github.com/haileyok/cocoon), is a PDS (personal data server) that is a alternative to the bluesky pds. Available as [services.cocoon](#opt-services.cocoon.enable).
 
 - [Ente Auth](https://ente.io/auth/), an open source 2FA authenticator, with end-to-end encrypted backups. Available as [programs.ente-auth](#opt-programs.ente-auth.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -334,6 +334,7 @@
   ./programs/trippy.nix
   ./programs/tsm-client.nix
   ./programs/turbovnc.nix
+  ./programs/tuxbox.nix
   ./programs/udevil.nix
   ./programs/usbtop.nix
   ./programs/vim.nix

--- a/nixos/modules/programs/tuxbox.md
+++ b/nixos/modules/programs/tuxbox.md
@@ -1,0 +1,37 @@
+# TuxBox {#module-programs-tuxbox}
+
+[TuxBox](https://github.com/AndyCappDev/tuxbox) is a Linux driver for TourBox devices.
+
+## Input and dialout group {#module-programs-tuxbox-groups}
+
+For the driver to work your user needs to be in the `input` and `dialout` group. This module does
+that setup for you, but you need to specify the user for which the setup should be done.
+
+```
+programs.tuxbox = {
+  enable = true;
+  user = [ "john" ];
+};
+```
+
+## Profile switching {#module-programs-tuxbox-profile-switching}
+
+Profile switching requires the Systemd service to have its path amended with the applications used
+to verify the running compositor. The upstream application checks can be found [here in the source
+code](https://github.com/AndyCappDev/tuxbox/blob/2827c69fa293fec6d6c00303707dd173c484d291/tuxbox/window_monitor.py#L72).
+
+Otherwise, profile switching will be disabled by the application.
+
+The module tries to handle this for you. However, you can specify the additional packages to add
+manually with the option `systemdPathPackages`.
+
+```
+programs.tuxbox = {
+  enable = true;
+  user = [ "john" ];
+  systemdPathPackages = [
+    pkgs.sway
+  ];
+};
+```
+

--- a/nixos/modules/programs/tuxbox.nix
+++ b/nixos/modules/programs/tuxbox.nix
@@ -1,0 +1,177 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.tuxbox;
+  upstreamCompositorChecks = [
+    pkgs.hyprland
+    pkgs.niri
+    pkgs.sway
+    pkgs.glib
+    pkgs.kdotool
+    pkgs.xdotool
+  ];
+  kdeSystemPackages = [
+    pkgs.kdePackages.kwin
+    pkgs.kdePackages.plasma-desktop
+  ];
+  gnomeSystemPackages = [
+    pkgs.gnome-shell
+  ];
+  x11SystemPackages = [
+    pkgs.awesome
+    pkgs.dwm
+    pkgs.herbstluftwm
+    pkgs.i3
+    pkgs.icewm
+    pkgs.kdePackages.kwin-x11
+    pkgs.xfdesktop
+    pkgs.haskellPackages.xmonad
+    pkgs.xmonad-with-packages
+  ];
+  mapSwayPackage = (
+    # `programs.sway` generates the final package that will be put into `environment.systemPackages`.
+    # Therefore, it will be different to the package in nixpkgs and `lib.elem pkgs.sway config.environment.systemPackages` will fail.
+    if (config.programs.sway.enable || lib.elem pkgs.sway config.environment.systemPackages) then
+      [ pkgs.sway ]
+    else
+      [ ]
+  );
+  mapPackageForSystem = (
+    toolPkg:
+    (
+      systemPkgs:
+      if (lib.filter (pkg: lib.elem pkg systemPkgs) config.environment.systemPackages) != [ ] then
+        [ toolPkg ]
+      else
+        [ ]
+    )
+  );
+in
+{
+  options.programs.tuxbox = {
+    enable = lib.mkEnableOption "TuxBox";
+    package = lib.mkPackageOption pkgs "tuxbox" { };
+    systemdPathPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = lib.lists.unique (
+        (lib.filter (
+          pkg:
+          lib.elem pkg
+            # Binaries checked by upstream for existence to enable profile switching
+            upstreamCompositorChecks
+
+        ) config.environment.systemPackages)
+        # Handle unique sway case
+        ++ mapSwayPackage
+        # Gnome cases
+        ++ mapPackageForSystem pkgs.glib gnomeSystemPackages
+        # KDE Wayland cases
+        ++ mapPackageForSystem pkgs.kdotool kdeSystemPackages
+        # X11 cases
+        ++ mapPackageForSystem pkgs.xdotool x11SystemPackages
+      );
+      defaultText = lib.literalExpression ''
+          lib.lists.unique (
+            (lib.filter (
+              pkg:
+              lib.elem pkg (
+                # Binaries checked by upstream for existence to enable profile switching
+                upstreamCompositorChecks
+              )
+            ) config.environment.systemPackages)
+            # Handle unique sway case
+            ++ mapSwayPackage
+            # Gnome cases
+            ++ mapPackageForSystem pkgs.glib gnomeSystemPackages
+            # KDE Wayland cases
+            ++ mapPackageForSystem pkgs.kdotool kdeSystemPackages
+            # X11 cases
+            ++ mapPackageForSystem pkgs.xdotool x11SystemPackages
+        );
+      '';
+      description = "Packages to include in the tuxbox Systemd service path.";
+      example = ''
+        programs.tuxbox = {
+          enable = true;
+          user = [ "john" ];
+          systemdPathPackages = [
+            pkgs.sway
+          ];
+        };
+      '';
+    };
+    users = lib.mkOption {
+      description = "User to add to the input and dialout group for the driver. If no user is assigned, the program will not work.";
+      default = [ ];
+      type = lib.types.listOf lib.types.str;
+      example = ''
+        programs.tuxbox = {
+          enable = true;
+          # The user name can be retrieved with `whoami` or `id -un`.
+          user = [ "john" ];
+        };
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    warnings =
+      if cfg.systemdPathPackages == [ ] then
+        [
+          "Your system is using a window manager / desktop environment for which TuxBox has no profile switching support!"
+        ]
+      else
+        [ ];
+
+    assertions = [
+      {
+        assertion = builtins.any (user: builtins.hasAttr user config.users.users) cfg.users;
+        message = "User for TuxBox driver is not set!";
+      }
+    ];
+
+    environment.systemPackages = [ cfg.package ];
+    services.udev.packages = [ pkgs.tuxbox ];
+
+    users.users = builtins.listToAttrs (
+      builtins.map (username: {
+        name = username;
+        value = {
+          extraGroups = [
+            "input"
+            "dialout"
+          ];
+        };
+      }) cfg.users
+    );
+
+    systemd.user.services."tuxbox" = {
+      enable = true;
+      name = "tuxbox.service";
+      after = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      wantedBy = [ "graphical-session.target" ];
+      path = cfg.systemdPathPackages;
+      unitConfig = {
+        Description = "TuxBox Driver for TourBox Devices";
+      };
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/bin/tuxbox";
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+    };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [
+      CompileTime
+    ];
+    doc = ./tuxbox.md;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1675,6 +1675,7 @@ in
   turbovnc-headless-server = runTest ./turbovnc-headless-server.nix;
   turn-rs = runTest ./turn-rs.nix;
   tusd = runTest ./tusd/default.nix;
+  tuxbox = runTest ./tuxbox.nix;
   tuxguitar = runTest ./tuxguitar.nix;
   twingate = runTest ./twingate.nix;
   txredisapi = runTest ./txredisapi.nix;

--- a/nixos/tests/tuxbox.nix
+++ b/nixos/tests/tuxbox.nix
@@ -1,0 +1,349 @@
+{ lib, ... }:
+{
+  meta = {
+    maintainers = with lib.maintainers; [ CompileTime ];
+  };
+
+  name = "tuxbox";
+  enableOCR = true;
+
+  nodes = {
+    gui =
+      { pkgs, ... }:
+      {
+        imports = [
+          ./common/wayland-cage.nix
+        ];
+
+        services.cage.program = "${pkgs.tuxbox}/bin/tuxbox-gui";
+
+        programs.tuxbox = {
+          enable = true;
+          users = [ "alice" ];
+        };
+      };
+    sway =
+      { ... }:
+      {
+        imports = [
+          ./common/user-account.nix
+        ];
+
+        services.displayManager.sddm = {
+          enable = true;
+          wayland.enable = true;
+        };
+        services.displayManager = {
+          defaultSession = "sway-uwsm";
+          autoLogin = {
+            enable = true;
+            user = "alice";
+          };
+        };
+
+        programs.sway = {
+          enable = true;
+        };
+
+        programs.tuxbox = {
+          enable = true;
+          users = [ "alice" ];
+        };
+
+        programs.uwsm = {
+          enable = true;
+          waylandCompositors = {
+            sway = {
+              prettyName = "Sway";
+              binPath = "/run/current-system/sw/bin/sway";
+            };
+          };
+        };
+
+        virtualisation = {
+          qemu.options = [ "-vga virtio" ];
+        };
+      };
+    niri =
+      { ... }:
+      {
+        imports = [
+          ./common/user-account.nix
+        ];
+
+        services.displayManager.sddm = {
+          enable = true;
+          wayland.enable = true;
+        };
+        services.displayManager = {
+          defaultSession = "niri";
+          autoLogin = {
+            enable = true;
+            user = "alice";
+          };
+        };
+
+        programs.niri = {
+          enable = true;
+        };
+
+        programs.tuxbox = {
+          enable = true;
+          users = [ "alice" ];
+        };
+
+        virtualisation = {
+          qemu.options = [ "-vga virtio" ];
+        };
+      };
+    hyprland =
+      { ... }:
+      {
+        imports = [
+          ./common/user-account.nix
+        ];
+
+        services.displayManager.sddm = {
+          enable = true;
+          wayland.enable = true;
+        };
+        services.displayManager = {
+          defaultSession = "hyprland-uwsm";
+          autoLogin = {
+            enable = true;
+            user = "alice";
+          };
+        };
+
+        programs.hyprland = {
+          enable = true;
+          withUWSM = true;
+        };
+
+        programs.tuxbox = {
+          enable = true;
+          users = [ "alice" ];
+        };
+
+        virtualisation = {
+          qemu.options = [ "-vga virtio" ];
+        };
+      };
+    gdm =
+      { ... }:
+      {
+        imports = [
+          ./common/user-account.nix
+        ];
+
+        services.displayManager.gdm = {
+          enable = true;
+          wayland = true;
+        };
+        services.desktopManager.gnome.enable = true;
+
+        services.displayManager = {
+          autoLogin = {
+            enable = true;
+            user = "alice";
+          };
+        };
+
+        programs.tuxbox = {
+          enable = true;
+          users = [ "alice" ];
+        };
+
+        virtualisation = {
+          qemu.options = [ "-vga virtio" ];
+        };
+      };
+    kde =
+      { ... }:
+      {
+        imports = [
+          ./common/user-account.nix
+        ];
+
+        services.desktopManager.plasma6.enable = true;
+        services.displayManager.sddm.enable = true;
+        services.displayManager.sddm.wayland.enable = true;
+
+        services.displayManager = {
+          autoLogin = {
+            enable = true;
+            user = "alice";
+          };
+        };
+
+        programs.tuxbox = {
+          enable = true;
+          users = [ "alice" ];
+        };
+
+        virtualisation = {
+          qemu.options = [ "-vga virtio" ];
+        };
+      };
+    # Note: Profile switching is not tested for this node.
+    # It was attempted to test this with KDE (X11) and Xfce but neither setups
+    # produced a valid value for XDG_SESSION_TYPE which is needed for TuxBox
+    # to setup profile switching for X11. Therefore, profile switching assertions
+    # are missing in the test suite.
+    # Feel free to provide insights/suggestions on how to properly set this up.
+    xfce =
+      { ... }:
+      {
+        imports = [
+          ./common/user-account.nix
+        ];
+
+        services.xserver = {
+          enable = true;
+          desktopManager = {
+            xterm.enable = false;
+            xfce.enable = true;
+          };
+        };
+
+        services.displayManager = {
+          defaultSession = "xfce";
+          autoLogin = {
+            enable = true;
+            user = "alice";
+          };
+        };
+
+        programs.tuxbox = {
+          enable = true;
+          users = [ "alice" ];
+        };
+
+        virtualisation = {
+          qemu.options = [ "-vga virtio" ];
+        };
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    with subtest("GUI should show up in kiosk"):
+        gui.wait_for_text("TuxBox Configuration")
+        gui.shutdown()
+
+    with subtest("sway: TuxBox service unit should start"):
+        sway.wait_for_unit("graphical.target", timeout=60)
+        sway.wait_for_console_text("Started TuxBox Driver for TourBox Devices.")
+
+    with subtest("sway: Window manager should be detected"):
+        sway.wait_for_console_text("tuxbox.window_monitor - INFO - Detected window manager: sway")
+
+    with subtest("sway: Virtual input device should be created"):
+        sway.wait_for_console_text("tuxbox.device_base - INFO - Creating virtual input device...")
+
+    with subtest("sway: Window monitor should be started"):
+        sway.wait_for_console_text("tuxbox.window_monitor - INFO - Starting window monitor \(compositor: sway, interval: .+s\)")
+
+    with subtest("sway: Driver binary should be in PATH"):
+        sway.succeed("tuxbox --version")
+
+    with subtest("sway: GUI application should be in PATH"):
+        sway.succeed("which tuxbox-gui")
+        sway.shutdown()
+
+    with subtest("niri: TuxBox service unit should start"):
+        niri.wait_for_unit("graphical.target", timeout=60)
+        niri.wait_for_console_text("Started TuxBox Driver for TourBox Devices.")
+
+    with subtest("niri: Window manager should be detected"):
+        niri.wait_for_console_text("tuxbox.window_monitor - INFO - Detected window manager: niri")
+
+    with subtest("niri: Virtual input device should be created"):
+        niri.wait_for_console_text("tuxbox.device_base - INFO - Creating virtual input device...")
+
+    with subtest("niri: Window monitor should be started"):
+        niri.wait_for_console_text("tuxbox.window_monitor - INFO - Starting window monitor \(compositor: niri, interval: .+s\)")
+
+    with subtest("niri: Driver binary should be in PATH"):
+        niri.succeed("tuxbox --version")
+
+    with subtest("niri: GUI application should be in PATH"):
+        niri.succeed("which tuxbox-gui")
+        niri.shutdown()
+
+    with subtest("hyprland: TuxBox service unit should start"):
+        hyprland.wait_for_unit("graphical.target", timeout=60)
+        hyprland.wait_for_console_text("Started TuxBox Driver for TourBox Devices.")
+
+    with subtest("hyprland: Window manager should be detected"):
+        hyprland.wait_for_console_text("tuxbox.window_monitor - INFO - Detected window manager: hyprland")
+
+    with subtest("hyprland: Virtual input device should be created"):
+        hyprland.wait_for_console_text("tuxbox.device_base - INFO - Creating virtual input device...")
+
+    with subtest("hyprland: Window monitor should be started"):
+        hyprland.wait_for_console_text("tuxbox.window_monitor - INFO - Starting window monitor \(compositor: hyprland, interval: .+s\)")
+
+    with subtest("hyprland: Driver binary should be in PATH"):
+        hyprland.succeed("tuxbox --version")
+
+    with subtest("hyprland: GUI application should be in PATH"):
+        hyprland.succeed("which tuxbox-gui")
+        hyprland.shutdown()
+
+    with subtest("Gnome (Wayland): TuxBox service unit should start"):
+        gdm.wait_for_unit("graphical.target", timeout=60)
+        gdm.wait_for_console_text("Started TuxBox Driver for TourBox Devices.")
+
+    with subtest("Gnome (Wayland): Window manager should be detected"):
+        gdm.wait_for_console_text("tuxbox.window_monitor - INFO - Detected window manager: gnome")
+
+    with subtest("Gnome (Wayland): Virtual input device should be created"):
+        gdm.wait_for_console_text("tuxbox.device_base - INFO - Creating virtual input device...")
+
+    with subtest("Gnome (Wayland): Window monitor should be started"):
+        gdm.wait_for_console_text("tuxbox.window_monitor - INFO - Starting window monitor \(compositor: gnome, interval: .+s\)")
+
+    with subtest("Gnome (Wayland): Driver binary should be in PATH"):
+        gdm.succeed("tuxbox --version")
+
+    with subtest("Gnome (Wayland): GUI application should be in PATH"):
+        gdm.succeed("which tuxbox-gui")
+        gdm.shutdown()
+
+    with subtest("KDE (Wayland): TuxBox service unit should start"):
+        kde.wait_for_unit("graphical.target", timeout=60)
+        kde.wait_for_console_text("Started TuxBox Driver for TourBox Devices.")
+
+    with subtest("KDE (Wayland): Window manager should be detected"):
+        kde.wait_for_console_text("tuxbox.window_monitor - INFO - Detected window manager: kde")
+
+    with subtest("KDE (Wayland): Virtual input device should be created"):
+        kde.wait_for_console_text("tuxbox.device_base - INFO - Creating virtual input device...")
+
+    with subtest("KDE (Wayland): Window monitor should be started"):
+        kde.wait_for_console_text("tuxbox.window_monitor - INFO - Starting window monitor \(compositor: kde, interval: .+s\)")
+
+    with subtest("KDE (Wayland): Driver binary should be in PATH"):
+        kde.succeed("tuxbox --version")
+
+    with subtest("KDE (Wayland): GUI application should be in PATH"):
+        kde.succeed("which tuxbox-gui")
+        kde.shutdown()
+
+    with subtest("Xfce: TuxBox service unit should start"):
+        xfce.wait_for_unit("graphical.target", timeout=60)
+        xfce.wait_for_console_text("Started TuxBox Driver for TourBox Devices.")
+
+    with subtest("Xfce: Virtual input device should be created"):
+        xfce.wait_for_console_text("tuxbox.device_base - INFO - Creating virtual input device...")
+
+    with subtest("Xfce: Driver binary should be in PATH"):
+        xfce.succeed("tuxbox --version")
+
+    with subtest("Xfce: GUI application should be in PATH"):
+        xfce.succeed("which tuxbox-gui")
+        xfce.shutdown()
+  '';
+}


### PR DESCRIPTION
Adds a module to configure the TuxBox TourBox Linux driver for the system. This module sets up necessary group assignments, udev rules and a SystemD user service.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
