### PR TITLE
sonar: init at 0.2.9

### DIFF
--- a/pkgs/by-name/so/sonar/package.nix
+++ b/pkgs/by-name/so/sonar/package.nix
@@ -1,0 +1,53 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+  nix-update-script,
+  stdenv,
+}:
+
+buildGoModule rec {
+  pname = "sonar";
+  version = "0.2.9";
+
+  src = fetchFromGitHub {
+    owner = "RasKrebs";
+    repo = "sonar";
+    tag = "v${version}";
+    hash = "sha256-rEAc0lmpxxnaS1kwyPPW6LE4XxjAItIV/vjYTRm+Cvw=";
+  };
+
+  vendorHash = "sha256-komX1AmHt2NoF1x6xsNa2RFkfVzOXfYEMPhT0zwMxjw=";
+
+  __structuredAttrs = true;
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/raskrebs/sonar/internal/selfupdate.Version=v${version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd sonar \
+      --bash <($out/bin/sonar completion bash) \
+      --fish <($out/bin/sonar completion fish) \
+      --zsh <($out/bin/sonar completion zsh)
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI tool for inspecting and managing services listening on localhost ports";
+    homepage = "https://github.com/RasKrebs/sonar";
+    changelog = "https://github.com/RasKrebs/sonar/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pbek ];
+    mainProgram = "sonar";
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+}


### PR DESCRIPTION
Add package for [sonar](https://github.com/raskrebs/sonar), a CLI tool for inspecting and managing services listening on localhost ports.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
