### PR TITLE
herdtools7: init at 7.58

### DIFF
--- a/pkgs/by-name/he/herdtools7/package.nix
+++ b/pkgs/by-name/he/herdtools7/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  fetchFromGitHub,
+  ocamlPackages,
+  python3,
+}:
+
+ocamlPackages.buildDunePackage rec {
+  pname = "herdtools7";
+  version = "7.58";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "herd";
+    repo = "herdtools7";
+    rev = version;
+    hash = "sha256-0+tyzuEPji/mCsN6ez4C+iJz5IroV3zAjVsbgG6lPJo=";
+  };
+
+  nativeBuildInputs = [
+    python3
+    ocamlPackages.menhir
+  ];
+
+  propagatedBuildInputs = with ocamlPackages; [
+    menhirLib
+    zarith
+  ];
+
+  env = {
+    DUNE_CACHE = "disabled";
+  };
+
+  preBuild = ''
+    ./version-gen.sh $out
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/herdtools7
+    cp -r herd/libdir $out/share/herdtools7/herd
+    cp -r litmus/libdir $out/share/herdtools7/litmus
+    cp -r jingle/libdir $out/share/herdtools7/jingle
+  '';
+
+  meta = {
+    homepage = "https://github.com/herd/herdtools7";
+    description = "The Herd toolsuite to deal with .cat memory models";
+    license = lib.licenses.cecill-b;
+    maintainers = with lib.maintainers; [ garyguo ];
+  };
+}


### PR DESCRIPTION
Homepage: https://github.com/herd/herdtools7

This tool is for running litmus tests, including the ones in the Linux kernel (https://github.com/torvalds/linux/tree/master/tools/memory-model).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
