### PR TITLE
python3Packages.harlequin-postgres: fix build

### DIFF
--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -29,6 +29,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "questionary"
     "rich-click"
     "textual"
+    "tomlkit"
     "tree-sitter"
     "tree-sitter-sql"
   ];

--- a/pkgs/development/python-modules/harlequin-postgres/default.nix
+++ b/pkgs/development/python-modules/harlequin-postgres/default.nix
@@ -4,6 +4,8 @@
   fetchPypi,
   hatchling,
   psycopg,
+  duckdb,
+  pythonAtLeast,
 }:
 
 buildPythonPackage rec {
@@ -24,7 +26,8 @@ buildPythonPackage rec {
   dependencies = [
     psycopg
     psycopg.pool
-  ];
+  ]
+  ++ lib.optional (pythonAtLeast "3.14") duckdb;
 
   # To prevent circular dependency
   # as harlequin-postgres requires harlequin which requires harlequin-postgres


### PR DESCRIPTION
- python314Packages.harlequin-postgres:
  - https://hydra.nixos.org/build/323106676
  - https://hydra.nixos.org/build/323106673
  - https://hydra.nixos.org/build/323106675
  - https://hydra.nixos.org/build/323106670

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
