### PR TITLE
simpleini: 4.22 -> 4.25

### DIFF
--- a/pkgs/by-name/si/simpleini/package.nix
+++ b/pkgs/by-name/si/simpleini/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   gtest,
   nix-update-script,
@@ -10,14 +9,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "simpleini";
-  version = "4.22";
+  version = "4.25";
 
   src = fetchFromGitHub {
     name = "simpleini-sources-${finalAttrs.version}";
     owner = "brofield";
     repo = "simpleini";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-H4J4+v/3A8ZTOp4iMeiZ0OClu68oP4vUZ8YOFZbllcM=";
+    hash = "sha256-1JTVjMfEuWqlyYAm4Er6HPjrP2Tnt0ntai8oVvIEOu0=";
   };
 
   nativeBuildInputs = [
@@ -31,14 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   cmakeFlags = [ (lib.cmakeBool "SIMPLEINI_USE_SYSTEM_GTEST" true) ];
-
-  patches = [
-    # Fixes for cmake export from master, can be removed after the next release
-    (fetchpatch {
-      url = "https://github.com/brofield/simpleini/commit/aeacf861a8ad8add5f4974792a88ffea393e41db.patch";
-      hash = "sha256-lpoQHff8JwfljMUxL6Y2MqsGDZtDPjnOIKSIJ1rqrAI=";
-    })
-  ];
 
   passthru.updateScript = nix-update-script { };
 
@@ -55,6 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       HeitorAugustoLN
+      miniharinn
     ];
     platforms = lib.platforms.all;
   };


### PR DESCRIPTION
Release: https://github.com/brofield/simpleini/releases/tag/v4.25
Diff: https://github.com/brofield/simpleini/compare/v4.22...v4.25

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
