### PR TITLE
katana-usb-audio: init at unstable-2026-03-20; nixos/katana-usb-audio: init

### DIFF
--- a/nixos/modules/hardware/katana-usb-audio.nix
+++ b/nixos/modules/hardware/katana-usb-audio.nix
@@ -1,0 +1,19 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.hardware.katana-usb-audio;
+  katana-usb-audio = config.boot.kernelPackages.katana-usb-audio;
+in
+{
+  options.hardware.katana-usb-audio = {
+    enable = lib.mkEnableOption "Enables the kernel module an udev rules for the Creative Katana Soundblaster";
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.kernelModules = [ "katana-usb-audio" ];
+    boot.extraModulePackages = [ katana-usb-audio ];
+    services.udev.packages = [ katana-usb-audio ];
+  };
+
+  meta.maintainers = [ lib.maintainers.Svenum ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -79,6 +79,7 @@
   ./hardware/infiniband.nix
   ./hardware/inputmodule.nix
   ./hardware/iosched.nix
+  ./hardware/katana-usb-audio.nix
   ./hardware/keyboard/qmk.nix
   ./hardware/keyboard/teck.nix
   ./hardware/keyboard/uhk.nix

--- a/pkgs/os-specific/linux/katana-usb-audio/default.nix
+++ b/pkgs/os-specific/linux/katana-usb-audio/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  udevCheckHook,
+  bash,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "katana-usb-audio";
+  version = "unstable-2026-03-20";
+
+  src = fetchFromGitHub {
+    owner = "mrworf";
+    repo = pname;
+    rev = "73783991f3044602197abd40f37650bdc5f8f030";
+    hash = "sha256-oLpQS0N1IscKPL8QPfMtIQw2bbkIqWdolGQWF7o64Ks=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies ++ [
+    udevCheckHook
+  ];
+
+  makeFlags = [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "MODULE_DIR=$(out)/lib/modules/${kernel.modDirVersion}/extras"
+    "UDEV_RULES_DIR=$(out)/etc/udev/rules.d"
+  ];
+
+  patches = [ ./makefile.patch ];
+
+  preBuild = ''
+    substituteInPlace 99-katana-usb-audio.rules \
+     --replace-fail "/bin/sh" "${lib.getExe bash}"
+  '';
+
+  meta = with lib; {
+    description = "Linux kernel driver for the SoundBlaster X Katana USB soundbar";
+    longDescription = ''
+      Replaces the generic snd-usb-audio driver for Creative Labs SoundBlaster X
+      Katana (USB) with a custom ALSA/USB kernel module that correctly handles
+      volume control and audio playback for this device.
+    '';
+    homepage = "https://github.com/mrworf/katana-usb-audio";
+    license = licenses.gpl2Only;
+    maintainers = [ maintainers.Svenum ];
+    platforms = platforms.linux;
+    broken = kernel.kernelOlder "5.15";
+  };
+}

--- a/pkgs/os-specific/linux/katana-usb-audio/makefile.patch
+++ b/pkgs/os-specific/linux/katana-usb-audio/makefile.patch
@@ -1,0 +1,33 @@
+diff --git a/Makefile b/Makefile
+index 031cf07..52f688b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -17,10 +17,9 @@ install: all
+ 	@echo "Installing Katana USB Audio driver..."
+ 	mkdir -p $(MODULE_DIR)
+ 	cp katana_usb_audio.ko $(MODULE_DIR)/
+-	depmod -a
+ 	@echo "Installing udev rule for driver priority..."
++	mkdir -p $(UDEV_RULES_DIR)
+ 	cp 99-katana-usb-audio.rules $(UDEV_RULES_DIR)/
+-	udevadm control --reload-rules
+ 	@echo "Installation complete!"
+ 	@echo ""
+ 	@echo "To load the driver now, run:"
+@@ -35,8 +34,6 @@ uninstall:
+ 	modprobe -r katana_usb_audio 2>/dev/null || true
+ 	rm -f $(MODULE_DIR)/katana_usb_audio.ko
+ 	rm -f $(UDEV_RULES_DIR)/99-katana-usb-audio.rules
+-	depmod -a
+-	udevadm control --reload-rules
+ 	@echo "Uninstall complete!"
+ 
+ dkms-install:
+@@ -53,4 +50,5 @@ dkms-status:
+ 	@echo "DKMS status for katana-usb-audio:"
+ 	@dkms status katana-usb-audio 2>/dev/null || echo "Package not found in DKMS"
+ 
+-.PHONY: all clean install uninstall dkms-install dkms-uninstall dkms-status
+\ No newline at end of file
++.PHONY: all clean install uninstall dkms-install dkms-uninstall dkms-status
++

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -432,6 +432,12 @@ in
 
         it87 = callPackage ../os-specific/linux/it87 { };
 
+        katana-usb-audio =
+          if lib.versionAtLeast kernel.version "5.15" then
+            callPackage ../os-specific/linux/katana-usb-audio { }
+          else
+            null;
+
         asus-ec-sensors = callPackage ../os-specific/linux/asus-ec-sensors { };
 
         ena = callPackage ../os-specific/linux/ena { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
