### PR TITLE
nixos/wrappers: verify that capabilities strings are valid

### DIFF
--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -356,8 +356,7 @@ in
 
           echo -n "Checking that Nix store paths of all wrapped programs exist... "
 
-          declare -A wrappers
-          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
+          ${lib.toShellVar "wrappers" (lib.mapAttrs (n: v: v.source) wrappers)}
 
           for name in "''${!wrappers[@]}"; do
             path="''${wrappers[$name]}"

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -370,6 +370,20 @@ in
             fi
           done
 
+          ${lib.toShellVar "capabilities" (lib.mapAttrs (n: v: v.capabilities) wrappers)}
+
+          for name in "''${!capabilities[@]}"; do
+            capability="''${capabilities[$name]}"
+            if ! ${lib.getExe pkgs.libcap-text-verifier} "$capability" > /dev/null; then
+              test -t 1 && echo -ne '\033[1;31m'
+              echo "FAIL"
+              echo "The capability $capability is invalid!"
+              echo 'Please, check the value of `security.wrappers."'$name'".capabilities`.'
+              test -t 1 && echo -ne '\033[0m'
+              exit 1
+            fi
+          done
+
           echo "OK"
         ''
     );

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -363,6 +363,7 @@ in
     system.checks = lib.singleton (
       pkgs.runCommandLocal "ensure-all-wrappers-paths-exist"
         {
+          nativeBuildInputs = [ pkgs.libcap-text-verifier ];
           preferLocalBuild = true;
         }
         ''
@@ -370,9 +371,7 @@ in
           mkdir -p $out
 
           echo -n "Checking that Nix store paths of all wrapped programs exist... "
-
           ${lib.toShellVar "wrappers" (lib.mapAttrs (n: v: v.source) wrappers)}
-
           for name in "''${!wrappers[@]}"; do
             path="''${wrappers[$name]}"
             if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
@@ -384,7 +383,21 @@ in
               exit 1
             fi
           done
+          echo "OK"
 
+          echo -n "Checking that all capabilities of all wrapped programs are valid... "
+          ${lib.toShellVar "capabilities" (lib.mapAttrs (n: v: v.capabilities) wrappers)}
+          for name in "''${!capabilities[@]}"; do
+            capability="''${capabilities[$name]}"
+            if ! libcap-text-verifier "$capability" > /dev/null; then
+              test -t 1 && echo -ne '\033[1;31m'
+              echo "FAIL"
+              echo "The capability $capability is invalid!"
+              echo 'Please, check the value of `security.wrappers."'$name'".capabilities`.'
+              test -t 1 && echo -ne '\033[0m'
+              exit 1
+            fi
+          done
           echo "OK"
         ''
     );

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -371,8 +371,7 @@ in
 
           echo -n "Checking that Nix store paths of all wrapped programs exist... "
 
-          declare -A wrappers
-          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
+          ${lib.toShellVar "wrappers" (lib.mapAttrs (n: v: v.source) wrappers)}
 
           for name in "''${!wrappers[@]}"; do
             path="''${wrappers[$name]}"

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -361,7 +361,7 @@ in
 
     ###### wrappers consistency checks
     system.checks = lib.singleton (
-      pkgs.runCommand "ensure-all-wrappers-paths-exist"
+      pkgs.runCommandLocal "ensure-all-wrappers-paths-exist"
         {
           preferLocalBuild = true;
         }

--- a/pkgs/by-name/li/libcap-text-verifier/package.nix
+++ b/pkgs/by-name/li/libcap-text-verifier/package.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  libcap,
+  stdenv,
+}:
+
+stdenv.mkDerivation {
+  pname = "libcap-text-verifier";
+  version = "0-unstable";
+
+  src = ./src;
+
+  buildInputs = [ libcap ];
+
+  meta = {
+    description = "Verify textual POSIX capability sets";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ amarshall ];
+    mainProgram = "libcap-text-verifier";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/li/libcap-text-verifier/package.nix
+++ b/pkgs/by-name/li/libcap-text-verifier/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   libcap,
+  nixosTests,
   stdenv,
 }:
 
@@ -16,6 +17,12 @@ stdenv.mkDerivation {
   buildInputs = [ libcap ];
 
   doCheck = true;
+
+  passthru = {
+    tests = {
+      vm = nixosTests.wrappers;
+    };
+  };
 
   meta = {
     description = "Verify textual POSIX capability sets";

--- a/pkgs/by-name/li/libcap-text-verifier/package.nix
+++ b/pkgs/by-name/li/libcap-text-verifier/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  libcap,
+  stdenv,
+}:
+
+stdenv.mkDerivation {
+  pname = "libcap-text-verifier";
+  version = "0-unstable";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = ./src;
+
+  buildInputs = [ libcap ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Verify textual POSIX capability sets";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ amarshall ];
+    mainProgram = "libcap-text-verifier";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/li/libcap-text-verifier/src/Makefile
+++ b/pkgs/by-name/li/libcap-text-verifier/src/Makefile
@@ -1,0 +1,11 @@
+.PHONY: all install
+
+LDFLAGS = -lcap
+
+all: libcap-text-verifier
+
+libcap-text-verifier: main.c
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
+install: libcap-text-verifier
+	install -Dm755 $< $(out)/bin/$<

--- a/pkgs/by-name/li/libcap-text-verifier/src/Makefile
+++ b/pkgs/by-name/li/libcap-text-verifier/src/Makefile
@@ -1,0 +1,15 @@
+.PHONY: all check install
+
+LDFLAGS = -lcap
+
+all: libcap-text-verifier
+
+libcap-text-verifier: main.c
+	$(CC) $(CFLAGS) -Wall -Wextra -Werror -o $@ $< $(LDFLAGS)
+
+install: libcap-text-verifier
+	install -Dm755 $< $(out)/bin/$<
+
+check: libcap-text-verifier
+	./$< "cap_setuid+ep" # should succeed
+	! ./$< "x=y" # should fail

--- a/pkgs/by-name/li/libcap-text-verifier/src/main.c
+++ b/pkgs/by-name/li/libcap-text-verifier/src/main.c
@@ -1,0 +1,35 @@
+/**
+ * Adapted from `man cap_from_text`
+ * https://git.kernel.org/pub/scm/libs/libcap/libcap.git/tree/doc/cap_from_text.3?id=e1e79bcbaec103c074dd4d501692ef8ff41d75ae
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/capability.h>
+
+#define handle_error(msg) do { perror(msg); exit(EXIT_FAILURE); } while (0)
+
+int main(int argc, char *argv[]) {
+   cap_t caps;
+   char *txt_caps;
+
+   if (argc != 2) {
+       fprintf(stderr, "%s <textual-cap-set>\n", argv[0]);
+       exit(EXIT_FAILURE);
+   }
+
+   caps = cap_from_text(argv[1]);
+   if (caps == NULL)
+       handle_error("cap_from_text");
+
+   txt_caps = cap_to_text(caps, NULL);
+   if (txt_caps == NULL)
+       handle_error("cap_to_text");
+
+   printf("caps_to_text() returned \"%s\"\n", txt_caps);
+
+   if (cap_free(txt_caps) != 0 || cap_free(caps) != 0)
+       handle_error("cap_free");
+
+   exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
See individual commits for details and elaboration. Fixes https://github.com/NixOS/nixpkgs/issues/398934.

Not sure the best name for the pkg, or if it would be better inlined in the module (possibly with `writeCBin`? though don’t think one can add flags with that…).

## Things done

`nix-build -A nixosTests.wrappers`, including manually changing one of the wrapper defs in the test to have a broken capabilities string.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
