### PR TITLE
zapret2: init at 0.9.5

### DIFF
--- a/pkgs/by-name/za/zapret2/package.nix
+++ b/pkgs/by-name/za/zapret2/package.nix
@@ -1,0 +1,145 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  pkg-config,
+  curl,
+  netcat,
+  gawk,
+  gnugrep,
+  luajit,
+  ipset,
+  libcap,
+  libmnl,
+  libnfnetlink,
+  libnetfilter_queue,
+  systemdLibs,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zapret2";
+  version = "0.9.5";
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "bol-van";
+    repo = "zapret2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KdkUCfxxe2ddcYebvKsslIUBkl5g7Rc/f+xY00hy5JM=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse --short=12 HEAD > COMMIT
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    luajit
+    zlib
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libcap
+    libmnl
+    libnfnetlink
+    libnetfilter_queue
+    ipset
+    systemdLibs
+  ];
+
+  postPatch = ''
+    substituteInPlace "init.d/systemd/nfqws2@.service" \
+      --replace-fail "ExecSearchPath=/opt/zapret2/nfq2" "ExecSearchPath=$out/bin"
+  '';
+
+  preBuild = ''
+    makeFlagsArray+=("CFLAGS=-DZAPRET_GH_VER=${finalAttrs.src.tag} -DZAPRET_GH_HASH=`cat $src/COMMIT`")
+  '';
+
+  makeFlags = [
+    (if stdenv.hostPlatform.isLinux then "systemd" else "bsd")
+    "TGT=${placeholder "out"}/bin"
+  ];
+
+  env = {
+    ZAPRET_BASE = "${placeholder "out"}/share/zapret2";
+    ZAPRET_RW = "/etc/zapret2";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$ZAPRET_BASE"
+    for spec in "blockcheck2.sh" "blockcheck2.d" "common" "ipset" "lua"; do
+      cp -R "$spec" "$ZAPRET_BASE/"
+    done
+
+    pushd docs
+    mkdir -p "$doc/share/doc/zapret2"
+    cp *.md changes*.txt "$doc/share/doc/zapret2"
+    popd
+
+    wrapProgram "$ZAPRET_BASE/blockcheck2.sh" \
+      --set ZAPRET_BASE "$ZAPRET_BASE" \
+      --set ZAPRET_RW "$ZAPRET_RW" \
+      --set NFQWS2 "$out/bin/nfqws2" \
+      --set DVTWS2 "$out/bin/dvtws2" \
+      --set MDIG "$out/bin/mdig" \
+      --prefix "PATH" : "${
+        lib.makeBinPath [
+          curl
+          netcat
+          # don't wrap with iptables/nftables so that it uses the one from the
+          # system path (depending on the networking firewall backend)
+        ]
+      }"
+
+    for file in "$ZAPRET_BASE/ipset"/*.sh; do
+      if [ -x "$file" ]; then
+        wrapProgram "$file" \
+          --set ZAPRET_BASE "$ZAPRET_BASE" \
+          --set ZAPRET_RW "$ZAPRET_RW" \
+          --prefix "PATH" : "${
+            lib.makeBinPath [
+              gawk
+              gnugrep
+            ]
+          }"
+      fi
+    done
+
+    ln -s "$ZAPRET_BASE/blockcheck2.sh" "$out/bin/blockcheck2"
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      install -Dm644 "init.d/systemd/nfqws2@.service" -t "$out/lib/systemd/system"
+    ''}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Anti-DPI software for bypassing DPI systems";
+    homepage = "https://github.com/bol-van/zapret2";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    # Darwin lacks ipdivert in kernel (making dvtws2 unusable) and zapret2
+    # doesn't include tpws
+    broken = stdenv.hostPlatform.isDarwin;
+    maintainers = with lib.maintainers; [ andre4ik3 ];
+    mainProgram = if stdenv.hostPlatform.isLinux then "nfqws2" else "dvtws2";
+  };
+})


### PR DESCRIPTION
Closes #478977 because that PR hasn't been updated in a while.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
