### PR TITLE
netbird: use buildGo125Module

### DIFF
--- a/pkgs/by-name/ne/netbird/package.nix
+++ b/pkgs/by-name/ne/netbird/package.nix
@@ -3,7 +3,7 @@
   lib,
   nixosTests,
   nix-update-script,
-  buildGoModule,
+  buildGo125Module,
   fetchFromGitHub,
   installShellFiles,
   pkg-config,
@@ -65,7 +65,9 @@ let
   };
   component = availableComponents.${componentName};
 in
-buildGoModule (finalAttrs: {
+# Vendored gvisor has a build-tag conflict with Go 1.26 (netbirdio/netbird#5290).
+# TODO: revert to 'buildGoModule' when a release includes netbirdio/netbird#5447.
+buildGo125Module (finalAttrs: {
   pname = "netbird-${componentName}";
   version = "0.65.3";
 


### PR DESCRIPTION
Vendored gvisor in netbird 0.65.3 has a build-tag conflict with Go 1.26: both
`runtime_constants_go125.go` and `runtime_constants_go126.go` are compiled
simultaneously because Go's `//go:build go1.25` tag means "≥ 1.25", so Go 1.26
satisfies it too. This causes symbol redeclaration errors (netbirdio/netbird#5290).

Pins netbird to `buildGo125Module` as a temporary workaround. The upstream fix
(netbirdio/netbird#5447, merged 2026-03-17) bumps the vendored gvisor; revert to
`buildGoModule` once a netbird release includes it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test