### PR TITLE
{openexr_2,ilmbase}: Replace meta.insecure with meta.knownVulnerabilities

### DIFF
--- a/pkgs/by-name/ge/gegl/package.nix
+++ b/pkgs/by-name/ge/gegl/package.nix
@@ -29,7 +29,7 @@
   gexiv2,
   libwebp,
   luajit,
-  openexr_2,
+  openexr,
   suitesparse,
   withLuaJIT ? lib.meta.availableOn stdenv.hostPlatform luajit,
   gimp,
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     libraw
     libwebp
     gexiv2
-    openexr_2
+    openexr
     suitesparse
   ]
   ++ lib.optionals stdenv.cc.isClang [

--- a/pkgs/by-name/il/ilmbase/package.nix
+++ b/pkgs/by-name/il/ilmbase/package.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation {
     homepage = "https://www.openexr.com/";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
-    insecure = true;
+    inherit (openexr_2.meta) knownVulnerabilities;
   };
 }

--- a/pkgs/development/libraries/openexr/2.nix
+++ b/pkgs/development/libraries/openexr/2.nix
@@ -75,6 +75,20 @@ stdenv.mkDerivation rec {
     homepage = "https://www.openexr.com/";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
-    insecure = true;
+    knownVulnerabilities = [
+      "CVE-2021-3598: ImfDeepScanLineInputFile Out-of-Bounds Read"
+      "CVE-2021-3605: rleUncompress Out-of-Bounds Read"
+      "CVE-2021-3933: Integer Overflow Vulnerability in File Processing on 32-bit Systems"
+      "CVE-2021-23169: copyIntoFrameBuffer Heap Buffer Overflow Leading to Arbitrary Code Execution"
+      "CVE-2021-23215: DwaCompressor Integer Overflow Leads to Heap Buffer Overflow"
+      "CVE-2021-26260: DwaCompressor Integer Overflow Leading to Heap Buffer Overflow"
+      "CVE-2021-26945: Integer Overflow Leading to Heap Buffer Overflow"
+      "CVE-2023-5841: Heap Overflow in Scanline Deep Data Parsing"
+      "CVE-2024-31047: convert Function Denial of Service"
+      "CVE-2025-12495: EXR File Parsing Heap-based Buffer Overflow Remote Code Execution"
+      "CVE-2025-12839: EXR File Parsing Heap-based Buffer Overflow Remote Code Execution"
+      "CVE-2025-12840: EXR File Parsing Heap-based Buffer Overflow Remote Code Execution"
+      "CVE-2026-27622: CompositeDeepScanLine integer-overflow leads to heap OOB write"
+    ];
   };
 }


### PR DESCRIPTION
~~`meta.insecure` is not a thing, and has never properly warned users about these packages being insecure.~~
`meta.insecure` is always overwritten to be based on `meta.knownVulnerabilities` being non-empty (input `meta.insecure` is not considered), so this doesn't prevent these packages from being built and used.

https://github.com/NixOS/nixpkgs/blob/23f10970547b5c953f4d2a95d308f8f51a7e1f81/pkgs/stdenv/generic/check-meta.nix#L641
https://github.com/NixOS/nixpkgs/blob/23f10970547b5c953f4d2a95d308f8f51a7e1f81/pkgs/stdenv/generic/check-meta.nix#L138

These attributes were added in #367406 before 25.05, so needs backporting to stable. `openexr_2` is still being pulled into current `gimp` via `gegl`, so switch that one to the unpinned `openexr`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
