### PR TITLE
kratos: add version check

### DIFF
--- a/pkgs/by-name/kr/kratos/package.nix
+++ b/pkgs/by-name/kr/kratos/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   lib,
   stdenv,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -24,9 +25,12 @@ buildGoModule (finalAttrs: {
 
   # Pass versioning information via ldflags
   ldflags = [
-    "-X github.com/ory/kratos/driver/config.Version=${finalAttrs.version}"
+    "-X github.com/ory/kratos/driver/config.Version=v${finalAttrs.version}"
   ];
 
+  # large portion of tests fail due to:
+  #     provider.go:39: building the Go binary returned error: exit status 1
+  #        cannot find module providing package github.com/ory/x/jsonnetsecure/cmd: import lookup disabled by -mod=vendor
   doCheck = false;
 
   preBuild = ''
@@ -42,6 +46,10 @@ buildGoModule (finalAttrs: {
     # patchShebangs doesn't work for this Makefile, do it manually
     substituteInPlace Makefile --replace-fail '/usr/bin/env bash' '${stdenv.shell}'
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "version" ];
 
   meta = {
     mainProgram = "kratos";


### PR DESCRIPTION
* fix ldflag version to match expected pattern
* introduce `versionCheckPhase`
* discovered why `doCheck` has been set to false, resolve this at a later time


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
