### PR TITLE
durdraw: init at 0.29.0

### DIFF
--- a/pkgs/by-name/du/durdraw/package.nix
+++ b/pkgs/by-name/du/durdraw/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  ansilove,
+  tzdata,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "durdraw";
+  version = "0.29.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cmang";
+    repo = "durdraw";
+    tag = finalAttrs.version;
+    hash = "sha256-a+4DGWBD5XLaNAfTN/fmI/gALe76SCoWrnjyglNhVPY=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    pillow
+  ];
+
+  makeWrapperArgs = [
+    "--prefix PATH : ${lib.makeBinPath [ ansilove ]}"
+  ];
+
+  nativeCheckInputs =
+    (with python3Packages; [
+      pytestCheckHook
+    ])
+    ++ [ tzdata ];
+
+  pytestFlagsArray = [ "test/" ];
+
+  preCheck = ''
+    export TZDIR=${tzdata}/share/zoneinfo
+  '';
+
+  pythonImportsCheck = [ "durdraw" ];
+
+  meta = {
+    description = "ASCII, ANSI and Unicode art editor for Unix terminals with animation support";
+    longDescription = ''
+      Terminal-based ASCII, ANSI and Unicode art editor for Unix-like systems.
+      Supports frame-based animation, custom themes, 256-color and 16-color
+      modes, terminal mouse input, IRC color export, Unicode and Code Page 437
+      block characters, and PNG/GIF export via ansilove.
+    '';
+    homepage = "https://durdraw.org";
+    changelog = "https://github.com/cmang/durdraw/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ rane ];
+    mainProgram = "durdraw";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds a new package for [durdraw](https://durdraw.org). A previous, stale MR exists #235730 and there is a stale packaging request in #286856

As ansilove has already been packaged since then, this PR just adds durdraw.

pbsds edit: closes https://github.com/NixOS/nixpkgs/pull/235730

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
