### PR TITLE
ghostty: add missing GStreamer dependencies

### DIFF
--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -9,6 +9,7 @@
   freetype,
   glib,
   glslang,
+  gst_all_1,
   gtk4-layer-shell,
   harfbuzz,
   libadwaita,
@@ -75,6 +76,9 @@ stdenv.mkDerivation (finalAttrs: {
     libadwaita
     libx11
     gtk4-layer-shell
+    gst_all_1.gstreamer # Used for playing audio, e.g. audible bells
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-base
 
     # OpenGL renderer
     glslang


### PR DESCRIPTION
Ghostty 1.2.0 added the ability to play audio snippets when encountering a bell character (BEL) using GStreamer. Before this commit, however, GStreamer was never listed as a direct dependency, though it was working for the majority of users, as it was still included as a transitive dependency from GTK 4 itself, except for one user who managed to crash Ghostty by trying to play MP3 audio while not having the "good" GStreamer plugins installed *anywhere* within their system, since only base and bad plugins are installed by default with GTK 4, and by extension, Ghostty.

See ghostty-org/ghostty#11720 for the initial report.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
