### PR TITLE
jwt_tool: init at 2.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25683,6 +25683,11 @@
     githubId = 7512804;
     name = "Martin Langlotz";
   };
+  stacksparrow4 = {
+    name = "Daniel Cooper";
+    github = "stacksparrow4";
+    githubId = 29905424;
+  };
   stapelberg = {
     name = "Michael Stapelberg";
     github = "stapelberg";

--- a/pkgs/by-name/jw/jwt_tool/package.nix
+++ b/pkgs/by-name/jw/jwt_tool/package.nix
@@ -1,0 +1,40 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "jwt_tool";
+  version = "2.3.0";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "ticarpi";
+    repo = "jwt_tool";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hro7Big55b26BW3hyr8pE7f8vq/ley+M4Yiuk9SJObg=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    termcolor
+    cprint
+    pycryptodomex
+    requests
+    ratelimit
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D jwt_tool.py "$out"/bin/jwt_tool
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Toolkit for testing, tweaking and cracking JSON Web Tokens";
+    mainProgram = "jwt_tool";
+    homepage = "https://github.com/ticarpi/jwt_tool";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ stacksparrow4 ];
+  };
+})

--- a/pkgs/development/python-modules/cprint/default.nix
+++ b/pkgs/development/python-modules/cprint/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+}:
+
+buildPythonPackage {
+  pname = "cprint";
+  version = "1.2.2";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "EVasseure";
+    repo = "cprint";
+    rev = "cae3fdce19c82608b426a6371c057f7d1c39ea6f";
+    hash = "sha256-JimZFYLeXCkGNkNijSTPEyjTkV+W4supe7RVEzKNsuk=";
+  };
+
+  pythonImportsCheck = [ "cprint" ];
+
+  meta = {
+    description = "Printing and debugging with color";
+    homepage = "https://github.com/EVasseure/cprint";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stacksparrow4 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3262,6 +3262,8 @@ self: super: with self; {
 
   cppy = callPackage ../development/python-modules/cppy { };
 
+  cprint = callPackage ../development/python-modules/cprint { };
+
   cpufeature = callPackage ../development/python-modules/cpufeature { };
 
   cpyparsing = callPackage ../development/python-modules/cpyparsing { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Homepage: https://github.com/ticarpi/jwt_tool

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
