### PR TITLE
rc: unstable-2023-06-14 -> unstable-2025-10-01

### DIFF
--- a/pkgs/by-name/rc/rc/package.nix
+++ b/pkgs/by-name/rc/rc/package.nix
@@ -31,25 +31,18 @@ assert
 assert (lineEditingLibrary == "readline") -> readlineSupport;
 stdenv.mkDerivation (finalAttrs: {
   pname = "rc";
-  version = "unstable-2023-06-14";
+  version = "unstable-2025-10-01";
 
   src = fetchFromGitHub {
     owner = "rakitzis";
     repo = "rc";
-    rev = "4aaba1a9cb9fdbb8660696a87850836ffdb09599";
-    hash = "sha256-Yql3mt7hTO2W7wTfPje+X2zBGTHiNXGGXYORJewJIM8=";
+    rev = "2bab312ea11cb77d2654a731357842971c0b5d18";
+    hash = "sha256-ViyO3i7P2RU5HZvbenANOT1WTF7JCLexeqeHPUT8PCQ=";
   };
 
   outputs = [
     "out"
     "man"
-  ];
-
-  patches = [
-    (fetchpatch2 {
-      url = "https://github.com/rakitzis/rc/commit/2bab312ea11cb77d2654a731357842971c0b5d18.patch";
-      hash = "sha256-LpnrsvJH/0CRS0bCgoZT2Dkac6AZH8DZIPU4MQ5MP0I=";
-    })
   ];
 
   # TODO: think on a less ugly fixup


### PR DESCRIPTION
This includes rakitzis/rc#117 that fixes the hydra build broken by gcc-15 migration.

https://hydra.nixos.org/build/324324334.
https://github.com/rakitzis/rc/pull/117
https://github.com/rakitzis/rc/compare/4aaba1a..2bab312
https://builds.sr.ht/~kaction/job/1715385

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
