### PR TITLE
azahar: Fix packaging issues on MacOS

### DIFF
--- a/pkgs/by-name/az/azahar/package.nix
+++ b/pkgs/by-name/az/azahar/package.nix
@@ -46,6 +46,7 @@
   gamemode,
   enableGamemode ? lib.meta.availableOn stdenv.hostPlatform gamemode,
   nix-update-script,
+  darwinMinVersionHook,
 }:
 let
   inherit (lib)
@@ -120,6 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ optionals stdenv.hostPlatform.isDarwin [
     moltenvk
+    (darwinMinVersionHook "13.4")
   ];
 
   postPatch = ''

--- a/pkgs/by-name/az/azahar/package.nix
+++ b/pkgs/by-name/az/azahar/package.nix
@@ -156,6 +156,9 @@ stdenv.mkDerivation (finalAttrs: {
     qtWrapperArgs+=(
       --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}"
       --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}"
+      ${optionalString stdenv.isDarwin "--prefix DYLD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [ moltenvk ]
+      }"}
     )
   '';
 

--- a/pkgs/by-name/az/azahar/package.nix
+++ b/pkgs/by-name/az/azahar/package.nix
@@ -145,6 +145,13 @@ stdenv.mkDerivation (finalAttrs: {
     (cmakeBool "ENABLE_SSE42" enableSSE42)
   ];
 
+  installPhase = optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications $out/bin
+
+    cp ./bin/Release/${finalAttrs.pname}-room $out/bin
+    cp -r ./bin/Release/${finalAttrs.pname}.app $out/Applications
+  '';
+
   preFixup = ''
     qtWrapperArgs+=(
       --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}"

--- a/pkgs/by-name/az/azahar/package.nix
+++ b/pkgs/by-name/az/azahar/package.nix
@@ -148,10 +148,14 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   installPhase = optionalString stdenv.isDarwin ''
+    runHook preInstall
+
     mkdir -p $out/Applications $out/bin
 
     cp ./bin/Release/${finalAttrs.pname}-room $out/bin
     cp -r ./bin/Release/${finalAttrs.pname}.app $out/Applications
+
+    runHook postInstall
   '';
 
   preFixup = ''


### PR DESCRIPTION
This package was empty on MacOS beforehand, and failed to load Vulkan when this was fixed. This PR both issues with two commits.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
