### PR TITLE
motioneye: init at 0.43.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1586,6 +1586,7 @@
   ./services/video/go2rtc/default.nix
   ./services/video/mediamtx.nix
   ./services/video/mirakurun.nix
+  ./services/video/motioneye.nix
   ./services/video/photonvision.nix
   ./services/video/ustreamer.nix
   ./services/video/v4l2-relayd.nix

--- a/nixos/modules/services/video/motioneye.nix
+++ b/nixos/modules/services/video/motioneye.nix
@@ -1,0 +1,122 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.motioneye;
+in
+{
+  options.services.motioneye = {
+    enable = lib.mkEnableOption "motionEye";
+
+    packages = {
+      motioneye = lib.mkPackageOption pkgs "motioneye" { };
+      motion = lib.mkPackageOption pkgs "motion" { };
+      ffmpeg = lib.mkPackageOption pkgs "ffmpeg" { };
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "motioneye";
+      description = "User to run motionEye under.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "motioneye";
+      description = "Group to run motionEye under.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      defaultText = lib.literalExpression /* nix */ ''
+        {
+          conf_path = lib.mkDefault "/var/lib/motioneye/conf";
+          run_path = lib.mkDefault "/run/motioneye";
+          log_path = lib.mkDefault "/var/log/motioneye";
+          media_path = lib.mkDefault "/var/lib/motioneye/media";
+        }
+      '';
+      description = ''
+        Configuration to put in motioneye.conf.
+        See <https://github.com/motioneye-project/motioneye/wiki/Configuration-File>  for more details.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.motioneye.settings = {
+      conf_path = lib.mkDefault "/var/lib/motioneye/conf";
+      run_path = lib.mkDefault "/run/motioneye";
+      log_path = lib.mkDefault "/var/log/motioneye";
+      media_path = lib.mkDefault "/var/lib/motioneye/media";
+    };
+
+    users = {
+      groups.${cfg.group} = { };
+      users.${cfg.user} = {
+        inherit (cfg) group;
+        isSystemUser = true;
+
+        # allow v4l access
+        extraGroups = [ "video" ];
+      };
+    };
+
+    systemd.tmpfiles.settings.motioneye =
+      let
+        config = {
+          d = {
+            inherit (cfg) user group;
+            mode = "0750";
+          };
+        };
+      in
+      {
+        "${cfg.settings.conf_path}" = config;
+        "${cfg.settings.run_path}" = config;
+        "${cfg.settings.log_path}" = config;
+        "${cfg.settings.media_path}" = config;
+      };
+
+    environment.etc."motioneye/motioneye.conf".text = lib.concatMapAttrsStringSep "\n" (
+      key: value: "${key} ${lib.escapeShellArg value}"
+    ) cfg.settings;
+
+    # https://github.com/motioneye-project/motioneye/blob/main/motioneye/extra/motioneye.systemd
+    systemd.services.motioneye = {
+      description = "motionEye Server";
+      after = [
+        "network.target"
+        "local-fs.target"
+        "remote-fs.target"
+      ];
+      wantedBy = [ "multi-user.target" ];
+      path =
+        (with pkgs; [
+          which
+          v4l-utils
+        ])
+        ++ [
+          cfg.packages.motion
+          cfg.packages.ffmpeg
+        ];
+      restartTriggers = [
+        config.environment.etc."motioneye/motioneye.conf".source
+      ];
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        RuntimeDirectory = "motioneye";
+        LogsDirectory = "motioneye";
+        StateDirectory = "motioneye";
+        ExecStart = "${lib.getExe' cfg.packages.motioneye "meyectl"} startserver -c /etc/motioneye/motioneye.conf";
+        Restart = "on-abort";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/mo/motioneye/package.nix
+++ b/pkgs/by-name/mo/motioneye/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  fetchpatch,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "motioneye";
+  version = "0.43.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "motioneye-project";
+    repo = "motioneye";
+    tag = version;
+    hash = "sha256-ckOgYmOP5irjNutcC3FMZPBexn/CldG0UtFZ+tPYNJ4=";
+  };
+
+  patches = [
+    # fix pytest
+    # https://github.com/motioneye-project/motioneye/pull/3271
+    (fetchpatch {
+      url = "https://github.com/motioneye-project/motioneye/commit/41c0727e2872af1b758743c41b529e76dcac6f84.patch";
+      hash = "sha256-0zDveoAN1T0SuCob0U/9GEGTh7pj2CXH/j4YrjO0VE0=";
+      includes = [ "conftest.py" ];
+    })
+  ];
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    babel
+    boto3
+    jinja2
+    pillow
+    pycurl
+    tornado
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "motioneye"
+  ];
+
+  meta = {
+    description = "Web frontend for the motion daemon";
+    homepage = "https://github.com/motioneye-project/motioneye";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ marcel ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Tested on Raspberry Pi 3b with PI Cam v2.

## Things done



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
