### PR TITLE
nemo-compare: init at 6.6.0

### DIFF
--- a/pkgs/by-name/ne/nemo-compare/package.nix
+++ b/pkgs/by-name/ne/nemo-compare/package.nix
@@ -1,0 +1,55 @@
+{
+  python3,
+  pkgs,
+  lib,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "nemo-compare";
+  version = "6.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "linuxmint";
+    repo = "nemo-extensions";
+    rev = finalAttrs.version;
+    hash = "sha256-tXeMkaCYnWzg+6ng8Tyg4Ms1aUeE3xiEkQ3tKEX6Vv8=";
+  };
+
+  nativeBuildInputs = with pkgs; [
+    wrapGAppsHook3
+    gobject-introspection
+  ];
+
+  sourceRoot = "${finalAttrs.src.name}/nemo-compare";
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  prePatch = ''
+    sed -i "s:/usr/share:share:" setup.py
+    sed -i "s:/usr/bin:bin:" setup.py
+    sed -i "s:/usr/share:$out/share:" src/nemo-compare-preferences
+    sed -i "s:/usr/share:$out/share:" src/nemo-compare.py
+    sed -i "s:\['/usr/bin', '/usr/local/bin'\]:\['/run/current-system/sw/bin/', '/usr/bin', '/usr/local/bin'\]:" src/utils.py
+    sed -i "s@import sys:@import sys:\nsys.path += '${
+      python3.pkgs.makePythonPath [ python3.pkgs.pygobject3 ]
+    }'.split(os.pathsep)@" src/nemo-compare.py
+    sed -i "s@import os@import os\nimport sys\nsys.path += '${
+      python3.pkgs.makePythonPath [ python3.pkgs.pygobject3 ]
+    }'.split(os.pathsep)@" src/nemo-compare-preferences.py
+  '';
+
+  meta = {
+    homepage = "https://github.com/linuxmint/nemo-extensions/tree/master/nemo-compare";
+    description = "Context menu comparison extension for Nemo file manager";
+    longDescription = ''
+      Context menu comparison extension for Nemo file manager
+      When adding this to nemo-with-extensions, you also need to add nemo-python,
+      and a file comparison tool like meld. See the [debian control file for supported comparison tools](https://github.com/linuxmint/nemo-extensions/blob/master/nemo-compare/debian/control)
+    '';
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ denperidge ];
+  };
+})


### PR DESCRIPTION
Packaged the nemo-compare extension

## Things done

Note: testing basic functionality includes the provided nemo-compare-preferences script *and* the  functionality within nemo

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
