### PR TITLE
pokerstove: init at 1.1-unstable-2024-12-14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25834,6 +25834,11 @@
     github = "StephenWithPH";
     githubId = 2990492;
   };
+  stephsi = {
+    name = "Stephan Siegl";
+    github = "stephsi";
+    githubId = 3120909;
+  };
   sterfield = {
     email = "sterfield@gmail.com";
     github = "sterfield";

--- a/pkgs/by-name/po/pokerstove/package.nix
+++ b/pkgs/by-name/po/pokerstove/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  boost,
+}:
+
+stdenv.mkDerivation {
+  pname = "pokerstove";
+  version = "1.1-unstable-2024-12-14";
+
+  src = fetchFromGitHub {
+    owner = "andrewprock";
+    repo = "pokerstove";
+    rev = "ae377e23cfd0cf2a5e2cdc11891a93307a30a65d";
+    hash = "sha256-7hqvd+cl6rvzvdb33+Too7XbFqMZc7FMlkKnvX/9y/o=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ boost ];
+
+  cmakeFlags = [
+    "-DBUILD_PYTHON=OFF"
+    "-DBUILD_WHEEL=OFF"
+  ];
+
+  meta = {
+    homepage = "https://github.com/andrewprock/pokerstove";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ stephsi ];
+    mainProgram = "ps-eval";
+    description = "Highly hand optimized C++ poker hand evaluation library";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
This PR adds [pokerstove](https://github.com/andrewprock/pokerstove), a poker evaluation and enumeration software.

The package version contains `unstable` in its name in accordance with the [versioning](https://github.com/NixOS/nixpkgs/tree/master/pkgs#versioning) description in nixpkgs.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
