### PR TITLE
nixos/luksroot: exclude aes_generic module for kernel >=7.0

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -633,23 +633,25 @@ in
 
     boot.initrd.luks.cryptoModules = mkOption {
       type = types.listOf types.str;
-      default = [
-        "aes"
-        "aes_generic"
-        "blowfish"
-        "twofish"
-        "serpent"
-        "cbc"
-        "xts"
-        "lrw"
-        "sha1"
-        "sha256"
-        "sha512"
-        "af_alg"
-        "algif_skcipher"
-        "cryptd"
-        "input_leds" # for capslock LED on most keyboards in case decryption requires password
-      ];
+      defaultText = lib.literalExpression ''
+        [
+          "aes"
+          "blowfish"
+          "twofish"
+          "serpent"
+          "cbc"
+          "xts"
+          "lrw"
+          "sha1"
+          "sha256"
+          "sha512"
+          "af_alg"
+          "algif_skcipher"
+          "cryptd"
+          "input_leds" # for capslock LED on most keyboards in case decryption requires password
+        ]
+        ++ (lib.optional (lib.versionOlder config.boot.kernelPackages.kernel.version "7.0") "aes_generic");
+      '';
       description = ''
         A list of cryptographic kernel modules needed to decrypt the root device(s).
         The default includes all common modules.
@@ -1126,12 +1128,40 @@ in
       }
     ];
 
+    warnings =
+      optional
+        (
+          (versionAtLeast kernelPackages.kernel.version "7.0")
+          && (builtins.elem "aes_generic" luks.cryptoModules)
+        )
+        ''
+          boot.initrd.luks.cryptoModules: "aes_generic" is no longer provided in kernel versions >= 7.0. This will fail if provided in a future version.
+        '';
+
     # actually, sbp2 driver is the one enabling the DMA attack, but this needs to be tested
     boot.blacklistedKernelModules = optionals luks.mitigateDMAAttacks [
       "firewire_ohci"
       "firewire_core"
       "firewire_sbp2"
     ];
+
+    boot.initrd.luks.cryptoModules = [
+      "aes"
+      "blowfish"
+      "twofish"
+      "serpent"
+      "cbc"
+      "xts"
+      "lrw"
+      "sha1"
+      "sha256"
+      "sha512"
+      "af_alg"
+      "algif_skcipher"
+      "cryptd"
+      "input_leds" # for capslock LED on most keyboards in case decryption requires password
+    ]
+    ++ (lib.optional (lib.versionOlder config.boot.kernelPackages.kernel.version "7.0") "aes_generic");
 
     # Some modules that may be needed for mounting anything ciphered
     boot.initrd.availableKernelModules = [


### PR DESCRIPTION
Starting with kernel 7.0, the aes-generic module was replaced which allowed for it to be unified with the aes module. This excludes the aes-generic module for kernels from 7.0 onward. This was tested using nixosTests.luks modified to use linuxPackages_testing.

This is related to #501777, but only fixes the luks side. stratis is not currently building, so I'm going to look into that before fixing there. I considered making a test to ensure that luks works with the kernel set to `linuxPackages_testing`, but I'm not sure how the tests are intended to be used exactly, and if there should be breakages for non-supported kernel versions.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
