### PR TITLE
iamb: temporary fix for matrix-sdk-sqlite failure

### DIFF
--- a/pkgs/by-name/ia/iamb/0001-increase-recursion-limit-to-fix-matrix-sdk-sqlite.patch
+++ b/pkgs/by-name/ia/iamb/0001-increase-recursion-limit-to-fix-matrix-sdk-sqlite.patch
@@ -1,0 +1,25 @@
+From 979dcc049c1d8b8b537ddf42133dba38ef17ee7f Mon Sep 17 00:00:00 2001
+From: azban <me@azban.net>
+Date: Sat, 21 Mar 2026 11:23:30 -0600
+Subject: [PATCH] increase recursion limit to fix matrix-sdk-sqlite
+
+This is a temporary fix for build errors in the matrix-sdk-sqlite dependency. A more durable fix should be checked for in https://github.com/matrix-org/matrix-rust-sdk/issues/6254.
+---
+ src/main.rs | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/main.rs b/src/main.rs
+index 0a316c7..794f838 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -15,6 +15,7 @@
+ #![allow(clippy::needless_return)]
+ #![allow(clippy::result_large_err)]
+ #![allow(clippy::bool_assert_comparison)]
++#![recursion_limit = "256"]
+ use std::collections::VecDeque;
+ use std::convert::TryFrom;
+ use std::fmt::Display;
+-- 
+2.51.2
+

--- a/pkgs/by-name/ia/iamb/package.nix
+++ b/pkgs/by-name/ia/iamb/package.nix
@@ -19,6 +19,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-nvEOtV1Y5K9E1Lj+bPnQ6k1AneDM9OT3RbV3Urm/1Qs=";
   };
 
+  patches = [
+    ./0001-increase-recursion-limit-to-fix-matrix-sdk-sqlite.patch
+  ];
+
   cargoHash = "sha256-uWYNFNoCiqw6gYuHZWmZmZVs7lKNvhzjwEyxgcbvv+8=";
 
   nativeBuildInputs = [


### PR DESCRIPTION
This adds a patch to increase the recursion limit for the crate while matrix-sdk-sqlite figures out a more durable solution.

Resolves #501937 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
