### PR TITLE
claude-desktop: init at 1.20186.1

### DIFF
--- a/pkgs/by-name/cl/claude-desktop/package.nix
+++ b/pkgs/by-name/cl/claude-desktop/package.nix
@@ -11,12 +11,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "claude-desktop";
-  version = "1.1.7714";
-  release = "3bd6f69326a0abac98bb269c29140e2a543cad64";
+  version = "1.20186.1";
+  release = "df1d8a339dfabcf359af7144fe142b59ff7d9a0f";
+  __structuredAttrs = true;
 
   src = fetchurl {
     url = "https://downloads.claude.ai/releases/darwin/universal/${finalAttrs.version}/Claude-${finalAttrs.release}.zip";
-    hash = "sha256-JeT0NYGteP0eU0/7AYaN9px4dpu4PiQkecg4WxN4RE4=";
+    hash = "sha256-JQYp6pXMlcDbRpYqwzCVw/ILGndqquTfeqUflhceeGY=";
   };
 
   dontUnpack = true;

--- a/pkgs/by-name/cl/claude-desktop/package.nix
+++ b/pkgs/by-name/cl/claude-desktop/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+  makeBinaryWrapper,
+  versionCheckHook,
+  writeShellScript,
+  xcbuild,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "claude-desktop";
+  version = "1.1.7714";
+  release = "3bd6f69326a0abac98bb269c29140e2a543cad64";
+
+  src = fetchurl {
+    url = "https://downloads.claude.ai/releases/darwin/universal/${finalAttrs.version}/Claude-${finalAttrs.release}.zip";
+    hash = "sha256-JeT0NYGteP0eU0/7AYaN9px4dpu4PiQkecg4WxN4RE4=";
+  };
+
+  dontUnpack = true;
+  # Keep upstream app bundle as-is.
+  dontFixup = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    unzip
+    makeBinaryWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    unzip -q "$src"
+
+    mkdir -p "$out/Applications"
+    cp -R "Claude.app" "$out/Applications/Claude.app"
+
+    # Nix-managed installs are immutable, so disable the app's self-updater.
+    makeBinaryWrapper "$out/Applications/Claude.app/Contents/MacOS/Claude" "$out/bin/claude-desktop" \
+      --set DISABLE_AUTOUPDATER 1
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = writeShellScript "version-check" ''
+    ${xcbuild}/bin/PlistBuddy -c "Print :CFBundleShortVersionString" "$1"
+  '';
+  versionCheckProgramArg = [ "${placeholder "out"}/Applications/Claude.app/Contents/Info.plist" ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Anthropic's official Claude AI desktop app";
+    homepage = "https://claude.com/download";
+    downloadPage = "https://claude.com/download";
+    changelog = "https://downloads.claude.ai/releases/darwin/universal/RELEASES.json";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ IanHollow ];
+    platforms = lib.platforms.darwin;
+    mainProgram = "claude-desktop";
+  };
+})

--- a/pkgs/by-name/cl/claude-desktop/update.sh
+++ b/pkgs/by-name/cl/claude-desktop/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq openssl gnused common-updater-scripts
+# shellcheck shell=bash
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+nixpkgs_root=$(git -C "$script_dir" rev-parse --show-toplevel)
+
+releases_url="https://downloads.claude.ai/releases/darwin/universal/RELEASES.json"
+package_file="$nixpkgs_root/pkgs/by-name/cl/claude-desktop/package.nix"
+
+release_data=$(curl --silent --show-error --fail "$releases_url")
+
+version=$(jq -er '.currentRelease' <<<"$release_data")
+url=$(jq -er --arg version "$version" '.releases[] | select(.version == $version) | .updateTo.url' <<<"$release_data")
+
+[[ -n "$url" ]]
+
+release=$(sed -E 's|.*/Claude-([0-9a-f]+)\.zip$|\1|' <<<"$url")
+if ! [[ "$release" =~ ^[0-9a-f]+$ ]]; then
+  echo "Could not extract release hash from URL: $url" >&2
+  exit 1
+fi
+
+hash="sha256-$(curl --silent --show-error --fail --location "$url" | openssl dgst -sha256 -binary | openssl base64)"
+
+sed -i -E \
+  's|(release = )"[0-9a-f]+";|\1"'"$release"'";|' \
+  "$package_file"
+
+update-source-version claude-desktop "$version" "$hash" --file="$package_file"


### PR DESCRIPTION
## Summary
- Add `claude-desktop`, Anthropic's official Claude Desktop app for macOS, packaged from the upstream universal release archive.
- Install `Claude.app` into `$out/Applications`, expose `claude-desktop` in `$out/bin`, and disable in-app auto-update for immutable Nix installs.
- Add `versionCheckHook` plist validation and an external `update.sh` (nix-shell shebang) that updates `version`, `release`, and source hash from upstream `RELEASES.json`.
- Set `meta.maintainers = [ ianhollow ]`.

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test