### PR TITLE
haskell.compiler: prevent hadrian from setting libffi/gmp flags in st…

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -325,6 +325,10 @@
         ./ghc-9.6-or-later-docs-sphinx-9.patch
       ]
 
+      ++ lib.optionals (stdenv.hostPlatform != stdenv.targetPlatform || stdenv.buildPlatform != stdenv.hostPlatform) [
+        ./hadrian-headers-hack.patch
+      ]
+
       ++ (import ./common-llvm-patches.nix { inherit lib version fetchpatch; });
 
     stdenv = stdenvNoCC;
@@ -770,6 +774,11 @@ stdenv.mkDerivation (
       buildCC
       # stage0 builds terminfo unconditionally, so we always need ncurses
       ncurses
+    ] ++ lib.optionals (!enableNativeBignum) [
+      gmp
+    ] ++ lib.optionals (libffi != null) [
+      # TODO(@AlexandreTunstall,@alexfmpe,@sternenseemann): revisit w.r.t. libffi handling in GHC >= 10
+      libffi
     ];
 
     # Prevent stage0 ghc from leaking into the final result. This was an issue

--- a/pkgs/development/compilers/ghc/hadrian-headers-hack.patch
+++ b/pkgs/development/compilers/ghc/hadrian-headers-hack.patch
@@ -1,0 +1,31 @@
+diff --git a/hadrian/src/Settings/Packages.hs b/hadrian/src/Settings/Packages.hs
+index 5346545d93..c9bcf21a9f 100644
+--- a/hadrian/src/Settings/Packages.hs
++++ b/hadrian/src/Settings/Packages.hs
+@@ -150,7 +150,7 @@ packageArgs = do
+           -- the Stage1 libraries, as we already know that the bootstrap
+           -- compiler comes with the same versions as the one we are building.
+           --
+-            builder (Cabal Setup) ? cabalExtraDirs ffiIncludeDir ffiLibraryDir
++            notStage0 ? builder (Cabal Setup) ? cabalExtraDirs ffiIncludeDir ffiLibraryDir
+           , builder (Cabal Flags) ? ifM stage0
+               (andM [cross, bootCross] `cabalFlag` "internal-interpreter")
+               (arg "internal-interpreter")
+@@ -261,7 +261,7 @@ ghcBignumArgs = package ghcBignum ? do
+ 
+                        -- Ensure that the ghc-bignum package registration includes
+                        -- knowledge of the system gmp's library and include directories.
+-                     , notM (flag GmpInTree) ? cabalExtraDirs includesGmp librariesGmp
++                     , notStage0 ? notM (flag GmpInTree) ? cabalExtraDirs includesGmp librariesGmp
+                      ]
+                   ]
+                _ -> mempty
+@@ -424,7 +424,7 @@ rtsPackageArgs = package rts ? do
+               [ cabalExtraDirs libdwIncludeDir libdwLibraryDir
+               , cabalExtraDirs libnumaIncludeDir libnumaLibraryDir
+               , cabalExtraDirs libzstdIncludeDir libzstdLibraryDir
+-              , useSystemFfi ? cabalExtraDirs ffiIncludeDir ffiLibraryDir
++              , notStage0 ? useSystemFfi ? cabalExtraDirs ffiIncludeDir ffiLibraryDir
+               ]
+         , builder (Cc (FindCDependencies CDep)) ? cArgs
+         , builder (Cc (FindCDependencies  CxxDep)) ? cArgs


### PR DESCRIPTION
…age0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
