### PR TITLE
python3Packages.pyaxencoapi: init at 1.0.6

### DIFF
--- a/pkgs/development/python-modules/pyaxencoapi/default.nix
+++ b/pkgs/development/python-modules/pyaxencoapi/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  aiohttp,
+  aioresponses,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest-asyncio,
+  pytestCheckHook,
+  python-socketio,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyaxencoapi";
+  version = "1.0.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "AXENCO-FR";
+    repo = "ha-py-axenco-api";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Tr5HPNUrbpapOcI8pyKnN25RgXh5AokWGQCe3X4645g=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    python-socketio
+  ]
+  ++ python-socketio.optional-dependencies.asyncio_client;
+
+  nativeCheckInputs = [
+    aioresponses
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pyaxencoapi" ];
+
+  meta = {
+    description = "Async Python client for Axenco MyNeomitis REST/Websocket API";
+    homepage = "https://github.com/AXENCO-FR/ha-py-axenco-api";
+    changelog = "https://github.com/AXENCO-FR/ha-py-axenco-api/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -4048,7 +4048,8 @@
       ];
     "myneomitis" =
       ps: with ps; [
-      ]; # missing inputs: pyaxencoapi
+        pyaxencoapi
+      ];
     "myq" =
       ps: with ps; [
       ];
@@ -7808,6 +7809,7 @@
     "music_assistant"
     "mutesync"
     "my"
+    "myneomitis"
     "myq"
     "mysensors"
     "mystrom"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13304,6 +13304,8 @@ self: super: with self; {
 
   pyavm = callPackage ../development/python-modules/pyavm { };
 
+  pyaxencoapi = callPackage ../development/python-modules/pyaxencoapi { };
+
   pyaxmlparser = callPackage ../development/python-modules/pyaxmlparser { };
 
   pybalboa = callPackage ../development/python-modules/pybalboa { };


### PR DESCRIPTION
- https://www.home-assistant.io/integrations/myneomitis/
- https://github.com/AXENCO-FR/ha-py-axenco-api
- https://pypi.org/project/pyaxencoapi/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
