### PR TITLE
jetbrains-toolbox: 3.1.0.62320 -> 3.4.0.77112

### DIFF
--- a/pkgs/by-name/je/jetbrains-toolbox/package.nix
+++ b/pkgs/by-name/je/jetbrains-toolbox/package.nix
@@ -10,7 +10,7 @@
 
 let
   pname = "jetbrains-toolbox";
-  version = "3.1.0.62320";
+  version = "3.4.0.77112";
 
   updateScript = ./update.sh;
 
@@ -55,10 +55,10 @@ let
         aarch64 = "-arm64";
       };
       hash = selectSystem {
-        x86_64-linux = "sha256-Fmnj1mYMpsiBpnERiWPAwQaH7qLqkrTICn0mxX0h+2U=";
-        aarch64-linux = "sha256-ogLaPN9nxZFQ09qmIF2mEi5o9LVgjoGtmYclc6KmrNU=";
-        x86_64-darwin = "sha256-hO5J9I8ZrzsgGtb9dMg2SeI/PrxpkFRjDRUdrjqMnPw=";
-        aarch64-darwin = "sha256-xA0LbwDKR6/64K9uUJHvrPC+0mRLGM/axz8+Knc+X8A=";
+        x86_64-linux = "sha256-erKYgZKu8tQS9VJH+46eYIxSma782oWPp5E+PrCiqKk=";
+        aarch64-linux = "sha256-AlLyissnPn6ghNeSg45UnJ60phsXsEpvUJJllo0URX8=";
+        x86_64-darwin = "sha256-RfSWKPtaJTDCxTKUbNbXUtSoRpiQVIt/jadJGh2ZCL8=";
+        aarch64-darwin = "sha256-JnK477IX6pElZ7WDDfrLWG5WILcDtjSTlKdyPGbpTSs=";
       };
     in
     selectKernel {


### PR DESCRIPTION
<!-- Nixpkgs pull request template -->
# Description

Update jetbrains-toolbox from 3.1.0.62320 to 3.4.0.77112 (released March 17, 2026).

# Checklist
<!-- The Nixpkgs contributing guide is at https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md -->
<!-- This checklist may not be relevant to all PRs. -->

- [ ] Tested using sandbox
- [x] Package built and tested locally on `x86_64-linux`
- [x] Updated version and hashes for all platforms (x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin)

<!-- comments -->
cc @ners