### PR TITLE
cgt-calc: 1.14.0-unstable-2026-02-23 -> 2.0.0

### DIFF
--- a/pkgs/by-name/cg/cgt-calc/package.nix
+++ b/pkgs/by-name/cg/cgt-calc/package.nix
@@ -7,35 +7,18 @@
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "cgt-calc";
-  # Includes updates to use pyrate-limiter v4 that are not released yet
-  # unfortunately.
-  version = "1.14.0-unstable-2026-02-23";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "KapJI";
     repo = "capital-gains-calculator";
-    rev = "3326514c8e99904eeeda676948c4404da6fe1adc";
-    hash = "sha256-6iOlDNlpfCrbRCxEJsRYw6zqOehv/buVN+iU6J6CtIk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KPzADW+n82X08IMfSIl5JyYPm8fxbbowud8sBdUxRgA=";
   };
 
-  pythonRelaxDeps = [
-    # The built wheel holds an upper bound requirement for the version of these
-    # dependenceis, while pyproject.toml doesn't. Upstream's `uv.lock` even
-    # uses yfinance 1.2.0 . See:
-    # https://github.com/KapJI/capital-gains-calculator/pull/744
-    "defusedxml"
-    "yfinance"
-  ];
-  pythonRemoveDeps = [
-    # Upstream's uv.lock doesn't reference this dependency, and lists
-    # pyrate-limiter instead. The built wheel from some reason requests it
-    # never the less.
-    "requests-ratelimiter"
-  ];
-
   build-system = with python3Packages; [
-    poetry-core
+    uv-build
   ];
 
   dependencies = with python3Packages; [
@@ -46,6 +29,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pyrate-limiter
     types-requests
     yfinance
+    colorama
   ];
 
   makeWrapperArgs = lib.optionals withTeXLive [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test