### PR TITLE
python3Packages.asyncstdlib: 3.13.3 -> 3.14.0

### DIFF
--- a/pkgs/development/python-modules/asyncstdlib/default.nix
+++ b/pkgs/development/python-modules/asyncstdlib/default.nix
@@ -4,23 +4,19 @@
   fetchFromGitHub,
   flit-core,
   pytestCheckHook,
-  pythonAtLeast,
   typing-extensions,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "asyncstdlib";
-  version = "3.13.3";
+  version = "3.14.0";
   pyproject = true;
-
-  # https://github.com/maxfischer2781/asyncstdlib/issues/189
-  disabled = pythonAtLeast "3.14";
 
   src = fetchFromGitHub {
     owner = "maxfischer2781";
     repo = "asyncstdlib";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3mM97zB/pEw8/kPO6jUL7dz6Q7kVatfsURy+5zSq9Bs=";
+    hash = "sha256-zp6F+Otb1d8kqdLO99shBA7ny7Zjq027T2dtTGHTcqI=";
   };
 
   build-system = [ flit-core ];


### PR DESCRIPTION
Release notes: https://github.com/maxfischer2781/asyncstdlib/releases/tag/v3.14.0

Closes #501616

adds python 314 support

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
