### PR TITLE
buck2: unstable-2025-12-01 -> unstable-2026-04-15

### DIFF
--- a/pkgs/by-name/bu/buck2/hashes.json
+++ b/pkgs/by-name/bu/buck2/hashes.json
@@ -1,21 +1,21 @@
 {
+  "aarch64-darwin": {
+    "buck2": "sha256-zBZ2gEPRxyaBYmnRfYfhYDqswqfiXvxYDHrUI92Z1UQ=",
+    "rust-project": "sha256-K86j0E32w0DUwzpPT0NBUiL3rV4Ze8hzfbKDkpy9JXo="
+  },
   "x86_64-linux": {
-    "buck2": "sha256-TOgL0pLnNEAhHkKvynnM91kW06K6jZPeJnpSibYg8EU=",
-    "rust-project": "sha256-s5JY/m+yC3YNHiOxk6D43ZkWdtWLxlI4X72jSFFd3Hc="
+    "buck2": "sha256-IqDsyQ7Omy7QujT85oKrWwyirG7gwfupdxzvRoMRmQs=",
+    "rust-project": "sha256-iFSko4FTvAVlKUxJE/6FzR6H7V2SryRfEi7nRhfyhxQ="
   },
   "x86_64-darwin": {
-    "buck2": "sha256-8SvAZ30ZFsamVAheKpa2vzGty1TZECUv+BHeXLlDneQ=",
-    "rust-project": "sha256-0af+q1s7iEb6dWl4WuNxFbIskTfrHtU2uhatPyAhZNM="
+    "buck2": "sha256-G/xarAld9dXanZl7Ivcuoer3YsytmFXWED44u2U4q8g=",
+    "rust-project": "sha256-jbvvqPI7+qpONhk8UZfSiFpMGCGWRr85BocA58d+C7Y="
   },
   "aarch64-linux": {
-    "buck2": "sha256-Pka0HEEqRsQp2R435duy6gJy/RQXp5lK5Dg9+rfr9L8=",
-    "rust-project": "sha256-u3b+XscQpNZOo8OTrLSazFZvm496U4nsWti/6TRf8ZA="
+    "buck2": "sha256-VKV1vltATu3tAPmMiifba7MV9kNFH754FDda6i8cQrU=",
+    "rust-project": "sha256-oqxHdbNzQn1KHObboAd4/LTbilIJgLqMiWCgHLaPFrc="
   },
-  "aarch64-darwin": {
-    "buck2": "sha256-1Fv0LzAZUN/BbcorCBaPBbm8JAzLarhJysLqPT78XEQ=",
-    "rust-project": "sha256-PQ7WKjzAPT0uRirWzwJPxKr9V1RQajnlXUMnv8SYdso="
-  },
-  "version": "2025-12-01",
-  "preludeGit": "0a994e0b600f7d035e1ac69f374c0e37e1e19af6",
-  "preludeFod": "sha256-IQa4VatN5OaDSyoTbAj1tHNBpJV6Ost9RbLxDD23xVQ="
+  "version": "2026-04-15",
+  "preludeGit": "f0896771c4cc1ab8f87e032c5293376c89e5096b",
+  "preludeFod": "sha256-Ga4q9zzifgFDGx0TbcbBoDN29H3A4s1BZnSwwv9Mix0="
 }


### PR DESCRIPTION
Routine upgrade, tested on my monorepo.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
