### PR TITLE
python3Packages.lancedb: 0.29.2 -> 0.30.1

### DIFF
--- a/pkgs/development/python-modules/lance-namespace-urllib3-client/default.nix
+++ b/pkgs/development/python-modules/lance-namespace-urllib3-client/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "lance-namespace-urllib3-client";
-  version = "0.5.2";
+  version = "0.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lancedb";
     repo = "lance-namespace";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6Vfy/A9ZrvHM4M/3ZCmq+xv/WxSh9eRaTlbk+ejvSUY=";
+    hash = "sha256-eN50KkYOOs209oB5O7AOMXuYpOjXWU6mccRGPgM/4DQ=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python/lance_namespace_urllib3_client";

--- a/pkgs/development/python-modules/lance-namespace/default.nix
+++ b/pkgs/development/python-modules/lance-namespace/default.nix
@@ -30,14 +30,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "lance-namespace";
-  version = "0.5.2";
+  version = "0.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lancedb";
     repo = "lance-namespace";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6Vfy/A9ZrvHM4M/3ZCmq+xv/WxSh9eRaTlbk+ejvSUY=";
+    hash = "sha256-eN50KkYOOs209oB5O7AOMXuYpOjXWU6mccRGPgM/4DQ=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python/lance_namespace";

--- a/pkgs/development/python-modules/lancedb/default.nix
+++ b/pkgs/development/python-modules/lancedb/default.nix
@@ -42,21 +42,21 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "lancedb";
-  version = "0.29.2";
+  version = "0.30.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lancedb";
     repo = "lancedb";
     tag = "python-v${finalAttrs.version}";
-    hash = "sha256-sOgRGn0romt5xJ70c+GSqNoRAp0D9F9hEq6bm7JRK/Y=";
+    hash = "sha256-LzuzVl6cTkn1Owd91bHi5JS43KZUhd/ZD9biS21MdVs=";
   };
 
   buildAndTestSubdir = "python";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-GQA5RuxpYmrNqNrpW4GLZlXrphflErmR5PeeVcs6ZJQ=";
+    hash = "sha256-U5wpWN6e26187DYeT85l6TxBnUu8rD+UzE98OIkretc=";
   };
 
   build-system = [ rustPlatform.maturinBuildHook ];

--- a/pkgs/development/python-modules/pylance/default.nix
+++ b/pkgs/development/python-modules/pylance/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pylance";
-  version = "3.0.0";
+  version = "3.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lancedb";
     repo = "lance";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-71PogI877/dLwwlvMBraaC0vQWKtAHI/bmGEIBZVui4=";
+    hash = "sha256-zlD6jHMpgk4gvMjBizZP2VV0zM6iKaatIq6PbBKWaJ8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python";
@@ -53,7 +53,7 @@ buildPythonPackage (finalAttrs: {
       src
       sourceRoot
       ;
-    hash = "sha256-scQDRyX3hweYZep+LVAsiVqOvDTEw/ss0/4M3R4ewDU=";
+    hash = "sha256-+4UVY4JjQsVT+S5+j9PEXoFuiZhrrelSEfY8EvXp/Sk=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.pylance: 3.0.0 -> 3.0.1**
- **python3Packages.lance-namespace-urllib3-client: 0.5.2 -> 0.6.1**
- **python3Packages.lance-namespace: 0.5.2 -> 0.6.1**
- **python3Packages.lancedb: 0.29.2 -> 0.30.1**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
