### PR TITLE
home-assistant-custom-components.oref_alert: 4.1.1 -> 6.14.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/oref_alert/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/oref_alert/package.nix
@@ -8,19 +8,27 @@
   pytestCheckHook,
   pytest-homeassistant-custom-component,
   pytest-freezer,
+  pytest-cov-stub,
+  home-assistant-frontend,
 }:
 
 buildHomeAssistantComponent rec {
   owner = "amitfin";
   domain = "oref_alert";
-  version = "4.1.1";
+  version = "6.14.0";
 
   src = fetchFromGitHub {
     owner = "amitfin";
     repo = "oref_alert";
     tag = "v${version}";
-    hash = "sha256-nWp8cG0lFYUEO11lcZGkqx5QvOSfSVnqIqpHA8YAN30=";
+    hash = "sha256-g3Ae2AwdhcBv9v3aFjFAqxCPYVBFtQxsbtVAEOL2A60=";
   };
+
+  # Do not publish cards, currently broken, attempting to write to nix store.
+  postPatch = ''
+    substituteInPlace custom_components/oref_alert/__init__.py \
+      --replace-fail 'version = await publish_cards(hass)' 'version = "1.0.0"'
+  '';
 
   dependencies = [
     aiofiles
@@ -30,10 +38,18 @@ buildHomeAssistantComponent rec {
 
   ignoreVersionRequirement = [ "shapely" ];
 
+  # These tests are broken with cards removed.
+  disabledTestPaths = [
+    "tests/test_custom_cards.py"
+    "tests/test_init.py"
+  ];
+
   nativeCheckInputs = [
     pytestCheckHook
     pytest-homeassistant-custom-component
     pytest-freezer
+    pytest-cov-stub
+    home-assistant-frontend
   ];
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/amitfin/oref_alert/compare/v4.1.1...v6.14.0

Changelog: https://github.com/amitfin/oref_alert/releases/tag/v6.14.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
