### PR TITLE
openvpn3: fix unused result from proto ParseString

### DIFF
--- a/pkgs/by-name/op/openvpn3/0001-handle-result-from-DcoKeyConfig_ParseFromString.patch
+++ b/pkgs/by-name/op/openvpn3/0001-handle-result-from-DcoKeyConfig_ParseFromString.patch
@@ -1,0 +1,28 @@
+From ee192f35d29ecae64dc00b4736e1870274b58cc8 Mon Sep 17 00:00:00 2001
+From: azban <me@azban.net>
+Date: Sat, 21 Mar 2026 18:41:34 -0600
+Subject: [PATCH] handle result from DcoKeyConfig_ParseFromString
+
+This previously failed with error unused-result. This checks the result and throws an exception if the parsing fails.
+---
+ src/netcfg/netcfg-dco.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/netcfg/netcfg-dco.cpp b/src/netcfg/netcfg-dco.cpp
+index 290c12a8..f41836bf 100644
+--- a/src/netcfg/netcfg-dco.cpp
++++ b/src/netcfg/netcfg-dco.cpp
+@@ -265,7 +265,9 @@ void NetCfgDCO::method_new_key(GVariant *params)
+     std::string key_config = glib2::Value::Extract<std::string>(params, 1);
+ 
+     DcoKeyConfig dco_kc;
+-    dco_kc.ParseFromString(base64->decode(key_config));
++    if (!dco_kc.ParseFromString(base64->decode(key_config))) {
++        throw NetCfgException("Failed to parse DCO key config");
++    }
+ 
+     auto copyKeyDirection = [](const DcoKeyConfig_KeyDirection &src, KoRekey::KeyDirection &dst)
+     {
+-- 
+2.51.2
+

--- a/pkgs/by-name/op/openvpn3/package.nix
+++ b/pkgs/by-name/op/openvpn3/package.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation rec {
   patches = [
     # Should be fixed in v26: https://codeberg.org/OpenVPN/openvpn3-linux/issues/70
     ./v25-latest-linux-fix.patch
+    ./0001-handle-result-from-DcoKeyConfig_ParseFromString.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
This was previously failing with an "unused-result" error. This patches that fix, and builds properly afterwards. A patch has been submitted to the development list.

Resolves #502073 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
