### PR TITLE
treewide: remove tlType, make tlDeps into a function

### DIFF
--- a/doc/languages-frameworks/texlive.section.md
+++ b/doc/languages-frameworks/texlive.section.md
@@ -112,7 +112,7 @@ Release 23.11 ships with a new interface that will eventually replace `texlive.c
 
 ## Custom packages {#sec-language-texlive-custom-packages}
 
-You may find that you need to use an external TeX package. A derivation for such package has to provide the contents of the "texmf" directory in its `"tex"` output, according to the [TeX Directory Structure](https://tug.ctan.org/tds/tds.html). Dependencies on other TeX packages can be listed in the attribute `tlDeps`.
+You may find that you need to use an external TeX package. A derivation for such package has to provide the contents of the "texmf" directory in its `"tex"` output, according to the [TeX Directory Structure](https://tug.ctan.org/tds/tds.html). Dependencies on other TeX packages can be listed in the attribute `passthru.tlDeps`, which is a function taking a package set and returning a list of packages.
 
 The functions `texlive.combine` and `texlive.withPackages` recognise the following outputs:
 
@@ -138,7 +138,7 @@ let
       "tex"
       "texdoc"
     ];
-    passthru.tlDeps = with texlive; [ latex ];
+    passthru.tlDeps = ps: [ ps.latex ];
 
     srcs = [
       (fetchurl {
@@ -169,12 +169,13 @@ let
           latexmk
         ]
       ))
-      # multiple-outputs.sh fails if $out is not defined
-      (writeShellScript "force-tex-output.sh" ''
-        out="''${tex-}"
-      '')
       writableTmpDirAsHomeHook # Need a writable $HOME for latexmk
     ];
+
+    # multiple-outputs.sh fails if $out is not defined
+    preHook = ''
+      out="''${tex-}"
+    '';
 
     dontConfigure = true;
 

--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -16,7 +16,6 @@
   perl,
   readline,
   tcl,
-  texlive,
   texliveSmall,
   tk,
   xz,
@@ -199,19 +198,19 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
   # dependencies (based on \RequirePackage in jss.cls, Rd.sty, Sweave.sty)
-  passthru.tlDeps = with texlive; [
-    amsfonts
-    amsmath
-    fancyvrb
-    graphics
-    hyperref
-    iftex
-    jknapltx
-    latex
-    lm
-    tools
-    upquote
-    url
+  passthru.tlDeps = ps: [
+    ps.amsfonts
+    ps.amsmath
+    ps.fancyvrb
+    ps.graphics
+    ps.hyperref
+    ps.iftex
+    ps.jknapltx
+    ps.latex
+    ps.lm
+    ps.tools
+    ps.upquote
+    ps.url
   ];
 
   meta = {

--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -198,9 +198,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
-  # make tex output available to texlive.combine
-  passthru.pkgs = [ finalAttrs.finalPackage.tex ];
-  passthru.tlType = "run";
   # dependencies (based on \RequirePackage in jss.cls, Rd.sty, Sweave.sty)
   passthru.tlDeps = with texlive; [
     amsfonts

--- a/pkgs/by-name/au/auctex/package.nix
+++ b/pkgs/by-name/au/auctex/package.nix
@@ -7,50 +7,43 @@
   ghostscript,
 }:
 
-let
-  auctex = stdenv.mkDerivation rec {
-    # Make this a valid tex(live-new) package;
-    # the pkgs attribute is provided with a hack below.
-    pname = "auctex";
-    version = "13.2";
-    tlType = "run";
+stdenv.mkDerivation rec {
+  pname = "auctex";
+  version = "13.2";
 
-    outputs = [
-      "out"
-      "tex"
-    ];
+  outputs = [
+    "out"
+    "tex"
+  ];
 
-    src = fetchurl {
-      url = "mirror://gnu/auctex/auctex-${version}.tar.gz";
-      hash = "sha256-Hn5AKrz4RmlOuncZklvwlcI+8zpeZgIgHHS2ymCUQDU=";
-    };
-
-    buildInputs = [
-      emacs
-      ghostscript
-      (texliveBasic.withPackages (ps: [
-        ps.etoolbox
-        ps.hypdoc
-      ]))
-    ];
-
-    preConfigure = ''
-      mkdir -p "$tex"
-      export HOME=$(mktemp -d)
-    '';
-
-    configureFlags = [
-      "--with-lispdir=\${out}/share/emacs/site-lisp"
-      "--with-texmf-dir=\${tex}"
-    ];
-
-    meta = {
-      homepage = "https://www.gnu.org/software/auctex";
-      description = "Extensible package for writing and formatting TeX files in GNU Emacs and XEmacs";
-      license = lib.licenses.gpl3Plus;
-      platforms = lib.platforms.unix;
-    };
+  src = fetchurl {
+    url = "mirror://gnu/auctex/auctex-${version}.tar.gz";
+    hash = "sha256-Hn5AKrz4RmlOuncZklvwlcI+8zpeZgIgHHS2ymCUQDU=";
   };
 
-in
-auctex // { pkgs = [ auctex.tex ]; }
+  buildInputs = [
+    emacs
+    ghostscript
+    (texliveBasic.withPackages (ps: [
+      ps.etoolbox
+      ps.hypdoc
+    ]))
+  ];
+
+  preConfigure = ''
+    mkdir -p "$tex"
+    export HOME=$(mktemp -d)
+  '';
+
+  configureFlags = [
+    "--with-lispdir=\${out}/share/emacs/site-lisp"
+    "--with-texmf-dir=\${tex}"
+  ];
+
+  meta = {
+    homepage = "https://www.gnu.org/software/auctex";
+    description = "Extensible package for writing and formatting TeX files in GNU Emacs and XEmacs";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/by-name/au/auto-multiple-choice/package.nix
+++ b/pkgs/by-name/au/auto-multiple-choice/package.nix
@@ -145,11 +145,6 @@ stdenv.mkDerivation (finalAttrs: {
     perlWithPackages
   ];
 
-  passthru = {
-    tlType = "run";
-    pkgs = [ finalAttrs.finalPackage ];
-  };
-
   meta = {
     description = "Create and manage multiple choice questionnaires with automated marking";
     mainProgram = "auto-multiple-choice";

--- a/pkgs/by-name/eu/eukleides/package.nix
+++ b/pkgs/by-name/eu/eukleides/package.nix
@@ -86,17 +86,13 @@ stdenv.mkDerivation (finalAttrs: {
     "tex"
   ];
 
-  passthru = {
-    tlType = "run";
-    # packages needed by euktoeps, euktopdf and eukleides.sty
-    tlDeps = with texlive; [
-      collection-pstricks
-      epstopdf
-      iftex
-      moreverb
-    ];
-    pkgs = [ finalAttrs.finalPackage.tex ];
-  };
+  # packages needed by euktoeps, euktopdf and eukleides.sty
+  passthru.tlDeps = with texlive; [
+    collection-pstricks
+    epstopdf
+    iftex
+    moreverb
+  ];
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/eu/eukleides/package.nix
+++ b/pkgs/by-name/eu/eukleides/package.nix
@@ -8,7 +8,6 @@
   getopt,
   readline,
   texinfo,
-  texlive,
   versionCheckHook,
 }:
 
@@ -87,11 +86,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # packages needed by euktoeps, euktopdf and eukleides.sty
-  passthru.tlDeps = with texlive; [
-    collection-pstricks
-    epstopdf
-    iftex
-    moreverb
+  passthru.tlDeps = ps: [
+    ps.collection-pstricks
+    ps.epstopdf
+    ps.iftex
+    ps.moreverb
   ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/eu/eukleides/package.nix
+++ b/pkgs/by-name/eu/eukleides/package.nix
@@ -9,7 +9,6 @@
   getopt,
   readline,
   texinfo,
-  texlive,
   versionCheckHook,
 }:
 
@@ -92,11 +91,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # packages needed by euktoeps, euktopdf and eukleides.sty
-  passthru.tlDeps = with texlive; [
-    collection-pstricks
-    epstopdf
-    iftex
-    moreverb
+  passthru.tlDeps = ps: [
+    ps.collection-pstricks
+    ps.epstopdf
+    ps.iftex
+    ps.moreverb
   ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/eu/eukleides/package.nix
+++ b/pkgs/by-name/eu/eukleides/package.nix
@@ -91,17 +91,13 @@ stdenv.mkDerivation (finalAttrs: {
     "tex"
   ];
 
-  passthru = {
-    tlType = "run";
-    # packages needed by euktoeps, euktopdf and eukleides.sty
-    tlDeps = with texlive; [
-      collection-pstricks
-      epstopdf
-      iftex
-      moreverb
-    ];
-    pkgs = [ finalAttrs.finalPackage.tex ];
-  };
+  # packages needed by euktoeps, euktopdf and eukleides.sty
+  passthru.tlDeps = with texlive; [
+    collection-pstricks
+    epstopdf
+    iftex
+    moreverb
+  ];
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/ju/junicode/package.nix
+++ b/pkgs/by-name/ju/junicode/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenvNoCC,
   fetchzip,
-  texlive,
   callPackage,
 }:
 
@@ -47,9 +46,9 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   passthru = {
-    tlDeps = with texlive; [
-      xkeyval
-      fontspec
+    tlDeps = ps: [
+      ps.xkeyval
+      ps.fontspec
     ];
 
     tests = callPackage ./tests.nix { };

--- a/pkgs/by-name/mf/mftrace/package.nix
+++ b/pkgs/by-name/mf/mftrace/package.nix
@@ -7,7 +7,6 @@
   python3,
   fontforge,
   potrace,
-  texlive,
   fetchpatch2,
 }:
 
@@ -59,12 +58,11 @@ stdenv.mkDerivation (finalAttrs: {
     wrapProgram $out/bin/mftrace --prefix PATH : ${lib.makeBinPath finalAttrs.buildInputs}
   '';
 
-  # experimental texlive.combine support
-  # (note that only the bin/ folder will be combined into texlive)
-  passthru.tlDeps = with texlive; [
-    kpathsea
-    t1utils
-    metafont
+  # for use with texlive.withPackages
+  passthru.tlDeps = ps: [
+    ps.kpathsea
+    ps.t1utils
+    ps.metafont
   ];
 
   meta = {

--- a/pkgs/by-name/no/noweb/package.nix
+++ b/pkgs/by-name/no/noweb/package.nix
@@ -88,11 +88,6 @@ stdenv.mkDerivation (finalAttrs: {
     "tex"
   ];
 
-  passthru = {
-    tlType = "run";
-    pkgs = [ finalAttrs.finalPackage.tex ];
-  };
-
   meta = {
     description = "Simple, extensible literate-programming tool";
     homepage = "https://www.cs.tufts.edu/~nr/noweb";

--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -76,7 +76,11 @@ lib.fix (
               p.pname or p.name
               + lib.optionalString (p.outputSpecified or false) ("-" + p.tlOutputName or p.outputName or "");
             inherit p;
-            tlDeps = if p ? tlDeps then ensurePkgSets p.tlDeps else (p.requiredTeXPackages or (_: [ ]) tl);
+            tlDeps =
+              if p ? tlDeps then
+                (if builtins.isFunction p.tlDeps then p.tlDeps tl else ensurePkgSets p.tlDeps)
+              else
+                [ ];
           };
         in
         # texlive.combine: the wrapper already resolves all dependencies

--- a/pkgs/tools/typesetting/tex/texlive/combine-wrapper.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine-wrapper.nix
@@ -2,7 +2,7 @@
 {
   lib,
   toTLPkgList,
-  toTLPkgSets,
+  tl,
   buildTeXEnv,
 }:
 args@{
@@ -46,7 +46,11 @@ let
       in
       builtins.genericClosure {
         startSet = pkgListToSets pkgList;
-        operator = { pkg, ... }: pkgListToSets (pkg.tlDeps or [ ]);
+        operator =
+          { pkg, ... }:
+          pkgListToSets (
+            if pkg ? tlDeps then if builtins.isFunction pkg.tlDeps then pkg.tlDeps tl else pkg.tlDeps else [ ]
+          );
       }
     );
   combined = combinePkgs (lib.attrValues pkgSet);

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -258,19 +258,31 @@ let
   # respecting specified outputs
   toTLPkgList =
     drv:
+    let
+      drvWithoutDeps = removeAttrs drv [ "tlDeps" ];
+      drvWithDeps =
+        if (drv ? tlDeps) then
+          drv // { tlDeps = if builtins.isFunction drv.tlDeps then drv.tlDeps tl else drv.tlDeps; }
+        else
+          drv;
+    in
     if drv.outputSpecified or false then
       let
         tlType = drv.tlType or tlOutToType.${drv.tlOutputName or drv.outputName} or null;
       in
-      lib.optional (tlType != null) (drv // { inherit tlType; })
+      lib.optional (tlType != null) (drvWithDeps // { inherit tlType; })
     else
-      [ (drv.tex // { tlType = "run"; }) ]
+      lib.optional (drv ? tex) (drvWithDeps.tex // { tlType = "run"; })
       ++ lib.optional (drv ? texdoc) (
-        drv.texdoc // { tlType = "doc"; } // lib.optionalAttrs (drv ? man) { hasManpages = true; }
+        drvWithoutDeps.texdoc
+        // {
+          tlType = "doc";
+        }
+        // lib.optionalAttrs (drv ? man) { hasManpages = true; }
       )
-      ++ lib.optional (drv ? texsource) (drv.texsource // { tlType = "source"; })
-      ++ lib.optional (drv ? tlpkg) (drv.tlpkg // { tlType = "tlpkg"; })
-      ++ lib.optional (drv ? out) (drv.out // { tlType = "bin"; });
+      ++ lib.optional (drv ? texsource) (drvWithoutDeps.texsource // { tlType = "source"; })
+      ++ lib.optional (drv ? tlpkg) (drvWithDeps.tlpkg // { tlType = "tlpkg"; })
+      ++ lib.optional (drv ? out) (drvWithDeps.out // { tlType = "bin"; });
   tlOutToType = {
     out = "bin";
     tex = "run";
@@ -313,8 +325,8 @@ let
     inherit
       buildTeXEnv
       lib
+      tl
       toTLPkgList
-      toTLPkgSets
       ;
   };
 

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -260,19 +260,31 @@ let
   # respecting specified outputs
   toTLPkgList =
     drv:
+    let
+      drvWithoutDeps = removeAttrs drv [ "tlDeps" ];
+      drvWithDeps =
+        if (drv ? tlDeps) then
+          drv // { tlDeps = if builtins.isFunction drv.tlDeps then drv.tlDeps tl else drv.tlDeps; }
+        else
+          drv;
+    in
     if drv.outputSpecified or false then
       let
         tlType = drv.tlType or tlOutToType.${drv.tlOutputName or drv.outputName} or null;
       in
-      lib.optional (tlType != null) (drv // { inherit tlType; })
+      lib.optional (tlType != null) (drvWithDeps // { inherit tlType; })
     else
-      [ (drv.tex // { tlType = "run"; }) ]
+      lib.optional (drv ? tex) (drvWithDeps.tex // { tlType = "run"; })
       ++ lib.optional (drv ? texdoc) (
-        drv.texdoc // { tlType = "doc"; } // lib.optionalAttrs (drv ? man) { hasManpages = true; }
+        drvWithoutDeps.texdoc
+        // {
+          tlType = "doc";
+        }
+        // lib.optionalAttrs (drv ? man) { hasManpages = true; }
       )
-      ++ lib.optional (drv ? texsource) (drv.texsource // { tlType = "source"; })
-      ++ lib.optional (drv ? tlpkg) (drv.tlpkg // { tlType = "tlpkg"; })
-      ++ lib.optional (drv ? out) (drv.out // { tlType = "bin"; });
+      ++ lib.optional (drv ? texsource) (drvWithoutDeps.texsource // { tlType = "source"; })
+      ++ lib.optional (drv ? tlpkg) (drvWithDeps.tlpkg // { tlType = "tlpkg"; })
+      ++ lib.optional (drv ? out) (drvWithDeps.out // { tlType = "bin"; });
   tlOutToType = {
     out = "bin";
     tex = "run";
@@ -315,8 +327,8 @@ let
     inherit
       buildTeXEnv
       lib
+      tl
       toTLPkgList
-      toTLPkgSets
       ;
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18541,10 +18541,6 @@ with self;
         }
       done
     '';
-    passthru = {
-      tlType = "run";
-      pkgs = [ LaTeXML.tex ];
-    };
     meta = {
       description = "Transforms TeX and LaTeX into XML/HTML/MathML";
       homepage = "https://dlmf.nist.gov/LaTeXML/";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18573,10 +18573,6 @@ with self;
         }
       done
     '';
-    passthru = {
-      tlType = "run";
-      pkgs = [ LaTeXML.tex ];
-    };
     meta = {
       description = "Transforms TeX and LaTeX into XML/HTML/MathML";
       homepage = "https://dlmf.nist.gov/LaTeXML/";


### PR DESCRIPTION
1. Remove `passthru.tlType` and `passthru.pkgs` from custom TeX packages (to eventually deprecate `texlive.combine`)
2. Make `passthru.tlDeps` into a function accepting a package set instead of hardcoding the `texlive` set (to eventually introduce `texliveUnstable`)
3. ~~Unrelated change: avoid that ugly `force-output.sh` derivation in `.withPackages`~~ removed to verify that the other changes do not affect the evaluation, will make this change another time

Change 1 ~and 3~ are trivial, but 2 is a little delicate and requires some testing. In my simple tests, both `texlive.combine` and `texlive.withPackages` keep working regardless of whether `tlDeps` is a function or a list, so this should be backward compatible.

To test this PR, you must call `texliveInfraOnly.withPackages (...)` and `texlive.combine { inherit (texlive) scheme-infraonly; ... }` with some packages not part of the `texlivePackages` set.

Please do not merge before #500729 in case it causes conflicts.

(Documentation updates will come later once I know we don't need any more changes pre 26.05.)

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
