### PR TITLE
nixos/tests: fix eval of several tests

### DIFF
--- a/nixos/tests/discourse.nix
+++ b/nixos/tests/discourse.nix
@@ -165,7 +165,7 @@ in
     };
 
   testScript =
-    { nodes }:
+    { nodes, ... }:
     let
       request = builtins.toJSON {
         title = "Private message";

--- a/nixos/tests/drbd.nix
+++ b/nixos/tests/drbd.nix
@@ -54,38 +54,36 @@ in
   nodes.drbd1 = drbdConfig;
   nodes.drbd2 = drbdConfig;
 
-  testScript =
-    { nodes }:
-    ''
-      drbd1.start()
-      drbd2.start()
+  testScript = ''
+    drbd1.start()
+    drbd2.start()
 
-      drbd1.wait_for_unit("network.target")
-      drbd2.wait_for_unit("network.target")
+    drbd1.wait_for_unit("network.target")
+    drbd2.wait_for_unit("network.target")
 
-      drbd1.succeed(
-          "drbdadm create-md r0",
-          "drbdadm up r0",
-          "drbdadm primary r0 --force",
-      )
+    drbd1.succeed(
+        "drbdadm create-md r0",
+        "drbdadm up r0",
+        "drbdadm primary r0 --force",
+    )
 
-      drbd2.succeed("drbdadm create-md r0", "drbdadm up r0")
+    drbd2.succeed("drbdadm create-md r0", "drbdadm up r0")
 
-      drbd1.succeed(
-          "mkfs.ext4 /dev/drbd0",
-          "mkdir -p /mnt/drbd",
-          "mount /dev/drbd0 /mnt/drbd",
-          "touch /mnt/drbd/hello",
-          "umount /mnt/drbd",
-          "drbdadm secondary r0",
-      )
-      drbd1.sleep(1)
+    drbd1.succeed(
+        "mkfs.ext4 /dev/drbd0",
+        "mkdir -p /mnt/drbd",
+        "mount /dev/drbd0 /mnt/drbd",
+        "touch /mnt/drbd/hello",
+        "umount /mnt/drbd",
+        "drbdadm secondary r0",
+    )
+    drbd1.sleep(1)
 
-      drbd2.succeed(
-          "drbdadm primary r0",
-          "mkdir -p /mnt/drbd",
-          "mount /dev/drbd0 /mnt/drbd",
-          "ls /mnt/drbd/hello",
-      )
-    '';
+    drbd2.succeed(
+        "drbdadm primary r0",
+        "mkdir -p /mnt/drbd",
+        "mount /dev/drbd0 /mnt/drbd",
+        "ls /mnt/drbd/hello",
+    )
+  '';
 }

--- a/nixos/tests/munge.nix
+++ b/nixos/tests/munge.nix
@@ -12,7 +12,7 @@
     };
 
   testScript =
-    { nodes }:
+    { nodes, ... }:
     let
       aliceUid = toString nodes.machine.users.users.alice.uid;
     in

--- a/nixos/tests/nixops/default.nix
+++ b/nixos/tests/nixops/default.nix
@@ -57,7 +57,7 @@ let
       };
 
       testScript =
-        { nodes }:
+        { nodes, ... }:
         let
           deployerSetup = pkgs.writeScript "deployerSetup" ''
             #!${pkgs.runtimeShell}

--- a/nixos/tests/parsedmarc/default.nix
+++ b/nixos/tests/parsedmarc/default.nix
@@ -91,7 +91,7 @@ in
       };
 
     testScript =
-      { nodes }:
+      { nodes, ... }:
       let
         esPort = toString nodes.parsedmarc.config.services.elasticsearch.port;
         valueObject = lib.optionalString (lib.versionAtLeast nodes.parsedmarc.config.services.elasticsearch.package.version "7") ".value";
@@ -202,7 +202,7 @@ in
       };
 
       testScript =
-        { nodes }:
+        { nodes, ... }:
         let
           esPort = toString nodes.parsedmarc.config.services.elasticsearch.port;
           valueObject = lib.optionalString (lib.versionAtLeast nodes.parsedmarc.config.services.elasticsearch.package.version "7") ".value";

--- a/nixos/tests/rspamd-trainer.nix
+++ b/nixos/tests/rspamd-trainer.nix
@@ -136,31 +136,29 @@ in
 
   };
 
-  testScript =
-    { nodes }:
-    ''
-      start_all()
-      machine.wait_for_unit("maddy.service")
-      machine.wait_for_open_port(143)
-      machine.wait_for_open_port(993)
-      machine.wait_for_open_port(587)
-      machine.wait_for_open_port(465)
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("maddy.service")
+    machine.wait_for_open_port(143)
+    machine.wait_for_open_port(993)
+    machine.wait_for_open_port(587)
+    machine.wait_for_open_port(465)
 
-      # Send test mail to spam@domain
-      machine.succeed("send-testmail")
+    # Send test mail to spam@domain
+    machine.succeed("send-testmail")
 
-      # Create mail directories required for rspamd-trainer and copy mail from
-      # INBOX into INBOX/report_ham
-      machine.succeed("create-mail-dirs")
+    # Create mail directories required for rspamd-trainer and copy mail from
+    # INBOX into INBOX/report_ham
+    machine.succeed("create-mail-dirs")
 
-      # Start rspamd-trainer. It should read mail from INBOX/report_ham
-      machine.wait_for_unit("rspamd.service")
-      machine.wait_for_unit("redis-rspamd.service")
-      machine.wait_for_file("/run/rspamd/rspamd.sock")
-      machine.succeed("systemctl start rspamd-trainer.service")
+    # Start rspamd-trainer. It should read mail from INBOX/report_ham
+    machine.wait_for_unit("rspamd.service")
+    machine.wait_for_unit("redis-rspamd.service")
+    machine.wait_for_file("/run/rspamd/rspamd.sock")
+    machine.succeed("systemctl start rspamd-trainer.service")
 
-      # Check if mail got processed by rspamd-trainer successfully and check for
-      # it in INBOX/learned_ham
-      machine.succeed("test-imap")
-    '';
+    # Check if mail got processed by rspamd-trainer successfully and check for
+    # it in INBOX/learned_ham
+    machine.succeed("test-imap")
+  '';
 }

--- a/nixos/tests/spire.nix
+++ b/nixos/tests/spire.nix
@@ -59,7 +59,7 @@ in
   };
 
   testScript =
-    { nodes }:
+    { nodes, ... }:
     let
       adminSocket = nodes.server.services.spire.server.settings.server.socket_path;
       workloadSocket = nodes.agent.services.spire.agent.settings.agent.socket_path;

--- a/nixos/tests/web-apps/peering-manager.nix
+++ b/nixos/tests/web-apps/peering-manager.nix
@@ -18,7 +18,7 @@
     };
 
   testScript =
-    { nodes }:
+    { nodes, ... }:
     ''
       machine.start()
       machine.wait_for_unit("peering-manager.target")

--- a/nixos/tests/web-apps/snipe-it.nix
+++ b/nixos/tests/web-apps/snipe-it.nix
@@ -44,7 +44,7 @@ in
   };
 
   testScript =
-    { nodes }:
+    { nodes, ... }:
     let
       backupPath = "${nodes.snipeit.services.snipe-it.dataDir}/storage/app/backups";
 


### PR DESCRIPTION
The addition of the nspawn backend introduced a second argument passed to the attribute-set passed to `testScript`, i.e. containers[1].

Note: this is by no means intended to replace the compat fix from #501599, I believe we shouldn't have deprecated invocations in-tree at all, hence the change on this end.

cc @kmein @tfc @mic92 

[1] https://github.com/NixOS/nixpkgs/pull/478109


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
