### PR TITLE
srelay: fix signal handler build faliure

### DIFF
--- a/pkgs/by-name/sr/srelay/package.nix
+++ b/pkgs/by-name/sr/srelay/package.nix
@@ -14,7 +14,10 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "1sn6005aqyfvrlkm5445cyyaj6h6wfyskfncfmds55x34hfyxpvl";
   };
 
-  patches = [ ./arm.patch ];
+  patches = [
+    ./arm.patch
+    ./signal-handler.patch
+  ];
 
   buildInputs = [ libxcrypt ];
 

--- a/pkgs/by-name/sr/srelay/signal-handler.patch
+++ b/pkgs/by-name/sr/srelay/signal-handler.patch
@@ -1,0 +1,44 @@
+diff --git a/main.c b/main.c
+index 00d1cf3..3526cfd 100644
+--- a/main.c
++++ b/main.c
+@@ -675,7 +675,7 @@ int main(int argc, char **argv)
+     msg_out(warn, "cannot open pidfile %s", pidfile);
+   }
+ 
+-  setsignal(SIGHUP, reload);
++  setsignal(SIGHUP, do_sighup);
+   setsignal(SIGINT, SIG_IGN);
+   setsignal(SIGQUIT, SIG_IGN);
+   setsignal(SIGILL, SIG_IGN);
+@@ -690,7 +690,7 @@ int main(int argc, char **argv)
+   setsignal(SIGSYS, SIG_IGN);
+   setsignal(SIGPIPE, SIG_IGN);
+   setsignal(SIGALRM, SIG_IGN);
+-  setsignal(SIGTERM, cleanup);
++  setsignal(SIGTERM, do_sigterm);
+   setsignal(SIGUSR1, SIG_IGN);
+   setsignal(SIGUSR2, SIG_IGN);
+ #ifdef SIGPOLL
+@@ -737,7 +737,7 @@ int main(int argc, char **argv)
+     }
+   } else {
+ #endif
+-    setsignal(SIGCHLD, reapchild);
++    setsignal(SIGCHLD, do_sigchld);
+     setregid(-1, PROCGID);
+     setreuid(-1, PROCUID);
+     msg_out(norm, "Starting: MAX_CH(%d)", max_child);
+diff --git a/srelay.h b/srelay.h
+index 3e4d5e7..35010f0 100644
+--- a/srelay.h
++++ b/srelay.h
+@@ -366,7 +366,7 @@ struct user_pass {
+ };
+ 
+ #ifndef SIGFUNC_DEFINED
+-typedef void            (*sigfunc_t)();
++typedef void            (*sigfunc_t)(int);
+ #endif
+ 
+ #ifndef MAX


### PR DESCRIPTION
With newer glibc and gcc toolchain, type checking is stricter. This PR patch that.

Fixes #501681 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
