### PR TITLE
processing: Use jogl from nixpkgs

### DIFF
--- a/pkgs/by-name/pr/processing/deps.json
+++ b/pkgs/by-name/pr/processing/deps.json
@@ -53,66 +53,17 @@
    "pom": "sha256-zzU+toek04gE0IYSpbxV5aO22ZWWdRC9yypfSH91bPY="
   }
  },
+ "https://dlcdn.apache.org": {
+  "/xmlgraphics/batik/binaries/batik-bin-1.19": {
+   "zip": "sha256-llQTrIM6XE5QPkVCk9L3TpZ8BEKqsgBpk+33LW7b6Oc="
+  }
+ },
  "https://github.com/processing": {
   "processing-examples/archive/b10c9e9a05a0d6c20d233ca7f30d315b5047720e": {
    "zip": "sha256-08ADdtsZ/lkbERbHliM5SSaFcTUnOplJdQx7eYR43qU="
   },
   "processing-website/archive/f11676d1b7464291a23ae834f2ef6ab00baaed8e": {
    "zip": "sha256-MC3Ce5B5bFUA0aCkFQPCMGA5QuUw5vjmSzFnyEfR3Nw="
-  }
- },
- "https://jogamp.org/deployment/maven/org/jogamp": {
-  "gluegen#gluegen-rt-main/2.5.0": {
-   "jar": "sha256-zBFPTAspsv5NBqXHkxg4gURSoEzJeJ4nshqwXTVBwQc=",
-   "pom": "sha256-KDtSN+Uh/300IFXZw6Zy0FgglyLQgvPnVPZw3mVtghg="
-  },
-  "gluegen#gluegen-rt/2.5.0": {
-   "jar": "sha256-NiDBhTaoZx/LHFlddEjp0xImuCQRevakxtRcZX9Nq+M=",
-   "pom": "sha256-6S7gyRmGFTV50qfh5QJQaMLCSlNSc3L+Vrqk2ZCwGPM="
-  },
-  "gluegen#gluegen-rt/2.5.0/natives-android-aarch64": {
-   "jar": "sha256-NFx328LbuUpcVwOVNfPp1k0LTqFyVS1lvwiyJKadhKc="
-  },
-  "gluegen#gluegen-rt/2.5.0/natives-linux-aarch64": {
-   "jar": "sha256-GuQH+YQzcknnzZvx8eFjdzvgVSi1Vi7KBhvM9jSxDa8="
-  },
-  "gluegen#gluegen-rt/2.5.0/natives-linux-amd64": {
-   "jar": "sha256-bZmNDB8E8QOJS3aQSQhhJFBQY86oaoKJYZS7U8iLBAo="
-  },
-  "gluegen#gluegen-rt/2.5.0/natives-linux-armv6hf": {
-   "jar": "sha256-STL1+0J/TAal/QOzhUPqAhmVY8QX8HS1gTf6JWSlRN0="
-  },
-  "gluegen#gluegen-rt/2.5.0/natives-macosx-universal": {
-   "jar": "sha256-Pb1dBU8QjD+MDAcoHm40lLhbibDYs/D770v2xByiVOw="
-  },
-  "gluegen#gluegen-rt/2.5.0/natives-windows-amd64": {
-   "jar": "sha256-pPA54vqdYWvp8mKE/9av5fribVIdIfKBJuXqoHP4pDg="
-  },
-  "jogl#jogl-all-main/2.5.0": {
-   "jar": "sha256-zBFPTAspsv5NBqXHkxg4gURSoEzJeJ4nshqwXTVBwQc=",
-   "pom": "sha256-mGNBTE/Rxfbuq3A2Lhs626GUgWl3cZVqMlbtU4nR0kc="
-  },
-  "jogl#jogl-all/2.5.0": {
-   "jar": "sha256-JFcXzOq8omSiEKiZ+IOdR70Sf1D4CJLq0id92Jy80wE=",
-   "pom": "sha256-awhqLkYde3kRocFl/8veKrebAMVMNgzxkcoA9feE22o="
-  },
-  "jogl#jogl-all/2.5.0/natives-android-aarch64": {
-   "jar": "sha256-M4/4m89L/TTDJSOYA9o+BB4ZmPUNuGCYzVSJoXTwk7U="
-  },
-  "jogl#jogl-all/2.5.0/natives-linux-aarch64": {
-   "jar": "sha256-5LngFakf5SKdPVOEjii4ZwCpD6vY5f6FeW9rHUm0Jm4="
-  },
-  "jogl#jogl-all/2.5.0/natives-linux-amd64": {
-   "jar": "sha256-6XhQ8pDY5Eugf6BQDXoHH/REIJCZ8Dct89unB8uj3cE="
-  },
-  "jogl#jogl-all/2.5.0/natives-linux-armv6hf": {
-   "jar": "sha256-tQgMQid574BQpqAk7O+AW8rP1Vp9TU4/b8XXDinY+4s="
-  },
-  "jogl#jogl-all/2.5.0/natives-macosx-universal": {
-   "jar": "sha256-Ay5WFnRDqA+fRHf77vJV5ZmIxs1SN6FRuUi95Ly3yAw="
-  },
-  "jogl#jogl-all/2.5.0/natives-windows-amd64": {
-   "jar": "sha256-zgt1X2vA7u/ThlOectE+TY6W4fCGyiIvigLhEyADIUI="
   }
  },
  "https://plugins.gradle.org/m2": {
@@ -387,10 +338,6 @@
   }
  },
  "https://repo.maven.apache.org/maven2": {
-  "antlr#antlr/2.7.7": {
-   "jar": "sha256-iPvaS5Ellrn1bo4S5YDMlUus+1F3bs/d0+GPwc9W3Ew=",
-   "pom": "sha256-EA95O6J/i05CBO20YXHr825U4PlM/AJSf+oHoLsfzrc="
-  },
   "bouncycastle#bcmail-jdk14/138": {
    "jar": "sha256-OJ9AXPpmsmAESEczk3oiYkeCpdhkVuDDXgB7YOvI41k=",
    "pom": "sha256-XP2ibQY7MUiu5Lcukc8NXRjGk4CAfGLr/NZXttk/ykw="
@@ -566,17 +513,17 @@
    "jar": "sha256-jOlpEWyslb1hsHqNXgcXSzUuYzAUc8qscsOV48CEiNI=",
    "pom": "sha256-wnn/o7UWjiIDCHIxxjiRmnzsdFgAaxzaZpWXR4YPtFc="
   },
-  "net/java/dev/jna#jna-platform/5.17.0": {
-   "jar": "sha256-t+PUbIe60utAmw5wSRa82BIGFo41cxLf3dDiU2ec2eA=",
-   "pom": "sha256-CjC3l622giFH75jLJJ7z+/SiQ1QqqGv59C+tnmgwWkQ="
+  "net/java/dev/jna#jna-platform/5.18.1": {
+   "jar": "sha256-rRTBsexPQ9OWIxIZ36Y16/go9zjqyfiQ6hvAd5WJLZo=",
+   "pom": "sha256-OdU4qVmaRHR3CDiGXtQs+j5rPRMIbLHld7i7QxSNGmU="
   },
   "net/java/dev/jna#jna/5.12.1": {
    "jar": "sha256-kagUrE9A1g3ukdhC4aith0xiGXmEQD0OPDDTnlXPU7M=",
    "pom": "sha256-Zf8lhJuthZVUtQMXeS9Wia20UprkAx6aUkYxnLK4U1Y="
   },
-  "net/java/dev/jna#jna/5.17.0": {
-   "jar": "sha256-s6lAjnxR4I7w47/MCPRD9uwPYZG6jNfBjVPSsi5b28A=",
-   "pom": "sha256-UBoP8F2EpK0Q9t4lvpT0k5i3CjG+jzoO2fTGtE++/uQ="
+  "net/java/dev/jna#jna/5.18.1": {
+   "jar": "sha256-JgxLHiKx254RDuRBxPE84RX4QfpIxB14dQmGIUs5VVc=",
+   "pom": "sha256-mLYq5v8oDXR/s1n8QuSP7RE9Rbw3Kagj3DC4MIqAZkU="
   },
   "net/thauvin/erik/urlencoder#urlencoder-lib-jvm/1.6.0": {
    "jar": "sha256-jQ/SrrSNGdxJxWPrwA8nSUfkX3FsEHU1wS6tY97NaI0=",
@@ -664,84 +611,84 @@
    "jar": "sha256-uukFuFg86nP70Lekel8pCX31l+EYdaRSXQ7rrj1JcqA=",
    "pom": "sha256-w9wJYboDpq7ZqYKYRdYP5zAgW/4i5cQKCPNC5aTbsVE="
   },
-  "org/eclipse/platform#org.eclipse.core.commands/3.12.400": {
-   "jar": "sha256-0IOPxFEzUjcgMUXtXAjnkxI2w1HwuG7gvtQY/ouD+xs=",
-   "pom": "sha256-VvaWUeXjKExahc04hAmgqVZ4ro+teQO7OuCufAJK0GU="
+  "org/eclipse/platform#org.eclipse.core.commands/3.12.500": {
+   "jar": "sha256-RHEzYuVe0o5ttdLDG/Z1JP7wh2RaRNwyOdrGDs4BfLk=",
+   "pom": "sha256-yD+4t0dc62ANfijxwyfGjhzSaFHeyEEKthn/9W17SoI="
   },
-  "org/eclipse/platform#org.eclipse.core.contenttype/3.9.700": {
-   "jar": "sha256-UQnqmnhxhPV/+CljW539Ytc2w5HUgefrKLqj0nj9wAY=",
-   "pom": "sha256-s1ueFPUNcb6ZBakpWBHiBV3dVBAWUwMhKSslFMhcV8c="
+  "org/eclipse/platform#org.eclipse.core.contenttype/3.9.800": {
+   "jar": "sha256-4MLblmANUZzjanX5t8lxr9KHDS0Fnu5L8kNtmzOqC40=",
+   "pom": "sha256-vZ20X3R3JIQpxxz4RlcC2r+xUgzoU0+dwl1BeOu1iXs="
   },
   "org/eclipse/platform#org.eclipse.core.expressions/3.9.500": {
    "jar": "sha256-hES13pDJtKtSjI6lw0HH6HLQ2+gkGreQhVUQhtlufJ4=",
    "pom": "sha256-1Ks7hbJUOHlXRXwfRrcAG1qQqJjFIixQIKB5DlFhalA="
   },
-  "org/eclipse/platform#org.eclipse.core.filesystem/1.11.300": {
-   "jar": "sha256-6zJJS6uuCiEGYuFhq8vE33BXdI4AMyahVupneDyorO4=",
-   "pom": "sha256-riTI0aUrpG3UKlyUP9xfw0Ky9A1Ff4E8N+gs/o/Gdp4="
+  "org/eclipse/platform#org.eclipse.core.filesystem/1.11.400": {
+   "jar": "sha256-b3C5XRS5DsV7lMXj26fh0YlnnPmkvEUm6ckb7tfWoO8=",
+   "pom": "sha256-sQA8+u8BN+YzwThrzFfbCl5Yelm1Fx5We6Uwz6u/jMU="
   },
   "org/eclipse/platform#org.eclipse.core.jobs/3.15.700": {
    "jar": "sha256-NwFReae5uQ0Wy5L0sb5gg6Gm2tJUKPqPa4libwzC2nk=",
    "pom": "sha256-OUVAotjHPjVRHz1f8J2fNkdm4P4steb4V8Tfqwl9Ot8="
   },
-  "org/eclipse/platform#org.eclipse.core.resources/3.23.0": {
-   "jar": "sha256-Llir4A41yZuFqq2Nc4wqh3EDa+L0oitl2QvBRKgGcnA=",
-   "pom": "sha256-AuUbd6oS0LZAFFNvA7dCjFpWF36Ettqb5sDnWm8jGo0="
+  "org/eclipse/platform#org.eclipse.core.resources/3.23.200": {
+   "jar": "sha256-d5PgetR4AfYqqnBPCkbWD4wK6AdeAPAucg1phiv+N7w=",
+   "pom": "sha256-CPZTnfSlOMqg0Hsde2tHJsDpck6GWH6qMXKx0RAH8fg="
   },
-  "org/eclipse/platform#org.eclipse.core.runtime/3.34.0": {
-   "jar": "sha256-B2s7+RXTzgN7eHfIfRfR0kQhNd0+eMXy7mEPXYg3kwE=",
-   "pom": "sha256-b8TJb6EII4AhaatyU943S3qvWnSYO4o+tLok9vELUvk="
+  "org/eclipse/platform#org.eclipse.core.runtime/3.34.200": {
+   "jar": "sha256-tPNqCssI8D0LPbVLIfxWOMggxEdEakELpJalBw+jQ2M=",
+   "pom": "sha256-VUfhQDP4BRrlX0qDhwRsdAk7UgNs3DVu9p6lGOrn5uw="
   },
-  "org/eclipse/platform#org.eclipse.equinox.app/1.7.500": {
-   "jar": "sha256-GfLjYRNH22QzpIpiGHyfa9RohtDVaDZpfa//6YXqk+8=",
-   "pom": "sha256-sKK1z+znfceXeW5uqiwkrBkwVnB9BPVWBe3PdJC0XFY="
+  "org/eclipse/platform#org.eclipse.equinox.app/1.7.600": {
+   "jar": "sha256-/TUzmINRB2CPVUd5pukYkXJe+5Tg9XVZ0Ks86kthVsc=",
+   "pom": "sha256-cZhnUaan5uJyMJs6ZqySGUPplQlqXIgI1C6aDMJR1eg="
   },
-  "org/eclipse/platform#org.eclipse.equinox.common/3.20.200": {
-   "jar": "sha256-m4tcijQuf1vl+VFU6frvrmhvOYfndtzgMPN72EfNfzU=",
-   "pom": "sha256-XYyNb/aVj33ouZDJ/A7Ff3gyf1HgZJc/V5LiA1Sx7m4="
+  "org/eclipse/platform#org.eclipse.equinox.common/3.20.300": {
+   "jar": "sha256-hV0jmvKd2x0iSNN4aXwJW+Yu+5pbPBuybTH3uXqOFq4=",
+   "pom": "sha256-ALs//vT1/wr/lXaIGYlvxY1kxitKkEc60niE6P0viFI="
   },
-  "org/eclipse/platform#org.eclipse.equinox.preferences/3.12.0": {
-   "jar": "sha256-1MnqXEzYCLl/FUkLu9fdj1jHZ8aFttBZGUdX5m1u7zU=",
-   "pom": "sha256-3SwqP9ZklaQTCAvJzkDktSg5SGV37IrnJ9APxoLhUO8="
+  "org/eclipse/platform#org.eclipse.equinox.preferences/3.12.100": {
+   "jar": "sha256-/QToGiirMra7BzKG6yk8RLdgF2/PHjXvFWFNYt+CD4Y=",
+   "pom": "sha256-IYxiWoWw5QQU6dGRKFYUtrL+qf9/0TITKm4PkyQzMZY="
   },
-  "org/eclipse/platform#org.eclipse.equinox.registry/3.12.500": {
-   "jar": "sha256-Tl7/034/bicyoeeIx2n267SdStYOnl2RxXokz/vC+v4=",
-   "pom": "sha256-ddMClkYdU0SA4qK9boylKnDd6+2KKNd8qBb0uVK9SdY="
+  "org/eclipse/platform#org.eclipse.equinox.registry/3.12.600": {
+   "jar": "sha256-T4zXJoFEa1mDkKjCTum5mW9uTF+r7QIrUL0m9vWgv2w=",
+   "pom": "sha256-Kwg3b6gZu5Q3vHDKJM6w8NtE3gE/63F9vmmaKU+2MSc="
   },
-  "org/eclipse/platform#org.eclipse.osgi/3.23.200": {
-   "jar": "sha256-jZQFjq0/RlGQAWaSSmd8O+tumW8HL6vzhf/dcFELxJM=",
-   "pom": "sha256-py2jWv3kgc2hDp2UsxpUwbkKe2hQqt5MmtnpVtdIWtA="
+  "org/eclipse/platform#org.eclipse.osgi/3.24.100": {
+   "jar": "sha256-0g+JIDBZb7wsJdoArNvSdQ93zv1oE2wzo+J5uJSYZ6g=",
+   "pom": "sha256-+U4i9QNmKcxz7AM41+C5wFx2g70TZ4wWa8p/fIfm+oE="
   },
-  "org/eclipse/platform#org.eclipse.text/3.14.400": {
-   "jar": "sha256-BIRcZhMn9wBe2WAzzzOCLU9gsBGJvD6ehk5RL1cJYhM=",
-   "pom": "sha256-e9x89hsAsHEpsEYWo3MrxTUjOnj9phwWBRl7kqCZE1A="
+  "org/eclipse/platform#org.eclipse.text/3.14.600": {
+   "jar": "sha256-1nW4pgPmL0PLqcHyS+ysEYKzKHwDPEL7gQYmjafTLXE=",
+   "pom": "sha256-ej/wQTbv0Vn8pN0QEk2idD+fSFUN7shfR4TTDxZIQx0="
   },
   "org/eclipse/platform/org.eclipse.core.filesystem/maven-metadata": {
    "xml": {
     "groupId": "org.eclipse.platform",
-    "lastUpdated": "20250906152134",
-    "release": "1.11.300"
+    "lastUpdated": "20251208072743",
+    "release": "1.11.400"
    }
   },
   "org/eclipse/platform/org.eclipse.core.resources/maven-metadata": {
    "xml": {
     "groupId": "org.eclipse.platform",
-    "lastUpdated": "20250906152140",
-    "release": "3.23.0"
+    "lastUpdated": "20260309141945",
+    "release": "3.23.200"
    }
   },
   "org/eclipse/platform/org.eclipse.core.runtime/maven-metadata": {
    "xml": {
     "groupId": "org.eclipse.platform",
-    "lastUpdated": "20250906152136",
-    "release": "3.34.0"
+    "lastUpdated": "20260309141943",
+    "release": "3.34.200"
    }
   },
   "org/eclipse/platform/org.eclipse.text/maven-metadata": {
    "xml": {
     "groupId": "org.eclipse.platform",
-    "lastUpdated": "20250906152155",
-    "release": "3.14.400"
+    "lastUpdated": "20260309142023",
+    "release": "3.14.600"
    }
   },
   "org/jetbrains#annotations/13.0": {

--- a/pkgs/by-name/pr/processing/package.nix
+++ b/pkgs/by-name/pr/processing/package.nix
@@ -72,6 +72,9 @@ stdenv.mkDerivation rec {
 
     # dirPermissions: Without this, some gradle tasks (e.g. includeJdk) fail to copy contents of read-only subfolders within the nix store
     ./fix-permissions.patch
+
+    # Use jogl from nixpkgs instead of downloading from maven
+    ./use-nixpkgs-jogl.patch
   ];
 
   nativeBuildInputs = [
@@ -104,8 +107,7 @@ stdenv.mkDerivation rec {
     runHook preBuild
     runHook preGradleUpdate
 
-    mkdir -p app/lib core/library
-    ln -s ${jogl}/share/java/* core/library/
+    mkdir -p app/lib
     ln -s ${vaqua} app/lib/VAqua9.jar
     ln -s ${flatlaf} app/lib/flatlaf.jar
     ln -s ${lsp4j} java/mode/org.eclipse.lsp4j.jar
@@ -129,13 +131,15 @@ stdenv.mkDerivation rec {
     substituteInPlace app/build.gradle.kts \
       --replace-fail "https://github.com/processing/processing-examples/archive/refs/heads/main.zip" "https://github.com/processing/processing-examples/archive/b10c9e9a05a0d6c20d233ca7f30d315b5047720e.zip" \
       --replace-fail "https://github.com/processing/processing-website/archive/refs/heads/main.zip" "https://github.com/processing/processing-website/archive/f11676d1b7464291a23ae834f2ef6ab00baaed8e.zip"
+
+    substituteInPlace core/build.gradle.kts \
+      --replace-fail "@@joglPath@@" "${jogl}"
   '';
 
   buildPhase = ''
     runHook preBuild
 
-    mkdir -p app/lib core/library
-    ln -s ${jogl}/share/java/* core/library/
+    mkdir -p app/lib
     ln -s ${vaqua} app/lib/VAqua9.jar
     ln -s ${flatlaf} app/lib/flatlaf.jar
     ln -s ${lsp4j} java/mode/org.eclipse.lsp4j.jar

--- a/pkgs/by-name/pr/processing/package.nix
+++ b/pkgs/by-name/pr/processing/package.nix
@@ -10,6 +10,7 @@
   stripJavaArchivesHook,
   wrapGAppsHook3,
   libGL,
+  libxxf86vm,
 }:
 let
   # Force use of JDK 17, see https://github.com/processing/processing4/issues/1043
@@ -49,6 +50,8 @@ stdenv.mkDerivation rec {
     jdk
     jogl
     rsync
+    libGL
+    libxxf86vm
   ];
 
   mitmCache = gradle.fetchDeps {
@@ -108,7 +111,12 @@ stdenv.mkDerivation rec {
 
     makeWrapper $out/unwrapped/Processing $out/bin/Processing \
       ''${gappsWrapperArgs[@]} \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}" \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          libGL
+          libxxf86vm
+        ]
+      }" \
       --prefix _JAVA_OPTIONS " " "-Dawt.useSystemAAFontSettings=gasp"
 
     runHook postInstall

--- a/pkgs/by-name/pr/processing/package.nix
+++ b/pkgs/by-name/pr/processing/package.nix
@@ -2,14 +2,11 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchurl,
-  unzip,
   makeWrapper,
   gradle_8,
   jdk17,
   jogl,
   rsync,
-  batik,
   stripJavaArchivesHook,
   wrapGAppsHook3,
   libGL,
@@ -19,41 +16,6 @@ let
   gradle = gradle_8.override { java = jdk17; };
   jdk = jdk17;
   buildNumber = "1310";
-  vaqua = fetchurl {
-    name = "VAqua9.jar";
-    url = "https://violetlib.org/release/vaqua/9/VAqua9.jar";
-    sha256 = "cd0b82df8e7434c902ec873364bf3e9a3e6bef8b59cbf42433130d71bf1a779c";
-  };
-
-  jna = fetchurl {
-    name = "jna-5.10.0.zip";
-    url = "https://github.com/java-native-access/jna/archive/5.10.0.zip";
-    sha256 = "B5CakOQ8225xNsk2TMV8CbK3RcsLlb+pHzjaY5JNwg0=";
-  };
-
-  flatlaf = fetchurl {
-    name = "flatlaf-2.4.jar";
-    url = "mirror://maven/com/formdev/flatlaf/2.4/flatlaf-2.4.jar";
-    sha256 = "NVMYiCd+koNCJ6X3EiRx1Aj+T5uAMSJ9juMmB5Os+zc=";
-  };
-
-  lsp4j = fetchurl {
-    name = "org.eclipse.lsp4j-0.19.0.jar";
-    url = "mirror://maven/org/eclipse/lsp4j/org.eclipse.lsp4j/0.19.0/org.eclipse.lsp4j-0.19.0.jar";
-    sha256 = "sha256-1DI5D9KW+GL4gT1qjwVZveOl5KVOEjt6uXDwsFzi8Sg=";
-  };
-
-  lsp4j-jsonrpc = fetchurl {
-    name = "org.eclipse.lsp4j.jsonrpc-0.19.0.jar";
-    url = "mirror://maven/org/eclipse/lsp4j/org.eclipse.lsp4j.jsonrpc/0.19.0/org.eclipse.lsp4j.jsonrpc-0.19.0.jar";
-    sha256 = "sha256-ozYTkvv7k0psCeX/PbSM3/Bl17qT3upX3trt65lmM9I=";
-  };
-
-  gson = fetchurl {
-    name = "gson-2.9.1.jar";
-    url = "mirror://maven/com/google/code/gson/gson/2.9.1/gson-2.9.1.jar";
-    sha256 = "sha256-N4U04znm5tULFzb7Ort28cFdG+P0wTzsbVNkEuI9pgM=";
-  };
 in
 stdenv.mkDerivation rec {
   pname = "processing";
@@ -79,7 +41,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     gradle
-    unzip
     makeWrapper
     stripJavaArchivesHook
     wrapGAppsHook3
@@ -88,7 +49,6 @@ stdenv.mkDerivation rec {
     jdk
     jogl
     rsync
-    batik
   ];
 
   mitmCache = gradle.fetchDeps {
@@ -106,19 +66,6 @@ stdenv.mkDerivation rec {
   gradleUpdateScript = ''
     runHook preBuild
     runHook preGradleUpdate
-
-    mkdir -p app/lib
-    ln -s ${vaqua} app/lib/VAqua9.jar
-    ln -s ${flatlaf} app/lib/flatlaf.jar
-    ln -s ${lsp4j} java/mode/org.eclipse.lsp4j.jar
-    ln -s ${lsp4j-jsonrpc} java/mode/org.eclipse.lsp4j.jsonrpc.jar
-    ln -s ${gson} java/mode/gson.jar
-    unzip -qo ${jna} -d app/lib/
-    mv app/lib/{jna-5.10.0/dist/jna.jar,}
-    mv app/lib/{jna-5.10.0/dist/jna-platform.jar,}
-
-    ln -sf ${batik}/* java/libraries/svg/library/
-    cp java/libraries/svg/library/share/java/batik-all-${batik.version}.jar java/libraries/svg/library/batik.jar
 
     gradle createDistributable
 
@@ -138,19 +85,6 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     runHook preBuild
-
-    mkdir -p app/lib
-    ln -s ${vaqua} app/lib/VAqua9.jar
-    ln -s ${flatlaf} app/lib/flatlaf.jar
-    ln -s ${lsp4j} java/mode/org.eclipse.lsp4j.jar
-    ln -s ${lsp4j-jsonrpc} java/mode/org.eclipse.lsp4j.jsonrpc.jar
-    ln -s ${gson} java/mode/gson.jar
-    unzip -qo ${jna} -d app/lib/
-    mv app/lib/{jna-5.10.0/dist/jna.jar,}
-    mv app/lib/{jna-5.10.0/dist/jna-platform.jar,}
-
-    ln -sf ${batik}/* java/libraries/svg/library/
-    cp java/libraries/svg/library/share/java/batik-all-${batik.version}.jar java/libraries/svg/library/batik.jar
 
     gradle assemble
 

--- a/pkgs/by-name/pr/processing/use-nixpkgs-jogl.patch
+++ b/pkgs/by-name/pr/processing/use-nixpkgs-jogl.patch
@@ -1,0 +1,14 @@
+diff --git a/core/build.gradle.kts b/core/build.gradle.kts
+index 8f7211b13..82c229f76 100644
+--- a/core/build.gradle.kts
++++ b/core/build.gradle.kts
+@@ -29,8 +29,7 @@ sourceSets{
+ }
+ 
+ dependencies {
+-    implementation(libs.jogl)
+-    implementation(libs.gluegen)
++    implementation(fileTree("@@joglPath@@/share/java") { include("*.jar") })
+
+     testImplementation(libs.junit)
+ }


### PR DESCRIPTION
Resolves https://github.com/NixOS/nixpkgs/issues/501949.

Following https://github.com/NixOS/nixpkgs/pull/466611, JOGL from Maven was being used instead of JOGL in nixpkgs. The nixpkgs JOGL contains a patch to nixify a reference to `/bin/true`.

@neobrain I didn't look into it but this makes me think the other nixpkgs dependencies may not be used correctly either. i.e.

```
    ln -s ${vaqua} app/lib/VAqua9.jar
    ln -s ${flatlaf} app/lib/flatlaf.jar
    ln -s ${lsp4j} java/mode/org.eclipse.lsp4j.jar
    ln -s ${lsp4j-jsonrpc} java/mode/org.eclipse.lsp4j.jsonrpc.jar
    ln -s ${gson} java/mode/gson.jar
```

Assisted-by: GLM-5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
