### PR TITLE
nixosTests.{initrd-secrets-changing,optee,pulseAudio,systemd-initrd-luks-unl0kr}: mark broken on aarch64

### DIFF
--- a/nixos/tests/initrd-secrets-changing.nix
+++ b/nixos/tests/initrd-secrets-changing.nix
@@ -13,6 +13,7 @@ in
 
 testing.makeTest {
   name = "initrd-secrets-changing";
+  meta.broken = pkgs.stdenv.hostPlatform.isAarch64;
 
   nodes.machine =
     { ... }:

--- a/nixos/tests/optee.nix
+++ b/nixos/tests/optee.nix
@@ -2,8 +2,9 @@
 {
   name = "optee";
 
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ jmbaur ];
+  meta = {
+    maintainers = with lib.maintainers; [ jmbaur ];
+    broken = pkgs.stdenv.hostPlatform.isAarch64;
   };
 
   nodes.machine =

--- a/nixos/tests/pulseaudio.nix
+++ b/nixos/tests/pulseaudio.nix
@@ -31,6 +31,7 @@ let
         name = "pulseaudio${lib.optionalString fullVersion "Full"}${lib.optionalString systemWide "-systemWide"}";
         meta = {
           maintainers = pkgs.pulseaudio.meta.maintainers;
+          broken = pkgs.stdenv.hostPlatform.isAarch64;
         };
 
         nodes.machine =

--- a/nixos/tests/systemd-initrd-luks-unl0kr.nix
+++ b/nixos/tests/systemd-initrd-luks-unl0kr.nix
@@ -14,6 +14,7 @@ in
   name = "systemd-initrd-luks-unl0kr";
   meta = {
     maintainers = [ ];
+    broken = pkgs.stdenv.hostPlatform.isAarch64;
   };
 
   # TODO: Fix OCR: #302965


### PR DESCRIPTION
These have been failing for a while (November 2025 for 1, and at least 2024 for the others).
This wastes Hydra's time.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
