### PR TITLE
python3Packages.pyproj: fix build with proj 9.8.0

### DIFF
--- a/pkgs/development/python-modules/pyproj/default.nix
+++ b/pkgs/development/python-modules/pyproj/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   pytestCheckHook,
   replaceVars,
 
@@ -32,6 +33,23 @@ buildPythonPackage rec {
     (replaceVars ./001.proj.patch {
       proj = proj;
       projdev = proj.dev;
+    })
+    # Let's hope upstream releases soon...
+    (fetchpatch2 {
+      url = "https://github.com/pyproj4/pyproj/pull/1557.diff?full_index=1";
+      hash = "sha256-3iK/JaQEgyQvPjybJF/ATxOy3fFl7q6aa9tdfsrhajM=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/pyproj4/pyproj/pull/1560.diff?full_index=1";
+      hash = "sha256-fr+lvDeVFDagc9aHzaQhyZtWK2sy5kR7iImJsuxW8Z4=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/pyproj4/pyproj/pull/1568.diff?full_index=1";
+      hash = "sha256-fVFg3/ikOk6LiRHA/u14g+ZFsROGE7me878Vvq4mxG4=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/pyproj4/pyproj/pull/1581.diff?full_index=1";
+      hash = "sha256-EdzUCt4P99ENS2qCBU30FUNnJYD0B2CqcmZXwEYLdVA=";
     })
   ];
 
@@ -72,9 +90,6 @@ buildPythonPackage rec {
     "test_sync__source_id__list"
     "test_sync_download"
     "test_transformer_group__download_grids"
-    # https://github.com/pyproj4/pyproj/issues/1553
-    "test_datum_horizontal"
-    "test_sub_crs"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done


Fix build when proj will be update to 9.8.0 (see https://github.com/NixOS/nixpkgs/pull/498606)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
