### PR TITLE
fedora-backgrounds: switch to replace-fail

### DIFF
--- a/pkgs/data/misc/fedora-backgrounds/generic.nix
+++ b/pkgs/data/misc/fedora-backgrounds/generic.nix
@@ -20,14 +20,14 @@ stdenvNoCC.mkDerivation {
   postPatch = ''
     for f in default/Makefile extras/Makefile; do
       substituteInPlace $f \
-        --replace "usr/share" "share" \
-        --replace "/usr/bin/" "" \
-        --replace "/bin/" ""
+        --replace-fail "usr/share" "share" \
+        --replace-fail "/usr/bin/" "" \
+        --replace-fail "/bin/" ""
     done
 
     for f in $(find . -name '*.xml'); do
       substituteInPlace $f \
-        --replace "/usr/share" "$out/share"
+        --replace-fail "/usr/share" "$out/share"
     done;
   '';
 


### PR DESCRIPTION
This pull request updates the patching commands in the `fedora-backgrounds` package to make the build process more robust by ensuring that substitutions fail if the target string is not found. This helps catch potential issues early during the build.

Build robustness improvements:

* Changed all `substituteInPlace` commands in `generic.nix` to use the `--replace-fail` flag instead of `--replace`, so the build will fail if a replacement string is not found.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
