### PR TITLE
nixos/firefox-syncserver: add PostgreSQL backend support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30451,6 +30451,12 @@
     github = "wentasah";
     githubId = 140542;
   };
+  weriomat = {
+    name = "Elias Engel";
+    email = "nixpkgs@weriomat.com";
+    github = "weriomat";
+    githubId = 59094810;
+  };
   wesleyjrz = {
     email = "dev@wesleyjrz.com";
     name = "Wesley V. Santos Jr.";

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -298,6 +298,9 @@
   "module-services-crab-hole-upstream-options": [
     "index.html#module-services-crab-hole-upstream-options"
   ],
+  "module-services-firefox-syncserver-database": [
+    "index.html#module-services-firefox-syncserver-database"
+  ],
   "module-services-firefox-syncserver-clients": [
     "index.html#module-services-firefox-syncserver-clients"
   ],

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -373,6 +373,9 @@
   "module-services-crab-hole-upstream-options": [
     "index.html#module-services-crab-hole-upstream-options"
   ],
+  "module-services-firefox-syncserver-database": [
+    "index.html#module-services-firefox-syncserver-database"
+  ],
   "module-services-firefox-syncserver-clients": [
     "index.html#module-services-firefox-syncserver-clients"
   ],

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -407,6 +407,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - IPVLAN interfaces can now be configured through the `networking.ipvlans` option in the networking module.
 
+- [](#opt-services.firefox-syncserver.database.type) has been added to allow choosing between MySQL/MariaDB (default) and PostgreSQL as the database backend for the Firefox Sync server.
+
 - `services.caddy` now supports setting `httpPort` and `httpsPort` and opening them in the firewall via `openFirewall`.
 
 - The latest available version of Nextcloud is v33 (available as `pkgs.nextcloud33`). The installation logic is as follows:

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -153,6 +153,8 @@
 
 - `slskd` has been updated to v0.25.0, which renames the `global` option to `transfers`. Please review the [changelog](https://github.com/slskd/slskd/releases#release-0.25.0).
 
+- [firefox-syncserver.database.type](#opt-services.firefox-syncserver.database.type) no longer defaults to `"mysql"`. You must now explicitly choose between `"mysql"` and `"postgresql"`. New deployments should prefer PostgreSQL.
+
 ## Other Notable Changes {#sec-release-26.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/networking/firefox-syncserver.md
+++ b/nixos/modules/services/networking/firefox-syncserver.md
@@ -32,6 +32,29 @@ This configuration should never be used in production. It is not encrypted and
 stores its secrets in a world-readable location.
 :::
 
+## Database backends {#module-services-firefox-syncserver-database}
+
+The sync server supports MySQL/MariaDB (the default) and PostgreSQL as database
+backends. Set `database.type` to choose the backend:
+
+```nix
+{
+  services.firefox-syncserver = {
+    enable = true;
+    database.type = "postgresql";
+    secrets = "/run/secrets/firefox-syncserver";
+    singleNode = {
+      enable = true;
+      hostname = "localhost";
+      url = "http://localhost:5000";
+    };
+  };
+}
+```
+
+When `database.createLocally` is `true` (the default), the module will
+automatically enable and configure the corresponding database service.
+
 ## More detailed setup {#module-services-firefox-syncserver-configuration}
 
 The `firefox-syncserver` service provides a number of options to make setting up

--- a/nixos/modules/services/networking/firefox-syncserver.nix
+++ b/nixos/modules/services/networking/firefox-syncserver.nix
@@ -27,7 +27,13 @@ let
   # where the syncserver starts before its database and role exist.
   dbService = if dbIsMySQL then "mysql.service" else "postgresql.target";
 
-  syncserver = cfg.package.override { dbBackend = cfg.database.type; };
+  syncserver =
+    if cfg.package != null then
+      cfg.package
+    else if dbIsMySQL then
+      pkgs.syncstorage-rs-mysql
+    else
+      pkgs.syncstorage-rs-pgsql;
 
   format = pkgs.formats.toml { };
   settings = {
@@ -139,7 +145,20 @@ in
         {option}`${opt.singleNode.enable}` does this automatically when enabled
       '';
 
-      package = lib.mkPackageOption pkgs "syncstorage-rs" { };
+      package = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+        defaultText = lib.literalExpression ''
+          if config.${opt.database.type} == "mysql" then
+            pkgs.syncstorage-rs-mysql
+          else
+            pkgs.syncstorage-rs-pgsql
+        '';
+        description = ''
+          Syncstorage server package to use. When `null`, the package is
+          selected automatically based on {option}`${opt.database.type}`.
+        '';
+      };
 
       database.type = lib.mkOption {
         type = lib.types.enum [

--- a/nixos/modules/services/networking/firefox-syncserver.nix
+++ b/nixos/modules/services/networking/firefox-syncserver.nix
@@ -13,7 +13,21 @@ let
   defaultUser = "firefox-syncserver";
 
   dbIsLocal = cfg.database.host == "localhost";
-  dbURL = "mysql://${cfg.database.user}@${cfg.database.host}/${cfg.database.name}${lib.optionalString dbIsLocal "?socket=/run/mysqld/mysqld.sock"}";
+  dbIsMySQL = cfg.database.type == "mysql";
+  dbIsPostgreSQL = cfg.database.type == "postgresql";
+
+  dbURL =
+    if dbIsMySQL then
+      "mysql://${cfg.database.user}@${cfg.database.host}/${cfg.database.name}${lib.optionalString dbIsLocal "?socket=/run/mysqld/mysqld.sock"}"
+    else
+      "postgres://${cfg.database.user}@${cfg.database.host}/${cfg.database.name}${lib.optionalString dbIsLocal "?host=/run/postgresql"}";
+
+  # postgresql.target waits for postgresql-setup.service (which runs
+  # ensureDatabases / ensureUsers) to complete, avoiding race conditions
+  # where the syncserver starts before its database and role exist.
+  dbService = if dbIsMySQL then "mysql.service" else "postgresql.target";
+
+  syncserver = cfg.package.override { dbBackend = cfg.database.type; };
 
   format = pkgs.formats.toml { };
   settings = {
@@ -22,7 +36,7 @@ let
       database_url = dbURL;
     };
     tokenserver = {
-      node_type = "mysql";
+      node_type = if dbIsMySQL then "mysql" else "postgres";
       database_url = dbURL;
       fxa_email_domain = "api.accounts.firefox.com";
       fxa_oauth_server_url = "https://oauth.accounts.firefox.com/v1";
@@ -41,44 +55,75 @@ let
     };
   };
   configFile = format.generate "syncstorage.toml" (lib.recursiveUpdate settings cfg.settings);
-  setupScript = pkgs.writeShellScript "firefox-syncserver-setup" ''
-    set -euo pipefail
-    shopt -s inherit_errexit
 
-    schema_configured() {
-      mysql ${cfg.database.name} -Ne 'SHOW TABLES' | grep -q services
-    }
+  setupScript =
+    let
+      dbSpecific =
+        if dbIsMySQL then
+          {
+            listTables = "mysql ${cfg.database.name} -Ne 'SHOW TABLES'";
+            execSql = "mysql ${cfg.database.name}";
+            upsertSql = ''
+              BEGIN;
 
-    update_config() {
-      mysql ${cfg.database.name} <<"EOF"
-        BEGIN;
+              INSERT INTO `services` (`id`, `service`, `pattern`)
+                VALUES (1, 'sync-1.5', '{node}/1.5/{uid}')
+                ON DUPLICATE KEY UPDATE service='sync-1.5', pattern='{node}/1.5/{uid}';
+              INSERT INTO `nodes` (`id`, `service`, `node`, `available`, `current_load`,
+                                   `capacity`, `downed`, `backoff`)
+                VALUES (1, 1, '${cfg.singleNode.url}', ${toString cfg.singleNode.capacity},
+                0, ${toString cfg.singleNode.capacity}, 0, 0)
+                ON DUPLICATE KEY UPDATE node = '${cfg.singleNode.url}', capacity=${toString cfg.singleNode.capacity};
 
-        INSERT INTO `services` (`id`, `service`, `pattern`)
-          VALUES (1, 'sync-1.5', '{node}/1.5/{uid}')
-          ON DUPLICATE KEY UPDATE service='sync-1.5', pattern='{node}/1.5/{uid}';
-        INSERT INTO `nodes` (`id`, `service`, `node`, `available`, `current_load`,
-                             `capacity`, `downed`, `backoff`)
-          VALUES (1, 1, '${cfg.singleNode.url}', ${toString cfg.singleNode.capacity},
-          0, ${toString cfg.singleNode.capacity}, 0, 0)
-          ON DUPLICATE KEY UPDATE node = '${cfg.singleNode.url}', capacity=${toString cfg.singleNode.capacity};
+              COMMIT;
+            '';
+          }
+        else
+          {
+            listTables = "psql -d ${cfg.database.name} -tAc \"SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'services')\"";
+            execSql = "psql -d ${cfg.database.name}";
+            upsertSql = ''
+              BEGIN;
 
-        COMMIT;
-    EOF
-    }
+              INSERT INTO services (id, service, pattern)
+                VALUES (1, 'sync-1.5', '{node}/1.5/{uid}')
+                ON CONFLICT (id) DO UPDATE SET service = 'sync-1.5', pattern = '{node}/1.5/{uid}';
+              INSERT INTO nodes (id, service, node, available, current_load,
+                                 capacity, downed, backoff)
+                VALUES (1, 1, '${cfg.singleNode.url}', ${toString cfg.singleNode.capacity},
+                0, ${toString cfg.singleNode.capacity}, 0, 0)
+                ON CONFLICT (id) DO UPDATE SET node = '${cfg.singleNode.url}', capacity = ${toString cfg.singleNode.capacity};
 
+              COMMIT;
+            '';
+          };
+    in
+    pkgs.writeShellScript "firefox-syncserver-setup" ''
+      set -euo pipefail
+      shopt -s inherit_errexit
 
-    for (( try = 0; try < 60; try++ )); do
-      if ! schema_configured; then
-        sleep 2
-      else
-        update_config
-        exit 0
-      fi
-    done
+      schema_configured() {
+        ${dbSpecific.listTables} | grep -q services
+      }
 
-    echo "Single-node setup failed"
-    exit 1
-  '';
+      update_config() {
+        ${dbSpecific.execSql} <<'EOF'
+      ${dbSpecific.upsertSql}
+      EOF
+      }
+
+      for (( try = 0; try < 60; try++ )); do
+        if ! schema_configured; then
+          sleep 2
+        else
+          update_config
+          exit 0
+        fi
+      done
+
+      echo "Single-node setup failed"
+      exit 1
+    '';
 in
 
 {
@@ -88,25 +133,26 @@ in
         the Firefox Sync storage service.
 
         Out of the box this will not be very useful unless you also configure at least
-        one service and one nodes by inserting them into the mysql database manually, e.g.
-        by running
-
-        ```
-          INSERT INTO `services` (`id`, `service`, `pattern`) VALUES ('1', 'sync-1.5', '{node}/1.5/{uid}');
-          INSERT INTO `nodes` (`id`, `service`, `node`, `available`, `current_load`,
-              `capacity`, `downed`, `backoff`)
-            VALUES ('1', '1', 'https://mydomain.tld', '1', '0', '10', '0', '0');
-        ```
+        one service and one nodes by inserting them into the database manually, e.g.
+        by running the equivalent SQL for your database backend.
 
         {option}`${opt.singleNode.enable}` does this automatically when enabled
       '';
 
       package = lib.mkPackageOption pkgs "syncstorage-rs" { };
 
+      database.type = lib.mkOption {
+        type = lib.types.enum [
+          "mysql"
+          "postgresql"
+        ];
+        default = "mysql";
+        description = ''
+          Which database backend to use for storage.
+        '';
+      };
+
       database.name = lib.mkOption {
-        # the mysql module does not allow `-quoting without resorting to shell
-        # escaping, so we restrict db names for forward compaitiblity should this
-        # behavior ever change.
         type = lib.types.strMatching "[a-z_][a-z0-9_]*";
         default = defaultDatabase;
         description = ''
@@ -117,9 +163,15 @@ in
 
       database.user = lib.mkOption {
         type = lib.types.str;
-        default = defaultUser;
+        default = if dbIsPostgreSQL then defaultDatabase else defaultUser;
+        defaultText = lib.literalExpression ''
+          if database.type == "postgresql" then "${defaultDatabase}" else "${defaultUser}"
+        '';
         description = ''
-          Username for database connections.
+          Username for database connections.  When using PostgreSQL with
+          `createLocally`, this defaults to the database name so that
+          `ensureDBOwnership` works (it requires user and database names
+          to match).
         '';
       };
 
@@ -137,7 +189,8 @@ in
         default = true;
         description = ''
           Whether to create database and user on the local machine if they do not exist.
-          This includes enabling unix domain socket authentication for the configured user.
+          This includes enabling the configured database service and setting up
+          authentication for the configured user.
         '';
       };
 
@@ -237,7 +290,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    services.mysql = lib.mkIf cfg.database.createLocally {
+    services.mysql = lib.mkIf (cfg.database.createLocally && dbIsMySQL) {
       enable = true;
       ensureDatabases = [ cfg.database.name ];
       ensureUsers = [
@@ -250,16 +303,27 @@ in
       ];
     };
 
+    services.postgresql = lib.mkIf (cfg.database.createLocally && dbIsPostgreSQL) {
+      enable = true;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
     systemd.services.firefox-syncserver = {
       wantedBy = [ "multi-user.target" ];
-      requires = lib.mkIf dbIsLocal [ "mysql.service" ];
-      after = lib.mkIf dbIsLocal [ "mysql.service" ];
+      requires = lib.mkIf dbIsLocal [ dbService ];
+      after = lib.mkIf dbIsLocal [ dbService ];
       restartTriggers = lib.optional cfg.singleNode.enable setupScript;
       environment.RUST_LOG = cfg.logLevel;
       serviceConfig = {
-        User = defaultUser;
-        Group = defaultUser;
-        ExecStart = "${cfg.package}/bin/syncserver --config ${configFile}";
+        User = cfg.database.user;
+        Group = cfg.database.user;
+        ExecStart = "${syncserver}/bin/syncserver --config ${configFile}";
         EnvironmentFile = lib.mkIf (cfg.secrets != null) "${cfg.secrets}";
 
         # hardening
@@ -303,10 +367,19 @@ in
 
     systemd.services.firefox-syncserver-setup = lib.mkIf cfg.singleNode.enable {
       wantedBy = [ "firefox-syncserver.service" ];
-      requires = [ "firefox-syncserver.service" ] ++ lib.optional dbIsLocal "mysql.service";
-      after = [ "firefox-syncserver.service" ] ++ lib.optional dbIsLocal "mysql.service";
-      path = [ config.services.mysql.package ];
-      serviceConfig.ExecStart = [ "${setupScript}" ];
+      requires = [ "firefox-syncserver.service" ] ++ lib.optional dbIsLocal dbService;
+      after = [ "firefox-syncserver.service" ] ++ lib.optional dbIsLocal dbService;
+      path =
+        if dbIsMySQL then [ config.services.mysql.package ] else [ config.services.postgresql.package ];
+      serviceConfig = {
+        ExecStart = [ "${setupScript}" ];
+      }
+      // lib.optionalAttrs dbIsPostgreSQL {
+        # PostgreSQL peer authentication requires the system user to match the
+        # database user. Run as the superuser so we can access all databases.
+        User = "postgres";
+        Group = "postgres";
+      };
     };
 
     services.nginx.virtualHosts = lib.mkIf cfg.singleNode.enableNginx {

--- a/nixos/modules/services/networking/firefox-syncserver.nix
+++ b/nixos/modules/services/networking/firefox-syncserver.nix
@@ -3,17 +3,35 @@
   pkgs,
   lib,
   options,
+  utils,
   ...
 }:
-
 let
   cfg = config.services.firefox-syncserver;
   opt = options.services.firefox-syncserver;
   defaultDatabase = "firefox_syncserver";
   defaultUser = "firefox-syncserver";
 
+  dbIsMySQL = cfg.database.type == "mysql";
+  dbIsPostgreSQL = cfg.database.type == "postgresql";
+
   dbIsLocal = cfg.database.host == "localhost";
-  dbURL = "mysql://${cfg.database.user}@${cfg.database.host}/${cfg.database.name}${lib.optionalString dbIsLocal "?socket=/run/mysqld/mysqld.sock"}";
+
+  dbURL =
+    if dbIsMySQL then
+      "mysql://${cfg.database.user}@${cfg.database.host}/${cfg.database.name}${lib.optionalString dbIsLocal "?socket=/run/mysqld/mysqld.sock"}"
+    else if dbIsLocal then
+      # Use Unix socket connection with peer authentication by default.
+      "postgres:///${cfg.database.name}?host=/run/postgresql&user=${cfg.database.user}"
+    else
+      "postgres://${cfg.database.user}@${cfg.database.host}/${cfg.database.name}";
+
+  # postgresql.target waits for postgresql-setup.service (which runs
+  # ensureDatabases / ensureUsers) to complete, avoiding race conditions
+  # where the syncserver starts before its database and role exist.
+  dbService = if dbIsMySQL then "mysql.service" else "postgresql.target";
+
+  syncserver = cfg.package.override { dbBackend = cfg.database.type; };
 
   format = pkgs.formats.toml { };
   settings = {
@@ -22,7 +40,7 @@ let
       database_url = dbURL;
     };
     tokenserver = {
-      node_type = "mysql";
+      node_type = if dbIsMySQL then "mysql" else "postgres";
       database_url = dbURL;
       fxa_email_domain = "api.accounts.firefox.com";
       fxa_oauth_server_url = "https://oauth.accounts.firefox.com/v1";
@@ -41,44 +59,75 @@ let
     };
   };
   configFile = format.generate "syncstorage.toml" (lib.recursiveUpdate settings cfg.settings);
-  setupScript = pkgs.writeShellScript "firefox-syncserver-setup" ''
-    set -euo pipefail
-    shopt -s inherit_errexit
 
-    schema_configured() {
-      mysql ${cfg.database.name} -Ne 'SHOW TABLES' | grep -q services
-    }
+  setupScript =
+    let
+      dbSpecific =
+        if dbIsMySQL then
+          {
+            listTables = "mysql ${cfg.database.name} -Ne 'SHOW TABLES'";
+            execSql = "mysql ${cfg.database.name}";
+            upsertSql = ''
+              BEGIN;
 
-    update_config() {
-      mysql ${cfg.database.name} <<"EOF"
-        BEGIN;
+              INSERT INTO `services` (`id`, `service`, `pattern`)
+                VALUES (1, 'sync-1.5', '{node}/1.5/{uid}')
+                ON DUPLICATE KEY UPDATE service='sync-1.5', pattern='{node}/1.5/{uid}';
+              INSERT INTO `nodes` (`id`, `service`, `node`, `available`, `current_load`,
+                                   `capacity`, `downed`, `backoff`)
+                VALUES (1, 1, '${cfg.singleNode.url}', ${toString cfg.singleNode.capacity},
+                0, ${toString cfg.singleNode.capacity}, 0, 0)
+                ON DUPLICATE KEY UPDATE node = '${cfg.singleNode.url}', capacity=${toString cfg.singleNode.capacity};
 
-        INSERT INTO `services` (`id`, `service`, `pattern`)
-          VALUES (1, 'sync-1.5', '{node}/1.5/{uid}')
-          ON DUPLICATE KEY UPDATE service='sync-1.5', pattern='{node}/1.5/{uid}';
-        INSERT INTO `nodes` (`id`, `service`, `node`, `available`, `current_load`,
-                             `capacity`, `downed`, `backoff`)
-          VALUES (1, 1, '${cfg.singleNode.url}', ${toString cfg.singleNode.capacity},
-          0, ${toString cfg.singleNode.capacity}, 0, 0)
-          ON DUPLICATE KEY UPDATE node = '${cfg.singleNode.url}', capacity=${toString cfg.singleNode.capacity};
+              COMMIT;
+            '';
+          }
+        else
+          {
+            listTables = "psql -d ${cfg.database.name} -tAc \"SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'\"";
+            execSql = "psql -d ${cfg.database.name}";
+            upsertSql = ''
+              BEGIN;
 
-        COMMIT;
-    EOF
-    }
+              INSERT INTO services (id, service, pattern)
+                VALUES (1, 'sync-1.5', '{node}/1.5/{uid}')
+                ON CONFLICT (id) DO UPDATE SET service = 'sync-1.5', pattern = '{node}/1.5/{uid}';
+              INSERT INTO nodes (id, service, node, available, current_load,
+                                 capacity, downed, backoff)
+                VALUES (1, 1, '${cfg.singleNode.url}', ${toString cfg.singleNode.capacity},
+                0, ${toString cfg.singleNode.capacity}, 0, 0)
+                ON CONFLICT (id) DO UPDATE SET node = '${cfg.singleNode.url}', capacity = ${toString cfg.singleNode.capacity};
 
+              COMMIT;
+            '';
+          };
+    in
+    pkgs.writeShellScript "firefox-syncserver-setup" ''
+      set -euo pipefail
+      shopt -s inherit_errexit
 
-    for (( try = 0; try < 60; try++ )); do
-      if ! schema_configured; then
-        sleep 2
-      else
-        update_config
-        exit 0
-      fi
-    done
+      schema_configured() {
+        ${dbSpecific.listTables} | grep -q services
+      }
 
-    echo "Single-node setup failed"
-    exit 1
-  '';
+      update_config() {
+        ${dbSpecific.execSql} <<'EOF'
+      ${dbSpecific.upsertSql}
+      EOF
+      }
+
+      for (( try = 0; try < 60; try++ )); do
+        if ! schema_configured; then
+          sleep 2
+        else
+          update_config
+          exit 0
+        fi
+      done
+
+      echo "Single-node setup failed"
+      exit 1
+    '';
 in
 
 {
@@ -88,14 +137,14 @@ in
         the Firefox Sync storage service.
 
         Out of the box this will not be very useful unless you also configure at least
-        one service and one nodes by inserting them into the mysql database manually, e.g.
+        one service and one nodes by inserting them into the database manually, e.g.
         by running
 
         ```
-          INSERT INTO `services` (`id`, `service`, `pattern`) VALUES ('1', 'sync-1.5', '{node}/1.5/{uid}');
-          INSERT INTO `nodes` (`id`, `service`, `node`, `available`, `current_load`,
-              `capacity`, `downed`, `backoff`)
-            VALUES ('1', '1', 'https://mydomain.tld', '1', '0', '10', '0', '0');
+          INSERT INTO services (id, service, pattern) VALUES (1, 'sync-1.5', '{node}/1.5/{uid}');
+          INSERT INTO nodes (id, service, node, available, current_load,
+              capacity, downed, backoff)
+            VALUES (1, 1, 'https://mydomain.tld', 1, 0, 10, 0, 0);
         ```
 
         {option}`${opt.singleNode.enable}` does this automatically when enabled
@@ -103,10 +152,21 @@ in
 
       package = lib.mkPackageOption pkgs "syncstorage-rs" { };
 
+      database.type = lib.mkOption {
+        type = lib.types.enum [
+          "mysql"
+          "postgresql"
+        ];
+        description = ''
+          Which database backend to use for storage.
+          ::: {.note}
+          `"postgresql"` is recommended for new deployments. `"mysql"` is the
+          backend used by legacy installations.
+          :::
+        '';
+      };
+
       database.name = lib.mkOption {
-        # the mysql module does not allow `-quoting without resorting to shell
-        # escaping, so we restrict db names for forward compaitiblity should this
-        # behavior ever change.
         type = lib.types.strMatching "[a-z_][a-z0-9_]*";
         default = defaultDatabase;
         description = ''
@@ -117,9 +177,15 @@ in
 
       database.user = lib.mkOption {
         type = lib.types.str;
-        default = defaultUser;
+        default = if dbIsPostgreSQL then defaultDatabase else defaultUser;
+        defaultText = lib.literalExpression ''
+          if database.type == "postgresql" then "${defaultDatabase}" else "${defaultUser}"
+        '';
         description = ''
-          Username for database connections.
+          Username for database connections.  When using PostgreSQL with
+          `createLocally`, this defaults to the database name so that
+          `ensureDBOwnership` works (it requires user and database names
+          to match).
         '';
       };
 
@@ -137,7 +203,8 @@ in
         default = true;
         description = ''
           Whether to create database and user on the local machine if they do not exist.
-          This includes enabling unix domain socket authentication for the configured user.
+          This includes enabling the configured database service and setting up
+          authentication for the configured user.
         '';
       };
 
@@ -237,7 +304,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    services.mysql = lib.mkIf cfg.database.createLocally {
+    services.mysql = lib.mkIf (cfg.database.createLocally && dbIsMySQL) {
       enable = true;
       ensureDatabases = [ cfg.database.name ];
       ensureUsers = [
@@ -250,17 +317,34 @@ in
       ];
     };
 
+    services.postgresql = lib.mkIf (cfg.database.createLocally && dbIsPostgreSQL) {
+      enable = true;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
     systemd.services.firefox-syncserver = {
       wantedBy = [ "multi-user.target" ];
-      requires = lib.mkIf dbIsLocal [ "mysql.service" ];
-      after = lib.mkIf dbIsLocal [ "mysql.service" ];
+      requires = lib.mkIf dbIsLocal [ dbService ];
+      after = lib.mkIf dbIsLocal [ dbService ];
       restartTriggers = lib.optional cfg.singleNode.enable setupScript;
       environment.RUST_LOG = cfg.logLevel;
       serviceConfig = {
-        User = defaultUser;
-        Group = defaultUser;
-        ExecStart = "${cfg.package}/bin/syncserver --config ${configFile}";
+        ExecStart = utils.escapeSystemdExecArgs [
+          (lib.getExe syncserver)
+          "--config"
+          configFile
+        ];
+        User = cfg.database.user;
+        Group = cfg.database.user;
         EnvironmentFile = lib.mkIf (cfg.secrets != null) "${cfg.secrets}";
+        Restart = "on-failure";
+        RestartSec = "5s";
 
         # hardening
         RemoveIPC = true;
@@ -303,10 +387,21 @@ in
 
     systemd.services.firefox-syncserver-setup = lib.mkIf cfg.singleNode.enable {
       wantedBy = [ "firefox-syncserver.service" ];
-      requires = [ "firefox-syncserver.service" ] ++ lib.optional dbIsLocal "mysql.service";
-      after = [ "firefox-syncserver.service" ] ++ lib.optional dbIsLocal "mysql.service";
-      path = [ config.services.mysql.package ];
-      serviceConfig.ExecStart = [ "${setupScript}" ];
+      requires = [ "firefox-syncserver.service" ] ++ lib.optional dbIsLocal dbService;
+      after = [ "firefox-syncserver.service" ] ++ lib.optional dbIsLocal dbService;
+      path =
+        if dbIsMySQL then [ config.services.mysql.package ] else [ config.services.postgresql.package ];
+      serviceConfig = {
+        ExecStart = [ "${setupScript}" ];
+      }
+      // lib.optionalAttrs dbIsPostgreSQL {
+        # Peer authentication maps the system user to the database role of the
+        # same name, which owns the database (ensureDBOwnership), so no
+        # superuser access is required.
+        User = cfg.database.user;
+        Group = cfg.database.user;
+        DynamicUser = true;
+      };
     };
 
     services.nginx.virtualHosts = lib.mkIf cfg.singleNode.enableNginx {

--- a/nixos/modules/services/networking/firefox-syncserver.nix
+++ b/nixos/modules/services/networking/firefox-syncserver.nix
@@ -31,7 +31,13 @@ let
   # where the syncserver starts before its database and role exist.
   dbService = if dbIsMySQL then "mysql.service" else "postgresql.target";
 
-  syncserver = cfg.package.override { dbBackend = cfg.database.type; };
+  syncserver =
+    if cfg.package != null then
+      cfg.package
+    else if dbIsMySQL then
+      pkgs.syncstorage-rs-mysql
+    else
+      pkgs.syncstorage-rs-pgsql;
 
   format = pkgs.formats.toml { };
   settings = {
@@ -150,7 +156,20 @@ in
         {option}`${opt.singleNode.enable}` does this automatically when enabled
       '';
 
-      package = lib.mkPackageOption pkgs "syncstorage-rs" { };
+      package = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+        defaultText = lib.literalExpression ''
+          if config.${opt.database.type} == "mysql" then
+            pkgs.syncstorage-rs-mysql
+          else
+            pkgs.syncstorage-rs-pgsql
+        '';
+        description = ''
+          Syncstorage server package to use. When `null`, the package is
+          selected automatically based on {option}`${opt.database.type}`.
+        '';
+      };
 
       database.type = lib.mkOption {
         type = lib.types.enum [

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -570,7 +570,7 @@ in
     imports = [ ./firefox.nix ];
     _module.args.firefoxPackage = pkgs.firefox-esr-140;
   };
-  firefox-syncserver = runTest ./firefox-syncserver.nix;
+  firefox-syncserver = discoverTests (import ./firefox-syncserver.nix);
   firefox_decrypt = runTest ./firefox_decrypt.nix;
   firefoxpwa = runTest ./firefoxpwa.nix;
   firejail = runTest ./firejail.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -610,7 +610,7 @@ in
     imports = [ ./firefox.nix ];
     _module.args.firefoxPackage = pkgs.firefox-esr-153;
   };
-  firefox-syncserver = runTest ./firefox-syncserver.nix;
+  firefox-syncserver = discoverTests (import ./firefox-syncserver.nix);
   firefox_decrypt = runTest ./firefox_decrypt.nix;
   firefoxpwa = runTest ./firefoxpwa.nix;
   firejail = runTest ./firejail.nix;

--- a/nixos/tests/firefox-syncserver.nix
+++ b/nixos/tests/firefox-syncserver.nix
@@ -1,32 +1,54 @@
-{
-  pkgs,
-  ...
-}:
+let
+  makeFirefoxSyncserverTest =
+    name:
+    {
+      backend ? name,
+    }:
+    import ./make-test-python.nix (
+      { lib, pkgs, ... }:
+      {
+        name = "firefox-syncserver-${name}";
 
-{
-  name = "firefox-syncserver";
-  nodes.machine = {
-    services.mysql = {
-      enable = true;
-      package = pkgs.mariadb;
-    };
+        nodes.machine =
+          { pkgs, ... }:
+          lib.mkMerge [
+            {
+              mysql = {
+                services.mysql = {
+                  enable = true;
+                  package = pkgs.mariadb;
+                };
+              };
+              postgresql = { };
+            }
+            .${backend}
 
-    services.firefox-syncserver = {
-      enable = true;
-      secrets = pkgs.writeText "secret" "this-is-a-test";
-      singleNode = {
-        enable = true;
-        hostname = "firefox-syncserver.local";
-        capacity = 1;
-      };
-    };
-  };
+            {
+              services.firefox-syncserver = {
+                enable = true;
+                database.type = backend;
+                secrets = pkgs.writeText "sync-secrets" ''
+                  SYNC_MASTER_SECRET=a-]test-secret-that-is-not-real
+                '';
+                singleNode = {
+                  enable = true;
+                  hostname = "firefox-syncserver.local";
+                  capacity = 1;
+                };
+              };
+            }
+          ];
 
-  testScript = ''
-    machine.wait_for_unit("firefox-syncserver.service")
-    machine.wait_for_open_port(5000)
-
-    machine.wait_until_succeeds("curl --fail http://127.0.0.1:5000")
-
-  '';
+        testScript = ''
+          machine.wait_for_unit("multi-user.target")
+          machine.wait_until_succeeds("systemctl is-active firefox-syncserver.service", timeout=120)
+          machine.wait_for_open_port(5000)
+          machine.wait_until_succeeds("curl --fail http://127.0.0.1:5000")
+        '';
+      }
+    );
+in
+builtins.mapAttrs (k: v: makeFirefoxSyncserverTest k v) {
+  mysql = { };
+  postgresql = { };
 }

--- a/nixos/tests/firefox-syncserver.nix
+++ b/nixos/tests/firefox-syncserver.nix
@@ -1,32 +1,54 @@
-{
-  pkgs,
-  ...
-}:
+let
+  makeFirefoxSyncserverTest =
+    name:
+    {
+      backend ? name,
+    }:
+    import ./make-test-python.nix (
+      { lib, pkgs, ... }:
+      {
+        name = "firefox-syncserver-${name}";
 
-{
-  name = "firefox-syncserver";
-  nodes.machine = {
-    services.mysql = {
-      enable = true;
-      package = pkgs.mariadb;
-    };
+        containers.machine =
+          { pkgs, ... }:
+          lib.mkMerge [
+            {
+              mysql = {
+                services.mysql = {
+                  enable = true;
+                  package = pkgs.mariadb;
+                };
+              };
+              postgresql = { };
+            }
+            .${backend}
 
-    services.firefox-syncserver = {
-      enable = true;
-      secrets = pkgs.writeText "secret" "this-is-a-test";
-      singleNode = {
-        enable = true;
-        hostname = "firefox-syncserver.local";
-        capacity = 1;
-      };
-    };
-  };
+            {
+              services.firefox-syncserver = {
+                enable = true;
+                database.type = backend;
+                secrets = pkgs.writeText "sync-secrets" ''
+                  SYNC_MASTER_SECRET=a-]test-secret-that-is-not-real
+                '';
+                singleNode = {
+                  enable = true;
+                  hostname = "firefox-syncserver.local";
+                  capacity = 1;
+                };
+              };
+              environment.systemPackages = [ pkgs.jq ];
+            }
+          ];
 
-  testScript = ''
-    machine.wait_for_unit("firefox-syncserver.service")
-    machine.wait_for_open_port(5000)
-
-    machine.wait_until_succeeds("curl --fail http://127.0.0.1:5000")
-
-  '';
+        testScript = ''
+          machine.wait_for_unit("multi-user.target")
+          machine.wait_until_succeeds("systemctl is-active firefox-syncserver.service", timeout=120)
+          machine.wait_until_succeeds("curl -s http://127.0.0.1:5000/__heartbeat__ | jq -e '.database == \"Ok\" and .status == \"Ok\"'")
+        '';
+      }
+    );
+in
+builtins.mapAttrs (k: v: makeFirefoxSyncserverTest k v) {
+  mysql = { };
+  postgresql = { };
 }

--- a/pkgs/by-name/sy/syncstorage-rs/package.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/package.nix
@@ -1,5 +1,6 @@
 {
   fetchFromGitHub,
+  fetchurl,
   rustPlatform,
   pkg-config,
   python3,
@@ -19,17 +20,23 @@ let
     p.tokenlib
     p.cryptography
   ]);
+  # utoipa-swagger-ui downloads Swagger UI assets at build time.
+  # Prefetch the archive for sandboxed builds.
+  swaggerUi = fetchurl {
+    url = "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip";
+    hash = "sha256-SBJE0IEgl7Efuu73n3HZQrFxYX+cn5UU5jrL4T5xzNw=";
+  };
 in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "syncstorage-rs";
-  version = "0.21.1-unstable-2026-01-26";
+  version = "0.22.2";
 
   src = fetchFromGitHub {
     owner = "mozilla-services";
     repo = "syncstorage-rs";
-    rev = "11659d98f9c69948a0aab353437ce2036c388711";
-    hash = "sha256-G37QvxTNh/C3gmKG0UYHI6QBr0F+KLGRNI/Sx33uOsc=";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-hEDa9hk00QvMY86zrtTq3+UOmbNehDb7Ya8St9u6IuA=";
   };
 
   nativeBuildInputs = [
@@ -43,12 +50,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libmysqlclient
   ];
 
+  SWAGGER_UI_DOWNLOAD_URL = "file://${swaggerUi}";
+
   preFixup = ''
     wrapProgram $out/bin/syncserver \
       --prefix PATH : ${lib.makeBinPath [ pyFxADeps ]}
   '';
 
-  cargoHash = "sha256-9Dcf5mDyK/XjsKTlCPXTHoBkIq+FFPDg1zfK24Y9nHQ=";
+  cargoHash = "sha256-lTjvRTenmxYAYS5HB32x19DLkdd09jeWOhUbzt7TQ4Y=";
 
   # almost all tests need a DB to test against
   doCheck = false;

--- a/pkgs/by-name/sy/syncstorage-rs/package.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/package.nix
@@ -35,6 +35,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "syncstorage-rs";
   version = "0.22.2";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "mozilla-services";
     repo = "syncstorage-rs";
@@ -70,7 +72,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
       "py_verifier"
     ];
 
-  SWAGGER_UI_DOWNLOAD_URL = "file://${swaggerUi}";
+  env = {
+    SWAGGER_UI_DOWNLOAD_URL = "file://${swaggerUi}";
+  };
 
   preFixup = ''
     wrapProgram $out/bin/syncserver \
@@ -84,7 +88,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru.updateScript = nix-update-script { };
 
-  passthru.tests = { inherit (nixosTests) firefox-syncserver; };
+  passthru.tests = {
+    firefox-syncserver =
+      nixosTests.firefox-syncserver.${if dbBackend == "postgresql" then "postgresql" else "mysql"};
+  };
 
   meta = {
     description = "Mozilla Sync Storage built with Rust";

--- a/pkgs/by-name/sy/syncstorage-rs/package.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/package.nix
@@ -6,10 +6,13 @@
   python3,
   cmake,
   libmysqlclient,
+  libpq,
+  openssl,
   makeBinaryWrapper,
   lib,
   nix-update-script,
   nixosTests,
+  dbBackend ? "mysql",
 }:
 
 let
@@ -46,9 +49,26 @@ rustPlatform.buildRustPackage (finalAttrs: {
     python3
   ];
 
-  buildInputs = [
-    libmysqlclient
-  ];
+  buildInputs =
+    lib.optional (dbBackend == "mysql") libmysqlclient
+    ++ lib.optionals (dbBackend == "postgresql") [
+      libpq
+      openssl
+    ];
+
+  buildNoDefaultFeatures = true;
+  # The syncserver "postgres" feature only enables syncstorage-db/postgres.
+  # tokenserver-db/postgres must be enabled separately so the tokenserver
+  # can also connect to PostgreSQL (it dispatches on the URL scheme at runtime).
+  buildFeatures =
+    let
+      cargoFeature = if dbBackend == "postgresql" then "postgres" else dbBackend;
+    in
+    [
+      cargoFeature
+      "tokenserver-db/${cargoFeature}"
+      "py_verifier"
+    ];
 
   SWAGGER_UI_DOWNLOAD_URL = "file://${swaggerUi}";
 

--- a/pkgs/by-name/sy/syncstorage-rs/package.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/package.nix
@@ -6,10 +6,13 @@
   python3,
   cmake,
   libmysqlclient,
+  libpq,
+  openssl,
   makeBinaryWrapper,
   lib,
   nix-update-script,
   nixosTests,
+  dbBackend ? "mysql",
 }:
 
 let
@@ -46,9 +49,26 @@ rustPlatform.buildRustPackage (finalAttrs: {
     python3
   ];
 
-  buildInputs = [
-    libmysqlclient
-  ];
+  buildInputs =
+    lib.optional (dbBackend == "mysql") libmysqlclient
+    ++ lib.optionals (dbBackend == "postgresql") [
+      libpq
+      openssl
+    ];
+
+  buildNoDefaultFeatures = true;
+  # The syncserver "postgres" feature only enables syncstorage-db/postgres.
+  # tokenserver-db/postgres must be enabled separately so the tokenserver
+  # can also connect to PostgreSQL (it dispatches on the URL scheme at runtime).
+  buildFeatures =
+    let
+      cargoFeature = if dbBackend == "postgresql" then "postgres" else dbBackend;
+    in
+    [
+      cargoFeature
+      "tokenserver-db/${cargoFeature}"
+      "py_verifier"
+    ];
 
   env = {
     SWAGGER_UI_DOWNLOAD_URL = "file://${swaggerUi}";

--- a/pkgs/by-name/sy/syncstorage-rs/package.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/package.nix
@@ -98,7 +98,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/mozilla-services/syncstorage-rs";
     changelog = "https://github.com/mozilla-services/syncstorage-rs/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ titaniumtown ];
+    maintainers = with lib.maintainers; [
+      titaniumtown
+      weriomat
+    ];
     platforms = lib.platforms.linux;
     mainProgram = "syncserver";
   };

--- a/pkgs/by-name/sy/syncstorage-rs/package.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/package.nix
@@ -35,6 +35,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "syncstorage-rs";
   version = "0.22.2";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "mozilla-services";
     repo = "syncstorage-rs";
@@ -86,7 +88,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru.updateScript = nix-update-script { };
 
-  passthru.tests = { inherit (nixosTests) firefox-syncserver; };
+  passthru.tests = {
+    firefox-syncserver =
+      nixosTests.firefox-syncserver.${if dbBackend == "postgresql" then "postgresql" else "mysql"};
+  };
 
   meta = {
     description = "Mozilla Sync Storage built with Rust";

--- a/pkgs/by-name/sy/syncstorage-rs/package.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/package.nix
@@ -98,7 +98,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/mozilla-services/syncstorage-rs";
     changelog = "https://github.com/mozilla-services/syncstorage-rs/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ titaniumtown ];
     platforms = lib.platforms.linux;
     mainProgram = "syncserver";
   };

--- a/pkgs/by-name/sy/syncstorage-rs/package.nix
+++ b/pkgs/by-name/sy/syncstorage-rs/package.nix
@@ -1,5 +1,6 @@
 {
   fetchFromGitHub,
+  fetchurl,
   rustPlatform,
   pkg-config,
   python3,
@@ -19,17 +20,23 @@ let
     p.tokenlib
     p.cryptography
   ]);
+  # utoipa-swagger-ui downloads Swagger UI assets at build time.
+  # Prefetch the archive for sandboxed builds.
+  swaggerUi = fetchurl {
+    url = "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip";
+    hash = "sha256-SBJE0IEgl7Efuu73n3HZQrFxYX+cn5UU5jrL4T5xzNw=";
+  };
 in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "syncstorage-rs";
-  version = "0.21.1-unstable-2026-01-26";
+  version = "0.22.2";
 
   src = fetchFromGitHub {
     owner = "mozilla-services";
     repo = "syncstorage-rs";
-    rev = "11659d98f9c69948a0aab353437ce2036c388711";
-    hash = "sha256-G37QvxTNh/C3gmKG0UYHI6QBr0F+KLGRNI/Sx33uOsc=";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-hEDa9hk00QvMY86zrtTq3+UOmbNehDb7Ya8St9u6IuA=";
   };
 
   nativeBuildInputs = [
@@ -43,12 +50,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libmysqlclient
   ];
 
+  env = {
+    SWAGGER_UI_DOWNLOAD_URL = "file://${swaggerUi}";
+  };
+
   preFixup = ''
     wrapProgram $out/bin/syncserver \
       --prefix PATH : ${lib.makeBinPath [ pyFxADeps ]}
   '';
 
-  cargoHash = "sha256-9Dcf5mDyK/XjsKTlCPXTHoBkIq+FFPDg1zfK24Y9nHQ=";
+  cargoHash = "sha256-lTjvRTenmxYAYS5HB32x19DLkdd09jeWOhUbzt7TQ4Y=";
 
   # almost all tests need a DB to test against
   doCheck = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10336,6 +10336,13 @@ with pkgs;
     waylandSupport = true;
   };
 
+  syncstorage-rs-mysql = callPackage ../by-name/sy/syncstorage-rs/package.nix {
+    dbBackend = "mysql";
+  };
+  syncstorage-rs-pgsql = callPackage ../by-name/sy/syncstorage-rs/package.nix {
+    dbBackend = "postgresql";
+  };
+
   inherit
     (callPackages ../applications/networking/syncthing {
       inherit (darwin) autoSignDarwinBinariesHook;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9378,6 +9378,13 @@ with pkgs;
     pythonBindings = true;
   };
 
+  syncstorage-rs-mysql = callPackage ../by-name/sy/syncstorage-rs/package.nix {
+    dbBackend = "mysql";
+  };
+  syncstorage-rs-pgsql = callPackage ../by-name/sy/syncstorage-rs/package.nix {
+    dbBackend = "postgresql";
+  };
+
   synergyWithoutGUI = synergy.override { withGUI = false; };
 
   tabbed = callPackage ../applications/window-managers/tabbed {


### PR DESCRIPTION
Added support to the firefox-syncserver module for PostgreSQL databases. The upstream project has support for it, but the module did not. I also modified the actual firefox-syncserver package to allow the PostgreSQL feature flag to be set by changing the target database backend.

I needed to bump the version of the underlying package as the version currently shipping doesn't contain PostgreSQL support.

One concern I have is about the feature flag handling, should we just compile for both mysql and PostgreSQL? Right now I have it so it's either-or and it's determined by a feature flag.

LLMs used: Claude Opus 4.6 via opencode

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [X] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
