### PR TITLE
mole-cleaner: init at 1.31.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11084,6 +11084,11 @@
     githubId = 69209;
     name = "Ian Duncan";
   };
+  IanHollow = {
+    github = "IanHollow";
+    githubId = 72767437;
+    name = "Ian Holloway";
+  };
   ianliu = {
     email = "ian.liu88@gmail.com";
     github = "ianliu";

--- a/pkgs/by-name/mo/mole-cleaner/package.nix
+++ b/pkgs/by-name/mo/mole-cleaner/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+  coreutils,
+  gnused,
+  gawk,
+  fd,
+  gitUpdater,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mole-cleaner";
+  version = "1.31.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tw93";
+    repo = "Mole";
+    tag = "V${finalAttrs.version}";
+    hash = "sha256-dalmW3W/seGZreSWuYP7JN/nMUbs3WyDHzKU83EveeY=";
+  };
+
+  vendorHash = "sha256-LznLZ0NO8VBWP95ReAVORUMIDhh7/pgTY5mGNN2tND8=";
+
+  subPackages = [
+    "cmd/analyze"
+    "cmd/status"
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+    coreutils
+    gnused
+    gawk
+  ];
+
+  postInstall = ''
+    install -Dm755 mole $out/libexec/mole/mole
+    install -Dm755 mo $out/libexec/mole/mo
+    cp -r bin lib $out/libexec/mole/
+
+    mv $out/bin/analyze $out/libexec/mole/bin/analyze-go
+    mv $out/bin/status $out/libexec/mole/bin/status-go
+
+    patchShebangs $out/libexec/mole
+
+    makeWrapper $out/libexec/mole/mole $out/bin/mole \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          fd
+          coreutils
+          gnused
+          gawk
+        ]
+      }
+    makeWrapper $out/libexec/mole/mo $out/bin/mo \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          fd
+          coreutils
+          gnused
+          gawk
+        ]
+      }
+  '';
+
+  doInstallCheck = true;
+  versionCheckKeepEnvironment = [ "HOME" ];
+  versionCheckProgramArg = "--version";
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/mole --help > /dev/null
+    $out/bin/mo --help > /dev/null
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = gitUpdater { rev-prefix = "V"; };
+
+  meta = {
+    description = "CLI tool for cleaning and optimizing macOS systems";
+    homepage = "https://github.com/tw93/Mole";
+    changelog = "https://github.com/tw93/Mole/releases/tag/V${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ IanHollow ];
+    mainProgram = "mole";
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Summary
- Add `mole-cleaner` (https://github.com/tw93/Mole), a CLI tool to clean and optimize macOS systems.
- Package with `buildGoModule`, install runtime shell assets under `libexec`, wrap `mole`/`mo`, and place Go helpers as `analyze-go` and `status-go` to match upstream runtime layout.
- Add `lib.maintainers.IanHollow` and set `mole-cleaner` maintainer.
- Add auto-update support via `gitUpdater { rev-prefix = \"V\"; }` to follow upstream uppercase tags.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests at `passthru.tests`
  - [x] Tests in `lib/tests` or `pkgs/test` for functions and core functionality (`nix-build lib/tests/maintainers.nix`)
- [ ] Ran `nixpkgs-review` on this PR
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` (`mole --help`, `mo --help`)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module
  - [ ] Module update: when the change is significant
- [x] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md` and other READMEs