### PR TITLE
python3Packages.nbsphinx: fix build

### DIFF
--- a/pkgs/development/python-modules/nbsphinx/default.nix
+++ b/pkgs/development/python-modules/nbsphinx/default.nix
@@ -1,9 +1,9 @@
 {
   lib,
   buildPythonPackage,
-  fetchpatch,
   fetchPypi,
   setuptools,
+  setuptools-scm,
   docutils,
   jinja2,
   nbconvert,
@@ -21,14 +21,11 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-0HZZCDmajuK1e+euiBzy6ljWbbOve78z5utI+DvqVJU=";
   };
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/spatialaudio/nbsphinx/commit/a921973a5d8ecc39c6e02184572b79ab72c9978c.patch";
-      hash = "sha256-uxfSaOESWn8uVcUm+1ADzQgMQDEqaTs0TbfNYsS+E6I=";
-    })
-  ];
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   dependencies = [
     docutils


### PR DESCRIPTION
- python313Packages.nbsphinx
  - https://hydra.nixos.org/build/322421264
  - https://hydra.nixos.org/build/322421260
  - https://hydra.nixos.org/build/322421263
  - https://hydra.nixos.org/build/322421262
- python314Packages.nbsphinx
  - https://hydra.nixos.org/build/322460398
  - https://hydra.nixos.org/build/322460394
  - https://hydra.nixos.org/build/322460395
  - https://hydra.nixos.org/build/322460392

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
