### PR TITLE
libsteam_api: init at 1.64

### DIFF
--- a/pkgs/by-name/li/libsteam_api/package.nix
+++ b/pkgs/by-name/li/libsteam_api/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  autoPatchelfHook,
+  writeScript,
+  requireFile,
+}:
+
+let
+  os = {
+    i686-linux = "linux32";
+    x86_64-linux = "linux64";
+    aarch64-linux = "linuxarm64";
+    x86_64-darwin = "osx";
+    aarch64-darwin = "osx";
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "libsteam_api";
+  version = "1.64";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = requireFile rec {
+    name = "steamworks_sdk_${lib.replaceString "." "" finalAttrs.version}.zip";
+    hashMode = "recursive";
+    hash = "sha256-RsUx+qKRxYDPW6BQa1QQQ4kTxpGGxyu62nu68g4VtBU=";
+    message = ''
+      Unfortunately, we cannot download file ${name} automatically
+      because it requires a logged-in Steam account.
+      Please go to https://partner.steamgames.com/downloads/list
+      to download it yourself, and add it to the Nix store using
+
+        nix-prefetch-url --type sha256 --unpack file:///path/to/${name}
+
+      Alternatively, you may use an unofficial mirror as long as
+      the hash matches, such as:
+
+        libsteam_api.overrideAttrs (prevAttrs: {
+          src = fetchFromGitHub {
+            owner = "UlyssesZh";
+            repo = "steamworks-sdk";
+            tag = "v''${prevAttrs.version}";
+            hash = prevAttrs.src.hash;
+          };
+        })
+    '';
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{include/steam,lib}
+    cp -a public/steam/*.h $out/include/steam
+    cp -a redistributable_bin/${os.${stdenvNoCC.hostPlatform.system}}/* $out/lib
+
+    runHook postInstall
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Library for interfacing with the Steamworks API";
+    homepage = "https://partner.steamgames.com/doc/sdk";
+    license = lib.licenses.unfreeRedistributable // {
+      fullName = "Valve Corporation Steamworks SDK Access Agreement";
+      shortName = "valveSDKLicense";
+      url = "https://partner.steamgames.com/documentation/sdk_access_agreement";
+    };
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    platforms = builtins.attrNames os;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
+  };
+})

--- a/pkgs/by-name/li/libsteam_api/update.sh
+++ b/pkgs/by-name/li/libsteam_api/update.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix-prefetch-git
+
+set -euo pipefail
+
+attr() {
+  nix-instantiate --eval --raw --attr "libsteam_api.$1"
+}
+
+githubMirror="UlyssesZh/steamworks-sdk"
+
+tag="$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} https://api.github.com/repos/$githubMirror/tags \
+  | jq -r 'map(.name)[]' | sort -V | tail -n 1)"
+
+version="${tag#v}"
+oldVersion="$(attr version)"
+if [[ "$version" == "$oldVersion" ]]; then
+  echo "Already up to date ($version)" >&2
+  exit 0
+fi
+
+nixFile="$(attr meta.position | cut -d : -f 1)"
+sed -i -E "s|version = \"[^\"]\";|version = \"$version\";|" "$nixFile"
+
+hash="$(nix-prefetch-git "https://github.com/$githubMirror.git" "$tag" --name "$(attr src.name)" | jq -r .hash)"
+sed -i -E "s|hash = \"[^\"]\";|hash = \"$hash\";|" "$nixFile"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

With this package, the library can be reusable for some other packages:
- arma3-unix-launcher
- ddnet
- keeperrl (after #502113)
- quaver (after #497714)
- rimsort
- samira
- taterclient-ddnet

Notice that the URLs `https://partner.steamgames.com/downloads/steamworks_sdk{,_164}.zip` can (by "can", I mean it is literally random) return 302 instead of 200 without cookies, so it is a bit of a pain. The URL without the version number is especially unreliable, but the URL with the version number can get 200 by about 1/3 chance. I do not know how to handle this better. Even Wayback Machine is not a good solution: it may archive the 302 redirection instead of the actual zip, and this URL can only be requested for archiving once a day. ~~One possible solution is to use the **unofficial** [mirror](https://github.com/rlabrecque/SteamworksSDK) on GitHub, which seems to be trustworthy (the owner of the repo is the developer of Steamworks.NET). We may at least use it in the update script if not as the package source.~~ I made my own [mirror](https://github.com/UlyssesZh/steamworks-sdk).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
