### PR TITLE
nixedit: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23105,6 +23105,12 @@
     name = "Michele Guerini Rocco";
     keys = [ { fingerprint = "92B2 904F D293 C94D C4C9  3E6B BFBA F4C9 75F7 6450"; } ];
   };
+  roamingparrot = {
+    email = "roamingparrot@protonmail.com";
+    github = "roamingparrot";
+    githubId = 190113561;
+    name = "roamingparrot";
+  };
   roastiek = {
     email = "r.dee.b.b@gmail.com";
     github = "roastiek";

--- a/pkgs/by-name/ni/nixedit/package.nix
+++ b/pkgs/by-name/ni/nixedit/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ncurses,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nixedit";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "roamingparrot";
+    repo = "nixos-config-manager";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-BF1PcsD1iXjLrbfioa7OIkb/YhN3IGWnHzlHk+1pScc=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ ncurses ];
+
+  strictDeps = true;
+
+  preConfigure = ''
+    cd src
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D nixedit --target-directory=$out/bin
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI for managing NixOS packages";
+    longDescription = ''
+      nixedit is a terminal-based user interface for searching, installing,
+      and removing NixOS packages by directly editing your Nix configuration files.
+      It provides an intuitive way to manage your system packages without
+      manually editing configuration files.
+    '';
+    homepage = "https://github.com/roamingparrot/nixos-config-manager";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ roamingparrot ];
+    mainProgram = "nixedit";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
# Description

nixedit is a terminal-based user interface for editing NixOS configuration files and managing packages. It provides:

- **Multi-file configuration support** - Follows imports and resolves relative paths
- **Package search** - Search nixpkgs using `nix-env -qaP`  
- **Smart syntax detection** - Auto-detects `with pkgs;` vs `pkgs.` patterns
- **Safe package removal** - Preserves formatting when editing files
- **Automatic rebuild integration** - Runs `nixos-rebuild switch` after changes
- **Duplicate detection** - Prevents adding packages twice
- **Syntax validation** - Validates Nix syntax with `nix-instantiate --parse` before rebuilding

## Motivation

Managing packages across multiple NixOS configuration files can be tedious when configurations are split into modules. nixedit provides a unified TUI view of all packages and handles the complexity of multi-file configurations automatically.

## Testing

```bash
nix-build -A nixedit
```

Successfully tested on NixOS 25.05.

## Checklist

- [x] Built locally
- [x] Tested on NixOS  
- [x] No network access during build
- [x] All dependencies declared
- [x] Meta attributes set (description, license, platforms, mainProgram)
- [x] Binary name matches directory (`nixedit`)
- [x] Uses `pkgs/by-name` structure

## Links

- Repository: https://github.com/roamingparrot/nixos-config-manager
- Release: https://github.com/roamingparrot/nixos-config-manager/releases/tag/v0.1.0