### PR TITLE
qemu: 10.2.2 -> 11.0.0

### DIFF
--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -138,11 +138,11 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString nixosTestRunner "-for-vm-tests"
     + lib.optionalString toolsOnly "-utils"
     + lib.optionalString userOnly "-user";
-  version = "10.2.2";
+  version = "11.0.0-rc4";
 
   src = fetchurl {
     url = "https://download.qemu.org/qemu-${finalAttrs.version}.tar.xz";
-    hash = "sha256-eEspb/KcFBeqcjI6vLLS6pq5dxck9Xfc14XDsE8h4XY=";
+    hash = "sha256-/ugRZyAwrCVmf0cYXzY7X1lTmkXGLCZZhTTljMylp2M=";
   };
 
   depsBuildBuild = [
@@ -163,6 +163,8 @@ stdenv.mkDerivation (finalAttrs: {
     # For python changes other than simple package additions, ping @dramforever for review.
     # Don't change `python3Packages` to `python3.pkgs.*`, breaks cross-compilation.
     python3Packages.distlib
+    python3Packages.setuptools
+    python3Packages.wheel
     # Hooks from the python package are needed to add `$pythonPath` so
     # `python/scripts/mkvenv.py` can detect `meson` otherwise the vendored meson without patches will be used.
     python3Packages.python
@@ -371,6 +373,10 @@ stdenv.mkDerivation (finalAttrs: {
   # tests can still timeout on slower systems
   doCheck = false;
   nativeCheckInputs = [ socat ];
+  checkInputs = [
+    python3Packages.pygdbmi
+    python3Packages.qemu-qmp
+  ];
   preCheck = ''
     # time limits are a little meagre for a build machine that's
     # potentially under load.
@@ -440,7 +446,7 @@ stdenv.mkDerivation (finalAttrs: {
       license = lib.licenses.gpl2Plus;
       maintainers = with lib.maintainers; [ qyliss ];
       teams = lib.optionals xenSupport xen.meta.teams;
-      platforms = lib.platforms.unix;
+      platforms = with lib.systems.inspect; patternLogicalAnd patterns.is64bit patterns.isUnix;
     }
     # toolsOnly: Does not have qemu-kvm and there's no main support tool
     # userOnly: There's one qemu-<arch> for every architecture
@@ -449,7 +455,14 @@ stdenv.mkDerivation (finalAttrs: {
     }
     # userOnly: https://qemu.readthedocs.io/en/v9.0.2/user/main.html
     // lib.optionalAttrs userOnly {
-      platforms = with lib.platforms; (linux ++ freebsd ++ openbsd ++ netbsd);
+      platforms =
+        with lib.systems.inspect;
+        patternLogicalAnd patterns.is64bit [
+          patterns.isLinux
+          patterns.isFreeBSD
+          patterns.isOpenBSD
+          patterns.isNetBSD
+        ];
       description = "QEMU User space emulator - launch executables compiled for one CPU on another CPU";
     };
 })

--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -140,11 +140,11 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString nixosTestRunner "-for-vm-tests"
     + lib.optionalString toolsOnly "-utils"
     + lib.optionalString userOnly "-user";
-  version = "10.2.2";
+  version = "11.0.0";
 
   src = fetchurl {
     url = "https://download.qemu.org/qemu-${finalAttrs.version}.tar.xz";
-    hash = "sha256-eEspb/KcFBeqcjI6vLLS6pq5dxck9Xfc14XDsE8h4XY=";
+    hash = "sha256-wEyjYBJlPzLRHGdNNwz1KnEOfT8Ywti2PkkyBSpIVNY=";
   };
 
   depsBuildBuild = [
@@ -165,6 +165,8 @@ stdenv.mkDerivation (finalAttrs: {
     # For python changes other than simple package additions, ping @dramforever for review.
     # Don't change `python3Packages` to `python3.pkgs.*`, breaks cross-compilation.
     python3Packages.distlib
+    python3Packages.setuptools
+    python3Packages.wheel
     # Hooks from the python package are needed to add `$pythonPath` so
     # `python/scripts/mkvenv.py` can detect `meson` otherwise the vendored meson without patches will be used.
     python3Packages.python
@@ -374,7 +376,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   # tests can still timeout on slower systems
   doCheck = false;
-  nativeCheckInputs = [ socat ];
+  nativeCheckInputs = [
+    python3Packages.pygdbmi
+    python3Packages.qemu-qmp
+    socat
+  ];
   preCheck = ''
     # time limits are a little meagre for a build machine that's
     # potentially under load.
@@ -444,7 +450,7 @@ stdenv.mkDerivation (finalAttrs: {
       license = lib.licenses.gpl2Plus;
       maintainers = with lib.maintainers; [ qyliss ];
       teams = lib.optionals xenSupport xen.meta.teams;
-      platforms = lib.platforms.unix;
+      platforms = with lib.systems.inspect; patternLogicalAnd patterns.is64bit patterns.isUnix;
     }
     # toolsOnly: Does not have qemu-kvm and there's no main support tool
     # userOnly: There's one qemu-<arch> for every architecture
@@ -453,7 +459,14 @@ stdenv.mkDerivation (finalAttrs: {
     }
     # userOnly: https://qemu.readthedocs.io/en/master/user/main.html#supported-operating-systems
     // lib.optionalAttrs userOnly {
-      platforms = with lib.platforms; (linux ++ freebsd ++ openbsd ++ netbsd);
+      platforms =
+        with lib.systems.inspect;
+        patternLogicalAnd patterns.is64bit [
+          patterns.isLinux
+          patterns.isFreeBSD
+          patterns.isOpenBSD
+          patterns.isNetBSD
+        ];
       description = "QEMU User space emulator - launch executables compiled for one CPU on another CPU";
     };
 })


### PR DESCRIPTION
- [Planning](https://wiki.qemu.org/Planning/11.0) (ETA: 2026-04-14)
- [ChangeLog](https://wiki.qemu.org/ChangeLog/11.0)

Important changes for us:

- All support for 32-bit host platforms has been removed.
- Big changes to how tests are run (now with Meson).  Getting this working in Nixpkgs required a patch that will hopefully be included in the next rc. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
