### PR TITLE
tailscale: 1.96.2 -> 1.96.3; trayscale: 0.18.5 -> 0.18.7; treewide: use buildGoModule without 1.26 override

### DIFF
--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -6,7 +6,6 @@
   lib,
   stdenv,
   writableTmpDirAsHomeHook,
-  go_1_26,
 }:
 
 let
@@ -22,7 +21,7 @@ let
   };
 in
 
-buildGoModule.override { go = go_1_26; } rec {
+buildGoModule rec {
   pname = "fluxcd";
   inherit vendorHash version;
 

--- a/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
+++ b/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
@@ -2,10 +2,9 @@
   lib,
   tailscale,
   buildGoModule,
-  go_1_26,
 }:
 
-buildGoModule.override { go = go_1_26; } {
+buildGoModule {
   pname = "tailscale-gitops-pusher";
   inherit (tailscale) version;
 

--- a/pkgs/by-name/ta/tailscale-nginx-auth/package.nix
+++ b/pkgs/by-name/ta/tailscale-nginx-auth/package.nix
@@ -2,11 +2,10 @@
   lib,
   stdenv,
   buildGoModule,
-  go_1_26,
   tailscale,
 }:
 
-buildGoModule.override { go = go_1_26; } {
+buildGoModule {
   pname = "tailscale-nginx-auth";
   inherit (tailscale) version src vendorHash;
 

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -3,7 +3,6 @@
   stdenv,
 
   buildGoModule,
-  go_1_26,
   fetchFromGitHub,
 
   makeWrapper,
@@ -23,7 +22,7 @@
   tailscale-nginx-auth,
 }:
 
-buildGoModule.override { go = go_1_26; } (finalAttrs: {
+buildGoModule (finalAttrs: {
   pname = "tailscale";
   version = "1.96.3";
 

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -25,7 +25,7 @@
 
 buildGoModule.override { go = go_1_26; } (finalAttrs: {
   pname = "tailscale";
-  version = "1.96.2";
+  version = "1.96.3";
 
   outputs = [
     "out"
@@ -36,7 +36,7 @@ buildGoModule.override { go = go_1_26; } (finalAttrs: {
     owner = "tailscale";
     repo = "tailscale";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6taTRKYFxCNK7BUnNZ3lljqVS7AeYEfm46gmilf6eEk=";
+    hash = "sha256-zEXRhnofNxDslnvT3NiAyVjZM1V9I7i4pXzhsIVEIZo=";
   };
 
   vendorHash = "sha256-rhuWEEN+CtumVxOw6Dy/IRxWIrZ2x6RJb6ULYwXCQc4=";

--- a/pkgs/by-name/tr/trayscale/package.nix
+++ b/pkgs/by-name/tr/trayscale/package.nix
@@ -12,16 +12,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "trayscale";
-  version = "0.18.5";
+  version = "0.18.7";
 
   src = fetchFromGitHub {
     owner = "DeedleFake";
     repo = "trayscale";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rrN0ofmKn8oSZ8jD3yMirTUSoXwqq1SJwXueG7mk0Ek=";
+    hash = "sha256-t284DpU4kmfrAgOmBZTwHYsxpl6vt7FPytv8/nsNfPM=";
   };
 
-  vendorHash = "sha256-N1FaKkOVzSdY+jTVroHDshPrzMORTWN3lzf+ugirJyw=";
+  vendorHash = "sha256-+2NoNIbB4lXcZhj2pifQpdiKZXslAhv6lxiKUThqTVc=";
 
   subPackages = [ "cmd/trayscale" ];
 


### PR DESCRIPTION
https://tailscale.com/changelog
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
