### PR TITLE
kdePackages.plasma-vault: remove fusermount replacement

### DIFF
--- a/pkgs/kde/plasma/plasma-vault/default.nix
+++ b/pkgs/kde/plasma/plasma-vault/default.nix
@@ -17,7 +17,6 @@ mkKdeDerivation {
       cryfs = lib.getExe' cryfs "cryfs";
       encfs = lib.getExe' encfs "encfs";
       encfsctl = lib.getExe' encfs "encfsctl";
-      fusermount = lib.getExe' fuse "fusermount";
       gocryptfs = lib.getExe' gocryptfs "gocryptfs";
       lsof = lib.getExe lsof;
     })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix build issue introduced in #501546

```
 > Running phase: buildPhase
       > substituteStream() in derivation hardcode-paths.patch: ERROR: pattern @fusermount@ doesn't match anything in file '/nix/store/vjmahzbfw7j908xs8lgsij5pwli4chk3-hardcode-paths.patch'
       For full logs, run:

```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
