### PR TITLE
rime-flypy: init at ea9455f2

### DIFF
--- a/pkgs/by-name/ri/rime-flypy/package.nix
+++ b/pkgs/by-name/ri/rime-flypy/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  librime,
+  rime-prelude,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "rime-flypy";
+  version = "0-unstable-2025-12-27";
+  src = fetchFromGitHub {
+    owner = "cubercsl";
+    repo = "rime-flypy";
+    rev = "ea9455f25995a2878485c85b111c34a2a897adac";
+    sha256 = "sha256-Lw54pNXUzsVv9OFp7c5Bf+pCCA0DWTslSTrN/raX9CM=";
+  };
+
+  nativeBuildInputs = [ librime ];
+  prePatch = "cp -r ${rime-prelude}/* .";
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Flypy phonetic=graphic input method for rime";
+    homepage = "https://github.com/cubercsl/rime-flypy";
+
+    # Packages are assumed unfree unless explicitly indicated otherwise
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ maikotan ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/ri/rime-prelude/package.nix
+++ b/pkgs/by-name/ri/rime-prelude/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "rime-prelude";
+  version = "0-unstable-2026-03-21";
+
+  src = fetchFromGitHub {
+    owner = "rime";
+    repo = "rime-prelude";
+    rev = "541e03e0f36ff42318848046a3b61ac47483dca3";
+    hash = "sha256-8eJc1n935KjmjvDRFksZKErt694keDeDxFRvzs++luQ=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r * $out/
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Essential files for building up your Rime configuration";
+    homepage = "https://github.com/rime/rime-prelude";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ maikotan ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR add a new package [rime-flypy](https://github.com/cubercsl/rime-flypy), an input method for [rime](https://rime.im), with flypy double pinyin phonetic-graphical input support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
