### PR TITLE
lief-patchelf: init at 0.17.6

### DIFF
--- a/pkgs/by-name/li/lief-patchelf/package.nix
+++ b/pkgs/by-name/li/lief-patchelf/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchzip,
+  rustPlatform,
+  installShellFiles,
+  versionCheckHook,
+}:
+
+let
+  version = "0.17.6";
+
+  # lief-ffi downloads this at build time via lief-build, we prefetch
+  # it and point LIEF_RUST_PRECOMPILED at the result.
+  # https://github.com/lief-project/LIEF/blob/d336834b11521ad1a93694f9f8f008149444f7c3/doc/sphinx/api/rust/index.rst#precompiled-ffi-bindings
+  lief-rs = fetchzip {
+    url = "https://github.com/lief-project/LIEF/releases/download/${version}/LIEF-rs-${stdenv.hostPlatform.rust.rustcTarget}.zip";
+    hash =
+      {
+        x86_64-linux = "sha256-zrSYfuIwlcmJ7dvRHq7ybyYKsBpiDMM8NG+0e1cFqS0=";
+        aarch64-linux = "sha256-bpGlvPry9exMNMKzWkz8VUpFqxIZnLvJFKy49HW1uME=";
+        x86_64-darwin = "sha256-Kb5R42SMelP6ShC5QuN7nRSvkndgUgxyL6EiBY4Jr+s=";
+        aarch64-darwin = "sha256-EjU2I4iNSLB8oP3VKEZHrkVVTJ3SLXLSHG4wrMlQ6Og=";
+      }
+      .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    stripRoot = false;
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "lief-patchelf";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "lief-project";
+    repo = "LIEF";
+    tag = version;
+    hash = "sha256-WcWKGIQIGngfzW+VnrZEnRPX2w4syNw+so2aqwSgecw=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/tools";
+
+  cargoHash = "sha256-Ht1DKFLveye5/qaIYAHZ4cP55nvPqJfpguFr/b/Yheg=";
+
+  env.LIEF_RUST_PRECOMPILED = "${lief-rs}";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd lief-patchelf \
+      --bash <($out/bin/lief-patchelf --generate bash) \
+      --fish <($out/bin/lief-patchelf --generate fish) \
+      --zsh <($out/bin/lief-patchelf --generate zsh)
+
+    $out/bin/lief-patchelf --generate-manpage lief-patchelf.1
+    installManPage lief-patchelf.1
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Patchelf based on LIEF";
+    homepage = "https://lief.re/doc/latest/tools/lief-patchelf/index.html";
+    changelog = "https://github.com/lief-project/LIEF/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ eilvelia ];
+    mainProgram = "lief-patchelf";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

lief-patchelf is a drop-in replacement for NixOS/patchelf based on lief: https://lief.re/doc/latest/tools/lief-patchelf/index.html

This package fetches several prebuilt dependencies, building them from source would be difficult

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
