### PR TITLE
stirling-pdf.services.default: init modular service

### DIFF
--- a/nixos/modules/misc/documentation/modular-services.nix
+++ b/nixos/modules/misc/documentation/modular-services.nix
@@ -21,6 +21,8 @@ let
     options = {
       "<imports = [ pkgs.ghostunnel.services.default ]>" = fakeSubmodule pkgs.ghostunnel.services.default;
       "<imports = [ pkgs.php.services.default ]>" = fakeSubmodule pkgs.php.services.default;
+      "<imports = [ pkgs.stirling-pdf.services.default ]>" =
+        fakeSubmodule pkgs.stirling-pdf.services.default;
     };
   };
 in

--- a/nixos/modules/services/web-apps/stirling-pdf.nix
+++ b/nixos/modules/services/web-apps/stirling-pdf.nix
@@ -4,116 +4,51 @@
   pkgs,
   ...
 }:
-
 let
+  inherit (lib.strings)
+    splitString
+    ;
   cfg = config.services.stirling-pdf;
 in
 {
+  imports =
+    map
+      (
+        opt:
+        lib.mkAliasOptionModule
+          (
+            [
+              "services"
+              "stirling-pdf"
+            ]
+            ++ splitString "." opt
+          )
+          (
+            [
+              "system"
+              "services"
+              "stirling-pdf"
+              "stirling-pdf"
+            ]
+            ++ splitString "." opt
+          )
+      )
+      [
+        "package"
+        "environment"
+        "environmentFiles"
+        "finalPackage"
+        "systemd.stateDir"
+        "systemd.user"
+      ];
+
   options.services.stirling-pdf = {
     enable = lib.mkEnableOption "the stirling-pdf service";
-
-    package = lib.mkPackageOption pkgs "stirling-pdf" { };
-
-    environment = lib.mkOption {
-      type = lib.types.attrsOf (
-        lib.types.oneOf [
-          lib.types.str
-          lib.types.int
-        ]
-      );
-      default = { };
-      example = {
-        SERVER_PORT = 8080;
-        INSTALL_BOOK_AND_ADVANCED_HTML_OPS = "true";
-      };
-      description = ''
-        Environment variables for the stirling-pdf app.
-        See <https://github.com/Stirling-Tools/Stirling-PDF#customisation> for available options.
-      '';
-    };
-
-    environmentFiles = lib.mkOption {
-      type = lib.types.listOf lib.types.path;
-      default = [ ];
-      description = ''
-        Files containing additional environment variables to pass to Stirling PDF.
-        Secrets should be added in environmentFiles instead of environment.
-      '';
-    };
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.services.stirling-pdf = {
-      environment = lib.mapAttrs (_: toString) cfg.environment;
-
-      # following https://docs.stirlingpdf.com/Installation/Unix%20Installation
-      path =
-        with pkgs;
-        [
-          # `which` is used to test command availability
-          # See https://github.com/Stirling-Tools/Stirling-PDF/blob/main/app/core/src/main/java/stirling/software/SPDF/config/ExternalAppDepConfig.java#L262
-          which
-          unpaper
-          libreoffice
-          qpdf
-          ocrmypdf
-          poppler-utils
-          unoconv
-          pngquant
-          tesseract
-          (python3.withPackages (
-            p: with p; [
-              weasyprint
-              opencv-python-headless
-            ]
-          ))
-          ghostscript_headless
-        ]
-        ++ lib.optional (cfg.environment.INSTALL_BOOK_AND_ADVANCED_HTML_OPS or "false" == "true") calibre;
-
-      wantedBy = [ "multi-user.target" ];
-
-      serviceConfig = {
-        BindReadOnlyPaths = [ "${pkgs.tesseract}/share/tessdata:/usr/share/tessdata" ];
-        CacheDirectory = "stirling-pdf";
-        Environment = [ "HOME=%S/stirling-pdf" ];
-        EnvironmentFile = cfg.environmentFiles;
-        ExecStart = lib.getExe cfg.package;
-        RuntimeDirectory = "stirling-pdf";
-        StateDirectory = "stirling-pdf";
-        SuccessExitStatus = 143;
-        User = "stirling-pdf";
-        WorkingDirectory = "/var/lib/stirling-pdf";
-
-        # Hardening
-        CapabilityBoundingSet = "";
-        DynamicUser = true;
-        LockPersonality = true;
-        NoNewPrivileges = true;
-        PrivateDevices = true;
-        PrivateUsers = true;
-        ProcSubset = "pid";
-        ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        ProtectProc = "invisible";
-        RestrictAddressFamilies = [
-          "AF_INET"
-          "AF_INET6"
-          "AF_UNIX"
-        ];
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        SystemCallArchitectures = "native";
-        SystemCallFilter = [
-          "~@cpu-emulation @debug @keyring @mount @obsolete @privileged @clock @setuid @chown"
-        ];
-        UMask = "0077";
-      };
+    system.services.stirling-pdf = {
+      imports = [ pkgs.stirling-pdf.services.default ];
     };
   };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1507,6 +1507,7 @@ in
   stash = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./stash.nix { };
   static-web-server = runTest ./web-servers/static-web-server.nix;
   step-ca = handleTestOn [ "x86_64-linux" ] ./step-ca.nix { };
+  stirling-pdf = recurseIntoAttrs pkgs.stirling-pdf.passthru.tests;
   stratis = handleTest ./stratis { };
   strongswan-swanctl = runTest ./strongswan-swanctl.nix;
   stub-ld = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./stub-ld.nix { };

--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -24,6 +24,8 @@
 
   isDesktopVariant ? false,
   buildWithFrontend ? !isDesktopVariant,
+
+  callPackage,
 }:
 
 # you may only toggle this when building the server
@@ -166,7 +168,17 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s ${jre} "$res_dir/runtime/jre"
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    services.default = {
+      imports = [
+        # do what importApply does without duplicating tons of arguments
+        (lib.setDefaultModuleLocation ./service.nix (callPackage ./service.nix { }))
+      ];
+      stirling-pdf.package = lib.mkDefault finalAttrs.finalPackage;
+    };
+    updateScript = nix-update-script { };
+    tests = callPackage ./tests { };
+  };
 
   meta = {
     changelog = "https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/st/stirling-pdf/service.nix
+++ b/pkgs/by-name/st/stirling-pdf/service.nix
@@ -1,0 +1,213 @@
+# Non-module dependencies (`callPackage`)
+{
+  which,
+  unpaper,
+  libreoffice,
+  qpdf,
+  ocrmypdf,
+  poppler-utils,
+  unoconv,
+  pngquant,
+  tesseract,
+  python3,
+  ghostscript_headless,
+  imagemagick,
+  calibre,
+  runCommand,
+  makeBinaryWrapper,
+  ...
+}:
+
+{
+  config,
+  options,
+  lib,
+  ...
+}:
+let
+  cfg = config.stirling-pdf;
+in
+{
+  _class = "service";
+
+  options.stirling-pdf = {
+    package = lib.mkOption {
+      description = "Package to use for stirling-pdf";
+      defaultText = "The stirling-pdf package that provided this module.";
+      type = lib.types.package;
+    };
+
+    environment = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.oneOf [
+          lib.types.str
+          lib.types.int
+        ]
+      );
+      default = { };
+      example = {
+        SERVER_PORT = 8080;
+        INSTALL_BOOK_AND_ADVANCED_HTML_OPS = "true";
+      };
+      description = ''
+        Environment variables for the stirling-pdf app.
+        See <https://github.com/Stirling-Tools/Stirling-PDF#customisation> for available options.
+      '';
+    };
+
+    environmentFiles = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
+      default = [ ];
+      description = ''
+        Files containing additional environment variables to pass to Stirling PDF.
+        Secrets should be added in environmentFiles instead of environment.
+      '';
+    };
+
+    finalPackage = lib.mkOption {
+      type = lib.types.package;
+      readOnly = true;
+      description = "The finalPackage used by the service, constructed from `package`.";
+    };
+  }
+  // lib.optionalAttrs (options ? systemd) {
+    systemd.stateDir = lib.mkOption {
+      type = lib.types.nonEmptyStr;
+      default = "stirling-pdf";
+      example = "stirling-pdf";
+      description = "Name of the systemd state directory.";
+    };
+
+    systemd.user = lib.mkOption {
+      type = lib.types.nonEmptyStr;
+      default = "stirling-pdf";
+      example = "stirling-pdf";
+      description = "Name of the systemd user.";
+    };
+  };
+
+  config = lib.mkMerge [
+    {
+      stirling-pdf.finalPackage =
+        let
+          # following https://docs.stirlingpdf.com/Installation/Unix%20Installation
+          path = lib.makeBinPath (
+            [
+              # `which` is used to test command availability
+              # See https://github.com/Stirling-Tools/Stirling-PDF/blob/main/app/core/src/main/java/stirling/software/SPDF/config/ExternalAppDepConfig.java#L262
+              which
+              unpaper
+              libreoffice
+              qpdf
+              ocrmypdf
+              poppler-utils
+              unoconv # TODO package and move to unoserver https://github.com/NixOS/nixpkgs/pull/380655#issuecomment-2692128291
+              pngquant
+              tesseract
+              (python3.withPackages (
+                p: with p; [
+                  weasyprint
+                  opencv-python-headless
+                ]
+              ))
+              ghostscript_headless
+              imagemagick
+            ]
+            ++ lib.optional (cfg.environment.INSTALL_BOOK_AND_ADVANCED_HTML_OPS or "false" == "true") calibre
+          );
+        in
+        runCommand "stirling-pdf"
+          {
+            nativeBuildInputs = [ makeBinaryWrapper ];
+            inherit (cfg.package) meta;
+          }
+          ''
+            makeWrapper \
+              "${lib.getExe cfg.package}" "$out/bin/${cfg.package.meta.mainProgram}" \
+              --prefix PATH : ${path} \
+              ${
+                lib.concatMapAttrsStringSep " " (name: value: "--set ${name} ${toString value}") cfg.environment
+              } \
+              ${lib.pipe cfg.environmentFiles [
+                (builtins.map (name: "--run '. ${name}'"))
+                (lib.concatStringsSep "\n")
+              ]}
+          '';
+      process.argv = [
+        (lib.getExe cfg.finalPackage)
+      ];
+    }
+    # TODO
+    # deplyoment targets
+    # - nixos systemd service
+    # - oci containers w/ nimi
+    # - nix run w/ nimi
+    # - systemd user service
+    #   - home manager service
+    # - sysm service
+    # - nod service
+    #   - For this service I don't know if it makes sense (too heavy and libreoffice drv can work on android?)
+    # - nix-darwin service
+    #   - For this I honestly don't care because I can't get access to free macos to improve their situation
+    #   - For this service I don't know if it makes sense (libreoffice drv can work on macos?)
+    # - systemd-nspawn containers
+    #
+    # - secret management for all above scenarios
+    (lib.optionalAttrs (options ? systemd) {
+      systemd.service = {
+        wantedBy = [ "multi-user.target" ];
+
+        serviceConfig = {
+          # NOTE: from redlib pr, to make it use process.argv?
+          # also systemd.mainExecStart is an option
+          ExecStart = lib.mkBefore [ "" ];
+
+          BindReadOnlyPaths = [ "${tesseract}/share/tessdata:/usr/share/tessdata" ];
+
+          Environment = [ "HOME=%S/${cfg.systemd.stateDir}" ];
+          CacheDirectory = cfg.systemd.stateDir;
+          RuntimeDirectory = cfg.systemd.stateDir;
+          StateDirectory = cfg.systemd.stateDir;
+          WorkingDirectory = "%S/${cfg.systemd.stateDir}";
+
+          SuccessExitStatus = 143;
+          User = cfg.systemd.user;
+
+          # Hardening
+          CapabilityBoundingSet = "";
+          DynamicUser = true;
+          LockPersonality = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateUsers = true;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "~@cpu-emulation @debug @keyring @mount @obsolete @privileged @clock @setuid @chown"
+          ];
+          UMask = "0077";
+        };
+      };
+    })
+  ];
+
+  meta.maintainers = with lib.maintainers; [
+    DCsunset
+    timhae
+  ];
+}

--- a/pkgs/by-name/st/stirling-pdf/service.nix
+++ b/pkgs/by-name/st/stirling-pdf/service.nix
@@ -6,7 +6,7 @@
   qpdf,
   ocrmypdf,
   poppler-utils,
-  unoconv,
+  unoserver,
   pngquant,
   tesseract,
   python3,
@@ -101,7 +101,7 @@ in
               qpdf
               ocrmypdf
               poppler-utils
-              unoconv # TODO package and move to unoserver https://github.com/NixOS/nixpkgs/pull/380655#issuecomment-2692128291
+              unoserver
               pngquant
               tesseract
               (python3.withPackages (

--- a/pkgs/by-name/st/stirling-pdf/tests/basic.nix
+++ b/pkgs/by-name/st/stirling-pdf/tests/basic.nix
@@ -1,0 +1,17 @@
+{
+  name = "stirling-pdf starts";
+
+  nodes.machine =
+    { pkgs, lib, ... }:
+    {
+      # give more memory
+      virtualisation.memorySize = 2048;
+      services.stirling-pdf.enable = true;
+    };
+
+  testScript = ''
+    machine.wait_for_unit("default.target")
+    machine.wait_for_unit("stirling-pdf.service")
+    machine.wait_for_open_port(8080)
+  '';
+}

--- a/pkgs/by-name/st/stirling-pdf/tests/default.nix
+++ b/pkgs/by-name/st/stirling-pdf/tests/default.nix
@@ -2,4 +2,5 @@
 {
   basic = pkgs.testers.runNixOSTest ./basic.nix;
   stirling-pdf-modular = pkgs.testers.runNixOSTest ./modular.nix;
+  stirling-pdf-desktop = pkgs.testers.runNixOSTest ./desktop-integration-test.nix;
 }

--- a/pkgs/by-name/st/stirling-pdf/tests/default.nix
+++ b/pkgs/by-name/st/stirling-pdf/tests/default.nix
@@ -1,0 +1,5 @@
+{ pkgs }:
+{
+  basic = pkgs.testers.runNixOSTest ./basic.nix;
+  stirling-pdf-modular = pkgs.testers.runNixOSTest ./modular.nix;
+}

--- a/pkgs/by-name/st/stirling-pdf/tests/desktop-integration-test.nix
+++ b/pkgs/by-name/st/stirling-pdf/tests/desktop-integration-test.nix
@@ -1,0 +1,106 @@
+{ lib, hostPkgs, ... }:
+let
+  port = 8080;
+  server = "http://server:${toString port}";
+in
+{
+  name = "stirling-pdf";
+  meta = {
+    maintainers = with lib.maintainers; [ timhae ];
+  };
+
+  enableOCR = true;
+  globalTimeout = 600;
+  nodes = {
+    server =
+      { config, pkgs, ... }:
+      {
+        services.stirling-pdf = {
+          enable = true;
+          package = pkgs.stirling-pdf;
+          environment = {
+            SERVER_PORT = port;
+            DISABLE_ADDITIONAL_FEATURES = "false";
+            SECURITY_ENABLELOGIN = "true";
+          };
+        };
+        networking.firewall = {
+          allowedTCPPorts = [ port ];
+          allowedUDPPorts = [ port ];
+        };
+      };
+    client =
+      { config, pkgs, ... }:
+      {
+        virtualisation.memorySize = 4096;
+        imports = [ (hostPkgs.path + "/nixos/tests/common/wayland-cage.nix") ];
+        services.cage.program = lib.getExe pkgs.stirling-pdf-desktop;
+        systemd.tmpfiles.settings."stirling-provisioning.json"."/etc/stirling-pdf/stirling-provisioning.json"."L+".argument =
+          builtins.toString (
+            pkgs.writeText "stirling-provisioning.json" ''
+              {
+                "serverUrl": "${server}",
+                "lockConnectionMode": true
+              }
+            ''
+          );
+      };
+  };
+
+  testScript = ''
+    server.start()
+    server.wait_for_unit("stirling-pdf.service")
+    server.wait_for_console_text("Stirling-PDF Started")
+
+    # initial login
+    client.start()
+    client.wait_for_text("Sign in to Server")
+    client.send_chars("admin", 0.1)
+    client.send_key("tab", 1)
+    client.send_chars("stirling\n", 0.1)
+
+    # skip telemetry prompt
+    client.sleep(10)
+    client.send_key("shift-tab", 1)
+    client.send_key("tab", 1)
+    client.send_key("tab", 1)
+    client.send_key("kp_enter", 1)
+
+    # update password
+    client.sleep(3)
+    client.send_key("tab", 1)
+    client.send_key("shift-tab", 1)
+    client.send_key("shift-tab", 1)
+    client.send_key("shift-tab", 1)
+    client.send_chars("stirling2", 0.1)
+    client.send_key("tab", 1)
+    client.send_chars("stirling2", 0.1)
+    client.send_key("tab", 1)
+    client.send_key("kp_enter", 1)
+
+    # final login
+    client.wait_for_text("Sign in to Server")
+    client.send_chars("admin", 0.1)
+    client.send_key("tab", 1)
+    client.send_chars("stirling2\n", 0.1)
+    client.wait_for_text("Welcome to Stirling")
+    client.send_key("kp_enter", 1)
+
+    # version prompt
+    client.send_key("tab", 1)
+    client.send_key("tab", 1)
+    client.send_key("tab", 1)
+    client.send_key("tab", 1)
+    client.send_key("tab", 1)
+    client.send_key("tab", 1)
+    client.send_key("tab", 1)
+    client.send_key("tab", 1)
+    client.send_key("kp_enter", 5)
+    client.screenshot("stirling-pdf-version")
+    # the screenshots sometimes produce huge ppm files for some reason and it
+    # takes forever for the ocr to take place..
+    # frontend version is lagging behind for some reason
+    # client.wait_for_text("Current Frontend Version: ${hostPkgs.stirling-pdf-desktop.version}")
+    # client.wait_for_text("Current Backend Version: ${hostPkgs.stirling-pdf.version}")
+  '';
+}

--- a/pkgs/by-name/st/stirling-pdf/tests/desktop-integration-test.nix
+++ b/pkgs/by-name/st/stirling-pdf/tests/desktop-integration-test.nix
@@ -4,7 +4,7 @@ let
   server = "http://server:${toString port}";
 in
 {
-  name = "stirling-pdf";
+  name = "stirling-pdf-desktop";
   meta = {
     maintainers = with lib.maintainers; [ timhae ];
   };
@@ -24,15 +24,17 @@ in
             SECURITY_ENABLELOGIN = "true";
           };
         };
-        networking.firewall = {
-          allowedTCPPorts = [ port ];
-          allowedUDPPorts = [ port ];
-        };
+        networking.firewall.allowedTCPPorts = [ port ];
       };
     client =
       { config, pkgs, ... }:
       {
+        virtualisation.cores = 4;
         virtualisation.memorySize = 4096;
+        virtualisation.qemu.options = [
+          # Force qemu at 640x480 resolution
+          "-vga none -device virtio-gpu-pci,xres=640,yres=480"
+        ];
         imports = [ (hostPkgs.path + "/nixos/tests/common/wayland-cage.nix") ];
         services.cage.program = lib.getExe pkgs.stirling-pdf-desktop;
         systemd.tmpfiles.settings."stirling-provisioning.json"."/etc/stirling-pdf/stirling-provisioning.json"."L+".argument =
@@ -44,6 +46,8 @@ in
               }
             ''
           );
+        programs.ydotool.enable = true;
+        users.users.alice.extraGroups = [ "ydotool" ];
       };
   };
 
@@ -60,14 +64,14 @@ in
     client.send_chars("stirling\n", 0.1)
 
     # skip telemetry prompt
-    client.sleep(10)
+    client.wait_for_text("analytics")
     client.send_key("shift-tab", 1)
     client.send_key("tab", 1)
     client.send_key("tab", 1)
     client.send_key("kp_enter", 1)
 
     # update password
-    client.sleep(3)
+    client.wait_for_text("password")
     client.send_key("tab", 1)
     client.send_key("shift-tab", 1)
     client.send_key("shift-tab", 1)
@@ -87,15 +91,10 @@ in
     client.send_key("kp_enter", 1)
 
     # version prompt
-    client.send_key("tab", 1)
-    client.send_key("tab", 1)
-    client.send_key("tab", 1)
-    client.send_key("tab", 1)
-    client.send_key("tab", 1)
-    client.send_key("tab", 1)
-    client.send_key("tab", 1)
-    client.send_key("tab", 1)
-    client.send_key("kp_enter", 5)
+    client.wait_for_text("Config")
+    client.execute("ydotool mousemove -a -- 290 220") # Config button
+    client.execute("ydotool click 0xC0")
+    client.wait_for_text("Current Frontend Version")
     client.screenshot("stirling-pdf-version")
     # the screenshots sometimes produce huge ppm files for some reason and it
     # takes forever for the ocr to take place..
@@ -103,4 +102,36 @@ in
     # client.wait_for_text("Current Frontend Version: ${hostPkgs.stirling-pdf-desktop.version}")
     # client.wait_for_text("Current Backend Version: ${hostPkgs.stirling-pdf.version}")
   '';
+
+  # Debug interactively with:
+  # - nix-build -A stirling-pdf.tests.stirling-pdf-desktop.driverInteractive
+  # - ./result/bin/nixos-test-driver
+  # - run_tests()
+  # ssh -o User=root vsock%3 (can also do vsock/3, but % works with scp etc.)
+  interactive.sshBackdoor.enable = true;
+
+  interactive.nodes.client =
+    { pkgs, ... }:
+    {
+      # make the mouse visible
+      services.cage.environment.WLR_NO_HARDWARE_CURSORS = "1";
+    };
+
+  interactive.nodes.server =
+    { ... }:
+    let
+      port = 8080;
+    in
+    {
+      virtualisation.forwardPorts = [
+        {
+          from = "host";
+          host.port = port;
+          guest.port = port;
+        }
+      ];
+
+      # forwarded ports need to be accessible
+      networking.firewall.allowedTCPPorts = [ port ];
+    };
 }

--- a/pkgs/by-name/st/stirling-pdf/tests/modular.nix
+++ b/pkgs/by-name/st/stirling-pdf/tests/modular.nix
@@ -1,0 +1,29 @@
+{
+  _class = "nixosTest";
+
+  name = "stirling-pdf-modular";
+
+  nodes.machine =
+    { pkgs, lib, ... }:
+    {
+      # give more memory for two instances
+      virtualisation.memorySize = 4096;
+      system.services.stirling-pdf-plain = pkgs.stirling-pdf.services.default;
+      system.services.stirling-pdf-custom = {
+        imports = [ pkgs.stirling-pdf.services.default ];
+        stirling-pdf = {
+          environment.SERVER_PORT = 8082;
+          systemd.stateDir = "stiring-pdf-custom";
+          systemd.user = "stiring-pdf-custom";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("default.target")
+    machine.wait_for_unit("stirling-pdf-plain.service")
+    machine.wait_for_unit("stirling-pdf-custom.service")
+    machine.wait_for_open_port(8080)
+    machine.wait_for_open_port(8082)
+  '';
+}

--- a/pkgs/by-name/un/unoserver/package.nix
+++ b/pkgs/by-name/un/unoserver/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "unoserver";
+  version = "3.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "unoconv";
+    repo = "unoserver";
+    tag = finalAttrs.version;
+    hash = "sha256-tQ/e2L8r0LSDJkXbtd6ygleXn1Z9uhXYoaJN6PVFGZU=";
+  };
+
+  build-system = [
+    python3.pkgs.setuptools
+  ];
+
+  pythonImportsCheck = [
+    "unoserver"
+  ];
+
+  meta = {
+    description = "LibreOffice as a server for converting documents.";
+    homepage = "https://github.com/unoconv/unoserver";
+    changelog = "https://github.com/unoconv/unoserver/blob/${finalAttrs.src.rev}/CHANGES.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ phanirithvij ];
+    mainProgram = "unoserver";
+    # windows and macos support untested https://github.com/unoconv/unoserver#installation
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Based on ideas from #475372 #496296

Includes work from https://github.com/NixOS/nixpkgs/pull/499612, will rebase once that is merged.

Stirling-PDF is a good candidate for modular services as it works fine with `process.argv` by default.

Note: this migrates an existing systemd nixos module service

**TBA** checklist for modular services

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] **TBA** Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
