### PR TITLE
deezer-desktop: 7.1.100 -> 7.1.110

### DIFF
--- a/pkgs/by-name/de/deezer-desktop/package.nix
+++ b/pkgs/by-name/de/deezer-desktop/package.nix
@@ -4,18 +4,19 @@
   fetchurl,
   makeWrapper,
   electron,
+  writeScript,
 }:
 
 let
-  version = "7.1.100";
+  version = "7.1.110";
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://github.com/aunetx/deezer-linux/releases/download/v${version}/deezer-desktop-${version}-x64.tar.xz";
-      hash = "sha256-KU7dmXXJGLVoDf/iHP3LBcbc/+ldTdYsRD3LyGvbvZc=";
+      hash = "sha256-g8HAAp36l0GrAg/bJOjlvNT13Z9p/geDbA5XQCk3QvM=";
     };
     aarch64-linux = fetchurl {
       url = "https://github.com/aunetx/deezer-linux/releases/download/v${version}/deezer-desktop-${version}-arm64.tar.xz";
-      hash = "sha256-sLso74DJaJK/o8cYYHEI/XNXjcl1MgfkegsCEOw+79Y=";
+      hash = "sha256-W6br5bvRwgrfSiwwO5OMwfReev7t3mvI6L0zTIIDiwI=";
     };
   };
 
@@ -61,6 +62,25 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru = {
+    inherit srcs;
+    updateScript = writeScript "update-deezer-desktop" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl jq common-updater-scripts
+      set -eu -o pipefail
+
+      latest_version="$(
+        curl --fail --silent --show-error --location \
+          'https://api.github.com/repos/aunetx/deezer-linux/releases/latest' |
+          jq -r '.tag_name | ltrimstr("v")'
+      )"
+
+      for platform in ${lib.escapeShellArgs (lib.attrNames srcs)}; do
+        update-source-version "${finalAttrs.pname}" "$latest_version" --ignore-same-version --source-key="passthru.srcs.$platform"
+      done
+    '';
+  };
 
   meta = {
     description = "Unofficial Linux port of the music streaming application";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updated Deezer-Desktop to v7.1.110 and added Update Script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
