### PR TITLE
dotnet/update.nix: fix update of sdk without bootstrap

### DIFF
--- a/pkgs/development/compilers/dotnet/update.nix
+++ b/pkgs/development/compilers/dotnet/update.nix
@@ -57,144 +57,148 @@ let
     lib.path.removePrefix root path;
 
 in
-writeScript "update-dotnet-vmr.sh" ''
-  #! ${nix}/bin/nix-shell
-  #! nix-shell -i ${runtimeShell} --pure ${drv} --keep UPDATE_NIX_ATTR_PATH
-  set -euo pipefail
+writeScript "update-dotnet-vmr.sh" (
+  ''
+    #! ${nix}/bin/nix-shell
+    #! nix-shell -i ${runtimeShell} --pure ${drv} --keep UPDATE_NIX_ATTR_PATH
+    set -euo pipefail
 
-  tag=''${1-}
+    tag=''${1-}
 
-  if [[ -n $tag ]]; then
-      query=$(cat <<EOF
-          map(
-              select(
-                  (.tag_name == "$tag"))) |
-          first
-  EOF
-      )
-  else
-      query=$(cat <<EOF
-          map(
-              select(
-                  ${lib.optionalString (!allowPrerelease) ".prerelease == false and"}
-                  .draft == false and
-                  (.tag_name | startswith("v${sdkVersionPrefix}")))) |
-          first
-  EOF
-      )
-  fi
-
-  query="$query "$(cat <<EOF
-      | (
-          .tag_name,
-          (.assets |
-              .[] |
-              select(.name == "release.json") |
-              .browser_download_url),
-          (.assets |
-              .[] |
-              select(.name | endswith(".tar.gz.sig")) |
-              .browser_download_url))
-  EOF
-  )
-
-  (
-      curl -fsSL https://api.github.com/repos/dotnet/dotnet/releases | \
-      jq -er "$query" \
-  ) | (
-      read tagName
-      read releaseUrl
-      read sigUrl
-
-      # TMPDIR might be really long, which breaks gpg
-      tmp="$(TMPDIR=/tmp mktemp -d)"
-      trap 'rm -rf "$tmp"' EXIT
-
-      cd "$tmp"
-
-      curl -fsSL "$releaseUrl" -o release.json
-
-      if [[ -z $tag && "$tagName" == "${tag}" ]]; then
-          >&2 echo "release is already $tagName"
-          exit
-      fi
-
-      tarballUrl=https://github.com/dotnet/dotnet/archive/refs/tags/$tagName.tar.gz
-
-      mapfile -t prefetch < <(nix-prefetch-url --print-path "$tarballUrl")
-      tarballHash=$(nix-hash --to-sri --type sha256 "''${prefetch[0]}")
-      tarball=''${prefetch[1]}
-
-      # recent dotnet 10 releases don't have a signature for the github tarball
-      if [[ ! $sigUrl = */dotnet-source-* ]]; then
-        curl -fssL "$sigUrl" -o release.sig
-
-        (
-            export GNUPGHOME=$PWD/.gnupg
-            mkdir -m 700 -p $GNUPGHOME
-            trap 'gpgconf --kill all' EXIT
-            gpg --no-autostart --batch --import ${releaseKey}
-            gpg --no-autostart --batch --verify release.sig "$tarball"
+    if [[ -n $tag ]]; then
+        query=$(cat <<EOF
+            map(
+                select(
+                    (.tag_name == "$tag"))) |
+            first
+    EOF
         )
-      fi
+    else
+        query=$(cat <<EOF
+            map(
+                select(
+                    ${lib.optionalString (!allowPrerelease) ".prerelease == false and"}
+                    .draft == false and
+                    (.tag_name | startswith("v${sdkVersionPrefix}")))) |
+            first
+    EOF
+        )
+    fi
 
-      tar --strip-components=1 --no-wildcards-match-slash --wildcards -xzf "$tarball" \*/eng/Versions.props \*/global.json \*/prep\*.sh
-      artifactsVersion=$(xq -r '.Project.PropertyGroup |
-          map(select(.PrivateSourceBuiltArtifactsVersion))
-          | .[] | .PrivateSourceBuiltArtifactsVersion' eng/Versions.props)
+    query="$query "$(cat <<EOF
+        | (
+            .tag_name,
+            (.assets |
+                .[] |
+                select(.name == "release.json") |
+                .browser_download_url),
+            (.assets |
+                .[] |
+                select(.name | endswith(".tar.gz.sig")) |
+                .browser_download_url))
+    EOF
+    )
 
-      if [[ "$artifactsVersion" != "" ]]; then
-          artifactVar=$(grep ^defaultArtifactsRid= prep-source-build.sh)
-          eval "$artifactVar"
+    (
+        curl -fsSL https://api.github.com/repos/dotnet/dotnet/releases | \
+        jq -er "$query" \
+    ) | (
+        read tagName
+        read releaseUrl
+        read sigUrl
 
-          artifactsFile=Private.SourceBuilt.Artifacts.$artifactsVersion.$defaultArtifactsRid.tar.gz
-          artifactsUrl=https://builds.dotnet.microsoft.com/${
-            if lib.versionAtLeast channel "10" then "dotnet/source-build" else "source-built-artifacts/assets"
-          }/$artifactsFile
+        # TMPDIR might be really long, which breaks gpg
+        tmp="$(TMPDIR=/tmp mktemp -d)"
+        trap 'rm -rf "$tmp"' EXIT
 
-          curl -fsSL "$artifactsUrl" --head || {
-            [[ $? == 22 ]]
-            artifactsUrl=https://ci.dot.net/public/source-build/$artifactsFile
-          }
-      else
-          artifactsUrl=$(xq -r '.Project.PropertyGroup |
-              map(select(.PrivateSourceBuiltArtifactsUrl))
-              | .[] | .PrivateSourceBuiltArtifactsUrl' eng/Versions.props)
-          artifactsUrl="''${artifactsUrl/dotnetcli.azureedge.net/builds.dotnet.microsoft.com}"
-      fi
+        cd "$tmp"
 
-      artifactsHash=$(nix-prefetch-url "$artifactsUrl")
-      artifactsHash=$(nix-hash --to-sri --type sha256 "$artifactsHash")
+        curl -fsSL "$releaseUrl" -o release.json
 
-      sdkVersion=$(jq -er .tools.dotnet global.json)
+        if [[ -z $tag && "$tagName" == "${tag}" ]]; then
+            >&2 echo "release is already $tagName"
+            exit
+        fi
 
-      # below needs to be run in nixpkgs because toOutputPath uses relative paths
-      cd -
+        tarballUrl=https://github.com/dotnet/dotnet/archive/refs/tags/$tagName.tar.gz
 
-      cp "$tmp"/release.json "${toOutputPath releaseManifestFile}"
+        mapfile -t prefetch < <(nix-prefetch-url --print-path "$tarballUrl")
+        tarballHash=$(nix-hash --to-sri --type sha256 "''${prefetch[0]}")
+        tarball=''${prefetch[1]}
 
-      jq --null-input \
-          --arg _0 "$tarballHash" \
-          --arg _1 "$artifactsUrl" \
-          --arg _2 "$artifactsHash" \
-          '{
-              "tarballHash": $_0,
-              "artifactsUrl": $_1,
-              "artifactsHash": $_2,
-          }' > "${toOutputPath releaseInfoFile}"
+        # recent dotnet 10 releases don't have a signature for the github tarball
+        if [[ ! $sigUrl = */dotnet-source-* ]]; then
+          curl -fssL "$sigUrl" -o release.sig
 
-      updateSDK() {
-          ${lib.escapeShellArg (toOutputPath ./update.sh)} \
-              -o ${lib.escapeShellArg (toOutputPath bootstrapSdkFile)} --sdk "$1" >&2
-      }
+          (
+              export GNUPGHOME=$PWD/.gnupg
+              mkdir -m 700 -p $GNUPGHOME
+              trap 'gpgconf --kill all' EXIT
+              gpg --no-autostart --batch --import ${releaseKey}
+              gpg --no-autostart --batch --verify release.sig "$tarball"
+          )
+        fi
 
-      updateSDK "$sdkVersion" || if [[ $? == 2 ]]; then
-          >&2 echo "WARNING: bootstrap sdk missing, attempting to bootstrap with self"
-          updateSDK "$(jq -er .sdkVersion "$tmp"/release.json)"
-      else
-          exit 1
-      fi
+        tar --strip-components=1 --no-wildcards-match-slash --wildcards -xzf "$tarball" \*/eng/Versions.props \*/global.json \*/prep\*.sh
+        artifactsVersion=$(xq -r '.Project.PropertyGroup |
+            map(select(.PrivateSourceBuiltArtifactsVersion))
+            | .[] | .PrivateSourceBuiltArtifactsVersion' eng/Versions.props)
 
-      $(nix-build -A $UPDATE_NIX_ATTR_PATH.fetch-deps --no-out-link) >&2
-  )
-''
+        if [[ "$artifactsVersion" != "" ]]; then
+            artifactVar=$(grep ^defaultArtifactsRid= prep-source-build.sh)
+            eval "$artifactVar"
+
+            artifactsFile=Private.SourceBuilt.Artifacts.$artifactsVersion.$defaultArtifactsRid.tar.gz
+            artifactsUrl=https://builds.dotnet.microsoft.com/${
+              if lib.versionAtLeast channel "10" then "dotnet/source-build" else "source-built-artifacts/assets"
+            }/$artifactsFile
+
+            curl -fsSL "$artifactsUrl" --head || {
+              [[ $? == 22 ]]
+              artifactsUrl=https://ci.dot.net/public/source-build/$artifactsFile
+            }
+        else
+            artifactsUrl=$(xq -r '.Project.PropertyGroup |
+                map(select(.PrivateSourceBuiltArtifactsUrl))
+                | .[] | .PrivateSourceBuiltArtifactsUrl' eng/Versions.props)
+            artifactsUrl="''${artifactsUrl/dotnetcli.azureedge.net/builds.dotnet.microsoft.com}"
+        fi
+
+        artifactsHash=$(nix-prefetch-url "$artifactsUrl")
+        artifactsHash=$(nix-hash --to-sri --type sha256 "$artifactsHash")
+
+        sdkVersion=$(jq -er .tools.dotnet global.json)
+
+        # below needs to be run in nixpkgs because toOutputPath uses relative paths
+        cd -
+
+        cp "$tmp"/release.json "${toOutputPath releaseManifestFile}"
+
+        jq --null-input \
+            --arg _0 "$tarballHash" \
+            --arg _1 "$artifactsUrl" \
+            --arg _2 "$artifactsHash" \
+            '{
+                "tarballHash": $_0,
+                "artifactsUrl": $_1,
+                "artifactsHash": $_2,
+            }' > "${toOutputPath releaseInfoFile}"
+  ''
+  + lib.optionalString (bootstrapSdkFile != null) ''
+    updateSDK() {
+        ${lib.escapeShellArg (toOutputPath ./update.sh)} \
+            -o ${lib.escapeShellArg (toOutputPath bootstrapSdkFile)} --sdk "$1" >&2
+    }
+
+    updateSDK "$sdkVersion" || if [[ $? == 2 ]]; then
+        >&2 echo "WARNING: bootstrap sdk missing, attempting to bootstrap with self"
+        updateSDK "$(jq -er .sdkVersion "$tmp"/release.json)"
+    else
+        exit 1
+    fi
+  ''
+  + ''
+        $(nix-build -A $UPDATE_NIX_ATTR_PATH.fetch-deps --no-out-link) >&2
+    )
+  ''
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
