### PR TITLE
driftwm: init at 0.1.1

### DIFF
--- a/pkgs/by-name/dr/driftwm/package.nix
+++ b/pkgs/by-name/dr/driftwm/package.nix
@@ -1,0 +1,78 @@
+{
+  autoPatchelfHook,
+  fetchFromGitHub,
+  lib,
+  libGL,
+  libdisplay-info,
+  libgbm,
+  libinput,
+  libxkbcommon,
+  makeBinaryWrapper,
+  nix-update-script,
+  pkg-config,
+  rustPlatform,
+  seatd,
+  versionCheckHook,
+  vulkan-loader,
+  wayland,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "driftwm";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "malbiruk";
+    repo = "driftwm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0nYE3W5HI+5bkYD7xQvqRtrjPBcmVOb57PB80jlnloA=";
+  };
+
+  cargoHash = "sha256-fza5n3ZiWWHiAuNvaJb27xt2Nwi+pMl/tZVT0zEmaOE=";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeBinaryWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    libdisplay-info
+    libgbm
+    libinput
+    libxkbcommon
+    seatd
+  ];
+
+  runtimeDependencies = [
+    vulkan-loader
+    wayland
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/driftwm \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libGL ]}
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Trackpad-first infinite canvas Wayland compositor";
+    longDescription = ''
+      Traditional window managers arrange windows to fit your screen.
+      driftwm flips this: windows float on an infinite 2D canvas and
+      you move the viewport around them.  Designed with laptops in
+      mind — trackpad support keeps getting better while display size
+      stays limited, so treating your screen as a camera onto a larger
+      canvas makes sense.  Pan, zoom, and navigate with trackpad
+      gestures.  No workspaces, no tiling — just drift.
+    '';
+    homepage = "https://github.com/malbiruk/driftwm";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "driftwm";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
