### PR TITLE
yaralyzer: relax dependency rich

### DIFF
--- a/pkgs/by-name/ya/yaralyzer/package.nix
+++ b/pkgs/by-name/ya/yaralyzer/package.nix
@@ -27,6 +27,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     yara-python
   ];
 
+  pythonRelaxDeps = [ "rich" ];
+
   pythonImportsCheck = [ "yaralyzer" ];
 
   passthru = {


### PR DESCRIPTION
fixes https://hydra.nixos.org/build/324355902

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 502201`
Commit: `ba1638e7aff5e3e16089b2c86f3d054ce16abf2e`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>yaralyzer</li>
    <li>yaralyzer.dist</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>yaralyzer</li>
    <li>yaralyzer.dist</li>
  </ul>
</details>

---
### `x86_64-darwin`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>yaralyzer</li>
    <li>yaralyzer.dist</li>
  </ul>
</details>

---
### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>yaralyzer</li>
    <li>yaralyzer.dist</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test