### PR TITLE
python3Packages.pycangjie: fix build with non-default python versions

### DIFF
--- a/pkgs/development/python-modules/pycangjie/default.nix
+++ b/pkgs/development/python-modules/pycangjie/default.nix
@@ -25,6 +25,17 @@ buildPythonPackage rec {
     hash = "sha256-REWX6u3Rc72+e5lIImBwV5uFoBBUTMM5BOfYdKIFL4k=";
   };
 
+  # `find_installation()` without the `name_or_path` argument uses the
+  # Python interpreter that Meson was built with, which may not be the
+  # one we're using to build pycangjie.
+  # https://mesonbuild.com/Python-module.html#find_installation
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail \
+        "import('python').find_installation()" \
+        "import('python').find_installation('python3')"
+  '';
+
   preConfigure = ''
     (
       cd subprojects


### PR DESCRIPTION
`find_installation()` without the `name_or_path` argument [uses the Python interpreter that Meson was built with](https://mesonbuild.com/Python-module.html#find_installation), which may not be the one we're using to build pycangjie.

Hydra: https://hydra.nixos.org/build/324644501/nixlog/1
Tracking: #475732

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.pycangjie`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
