### PR TITLE
python3Packages.conda-libmamba-solver: fix build

### DIFF
--- a/pkgs/development/python-modules/conda-libmamba-solver/default.nix
+++ b/pkgs/development/python-modules/conda-libmamba-solver/default.nix
@@ -6,6 +6,9 @@
   hatch-vcs,
   boltons,
   libmambapy,
+  msgpack,
+  requests,
+  zstandard,
 }:
 buildPythonPackage rec {
   pname = "conda-libmamba-solver";
@@ -28,6 +31,9 @@ buildPythonPackage rec {
   dependencies = [
     boltons
     libmambapy
+    msgpack
+    requests
+    zstandard
   ];
 
   # this package depends on conda for the import to run successfully, but conda depends on this package to execute.


### PR DESCRIPTION
- python313Packages.conda-libmamba-solver
  - https://hydra.nixos.org/build/322407219
  - https://hydra.nixos.org/build/322407195
  - https://hydra.nixos.org/build/322407199
  - https://hydra.nixos.org/build/322407202
- python314Packages.conda-libmamba-solver
  - https://hydra.nixos.org/build/322446872
  - https://hydra.nixos.org/build/322446842
  - https://hydra.nixos.org/build/322446847
  - https://hydra.nixos.org/build/322446846

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
