### PR TITLE
webull-desktop: fix un-findable .desktop file

### DIFF
--- a/pkgs/by-name/we/webull-desktop/package.nix
+++ b/pkgs/by-name/we/webull-desktop/package.nix
@@ -60,7 +60,13 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir $out/bin
     ln -s $out/usr/local/WebullDesktop/WebullDesktop $out/bin/webull-desktop
     substituteInPlace $out/usr/share/applications/WebullDesktop.desktop \
-      --replace-fail Categories=Utiltity Categories=Finance
+      --replace-fail Categories=Utiltity Categories=Finance \
+      --replace-fail "Exec=/usr/local/WebullDesktop/WebullDesktop" "Exec=webull-desktop" \
+      --replace-fail "Icon=WebullDesktop.png" "Icon=WebullDesktop" \
+      --replace-fail "Version=8.2.0" "Version=${finalAttrs.version}"
+
+    ln -s $out/usr/share $out/share
+
 
     addAutoPatchelfSearchPath $out/usr/local/WebullDesktop
     addAutoPatchelfSearchPath $out/usr/local/WebullDesktop/platforms


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Updated `installPhase` to correct un-findable `.desktop` file.
Closes issue #484730

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
