### PR TITLE
python314Packages.eliot: fix build

### DIFF
--- a/pkgs/development/python-modules/eliot/default.nix
+++ b/pkgs/development/python-modules/eliot/default.nix
@@ -37,6 +37,11 @@ buildPythonPackage rec {
     hash = "sha256-x6zonKL6Ys1fyUjyOgVgucAN64Dt6dCzdBrxRZa+VDQ=";
   };
 
+  patches = [
+    # Upstream PR: https://github.com/itamarst/eliot/pull/520
+    ./python-3.14.patch
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/eliot/python-3.14.patch
+++ b/pkgs/development/python-modules/eliot/python-3.14.patch
@@ -1,0 +1,23 @@
+From a5fc2936e8e13ebb73de4254234ca4d6ead15d1e Mon Sep 17 00:00:00 2001
+From: Itamar Turner-Trauring <itamar@pythonspeed.com>
+Date: Sun, 18 Jan 2026 14:15:02 -0500
+Subject: [PATCH] Pass tests for 3.14.
+
+---
+ eliot/tests/test_coroutines.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/eliot/tests/test_coroutines.py b/eliot/tests/test_coroutines.py
+index 39c5496c..cb2c1b13 100644
+--- a/eliot/tests/test_coroutines.py
++++ b/eliot/tests/test_coroutines.py
+@@ -34,7 +34,8 @@ def run_coroutines(*async_functions):
+     """
+     Run a coroutine until it finishes.
+     """
+-    loop = asyncio.get_event_loop()
++    loop = asyncio.new_event_loop()
++    asyncio.set_event_loop(loop)
+     futures = [asyncio.ensure_future(f()) for f in async_functions]
+ 
+     async def wait_for_futures():


### PR DESCRIPTION
Upstream PR: https://github.com/itamarst/eliot/pull/520

Hydra: https://hydra.nixos.org/build/324629795/nixlog/1
Tracking: #475732

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.eliot`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
