### PR TITLE
critiq: init at 1.9.1

### DIFF
--- a/pkgs/by-name/cr/critiq/package.nix
+++ b/pkgs/by-name/cr/critiq/package.nix
@@ -1,0 +1,112 @@
+{
+  alsa-lib,
+  autoPatchelfHook,
+  cups,
+  dpkg,
+  fetchurl,
+  gtk3,
+  lib,
+  libgbm,
+  libsecret,
+  makeBinaryWrapper,
+  musl,
+  nss,
+  stdenvNoCC,
+  undmg,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "critiq";
+  version = "1.9.1";
+
+  src = fetchurl (
+    if with stdenvNoCC.hostPlatform; (isDarwin && isAarch64) then
+      {
+        url = "https://downloads.getcritiq.dev/releases/v${finalAttrs.version}/Critiq_${finalAttrs.version}_arm64.dmg";
+        hash = "sha256-xT4rtz7wChkGmf0m+qLq3+5YZEO9r0kWPvjgf1nF3OY=";
+      }
+    else if with stdenvNoCC.hostPlatform; (isDarwin && isx86_64) then
+      {
+        url = "https://downloads.getcritiq.dev/releases/v${finalAttrs.version}/Critiq_${finalAttrs.version}_x64.dmg";
+        hash = "sha256-JW31az3/UcgjCcl0xoO9N+8qDtax57x9Im8U3NBjDlw=";
+      }
+    else if with stdenvNoCC.hostPlatform; (isLinux && isx86_64) then
+      {
+        url = "https://downloads.getcritiq.dev/releases/v${finalAttrs.version}/Critiq.deb";
+        hash = "sha256-wmJN3RDngcimy//365z0iCd0K8TSYzM3VHAanCwvtmg=";
+      }
+    else
+      throw "Unsupported platform"
+  );
+
+  strictDeps = true;
+
+  nativeBuildInputs = (
+    if stdenvNoCC.hostPlatform.isLinux then
+      [
+        autoPatchelfHook
+        dpkg
+        makeBinaryWrapper
+      ]
+    else
+      [ undmg ]
+  );
+
+  buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    alsa-lib
+    cups
+    gtk3
+    libgbm
+    libsecret
+    musl
+    nss
+  ];
+
+  sourceRoot = lib.optionalString stdenvNoCC.hostPlatform.isDarwin "Critiq.app";
+
+  buildPhase = lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
+    runHook preBuild
+
+    dpkg-deb --extract $src $out
+
+    runHook postBuild
+  '';
+
+  postInstall = ''
+    mkdir --parents $out/bin
+  ''
+  + lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
+    mv $out/usr/share $out
+    rmdir $out/usr
+    makeWrapper $out/opt/Critiq/critiq $out/bin/critiq \
+      --prefix PATH : $PATH
+  ''
+  + lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+    mkdir --parents "$out"/Applications
+    cp --recursive . "$out"/Applications/Critiq.app
+    cat >"$out"/bin/critiq <<'EOF'
+    #!/usr/bin/env sh
+    exec "${placeholder "out"}/Applications/Critiq.app/Contents/MacOS/Critiq" "$@"
+    EOF
+    chmod +x "$out"/bin/critiq
+  '';
+
+  meta = {
+    description = "Native Git client for code review";
+    longDescription = ''
+      Compare branches, review PRs with inline comments, trace history
+      with blame, full language support and symbol indexing all in one
+      native workspace.
+    '';
+    homepage = "https://getcritiq.dev";
+    license = lib.licenses.unfree;
+    mainProgram = "critiq";
+    maintainers = with lib.maintainers; [ yiyu ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
