### PR TITLE
vulkan-tools: enable darwin cube app

### DIFF
--- a/pkgs/by-name/vu/vulkan-tools/icd-path.patch
+++ b/pkgs/by-name/vu/vulkan-tools/icd-path.patch
@@ -1,0 +1,73 @@
+From a6e43cd21bdac466a14dc43eb03a627710085ea3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Stanis=C5=82aw=20Pitucha?= <git@viraptor.info>
+Date: Fri, 20 Mar 2026 01:32:21 +1100
+Subject: [PATCH] mac path
+
+---
+ cube/CMakeLists.txt              | 6 +++---
+ cube/macOS/cube/CMakeLists.txt   | 4 ++--
+ cube/macOS/cubepp/CMakeLists.txt | 4 ++--
+ 3 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/cube/CMakeLists.txt b/cube/CMakeLists.txt
+index dac6bfed..b07632bf 100644
+--- a/cube/CMakeLists.txt
++++ b/cube/CMakeLists.txt
+@@ -28,7 +28,7 @@ if(APPLE)
+     # MoltenVK JSON File
+     execute_process(COMMAND mkdir -p ${PROJECT_BINARY_DIR}/staging-json)
+     execute_process(COMMAND sed -e "/\"library_path\":/s$:[[:space:]]*\"[[:space:]]*[\\.\\/]*$: \"..\\/..\\/..\\/Frameworks\\/$"
+-                            ${MOLTENVK_DIR}/MoltenVK/icd/MoltenVK_icd.json
++                            ${MOLTENVK_DIR}/share/vulkan/icd.d/MoltenVK_icd.json
+                     OUTPUT_FILE ${PROJECT_BINARY_DIR}/staging-json/MoltenVK_icd.json)
+ 
+     # ~~~
+@@ -41,9 +41,9 @@ if(APPLE)
+     add_custom_target(MoltenVK_icd-staging-json ALL
+         COMMAND mkdir -p ${PROJECT_BINARY_DIR}/staging-json
+         COMMAND sed -e "/\"library_path\":/s$:[[:space:]]*\"[[:space:]]*[\\.\\/]*$: \"..\\/..\\/..\\/Frameworks\\/$"
+-                ${MOLTENVK_DIR}/MoltenVK/icd/MoltenVK_icd.json > ${PROJECT_BINARY_DIR}/staging-json/MoltenVK_icd.json
++                ${MOLTENVK_DIR}/share/vulkan/icd.d/MoltenVK_icd.json > ${PROJECT_BINARY_DIR}/staging-json/MoltenVK_icd.json
+         VERBATIM
+-        DEPENDS "${MOLTENVK_DIR}/MoltenVK/icd/MoltenVK_icd.json"
++        DEPENDS "${MOLTENVK_DIR}/share/vulkan/icd.d/MoltenVK_icd.json"
+     )
+     set_source_files_properties(${PROJECT_BINARY_DIR}/staging-json/MoltenVK_icd.json PROPERTIES GENERATED TRUE)
+ 
+diff --git a/cube/macOS/cube/CMakeLists.txt b/cube/macOS/cube/CMakeLists.txt
+index 3300d6b4..a3fd714c 100644
+--- a/cube/macOS/cube/CMakeLists.txt
++++ b/cube/macOS/cube/CMakeLists.txt
+@@ -78,10 +78,10 @@ set_source_files_properties("${PROJECT_BINARY_DIR}/staging-json/MoltenVK_icd.jso
+ # Copy the MoltenVK lib into the bundle.
+ if(XCODE)
+     add_custom_command(TARGET vkcube POST_BUILD
+-                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib"
++                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/lib/libMoltenVK.dylib"
+                                ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/vkcube.app/Contents/Frameworks/libMoltenVK.dylib)
+ else()
+     add_custom_command(TARGET vkcube POST_BUILD
+-                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib"
++                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/lib/libMoltenVK.dylib"
+                                ${CMAKE_CURRENT_BINARY_DIR}/vkcube.app/Contents/Frameworks/libMoltenVK.dylib)
+ endif()
+diff --git a/cube/macOS/cubepp/CMakeLists.txt b/cube/macOS/cubepp/CMakeLists.txt
+index cf051654..793bd431 100644
+--- a/cube/macOS/cubepp/CMakeLists.txt
++++ b/cube/macOS/cubepp/CMakeLists.txt
+@@ -76,10 +76,10 @@ set_source_files_properties("${PROJECT_BINARY_DIR}/staging-json/MoltenVK_icd.jso
+ # Copy the MoltenVK lib into the bundle.
+ if(XCODE)
+     add_custom_command(TARGET vkcubepp POST_BUILD
+-                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib"
++                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/lib/libMoltenVK.dylib"
+                                ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/vkcubepp.app/Contents/Frameworks/libMoltenVK.dylib)
+ else()
+     add_custom_command(TARGET vkcubepp POST_BUILD
+-                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/Package/Release/MoltenVK/dynamic/dylib/macOS/libMoltenVK.dylib"
++                       COMMAND ${CMAKE_COMMAND} -E copy "${MOLTENVK_DIR}/lib/libMoltenVK.dylib"
+                                ${CMAKE_CURRENT_BINARY_DIR}/vkcubepp.app/Contents/Frameworks/libMoltenVK.dylib)
+ endif()
+-- 
+2.51.2
+

--- a/pkgs/by-name/vu/vulkan-tools/package.nix
+++ b/pkgs/by-name/vu/vulkan-tools/package.nix
@@ -20,6 +20,8 @@
   wayland-protocols,
   wayland-scanner,
   moltenvk,
+  ibtool,
+  makeWrapper,
 }:
 
 stdenv.mkDerivation rec {
@@ -33,13 +35,19 @@ stdenv.mkDerivation rec {
     hash = "sha256-+5BL28h7+r+mLr1Tr7UT4UEB8jRrIc2JwoasJ7HzxI0=";
   };
 
-  patches = [ ./wayland-scanner.patch ];
+  patches = [
+    ./wayland-scanner.patch
+    ./icd-path.patch
+  ];
 
   nativeBuildInputs = [
     cmake
     pkg-config
     python3
     wayland-scanner
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    makeWrapper
   ];
 
   buildInputs = [
@@ -61,6 +69,7 @@ stdenv.mkDerivation rec {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     moltenvk
     moltenvk.dev
+    ibtool
   ];
 
   libraryPath = lib.strings.makeLibraryPath [ vulkan-loader ];
@@ -79,10 +88,13 @@ stdenv.mkDerivation rec {
     "-Wno-dev"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    "-DMOLTENVK_REPO_ROOT=${moltenvk}/share/vulkan/icd.d"
-    # Don’t build the cube demo because it requires `ibtool`, which is not available in nixpkgs.
-    "-DBUILD_CUBE=OFF"
+    "-DMOLTENVK_REPO_ROOT=${moltenvk}"
   ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    makeWrapper $out/cube/vkcubepp.app/Contents/MacOS/vkcubepp $out/bin/vkcubepp
+    makeWrapper $out/cube/vkcube.app/Contents/MacOS/vkcube $out/bin/vkcube
+  '';
 
   meta = {
     description = "Khronos official Vulkan Tools and Utilities";


### PR DESCRIPTION
Use the new reimplementation of ibtool to enable the vkcube compilation on darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
