### PR TITLE
shrinkray: Fix broken shrinkray-worker invocation

### DIFF
--- a/pkgs/by-name/sh/shrinkray/package.nix
+++ b/pkgs/by-name/sh/shrinkray/package.nix
@@ -38,6 +38,10 @@ python3.pkgs.buildPythonApplication rec {
       --replace-fail 'which("clang-format")' '"${lib.getExe' clang-tools "clang-format"}"'
     substituteInPlace src/shrinkray/passes/clangdelta.py \
       --replace-fail 'which("clang_delta")' '"${cvise}/libexec/cvise/clang_delta"'
+    substituteInPlace src/shrinkray/subprocess/client.py \
+      --replace-fail 'sys.executable,
+                "-m",
+                "shrinkray.subprocess.worker"' "\"$out/bin/shrinkray-worker\""
   '';
 
   build-system = [ python3.pkgs.setuptools ];

--- a/pkgs/by-name/sh/shrinkray/package.nix
+++ b/pkgs/by-name/sh/shrinkray/package.nix
@@ -81,6 +81,8 @@ python3.pkgs.buildPythonApplication rec {
     "tests/test_clang_delta.py::test_find_clang_delta_when_found_in_path"
     "tests/test_clang_delta.py::test_find_clang_delta_when_not_found_anywhere"
     "tests/test_formatting.py::test_default_formatter_python_files_without_black"
+    # This test is too timing sensitive
+    "tests/test_validation.py::test_validation_output_streams_immediately"
   ];
 
   meta = {


### PR DESCRIPTION
shrinkray tries to run `shrinkray-worker` via `sys.executable`, which skips the required `sys.path` adjustments injected by `wrap-python.nix`. Fix it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
