### PR TITLE
talosctl-oidc: init at 0.0.3

### DIFF
--- a/pkgs/by-name/ta/talosctl-oidc/package.nix
+++ b/pkgs/by-name/ta/talosctl-oidc/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "talosctl-oidc";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "qjoly";
+    repo = "talosctl-oidc";
+    rev = "v${version}";
+    hash = "sha256-U4y9cKjspXwxOBdYad3NiDfZmmnVSoyIURy0uF+8fqM=";
+  };
+
+  vendorHash = "sha256-hpQ+Bvppu+8x8+Fd/y6A47E4zgBNx/ZK74Z7ZI/aW8o=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+    "-X main.commit=v${version}"
+    "-X main.date=unknown"
+  ];
+
+  meta = with lib; {
+    description = "OIDC certificate exchange server and client for Talos Linux";
+    homepage = "https://github.com/qjoly/talosctl-oidc";
+    changelog = "https://github.com/qjoly/talosctl-oidc/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ qjoly ];
+    mainProgram = "talosctl-oidc";
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
