### PR TITLE
tshock: 6.0.0-pre1 -> 6.1.0

### DIFF
--- a/pkgs/by-name/ts/tshock/deps.json
+++ b/pkgs/by-name/ts/tshock/deps.json
@@ -66,8 +66,8 @@
   },
   {
     "pname": "ModFramework",
-    "version": "1.1.13",
-    "hash": "sha256-hHIGIONRhs47ER7SW6/LFZYRoBAG1xG/KTkxII4GuQ0="
+    "version": "1.1.15",
+    "hash": "sha256-wxE2PZzSOdsg9hwejRAutjJV3Q0srJl0xrk232GVpjg="
   },
   {
     "pname": "Mono.Cecil",
@@ -91,8 +91,8 @@
   },
   {
     "pname": "MonoMod.Core",
-    "version": "1.2.2",
-    "hash": "sha256-yumeVML9tOjGp1KHKETGBoylTBwIr8ZUjxZ0SCRrB+c="
+    "version": "1.2.3",
+    "hash": "sha256-+lW1q6iVXb4jXvPoRp7KGJdZ6KlZUGtHBFnFo5dA7lg="
   },
   {
     "pname": "MonoMod.ILHelpers",
@@ -101,8 +101,8 @@
   },
   {
     "pname": "MonoMod.RuntimeDetour",
-    "version": "25.2.2",
-    "hash": "sha256-pjqeamXxZ2E9vxS7jn2o5UfPutdxoEN0Ps/9XtxdEqs="
+    "version": "25.2.3",
+    "hash": "sha256-SNecVmNFMCH3SeUajvSvULSwaxcruYspZzlOxO7cdAE="
   },
   {
     "pname": "MonoMod.Utils",
@@ -135,9 +135,19 @@
     "hash": "sha256-k6JAFqHFinTakwNuW666aXYPhR7TpI/rb+KbHm1S2TM="
   },
   {
+    "pname": "NuGet.Common",
+    "version": "6.13.2",
+    "hash": "sha256-ASLa/Jigg5Eop0ZrXPl98RW2rxnJRC7pbbxhuV74hFw="
+  },
+  {
     "pname": "NuGet.Configuration",
     "version": "6.12.1",
     "hash": "sha256-e/4lvyl7o7g4aWTAtr9S2yiGgk7V0E9p6DXpsy7GgVw="
+  },
+  {
+    "pname": "NuGet.Configuration",
+    "version": "6.13.2",
+    "hash": "sha256-z8VW1YdRDanyyRTDYRvRkSv/XPR3c/hMM1y8cNNjx0Y="
   },
   {
     "pname": "NuGet.Frameworks",
@@ -145,14 +155,29 @@
     "hash": "sha256-GGpkbas+PNLx35vvr3nyAVz5lY/aeoMx6qjmT368Lpg="
   },
   {
+    "pname": "NuGet.Frameworks",
+    "version": "6.13.2",
+    "hash": "sha256-caDyc+WgYOo43AUTjtbP0MyvYDb6JweEKDdIul61Cac="
+  },
+  {
     "pname": "NuGet.Packaging",
     "version": "6.12.1",
     "hash": "sha256-3h8Nmjpt383+dCg9GJ1BJ26UirwEQsWCPcTiT0+wGeI="
   },
   {
+    "pname": "NuGet.Packaging",
+    "version": "6.13.2",
+    "hash": "sha256-lhO+SFwIYZ4aPHxIGm5ubkkE2a5Ve2xgtroRbNh7hpw="
+  },
+  {
     "pname": "NuGet.Protocol",
     "version": "6.12.1",
     "hash": "sha256-l+CHnAcit6Y9OjBxereRP5JzOuWbuZZQYkFOKsUkdQ8="
+  },
+  {
+    "pname": "NuGet.Protocol",
+    "version": "6.13.2",
+    "hash": "sha256-5lnAHHZjy7A4vgv65AeBAs64mSNpuoUjxW3HnrMpuzY="
   },
   {
     "pname": "NuGet.Resolver",
@@ -165,9 +190,14 @@
     "hash": "sha256-f/ejCuzCAwKs4N4Ec6yf2RovrhBT0nj0hRDP+03/Iy4="
   },
   {
+    "pname": "NuGet.Versioning",
+    "version": "6.13.2",
+    "hash": "sha256-gmpyBpKnt+GHqgx/2uFKp+J2csbxEAy1E7WdVT117sw="
+  },
+  {
     "pname": "OTAPI.Upcoming",
-    "version": "3.2.4",
-    "hash": "sha256-XOE1fX9FDwCXUVh/TuMvmOxHxtZj+2+upHwQ2NoXzy4="
+    "version": "3.3.11",
+    "hash": "sha256-2v5hl1UUSUmGWnZXWKx2Y3ZmLUwbI0PlEb6mlb9qO0U="
   },
   {
     "pname": "runtime.any.System.Collections",
@@ -345,6 +375,11 @@
     "hash": "sha256-afY7VUtD6w/5mYqrce8kQrvDIfS2GXDINDh73IjxJKc="
   },
   {
+    "pname": "System.Collections.Immutable",
+    "version": "8.0.0",
+    "hash": "sha256-F7OVjKNwpqbUh8lTidbqJWYi476nsq9n+6k0+QVRo3w="
+  },
+  {
     "pname": "System.Collections.NonGeneric",
     "version": "4.3.0",
     "hash": "sha256-8/yZmD4jjvq7m68SPkJZLBQ79jOTOyT5lyzX4SCYAx8="
@@ -438,6 +473,11 @@
     "pname": "System.IO.FileSystem.Primitives",
     "version": "4.3.0",
     "hash": "sha256-LMnfg8Vwavs9cMnq9nNH8IWtAtSfk0/Fy4s4Rt9r1kg="
+  },
+  {
+    "pname": "System.IO.Packaging",
+    "version": "9.0.2",
+    "hash": "sha256-633GG/fTf5MHhi5RrCiuD5q2JzWUUeuDashmYWIBrXo="
   },
   {
     "pname": "System.IO.Pipelines",

--- a/pkgs/by-name/ts/tshock/package.nix
+++ b/pkgs/by-name/ts/tshock/package.nix
@@ -4,16 +4,17 @@
   buildDotnetModule,
   dotnet-sdk_9,
   dotnet-runtime_9,
+  nix-update-script,
 }:
 buildDotnetModule rec {
   pname = "tshock";
-  version = "6.0.0-pre1";
+  version = "6.1.0";
 
   src = fetchFromGitHub {
     owner = "Pryaxis";
     repo = "TShock";
     rev = "v${version}";
-    hash = "sha256-nMCtOSfhneE4q/bqZcLVkfxObOpCEgNpSODMErKuTYw=";
+    hash = "sha256-s6v/OUZmU0/kOH83N7xnurXdAtf49q/X69XWcKrKi/c=";
     fetchSubmodules = true;
   };
 
@@ -33,6 +34,8 @@ buildDotnetModule rec {
 
   nugetSource = "https://api.nuget.org/v3/index.json";
   nugetDeps = ./deps.json;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/Pryaxis/TShock";


### PR DESCRIPTION
Updates tshock from the 6.0.0 prerelease version to the latest 6.1.0. I also noticed that r-ryantm was failing because it wasn't refreshing `deps.json`, so I added `nix-update-script` to fix that (and tested it).

I am actively running a TShock server on a VPS using this updated package and everything seems to be working.

Resolves #501766 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
