### PR TITLE
wpsoffice-cn: remove absolute Exec path, unused deps and dirs

### DIFF
--- a/pkgs/by-name/wp/wpsoffice-cn/package.nix
+++ b/pkgs/by-name/wp/wpsoffice-cn/package.nix
@@ -189,7 +189,7 @@ else
 
       for i in $out/share/applications/*; do
         substituteInPlace $i \
-          --replace-fail /usr/bin $out/bin
+          --replace-fail /usr/bin/ ""
       done
 
       runHook postInstall

--- a/pkgs/by-name/wp/wpsoffice-cn/package.nix
+++ b/pkgs/by-name/wp/wpsoffice-cn/package.nix
@@ -167,9 +167,9 @@ else
       tar -xf data.tar.xz
 
       # Remove unneeded files
-      rm -rf usr/share/{fonts,locale}
+      rm -rf usr/share/{fonts,locale,templates}
       rm -f usr/bin/misc
-      rm -rf opt/kingsoft/wps-office/{desktops,INSTALL}
+      rm -rf opt/kingsoft/wps-office/{desktops,INSTALL,templates}
       rm -f opt/kingsoft/wps-office/office6/lib{peony-wpsprint-menu-plugin,bz2,jpeg,stdc++,gcc_s,odbc*,dbus-1}.so*
     '';
 

--- a/pkgs/by-name/wp/wpsoffice-cn/package.nix
+++ b/pkgs/by-name/wp/wpsoffice-cn/package.nix
@@ -13,7 +13,6 @@
   libjpeg,
   libtool,
   libxkbcommon,
-  nss,
   nspr,
   udev,
   gtk3,


### PR DESCRIPTION
Edit: There is no universal document templates specification. Although I haven't delved deeply into how nix handles `share/templates/*.desktop` (and how `.source` points to), it takes no effect on my machine so far.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
