### PR TITLE
python3Packages.django-money: init at 3.6.0

### DIFF
--- a/pkgs/development/python-modules/django-money/default.nix
+++ b/pkgs/development/python-modules/django-money/default.nix
@@ -1,0 +1,57 @@
+{
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  lib,
+  py-moneyed,
+  django,
+  certifi,
+  pytestCheckHook,
+  pytest-django,
+  pytest-cov-stub,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "django-money";
+  version = "3.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "django-money";
+    repo = "django-money";
+    tag = finalAttrs.version;
+    hash = "sha256-VxAKTtrbDMRhiLxqjVYt7pLGl0sy9F1iwswP/hxQ01k=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    django
+    py-moneyed
+  ];
+
+  optional-dependencies = {
+    exchange = [ certifi ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-django
+    pytest-cov-stub
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  pythonImportsCheck = [ "djmoney" ];
+
+  disabledTests = [
+    # avoid tests which import mixer, an abandoned library
+    "test_mixer_blend"
+  ];
+
+  meta = {
+    description = "Money fields for Django forms and models";
+    homepage = "https://github.com/django-money/django-money";
+    changelog = "https://github.com/django-money/django-money/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ kurogeek ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4276,6 +4276,8 @@ self: super: with self; {
 
   django-modeltranslation = callPackage ../development/python-modules/django-modeltranslation { };
 
+  django-money = callPackage ../development/python-modules/django-money { };
+
   django-mptt = callPackage ../development/python-modules/django-mptt { };
 
   django-multiselectfield = callPackage ../development/python-modules/django-multiselectfield { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
