### PR TITLE
keto: run upstream test suite

### DIFF
--- a/pkgs/by-name/ke/keto/package.nix
+++ b/pkgs/by-name/ke/keto/package.nix
@@ -2,19 +2,20 @@
   fetchFromGitHub,
   buildGoModule,
   lib,
+  versionCheckHook,
 }:
 let
   pname = "keto";
   version = "26.2.0";
   commit = "e4393662cd2e744deeb79de77669e07b6ccf51f3";
 in
-buildGoModule {
+buildGoModule rec {
   inherit pname version commit;
 
   src = fetchFromGitHub {
     owner = "ory";
     repo = "keto";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-wRtz4RvJ7LxVnSLmXVZFGa9QXjcPnDNJxHKosbyTed0=";
   };
 
@@ -32,9 +33,27 @@ buildGoModule {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/ory/keto/internal/driver/config.Version=${version}"
+    "-X github.com/ory/keto/internal/driver/config.Version=${src.tag}"
     "-X github.com/ory/keto/internal/driver/config.Commit=${commit}"
   ];
+
+  # tests use dynamic port assignment via port `0`
+  __darwinAllowLocalNetworking = true;
+
+  preCheck = ''
+    export version='${src.tag}'
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    # https://github.com/ory/keto/blob/be24ba30ae7e5614fa677e3bcfc1dd6c109251f0/DEVELOP.md?plain=1#L70
+    go test -short -tags sqlite ./...
+    runHook postCheck
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "version" ];
 
   meta = {
     description = "ORY Keto, the open source access control server";
@@ -44,5 +63,6 @@ buildGoModule {
       mrmebelman
       debtquity
     ];
+    mainProgram = "keto";
   };
 }

--- a/pkgs/by-name/ke/keto/package.nix
+++ b/pkgs/by-name/ke/keto/package.nix
@@ -1,24 +1,25 @@
 {
+  lib,
+  stdenv,
   fetchFromGitHub,
   buildGoModule,
-  lib,
+  versionCheckHook,
+  installShellFiles,
 }:
-let
+buildGoModule (finalAttrs: {
   pname = "keto";
   version = "26.2.0";
-  commit = "e4393662cd2e744deeb79de77669e07b6ccf51f3";
-in
-buildGoModule {
-  inherit pname version commit;
 
   src = fetchFromGitHub {
     owner = "ory";
     repo = "keto";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-wRtz4RvJ7LxVnSLmXVZFGa9QXjcPnDNJxHKosbyTed0=";
   };
 
   vendorHash = "sha256-B27aC4yXS36eOoq53+RWp0vq1Oqw2aR+gOjv0m+b/I4=";
+
+  __structuredAttrs = true;
 
   tags = [
     "sqlite"
@@ -26,23 +27,58 @@ buildGoModule {
     "hsm"
   ];
 
-  subPackages = [ "." ];
+  subPackages = [ "..." ];
 
   # Pass versioning information via ldflags
   ldflags = [
     "-s"
-    "-w"
-    "-X github.com/ory/keto/internal/driver/config.Version=${version}"
-    "-X github.com/ory/keto/internal/driver/config.Commit=${commit}"
+    "-X github.com/ory/keto/internal/driver/config.Version=${finalAttrs.src.tag}"
+    "-X github.com/ory/keto/internal/driver/config.Commit=${finalAttrs.src.rev}"
   ];
 
+  nativeBuildInputs = [ installShellFiles ];
+  # tests use dynamic port assignment via port `0`
+  __darwinAllowLocalNetworking = true;
+
+  preCheck = ''
+    export version='${finalAttrs.src.tag}'
+  '';
+  checkFlags = [
+    "-short"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "version" ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd keto \
+      --bash <($out/bin/keto completion bash) \
+      --fish <($out/bin/keto completion fish) \
+      --zsh <($out/bin/keto completion zsh)
+  '';
+
   meta = {
-    description = "ORY Keto, the open source access control server";
-    homepage = "https://www.ory.sh/keto/";
+    description = "Scalable and customizable permission server ";
+    longDescription = ''
+      Open source implementation of "Zanzibar: Google's Consistent, Global Authorization System". It follows
+      [cloud architecture best practices](https://www.ory.com/docs/ecosystem/software-architecture-philosophy)
+      and focuses on:
+
+      - Scalable permission checks based on the Zanzibar model
+      - The Ory Permission Language for defining access control policies
+      - Relationship-based access control (ReBAC)
+      - Low latency permission checks (sub-10ms)
+      - Horizontal scaling to billions of relationships
+      - Consistency and high availability
+    '';
+    homepage = "https://github.com/ory/keto";
+    changelog = "https://github.com/ory/keto/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       mrmebelman
       debtquity
     ];
+    mainProgram = "keto";
   };
-}
+})


### PR DESCRIPTION
* fix test suite not running as part of build, use default `checkPhase`
* fix ldflag by prepending `v` to version
* add versionCheckPhase and define meta.mainProgram
* add `postInstall` to add shell completions
* add __darwinAllowLocalNetworking, __structuredAttrs
* simplify comment
  (https://github.com/NixOS/nixpkgs/pull/502025#discussion_r3016679780)
* use `src.tag` (https://github.com/NixOS/nixpkgs/pull/502025#discussion_r3016680715)
* update `meta` attrs

---

## before

```
# nix-build -A ory-hydra
...
Running phase: checkPhase
?       github.com/ory/keto       [no test files]
Running phase: installPhase
```

## after

```
# nix-build -A ory-hydra
...
Running phase: checkPhase
?       github.com/ory/keto     [no test files]
ok      github.com/ory/keto/cmd 0.477s
ok      github.com/ory/keto/cmd/check   0.879s
?       github.com/ory/keto/cmd/clidoc  [no test files]
ok      github.com/ory/keto/cmd/client  1.200s
ok      github.com/ory/keto/cmd/expand  1.595s
?       github.com/ory/keto/cmd/helpers [no test files]
ok      github.com/ory/keto/cmd/migrate 2.088s
ok      github.com/ory/keto/cmd/namespace       2.290s
ok      github.com/ory/keto/cmd/relationtuple   2.621s
?       github.com/ory/keto/cmd/server  [no test files]
ok      github.com/ory/keto/cmd/status  3.172s
?       github.com/ory/keto/contrib/docs-code-samples/expand-api-display-access/00-create-tuples        [no test files]
?       github.com/ory/keto/contrib/docs-code-samples/expand-api-display-access/01-expand-beach [no test files]
?       github.com/ory/keto/contrib/docs-code-samples/list-api-display-objects/00-create-tuples [no test files]
?       github.com/ory/keto/contrib/docs-code-samples/list-api-display-objects/01-list-PM       [no test files]
?       github.com/ory/keto/contrib/docs-code-samples/list-api-display-objects/02-list-coffee-break     [no test files]
?       github.com/ory/keto/contrib/docs-code-samples/simple-access-check-guide/00-write-direct-access  [no test files]
?       github.com/ory/keto/contrib/docs-code-samples/simple-access-check-guide/01-check-direct-access  [no test files]
?       github.com/ory/keto/contrib/docs-code-samples/simple-access-check-guide/99-cleanup      [no test files]
ok      github.com/ory/keto/embedx      2.815s
ok      github.com/ory/keto/internal/check      2.712s
ok      github.com/ory/keto/internal/check/checkgroup   3.175s
ok      github.com/ory/keto/internal/driver     3.240s
ok      github.com/ory/keto/internal/driver/config      4.007s
ok      github.com/ory/keto/internal/e2e        52.580s
ok      github.com/ory/keto/internal/expand     4.236s
?       github.com/ory/keto/internal/httpclient [no test files]
ok      github.com/ory/keto/internal/namespace  4.422s
?       github.com/ory/keto/internal/namespace/ast      [no test files]
?       github.com/ory/keto/internal/namespace/namespacehandler [no test files]
?       github.com/ory/keto/internal/persistence        [no test files]
ok      github.com/ory/keto/internal/persistence/sql    4.343s
ok      github.com/ory/keto/internal/persistence/sql/migrations/migratest       5.435s
ok      github.com/ory/keto/internal/persistence/sql/migrations/uuidmapping     4.650s
ok      github.com/ory/keto/internal/relationtuple      4.939s
ok      github.com/ory/keto/internal/schema     5.190s
?       github.com/ory/keto/internal/x  [no test files]
ok      github.com/ory/keto/internal/x/dbx      5.289s
ok      github.com/ory/keto/internal/x/graph    5.485s
ok      github.com/ory/keto/internal/x/validate 5.065s
ok      github.com/ory/keto/ketoapi     5.269s
ok      github.com/ory/keto/ketoctx     5.076s
?       github.com/ory/keto/ketodriver  [no test files]
?       github.com/ory/keto/spec        [no test files]
?       github.com/ory/keto/x/events    [no test files]
checkPhase completed in 58 seconds
Running phase: installPhase
...
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
