### PR TITLE
dcpj785dw{lpr,-cupswrapper}: init at 1.0.0_0

### DIFF
--- a/pkgs/misc/cups/drivers/brother/dcpj785dw/default.nix
+++ b/pkgs/misc/cups/drivers/brother/dcpj785dw/default.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  cups,
+  dpkg,
+  gnused,
+  makeWrapper,
+  ghostscript,
+  file,
+  a2ps,
+  coreutils,
+  gnugrep,
+  which,
+  gawk,
+  pkgsi686Linux,
+}:
+
+let
+  version = "1.0.0_0";
+  model = "dcpj785dw";
+in
+{
+  driver = stdenv.mkDerivation {
+    pname = "${model}-lpr";
+    inherit version;
+
+    src = fetchurl {
+
+      url = "https://download.brother.com/welcome/dlf102774/${model}lpr-1.0.0-0.i386.deb";
+      sha256 = "sha256-EXUN69YJEz1M0ADEF+0uZ+hdMgIiXChwtf+NzeFk7j0=";
+    };
+
+    nativeBuildInputs = [
+      dpkg
+      makeWrapper
+    ];
+    buildInputs = [
+      cups
+      ghostscript
+      a2ps
+      gawk
+    ];
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      substituteInPlace $out/opt/brother/Printers/${model}/lpd/filter${model} \
+      --replace /opt "$out/opt"
+
+      patchelf --set-interpreter ${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2 $out/opt/brother/Printers/${model}/lpd/br${model}filter
+
+      mkdir -p $out/lib/cups/filter/
+      ln -s $out/opt/brother/Printers/${model}/lpd/filter${model} $out/lib/cups/filter/brother_lpdwrapper_${model}
+
+      wrapProgram $out/opt/brother/Printers/${model}/lpd/filter${model} \
+        --prefix PATH ":" ${
+          lib.makeBinPath [
+            gawk
+            ghostscript
+            a2ps
+            file
+            gnused
+            gnugrep
+            coreutils
+            which
+          ]
+        } \
+        --set LD_PRELOAD ${pkgsi686Linux.libredirect}/lib/libredirect.so \
+        --set NIX_REDIRECTS /opt/=$out/opt/
+    '';
+
+    meta = {
+      homepage = "http://www.brother.com/";
+      description = "Brother ${model} printer driver";
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      license = lib.licenses.unfree;
+      platforms = lib.platforms.linux;
+      downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=gb&lang=en&prod=${model}_all&os=128";
+      maintainers = with lib.maintainers; [ marcovergueira ];
+    };
+  };
+
+  cupswrapper = stdenv.mkDerivation {
+    pname = "${model}-cupswrapper";
+    inherit version;
+
+    src = fetchurl {
+      url = "https://download.brother.com/welcome/dlf102775/${model}cupswrapper-1.0.0-0.i386.deb";
+      sha256 = "sha256-JrYn9UlQr48HlETUmsNRq4oNPwtSiTFCsOuPMJ2kzSU=";
+    };
+
+    nativeBuildInputs = [
+      dpkg
+      makeWrapper
+    ];
+    buildInputs = [
+      cups
+      ghostscript
+      a2ps
+      gawk
+    ];
+    unpackPhase = "dpkg-deb -x $src $out";
+
+    installPhase = ''
+      for f in $out/opt/brother/Printers/${model}/cupswrapper/cupswrapper${model}; do
+        wrapProgram $f --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            ghostscript
+            gnugrep
+            gnused
+          ]
+        }
+      done
+
+      mkdir -p $out/share/cups/model
+      ln -s $out/opt/brother/Printers/${model}/cupswrapper/brother_${model}_printer_en.ppd $out/share/cups/model/
+    '';
+
+    meta = {
+      homepage = "http://www.brother.com/";
+      description = "Brother ${model} printer CUPS wrapper driver";
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      license = lib.licenses.unfree;
+      platforms = lib.platforms.linux;
+      downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=gb&lang=en&prod=${model}_all&os=128";
+      maintainers = with lib.maintainers; [ lewo ];
+    };
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11935,6 +11935,10 @@ with pkgs;
 
   dcp9020cdw-cupswrapper = (callPackage ../misc/cups/drivers/brother/dcp9020cdw { }).cupswrapper;
 
+  dcpj785dw = (pkgsi686Linux.callPackage ../misc/cups/drivers/brother/dcpj785dw { }).driver;
+
+  dcpj785dw-cupswrapper = (callPackage ../misc/cups/drivers/brother/dcpj785dw { }).cupswrapper;
+
   cups-brother-hl1110 = pkgsi686Linux.callPackage ../misc/cups/drivers/hl1110 { };
 
   cups-brother-hl1210w = pkgsi686Linux.callPackage ../misc/cups/drivers/hl1210w { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I'm using this patch with the Brother printer dcpj785dw and it is working. The main issue is that `/opt` is hardcoded in the binary provided by Brother. Thx to libredirect, this path is patched at runtime.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
