### PR TITLE
paperless-ngx: 2.20.11 -> 2.20.13

### DIFF
--- a/pkgs/by-name/pa/paperless-ngx/package.nix
+++ b/pkgs/by-name/pa/paperless-ngx/package.nix
@@ -29,13 +29,13 @@
   lndir,
 }:
 let
-  version = "2.20.11";
+  version = "2.20.13";
 
   src = fetchFromGitHub {
     owner = "paperless-ngx";
     repo = "paperless-ngx";
     tag = "v${version}";
-    hash = "sha256-Bn5k6h80nSNxWYsIpqVLXp+udzxDCY8f/jbgDvyATM0=";
+    hash = "sha256-Oh0iFcGWsiPe7xCHw1+9z3BuWikEshVDLWeBPHrEJA0=";
   };
 
   python = python3.override {


### PR DESCRIPTION
Diff: https://github.com/paperless-ngx/paperless-ngx/compare/v2.20.11...v2.20.13

Changelogs: 
> v2.20.12: https://github.com/paperless-ngx/paperless-ngx/releases/tag/v2.20.12
> v2.20.13: https://github.com/paperless-ngx/paperless-ngx/releases/tag/v2.20.13

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
