### PR TITLE
python3Packages.qtile: enable (most) tests

### DIFF
--- a/pkgs/development/python-modules/qtile/default.nix
+++ b/pkgs/development/python-modules/qtile/default.nix
@@ -123,7 +123,6 @@ buildPythonPackage (finalAttrs: {
   propagatedBuildInputs = [
     wayland-protocols
     cffi
-    xcffib
     aiohttp
   ];
 

--- a/pkgs/development/python-modules/qtile/default.nix
+++ b/pkgs/development/python-modules/qtile/default.nix
@@ -2,53 +2,70 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # nativeBuildInputs
+  pkg-config,
+  wayland-scanner,
+
+  # dependencies
   cairocffi,
   dbus-fast,
-  aiohttp,
-  cairo,
-  cffi,
-  glib,
   iwlib,
   libcst,
-  libdrm,
-  libinput,
-  libxkbcommon,
   mpd2,
-  pango,
-  pixman,
-  pkg-config,
   psutil,
   pulsectl-asyncio,
   pygobject3,
   pytz,
   pyxdg,
-  setuptools,
-  setuptools-scm,
-  wayland,
-  wayland-protocols,
-  wayland-scanner,
-  wlroots,
-  libxcb-cursor,
-  libxcb-wm,
   xcffib,
-  nixosTests,
+  extraPackages ? [ ],
+
+  # buildInputs
+  cairo,
+  libinput,
+  libxcb-wm,
+  libxkbcommon,
+  wayland,
+  wlroots,
+  # environment & pypaBuildFlags
+  libdrm,
+  pixman,
+  glib,
+  pango,
+  libxcb-cursor,
+
+  # propagatedBuildInputs
+  aiohttp,
+  cffi,
+  wayland-protocols,
+
+  # checkInputs
+  gtk3,
+  librsvg,
+
+  # nativeCheckInputs
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-httpbin,
+  pytest-xdist,
+  writableTmpDirAsHomeHook,
   anyio,
   fontconfig,
   gdk-pixbuf,
   gobject-introspection,
-  gtk3,
   isort,
-  librsvg,
-  pytest-asyncio,
-  pytest-httpbin,
-  pytest-xdist,
-  pytestCheckHook,
-  writableTmpDirAsHomeHook,
   wxsvg,
   xorg-server,
   xterm,
   xvfb,
-  extraPackages ? [ ],
+
+  # passthru.tests
+  nixosTests,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -116,10 +133,10 @@ buildPythonPackage (finalAttrs: {
   buildInputs = [
     cairo
     libinput
+    libxcb-wm
     libxkbcommon
     wayland
     wlroots
-    libxcb-wm
   ];
 
   propagatedBuildInputs = [
@@ -134,16 +151,16 @@ buildPythonPackage (finalAttrs: {
   ];
 
   nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-httpbin
+    pytest-xdist
+    writableTmpDirAsHomeHook
     anyio
     fontconfig
     gdk-pixbuf
     gobject-introspection
     isort
-    pytest-asyncio
-    pytest-httpbin
-    pytest-xdist
-    pytestCheckHook
-    writableTmpDirAsHomeHook
     wxsvg
     xorg-server
     xterm

--- a/pkgs/development/python-modules/qtile/default.nix
+++ b/pkgs/development/python-modules/qtile/default.nix
@@ -98,7 +98,9 @@ buildPythonPackage (finalAttrs: {
   ];
 
   dependencies = extraPackages ++ [
+    aiohttp
     (cairocffi.override { withXcffib = true; })
+    cffi
     dbus-fast
     iwlib
     libcst
@@ -122,8 +124,6 @@ buildPythonPackage (finalAttrs: {
 
   propagatedBuildInputs = [
     wayland-protocols
-    cffi
-    aiohttp
   ];
 
   pythonImportsCheck = [ "libqtile" ];

--- a/pkgs/development/python-modules/qtile/default.nix
+++ b/pkgs/development/python-modules/qtile/default.nix
@@ -32,6 +32,22 @@
   libxcb-wm,
   xcffib,
   nixosTests,
+  anyio,
+  fontconfig,
+  gdk-pixbuf,
+  gobject-introspection,
+  gtk3,
+  isort,
+  librsvg,
+  pytest-asyncio,
+  pytest-httpbin,
+  pytest-xdist,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+  wxsvg,
+  xorg-server,
+  xterm,
+  xvfb,
   extraPackages ? [ ],
 }:
 
@@ -50,10 +66,16 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-5XHzlS/Knw/VmVtnM7wToJ/F12GAa2lwdWuXBJHXnZM=";
   };
 
+  patches = [
+    # https://github.com/qtile/qtile/pull/5889
+    ./fix-test-net.patch
+  ];
+
   build-system = [
     setuptools
     setuptools-scm
   ];
+
   nativeBuildInputs = [
     pkg-config
     wayland-scanner
@@ -105,7 +127,61 @@ buildPythonPackage (finalAttrs: {
     aiohttp
   ];
 
-  doCheck = false;
+  pythonImportsCheck = [ "libqtile" ];
+
+  checkInputs = [
+    gtk3
+    librsvg
+  ];
+
+  nativeCheckInputs = [
+    anyio
+    fontconfig
+    gdk-pixbuf
+    gobject-introspection
+    isort
+    pytest-asyncio
+    pytest-httpbin
+    pytest-xdist
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+    wxsvg
+    xorg-server
+    xterm
+    xvfb
+  ];
+
+  preCheck = ''
+    export PATH=$PATH:$out/bin
+  '';
+
+  disabledTests = [
+    # ModuleNotFoundError: No module named 'libqtile'
+    # known issue upstream: https://github.com/qtile/qtile/issues/5883
+    "test_identify_output"
+
+    # caused by dbus-fast trying to read '/var/lib/dbus/machine-id'
+    "test_defaults"
+    "test_device_actions"
+    "test_adapter_actions"
+    "test_statusnotifier_defaults"
+    "test_custom_symbols"
+    "test_statusnotifier_defaults_vertical_bar"
+    "test_default_show_battery"
+    "test_statusnotifier_icon_size"
+    "test_missing_adapter"
+    "test_statusnotifier_left_click"
+    "test_default_text"
+    "test_statusnotifier_left_click_vertical_bar"
+    "test_default_device"
+
+    # PermissionError: [Errno 13] Permission denied: '/var'
+    "test_thermal_zone_getting_value"
+
+    # Probably won't work in the Nix sandbox due to `xcffib.ConnectionException`
+    "test_urgent_hook_fire"
+  ];
+
   passthru = {
     tests.qtile = nixosTests.qtile;
     providedSessions = [ "qtile" ];

--- a/pkgs/development/python-modules/qtile/fix-test-net.patch
+++ b/pkgs/development/python-modules/qtile/fix-test-net.patch
@@ -1,0 +1,63 @@
+From 71c70072524ee2fb2f4683861236894e51c50d6e Mon Sep 17 00:00:00 2001
+From: elParaguayo <elparaguayocode@gmail.com>
+Date: Tue, 24 Mar 2026 20:38:18 +0000
+Subject: [PATCH] Fix test_net.py
+
+The test uses a fake psutil module to get net statistics. However,
+values are increased between tests and so will fail if tests are run in
+a different order. We fix this by resetting stats between tests.
+---
+ test/widgets/test_net.py | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/test/widgets/test_net.py b/test/widgets/test_net.py
+index dcb0966c50..ea6a849a3a 100644
+--- a/test/widgets/test_net.py
++++ b/test/widgets/test_net.py
+@@ -34,6 +34,8 @@ def __init__(self, up, down):
+ @pytest.fixture
+ def patch_net(fake_qtile, monkeypatch, fake_window):
+     def build_widget(**kwargs):
++        MockPsutil.up = 0
++        MockPsutil.down = 0
+         monkeypatch.setitem(sys.modules, "psutil", MockPsutil("psutil"))
+         from libqtile.widget import net
+
+@@ -62,15 +64,15 @@ def test_net_defaults(patch_net):
+ def test_net_single_interface(patch_net):
+     """Display single named interface"""
+     net2 = patch_net(interface="wlp58s0")
+-    assert net2.poll() == "wlp58s0: U 40.0kB 160.0kB D 1.2MB 4.8MB T 1.24MB 4.96MB"
++    assert net2.poll() == "wlp58s0: U 40.0kB 80.0kB D 1.2MB 2.4MB T 1.24MB 2.48MB"
+
+
+ def test_net_list_interface(patch_net):
+     """Display multiple named interfaces"""
+     net2 = patch_net(interface=["wlp58s0", "lo"])
+     assert net2.poll() == (
+-        "wlp58s0: U 40.0kB 240.0kB D 1.2MB 7.2MB T 1.24MB 7.44MB lo: U 40.0kB "
+-        "240.0kB D 1.2MB 7.2MB T 1.24MB 7.44MB"
++        "wlp58s0: U 40.0kB 80.0kB D 1.2MB 2.4MB T 1.24MB 2.48MB "
++        "lo: U 40.0kB 80.0kB D 1.2MB 2.4MB T 1.24MB 2.48MB"
+     )
+
+
+@@ -83,7 +85,7 @@ def test_net_invalid_interface(patch_net):
+ def test_net_use_bits(patch_net):
+     """Display all interfaces in bits rather than bytes"""
+     net4 = patch_net(use_bits=True)
+-    assert net4.poll() == "all: U 320.0kb 2.56Mb D 9.6Mb 76.8Mb T 9.92Mb 79.36Mb"
++    assert net4.poll() == "all: U 320.0kb 640.0kb D 9.6Mb 19.2Mb T 9.92Mb 19.84Mb"
+
+
+ def test_net_convert_zero_b(patch_net):
+@@ -95,7 +97,7 @@ def test_net_convert_zero_b(patch_net):
+ def test_net_use_prefix(patch_net):
+     """Tests `prefix` configurable option"""
+     net6 = patch_net(prefix="M")
+-    assert net6.poll() == "all: U 0.04MB 440.0kB D 1.2MB 13.2MB T 1.24MB 13.64MB"
++    assert net6.poll() == "all: U 0.04MB 80.0kB D 1.2MB 2.4MB T 1.24MB 2.48MB"
+
+
+ def test_net_missing_interface(patch_net):
+


### PR DESCRIPTION
Enables 1280 passing tests from Qtile

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
