### PR TITLE
moz-idb-edit: init at unstable-2025-10-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11857,6 +11857,11 @@
     githubId = 7005773;
     keys = [ { fingerprint = "B982 0250 1720 D540 6A18  2DA8 188E 4945 E85B 2D21"; } ];
   };
+  jakehpark = {
+    name = "Jake Park";
+    github = "JakeHPark";
+    githubId = 268660459;
+  };
   jakeisnt = {
     name = "Jacob Chvatal";
     email = "jake@isnt.online";

--- a/pkgs/by-name/mo/moz-idb-edit/package.nix
+++ b/pkgs/by-name/mo/moz-idb-edit/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitLab,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "moz-idb-edit";
+  version = "0-unstable-2025-10-13";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "ntninja";
+    repo = "moz-idb-edit";
+    rev = "e008c289609138b6c575357b9889c0aa0ed14f07";
+    hash = "sha256-4Ddfv+MZ146mQo7zOPwcmf/gUTEB4usJWjHf6y2KZ5E=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    cramjam
+    jmespath
+  ];
+
+  pythonImportsCheck = [ "mozidbedit" ];
+
+  meta = {
+    description = "IndexedDB reader for Firefox and other MozTK applications";
+    homepage = "https://gitlab.com/ntninja/moz-idb-edit";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ jakehpark ];
+    mainProgram = "moz-idb-edit";
+  };
+}


### PR DESCRIPTION
moz-idb-edit is an IndexedDB reader for Firefox and other MozTK applications. For instance, it allows reading Firefox extension settings in `~/.config/mozilla/firefox/<profile>/storage/default/<extension>/idb/<db>.sqlite`. This is particularly useful for figuring out extension settings for Home Manager's Firefox module, so I figured this might be useful for others as well, but if it's too niche, feel free to ignore this.

## Things done
- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
