### PR TITLE
amtterm: fix broken homepage link

### DIFF
--- a/pkgs/by-name/am/amtterm/package.nix
+++ b/pkgs/by-name/am/amtterm/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Intel AMT® SoL client + tools";
-    homepage = "https://www.kraxel.org/cgit/amtterm/";
+    homepage = "https://github.com/kraxel/amtterm";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
The previous homepage at `https://www.kraxel.org/cgit/amtterm/` returns a 404. The package source is already fetched from the GitHub mirror at `kraxel/amtterm`, so this updates the homepage to point there instead.

Ref #60004