### PR TITLE
python314Packages.propka: fix build

### DIFF
--- a/pkgs/development/python-modules/propka/default.nix
+++ b/pkgs/development/python-modules/propka/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   setuptools,
   pytestCheckHook,
 }:
@@ -17,6 +18,15 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-EJQqCe4WPOpqsSxxfbTjF0qETpSPYqpixpylweTCjko=";
   };
+
+  patches = [
+    # Upstream PR: https://github.com/jensengroup/propka/pull/202
+    (fetchpatch {
+      name = "python-3.14.patch";
+      url = "https://github.com/jensengroup/propka/commit/5eb80b7836b2e71b37598d2c7fa06ed8141ff6fd.patch";
+      hash = "sha256-tuhUfc7SGjdGxAPcsbrwOyqgTesg7k+FruJjY05YOUs=";
+    })
+  ];
 
   nativeBuildInputs = [ setuptools ];
 


### PR DESCRIPTION
Upstream PR: https://github.com/jensengroup/propka/pull/202

Hydra: https://hydra.nixos.org/build/324643659/nixlog/1
Tracking: #475732

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.propka`, `python314Packages.pdb2pqr`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
