### PR TITLE
seanime: 3.5.0 -> 3.5.2, refactor

### DIFF
--- a/pkgs/by-name/se/seanime/default-disable-update-check.patch
+++ b/pkgs/by-name/se/seanime/default-disable-update-check.patch
@@ -1,8 +1,8 @@
-diff --git a/src/lib/server/settings.ts b/src/lib/server/settings.ts
-index c28f466..4555e90 100644
---- a/src/lib/server/settings.ts
-+++ b/src/lib/server/settings.ts
-@@ -65,7 +65,7 @@ export const settingsSchema = z.object({
+diff --git a/seanime-web/src/lib/server/settings.ts b/seanime-web/src/lib/server/settings.ts
+index 2d80eb8..9fcd986 100644
+--- a/seanime-web/src/lib/server/settings.ts
++++ b/seanime-web/src/lib/server/settings.ts
+@@ -66,7 +66,7 @@ export const settingsSchema = z.object({
      transmissionPassword: z.string().optional().default(""),
      hideAudienceScore: z.boolean().optional().default(false),
      autoUpdateProgress: z.boolean().optional().default(false),

--- a/pkgs/by-name/se/seanime/package.nix
+++ b/pkgs/by-name/se/seanime/package.nix
@@ -1,53 +1,48 @@
 {
   lib,
   fetchFromGitHub,
-  buildGo126Module,
-  buildNpmPackage,
+  buildGoModule,
   ffmpeg,
+  nodejs,
+  npmHooks,
+  fetchNpmDeps,
+  nix-update-script,
 }:
-let
-  version = "3.5.0";
+buildGoModule (finalAttrs: {
+  pname = "seanime";
+  version = "3.5.2";
+
   src = fetchFromGitHub {
     owner = "5rahim";
     repo = "seanime";
-    rev = "v${version}";
-    hash = "sha256-5A2gg0ZFy9JP42I6fh9dcVUkS7P+0aH7arT4gdjAYHM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ejXWQPUROIzu6RlUJIaKaiJfPb59kupQDhqWU83EqP4=";
   };
 
-  seanime-web = buildNpmPackage {
-    pname = "seanime-web";
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+  ];
 
-    inherit src version;
-
-    sourceRoot = "${src.name}/seanime-web";
-
-    patches = [ ./default-disable-update-check.patch ];
-
-    npmDepsHash = "sha256-kO5k4B5mKoIfhhujNM0jw+/ErVwxm9/nZ5eBTWnA7HQ=";
-
-    installPhase = ''
-      runHook preInstall
-
-      mkdir -p $out
-      cp -r out $out/web
-
-      runHook postInstall
-    '';
+  env = {
+    npmRoot = "seanime-web";
+    npmDeps = fetchNpmDeps {
+      src = "${finalAttrs.src}/seanime-web";
+      hash = "sha256-fWlK2h0RQF9GnEogXW3bwM01RCCDVij/9S2sn2BA3S4=";
+    };
   };
-in
-buildGo126Module {
-  pname = "seanime";
 
-  inherit src version;
-
-  vendorHash = "sha256-jdGkrU4WGgqkWN0FIaxVhtYfFnS+/ZnAY6dWB+gOmNQ=";
+  patches = [ ./default-disable-update-check.patch ];
 
   preBuild = ''
-    cp -r ${seanime-web}/web .
+    npm run build --prefix seanime-web
+    cp -r seanime-web/out web
 
     # .github scripts redeclare main
     rm -rf .github
   '';
+
+  vendorHash = "sha256-TN9shH4B7XVDIa541+7MHTNQs1IKPRJW1dn8tmES5jg=";
 
   subPackages = [ "." ];
 
@@ -58,6 +53,7 @@ buildGo126Module {
     "-w"
   ];
 
+  # for transcoding
   makeWrapperArgs = [
     "--prefix PATH : ${
       lib.makeBinPath [
@@ -65,6 +61,8 @@ buildGo126Module {
       ]
     }"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Open-source media server for anime and manga";
@@ -74,4 +72,4 @@ buildGo126Module {
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ thegu5 ];
   };
-}
+})


### PR DESCRIPTION
Now the package is a single derivation, and uses `finalAttrs`.
https://matrix.to/#/#nixpkgs-update:nixos.org/$9HXMvb0FjYJ6GeanztnV_8H2dvq1PwwJE42EuX0TqLo

https://github.com/5rahim/seanime/releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
