### PR TITLE
guile-json-rpc: 0.5.0 -> 0.6.1 and deps

### DIFF
--- a/pkgs/by-name/gu/guile-irregex/package.nix
+++ b/pkgs/by-name/gu/guile-irregex/package.nix
@@ -7,11 +7,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "guile-irregex";
-  version = "0.9.11";
+  version = "0.9.12";
 
   src = fetchzip {
     url = "https://synthcode.com/scheme/irregex/irregex-${finalAttrs.version}.tar.gz";
-    hash = "sha256-abBCMNsr6GTBOm+eQWuOX8JYx/qMA/V6TwGdYRjznWU=";
+    hash = "sha256-Iwt6mdgp5d0q2hweU2+9dPLs8j4Jd4GOdZvfvTe8Uvw=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/gu/guile-json-rpc/package.nix
+++ b/pkgs/by-name/gu/guile-json-rpc/package.nix
@@ -9,13 +9,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "guile-json-rpc";
-  version = "0.5.0";
+  version = "0.6.1";
 
   src = fetchFromCodeberg {
     owner = "rgherdt";
     repo = "scheme-json-rpc";
     tag = finalAttrs.version;
-    hash = "sha256-xCykgq0L6PDqjXfNwsqV9u1nFiK9t+qCUgIgzZoIsxc=";
+    hash = "sha256-3Wb3ZtcFQCOESe0Yq4cEG2jJ4+dOjlf9LKrclHhpkbU=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/gu/guile-srfi-145/package.nix
+++ b/pkgs/by-name/gu/guile-srfi-145/package.nix
@@ -7,13 +7,13 @@
 }:
 stdenv.mkDerivation {
   pname = "guile-srfi-145";
-  version = "0-unstable-2023-06-04";
+  version = "0-unstable-2025-08-11";
 
   src = fetchFromCodeberg {
     owner = "rgherdt";
     repo = "srfi";
-    rev = "e598c28eb78e9c3e44f5c3c3d997ef28abb6f32e";
-    hash = "sha256-kvM2v/nDou0zee4+qcO5yN2vXt2y3RUnmKA5S9iKFE0=";
+    rev = "1f78a684e73c8d82fdd116716e341bc177e8d229";
+    hash = "sha256-mVIAg3QrH6+0VFWZ22KHGhxMn8lRYHj154b7YQf+maE=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/gu/guile-srfi-180/package.nix
+++ b/pkgs/by-name/gu/guile-srfi-180/package.nix
@@ -7,13 +7,13 @@
 }:
 stdenv.mkDerivation {
   pname = "guile-srfi-180";
-  version = "0-unstable-2023-06-04";
+  version = "0-unstable-2025-08-11";
 
   src = fetchFromCodeberg {
     owner = "rgherdt";
     repo = "srfi";
-    rev = "e598c28eb78e9c3e44f5c3c3d997ef28abb6f32e";
-    hash = "sha256-kvM2v/nDou0zee4+qcO5yN2vXt2y3RUnmKA5S9iKFE0=";
+    rev = "1f78a684e73c8d82fdd116716e341bc177e8d229";
+    hash = "sha256-mVIAg3QrH6+0VFWZ22KHGhxMn8lRYHj154b7YQf+maE=";
   };
 
   strictDeps = true;
@@ -46,8 +46,7 @@ stdenv.mkDerivation {
     mkdir -p $site_dir/srfi
     cp $src/srfi/srfi-180.scm $site_dir/srfi
     cp -R $src/srfi/srfi-180/ $site_dir/srfi
-    cp -R $src/srfi/180/ $site_dir/srfi
-    guild compile -x "sld" --r7rs $site_dir/srfi/srfi-180/helpers.sld -o $lib_dir/srfi/srfi-180/helpers.go
+    guild compile --r7rs $site_dir/srfi/srfi-180/helpers.scm -o $lib_dir/srfi/srfi-180/helpers.go
     guild compile --r7rs $site_dir/srfi/srfi-180.scm -o $lib_dir/srfi/srfi-180.go
 
     runHook postBuild


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Supersedes https://github.com/NixOS/nixpkgs/pull/502035