### PR TITLE
spaghettikart: 0.9.9.1-unstable-2025-12-23 -> 1.0.0

### DIFF
--- a/pkgs/by-name/sp/spaghettikart/package.nix
+++ b/pkgs/by-name/sp/spaghettikart/package.nix
@@ -124,13 +124,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "spaghettikart";
-  version = "0.9.9.1-unstable-2025-12-23";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "HarbourMasters";
     repo = "SpaghettiKart";
-    rev = "b0582b5c32914a815fe6a2ffc41f3eb9c24a3a2b";
-    hash = "sha256-TTsW49jo8yNxuL5GFStiQRWOBw/X8Pt2hMKmDZPpEVI=";
+    tag = finalAttrs.version;
+    hash = "sha256-XEsOtt2Xg/HyYw07YGXTIBOCtIDbh3hmaBEQpbFVFYc=";
     fetchSubmodules = true;
     deepClone = true;
     postFetch = ''
@@ -279,7 +279,6 @@ stdenv.mkDerivation (finalAttrs: {
       icon = "spaghettikart";
       exec = "Spaghettify";
       comment = finalAttrs.meta.description;
-      genericName = "spaghettikart";
       desktopName = "spaghettikart";
       categories = [ "Game" ];
     })


### PR DESCRIPTION
https://github.com/HarbourMasters/SpaghettiKart/releases/tag/1.0.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
