### PR TITLE
uucp: fix build with GCC 14+/15+

### DIFF
--- a/pkgs/by-name/uu/uucp/package.nix
+++ b/pkgs/by-name/uu/uucp/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchDebianPatch,
   autoreconfHook,
   testers,
 }:
@@ -22,14 +23,28 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace Makefile.am \
       --replace-fail 4555 0555
     sed -i '/chown $(OWNER)/d' Makefile.am
-
-    # don't reply on implicitly defined `exit` function in `HAVE_VOID` test:
-    substituteInPlace configure.in \
-      --replace-fail '(void) exit (0)' '(void) (0)'
   '';
 
   patches = [
     ./socklen_t.patch
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname version;
+      debianRevision = "31";
+      patch = "configure.patch";
+      hash = "sha256-6Aqghz6P+bWULHOXCQIdQLRuaE+Lci7t5ojQXJOyeA0=";
+    })
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname version;
+      debianRevision = "31";
+      patch = "implicit.patch";
+      hash = "sha256-EsJqZCV4x7ggzpoa4OaibCLvF8L8FGGnLlBtr4Cee18=";
+    })
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname version;
+      debianRevision = "31";
+      patch = "gcc15.patch";
+      hash = "sha256-+9H/gQLwkPx4GeWiZyy6oQdysvw2+P1O8wP5It/Tg5k=";
+    })
   ];
 
   # Regenerate `configure`; the checked in version was generated in 2002 and


### PR DESCRIPTION
Resolves #481698

uucp doesn't build with modern GCC. The 2003-era source uses K&R-style `extern int strcmp ()` declarations that conflict with glibc's proper prototypes, which GCC 14+ treats as hard errors.

Applied three patches from Debian's uucp 1.07-31 using `fetchDebianPatch`:
- `configure.patch`: adds missing includes to autoconf tests (replaces the old `prePatch` workaround for `exit`)
- `implicit.patch`: adds `sys/types.h` and `sys/wait.h` to `unix/pipe.c` for `waitpid`
- `gcc15.patch`: comments out the K&R extern declarations across 15 source files

Kept the existing socklen_t.patch. Debian's `gcc14.patch` was skipped because it depends on another Debian patch (`improved-pipe.patch`) we don't carry.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
