### PR TITLE
zmk-cli: init at 0.4.1

### DIFF
--- a/pkgs/by-name/zm/zmk-cli/package.nix
+++ b/pkgs/by-name/zm/zmk-cli/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  python3Packages,
+  versionCheckHook,
+  fetchPypi,
+  installShellFiles,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "zmk-cli";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "zmk";
+    inherit (finalAttrs) version;
+    hash = "sha256-vRpzNPW4j6g1N9ZKVBEF6e7Ohwbx/+HrpI4GpyFDVzg=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools-scm
+    installShellFiles
+  ];
+
+  dependencies = with python3Packages; [
+    dacite
+    giturlparse
+    mako
+    rich
+    ruamel-yaml
+    shellingham
+    typer
+    west
+  ];
+
+  # dacite<2.0.0,>=1.9.2 not satisfied by version 1.9.1
+  # mako<2.0.0,>=1.3.10 not satisfied by version 1.3.10.dev0
+  # ruamel-yaml<0.19.0,>=0.18.17 not satisfied by version 0.19.1
+  # typer<0.22.0,>=0.21.0 not satisfied by version 0.24.0
+  pythonRelaxDeps = true;
+
+  postPatch = ''
+    cat ./zmk/repo.py
+    substituteInPlace ./zmk/repo.py --replace-fail \
+      '[sys.executable, "-m", "west", *args]' \
+      '["${python3Packages.west}/bin/west", *args]'
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd zmk \
+      --bash <(_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION=1 $out/bin/zmk --show-completion bash) \
+      --zsh <(_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION=1 $out/bin/zmk --show-completion zsh) \
+      --fish <(_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION=1 $out/bin/zmk --show-completion fish)
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "zmk";
+    description = "Command line tool for ZMK Firmware";
+    homepage = "https://zmk.dev/docs/zmk-cli";
+    changelog = "https://github.com/zmkfirmware/zmk-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.progrm_jarvis ];
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+})
+

--- a/pkgs/by-name/zm/zmk-cli/package.nix
+++ b/pkgs/by-name/zm/zmk-cli/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  python3Packages,
+  versionCheckHook,
+  fetchPypi,
+  installShellFiles,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "zmk-cli";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "zmk";
+    inherit (finalAttrs) version;
+    hash = "sha256-vRpzNPW4j6g1N9ZKVBEF6e7Ohwbx/+HrpI4GpyFDVzg=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  build-system = with python3Packages; [ setuptools ];
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools-scm
+    installShellFiles
+  ];
+
+  dependencies = with python3Packages; [
+    dacite
+    giturlparse
+    mako
+    rich
+    ruamel-yaml
+    shellingham
+    typer
+    west
+  ];
+
+  # nixpkgs dependencies are too fresh but seem to work just fine
+  pythonRelaxDeps = true;
+
+  postPatch = ''
+    cat ./zmk/repo.py
+    substituteInPlace ./zmk/repo.py --replace-fail \
+      '[sys.executable, "-m", "west", *args]' \
+      '["${python3Packages.west}/bin/west", *args]'
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd zmk \
+      --bash <(_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION=1 $out/bin/zmk --show-completion bash) \
+      --zsh <(_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION=1 $out/bin/zmk --show-completion zsh) \
+      --fish <(_TYPER_COMPLETE_TEST_DISABLE_SHELL_DETECTION=1 $out/bin/zmk --show-completion fish)
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "zmk";
+    description = "Command line tool for ZMK Firmware";
+    homepage = "https://zmk.dev/docs/zmk-cli";
+    changelog = "https://github.com/zmkfirmware/zmk-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.progrm_jarvis ];
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+})


### PR DESCRIPTION
Init [`zmk-cli`](https://github.com/zmkfirmware/zmk-cli) at `0.4.1`.

Upstream package description:

> A command line program to help set up ZMK Firmware


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
