### PR TITLE
python3Packages.segyio: fix build

### DIFF
--- a/pkgs/development/python-modules/segyio/default.nix
+++ b/pkgs/development/python-modules/segyio/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   ninja,
   scikit-build,
@@ -15,18 +14,7 @@ buildPythonPackage rec {
   version = "1.9.14";
   pyproject = false; # Built with cmake
 
-  patches = [
-    # Bump minimum CMake version to 3.11
-    (fetchpatch {
-      url = "https://github.com/equinor/segyio/commit/3e2cbe6ca6d4bc7d4f4d95666f5d2983836e8461.patch?full_index=1";
-      hash = "sha256-sOBHi8meMSkxEZy0AXwebAnIVPatpwQHd+4Co5zIhLQ=";
-    })
-  ];
-
   postPatch = ''
-    # Removing unecessary build dependency
-    substituteInPlace python/setup.py --replace "'pytest-runner'," ""
-
     # Fixing bug making one test fail in the python 3.10 build
     substituteInPlace python/segyio/open.py --replace \
     "cube_metrics = f.xfd.cube_metrics(iline, xline)" \


### PR DESCRIPTION
- python313Packages.segyio
  - https://hydra.nixos.org/build/322432585
  - https://hydra.nixos.org/build/322432587
  - https://hydra.nixos.org/build/322432583
  - https://hydra.nixos.org/build/322432582
- python314Packages.segyio
  - https://hydra.nixos.org/build/322471464
  - https://hydra.nixos.org/build/322471462
  - https://hydra.nixos.org/build/322471463
  - https://hydra.nixos.org/build/322471461

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
