### PR TITLE
python3Packages.exiv2: 0.18.0 -> 0.18.1; several improvements

### DIFF
--- a/pkgs/development/python-modules/exiv2/default.nix
+++ b/pkgs/development/python-modules/exiv2/default.nix
@@ -10,7 +10,7 @@
   toml,
   pytestCheckHook,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "exiv2";
   version = "0.18.1";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "jim-easterbrook";
     repo = "python-exiv2";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-3r0qGsCkfe2sQuXiCipXzW0vF2JRg77L1IcOiLTPslM=";
   };
 
@@ -41,8 +41,8 @@ buildPythonPackage rec {
   meta = {
     description = "Low level Python interface to the Exiv2 C++ library";
     homepage = "https://github.com/jim-easterbrook/python-exiv2";
-    changelog = "https://github.com/jim-easterbrook/python-exiv2/blob/${src.tag}/CHANGELOG.txt";
+    changelog = "https://github.com/jim-easterbrook/python-exiv2/blob/${finalAttrs.src.tag}/CHANGELOG.txt";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ zebreus ];
   };
-}
+})

--- a/pkgs/development/python-modules/exiv2/default.nix
+++ b/pkgs/development/python-modules/exiv2/default.nix
@@ -9,31 +9,18 @@
   setuptools,
   toml,
   pytestCheckHook,
-  fetchpatch,
 }:
 buildPythonPackage rec {
   pname = "exiv2";
-  version = "0.18.0";
+  version = "0.18.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jim-easterbrook";
     repo = "python-exiv2";
     tag = version;
-    hash = "sha256-lYz0TWiiBtpwZ56Oiy2v8DFBXoofMv60hxsG0q7Cx9Y=";
+    hash = "sha256-3r0qGsCkfe2sQuXiCipXzW0vF2JRg77L1IcOiLTPslM=";
   };
-
-  patches = [
-    # Disable refcount tests for python >= 3.14
-    (fetchpatch {
-      url = "https://github.com/jim-easterbrook/python-exiv2/commit/fe98ad09ff30f1b6cc5fd5dcc0769f9505c09166.patch";
-      hash = "sha256-+KepYfzocG6qkak+DwXFtCaMiLEAE+FegONgL4vo21o=";
-    })
-    (fetchpatch {
-      url = "https://github.com/jim-easterbrook/python-exiv2/commit/e0a5284620e8d020771bf8c1fa73d6113e662ebf.patch";
-      hash = "sha256-n/yfhP/Z4Is/+2bKsFZtcNXnQe61DjoE9Ryi2q9yTSA=";
-    })
-  ];
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/exiv2/default.nix
+++ b/pkgs/development/python-modules/exiv2/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
   meta = {
     description = "Low level Python interface to the Exiv2 C++ library";
     homepage = "https://github.com/jim-easterbrook/python-exiv2";
-    changelog = "https://python-exiv2.readthedocs.io/en/release-${src.tag}/misc/changelog.html";
+    changelog = "https://github.com/jim-easterbrook/python-exiv2/blob/${src.tag}/CHANGELOG.txt";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ zebreus ];
   };


### PR DESCRIPTION
- Update from version 0.18.0 to 0.18.1
  - Changelog: https://github.com/jim-easterbrook/python-exiv2/blob/0.18.1/CHANGELOG.txt
  - Diff: https://github.com/jim-easterbrook/python-exiv2/compare/0.18.0...0.18.1
- This update also fixes the build of `python3{13,14}Packages.exiv2`
  - Hydra: https://hydra.nixos.org/build/324590219/nixlog/1, https://hydra.nixos.org/build/324630240/nixlog/1
  - Tracking: #475732
- Fix `meta.changelog` (404 with old URL)
- Use `finalAttrs`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.exiv2`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
