### PR TITLE
python3Packages.tensorflow-datasets: fix tests

### DIFF
--- a/pkgs/development/python-modules/tensorflow-datasets/default.nix
+++ b/pkgs/development/python-modules/tensorflow-datasets/default.nix
@@ -85,6 +85,25 @@ buildPythonPackage (finalAttrs: {
     })
   ];
 
+  postPatch =
+    # AttributeError: 'google._upb._message.FieldDescriptor' object has no attribute 'label'
+    ''
+      substituteInPlace tensorflow_datasets/core/dataset_info.py \
+        --replace-fail \
+          "elif field.label == field.LABEL_REPEATED:" \
+          "elif hasattr(field_value, 'extend'):"
+    ''
+    # TypeError: only 0-dimensional arrays can be converted to Python scalars
+    + ''
+      substituteInPlace tensorflow_datasets/datasets/smallnorb/smallnorb_dataset_builder.py \
+        --replace-fail \
+          "magic = int(np.frombuffer(s, dtype=int32_dtype, count=1))" \
+          "magic = int(np.squeeze(np.frombuffer(s, dtype=int32_dtype, count=1)))" \
+        --replace-fail \
+          "ndim = int(np.frombuffer(s, dtype=int32_dtype, count=1, offset=4))" \
+          "ndim = int(np.squeeze(np.frombuffer(s, dtype=int32_dtype, count=1, offset=4)))"
+    '';
+
   build-system = [ setuptools ];
 
   dependencies = [


### PR DESCRIPTION
## Things done

cc @ndl

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
