### PR TITLE
gexiv2_0_16: init at 0.16.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -277,6 +277,12 @@
     githubId = 92977828;
     name = "Mori Zen";
   };
+  _7591yj = {
+    email = "yeongjin.kim@proton.me";
+    github = "7591yj";
+    githubId = 77034308;
+    name = "Yeongjin Kim";
+  };
   _7karni = {
     email = "7karni@proton.me";
     name = "7karni";

--- a/pkgs/by-name/ge/gexiv2_0_16/package.nix
+++ b/pkgs/by-name/ge/gexiv2_0_16/package.nix
@@ -1,0 +1,90 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  meson,
+  mesonEmulatorHook,
+  ninja,
+  pkg-config,
+  exiv2,
+  glib,
+  gobject-introspection,
+  vala,
+  gi-docgen,
+  python3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gexiv2";
+  __structuredAttrs = true;
+  strictDeps = true;
+  version = "0.16.0";
+
+  outputs = [
+    "out"
+    "dev"
+    "devdoc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/gexiv2/${lib.versions.majorMinor finalAttrs.version}/gexiv2-${finalAttrs.version}.tar.xz";
+    sha256 = "2W+JXyRTn5ZvV3srskia6E+CMpcKjQwGTkoAdHSne7s=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+    vala
+    gi-docgen
+    (python3.pythonOnBuildForHost.withPackages (ps: [ ps.pygobject3 ]))
+  ]
+  ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    mesonEmulatorHook
+  ];
+
+  buildInputs = [
+    glib
+    gi-docgen
+  ];
+
+  propagatedBuildInputs = [
+    exiv2
+  ];
+
+  mesonFlags = [
+    "-Dgtk_doc=true"
+    "-Dtests=true"
+  ];
+
+  doCheck = true;
+
+  preCheck =
+    let
+      libName = if stdenv.hostPlatform.isDarwin then "libgexiv2-0.16.4.dylib" else "libgexiv2-0.16.so.4";
+    in
+    ''
+      # Our gobject-introspection patches make the shared library paths absolute
+      # in the GIR files. When running unit tests, the library is not yet installed,
+      # though, so we need to replace the absolute path with a local one during build.
+      # We are using a symlink that will be overridden during installation.
+      mkdir -p $out/lib
+      ln -s $PWD/gexiv2/${libName} $out/lib/${libName}
+      export GI_TYPELIB_PATH=$PWD/gexiv2
+    '';
+
+  postFixup = ''
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
+  '';
+
+  meta = {
+    homepage = "https://gitlab.gnome.org/GNOME/gexiv2";
+    description = "GObject wrapper around the Exiv2 photo metadata library";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    teams = [ lib.teams.gnome ];
+    maintainers = [ lib.maintainers._7591yj ];
+  };
+})


### PR DESCRIPTION
Upstream changelog: https://gitlab.gnome.org/GNOME/gexiv2/-/blob/master/NEWS

This PR adds a new package alongside `gexiv2` (0.14.x) due to API break, as suggested in #501263 
The `pkgconfig` file changed from `gexiv2.pc` to `gexiv2-0.16.pc`, breaking downstream reverse dependencies

Packaging changes from `gexiv2`:
- switched doc toolchain from `gtk-doc`/`docbook-xsl-nons`/`docbook_xml_dtd_43` to `gi-docgen`
- fixed library symlink name in `preCheck` to match new SONAME (`libgexiv2-0.16.so.4`)
- added `GI_TYPELIB_PATH` export in `preCheck`                                    
- added `postFixup` to correctly place docs into `$devdoc`

verified `.pc` file (`gexiv2-0.16.pc`) and `.so` present in output.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
