### PR TITLE
borgmatic: 2.1.3 -> 2.5.1; upstream fixes for tests using hardcoded /tmp/ paths

### DIFF
--- a/pkgs/by-name/bo/borgmatic/package.nix
+++ b/pkgs/by-name/bo/borgmatic/package.nix
@@ -35,9 +35,14 @@ python3Packages.buildPythonApplication rec {
     ++ optional-dependencies.apprise;
 
   # - test_borgmatic_version_matches_news_version
-  # The file NEWS not available on the pypi source, and this test is useless
+  #   NEWS file not available on the pypi source
+  # - test_log_outputs_includes_error_output_in_exception
+  #   TOCTOU race in log_outputs(): process.poll() returns None in
+  #   raise_for_process_errors but non-None in the while-loop exit check,
+  #   so the error is never raised. Timing-dependent; fails on x86_64-darwin.
   disabledTests = [
     "test_borgmatic_version_matches_news_version"
+    "test_log_outputs_includes_error_output_in_exception"
   ];
 
   nativeBuildInputs = [ installShellFiles ];

--- a/pkgs/by-name/bo/borgmatic/package.nix
+++ b/pkgs/by-name/bo/borgmatic/package.nix
@@ -15,12 +15,12 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "borgmatic";
-  version = "2.1.3";
+  version = "2.1.5";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-mWZQBoQUd+cwOV3QU62XyTCFdFpnBz2BsyImzVAozJE=";
+    hash = "sha256-T0+E6opyfr7zxfP44OlNuhqsdQyi7OdIXiE5r310LaU=";
   };
 
   passthru.updateScript = nix-update-script { };
@@ -31,6 +31,7 @@ python3Packages.buildPythonApplication rec {
       flexmock
       pytestCheckHook
       pytest-cov-stub
+      pytest-timeout
     ]
     ++ optional-dependencies.apprise;
 


### PR DESCRIPTION
This update brings in fixes merged upstream (https://projects.torsion.org/borgmatic-collective/borgmatic/pulls/1296) for tests which write to hardcoded `/tmp` paths; these would fail in multi-user build environments (e.g. Nix with `_nixbld1`–`_nixbld32`): stale files owned by one build user cause `PermissionError` for subsequent
builds assigned a different user (sticky bit on `/tmp/` prevents deletion by non-owners).

This update also disables a test with a TOCTOU race observed on `x86_64-darwin`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test