### PR TITLE
python3Packages.scikit-rf: fix build

### DIFF
--- a/pkgs/development/python-modules/scikit-rf/default.nix
+++ b/pkgs/development/python-modules/scikit-rf/default.nix
@@ -22,6 +22,7 @@
   pytestCheckHook,
   pytest-cov-stub,
   pytest-mock,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -43,6 +44,8 @@ buildPythonPackage rec {
     scipy
     pandas
   ];
+
+  pythonRemoveDeps = [ "pre-commit" ];
 
   optional-dependencies = {
     plot = [ matplotlib ];
@@ -72,13 +75,17 @@ buildPythonPackage rec {
     networkx
     pytestCheckHook
     pytest-cov-stub
+    writableTmpDirAsHomeHook
   ];
 
-  # test_calibration.py generates a divide by zero error on darwin
-  # and fails on Linux after updates of dependenceis
-  # https://github.com/scikit-rf/scikit-rf/issues/972
-  disabledTestPaths = [
-    "skrf/calibration/tests/test_calibration.py"
+  pytestFlags = [ "-Wignore::pytest.PytestUnraisableExceptionWarning" ];
+
+  disabledTests = [
+    # numpy.exceptions.VisibleDeprecationWarning: dtype(): align should be
+    #  passed as Python or NumPy boolean but got `align=0`
+    "test_constructor_from_pathlib"
+    "test_constructor_from_pickle"
+    "test_constructor_from_touchstone_special_encoding"
   ];
 
   pythonImportsCheck = [ "skrf" ];


### PR DESCRIPTION
- python313Packages.scikit-rf:
  - https://hydra.nixos.org/build/322432372
  - https://hydra.nixos.org/build/322432369
  - https://hydra.nixos.org/build/322432371
  - https://hydra.nixos.org/build/322432368
- python314Packages.scikit-rf:
  - https://hydra.nixos.org/build/322471255
  - https://hydra.nixos.org/build/322471250
  - https://hydra.nixos.org/build/322471253
  - https://hydra.nixos.org/build/322471254

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
