### PR TITLE
mpdscribble: 0.24 -> 0.25

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14709,6 +14709,14 @@
     github = "kxxt";
     githubId = 18085551;
   };
+  kybe236 = {
+    name = "kybe236";
+    github = "kybe236";
+    githubId = 118068228;
+    email = "kybe@kybe.xyz";
+    matrix = "@kybe:kybe.xyz";
+    keys = [ { fingerprint = "4B20 67C3 BD6D 410F 13E5  36A3 43CE 4393 8A3C 7A8F"; } ];
+  };
   kyehn = {
     name = "kyehn";
     github = "kyehn";

--- a/pkgs/by-name/mp/mpdscribble/package.nix
+++ b/pkgs/by-name/mp/mpdscribble/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   pkg-config,
   meson,
   ninja,
@@ -15,20 +14,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mpdscribble";
-  version = "0.24";
+  version = "0.25";
 
   src = fetchurl {
     url = "https://www.musicpd.org/download/mpdscribble/${finalAttrs.version}/mpdscribble-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-9rTLp0izuH5wUnC0kjyOI+lMLgD+3VC+sUaNvi+yqOc=";
+    sha256 = "sha256-IPidlFv1F8TWi/d6d6NZ/bE4QqsSlejSHtp5vitbNc4=";
   };
 
-  # Fix build issue on darwin; to be removed after the next release
-  patches = [
-    (fetchpatch {
-      name = "remove-empty-static-lib.patch";
-      url = "https://github.com/MusicPlayerDaemon/mpdscribble/commit/0dbcea25c81f3fdc608f71ef71a9784679fee17f.patch";
-      sha256 = "sha256-3wLfQvbwx+OFrCl5vMV7Zps4e4iEYFhqPiVCo5hDqgw=";
-    })
+  mesonFlags = [
+    (lib.mesonOption "systemd_user_unit_dir" "etc/systemd/user")
+    (lib.mesonOption "systemd_system_unit_dir" "etc/systemd/system")
   ];
 
   postPatch = ''

--- a/pkgs/by-name/mp/mpdscribble/package.nix
+++ b/pkgs/by-name/mp/mpdscribble/package.nix
@@ -47,7 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "MPD client which submits info about tracks being played to a scrobbler";
     homepage = "https://www.musicpd.org/clients/mpdscribble/";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.sohalt ];
+    maintainers = [
+      lib.maintainers.sohalt
+      lib.maintainers.kybe236
+    ];
     platforms = lib.platforms.unix;
     mainProgram = "mpdscribble";
   };


### PR DESCRIPTION
Diff: https://github.com/MusicPlayerDaemon/mpdscribble/compare/v0.24...v0.25
Also added myself as a maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
