### PR TITLE
[Backport release-25.11] siyuan: 3.5.4 -> 3.6.1

### DIFF
--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.5.4";
+  version = "3.5.5";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-uiI8cB/bi6P4PByOBUGK4d2DUelACThC+e5rBFv35ow=";
+    hash = "sha256-iGwREddg5Pzr6fM/YTYj28g+p8tkQa9EiM6py94UlSc=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-SQ7QBtPwQaQgp6S54dnwfV44SLos1QY5NotnpEz4OPY=";
+    vendorHash = "sha256-4yqUUP6b2KL+xLKQTiTPqIISyqdIsHpf+p1jsG/kquI=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_9;
     fetcherVersion = 1;
-    hash = "sha256-DxMeZqFqR5vybwEiYzYhYMn7S3P/boHrOXkS+57Yrz4=";
+    hash = "sha256-i11Hr/KA7Q27Z26AOmc6GNwSW/ZcwSyaNtNBJii5r2A=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/app";

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -98,8 +98,8 @@ stdenv.mkDerivation (finalAttrs: {
       postPatch
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-GLwREEnDf3NIbQsX+LA/n6zZYvTlyiJaozfKyk04go8=";
+    fetcherVersion = 3;
+    hash = "sha256-Dp684KKAb8Ge2PyPhBFgIB17Fs6swAF/Fw2z9SN4Aio=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/app";

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.5.10";
+  version = "3.6.0";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-IJKWrveUn7kvJjSu0YYGargGFY8T8gxAAh2fr0BnbUE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0CP9ypx1w2s949oDYYvv96p8xvhPZs5y1FLWoUBN5r4=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-JwtXllLj6+ALrDZMjFoX5TDwE3yMaij2a9t+T1F1hG0=";
+    vendorHash = "sha256-IAkohYOF8s8NFsy/fagVXddtym6URop6tvEIB6H8gI0=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_9;
     fetcherVersion = 3;
-    hash = "sha256-KXSR2QCcYdUCaQhDZAF/4rwlAmn7GtUHVbP8xYKcxVI=";
+    hash = "sha256-N/LKkE0I6sIiO0+wGvPZMgaWKUPcq7Gjpsw5Oj9cvqI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/app";

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.5.8";
+  version = "3.5.9";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-mXDro4m2QZEUcljpQNC5JqhVbRZgBVU1Wfiq1JtS0B0=";
+    hash = "sha256-lQtgVYYinkgxgwnxyhsebt8CpdCDClcS+qo0tQaTD94=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-i7eq8RDbuv+FzreClW8JFocUs7R8A02cOZ8NaAGBMfA=";
+    vendorHash = "sha256-Qz2LAtznJ8MxPQ6bSuMuvCDWt+8JSe0MawNWH70X/5k=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_9;
     fetcherVersion = 3;
-    hash = "sha256-Dp684KKAb8Ge2PyPhBFgIB17Fs6swAF/Fw2z9SN4Aio=";
+    hash = "sha256-KXSR2QCcYdUCaQhDZAF/4rwlAmn7GtUHVbP8xYKcxVI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/app";

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.5.5";
+  version = "3.5.8";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-iGwREddg5Pzr6fM/YTYj28g+p8tkQa9EiM6py94UlSc=";
+    hash = "sha256-mXDro4m2QZEUcljpQNC5JqhVbRZgBVU1Wfiq1JtS0B0=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-4yqUUP6b2KL+xLKQTiTPqIISyqdIsHpf+p1jsG/kquI=";
+    vendorHash = "sha256-i7eq8RDbuv+FzreClW8JFocUs7R8A02cOZ8NaAGBMfA=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_9;
     fetcherVersion = 1;
-    hash = "sha256-i11Hr/KA7Q27Z26AOmc6GNwSW/ZcwSyaNtNBJii5r2A=";
+    hash = "sha256-GLwREEnDf3NIbQsX+LA/n6zZYvTlyiJaozfKyk04go8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/app";

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.5.9";
+  version = "3.5.10";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-lQtgVYYinkgxgwnxyhsebt8CpdCDClcS+qo0tQaTD94=";
+    hash = "sha256-IJKWrveUn7kvJjSu0YYGargGFY8T8gxAAh2fr0BnbUE=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-Qz2LAtznJ8MxPQ6bSuMuvCDWt+8JSe0MawNWH70X/5k=";
+    vendorHash = "sha256-JwtXllLj6+ALrDZMjFoX5TDwE3yMaij2a9t+T1F1hG0=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -35,20 +35,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "siyuan";
-  version = "3.6.0";
+  version = "3.6.1";
 
   src = fetchFromGitHub {
     owner = "siyuan-note";
     repo = "siyuan";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0CP9ypx1w2s949oDYYvv96p8xvhPZs5y1FLWoUBN5r4=";
+    hash = "sha256-Qsqg6WKfpPOZwvH6aFcDVjIAJcBckClqE/1g92JvR2M=";
   };
 
   kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";
-    vendorHash = "sha256-IAkohYOF8s8NFsy/fagVXddtym6URop6tvEIB6H8gI0=";
+    vendorHash = "sha256-R+/njKBraRPgWLnhBXy969ILA/fn0wyq6OkYgJnS1WM=";
 
     patches = [
       (replaceVars ./set-pandoc-path.patch {


### PR DESCRIPTION
Manual backport of:
- #490006
- #492578
- #494401 (partial)
- #497945
- #499368
- #500300
- #502753

---

- Fixes: #497608 (CVE-2026-29073)
- Fixes: #502626
- Fixes: #502615
- Fixes: #502612
- Fixes: #502605
- Fixes: #502592
- Fixes: #502590
- Fixes: #502589 
- Fixes: #502586 
- Fixes: #502530 
- Fixes: #500149

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
