### PR TITLE
python3Packages.tsplib95: fix build

### DIFF
--- a/pkgs/development/python-modules/tsplib95/default.nix
+++ b/pkgs/development/python-modules/tsplib95/default.nix
@@ -42,6 +42,7 @@ buildPythonPackage rec {
   '';
 
   pythonRelaxDeps = [
+    "deprecated"
     "networkx"
     "tabulate"
   ];


### PR DESCRIPTION
- python313Packages.tsplib95:
  - https://hydra.nixos.org/build/322437475
  - https://hydra.nixos.org/build/322437476
  - https://hydra.nixos.org/build/322437474
  - https://hydra.nixos.org/build/322437471
- python314Packages.tsplib95
  - https://hydra.nixos.org/build/322476195
  - https://hydra.nixos.org/build/322476197
  - https://hydra.nixos.org/build/322476199
  - https://hydra.nixos.org/build/322476196

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
