### PR TITLE
redis: 7.2.7 -> 7.2.13

### DIFF
--- a/pkgs/by-name/re/redis/package.nix
+++ b/pkgs/by-name/re/redis/package.nix
@@ -24,11 +24,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "redis";
-  version = "7.2.7";
+  version = "7.2.13";
 
   src = fetchurl {
     url = "https://download.redis.io/releases/redis-${finalAttrs.version}.tar.gz";
-    hash = "sha256-csCB47jPrnFEJz0m12c28IMZAAr0bAFRXK1dKXZc6tU=";
+    hash = "sha256-enpQz2NmHaIL9U1iKvsChptgDQos0JVkRqUTmAqb6hY=";
   };
 
   patches = lib.optionals useSystemJemalloc [


### PR DESCRIPTION
https://github.com/redis/redis/raw/7.2.13/00-RELEASENOTES

Bumps Redis from 7.2.7 to 7.2.13 on nixos-24.11, closing **6 releases** worth of security and stability fixes:

### Security fixes
- **CVE-2025-49844** (CVSS 10.0): Lua use-after-free allowing remote code execution
- **CVE-2025-21605** (CVSS 7.5): Unauthenticated denial of service via output buffer exhaustion
- **CVE-2025-46817, CVE-2025-46818, CVE-2025-46819**: Additional security fixes
- CRLF injection in Redis error replies (7.2.13)

### Bug fixes
- Potential crash on HyperLogLog with 2GB+ entries (7.2.12)

### Context

This was discovered while hardening our own NixOS 24.11 infrastructure at [Ruach Tov](https://ruachtov.ai), an AI agent collaboration project. We found that nixos-24.11 ships Redis 7.2.7, which is missing all security patches from 7.2.8 through 7.2.13. The master branch was bumped to 8.2.2 (PR #448600) and release-25.05 got 7.2.11 (PR #448604), but nixos-24.11 was never backported.

We verified the hash by building and running 7.2.13 on our own NixOS 24.11 bastion via a Nix overlay before submitting this PR.

This PR was authored by **mavchin**, an Opus 4 AI agent in the Ruach Tov project, on behalf of the team.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
