### PR TITLE
catppuccin-whiskers: 2.5.1 -> 2.9.0; add isabelroses as maintainer

### DIFF
--- a/pkgs/by-name/ca/catppuccin-whiskers/package.nix
+++ b/pkgs/by-name/ca/catppuccin-whiskers/package.nix
@@ -23,7 +23,10 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/catppuccin/whiskers";
     description = "Templating tool to simplify the creation of Catppuccin ports";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ Name ];
+    maintainers = with lib.maintainers; [
+      Name
+      isabelroses
+    ];
     mainProgram = "whiskers";
   };
 }

--- a/pkgs/by-name/ca/catppuccin-whiskers/package.nix
+++ b/pkgs/by-name/ca/catppuccin-whiskers/package.nix
@@ -4,7 +4,7 @@
   rustPlatform,
 }:
 let
-  version = "2.5.1";
+  version = "2.9.0";
 in
 rustPlatform.buildRustPackage {
   pname = "catppuccin-whiskers";
@@ -14,10 +14,10 @@ rustPlatform.buildRustPackage {
     owner = "catppuccin";
     repo = "whiskers";
     tag = "v${version}";
-    hash = "sha256-OLEXy9MCrPQu1KWICsYhe/ayVqxkYIFwyJoJhgiNDz4=";
+    hash = "sha256-KU2cHBtz9rdfhulINRaQm+YZ7n8OBULrSHSSxmoitnk=";
   };
 
-  cargoHash = "sha256-CVg7kcOTRa8KfDwiJHQhTPQfK6g3jOMa4h/BCUo3ehw=";
+  cargoHash = "sha256-40IPDdxKTWYxsCfsECsXDGwfxXiTEIelxIGAFv3xlU4=";
 
   meta = {
     homepage = "https://github.com/catppuccin/whiskers";

--- a/pkgs/by-name/ca/catppuccin-whiskers/package.nix
+++ b/pkgs/by-name/ca/catppuccin-whiskers/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  nix-update-script,
 }:
 let
   version = "2.9.0";
@@ -18,6 +19,8 @@ rustPlatform.buildRustPackage {
   };
 
   cargoHash = "sha256-40IPDdxKTWYxsCfsECsXDGwfxXiTEIelxIGAFv3xlU4=";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/catppuccin/whiskers";


### PR DESCRIPTION
superceds https://github.com/NixOS/nixpkgs/pull/491572

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
