### PR TITLE
python3Packages.hepuints: fix build

### DIFF
--- a/pkgs/development/python-modules/hepunits/default.nix
+++ b/pkgs/development/python-modules/hepunits/default.nix
@@ -4,6 +4,7 @@
   fetchPypi,
   hatch-vcs,
   hatchling,
+  pint,
   pytestCheckHook,
 }:
 
@@ -22,7 +23,10 @@ buildPythonPackage rec {
     hatchling
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pint
+  ];
 
   meta = {
     description = "Units and constants in the HEP system of units";


### PR DESCRIPTION
- python313Packages.hepunits:
  - https://hydra.nixos.org/build/322413974
  - https://hydra.nixos.org/build/322413973
  - https://hydra.nixos.org/build/322413975
  - https://hydra.nixos.org/build/322413972
- python314Packages.hepunits
  - https://hydra.nixos.org/build/322453366
  - https://hydra.nixos.org/build/322453364
  - https://hydra.nixos.org/build/322453365
  - https://hydra.nixos.org/build/322453363

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
