### PR TITLE
guile-json-rpc: 0.5.0 → 0.6.1

### DIFF
--- a/pkgs/by-name/gu/guile-json-rpc/package.nix
+++ b/pkgs/by-name/gu/guile-json-rpc/package.nix
@@ -9,13 +9,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "guile-json-rpc";
-  version = "0.5.0";
+  version = "0.6.1";
 
   src = fetchFromCodeberg {
     owner = "rgherdt";
     repo = "scheme-json-rpc";
     tag = finalAttrs.version;
-    hash = "sha256-xCykgq0L6PDqjXfNwsqV9u1nFiK9t+qCUgIgzZoIsxc=";
+    hash = "sha256-3Wb3ZtcFQCOESe0Yq4cEG2jJ4+dOjlf9LKrclHhpkbU=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
https://codeberg.org/rgherdt/scheme-json-rpc/compare/0.5.0...0.6.1

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
