### PR TITLE
python3Packages.qtile{,-extras}: 0.34.1 -> 0.35.0

### DIFF
--- a/pkgs/development/python-modules/qtile-extras/default.nix
+++ b/pkgs/development/python-modules/qtile-extras/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   anyio,
   gobject-introspection,
   gtk3,
@@ -24,7 +23,7 @@
 }:
 buildPythonPackage rec {
   pname = "qtile-extras";
-  version = "0.34.1";
+  version = "0.35.0";
   # nixpkgs-update: no auto update
   # should be updated alongside with `qtile`
   pyproject = true;
@@ -33,17 +32,8 @@ buildPythonPackage rec {
     owner = "elParaguayo";
     repo = "qtile-extras";
     tag = "v${version}";
-    hash = "sha256-CtmTZmUQlqkDPd++n3fPbRB4z1NA4ZxnmIR84IjsURw=";
+    hash = "sha256-xZ1pxe1EUnnjqz+46R4R9DWKi7M2j1pgvY4uy1dBak8=";
   };
-
-  patches = [
-    # Remove unpack of widget.eval call in tests
-    # https://github.com/elParaguayo/qtile-extras/pull/460
-    (fetchpatch {
-      url = "https://github.com/elParaguayo/qtile-extras/commit/359964520a9dcd2c7e12680bfc53e359d74c489b.patch?full_index=1";
-      hash = "sha256-nKt39bTaBbvEC5jWU6XH0pigTs4hpSmMIwFe/A9YdJA=";
-    })
-  ];
 
   build-system = [ setuptools-scm ];
 

--- a/pkgs/development/python-modules/qtile-extras/default.nix
+++ b/pkgs/development/python-modules/qtile-extras/default.nix
@@ -21,7 +21,7 @@
   xorg-server,
   nixosTests,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "qtile-extras";
   version = "0.35.0";
   # nixpkgs-update: no auto update
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "elParaguayo";
     repo = "qtile-extras";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-xZ1pxe1EUnnjqz+46R4R9DWKi7M2j1pgvY4uy1dBak8=";
   };
 
@@ -97,8 +97,8 @@ buildPythonPackage rec {
   meta = {
     description = "Extra modules and widgets for the Qtile tiling window manager";
     homepage = "https://github.com/elParaguayo/qtile-extras";
-    changelog = "https://github.com/elParaguayo/qtile-extras/blob/${src.tag}/CHANGELOG";
+    changelog = "https://github.com/elParaguayo/qtile-extras/blob/${finalAttrs.src.tag}/CHANGELOG";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ arjan-s ];
   };
-}
+})

--- a/pkgs/development/python-modules/qtile/default.nix
+++ b/pkgs/development/python-modules/qtile/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   cairocffi,
   dbus-fast,
   aiohttp,
@@ -38,7 +37,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "qtile";
-  version = "0.34.1";
+  version = "0.35.0";
   # nixpkgs-update: no auto update
   # should be updated alongside with `qtile-extras`
 
@@ -48,24 +47,8 @@ buildPythonPackage (finalAttrs: {
     owner = "qtile";
     repo = "qtile";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PPyI+IGvHBQusVmU3D26VjYjLaa9+94KUqNwbQSzeaI=";
+    hash = "sha256-5XHzlS/Knw/VmVtnM7wToJ/F12GAa2lwdWuXBJHXnZM=";
   };
-
-  patches = [
-    # The patch below makes upstream's build script search for wayland-scanner
-    # simply in $PATH, and not via `pkg-config`. This allows us to put
-    # wayland-scanner in nativeBuildInputs and keep using `strictDeps`. See:
-    #
-    # https://github.com/qtile/qtile/pull/5726
-    #
-    # Upstream has merged the PR directly - without creating a merge commit, so
-    # using a range is required.
-    (fetchpatch {
-      name = "qtile-PR5726-wayland-scanner-pkg-config.patch";
-      url = "https://github.com/qtile/qtile/compare/f0243abee5e6b94ef92b24e99d09037a4f40272b..553845bd17f38a6d1dee763a23c1b015df894794.patch";
-      hash = "sha256-hRArLC4nQMAbT//QhQeAUL1o7OCV0zvrlJztDavI0K0=";
-    })
-  ];
 
   build-system = [
     setuptools


### PR DESCRIPTION
changelog: https://github.com/qtile/qtile/compare/v0.34.1...v0.35.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
