### PR TITLE
openexr_2: Disable IlmImf test on powerpc64

### DIFF
--- a/pkgs/development/libraries/openexr/2.nix
+++ b/pkgs/development/libraries/openexr/2.nix
@@ -6,6 +6,7 @@
   ilmbase,
   fetchpatch,
   cmake,
+  ctestCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -61,6 +62,9 @@ stdenv.mkDerivation rec {
   ++ lib.optional stdenv.hostPlatform.isStatic "-DCMAKE_SKIP_RPATH=ON";
 
   nativeBuildInputs = [ cmake ];
+  nativeCheckInputs = [
+    ctestCheckHook
+  ];
   propagatedBuildInputs = [
     ilmbase
     zlib
@@ -69,6 +73,11 @@ stdenv.mkDerivation rec {
   # https://github.com/AcademySoftwareFoundation/openexr/issues/1400
   # https://github.com/AcademySoftwareFoundation/openexr/issues/1281
   doCheck = !stdenv.hostPlatform.isAarch32 && !stdenv.hostPlatform.isi686;
+
+  disabledTests = lib.optionals (stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isBigEndian) [
+    # https://github.com/AcademySoftwareFoundation/openexr/issues/222
+    "OpenEXR.IlmImf"
+  ];
 
   meta = {
     description = "High dynamic-range (HDR) image file format";


### PR DESCRIPTION
https://github.com/AcademySoftwareFoundation/openexr/issues/222

Less important to merge this after #501924, cus then this'll just be properly marked as insecure and no longer included in `gimp`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
