### PR TITLE
asccli: init at 1.0.1

### DIFF
--- a/pkgs/by-name/as/asccli/package.nix
+++ b/pkgs/by-name/as/asccli/package.nix
@@ -1,0 +1,66 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  git,
+  lib,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "asccli";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "rudrankriyam";
+    repo = "App-Store-Connect-CLI";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-e2USts+HC3skFvexeKhKSJT0KxHlB5LFr54lqGjhZqM=";
+  };
+
+  vendorHash = "sha256-712Q7KiFQyTDjX4Srhukv3eQ84MRjnQxrpgBfqK2xa4=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+    "-X main.commit=${finalAttrs.src.rev}"
+    "-X main.date=1970-01-01T00:00:00Z"
+  ];
+
+  postInstall = ''
+    mv $out/bin/App-Store-Connect-CLI $out/bin/asc
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  __darwinAllowLocalNetworking = true;
+  nativeCheckInputs = [ git ];
+  preCheck = ''
+    export ASC_BYPASS_KEYCHAIN=1
+  '';
+  checkFlags =
+    let
+      skippedTests = [
+        "TestDefaultRunSkillsCheckCommand_UsesSkillsBinaryCheckCommand"
+        "TestDefaultRunSkillsCheckCommand_FallsBackToNpxOffline"
+        "TestDefaultRunSkillsCheckCommand_OfflineCacheMissIsUnavailable"
+        "TestAuthLogoutCommand"
+        "TestAuthStatusInvalidBypassWarningPrintedOnce"
+      ];
+    in
+    [
+      "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$"
+    ];
+
+  meta = {
+    description = "Scriptable CLI for the App Store Connect API";
+    homepage = "https://asccli.sh";
+    changelog = "https://github.com/rudrankriyam/App-Store-Connect-CLI/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      DimitarNestorov
+    ];
+    mainProgram = "asc";
+  };
+})


### PR DESCRIPTION
https://asccli.sh

https://github.com/rudrankriyam/App-Store-Connect-CLI

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
