### PR TITLE
fmd-server: 0.13.0 -> 0.14.0

### DIFF
--- a/pkgs/by-name/fm/fmd-server/package.nix
+++ b/pkgs/by-name/fm/fmd-server/package.nix
@@ -2,23 +2,69 @@
   lib,
   buildGoModule,
   fetchFromGitLab,
+  fetchPnpmDeps,
+  nodejs_22,
+  pnpm_10,
+  pnpmConfigHook,
+  stdenv,
   nix-update-script,
   versionCheckHook,
 }:
 let
-  version = "0.13.0";
+  version = "0.14.0";
+  nodejs = nodejs_22;
 in
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "fmd-server";
   inherit version;
+
   src = fetchFromGitLab {
     owner = "fmd-foss";
     repo = "fmd-server";
     tag = "v${version}";
-    hash = "sha256-pIVsdoen45YWG/V8qW/DE/yet4o+8MqpVHgHh70Fty8=";
+    hash = "sha256-6dqLJDVQfwwNW40Wsu0Sb2kqtDLLJxQeSUcnFasLyN0=";
   };
 
-  vendorHash = "sha256-d8QP6k7vEX0jBcpIMZymgOFYyKqGhND4Xa+mANg172s=";
+  webui = stdenv.mkDerivation {
+    pname = "fmd-server-webui";
+    inherit (finalAttrs) version src;
+
+    sourceRoot = "${finalAttrs.src.name}/web";
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      pnpm = pnpm_10;
+      fetcherVersion = 3;
+      sourceRoot = "${finalAttrs.src.name}/web";
+      hash = "sha256-8emvxvsP60RxV7F7dBIyexKW51u+sPl2+NO/tfH+OLc=";
+    };
+
+    nativeBuildInputs = [
+      nodejs
+      pnpmConfigHook
+      pnpm_10
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r dist/* $out
+      runHook postInstall
+    '';
+  };
+
+  vendorHash = "sha256-cFIg9mOSQbrYHW4kg4aTeTaF+gy1jNpAlg8qepb81Jc=";
+
+  preBuild = ''
+    mkdir -p web/dist/
+    cp -r ${finalAttrs.webui}/* web/dist/
+  '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "version";
@@ -31,8 +77,11 @@ buildGoModule {
     homepage = "https://fmd-foss.org/";
     downloadPage = "https://gitlab.com/fmd-foss/fmd-server";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ j0hax ];
+    maintainers = with lib.maintainers; [
+      j0hax
+      shellhazard
+    ];
     teams = [ lib.teams.ngi ];
     mainProgram = "fmd-server";
   };
-}
+})


### PR DESCRIPTION
Update to latest [released upstream version](https://gitlab.com/fmd-foss/fmd-server/-/tags).

Note that since 0.14.0, the embedded web UI is built with React and [must be compiled as part of the build process](https://fmd-foss.org/docs/fmd-server/installation/configuration#web-static-files) for it to be included with the server binary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
