### PR TITLE
python3Packages.pint-xarray: fix build

### DIFF
--- a/pkgs/development/python-modules/pint-xarray/default.nix
+++ b/pkgs/development/python-modules/pint-xarray/default.nix
@@ -2,10 +2,12 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   setuptools,
   setuptools-scm,
   numpy,
   pint,
+  toolz,
   xarray,
   pytestCheckHook,
 }:
@@ -27,9 +29,25 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
+  patches = [
+    # Fixes 2 test failures. The merge commit of PR:
+    # https://github.com/xarray-contrib/pint-xarray/pull/367
+    (fetchpatch2 {
+      url = "https://github.com/xarray-contrib/pint-xarray/commit/296ee2e60c671175507de1fe904fa7e4d0a70586.patch?full_index=1";
+      hash = "sha256-SS2zQ7fIeLzEUTd+8BW1PFBw8+qed0fLslns1jNpLtA=";
+    })
+    # Similarly to the above, fixes 3 more test failures. See:
+    # https://github.com/xarray-contrib/pint-xarray/pull/368
+    (fetchpatch2 {
+      url = "https://github.com/xarray-contrib/pint-xarray/commit/6134b61e2cb6b4c46b7b0974a6e499dff2d9e18e.patch?full_index=1";
+      hash = "sha256-s1AbaXAeL0sGkj/DWV5145FKGHW4eF+a11w1yg5QENA=";
+    })
+  ];
+
   dependencies = [
     numpy
     pint
+    toolz
     xarray
   ];
 


### PR DESCRIPTION
- python313Packages.pint-xarray
  - https://hydra.nixos.org/build/322423872
  - https://hydra.nixos.org/build/322423868
  - https://hydra.nixos.org/build/322423896
  - https://hydra.nixos.org/build/322424026
- python314Packages.pint-xarray
  - https://hydra.nixos.org/build/322462925
  - https://hydra.nixos.org/build/322462919
  - https://hydra.nixos.org/build/322462950
  - https://hydra.nixos.org/build/322462931

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
