### PR TITLE
python3Packages.blivet: fix dbus dependency

### DIFF
--- a/pkgs/development/python-modules/blivet/default.nix
+++ b/pkgs/development/python-modules/blivet/default.nix
@@ -8,7 +8,7 @@
   libblockdev,
   bytesize,
   pyudev,
-  dbus-python,
+  dasbus,
   util-linux,
   kmod,
   libndctl,
@@ -27,6 +27,7 @@
   multipath-tools,
   dracut,
   stratisd,
+  setuptools,
 }:
 
 let
@@ -35,7 +36,9 @@ in
 buildPythonPackage rec {
   pname = "blivet";
   version = "3.13.1";
-  format = "setuptools";
+  pyproject = true;
+
+  build-system = [ setuptools ];
 
   src = fetchFromGitHub {
     owner = "storaged-project";
@@ -62,7 +65,7 @@ buildPythonPackage rec {
     libblockdevPython
     bytesize
     pyudev
-    dbus-python
+    dasbus
     util-linux
     kmod
     libndctl


### PR DESCRIPTION
This build was failing because stratisd builds were failing, but it uncovered an underlying issue that python3Packages.dasbus was not not available. This changes out that dependency.

This also designates that the project is using pyproject, as it moved to that from setup.py recently.

Resolves #484063, but is dependent on #501814 for this to build successfully. I'm not how to handle both of these failing and requiring each other to pass checks, but I'm guessing #501814 should be merged first.  

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
