### PR TITLE
pulseaudio: Fix RTP receiver binding on the wrong port (37670 instead of 9875).

### DIFF
--- a/pkgs/by-name/pu/pulseaudio/package.nix
+++ b/pkgs/by-name/pu/pulseaudio/package.nix
@@ -94,6 +94,12 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/commit/ed3d4f0837f670e5e5afb1afa5bcfc8ff05d3407.patch";
       hash = "sha256-fMJ3EYq56sHx+zTrG6osvI/QgnhqLvWiifZxrRLMvns=";
     })
+    # Fix RTP receiver binding on the wrong port (37670 instead of 9875).
+    (fetchpatch2 {
+      name = "rtp-recv-remove-inappropriate-byte-order-conversion.patch";
+      url = "https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/commit/8ef0d597a1561ee9988dc31f04925e4412d69957.patch";
+      hash = "sha256-C5TaK5paV6UGBoa4QA5rj0f5PNBD/F9UwoTkd0ezTLY=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
This PR applies a patch for PulseAudio that fixes wrong RTP port. Without this patch `module-rtp-send` can't communicate with `module-rtp-recv` because the latter binds on port 37670 and the former expects it on the port 9875. The port is hard-coded and can't be changed via configuration.

Link to the commit that fixes the problem:
https://github.com/pulseaudio/pulseaudio/commit/8ef0d597a1561ee9988dc31f04925e4412d69957

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
