### PR TITLE
python3Packages.pytest-subprocess: 1.5.3 -> 1.5.4

### DIFF
--- a/pkgs/development/python-modules/pytest-subprocess/default.nix
+++ b/pkgs/development/python-modules/pytest-subprocess/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonAtLeast,
   fetchpatch,
   setuptools,
   pytest,
@@ -17,23 +16,22 @@
 
 buildPythonPackage rec {
   pname = "pytest-subprocess";
-  version = "1.5.3";
+  version = "1.5.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aklajnert";
     repo = "pytest-subprocess";
     tag = version;
-    hash = "sha256-3vBYOk/P78NOjAbs3fT6py5QOOK3fX+AKtO4j5vxZfk=";
+    hash = "sha256-TFTY6enuyzQx0U+qHVde71VHqVa0oEGbSJUwhMAsI7Q=";
   };
 
-  patches = lib.optionals (pythonAtLeast "3.13") [
+  patches = [
+    # https://github.com/aklajnert/pytest-subprocess/pull/202
     (fetchpatch {
-      # python 3.14 compat
-      # the patch however breaks 3.12:
-      # https://github.com/aklajnert/pytest-subprocess/issues/192
-      url = "https://github.com/aklajnert/pytest-subprocess/commit/be30d9a94ba45afb600717e3fcd95b8b2ff2c60e.patch";
-      hash = "sha256-TYk/Zu2MF+ROEKTgZI1rzA2MlW2it++xElfGZS0Dn5s=";
+      name = "fix-test_any_matching_program.patch";
+      url = "https://github.com/aklajnert/pytest-subprocess/commit/14c571b9b72a7b7e429189a9455fc715e6f0dbce.patch";
+      hash = "sha256-xDj5KSyv+JXRuMoUKpIr5oDN9y8V14LApRXbzNi9HI8=";
     })
   ];
 
@@ -50,8 +48,6 @@ buildPythonPackage rec {
     anyio
     typing-extensions
   ];
-
-  pytestFlags = [ "-Wignore::DeprecationWarning" ];
 
   meta = {
     description = "Plugin to fake subprocess for pytest";


### PR DESCRIPTION
Diff: https://github.com/aklajnert/pytest-subprocess/compare/1.5.3...1.5.4

Changelog: https://github.com/aklajnert/pytest-subprocess/blob/1.5.4/HISTORY.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
