### PR TITLE
python314Packages.nikola: fix build

### DIFF
--- a/pkgs/development/python-modules/nikola/default.nix
+++ b/pkgs/development/python-modules/nikola/default.nix
@@ -7,6 +7,7 @@
   docutils,
   doit,
   feedparser,
+  fetchpatch,
   fetchPypi,
   freezegun,
   ghp-import,
@@ -34,6 +35,7 @@
   requests,
   ruamel-yaml,
   setuptools,
+  stdenv,
   toml,
   typogrify,
   unidecode,
@@ -50,6 +52,15 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-Y219b/wqsk9MJknoaV+LtWBOMJFT6ktgt4b6yuA6scc=";
   };
+
+  patches = [
+    # Upstream PR: https://github.com/getnikola/nikola/pull/3878
+    (fetchpatch {
+      name = "python-3.14.patch";
+      url = "https://github.com/getnikola/nikola/commit/635366b64149055844f2d2ef6070b456bd4ba245.patch";
+      hash = "sha256-TmrYHEIvC8ZKngBJnnKcyU5S4kjzIjLk7KKm72hXx1A=";
+    })
+  ];
 
   build-system = [ setuptools ];
 
@@ -105,6 +116,13 @@ buildPythonPackage rec {
     "test_format_date_locale_variants"
     "test_format_date_locale_variants"
   ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Segfault in darwin sandbox via watchdog
+    "tests/integration/test_dev_server_auto.py::test_serves_root_dir"
+  ];
+
+  __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [ "nikola" ];
 


### PR DESCRIPTION
Upstream PR: https://github.com/getnikola/nikola/pull/3878

Hydra: https://hydra.nixos.org/build/324640667/nixlog/1
Tracking: #475732

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
