### PR TITLE
intel-oneapi.{base,hpc}: unbreak updateScript, update both

### DIFF
--- a/pkgs/development/libraries/intel-oneapi/base.nix
+++ b/pkgs/development/libraries/intel-oneapi/base.nix
@@ -67,14 +67,14 @@ intel-oneapi.mkIntelOneApi (finalAttrs: {
   pname = "intel-oneapi-base-toolkit";
 
   src = fetchurl {
-    url = "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3b7a16b3-a7b0-460f-be16-de0d64fa6b1e/intel-oneapi-base-toolkit-2025.2.1.44_offline.sh";
-    hash = "sha256-oVURJZG6uZ3YvYefUuqeakbaVR47ZgWduBV6bS6r5Dk=";
+    url = "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/6caa93ca-e10a-4cc5-b210-68f385feea9e/intel-oneapi-base-toolkit-2025.3.1.36_offline.sh";
+    hash = "sha256-xXV6FP4t1ChSi/bcDFpkmMexNejPTtk2Nay/PmSpCFA=";
   };
 
   versionYear = "2025";
-  versionMajor = "2";
+  versionMajor = "3";
   versionMinor = "1";
-  versionRel = "44";
+  versionRel = "36";
 
   inherit components;
 

--- a/pkgs/development/libraries/intel-oneapi/base.nix
+++ b/pkgs/development/libraries/intel-oneapi/base.nix
@@ -180,6 +180,7 @@ intel-oneapi.mkIntelOneApi (finalAttrs: {
     "libffi.so.6"
     "libgdbm.so.4"
     "libopencl-clang.so.14"
+    "libreadline.so.6"
   ];
 
   passthru.updateScript = intel-oneapi.mkUpdateScript {

--- a/pkgs/development/libraries/intel-oneapi/default.nix
+++ b/pkgs/development/libraries/intel-oneapi/default.nix
@@ -172,7 +172,7 @@
         fi
 
         echo "The new download URL is $url, prefetching it to store" >&2
-        hash="$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url --quiet "$url")")"
+        hash="$(nix hash convert --hash-algo sha256 "$(nix-prefetch-url --quiet "$url")")"
 
         sed -i "s|versionYear = \".*\";|versionYear = \"$versionYear\";|" "$file"
         sed -i "s|versionMajor = \".*\";|versionMajor = \"$versionMajor\";|" "$file"

--- a/pkgs/development/libraries/intel-oneapi/default.nix
+++ b/pkgs/development/libraries/intel-oneapi/default.nix
@@ -150,17 +150,21 @@
           | htmlq 'code' --text \
           | grep "wget.*$pname.*sh")"
 
-        regex="wget (.*$pname.([0-9]+)[.]([0-9]+)[.]([0-9]+)[.]([0-9]+)_offline[.]sh)"
+        # _offline is optional: Intel sometimes only links the online installer, which shares the same UUID and version.
+        regex="wget (https://registrationcenter-download[.]intel[.]com/akdlm/IRC_NAS/([0-9a-z-]+)/$pname.([0-9]+)[.]([0-9]+)[.]([0-9]+)[.]([0-9]+)(_offline)?[.]sh)"
         if [[ "$wget_command" =~ $regex ]]; then
-            url="''${BASH_REMATCH[1]}"
-            versionYear="''${BASH_REMATCH[2]}"
-            versionMajor="''${BASH_REMATCH[3]}"
-            versionMinor="''${BASH_REMATCH[4]}"
-            versionRel="''${BASH_REMATCH[5]}"
+            uuid="''${BASH_REMATCH[2]}"
+            versionYear="''${BASH_REMATCH[3]}"
+            versionMajor="''${BASH_REMATCH[4]}"
+            versionMinor="''${BASH_REMATCH[5]}"
+            versionRel="''${BASH_REMATCH[6]}"
         else
             echo "'$wget_command' does not match the expected format $regex" >&2
             exit 1
         fi
+
+        # Always reconstruct to point at the offline installer
+        url="https://registrationcenter-download.intel.com/akdlm/IRC_NAS/$uuid/$pname-$versionYear.$versionMajor.$versionMinor.''${versionRel}_offline.sh"
 
         if grep -qF "url = \"$url\"" "$file"; then
             echo "The URL is the same ($url), skipping update" >&2

--- a/pkgs/development/libraries/intel-oneapi/default.nix
+++ b/pkgs/development/libraries/intel-oneapi/default.nix
@@ -129,7 +129,7 @@
       downloadPage,
       file,
     }:
-    writeShellApplication {
+    lib.getExe (writeShellApplication {
       name = "update-intel-oneapi";
       runtimeInputs = [
         curl
@@ -141,7 +141,7 @@
         download_page=${lib.escapeShellArg downloadPage}
         pname=${lib.escapeShellArg pname}
         nixpkgs="$(git rev-parse --show-toplevel)"
-        packageDir="$nixpkgs/pkgs/by-name/in/intel-oneapi"
+        packageDir="$nixpkgs/pkgs/development/libraries/intel-oneapi"
         file="$packageDir"/${lib.escapeShellArg file}
 
         echo 'Figuring out the download URL' >&2
@@ -164,12 +164,13 @@
             exit 1
         fi
 
-        if [[ "$(grep 'url =' "$file")" =~ "$url" ]] && [[ "''${BASH_REMATCH[0]}" == "$url" ]]; then
+        if grep -qF "url = \"$url\"" "$file"; then
             echo "The URL is the same ($url), skipping update" >&2
-        else
-            echo "The new download URL is $url, prefetching it to store" >&2
-            hash="$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url --quiet "$url")")"
+            exit 0
         fi
+
+        echo "The new download URL is $url, prefetching it to store" >&2
+        hash="$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url --quiet "$url")")"
 
         sed -i "s|versionYear = \".*\";|versionYear = \"$versionYear\";|" "$file"
         sed -i "s|versionMajor = \".*\";|versionMajor = \"$versionMajor\";|" "$file"
@@ -178,7 +179,7 @@
         sed -i "s|url = \".*\";|url = \"$url\";|" "$file"
         sed -i "s|hash = \".*\";|hash = \"$hash\";|" "$file"
       '';
-    };
+    });
 
   base = callPackage ./base.nix { };
   hpc = callPackage ./hpc.nix { };

--- a/pkgs/development/libraries/intel-oneapi/default.nix
+++ b/pkgs/development/libraries/intel-oneapi/default.nix
@@ -16,7 +16,6 @@
   # For the updater script
   writeShellApplication,
   curl,
-  jq,
   htmlq,
   common-updater-scripts,
   writableTmpDirAsHomeHook,
@@ -133,7 +132,6 @@
       name = "update-intel-oneapi";
       runtimeInputs = [
         curl
-        jq
         htmlq
         common-updater-scripts
       ];

--- a/pkgs/development/libraries/intel-oneapi/hpc.nix
+++ b/pkgs/development/libraries/intel-oneapi/hpc.nix
@@ -30,14 +30,14 @@ intel-oneapi.mkIntelOneApi (finalAttrs: {
   pname = "intel-oneapi-hpc-toolkit";
 
   src = fetchurl {
-    url = "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2d2a6686-ff06-44ce-baf0-ab84f8dafa89/intel-oneapi-hpc-toolkit-2025.2.1.44_offline.sh";
-    hash = "sha256-SC0eDu4TGf9bZB8aAX4AnIvguTpP0afOj9JqA63QSPs=";
+    url = "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/f59a79aa-4a6e-46e8-a6c2-be04bb13f274/intel-oneapi-hpc-toolkit-2025.3.1.55_offline.sh";
+    hash = "sha256-NwLR7OWzmKYM05BZ2U7IZI+3IBnb0wiUgF+vHrX0Tro=";
   };
 
   versionYear = "2025";
-  versionMajor = "2";
+  versionMajor = "3";
   versionMinor = "1";
-  versionRel = "44";
+  versionRel = "55";
 
   inherit components;
 


### PR DESCRIPTION
`intel-oneapi.{base,hpc}`'s `updateScript` was broken (see https://r.ryantm.com/log/intel-oneapi.base/2026-03-19.log)

This PR fixes the script, as well as some minor robustness tweaks.

Additionally, it updates `intel-oneapi.{base,hpc}` both to the current latest version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
