### PR TITLE
ardopc: fix broken homepage link

### DIFF
--- a/pkgs/by-name/ar/ardopc/package.nix
+++ b/pkgs/by-name/ar/ardopc/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "ARDOP (Amateur Radio Digital Open Protocol) TNC implementation by John Wiseman (GM8BPQ)";
-    homepage = "https://github.com/hamarituc/ardop/ARDOPC";
+    homepage = "https://github.com/hamarituc/ardop";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ oliver-koss ];
     mainProgram = "ardopc";


### PR DESCRIPTION
The homepage URL was pointing to `https://github.com/hamarituc/ardop/ARDOPC`, which returns a 404 since there's no such path in the repository. Updated to the correct repository root URL.

Ref #60004