### PR TITLE
python3Packages.logilab-common: 2.0.0 -> 2.1.0; several improvements

### DIFF
--- a/pkgs/development/python-modules/logilab/common.nix
+++ b/pkgs/development/python-modules/logilab/common.nix
@@ -9,7 +9,7 @@
   typing-extensions,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "logilab-common";
   version = "2.1.0";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     domain = "forge.extranet.logilab.fr";
     owner = "open-source";
     repo = "logilab-common";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-cKodCj9m3n4P54CZ2X+BXN62ewd9nHSZBMENlo8S1iY=";
   };
 
@@ -42,9 +42,9 @@ buildPythonPackage rec {
   meta = {
     description = "Python packages and modules used by Logilab";
     homepage = "https://logilab-common.readthedocs.io/";
-    changelog = "https://forge.extranet.logilab.fr/open-source/logilab-common/-/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://forge.extranet.logilab.fr/open-source/logilab-common/-/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.lgpl21Plus;
     maintainers = [ ];
     mainProgram = "logilab-pytest";
   };
-}
+})

--- a/pkgs/development/python-modules/logilab/common.nix
+++ b/pkgs/development/python-modules/logilab/common.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitLab,
   mypy-extensions,
   pytestCheckHook,
   pytz,
@@ -14,10 +14,12 @@ buildPythonPackage rec {
   version = "2.1.0";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "logilab_common";
-    inherit version;
-    hash = "sha256-2GPHkd6gj85dPpMrrC8DwyK/wOuT1i1r+XTnZZ4r+34=";
+  src = fetchFromGitLab {
+    domain = "forge.extranet.logilab.fr";
+    owner = "open-source";
+    repo = "logilab-common";
+    tag = version;
+    hash = "sha256-cKodCj9m3n4P54CZ2X+BXN62ewd9nHSZBMENlo8S1iY=";
   };
 
   build-system = [ setuptools ];
@@ -40,7 +42,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python packages and modules used by Logilab";
     homepage = "https://logilab-common.readthedocs.io/";
-    changelog = "https://forge.extranet.logilab.fr/open-source/logilab-common/-/blob/${version}/CHANGELOG.md";
+    changelog = "https://forge.extranet.logilab.fr/open-source/logilab-common/-/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.lgpl21Plus;
     maintainers = [ ];
     mainProgram = "logilab-pytest";

--- a/pkgs/development/python-modules/logilab/common.nix
+++ b/pkgs/development/python-modules/logilab/common.nix
@@ -4,7 +4,6 @@
   fetchPypi,
   mypy-extensions,
   pytestCheckHook,
-  pythonAtLeast,
   pytz,
   setuptools,
   typing-extensions,
@@ -12,18 +11,14 @@
 
 buildPythonPackage rec {
   pname = "logilab-common";
-  version = "2.0.0";
+  version = "2.1.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-ojvR2k3Wpj5Ej0OS57I4aFX/cGFVeL/PmT7riCTelws=";
+    pname = "logilab_common";
+    inherit version;
+    hash = "sha256-2GPHkd6gj85dPpMrrC8DwyK/wOuT1i1r+XTnZZ4r+34=";
   };
-
-  postPatch = lib.optionals (pythonAtLeast "3.12") ''
-    substituteInPlace logilab/common/testlib.py \
-      --replace-fail "_TextTestResult" "TextTestResult"
-  '';
 
   build-system = [ setuptools ];
 
@@ -45,7 +40,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python packages and modules used by Logilab";
     homepage = "https://logilab-common.readthedocs.io/";
-    changelog = "https://forge.extranet.logilab.fr/open-source/logilab-common/-/blob/branch/default/CHANGELOG.md";
+    changelog = "https://forge.extranet.logilab.fr/open-source/logilab-common/-/blob/${version}/CHANGELOG.md";
     license = lib.licenses.lgpl21Plus;
     maintainers = [ ];
     mainProgram = "logilab-pytest";


### PR DESCRIPTION
- Update from version 2.0.0 to 2.1.0
  - Changelog: https://forge.extranet.logilab.fr/open-source/logilab-common/-/blob/2.1.0/CHANGELOG.md
  - Diff: https://forge.extranet.logilab.fr/open-source/logilab-common/-/compare/2.0.0...2.1.0
- This update also fixes the build of `python314Packages.logilab-common`
  - Hydra: https://hydra.nixos.org/build/324636786/nixlog/1
  - Tracking: #475732
- Fetch `src` from [GitLab repo](https://forge.extranet.logilab.fr/open-source/logilab-common)
- Migrate to `finalAttrs`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.logilab-{common,constraint}`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
