### PR TITLE
nixos/plasma-login-manager: use display-manager.service to prevent session kill on switch

### DIFF
--- a/nixos/modules/services/display-managers/plasma-login-manager.nix
+++ b/nixos/modules/services/display-managers/plasma-login-manager.nix
@@ -53,18 +53,36 @@ in
   };
 
   config = mkIf cfg.enable {
-    services.displayManager.enable = true;
+    # Use NixOS's display-manager.service instead of upstream's plasmalogin.service.
+    # The upstream unit has Alias=display-manager.service, which causes systemd to
+    # establish a ConsistsOf relationship with graphical.target. When
+    # switch-to-configuration restarts graphical.target, PLM gets stopped as a
+    # side effect, killing the user session.
+    services.displayManager = {
+      enable = true;
+      execCmd = "exec ${cfg.package}/bin/plasmalogin";
+    };
 
     environment.systemPackages = [ cfg.package ];
-    systemd.packages = [ cfg.package ];
+    # Don't use systemd.packages as it imports the upstream plasmalogin.service
     systemd.tmpfiles.packages = [ cfg.package ];
     services.dbus.packages = [ cfg.package ];
 
-    systemd.services.plasmalogin = {
-      aliases = [ "display-manager.service" ];
+    # Force enable display-manager.service (default.nix disables it when no
+    # known DM like sddm/gdm is enabled)
+    systemd.services.display-manager.enable = true;
+
+    # Copy the After/Conflicts from the upstream unit and add PLM to PATH
+    systemd.services.display-manager = {
+      after = [
+        "systemd-user-sessions.service"
+        "plymouth-quit.service"
+        "systemd-logind.service"
+      ];
+      conflicts = [
+        "getty@tty1.service"
+      ];
       path = [ cfg.package ];
-      wantedBy = [ "graphical.target" ];
-      restartIfChanged = false;
     };
 
     systemd.defaultUnit = "graphical.target";


### PR DESCRIPTION
## Description

The Plasma Login Manager (PLM) NixOS module currently uses `systemd.packages` to import the upstream `plasmalogin.service` unit, which has `Alias=display-manager.service`. This alias causes systemd to create a `ConsistsOf` dependency between `graphical.target` and `plasmalogin.service`. When `switch-to-configuration` restarts `graphical.target` during `nixos-rebuild switch`, PLM gets stopped as a side effect, killing the active user session.

## Changes

- Remove `systemd.packages = [ cfg.package ]` to avoid importing the upstream `plasmalogin.service` unit (and its problematic alias)
- Use NixOS's standard `display-manager.service` via `services.displayManager.execCmd` instead
- Force `systemd.services.display-manager.enable = true` (because `default.nix` disables it when no known DM like SDDM/GDM is detected)
- Add PLM to `display-manager.service`'s PATH and replicate the upstream unit's `After=` and `Conflicts=` directives
- Remove the now-unnecessary `systemd.services.plasmalogin` block

This follows the same pattern used by SDDM and GDM modules, which also use the NixOS `display-manager.service` wrapper. The `display-manager.service` has `restartIfChanged = false` and `stopIfChanged = false` by default, preventing it from being killed during system activation.

## Testing

Tested on a NixOS system running KDE Plasma 6 with Plasma Login Manager. After this change:
- PLM starts correctly via `display-manager.service`
- `nixos-rebuild switch` no longer kills the active user session
- Auto-login continues to work