### PR TITLE
[Backport release-25.11] radare2: 6.0.4 -> 6.1.2; iaito: 6.0.4 -> 6.1.0

### DIFF
--- a/pkgs/by-name/ia/iaito/package.nix
+++ b/pkgs/by-name/ia/iaito/package.nix
@@ -11,14 +11,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "iaito";
-  version = "6.0.4";
+  version = "6.0.7";
 
   srcs = [
     (fetchFromGitHub {
       owner = "radareorg";
       repo = "iaito";
       tag = finalAttrs.version;
-      hash = "sha256-99SuUTwHcpyJ5V9Cnanm6ylH3NVgyk3TmDoaFVwFE4E=";
+      hash = "sha256-sATBtjNboSnk3j1PVm60HZO1MDw1A4FRttVp0M4t+/I=";
       name = "main";
     })
     (fetchFromGitHub {

--- a/pkgs/by-name/ia/iaito/package.nix
+++ b/pkgs/by-name/ia/iaito/package.nix
@@ -11,14 +11,14 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "iaito";
-  version = "6.0.7";
+  version = "6.1.0";
 
   srcs = [
     (fetchFromGitHub {
       owner = "radareorg";
       repo = "iaito";
       tag = finalAttrs.version;
-      hash = "sha256-sATBtjNboSnk3j1PVm60HZO1MDw1A4FRttVp0M4t+/I=";
+      hash = "sha256-nvMx0zbfsphfBgxdQnk+EhRpQnJ2Qv05rF7w+zQUUQg=";
       name = "main";
     })
     (fetchFromGitHub {
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    "-Dwith_qt6=true"
+    (lib.mesonBool "with_qt6" true)
   ];
 
   postBuild = ''

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -32,33 +32,33 @@ let
   binaryninja = fetchFromGitHub {
     owner = "Vector35";
     repo = "binaryninja-api";
-    rev = "c40a5f04deec68d388b2072dc42b29141089f9ce"; # https://github.com/radareorg/radare2/blob/master/subprojects/binaryninja.wrap
-    hash = "sha256-IfuGgwVI51urQxhaYkYsE45NkScgxKmmEBV6Pllhwmo=";
+    rev = "5accfca2dc53fe5685dbe9e74f519a7f2f657d48"; # https://github.com/radareorg/radare2/blob/master/subprojects/binaryninja.wrap
+    hash = "sha256-ysTLRmD372mZNAxL+ua7tsPsYyFVPaiDctLUNKKIE4o=";
   };
 
   sdb = fetchFromGitHub {
-    owner = "radare";
+    owner = "radareorg";
     repo = "sdb";
-    tag = "2.2.0"; # https://github.com/radareorg/radare2/blob/master/subprojects/sdb.wrap
-    hash = "sha256-S/aL3F6+Z/rqelfIJaZaBF1IxSmhA1qE9ahFvKARoaE=";
+    tag = "2.3.0"; # https://github.com/radareorg/radare2/blob/master/subprojects/sdb.wrap
+    hash = "sha256-u8sD278Gd5XZkxJZikojh44WketQImx+FtHBQEj8EO0=";
   };
 
   qjs = fetchFromGitHub {
     owner = "quickjs-ng";
     repo = "quickjs";
-    rev = "7238ee64dbc2fbdea044555cda8cda78785a93ed"; # https://github.com/radareorg/radare2/blob/master/subprojects/qjs.wrap
-    hash = "sha256-1ZeLCTmbrlRrZB9El3L497gt3QUA5GIScrFVIBkxA88=";
+    rev = "d405777f7eefa22c17c12970317ef3d6e7658f5a"; # https://github.com/radareorg/radare2/blob/master/subprojects/qjs.wrap
+    hash = "sha256-6/9DmEU+CrZiykiKdLaQy7ds1TvNuyEbat7M6RNuTgs=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "radare2";
-  version = "6.0.4";
+  version = "6.0.7";
 
   src = fetchFromGitHub {
     owner = "radare";
     repo = "radare2";
     tag = finalAttrs.version;
-    hash = "sha256-B0xCQPD27NcCDvRJK1/yyjtrlEJoSTD7e2cu5JIo95w=";
+    hash = "sha256-/WVzqHaDwztvLskE9mSewPlfnVfFPRHQYKvuOitSeNo=";
   };
 
   mesonFlags = [

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -52,23 +52,23 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "radare2";
-  version = "6.0.7";
+  version = "6.1.0";
 
   src = fetchFromGitHub {
     owner = "radare";
     repo = "radare2";
     tag = finalAttrs.version;
-    hash = "sha256-/WVzqHaDwztvLskE9mSewPlfnVfFPRHQYKvuOitSeNo=";
+    hash = "sha256-OGwMfiY689NFbIPIyY+vKDEC6dB40yiMC6uwRIPBiSQ=";
   };
 
   mesonFlags = [
-    (lib.mesonOption "use_sys_capstone" "true")
-    (lib.mesonOption "use_sys_lz4" "true")
-    (lib.mesonOption "use_sys_magic" "true")
-    (lib.mesonOption "use_sys_openssl" "true")
-    (lib.mesonOption "use_sys_xxhash" "true")
-    (lib.mesonOption "use_sys_zip" "true")
-    (lib.mesonOption "use_sys_zlib" "true")
+    (lib.mesonBool "use_sys_capstone" true)
+    (lib.mesonBool "use_sys_lz4" true)
+    (lib.mesonBool "use_sys_magic" true)
+    (lib.mesonBool "use_sys_openssl" true)
+    (lib.mesonBool "use_sys_xxhash" true)
+    (lib.mesonBool "use_sys_zip" true)
+    (lib.mesonBool "use_sys_zlib" true)
     (lib.mesonOption "r2_gittap" finalAttrs.version)
   ];
 

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -32,33 +32,33 @@ let
   binaryninja = fetchFromGitHub {
     owner = "Vector35";
     repo = "binaryninja-api";
-    rev = "5accfca2dc53fe5685dbe9e74f519a7f2f657d48"; # https://github.com/radareorg/radare2/blob/master/subprojects/binaryninja.wrap
-    hash = "sha256-ysTLRmD372mZNAxL+ua7tsPsYyFVPaiDctLUNKKIE4o=";
+    rev = "ba13f6ec7d0ce9a18a03a1c895fb72d18e03014a"; # https://github.com/radareorg/radare2/blob/master/subprojects/binaryninja.wrap
+    hash = "sha256-ApBDmrepz27ioEjtqgdGzGF0tPkDghp7dA8L9eHHW6w=";
   };
 
   sdb = fetchFromGitHub {
     owner = "radareorg";
     repo = "sdb";
-    tag = "2.3.0"; # https://github.com/radareorg/radare2/blob/master/subprojects/sdb.wrap
-    hash = "sha256-u8sD278Gd5XZkxJZikojh44WketQImx+FtHBQEj8EO0=";
+    tag = "2.4.2"; # https://github.com/radareorg/radare2/blob/master/subprojects/sdb.wrap
+    hash = "sha256-JN27SkDqHtX83d1CPUF9hbVKwE/dwhDgn5MlCX9RPrc=";
   };
 
   qjs = fetchFromGitHub {
     owner = "quickjs-ng";
     repo = "quickjs";
-    rev = "d405777f7eefa22c17c12970317ef3d6e7658f5a"; # https://github.com/radareorg/radare2/blob/master/subprojects/qjs.wrap
-    hash = "sha256-6/9DmEU+CrZiykiKdLaQy7ds1TvNuyEbat7M6RNuTgs=";
+    rev = "e2b100e8c5fa7131e9fb22b8a0e9ca0f16eb9892"; # https://github.com/radareorg/radare2/blob/master/subprojects/qjs.wrap
+    hash = "sha256-vq+K93MuvFC+JKw4623gKs53ngw1097l5Kf/RBGU+mA=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "radare2";
-  version = "6.1.0";
+  version = "6.1.2";
 
   src = fetchFromGitHub {
     owner = "radare";
     repo = "radare2";
     tag = finalAttrs.version;
-    hash = "sha256-OGwMfiY689NFbIPIyY+vKDEC6dB40yiMC6uwRIPBiSQ=";
+    hash = "sha256-YiKbXKKwbeAUkeq4LcUwOxTHU1Hua4YhcwDULiHVmrQ=";
   };
 
   mesonFlags = [


### PR DESCRIPTION
Manual backport of:
- https://github.com/NixOS/nixpkgs/pull/475394
- https://github.com/NixOS/nixpkgs/pull/475344
- https://github.com/NixOS/nixpkgs/pull/500199
- https://github.com/NixOS/nixpkgs/pull/501314

Fixes: #500365 ([CVE-2026-4174](https://nvd.nist.gov/vuln/detail/CVE-2026-4174))
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
