### PR TITLE
zsh-fzf-tab: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/by-name/zs/zsh-fzf-tab/package.nix
+++ b/pkgs/by-name/zs/zsh-fzf-tab/package.nix
@@ -13,13 +13,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "zsh-fzf-tab";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "Aloxaf";
     repo = "fzf-tab";
     rev = "v${version}";
-    hash = "sha256-q26XVS/LcyZPRqDNwKKA9exgBByE0muyuNb0Bbar2lY=";
+    hash = "sha256-8atbysoOyCBW2OYKmdc91x9V/Mk3eyg3hvzvhJpQ32w=";
   };
 
   strictDeps = true;
@@ -96,8 +96,12 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/Aloxaf/fzf-tab";
     description = "Replace zsh's default completion selection menu with fzf";
+    changelog = "https://github.com/Aloxaf/fzf-tab/releases/tag/v${finalAttrs.version}"
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ diredocks ];
+    maintainers = with lib.maintainers; [
+      diredocks
+      miniharinn
+    ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/zs/zsh-fzf-tab/package.nix
+++ b/pkgs/by-name/zs/zsh-fzf-tab/package.nix
@@ -11,14 +11,14 @@
 let
   INSTALL_PATH = "${placeholder "out"}/share/fzf-tab";
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zsh-fzf-tab";
   version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "Aloxaf";
     repo = "fzf-tab";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-8atbysoOyCBW2OYKmdc91x9V/Mk3eyg3hvzvhJpQ32w=";
   };
 
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/Aloxaf/fzf-tab";
     description = "Replace zsh's default completion selection menu with fzf";
-    changelog = "https://github.com/Aloxaf/fzf-tab/releases/tag/v${finalAttrs.version}"
+    changelog = "https://github.com/Aloxaf/fzf-tab/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       diredocks
@@ -104,4 +104,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Release: https://github.com/Aloxaf/fzf-tab/releases/tag/v1.3.0
Diff: https://github.com/Aloxaf/fzf-tab/compare/v1.2.0...v1.3.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
