### PR TITLE
frizbee: init at 0.1.10

### DIFF
--- a/pkgs/by-name/fr/frizbee/package.nix
+++ b/pkgs/by-name/fr/frizbee/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  testers,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "frizbee";
+  version = "0.1.10";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "stacklok";
+    repo = "frizbee";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DgUHGIld5T+eg9DemANE4exk0/JzMp7gBdbVtCi2nEc=";
+  };
+
+  vendorHash = "sha256-XJJ9375jJ0lN0VRO2c9QoG+1jkBmzKZG+T1DIHaLaq0=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  env.CGO_ENABLED = 0;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd frizbee \
+      --bash <($out/bin/frizbee completion bash) \
+      --fish <($out/bin/frizbee completion fish) \
+      --zsh <($out/bin/frizbee completion zsh)
+
+    mkdir $out/share/powershell/ -p
+    $out/bin/frizbee completion pwsh > $out/share/powershell/frizbee.Completion.ps1
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+    "-X main.Commit=${finalAttrs.src.rev}"
+    # "-X main.CommitDate=1970-01-01" # epoch as placeholder
+    "-X main.TreeState=clean"
+    "-X github.com/stacklok/frizbee/internal/cli.CLIVersion=${finalAttrs.version}"
+  ];
+
+  # Skip tests that require network access.
+  checkFlags = [
+    "-skip"
+    (lib.concatStringsSep "|" [
+      "TestReplacer_ParseGitHubActionString"
+      "TestReplacer_ParseGitHubActionsInFile"
+      "TestGetChecksum"
+    ])
+  ];
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "frizbee version";
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Throw a tag at it and it comes back with a checksum";
+    homepage = "https://github.com/stacklok/frizbee";
+    changelog = "https://github.com/stacklok/frizbee/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lafrenierejm ];
+    mainProgram = "frizbee";
+  };
+})

--- a/pkgs/by-name/fr/frizbee/package.nix
+++ b/pkgs/by-name/fr/frizbee/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "frizbee";
+  version = "0.1.10";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "stacklok";
+    repo = "frizbee";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DgUHGIld5T+eg9DemANE4exk0/JzMp7gBdbVtCi2nEc=";
+  };
+
+  vendorHash = "sha256-XJJ9375jJ0lN0VRO2c9QoG+1jkBmzKZG+T1DIHaLaq0=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  env.CGO_ENABLED = 0;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd frizbee \
+      --bash <($out/bin/frizbee completion bash) \
+      --fish <($out/bin/frizbee completion fish) \
+      --zsh <($out/bin/frizbee completion zsh)
+
+    mkdir $out/share/powershell/ -p
+    $out/bin/frizbee completion pwsh > $out/share/powershell/frizbee.Completion.ps1
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+    "-X main.Commit=${finalAttrs.src.rev}"
+    # "-X main.CommitDate=1970-01-01" # epoch as placeholder
+    "-X main.TreeState=clean"
+    "-X github.com/stacklok/frizbee/internal/cli.CLIVersion=${finalAttrs.version}"
+  ];
+
+  # Skip tests that require network access.
+  checkFlags = [
+    "-skip"
+    (lib.concatStringsSep "|" [
+      "TestReplacer_ParseGitHubActionString"
+      "TestReplacer_ParseGitHubActionsInFile"
+      "TestGetChecksum"
+    ])
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Throw a tag at it and it comes back with a checksum";
+    homepage = "https://github.com/stacklok/frizbee";
+    changelog = "https://github.com/stacklok/frizbee/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ lafrenierejm ];
+    mainProgram = "frizbee";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Homepage: <https://github.com/stacklok/frizbee>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
