### PR TITLE
 python3Packages.numba: tbb support

### DIFF
--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -5,6 +5,7 @@
   buildPythonPackage,
   replaceVars,
   fetchpatch,
+  symlinkJoin,
 
   # nativeBuildInputs
   setuptools,
@@ -12,6 +13,7 @@
   # dependencies
   llvmlite,
   numpy,
+  onetbb,
 
   # tests
   numba,
@@ -35,6 +37,16 @@
 
 let
   cudatoolkit = cudaPackages.cuda_nvcc;
+
+  # numba needs both `lib/` and `include/` in that path, so we make a `_joined` output for it.
+  onetbb_joined = symlinkJoin {
+    name = "onetbb_joined";
+    paths = [
+      onetbb.dev
+      onetbb.out
+    ];
+  };
+
 in
 buildPythonPackage (finalAttrs: {
   version = "0.63.1";
@@ -56,12 +68,28 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-M7Hdc1Qakclz7i/HujBUqVEWFsHj9ZGQDzb8Ze9AztA=";
   };
 
+  env.TBBROOT = "${onetbb_joined}";
+
   postPatch = ''
     substituteInPlace numba/cuda/cudadrv/driver.py \
       --replace-fail \
         "dldir = [" \
         "dldir = [ '${addDriverRunpath.driverLink}/lib', "
-  '';
+  ''
+  +
+    # At runtime, `numba` does `CDLL('libtbb.so.12')` in `_check_tbb_version_compatible()`
+    # to check the TBB version before loading the TBB threading layer.
+    # That bare `dlopen` does not find the library without `LD_LIBRARY_PATH`.
+    # We patch it to use the absolute path instead.
+    ''
+      substituteInPlace numba/np/ufunc/parallel.py \
+        --replace-fail \
+          "libtbb_name = 'libtbb.so.12'" \
+          "libtbb_name = '${onetbb_joined}/lib/libtbb.so.12'" \
+        --replace-fail \
+          "libtbb_name = 'libtbb.12.dylib'" \
+          "libtbb_name = '${onetbb_joined}/lib/libtbb.12.dylib'"
+    '';
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -6,6 +6,7 @@
   replaceVars,
   fetchpatch,
   symlinkJoin,
+  runCommand,
 
   # nativeBuildInputs
   setuptools,
@@ -194,6 +195,47 @@ buildPythonPackage (finalAttrs: {
     numpy_1 = numba.override {
       numpy = numpy_1;
     };
+    # Tests whether the various numba threading backends work.
+    threadingLayers =
+      let
+        numbaTestScript = writers.writePython3 "numba-test" { } ''
+          import numba
+          import numpy as np
+          from numba import njit
+
+
+          print("numba from:", numba.__file__)
+
+
+          @njit(parallel=True)
+          def test():
+              return np.sum(np.arange(100))
+
+
+          print("Result:", test())
+          print("Threading layer:", numba.threading_layer())
+          print("Success")
+        '';
+        makeThreadingLayerTest =
+          threadingLayerName:
+          runCommand "${finalAttrs.pname}-test-${threadingLayerName}"
+            {
+              nativeBuildInputs = [
+                (python.withPackages (ps: [
+                  finalAttrs.finalPackage
+                ]))
+              ];
+            }
+            ''
+              NUMBA_THREADING_LAYER=${threadingLayerName} python ${numbaTestScript} > $out
+            '';
+      in
+
+      {
+        workqueue = makeThreadingLayerTest "workqueue";
+        omp = makeThreadingLayerTest "omp";
+        tbb = makeThreadingLayerTest "tbb";
+      };
   };
 
   meta = {


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
