### PR TITLE
python3Packages.disnake: fix build

### DIFF
--- a/pkgs/development/python-modules/disnake/default.nix
+++ b/pkgs/development/python-modules/disnake/default.nix
@@ -7,6 +7,9 @@
   typing-extensions,
   libopus,
   pynacl,
+  pytestCheckHook,
+  pytest-asyncio,
+  looptime,
   withVoice ? true,
   ffmpeg,
 }:
@@ -42,8 +45,16 @@ buildPythonPackage rec {
       --replace-fail 'executable: str = "ffmpeg"' 'executable: str="${ffmpeg}/bin/ffmpeg"'
   '';
 
-  # Only have integration tests with discord
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    looptime
+  ];
+
+  pytestFlags = [
+    # DeprecationWarning: There is no current event loop
+    "-Wignore::DeprecationWarning"
+  ];
 
   pythonImportsCheck = [
     "disnake"

--- a/pkgs/development/python-modules/disnake/default.nix
+++ b/pkgs/development/python-modules/disnake/default.nix
@@ -4,6 +4,7 @@
   aiohttp,
   buildPythonPackage,
   fetchFromGitHub,
+  typing-extensions,
   libopus,
   pynacl,
   withVoice ? true,
@@ -26,6 +27,7 @@ buildPythonPackage rec {
 
   dependencies = [
     aiohttp
+    typing-extensions
   ]
   ++ lib.optionals withVoice [
     libopus


### PR DESCRIPTION
- python313Packages.disnake:
  - https://hydra.nixos.org/build/322408730
  - https://hydra.nixos.org/build/322408726
  - https://hydra.nixos.org/build/322408729
  - https://hydra.nixos.org/build/322408725
- python314Packages.disnake:
  - https://hydra.nixos.org/build/322448612
  - https://hydra.nixos.org/build/322448337
  - https://hydra.nixos.org/build/322448339
  - https://hydra.nixos.org/build/322448338

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
