### PR TITLE
antigen: fix broken homepage link

### DIFF
--- a/pkgs/by-name/an/antigen/package.nix
+++ b/pkgs/by-name/an/antigen/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Plugin manager for zsh";
-    homepage = "https://antigen.sharats.me/";
+    homepage = "https://github.com/zsh-users/antigen";
     license = lib.licenses.mit;
   };
 })


### PR DESCRIPTION
The previous homepage at `https://antigen.sharats.me/` has an expired SSL certificate and is no longer accessible. Updated to the GitHub repository URL, which is where the source is hosted and releases are published from.

Ref #60004