### PR TITLE
dart.fetchGitHashesScript: fetch submodules to match behavior of fetchgit

### DIFF
--- a/pkgs/development/compilers/dart/fetch-git-hashes.py
+++ b/pkgs/development/compilers/dart/fetch-git-hashes.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 def fetch_git_hash(url: str, rev: str) -> str:
     result = subprocess.run(
-        ["nix-prefetch-git", "--url", url, "--rev", rev],
+        ["nix-prefetch-git", "--fetch-submodules", "--url", url, "--rev", rev],
         capture_output=True,
         text=True,
         check=True,


### PR DESCRIPTION
This is needed to add a update script to finamp.
See [pubspec.lock.json](https://github.com/NixOS/nixpkgs/blob/1dd3f2f3af9f111c226c70e42e81fc916f8554c6/pkgs/by-name/fi/finamp/pubspec.lock.json#L1424-L1434) [packages repo](https://github.com/jmshrv/packages.git)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
