### PR TITLE
hugo: 0.155.3 -> 0.158.0

### DIFF
--- a/pkgs/by-name/hu/hugo/package.nix
+++ b/pkgs/by-name/hu/hugo/package.nix
@@ -7,6 +7,7 @@
   buildPackages,
   versionCheckHook,
   nix-update-script,
+  git,
 }:
 
 buildGoModule (finalAttrs: {
@@ -25,8 +26,6 @@ buildGoModule (finalAttrs: {
   checkFlags =
     let
       skippedTestPrefixes = [
-        # Workaround for "failed to load modules"
-        "TestCommands/mod"
         # Server tests are flaky, at least in x86_64-darwin. See #368072
         # We can try testing again after updating the `httpget` helper
         # ref: https://github.com/gohugoio/hugo/blob/v0.140.1/main_test.go#L220-L233
@@ -45,6 +44,10 @@ buildGoModule (finalAttrs: {
   subPackages = [ "." ];
 
   nativeBuildInputs = [ installShellFiles ];
+
+  nativeCheckInputs = [
+    git
+  ];
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/hu/hugo/package.nix
+++ b/pkgs/by-name/hu/hugo/package.nix
@@ -12,16 +12,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "hugo";
-  version = "0.155.3";
+  version = "0.158.0";
 
   src = fetchFromGitHub {
     owner = "gohugoio";
     repo = "hugo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2TvzM7veSAGDqomWXHuEnYX8bGVxAxTto0Xzc+vypDY=";
+    hash = "sha256-7/zrJdoJVDVHt/2qKPkfrxjxMMpB2F2i0fCXZLkd7gw=";
   };
 
-  vendorHash = "sha256-Fh38o7wD6/gL4szvT4UmA4lzIStqITjgjulsIQlPmHU=";
+  vendorHash = "sha256-StGdZ1FP6906jFbqoYQgrbEOx1YPCsqE+01ITQgtaEU=";
 
   checkFlags =
     let


### PR DESCRIPTION
r-ryantm had failed on multiple builds due to a new test added by Hugo that required git. In the past another maintainer choose to ignore a previous test that also relied on git, called `TestCommands/mod`. This was completely unnecessary and led to another failing test now for `TestCommands/hugo__static_issue14507`. Instead of continually adding these ignores as more tests are created I added git to the `nativeCheckInputs`. I kept the other remaining ignored test `TestCommands/server` because Hugo itself says the test is flakey and nothing has been updated in the project to address it.

Failing build by r-ryantm: https://nixpkgs-update-logs.nix-community.org/hugo/2026-03-15.log

This build addresses the failing test, refactors for future stability, and upgrades the version 0.155.3 -> 0.158.0

Resolves https://github.com/NixOS/nixpkgs/issues/501440

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
