### PR TITLE
python3Packages.django-structlog: init at 10.0.0

### DIFF
--- a/pkgs/development/python-modules/django-structlog/default.nix
+++ b/pkgs/development/python-modules/django-structlog/default.nix
@@ -1,0 +1,86 @@
+{
+  asgiref,
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  setuptools,
+  django,
+  django-allauth,
+  crispy-bootstrap5,
+  django-environ,
+  django-extensions,
+  django-ipware,
+  django-ninja,
+  django-redis,
+  djangorestframework,
+  structlog,
+  celery,
+  factory-boy,
+  pytest-asyncio,
+  pytest-django,
+  pytest-mock,
+  redisTestHook,
+  pytestCheckHook,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "django-structlog";
+  version = "10.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jrobichaud";
+    repo = "django-structlog";
+    tag = finalAttrs.version;
+    hash = "sha256-BNZ+nk2NK5x2YsTDZjH5BVizXAyLZhKp8zRvkWi068k=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    asgiref
+    django
+    structlog
+    django-ipware
+  ];
+
+  optional-dependencies = {
+    celery = [ celery ];
+    commands = [ django-extensions ];
+  };
+
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE=config.settings.test_demo_app
+  '';
+
+  enabledTestPaths = [ "django_structlog_demo_project" ];
+
+  pythonImportsCheck = [
+    "django_structlog"
+  ];
+
+  nativeCheckInputs = [
+    redisTestHook
+    factory-boy
+    pytest-asyncio
+    pytest-django
+    pytest-mock
+    pytestCheckHook
+    django-allauth
+    crispy-bootstrap5
+    django-environ
+    django-ninja
+    django-redis
+    djangorestframework
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = {
+    description = "Structured Logging for Django";
+    homepage = "https://github.com/jrobichaud/django-structlog";
+    changelog = "https://github.com/jrobichaud/django-structlog/blob/${finalAttrs.src.tag}/docs/changelog.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kurogeek ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4382,6 +4382,8 @@ self: super: with self; {
 
   django-storages = callPackage ../development/python-modules/django-storages { };
 
+  django-structlog = callPackage ../development/python-modules/django-structlog { };
+
   django-stubs = callPackage ../development/python-modules/django-stubs { };
 
   django-stubs-ext = callPackage ../development/python-modules/django-stubs-ext { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
