### PR TITLE
cosmic-settings-daemon, cosmic-applets: deduplicate internal dependencies

### DIFF
--- a/pkgs/by-name/co/cosmic-applets/dedup-cosmic-settings.patch
+++ b/pkgs/by-name/co/cosmic-applets/dedup-cosmic-settings.patch
@@ -1,0 +1,58 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 7c10e63a..052a5852 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1658,7 +1658,7 @@ dependencies = [
+ [[package]]
+ name = "cosmic-settings-a11y-manager-subscription"
+ version = "1.0.2"
+-source = "git+https://github.com/pop-os/cosmic-settings#55b502dff39bf4be056c23888aaad185f9227eb2"
++source = "git+https://github.com/pop-os/cosmic-settings#b46a55d4237f1fd6e1bacc852ceb053e6a26c2fe"
+ dependencies = [
+  "cosmic-protocols",
+  "iced_futures",
+@@ -1672,7 +1672,7 @@ dependencies = [
+ [[package]]
+ name = "cosmic-settings-accessibility-subscription"
+ version = "1.0.2"
+-source = "git+https://github.com/pop-os/cosmic-settings#55b502dff39bf4be056c23888aaad185f9227eb2"
++source = "git+https://github.com/pop-os/cosmic-settings#b46a55d4237f1fd6e1bacc852ceb053e6a26c2fe"
+ dependencies = [
+  "cosmic-dbus-a11y",
+  "futures",
+@@ -1685,7 +1685,7 @@ dependencies = [
+ [[package]]
+ name = "cosmic-settings-airplane-mode-subscription"
+ version = "1.0.2"
+-source = "git+https://github.com/pop-os/cosmic-settings#55b502dff39bf4be056c23888aaad185f9227eb2"
++source = "git+https://github.com/pop-os/cosmic-settings#b46a55d4237f1fd6e1bacc852ceb053e6a26c2fe"
+ dependencies = [
+  "futures",
+  "iced_futures",
+@@ -1718,7 +1718,7 @@ dependencies = [
+ [[package]]
+ name = "cosmic-settings-daemon-subscription"
+ version = "1.0.2"
+-source = "git+https://github.com/pop-os/cosmic-settings#55b502dff39bf4be056c23888aaad185f9227eb2"
++source = "git+https://github.com/pop-os/cosmic-settings#b46a55d4237f1fd6e1bacc852ceb053e6a26c2fe"
+ dependencies = [
+  "futures",
+  "iced_futures",
+@@ -1731,7 +1731,7 @@ dependencies = [
+ [[package]]
+ name = "cosmic-settings-network-manager-subscription"
+ version = "1.0.2"
+-source = "git+https://github.com/pop-os/cosmic-settings#55b502dff39bf4be056c23888aaad185f9227eb2"
++source = "git+https://github.com/pop-os/cosmic-settings#b46a55d4237f1fd6e1bacc852ceb053e6a26c2fe"
+ dependencies = [
+  "bitflags 2.10.0",
+  "cosmic-dbus-networkmanager",
+@@ -1765,7 +1765,7 @@ dependencies = [
+ [[package]]
+ name = "cosmic-settings-upower-subscription"
+ version = "1.0.2"
+-source = "git+https://github.com/pop-os/cosmic-settings#55b502dff39bf4be056c23888aaad185f9227eb2"
++source = "git+https://github.com/pop-os/cosmic-settings#b46a55d4237f1fd6e1bacc852ceb053e6a26c2fe"
+ dependencies = [
+  "futures",
+  "iced_futures",

--- a/pkgs/by-name/co/cosmic-applets/package.nix
+++ b/pkgs/by-name/co/cosmic-applets/package.nix
@@ -30,7 +30,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-x2FHzgbxxHJEYlCK0bi5j7WdAqAlcocLYW20y2ionBc=";
   };
 
-  cargoHash = "sha256-FWpfgqPqjbzzv6yaBKx9eq+PHCCQ/TErx+TGWqmXqXA=";
+  cargoPatches = [
+    # The lockfile references two different revisions of the same internal repository cosmic-settings,
+    # which likely is unintentional and currently causing issues with fetchCargoVendor.
+    # Upstream already resolved this because of a general dependency update, so this can be removed on the
+    # next update.
+    ./dedup-cosmic-settings.patch
+  ];
+
+  cargoHash = "sha256-R9d7slLid3x7NYXkMfcRRa4zY8/RxW+QLMZGsvHdfCw=";
 
   nativeBuildInputs = [
     just

--- a/pkgs/by-name/co/cosmic-settings-daemon/dedup-dbus-settings-bindings.patch
+++ b/pkgs/by-name/co/cosmic-settings-daemon/dedup-dbus-settings-bindings.patch
@@ -1,0 +1,31 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index e8a98ee..3902dcf 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -912,7 +912,7 @@ dependencies = [
+ [[package]]
+ name = "cosmic-dbus-a11y"
+ version = "0.1.0"
+-source = "git+https://github.com/pop-os/dbus-settings-bindings#3b86984332be2c930a3536ab714b843c851fa8ca"
++source = "git+https://github.com/pop-os/dbus-settings-bindings#0fa672f8dadb884001ef9a251b149ed432879629"
+ dependencies = [
+  "zbus",
+ ]
+@@ -3160,7 +3160,7 @@ checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+ [[package]]
+ name = "locale1"
+ version = "0.1.0"
+-source = "git+https://github.com/pop-os/dbus-settings-bindings#3b86984332be2c930a3536ab714b843c851fa8ca"
++source = "git+https://github.com/pop-os/dbus-settings-bindings#0fa672f8dadb884001ef9a251b149ed432879629"
+ dependencies = [
+  "zbus",
+ ]
+@@ -5577,7 +5577,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+ [[package]]
+ name = "upower_dbus"
+ version = "0.3.2"
+-source = "git+https://github.com/pop-os/dbus-settings-bindings#3b86984332be2c930a3536ab714b843c851fa8ca"
++source = "git+https://github.com/pop-os/dbus-settings-bindings#0fa672f8dadb884001ef9a251b149ed432879629"
+ dependencies = [
+  "serde",
+  "serde_repr",

--- a/pkgs/by-name/co/cosmic-settings-daemon/package.nix
+++ b/pkgs/by-name/co/cosmic-settings-daemon/package.nix
@@ -26,6 +26,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-np1syOfFqL6eZpnlwNb8WOXB0oqSkxIshX0JiyDlN1A=";
   };
 
+  cargoPatches = [
+    # The lockfile references two different revisions of the same internal repository dbus-settings-bindings,
+    # which likely is unintentional and currently causing issues with fetchCargoVendor.
+    # Upstream PR: https://github.com/pop-os/cosmic-settings-daemon/pull/139
+    ./dedup-dbus-settings-bindings.patch
+  ];
+
   postPatch = ''
     substituteInPlace src/battery.rs \
       --replace-fail '/usr/share/sounds/Pop/' '${pop-gtk-theme}/share/sounds/Pop/'
@@ -33,7 +40,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '/usr/share/themes/adw-gtk3' '${adw-gtk3}/share/themes/adw-gtk3'
   '';
 
-  cargoHash = "sha256-p0Dda0Chy8qJNIMAbSnqeC8kHDYIf4tsk7+NCd9/nDQ=";
+  cargoHash = "sha256-r9ZL3eNvoCWHFfxzSrETewPXIo+aGebWzBk19ra4AXY=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #501981

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
