### PR TITLE
hanko: 0.5.4 -> 1.1.2

### DIFF
--- a/pkgs/by-name/ha/hanko/package.nix
+++ b/pkgs/by-name/ha/hanko/package.nix
@@ -8,16 +8,19 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hanko";
-  version = "0.5.4";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "SRv6d";
     repo = "hanko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9HRoXqZ3wdD6xf33tooEHiBWSZlggjUFomblwF4cFtA=";
+    hash = "sha256-tmspfsIIxYa9fTPhHJrVRUcpC8gZ0R4prTLTDstuwbg=";
   };
 
-  cargoHash = "sha256-wHvhlWi99igZ2gKAIcBYg207JrbQNCOjlcVttIy3MV0=";
+  cargoHash = "sha256-IcQtG29qTQl4U0HwG+kvPT07RhSgUADtejV7ObWyjG0=";
+
+  # Upstream tests require network access, which is unavailable in the sandbox.
+  doCheck = false;
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
Updates hanko from 0.5.4 to 1.1.2 and disables doCheck because the upstream test suite is not compatible with the Nix sandbox. The full upstream test suite already runs in GitHub CI before release, and the packaged binary was smoke-tested separately.

Upstream releases:
- https://github.com/SRv6d/hanko/releases

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test