### PR TITLE
nixos/bind: fix check of config file

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -76,25 +76,26 @@ let
     text = ''
       key "rndc-key" {
         algorithm ${bindRndcMacType};
-        secret "0123456789abcdefghijklmnopqrstuvw=";
+        secret "Ini0XSebb9LrYz7zprobBLZ2iwBEK5S9vh9zj/DozR8=";
       };
     '';
   };
 
+  testFakeDir = "/tmp/test-fake-directory-for-named-checkconf";
+
   confFile = pkgs.writeTextFile {
     name = "named.conf";
     checkPhase = ''
-      runHook preCheck
-      echo "Checking named configuration file...";
-      ${lib.getExe' bindPkg "named-checkconf"} -z $target -t ${cfg.directory}
-      runHook postCheck
+      ${lib.optionalString cfg.checkConfig ''
+        echo "Checking named configuration file...";
+        mkdir -p ${testFakeDir}
+        ${lib.getExe' bindPkg "named-checkconf"} -z $target
+      ''}
+
+      substituteInPlace $target \
+        --replace-fail ${testRndcKey} ${bindRndcKeyFile} \
+        --replace-fail ${testFakeDir} ${cfg.directory}
     '';
-    derivationArgs = {
-      doCheck = true;
-      postCheck = ''
-        substituteInPlace $target --replace-fail ${testRndcKey} ${bindRndcKeyFile}
-      '';
-    };
 
     # The include path in the first line will be replaced in the postCheck hook.
     text = ''
@@ -117,7 +118,7 @@ let
         blackhole { badnetworks; };
         forward ${cfg.forward};
         forwarders { ${lib.concatMapStrings (entry: " ${entry}; ") cfg.forwarders} };
-        directory "${cfg.directory}";
+        directory "${testFakeDir}";
         pid-file "/run/named/named.pid";
         ${cfg.extraOptions}
       };
@@ -323,6 +324,16 @@ in
         '';
       };
 
+      checkConfig = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Check configuration.
+
+          The configuration will not be checked if you override the config file
+          with `configFile`.
+        '';
+      };
     };
 
   };


### PR DESCRIPTION
The check was silently failing and did not check anything at all.

Fixes 1020145d49afaccb4fc2ab99d3486503e1c97883 (https://github.com/NixOS/nixpkgs/pull/389406).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
