### PR TITLE
kittysay: 0.8.0 -> 1.1.1

### DIFF
--- a/pkgs/by-name/ki/kittysay/package.nix
+++ b/pkgs/by-name/ki/kittysay/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 let
-  version = "0.8.0";
+  version = "1.1.1";
 in
 rustPlatform.buildRustPackage {
   pname = "kittysay";
@@ -14,10 +14,12 @@ rustPlatform.buildRustPackage {
     owner = "uncenter";
     repo = "kittysay";
     rev = "v${version}";
-    hash = "sha256-ZYHrDBJ8cTqJAh2KUGSCsS1bY/emHRodPxZX2vxAhDs=";
+    hash = "sha256-+WrIMte1RXi8nZNvrH/e/2JMx39LkKi8pkq/TUfmzFo=";
   };
 
-  cargoHash = "sha256-LIAXlOArm5V7Kbm82GDRs3XvMTgKjuOL2C+fQfEDwb4=";
+  cargoHash = "sha256-7bAPKZAiX/p5xvIbGBBf8O1rksnizIJfMkUwhkpouAA=";
+
+  doCheck = false;
 
   meta = {
     description = "Cowsay, but with a cute kitty :3";


### PR DESCRIPTION
Diff: https://github.com/uncenter/kittysay/compare/v0.8.0...v1.1.1

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
