### PR TITLE
python3Packages.bork: fix build

### DIFF
--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -8,9 +8,12 @@
   setuptools,
   build,
   coloredlogs,
+  homf,
   packaging,
   pip,
+  pydantic,
   urllib3,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -38,8 +41,10 @@ buildPythonPackage rec {
   dependencies = [
     build
     coloredlogs
+    homf
     packaging
     pip
+    pydantic
     urllib3
   ];
 
@@ -49,13 +54,18 @@ buildPythonPackage rec {
     "bork.cli"
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   disabledTestMarks = [ "network" ];
 
   disabledTests = [
     # tries to call python -m bork
     "test_repo"
+    # Attempt to install packages via pip
+    "test_builder_cwd"
+    "test_builder_order"
   ];
 
   passthru.tests = callPackage ./tests.nix { };


### PR DESCRIPTION
- python313Packages.bork:
  - https://hydra.nixos.org/build/322405672
  - https://hydra.nixos.org/build/322405658
  - https://hydra.nixos.org/build/322405659
  - https://hydra.nixos.org/build/322405656
- python314Packages.bork:
  - https://hydra.nixos.org/build/322445373
  - https://hydra.nixos.org/build/322445369
  - https://hydra.nixos.org/build/322445370
  - https://hydra.nixos.org/build/322445367

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
