### PR TITLE
agda: skip eval errors in allPackages

### DIFF
--- a/pkgs/build-support/agda/lib.nix
+++ b/pkgs/build-support/agda/lib.nix
@@ -21,5 +21,10 @@
     Takes an arbitrary derivation and says whether it is an agda library package
     *  that is not marked as broken.
   */
-  isUnbrokenAgdaPackage = pkg: pkg.isAgdaDerivation or false && !pkg.meta.broken;
+  isUnbrokenAgdaPackage =
+    pkg:
+    let
+      r = builtins.tryEval (pkg.isAgdaDerivation or false && !pkg.meta.broken);
+    in
+    r.success && r.value;
 }


### PR DESCRIPTION
This fixes `agda.tests.allPackages`, which currently fails when aliases are enabled because `agdaPackages.generic` throws an evaluation error.