### PR TITLE
nixosTests.lomiri-clock-app: Fix OCR further

### DIFF
--- a/nixos/tests/lomiri-clock-app.nix
+++ b/nixos/tests/lomiri-clock-app.nix
@@ -18,6 +18,12 @@
         variables = {
           UITK_ICON_THEME = "suru";
         };
+
+        # App has a somewhat small horizontal max size and a white background, while we configure IceWM to have a black background.
+        # Makes OCR less reliable, often completely fails to find the localised text. Force background to be white instead.
+        etc."icewm/prefoverride".text = ''
+          DesktopBackgroundColor=#FFFFFF
+        '';
       };
 
       i18n.supportedLocales = [ "all" ];


### PR DESCRIPTION
Localised strings still struggle to be found consistently. Issue seems to be that the app has a somewhat small horizontal max size, leaving more than half of the screen at the same colour as the app's text. Set IceWM's background colour to #FFFFFF to fix that discrepancy in background colours.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
