### PR TITLE
netifd: unstable-2023-11-27 -> 0-unstable-2026-02-26

### DIFF
--- a/pkgs/by-name/ne/netifd/package.nix
+++ b/pkgs/by-name/ne/netifd/package.nix
@@ -3,10 +3,11 @@
   stdenv,
   cmake,
   fetchgit,
-  libnl,
+  libnl-tiny,
   libubox,
   uci,
   ubus,
+  ucode,
   json_c,
   pkg-config,
   udebug,
@@ -14,19 +15,20 @@
 
 stdenv.mkDerivation {
   pname = "netifd";
-  version = "unstable-2023-11-27";
+  version = "0-unstable-2026-02-26";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/netifd.git";
-    rev = "02bc2e14d1d37500e888c0c53ac41398a56b5579";
-    hash = "sha256-aMs/Y50+1Yk/j5jGubjBCRcPGw03oIitvEygaxRlr90=";
+    rev = "69a5afc9713adf31edbf3228a7a372ada7bba449";
+    hash = "sha256-R/ryiFiKNM7zrIgzlalAK0lNJF/vzWL56E9CbptJtmI=";
   };
 
   buildInputs = [
-    libnl.dev
+    libnl-tiny
     libubox
     uci
     ubus
+    ucode
     json_c
     udebug
   ];
@@ -45,11 +47,11 @@ stdenv.mkDerivation {
     sed "s|./ethtool-modes.h|$PWD/ethtool-modes.h|g" -i CMakeLists.txt
   '';
 
-  env.NIX_CFLAGS_COMPILE = toString (
-    lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "12") [
-      "-Wno-error=maybe-uninitialized"
-    ]
-  );
+  cmakeFlags = [
+    (lib.cmakeFeature "LIBNL_LIBS" "-lnl-tiny")
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-I${libnl-tiny}/include/libnl-tiny";
 
   meta = {
     description = "OpenWrt Network interface configuration daemon";


### PR DESCRIPTION
Updated to latest HEAD to fix cmake 4 compilation problem.

Per OpenWrt's package [Makefile](https://github.com/openwrt/openwrt/blob/b9299ae0e7b939659d2549fe1e69768eeb1cf944/package/network/config/netifd/Makefile#L24) this should link to their `libnl-tiny` fork. It contains some debug functions called by netifd such as `nl_socket_set_tx_debug_cb` and `nl_socket_set_rx_debug_cb` which isn't in upstream libnl.

The `maybe-uninitialized` error seems to not trigger with current gcc, thus also removed the CFLAGS.

Ref #445447
Ref #452993

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
