### PR TITLE
bupc: 2020.12.0 -> 2022.10.0

### DIFF
--- a/pkgs/by-name/bu/bupc/package.nix
+++ b/pkgs/by-name/bu/bupc/package.nix
@@ -8,16 +8,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "berkeley_upc";
-  version = "2020.12.0";
+  version = "2022.10.0";
 
   src = fetchurl {
     url = "https://upc.lbl.gov/download/release/berkeley_upc-${finalAttrs.version}.tar.gz";
-    hash = "sha256-JdpFORlXHpCQE+TivoQQnjQlxQN7C8BNfHvTOSwXbYQ=";
+    hash = "sha256-ZckvdxDixr06BTzJ0ErEdtmR4G05llIUsVgLEUR65LU=";
   };
 
   postPatch = ''
     patchShebangs .
   '';
+
+  # gcc 15
+  env.NIX_CFLAGS_COMPILE = "-Wno-incompatible-pointer-types";
 
   # Used during the configure phase
   env.ENVCMD = "${coreutils}/bin/env";


### PR DESCRIPTION
Fix gcc15 compilation

Ref #475479

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
