### PR TITLE
rtk: 0.30.0 -> 0.31.0

### DIFF
--- a/pkgs/by-name/rt/rtk/package.nix
+++ b/pkgs/by-name/rt/rtk/package.nix
@@ -12,18 +12,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rtk";
-  version = "0.30.0";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "rtk-ai";
     repo = "rtk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-aB9SWF9jYHeH3Apz5v4mQptLa6tS9cIfyfo6rHqsD8w=";
+    hash = "sha256-p4OX3SSDGKlHVLIWhgKpcme449wOHbfWbc3mxlCkaMI=";
   };
 
   strictDeps = true;
 
-  cargoHash = "sha256-0dpZRBPubzd2GuK02/jbNBWOR/TpFM5lVMucEii/JxM=";
+  cargoHash = "sha256-37YHhccgPNUrlFh35CoQv2H+Y4e41ax0ZoIvrIC0o6I=";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
## Things done

Diff: rtk-ai/rtk@v0.30.0...v0.31.0

Changelog: https://github.com/rtk-ai/rtk/blob/v0.31.0/CHANGELOG.md

Built on platform:
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin

Tested, as applicable:
- [ ] NixOS tests in `nixos/tests`.
- [ ] Package tests at `passthru.tests`.
- [ ] Tests in `lib/tests` or `pkgs/test` for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.