### PR TITLE
serious-sam-class-vulkan: fix build with xcb build input

### DIFF
--- a/pkgs/by-name/se/serious-sam-classic-vulkan/package.nix
+++ b/pkgs/by-name/se/serious-sam-classic-vulkan/package.nix
@@ -1,4 +1,5 @@
 {
+  libxcb,
   serious-sam-classic,
   vulkan-headers,
   vulkan-loader,
@@ -11,7 +12,10 @@ serious-sam-classic.overrideAttrs (oldAttrs: {
     hash = "sha256-fnWJOmgaW4/PfrmXiN7qodHEXc96/AZCbUo3dwelY6s=";
   };
 
-  nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ vulkan-headers ];
+  nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [
+    libxcb
+    vulkan-headers
+  ];
 
   buildInputs = oldAttrs.buildInputs ++ [ vulkan-loader ];
 })


### PR DESCRIPTION
This was failing because vulkan-headers now requires xcb headers to be imported.

Resolves #502135 

This is also failing on stable, so maybe needs a backport.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
