### PR TITLE
python3Packages.dask: 2026.1.2 -> 2026.3.0

### DIFF
--- a/pkgs/development/python-modules/dask/default.nix
+++ b/pkgs/development/python-modules/dask/default.nix
@@ -44,14 +44,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "dask";
-  version = "2026.1.2";
+  version = "2026.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dask";
     repo = "dask";
     tag = finalAttrs.version;
-    hash = "sha256-cyeAU5r8uYb7aAII9HztKY+3On44/nOC9eU9stYYWzE=";
+    hash = "sha256-JfCiABGSCJKKSz2/r8fvpVwdQSZqvoQICe+lDvuNhoM=";
   };
 
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
@@ -118,6 +118,10 @@ buildPythonPackage (finalAttrs: {
   pytestFlags = [
     # Rerun failed tests up to three times
     "--reruns=3"
+
+    # FutureWarning: The previous implementation of stack is deprecated and will be removed in a
+    # future version of pandas.
+    "-Wignore::FutureWarning"
   ];
 
   disabledTestMarks = [
@@ -125,8 +129,16 @@ buildPythonPackage (finalAttrs: {
     "network"
   ];
 
-  # https://github.com/dask/dask/issues/12042
-  disabledTests = lib.optionals (pythonAtLeast "3.14") [
+  disabledTests = [
+    # https://github.com/dask/dask/issues/10931
+    "test_combine_first_all_nans"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # RuntimeWarning: divide by zero encountered in det
+    "test_array_notimpl_function_dask"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # https://github.com/dask/dask/issues/12042
     "test_multiple_repartition_partition_size"
   ];
 

--- a/pkgs/development/python-modules/distributed/default.nix
+++ b/pkgs/development/python-modules/distributed/default.nix
@@ -27,14 +27,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "distributed";
-  version = "2026.1.2";
+  version = "2026.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dask";
     repo = "distributed";
     tag = finalAttrs.version;
-    hash = "sha256-VkZ9rd+eVyfwfRMSAqriR8UjdlqsqHYCkCHZJnk0VOU=";
+    hash = "sha256-lStJwJbhuyPuJ7Nbcm6S6f7tq1T5DtAy8zE1p2Mdrt0=";
   };
 
   build-system = [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/dask/dask/compare/2026.1.2...2026.3.0
Changelog: https://docs.dask.org/en/latest/changelog.html

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test