### PR TITLE
perlPackages.Po4a: fix compatibility with gettext 1.0

### DIFF
--- a/pkgs/development/perl-modules/Po4a/default.nix
+++ b/pkgs/development/perl-modules/Po4a/default.nix
@@ -34,6 +34,14 @@ buildPerlPackage rec {
     hash = "sha256-JfwyPyuje71Iw68Ov0mVJkSw5GgmH5hjPpEhmoOP58I=";
   };
 
+  patches = [
+    # Fix compatibility with gettext >= 1.0, whose msginit merges into
+    # existing files instead of overwriting, producing broken PO headers
+    # when the output file already exists but is empty.
+    # https://github.com/mquinson/po4a/issues/636
+    ./gettext-1.0-msginit-compat.patch
+  ];
+
   strictDeps = true;
 
   nativeBuildInputs =

--- a/pkgs/development/perl-modules/Po4a/gettext-1.0-msginit-compat.patch
+++ b/pkgs/development/perl-modules/Po4a/gettext-1.0-msginit-compat.patch
@@ -1,0 +1,27 @@
+Fix po4a compatibility with gettext >= 1.0
+
+gettext 1.0 changed msginit behavior: when the output file already
+exists, msginit now merges into it (like msgmerge) instead of
+overwriting. This causes problems when po4a passes an empty PO file as
+the output target, because msginit produces a PO with stripped headers
+and corrupted UTF-8 content.
+
+Fix by removing the output file before calling msginit, ensuring
+msginit creates a fresh PO file with proper headers.
+
+See: https://github.com/mquinson/po4a/issues/636
+See: https://savannah.gnu.org/news/?id=10853
+
+--- a/po4a
++++ b/po4a
+@@ -1875,6 +1875,10 @@
+                 }
+
+                 my $read_pot_filename = find_input_file($pot_filename);
++                # Remove the output file if it exists (e.g. as an empty file),
++                # because gettext >= 1.0's msginit merges into existing files
++                # instead of overwriting, producing broken PO headers.
++                unlink $outfile if ( -e $outfile && -z $outfile );
+                 my $cmd =
+                   "msginit$Config{_exe} -i \"$read_pot_filename\" --locale $lang -o \"$outfile\" --no-translator >$devnull";
+                 run_cmd($cmd);


### PR DESCRIPTION
[`gettext` 1.0](https://savannah.gnu.org/news/?id=10853) changed `msginit` to merge into existing output files instead of overwriting them. When `po4a` passes an empty PO file as the output target, this produces a PO with stripped headers and corrupted UTF-8 content (e.g. "nämes" becomes "nmes").

Fix by removing empty output files before calling `msginit`, so it creates a fresh PO file with proper headers.

Upstream:
- https://github.com/mquinson/po4a/issues/636
- https://github.com/mquinson/po4a/pull/645

I tested this with both [`gettext` 1.0](https://github.com/NixOS/nixpkgs/pull/485233) and with the current `gettext` 0.26 with `nixosTests.simple`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
