### PR TITLE
tree-wide: make sudo wrappers compatible with nspawn containers

### DIFF
--- a/nixos/modules/services/mail/mailman.nix
+++ b/nixos/modules/services/mail/mailman.nix
@@ -547,7 +547,9 @@ in
           mv $out/bin/mailman $out/bin/.mailman-wrapped
           echo '#!${pkgs.runtimeShell}
           sudo=exec
-          if [[ "$USER" != mailman ]]; then
+          if [[ "''${USER:-root}" == 'root' ]]; then
+            sudo='exec runuser -u mailman --'
+          elif [[ "$USER" != "mailman" ]]; then
             sudo="exec /run/wrappers/bin/sudo -u mailman"
           fi
           $sudo ${placeholder "out"}/bin/.mailman-wrapped "$@"

--- a/nixos/modules/services/misc/omnom.nix
+++ b/nixos/modules/services/misc/omnom.nix
@@ -259,7 +259,9 @@ in
           #! ${pkgs.runtimeShell}
           cd ${cfg.dataDir}
           sudo=exec
-          if [[ "$USER" != ${cfg.user} ]]; then
+          if [[ "''${USER:-root}" == 'root' ]]; then
+            sudo='exec runuser -u ${cfg.user} --'
+          elif [[ "$USER" != "${cfg.user}" ]]; then
             sudo='exec /run/wrappers/bin/sudo -u ${cfg.user}'
           fi
           $sudo ${lib.getExe cfg.package} "$@"

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -54,7 +54,9 @@ let
 
     cd '${cfg.dataDir}'
     sudo=exec
-    if [[ "$USER" != ${cfg.user} ]]; then
+    if [[ "''${USER:-root}" == 'root' ]]; then
+      sudo='exec runuser -u ${cfg.user} --'
+    elif [[ "$USER" != "${cfg.user}" ]]; then
       ${
         if config.security.sudo.enable then
           "sudo='exec ${config.security.wrapperDir}/sudo -u ${cfg.user} -E'"

--- a/nixos/modules/services/monitoring/librenms.nix
+++ b/nixos/modules/services/monitoring/librenms.nix
@@ -41,7 +41,9 @@ let
   artisanWrapper = pkgs.writeShellScriptBin "librenms-artisan" ''
     cd ${package}
     sudo=exec
-    if [[ "$USER" != ${cfg.user} ]]; then
+    if [[ "''${USER:-root}" == 'root' ]]; then
+      sudo='exec runuser -u ${cfg.user} --'
+    elif [[ "$USER" != "${cfg.user}" ]]; then
       sudo='exec /run/wrappers/bin/sudo -u ${cfg.user}'
     fi
     $sudo ${package}/artisan "$@"
@@ -50,8 +52,10 @@ let
   lnmsWrapper = pkgs.writeShellScriptBin "lnms" ''
     cd ${package}
     sudo=exec
-    if [[ "$USER" != ${cfg.user} ]]; then
-    sudo='exec /run/wrappers/bin/sudo -u ${cfg.user}'
+    if [[ "''${USER:-root}" == 'root' ]]; then
+      sudo='exec runuser -u ${cfg.user} --'
+    elif [[ "$USER" != "${cfg.user}" ]]; then
+      sudo='exec /run/wrappers/bin/sudo -u ${cfg.user}'
     fi
     $sudo ${package}/lnms "$@"
   '';

--- a/nixos/modules/services/networking/pihole-ftl.nix
+++ b/nixos/modules/services/networking/pihole-ftl.nix
@@ -25,7 +25,9 @@ let
 
   piholeScript = pkgs.writeScriptBin "pihole" ''
     sudo=exec
-    if [[ "$USER" != '${cfg.user}' ]]; then
+    if [[ "''${USER:-root}" == 'root' ]]; then
+      sudo='exec runuser -u ${cfg.user} --'
+    elif [[ "$USER" != "${cfg.user}" ]]; then
       sudo='exec /run/wrappers/bin/sudo -u ${cfg.user}'
     fi
     $sudo ${getExe cfg.piholePackage} "$@"

--- a/nixos/modules/services/security/crowdsec.nix
+++ b/nixos/modules/services/security/crowdsec.nix
@@ -513,7 +513,9 @@ in
         # cscli needs crowdsec on it's path in order to be able to run `cscli explain`
         export PATH="$PATH:${lib.makeBinPath [ cfg.package ]}"
                 sudo=exec
-        if [ "$USER" != "${cfg.user}" ]; then
+        if [[ "''${USER:-root}" == 'root' ]]; then
+          sudo='exec runuser -u ${cfg.user} --'
+        elif [[ "$USER" != "${cfg.user}" ]]; then
           ${
             if config.security.sudo.enable then
               "sudo='exec ${config.security.wrapperDir}/sudo -u ${cfg.user}'"

--- a/nixos/modules/services/web-apps/gancio.nix
+++ b/nixos/modules/services/web-apps/gancio.nix
@@ -171,7 +171,9 @@ in
         echo '#!${pkgs.runtimeShell}
         cd /var/lib/gancio/
         sudo=exec
-        if [[ "$USER" != ${cfg.user} ]]; then
+        if [[ "''${USER:-root}" == 'root' ]]; then
+          sudo='exec runuser -u ${cfg.user} --'
+        elif [[ "$USER" != "${cfg.user}" ]]; then
           sudo="exec /run/wrappers/bin/sudo -u ${cfg.user}"
         fi
         $sudo ${lib.getExe cfg.package} "''${@:--help}"

--- a/nixos/modules/services/web-apps/healthchecks.nix
+++ b/nixos/modules/services/web-apps/healthchecks.nix
@@ -27,7 +27,9 @@ let
 
   healthchecksManageScript = pkgs.writeShellScriptBin "healthchecks-manage" ''
     sudo=exec
-    if [[ "$USER" != "${cfg.user}" ]]; then
+    if [[ "''${USER:-root}" == 'root' ]]; then
+      sudo='exec runuser -u ${cfg.user} --preserve-environment --'
+    elif [[ "$USER" != "${cfg.user}" ]]; then
       sudo='exec /run/wrappers/bin/sudo -u ${cfg.user} --preserve-env --preserve-env=PYTHONPATH'
     fi
     export $(cat ${environmentFile} | xargs)

--- a/nixos/modules/services/web-apps/libretranslate.nix
+++ b/nixos/modules/services/web-apps/libretranslate.nix
@@ -11,7 +11,9 @@ let
     set -a
     export HOME="/var/lib/libretranslate"
     sudo=exec
-    if [[ "$USER" != ${cfg.user} ]]; then
+    if [[ "''${USER:-root}" == 'root' ]]; then
+      sudo='exec runuser -u ${cfg.user} --preserve-environment --'
+    elif [[ "$USER" != "${cfg.user}" ]]; then
       sudo='exec /run/wrappers/bin/sudo -u ${cfg.user} --preserve-env'
     fi
     $sudo ${cfg.package}/bin/ltmanage keys --api-keys-db-path ${cfg.dataDir}/db/api_keys.db "$@"

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -150,7 +150,9 @@ let
       ${sourceExtraEnv}
 
       sudo=exec
-      if [[ "$USER" != ${cfg.user} ]]; then
+      if [[ "''${USER:-root}" == 'root' ]]; then
+        sudo='exec runuser -u ${cfg.user} --preserve-environment --'
+      elif [[ "$USER" != "${cfg.user}" ]]; then
         sudo='exec /run/wrappers/bin/sudo -u ${cfg.user} --preserve-env'
       fi
       $sudo ${cfg.package}/bin/tootctl "$@"

--- a/nixos/modules/services/web-apps/mediagoblin.nix
+++ b/nixos/modules/services/web-apps/mediagoblin.nix
@@ -196,7 +196,9 @@ in
     environment.systemPackages = [
       (pkgs.writeShellScriptBin "mediagoblin-gmg" ''
         sudo=exec
-        if [[ "$USER" != mediagoblin ]]; then
+        if [[ "''${USER:-root}" == 'root' ]]; then
+          sudo='exec runuser -u mediagoblin --'
+        elif [[ "$USER" != "mediagoblin" ]]; then
          sudo='exec /run/wrappers/bin/sudo -u mediagoblin'
         fi
         $sudo sh -c "cd /var/lib/mediagoblin; env GI_TYPELIB_PATH=${GI_TYPELIB_PATH} GST_PLUGIN_PATH=${GST_PLUGIN_PATH} PATH=$PATH:${lib.makeBinPath path} ${lib.getExe' finalPackage "gmg"} $*"

--- a/nixos/modules/services/web-apps/pdfding.nix
+++ b/nixos/modules/services/web-apps/pdfding.nix
@@ -302,7 +302,9 @@ in
             set +a
             ${loadCreds}
             sudo=exec
-            if [[ "$USER" != ${cfg.user} ]]; then
+            if [[ "''${USER:-root}" == 'root' ]]; then
+              sudo='exec runuser -u ${cfg.user} --preserve-environment --'
+            elif [[ "$USER" != "${cfg.user}" ]]; then
               sudo='${config.security.wrapperDir}/sudo -E -u ${cfg.user}'
             fi
             ${cmd}

--- a/nixos/modules/services/web-apps/pixelfed.nix
+++ b/nixos/modules/services/web-apps/pixelfed.nix
@@ -42,7 +42,9 @@ let
   pixelfed-manage = pkgs.writeShellScriptBin "pixelfed-manage" ''
     cd ${pixelfed}
     sudo=exec
-    if [[ "$USER" != ${user} ]]; then
+    if [[ "''${USER:-root}" == 'root' ]]; then
+      sudo='exec runuser -u ${cfg.user} --'
+    elif [[ "$USER" != "${cfg.user}" ]]; then
       sudo='exec /run/wrappers/bin/sudo -u ${user}'
     fi
     $sudo ${phpPackage}/bin/php artisan "$@"

--- a/nixos/modules/services/web-apps/pretalx.nix
+++ b/nixos/modules/services/web-apps/pretalx.nix
@@ -328,7 +328,9 @@ in
       (pkgs.writeScriptBin "pretalx-manage" ''
         cd ${cfg.settings.filesystem.data}
         sudo=exec
-        if [[ "$USER" != ${cfg.user} ]]; then
+        if [[ "''${USER:-root}" == 'root' ]]; then
+          sudo='exec runuser -u ${cfg.user} --preserve-environment --'
+        elif [[ "$USER" != "${cfg.user}" ]]; then
           sudo='exec /run/wrappers/bin/sudo -u ${cfg.user} --preserve-env=PRETALX_CONFIG_FILE'
         fi
         set -a

--- a/nixos/modules/services/web-apps/pretix.nix
+++ b/nixos/modules/services/web-apps/pretix.nix
@@ -399,7 +399,9 @@ in
       (pkgs.writeScriptBin "pretix-manage" ''
         cd ${cfg.settings.pretix.datadir}
         sudo=exec
-        if [[ "$USER" != ${cfg.user} ]]; then
+        if [[ "''${USER:-root}" == 'root' ]]; then
+          sudo='exec runuser -u ${cfg.user} --preserve-environment --'
+        elif [[ "$USER" != "${cfg.user}" ]]; then
           sudo='exec /run/wrappers/bin/sudo -u ${cfg.user} ${optionalString withRedis "-g redis-pretix"} --preserve-env=PRETIX_CONFIG_FILE'
         fi
         export PRETIX_CONFIG_FILE=${configFile}

--- a/nixos/modules/services/web-apps/snipe-it.nix
+++ b/nixos/modules/services/web-apps/snipe-it.nix
@@ -28,7 +28,9 @@ let
       #! ${pkgs.runtimeShell}
       cd "${snipe-it}/share/php/snipe-it"
       sudo=exec
-      if [[ "$USER" != ${user} ]]; then
+      if [[ "''${USER:-root}" == 'root' ]]; then
+        sudo='exec runuser -u ${cfg.user} --'
+      elif [[ "$USER" != "${cfg.user}" ]]; then
         sudo='exec /run/wrappers/bin/sudo -u ${user}'
       fi
       $sudo ${phpPackage}/bin/php artisan $*


### PR DESCRIPTION
Makes sudo wrappers compatible with the recent nspawn container tests (#478109).

To test this, further ports the tests for Mastodon to nspawn container tests.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
