### PR TITLE
ory-hydra: run upstream test suite

### DIFF
--- a/pkgs/by-name/or/ory-hydra/package.nix
+++ b/pkgs/by-name/or/ory-hydra/package.nix
@@ -29,9 +29,25 @@ buildGoModule (finalAttrs: {
 
   ldflags = [
     "-s"
-    "-X github.com/ory/hydra/v2/driver/config.Version=v${finalAttrs.version}"
+    "-X github.com/ory/hydra/v2/driver/config.Version=${finalAttrs.src.tag}"
     "-X github.com/ory/hydra/v2/driver/config.Commit=${finalAttrs.src.rev}"
   ];
+
+  # tests use dynamic port assignment via port `0`
+  __darwinAllowLocalNetworking = true;
+
+  preCheck = ''
+    export version='${finalAttrs.src.tag}'
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    export GOFLAGS=''${GOFLAGS//-trimpath/}
+    # full test suite expects pristine/fresh database(s), thus opting to use `-short` flag to skip those integration tests
+    # https://github.com/ory/hydra/blob/83559dffbb7b1bdd3a05dd6210654c3f5a876771/Makefile#L71
+    go test -short -tags sqlite,sqlite_omit_load_extension ./...
+    runHook postCheck
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/or/ory-hydra/package.nix
+++ b/pkgs/by-name/or/ory-hydra/package.nix
@@ -1,8 +1,10 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   versionCheckHook,
+  installShellFiles,
 }:
 buildGoModule (finalAttrs: {
   pname = "hydra";
@@ -17,6 +19,7 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-KVCoDATyt5Qp0r3vGwdXqkjh0FEdNyKi6mXk99D6HD8=";
 
+  __structuredAttrs = true;
   # `json1` not needed (see: https://github.com/ory/hydra/commit/93edc9ad894771c67f46ae2c57ee7e50382d73cd)
   # `sqlite_omit_load_extension` consistency with upstream (see: https://github.com/ory/hydra/blob/master/.docker/Dockerfile-local-build#L20C58-L20C84). Will disable sqlite runtime extension loading (see: https://sqlite.org/loadext.html)
   tags = [
@@ -25,22 +28,49 @@ buildGoModule (finalAttrs: {
     "sqlite_omit_load_extension"
   ];
 
-  subPackages = [ "." ];
+  subPackages = [ "..." ];
 
   ldflags = [
     "-s"
-    "-X github.com/ory/hydra/v2/driver/config.Version=v${finalAttrs.version}"
+    "-X github.com/ory/hydra/v2/driver/config.Version=${finalAttrs.src.tag}"
     "-X github.com/ory/hydra/v2/driver/config.Commit=${finalAttrs.src.rev}"
   ];
 
+  nativeBuildInputs = [ installShellFiles ];
+  # tests use dynamic port assignment via port `0`
+  __darwinAllowLocalNetworking = true;
+  preCheck = ''
+    export version="${finalAttrs.src.tag}"
+  '';
+  checkFlags = [
+    "-short"
+  ];
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = [ "version" ];
 
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd hydra \
+      --bash <($out/bin/hydra completion bash) \
+      --fish <($out/bin/hydra completion fish) \
+      --zsh <($out/bin/hydra completion zsh)
+  '';
+
   meta = {
     description = "OpenID Certified™ OAuth 2.0 Server and OpenID Connect Provider";
-    homepage = "https://www.ory.com/hydra";
-    changelog = "https://github.com/ory/hydra/releases/tag/v${finalAttrs.version}";
+    longDescription = ''
+      Server implementation of the OAuth 2.0 authorization framework and the OpenID Connect Core 1.0. It follows
+      [cloud architecture best practices](https://www.ory.com/docs/ecosystem/software-architecture-philosophy) and focuses on:
+
+      - OAuth 2.0 and OpenID Connect flows
+      - Token issuance and validation
+      - Client management
+      - Consent and login flow orchestration
+      - JWKS management
+      - Low latency and high throughput
+    '';
+    homepage = "https://github.com/ory/hydra";
+    changelog = "https://github.com/ory/hydra/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       debtquity


### PR DESCRIPTION
* add `subPackages` attr to build and test relevant artifacts, remove
  custom `checkPhase`
* add __darwinAllowLocalNetworking
* update comment (https://github.com/NixOS/nixpkgs/pull/502029#discussion_r3016666366)
* use `finalAttrs.src.tag` (https://github.com/NixOS/nixpkgs/pull/502029#discussion_r3016668229)
* remove `-failfast` switch (https://github.com/NixOS/nixpkgs/pull/502029#discussion_r3016669901)
* fix tests by adding `export GOFLAGS=''${GOFLAGS//-trimpath/}`
* add `postInstall` to install shell completion, update meta attrs

---

## before

```
# nix-build -A ory-hydra
...
Running phase: checkPhase
?       github.com/ory/hydra       [no test files]
Running phase: installPhase
```

## after

```
# nix-build -A ory-hydra
...
Running phase: checkPhase
?       github.com/ory/hydra/v2 [no test files]
ok      github.com/ory/hydra/v2/aead    0.610s
ok      github.com/ory/hydra/v2/client  1.135s
ok      github.com/ory/hydra/v2/cmd     5.721s
ok      github.com/ory/hydra/v2/cmd/cli 2.046s
?       github.com/ory/hydra/v2/cmd/cliclient   [no test files]
?       github.com/ory/hydra/v2/cmd/clidoc      [no test files]
ok      github.com/ory/hydra/v2/cmd/server      3.593s
ok      github.com/ory/hydra/v2/consent 29.209s
?       github.com/ory/hydra/v2/consent/test    [no test files]
ok      github.com/ory/hydra/v2/driver  5.467s
ok      github.com/ory/hydra/v2/driver/config   1.030s
ok      github.com/ory/hydra/v2/flow    3.438s
ok      github.com/ory/hydra/v2/fosite  4.158s
?       github.com/ory/hydra/v2/fosite/compose  [no test files]
ok      github.com/ory/hydra/v2/fosite/handler/oauth2   3.436s
ok      github.com/ory/hydra/v2/fosite/handler/openid   3.634s
ok      github.com/ory/hydra/v2/fosite/handler/par      3.651s
ok      github.com/ory/hydra/v2/fosite/handler/pkce     3.730s
ok      github.com/ory/hydra/v2/fosite/handler/rfc7523  4.146s
ok      github.com/ory/hydra/v2/fosite/handler/rfc8628  14.009s
ok      github.com/ory/hydra/v2/fosite/handler/verifiable       4.237s
ok      github.com/ory/hydra/v2/fosite/i18n     4.388s
ok      github.com/ory/hydra/v2/fosite/integration      54.558s
?       github.com/ory/hydra/v2/fosite/integration/clients      [no test files]
?       github.com/ory/hydra/v2/fosite/internal [no test files]
?       github.com/ory/hydra/v2/fosite/internal/gen     [no test files]
ok      github.com/ory/hydra/v2/fosite/storage  3.946s
ok      github.com/ory/hydra/v2/fosite/token/hmac       2.811s
ok      github.com/ory/hydra/v2/fosite/token/jwt        2.997s
ok      github.com/ory/hydra/v2/fositex 3.074s
ok      github.com/ory/hydra/v2/health  3.287s
?       github.com/ory/hydra/v2/hsm     [no test files]
?       github.com/ory/hydra/v2/internal        [no test files]
?       github.com/ory/hydra/v2/internal/kratos [no test files]
?       github.com/ory/hydra/v2/internal/mock   [no test files]
?       github.com/ory/hydra/v2/internal/testhelpers    [no test files]
?       github.com/ory/hydra/v2/internal/testhelpers/uuid       [no test files]
ok      github.com/ory/hydra/v2/jwk     5.071s
ok      github.com/ory/hydra/v2/oauth2  105.966s
ok      github.com/ory/hydra/v2/oauth2/trust    3.430s
?       github.com/ory/hydra/v2/persistence     [no test files]
ok      github.com/ory/hydra/v2/persistence/sql 22.066s
ok      github.com/ory/hydra/v2/persistence/sql/migratest       3.910s
ok      github.com/ory/hydra/v2/spec    4.015s
?       github.com/ory/hydra/v2/test    [no test files]
?       github.com/ory/hydra/v2/test/mock-cb    [no test files]
?       github.com/ory/hydra/v2/test/mock-client        [no test files]
?       github.com/ory/hydra/v2/test/mock-lcp   [no test files]
ok      github.com/ory/hydra/v2/x       4.518s
?       github.com/ory/hydra/v2/x/events        [no test files]
ok      github.com/ory/hydra/v2/x/oauth2cors    4.768s
?       github.com/ory/hydra/v2/x/swagger       [no test files]
checkPhase completed in 1 minutes 58 seconds
Running phase: installPhase
...
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
