### PR TITLE
haskell: allow direct -package-db of haskell derivations

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -905,6 +905,13 @@ lib.fix (
 
               # delete confdir if there are no libraries
               find $packageConfDir -maxdepth 0 -empty -delete;
+
+              # if there *is* anything in there, generate a package cache,
+              # allowing directly using packages with ghc -package-db without
+              # needing to create a ghc-with-packages derivation
+              if [[ -d "$packageConfDir" ]]; then
+                ${ghcCommand}-pkg recache --package-db=$packageConfDir
+              fi
             ''
         }
 


### PR DESCRIPTION
We generate $out/lib/ghc9.10.3/package.conf.d/package.cache.

The purpose of this is to allow non-Nix build systems (buck2, e.g.) to consume Haskell derivations from nixpkgs without having to create a new package db for each combination of packages to be used; instead they can pass `-package-db` once for each desired package to compiler invocations.

Note: I do wonder if this is a mildly silly design on the part of the buck2-haskell rules given there's surely a reason these caches exist in the first place i.e. to avoid having to touch a whole bunch of directories merely to know about packages, and read a single file instead? Though if this were revised to use anonymous targets for the package caches, those targets will likely experience very limited sharing (and the reason they're *not* copying nixpkgs' ghc-with-packages idea is because it would create false sharing of *all* nix-provided libs).

The nix equivalent of the thing being avoided is the `ghc-with-packages` derivations.

Testing plan:
- Built a bad version of this with an overlay, validated that the closure size was not appreciably different for hs-opentelemetry-api (has lots of dependencies).
- Built up to hscolour on aarch64-darwin, including bootstrapping GHC.
- Really ought to write a nixpkgs test to make sure this doesn't regress any of these funny out-of-tree use cases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
