### PR TITLE
jetbrains-toolbox: 3.1.0.62320 -> 3.4.0.77112

### DIFF
--- a/pkgs/by-name/je/jetbrains-toolbox/package.nix
+++ b/pkgs/by-name/je/jetbrains-toolbox/package.nix
@@ -10,7 +10,7 @@
 
 let
   pname = "jetbrains-toolbox";
-  version = "3.1.0.62320";
+  version = "3.4.0.77112";
 
   updateScript = ./update.sh;
 
@@ -55,10 +55,10 @@ let
         aarch64 = "-arm64";
       };
       hash = selectSystem {
-        x86_64-linux = "sha256-Fmnj1mYMpsiBpnERiWPAwQaH7qLqkrTICn0mxX0h+2U=";
-        aarch64-linux = "sha256-ogLaPN9nxZFQ09qmIF2mEi5o9LVgjoGtmYclc6KmrNU=";
-        x86_64-darwin = "sha256-hO5J9I8ZrzsgGtb9dMg2SeI/PrxpkFRjDRUdrjqMnPw=";
-        aarch64-darwin = "sha256-xA0LbwDKR6/64K9uUJHvrPC+0mRLGM/axz8+Knc+X8A=";
+        x86_64-linux = "sha256-7kPUdDapRWPfDpJqPtC0x6B6slZMhgvXQ8oi/eq3z3Y=";
+        aarch64-linux = "sha256-qtJ+y1q8jo+2c4XC6WG6YDG7Rdn14OdoAJ1pTqQWWqA=";
+        x86_64-darwin = "sha256-RfSWKPtaJTDCxTKUbNbXUtSoRpiQVIt/jadJGh2ZCL8=";
+        aarch64-darwin = "sha256-JnK477IX6pElZ7WDDfrLWG5WILcDtjSTlKdyPGbpTSs=";
       };
     in
     selectKernel {


### PR DESCRIPTION
Update `jetbrains-toolbox` from `3.1.0.62320` to `3.4.0.77112`.

This update brings the package to the latest release of the JetBrains Toolbox App. Detailed release notes and bug fixes can be found on [YouTrack](https://youtrack.jetbrains.com/releaseNotes?title=Toolbox%20App%203.1.0%20-%3E%203.4.0%20Release%20Notes&q=in:%20TBX%20Fix%20versions:%203.1.1,%203.1.2,%203.2,%203.3,%203.3.1,%203.4%20%23Resolved%20-Duplicate%20-Answered).

Closes #499046.
   
## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 501817`
Commit: `164de6e024ee5ca94b987df1873d4c216d5c6150`

---
### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>jetbrains-toolbox</li>
  </ul>
</details>
