### PR TITLE
rime-tlpa: init at 0.1

### DIFF
--- a/pkgs/by-name/ri/rime-tlpa/package.nix
+++ b/pkgs/by-name/ri/rime-tlpa/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  librime,
+  rime-prelude,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "rime-tlpa";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "AlanJui";
+    repo = "rime-tlpa";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kKGdnmCONEtPt5vnA/8dc2y/wyZE7sgI3j4YVuBIFYQ=";
+  };
+
+  nativeBuildInputs = [ librime ];
+  prePatch = "cp -r ${rime-prelude}/* .";
+
+  buildPhase = ''
+    runHook preBuild
+
+    ls ./*.schema.yaml | while read f; do
+      rime_deployer --compile "$f"
+    done
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    rm -rf build/*.txt > /dev/null 2>&1 || true
+
+    mkdir -p $out/share/rime-data/lua
+    mkdir -p $out/share/rime-data/build
+    install -Dm644 -t $out/share/rime-data/lua ./*.lua
+    install -Dm644 -t $out/share/rime-data/ ./*.schema.yaml ./*.dict.yaml
+    install -Dm644 -t $out/share/rime-data/build ./build/*.bin ./build/*.yaml
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Rime input method schema for Taiwanese Language Phonetic Alphabet (TLPA)";
+    longDescription = ''
+      Rime input method schema for Taiwanese Language Phonetic Alphabet (TLPA),
+      providing support for inputting Taiwanese Hokkien (Bân-lâm-gú / 閩南語)
+      with Pinyin (拼音) romanization system including 台語拼音 (TLPA), 台語拼音二式 (WSL)
+      and 閩拼方案 (MP), as well as Zhuyin (注音) and Fanqie (反切) phonetic annotations.
+    '';
+    homepage = "https://github.com/AlanJui/rime-tlpa";
+
+    # Packages are assumed unfree unless explicitly indicated otherwise
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ maikotan ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR add a new package [rime-tlpa](https://github.com/AlanJui/rime-tlpa), an input method for [rime](https://rime.im), with Hokkien (閩南語 / 台語) Pinyin and Zhuyin input support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
