### PR TITLE
mitmproxy-linux: fix fetchCargoVendor path

### DIFF
--- a/pkgs/development/python-modules/mitmproxy-linux/default.nix
+++ b/pkgs/development/python-modules/mitmproxy-linux/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage {
   pyproject = true;
 
   postPatch = ''
-    substituteInPlace ../mitmproxy-rs-*-vendor/aya-build-*/src/lib.rs \
+    substituteInPlace ../mitmproxy-rs-*-vendor/*/aya-build-*/src/lib.rs \
       --replace-fail '"+nightly",' "" \
       --replace-fail '"-Z",' "" \
       --replace-fail '"build-std=core",' ""


### PR DESCRIPTION
PR #387337 changed the directory layout of the vendored sources to include an additional sub directory.

See the hydra logs: https://hydra.nixos.org/build/324292168/nixlog/2/tail

```
Finished cargoSetupPostUnpackHook
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/wireguard-test-client/wireguard_echo_test_server.py"
Running phase: patchPhase
substituteInPlace called without any files to operate on (files must come before options!)
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
