### PR TITLE
ocamlPackages.posix-base: 2.2.0 → 4.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/posix/base.nix
+++ b/pkgs/development/ocaml-modules/posix/base.nix
@@ -6,18 +6,16 @@
   integers,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "posix-base";
-  version = "2.2.0";
+  version = "4.0.2";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-posix";
-    tag = "v${version}";
-    hash = "sha256-JKJIiuo4lW8DmcK1mJlT22784J1NS2ig860jDbRIjIo=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nBSIuz4WEnESlECdKujEcSxFOcSBFxW1zo7J/lT/lCY=";
   };
-
-  minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [
     ctypes
@@ -30,4 +28,4 @@ buildDunePackage rec {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.vbgl ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/posix/errno.nix
+++ b/pkgs/development/ocaml-modules/posix/errno.nix
@@ -1,0 +1,20 @@
+{
+  buildDunePackage,
+  posix-base,
+}:
+
+buildDunePackage {
+  pname = "posix-errno";
+
+  inherit (posix-base) version src;
+
+  propagatedBuildInputs = [
+    posix-base
+  ];
+
+  doCheck = true;
+
+  meta = posix-base.meta // {
+    description = "Posix-errno provides comprehensive errno handling";
+  };
+}

--- a/pkgs/development/ocaml-modules/posix/math2.nix
+++ b/pkgs/development/ocaml-modules/posix/math2.nix
@@ -1,7 +1,6 @@
 {
   buildDunePackage,
   posix-base,
-  unix-errno,
 }:
 
 buildDunePackage {
@@ -10,7 +9,6 @@ buildDunePackage {
 
   propagatedBuildInputs = [
     posix-base
-    unix-errno
   ];
 
   meta = posix-base.meta // {

--- a/pkgs/development/ocaml-modules/posix/socket.nix
+++ b/pkgs/development/ocaml-modules/posix/socket.nix
@@ -1,4 +1,8 @@
-{ buildDunePackage, posix-base }:
+{
+  buildDunePackage,
+  posix-base,
+  dune-configurator,
+}:
 
 buildDunePackage {
   pname = "posix-socket";
@@ -6,6 +10,8 @@ buildDunePackage {
   inherit (posix-base) version src;
 
   minimalOCamlVersion = "4.12";
+
+  buildInputs = [ dune-configurator ];
 
   propagatedBuildInputs = [ posix-base ];
 

--- a/pkgs/development/ocaml-modules/posix/time2.nix
+++ b/pkgs/development/ocaml-modules/posix/time2.nix
@@ -3,7 +3,7 @@
   buildDunePackage,
   posix-base,
   posix-types,
-  unix-errno,
+  posix-errno,
 }:
 
 buildDunePackage {
@@ -14,7 +14,7 @@ buildDunePackage {
   propagatedBuildInputs = [
     posix-base
     posix-types
-    unix-errno
+    posix-errno
   ];
 
   doCheck = true;

--- a/pkgs/development/ocaml-modules/srt/default.nix
+++ b/pkgs/development/ocaml-modules/srt/default.nix
@@ -8,17 +8,17 @@
   ctypes-foreign,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "srt";
-  version = "0.3.3";
+  version = "0.3.4";
 
   minimalOCamlVersion = "4.12";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-srt";
-    rev = "v${version}";
-    hash = "sha256-FVgOEBPYZz7SQ5c6mLAssDwY1NuXsV3ghP7OyLRd9Kw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+1/TffqssRA9YR3KLfbAr/ZpDF5XUKw24gj4HWrhObU=";
   };
 
   buildInputs = [ dune-configurator ];
@@ -31,10 +31,10 @@ buildDunePackage rec {
   meta = {
     description = "OCaml bindings for the libsrt library";
     license = lib.licenses.gpl2Plus;
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/savonet/ocaml-srt";
     maintainers = with lib.maintainers; [
       vbgl
       dandellion
     ];
   };
-}
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1746,6 +1746,8 @@ let
 
         posix-base = callPackage ../development/ocaml-modules/posix/base.nix { };
 
+        posix-errno = callPackage ../development/ocaml-modules/posix/errno.nix { };
+
         posix-math2 = callPackage ../development/ocaml-modules/posix/math2.nix { };
 
         posix-socket = callPackage ../development/ocaml-modules/posix/socket.nix { };


### PR DESCRIPTION
ocamlPackages.posix-errno: init at 4.0.2
ocamlPackages.srt: 0.3.3 → 0.3.4


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
