### PR TITLE
krr: 1.7.1 -> 1.28.0

### DIFF
--- a/pkgs/by-name/kr/krr/package.nix
+++ b/pkgs/by-name/kr/krr/package.nix
@@ -1,51 +1,83 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   testers,
   krr,
 }:
 
-python3.pkgs.buildPythonPackage rec {
+let
+  pythonPackages = python3Packages.overrideScope (
+    self: super: {
+      pydantic = self.pydantic_1;
+      # yarl only uses pydantic in tests; skip its pydantic tests under v1
+      yarl = super.yarl.overridePythonAttrs {
+        disabledTestPaths = (super.yarl.disabledTestPaths or [ ]) ++ [ "test_pydantic.py" ];
+      };
+      # django test_media_root_pathlib fails when building from source (not pydantic-related)
+      django = super.django.overridePythonAttrs {
+        disabledTests = (super.django.disabledTests or [ ]) ++ [ "test_media_root_pathlib" ];
+      };
+    }
+  );
+in
+pythonPackages.buildPythonApplication rec {
   pname = "krr";
-  version = "1.7.1";
+  version = "1.28.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "robusta-dev";
     repo = "krr";
     tag = "v${version}";
-    hash = "sha256-Bc1Ql3z/UmOXE2RJYC5/sE4a3MFdE06I3HwKY+SdSlk=";
+    hash = "sha256-1wCvoqlFBgC7SSPdq13q4CjR/rJnhv5g/xrty9YUQtg=";
   };
 
   postPatch = ''
     substituteInPlace robusta_krr/__init__.py \
-      --replace-warn '1.7.0-dev' '${version}'
+      --replace-fail 'dev' '${version}'
 
     substituteInPlace pyproject.toml \
-      --replace-warn '1.7.0-dev' '${version}' \
-      --replace-fail 'aiostream = "^0.4.5"' 'aiostream = "*"' \
-      --replace-fail 'kubernetes = "^26.1.0"' 'kubernetes = "*"' \
-      --replace-fail 'pydantic = "1.10.7"' 'pydantic = "*"' \
-      --replace-fail 'typer = { extras = ["all"], version = "^0.7.0" }' 'typer = { extras = ["all"], version = "*" }'
+      --replace-fail '1.8.2-dev' '${version}'
   '';
 
-  propagatedBuildInputs = with python3.pkgs; [
-    aiostream
+  pythonRelaxDeps = true;
+
+  pythonRemoveDeps = [
+    # Transitive dependency version pins, not direct imports
+    "idna"
+    "setuptools"
+    "urllib3"
+    "zipp"
+  ];
+
+  build-system = with pythonPackages; [
+    poetry-core
+  ];
+
+  dependencies = with pythonPackages; [
     alive-progress
+    cachetools
     kubernetes
     numpy
-    poetry-core
+    pandas
     prometheus-api-client
     prometrix
-    pydantic_1
+    pydantic
+    pyyaml
+    requests
     slack-sdk
+    tenacity
     typer
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with pythonPackages; [
+    pytest-asyncio
     pytestCheckHook
   ];
+
+  # Tests require a Kubernetes cluster and use deprecated click API (mix_stderr)
+  doCheck = false;
 
   pythonImportsCheck = [
     "robusta_krr"
@@ -65,7 +97,7 @@ python3.pkgs.buildPythonPackage rec {
       reduces costs and improves performance.
     '';
     homepage = "https://github.com/robusta-dev/krr";
-    changelog = "https://github.com/robusta-dev/krr/releases/tag/v${src.rev}";
+    changelog = "https://github.com/robusta-dev/krr/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "krr";

--- a/pkgs/by-name/kr/krr/package.nix
+++ b/pkgs/by-name/kr/krr/package.nix
@@ -1,50 +1,94 @@
 {
   lib,
-  python3,
+  python313Packages,
   fetchFromGitHub,
   testers,
   krr,
 }:
 
-python3.pkgs.buildPythonPackage (finalAttrs: {
+let
+  pythonPackages = python313Packages.overrideScope (
+    final: prev: {
+      # KRR requires Pydantic 1, which is incompatible with Python 3.14.
+      # https://github.com/robusta-dev/krr/pull/512
+      # https://github.com/pydantic/pydantic/pull/12263
+      prometrix = prev.prometrix.override { pydantic = final.pydantic_1; };
+    }
+  );
+in
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "krr";
-  version = "1.7.1";
+  version = "1.28.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "robusta-dev";
     repo = "krr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Bc1Ql3z/UmOXE2RJYC5/sE4a3MFdE06I3HwKY+SdSlk=";
+    hash = "sha256-1wCvoqlFBgC7SSPdq13q4CjR/rJnhv5g/xrty9YUQtg=";
   };
 
   postPatch = ''
     substituteInPlace robusta_krr/__init__.py \
-      --replace-warn '1.7.0-dev' '${finalAttrs.version}'
+      --replace-fail 'dev' '${finalAttrs.version}'
 
     substituteInPlace pyproject.toml \
-      --replace-warn '1.7.0-dev' '${finalAttrs.version}' \
-      --replace-fail 'aiostream = "^0.4.5"' 'aiostream = "*"' \
-      --replace-fail 'kubernetes = "^26.1.0"' 'kubernetes = "*"' \
-      --replace-fail 'pydantic = "1.10.7"' 'pydantic = "*"' \
-      --replace-fail 'typer = { extras = ["all"], version = "^0.7.0" }' 'typer = { extras = ["all"], version = "*" }'
+      --replace-fail '1.8.2-dev' '${finalAttrs.version}'
   '';
 
-  propagatedBuildInputs = with python3.pkgs; [
-    aiostream
+  pythonRelaxDeps = [
+    # The enabled tests and import check pass with nixpkgs' versions.
+    # Exact upstream pins and ranges do not match the versions packaged by nixpkgs.
+    "idna"
+    "pandas"
+    "prometheus-api-client"
+    "prometrix"
+    "pyyaml"
+    "typing-extensions"
+    "kubernetes"
+    "numpy"
+    "typer"
+  ];
+
+  pythonRemoveDeps = [
+    # Added upstream to pin transitive dependencies for CVE remediation:
+    # https://github.com/robusta-dev/krr/commit/089285b533635015f092ecc3603416d67c1e8bcc
+    # KRR does not import them at runtime.
+    "setuptools"
+    "zipp"
+  ];
+
+  build-system = with pythonPackages; [
+    poetry-core
+  ];
+
+  dependencies = with pythonPackages; [
     alive-progress
+    cachetools
     kubernetes
     numpy
-    poetry-core
+    pandas
     prometheus-api-client
     prometrix
     pydantic_1
+    pyyaml
+    requests
     slack-sdk
+    tenacity
     typer
+    urllib3
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with pythonPackages; [
+    pytest-asyncio
     pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Click no longer accepts CliRunner(mix_stderr = false).
+    # https://github.com/robusta-dev/krr/issues/544
+    "tests/test_krr.py"
+    "tests/test_runner.py"
   ];
 
   pythonImportsCheck = [
@@ -65,7 +109,7 @@ python3.pkgs.buildPythonPackage (finalAttrs: {
       reduces costs and improves performance.
     '';
     homepage = "https://github.com/robusta-dev/krr";
-    changelog = "https://github.com/robusta-dev/krr/releases/tag/v${finalAttrs.src.rev}";
+    changelog = "https://github.com/robusta-dev/krr/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "krr";

--- a/pkgs/development/python-modules/prometrix/default.nix
+++ b/pkgs/development/python-modules/prometrix/default.nix
@@ -3,33 +3,35 @@
   boto3,
   botocore,
   buildPythonPackage,
-  dateparser,
   fetchFromGitHub,
-  matplotlib,
-  numpy,
-  pandas,
   poetry-core,
   prometheus-api-client,
   pydantic,
+  pythonAtLeast,
   requests,
+  unstableGitUpdater,
 }:
 
 buildPythonPackage {
   pname = "prometrix";
-  version = "0.1.18-unstable-2024-04-30";
+  version = "0.2.11-unstable-2026-03-11";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "robusta-dev";
     repo = "prometrix";
-    # https://github.com/robusta-dev/prometrix/issues/19
-    rev = "35128847d46016b88455e0a98f0eeec08d042107";
-    hash = "sha256-g8ZqgL9ETVwpKLMQS7s7A4GpSGfaFEDLOr8JBvFl2C4=";
+    rev = "e84d6639226aea5f9ef1ea565d1932bf29807344";
+    hash = "sha256-V4lG47vn+nXa1H8Tp/RsZ2KUk7HhojrzNZQBlnWL1eE=";
   };
 
-  pythonRelaxDeps = [
-    "pydantic"
-    "urllib3"
+  pythonRelaxDeps = true;
+
+  pythonRemoveDeps = [
+    # Transitive dependency version pins for CVE patches, not direct imports
+    "fonttools"
+    "idna"
+    "pillow"
+    "zipp"
   ];
 
   build-system = [ poetry-core ];
@@ -37,10 +39,6 @@ buildPythonPackage {
   dependencies = [
     boto3
     botocore
-    dateparser
-    matplotlib
-    numpy
-    pandas
     prometheus-api-client
     pydantic
     requests
@@ -52,6 +50,8 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "prometrix" ];
 
+  passthru.updateScript = unstableGitUpdater { };
+
   meta = {
     description = "Unified Prometheus client";
     longDescription = ''
@@ -61,8 +61,5 @@ buildPythonPackage {
     homepage = "https://github.com/robusta-dev/prometrix";
     license = lib.licenses.mit;
     maintainers = [ ];
-    # prometheus-api-client 0.5.5 is not working
-    # https://github.com/robusta-dev/prometrix/issues/14
-    broken = lib.versionAtLeast prometheus-api-client.version "0.5.3";
   };
 }

--- a/pkgs/development/python-modules/prometrix/default.nix
+++ b/pkgs/development/python-modules/prometrix/default.nix
@@ -3,11 +3,7 @@
   boto3,
   botocore,
   buildPythonPackage,
-  dateparser,
   fetchFromGitHub,
-  matplotlib,
-  numpy,
-  pandas,
   poetry-core,
   prometheus-api-client,
   pydantic,
@@ -16,20 +12,22 @@
 
 buildPythonPackage {
   pname = "prometrix";
-  version = "0.1.18-unstable-2024-04-30";
+  version = "0.2.12-unstable-2026-06-08";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "robusta-dev";
     repo = "prometrix";
-    # https://github.com/robusta-dev/prometrix/issues/19
-    rev = "35128847d46016b88455e0a98f0eeec08d042107";
-    hash = "sha256-g8ZqgL9ETVwpKLMQS7s7A4GpSGfaFEDLOr8JBvFl2C4=";
+    # Upstream does not publish tags or releases, see:
+    # https://github.com/robusta-dev/prometrix/issues/8
+    rev = "4830ebd9726075ac3e12a5644a9e4668c0bba419";
+    hash = "sha256-K8IKfI9vxz251+CZ/L/c1oPxgST6fOiCGJCasw+KBFs=";
   };
 
-  pythonRelaxDeps = [
-    "pydantic"
-    "urllib3"
+  pythonRemoveDeps = [
+    # Added upstream only to pin a transitive dependency for CVE remediation:
+    # https://github.com/robusta-dev/prometrix/commit/9a320185d12c8239a7fda95d78bf928cb0975eb7
+    "zipp"
   ];
 
   build-system = [ poetry-core ];
@@ -37,10 +35,6 @@ buildPythonPackage {
   dependencies = [
     boto3
     botocore
-    dateparser
-    matplotlib
-    numpy
-    pandas
     prometheus-api-client
     pydantic
     requests
@@ -61,8 +55,5 @@ buildPythonPackage {
     homepage = "https://github.com/robusta-dev/prometrix";
     license = lib.licenses.mit;
     maintainers = [ ];
-    # prometheus-api-client 0.5.5 is not working
-    # https://github.com/robusta-dev/prometrix/issues/14
-    broken = lib.versionAtLeast prometheus-api-client.version "0.5.3";
   };
 }


### PR DESCRIPTION
Updates KRR and Prometrix to fix #327629.

- `prometrix`: `0.1.18-unstable-2024-04-30` -> `0.2.12-unstable-2026-06-08`
- `krr`: `1.7.1` -> `1.28.0`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests]
  - [x] [Package tests]
  - [ ] Tests in [lib/tests] or [pkgs/test]
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition.
  - [ ] Module update.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md], and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[lib/tests]: https://github.com/NixOS/nixpkgs/tree/master/lib/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/tree/master/pkgs/test
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
