### PR TITLE
python3Packages.pyads: fix build failure; 3.5.1 -> 3.5.2

### DIFF
--- a/pkgs/development/python-modules/pyads/default.nix
+++ b/pkgs/development/python-modules/pyads/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   adslib,
   buildPythonPackage,
   fetchFromGitHub,
@@ -23,12 +24,24 @@ buildPythonPackage rec {
 
   buildInputs = [ adslib ];
 
-  patchPhase = ''
-    substituteInPlace pyads/pyads_ex.py \
-      --replace-fail "ctypes.CDLL(adslib)" "ctypes.CDLL(\"${adslib}/lib/adslib.so\")"
+  postPatch = ''
+    # Skip compilation of bundled adslib - we provide it as a separate nix package
+    substituteInPlace setup.py \
+      --replace-fail \
+        'return sys.platform.startswith("linux") or sys.platform.startswith("darwin")' \
+        'return False'
+
+    # Load adslib from nix store instead of searching sys.path
+    substituteInPlace src/pyads/pyads_ex.py \
+      --replace-fail \
+        'ctypes.CDLL(adslib_path)' \
+        'ctypes.CDLL("${lib.getLib adslib}/lib/adslib.so")'
   '';
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  # Test suite has port reuse races and UDP timing issues on darwin
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   pythonImportsCheck = [ "pyads" ];
 

--- a/pkgs/development/python-modules/pyads/default.nix
+++ b/pkgs/development/python-modules/pyads/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pyads";
-  version = "3.5.1";
+  version = "3.5.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "stlehmann";
     repo = "pyads";
     tag = version;
-    hash = "sha256-Uh8QS9l0O1UCOM03eZ3Wo8aohgUxSbErRX2/zEUP10k=";
+    hash = "sha256-mXWLVWzgdWIDpzfBLITLz5olhitkcp/QDrlFj2YMYLw=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/stlehmann/pyads/compare/3.5.1...3.5.2

- fixed build by forcing pyads to use nixpkgs' adslib
- updated to 3.5.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
