### PR TITLE
python3Packages.epitran: fix build

### DIFF
--- a/pkgs/development/python-modules/epitran/default.nix
+++ b/pkgs/development/python-modules/epitran/default.nix
@@ -6,7 +6,9 @@
   unittestCheckHook,
 
   setuptools,
+  setuptools-scm,
 
+  jamo,
   regex,
   panphon,
   marisa-trie,
@@ -25,9 +27,13 @@ buildPythonPackage rec {
     hash = "sha256-LKESBSLn2gpXx8kEXmykEkTboIMiS5gZ2Kb9rj1lDTk=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   dependencies = [
+    jamo
     regex
     panphon
     marisa-trie


### PR DESCRIPTION
- python313Packages.epitran
  - https://hydra.nixos.org/build/322410715
  - https://hydra.nixos.org/build/322410710
  - https://hydra.nixos.org/build/324052306
  - https://hydra.nixos.org/build/324052291
- python314Packages.epitran
  - https://hydra.nixos.org/build/322450223
  - https://hydra.nixos.org/build/322450222
  - https://hydra.nixos.org/build/324052633
  - https://hydra.nixos.org/build/324052642

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
