### PR TITLE
python3Packages.slixmpp-omemo: init at 2.1.0

### DIFF
--- a/pkgs/development/python-modules/slixmpp-omemo/default.nix
+++ b/pkgs/development/python-modules/slixmpp-omemo/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  slixmpp,
+  omemo,
+  oldmemo,
+  twomemo,
+  typing-extensions,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "slixmpp-omemo";
+  version = "2.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Syndace";
+    repo = "slixmpp-omemo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UL7rIzuG33yIB+mvgcgC19cBrNobLi15bRaJjWrDNF4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    slixmpp
+    omemo
+    oldmemo
+    twomemo
+    typing-extensions
+  ]
+  ++ oldmemo.optional-dependencies.xml;
+
+  doCheck = true;
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-cov-stub
+  ];
+
+  meta = {
+    changelog = "https://github.com/Syndace/slixmpp-omemo/releases/tag/v${finalAttrs.version}/CHANGELOG.md";
+    description = "Slixmpp plugin for the Multi-End Message and Object Encryption protocol";
+    homepage = "https://github.com/Syndace/slixmpp-omemo";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ marijanp ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17800,6 +17800,8 @@ self: super: with self; {
 
   slixmpp = callPackage ../development/python-modules/slixmpp { inherit (pkgs) gnupg; };
 
+  slixmpp-omemo = callPackage ../development/python-modules/slixmpp-omemo { };
+
   slob = callPackage ../development/python-modules/slob { };
 
   slovnet = callPackage ../development/python-modules/slovnet { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
