### PR TITLE
v2f: init at 0-unstable-2026-03-21

### DIFF
--- a/pkgs/by-name/v2/v2f/package.nix
+++ b/pkgs/by-name/v2/v2f/package.nix
@@ -1,0 +1,71 @@
+{
+  autoPatchelfHook,
+  fetchFromGitHub,
+  lib,
+  libGL,
+  libgcc,
+  libxkbcommon,
+  lua5_4_compat,
+  nix-update-script,
+  pkg-config,
+  rustPlatform,
+  stdenvNoCC,
+  wayland,
+}:
+
+let
+  lua = lua5_4_compat;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "v2f";
+  version = "0-unstable-2026-03-21";
+
+  src = fetchFromGitHub {
+    owner = "ben-j-c";
+    repo = "verilog2factorio";
+    rev = "5a96763e2c170f5229c7f98615220fe682ef0894";
+    hash = "sha256-dKXTANRvrP1EHmzguBLpaR4kwIrc53JKAXiZ6U0xBzY=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-O5htpvkUnWdRTbIusTHxCTFLu45z/ZsQdHNtF4OazpQ=";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    libgcc
+    lua
+  ];
+
+  runtimeDependencies = lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    libGL
+    libxkbcommon
+    wayland
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Verilog to Factorio";
+    longDescription = ''
+      The purpose of this tool is to allow Factorio players to use
+      Verilog to describe combinator circuits.  An additional purpose
+      is to provide a simple API for describing combinators, so
+      players can manually create designs.
+
+      - Take a Verilog file and outputs json blueprint strings that
+        can be imported in Factorio 2.0.
+      - Exposes a Rust and Lua API for players to make designs in
+        code.
+    '';
+    homepage = "https://github.com/ben-j-c/verilog2factorio";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "v2f";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
