### PR TITLE
stratisd: fix build with rust 1.92+

### DIFF
--- a/pkgs/by-name/st/stratisd/package.nix
+++ b/pkgs/by-name/st/stratisd/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   rustPlatform,
   cargo,
   rustc,
@@ -43,6 +44,14 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) src;
     hash = "sha256-zA+GEKmg5iV1PaGh0yjNb4h52PH7PwpN53xLV8P9Gac=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "0001-fixes_for_rust_1_9_2";
+      url = "https://github.com/stratis-storage/stratisd/commit/d65c3b7a7f9d7a332b4c59089b8fa96ff1fefb45.patch";
+      sha256 = "sha256-cNbx9+JgQgyO+o5YX7sLDe64qNWfpDr5itux+LZSgxs=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace udev/61-stratisd.rules \


### PR DESCRIPTION
This has been fixed upstream and not released, so this patches with changes from https://github.com/stratis-storage/stratisd/pull/3942.

This is required to fix #484063, but needs #501855 to merge first before that.

This is required to make and test the stratisd changes for #501777

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
