### PR TITLE
python3Packages.niaaml: fix build

### DIFF
--- a/pkgs/development/python-modules/niaaml/default.nix
+++ b/pkgs/development/python-modules/niaaml/default.nix
@@ -11,6 +11,8 @@
   scikit-learn,
   toml-adapt,
   typer,
+  typing-extensions,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -43,6 +45,7 @@ buildPythonPackage rec {
     pandas
     scikit-learn
     typer
+    typing-extensions
   ];
 
   # create scikit-learn and niapy deps version consistent
@@ -51,7 +54,10 @@ buildPythonPackage rec {
     toml-adapt -path pyproject.toml -a change -dep niapy -ver X
   '';
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
 
   pythonImportsCheck = [ "niaaml" ];
 


### PR DESCRIPTION
- python313Packages.niaaml
  - https://hydra.nixos.org/build/322421538
  - https://hydra.nixos.org/build/322421536
  - https://hydra.nixos.org/build/322421537
  - https://hydra.nixos.org/build/322421535
- python314Packages.niaaml
  - https://hydra.nixos.org/build/322460654
  - https://hydra.nixos.org/build/322460652
  - https://hydra.nixos.org/build/322460651
  - https://hydra.nixos.org/build/322460653

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
