### PR TITLE
buildMavenPackage: do not clobber env variables, use this to fix cryptomator env variables

### DIFF
--- a/pkgs/by-name/cr/cryptomator/package.nix
+++ b/pkgs/by-name/cr/cryptomator/package.nix
@@ -35,12 +35,11 @@ maven.buildMavenPackage rec {
   mvnParameters = "-Dmaven.test.skip=true -Plinux";
   mvnHash = "sha256-IVOcDFW5YKgUHJKX3ZXYVnOevwmOwN5yEU8jfPtCY1I=";
   mvnFetchExtraArgs.env = {
-    inherit SOURCE_DATE_EPOCH;
+    inherit (env) SOURCE_DATE_EPOCH;
   };
 
   # fix for "date 1980-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z"
-  # this should be in env, but looks like buildMavenPackage doesn't support that
-  SOURCE_DATE_EPOCH = 315532802; # 1980-01-01T00:00:02Z
+  env.SOURCE_DATE_EPOCH = 315532802; # 1980-01-01T00:00:02Z
 
   preBuild = ''
     VERSION=${version}

--- a/pkgs/by-name/ma/maven/build-maven-package.nix
+++ b/pkgs/by-name/ma/maven/build-maven-package.nix
@@ -52,7 +52,9 @@ let
       ]
       ++ args.nativeBuildInputs or [ ];
 
-      env.JAVA_HOME = mvnJdk;
+      env = mvnFetchExtraArgs.env or { } // {
+        JAVA_HOME = mvnJdk;
+      };
 
       impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 
@@ -119,7 +121,7 @@ let
       outputHashMode = "recursive";
       outputHash = mvnHash;
     }
-    // mvnFetchExtraArgs
+    // (removeAttrs mvnFetchExtraArgs [ "env" ])
   );
 in
 stdenv.mkDerivation (
@@ -131,7 +133,9 @@ stdenv.mkDerivation (
       maven
     ];
 
-    env.JAVA_HOME = mvnJdk;
+    env = args.env or { } // {
+      JAVA_HOME = mvnJdk;
+    };
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
