### PR TITLE
python3Packages.nbconflux: fix build

### DIFF
--- a/pkgs/development/python-modules/nbconflux/default.nix
+++ b/pkgs/development/python-modules/nbconflux/default.nix
@@ -2,11 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  bleach,
+  html5lib,
   nbconvert,
   pytestCheckHook,
   requests,
   responses,
   setuptools,
+  traitlets,
   versioneer,
 }:
 
@@ -28,8 +31,11 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
+    bleach
+    html5lib
     nbconvert
     requests
+    traitlets
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
- python313Packages.nbconflux
  - https://hydra.nixos.org/build/322421242
  - https://hydra.nixos.org/build/322421232
  - https://hydra.nixos.org/build/322421233
  - https://hydra.nixos.org/build/322421234
- python314Packages.nbconflux
  - https://hydra.nixos.org/build/322460369
  - https://hydra.nixos.org/build/322460368
  - https://hydra.nixos.org/build/322460366
  - https://hydra.nixos.org/build/322460364

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
