### PR TITLE
python3Packages.sqlalchemy_1_4: 1.4.54 -> 1.4.54-unstable-2025-08-16

### DIFF
--- a/pkgs/development/python-modules/sqlalchemy/1_4.nix
+++ b/pkgs/development/python-modules/sqlalchemy/1_4.nix
@@ -36,14 +36,14 @@
 
 buildPythonPackage rec {
   pname = "sqlalchemy";
-  version = "1.4.54";
+  version = "1.4.54-unstable-2025-08-16";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sqlalchemy";
     repo = "sqlalchemy";
-    rev = "rel_${lib.replaceStrings [ "." ] [ "_" ] version}";
-    hash = "sha256-6qAjyqMVrugABHssAQuql3z1YHTAOSm5hARJuJXJJvo=";
+    rev = "1712b81a5b8d9d3abd5a85fbb089470f0bc38cdd";
+    hash = "sha256-BqhH6CqvWQvUllCh0JAIM/K+W3KtLIRe30WGJrqafoI=";
   };
 
   postPatch = ''


### PR DESCRIPTION
This fixes the build of `python314Packages.sqlalchemy_1_4`.

Fixing by patching would require fetching a bunch of different patches for the Python 3.14 fixes to apply cleanly, so I guess bumping to an unstable commit is a better option for now.

Diff: https://github.com/sqlalchemy/sqlalchemy/compare/rel_1_4_54...1712b81a5b8d9d3abd5a85fbb089470f0bc38cdd

Tracking: https://github.com/NixOS/nixpkgs/issues/475732


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.sqlalchemy_1_4`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
