### PR TITLE
fedora-backgrounds: add fedora 39-43 wallpapers, add imagemagick

### DIFF
--- a/pkgs/data/misc/fedora-backgrounds/default.nix
+++ b/pkgs/data/misc/fedora-backgrounds/default.nix
@@ -69,4 +69,44 @@ in
       hash = "sha256-YSNP7GhS5i5mJDsa4UwsXJm8Tv43r9JxrcYIbkXQKm4=";
     };
   };
+
+  f39 = fedoraBackground rec {
+    version = "39.0.5";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-+dHhLs1X+oe/iLX4A3GlZfjqgZyNfY5f9e1L+Lq1yvo=";
+    };
+  };
+
+  f40 = fedoraBackground rec {
+    version = "40.2.0";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-5CRZV34NJG5K3vZkIsFssot5RXqgcwe9CmHpFofeIFE=";
+    };
+  };
+
+  f41 = fedoraBackground rec {
+    version = "41.0.2";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-CRKy9yqa6BEr8H52YofHN4+1RKm8rq7fln74NkONP1c=";
+    };
+  };
+
+  f42 = fedoraBackground rec {
+    version = "42.0.0";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-QRy1gUelUf2txyDr1NJ+go6HixhYtOzHomlMINa/baM=";
+    };
+  };
+
+  f43 = fedoraBackground rec {
+    version = "43.0.4";
+    src = fetchurl {
+      url = "https://github.com/fedoradesign/backgrounds/releases/download/v${version}/f${lib.versions.major version}-backgrounds-${version}.tar.xz";
+      hash = "sha256-/EjGszi6gTpcD5iPpABUsoJeBi31y1QDcFIvbWeq6yM=";
+    };
+  };
 }

--- a/pkgs/data/misc/fedora-backgrounds/generic.nix
+++ b/pkgs/data/misc/fedora-backgrounds/generic.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   coreutils,
+  imagemagick,
 }:
 
 {
@@ -17,17 +18,21 @@ stdenvNoCC.mkDerivation {
 
   dontBuild = true;
 
+  nativeBuildInputs = [
+    imagemagick
+  ];
+
   postPatch = ''
-    for f in default/Makefile extras/Makefile; do
+    for f in $(find . -name 'Makefile*'); do
       substituteInPlace $f \
-        --replace-fail "usr/share" "share" \
-        --replace-fail "/usr/bin/" "" \
-        --replace-fail "/bin/" ""
+        --replace-warn "usr/share" "share" \
+        --replace-warn "/usr/bin/" "" \
+        --replace-warn "/bin/" ""
     done
 
     for f in $(find . -name '*.xml'); do
       substituteInPlace $f \
-        --replace-fail "/usr/share" "$out/share"
+        --replace-warn "/usr/share" "$out/share"
     done;
   '';
 


### PR DESCRIPTION
This pull request updates the Fedora backgrounds package definitions, adding support for newer Fedora releases and improving the build process for better compatibility and maintainability.

**New Fedora backgrounds support:**
* Added new entries for Fedora versions 39 through 43 in `default.nix`, each with the correct version, source URL, and hash to fetch the respective background images.

**Build process improvements:**
* Added `imagemagick` as a native build input in `generic.nix` to support JXL image processing during the build. 

* Updated the patching logic in `generic.nix` to:
  - Use `find . -name 'Makefile*'` for broader Makefile matching.
  - Replace `--replace-fail` with `--replace-warn` in `substituteInPlace` to prevent build failures in newer fedora versions.
  - Apply the same `--replace-warn` logic to XML file substitutions.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
