### PR TITLE
[25.11] binaryen: 124 -> 126

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -85,7 +85,6 @@ stdenv.mkDerivation rec {
     description = "Compiler infrastructure and toolchain library for WebAssembly, in C++";
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
-      asppsa
       willcohen
     ];
     license = lib.licenses.asl20;

--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -4,7 +4,6 @@
   cmake,
   python3,
   fetchFromGitHub,
-  fetchpatch2,
   emscripten,
   gtest,
   lit,
@@ -21,25 +20,14 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "binaryen";
-  version = "125";
+  version = "126";
 
   src = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "binaryen";
     rev = "version_${version}";
-    hash = "sha256-QG8ZhvjcTbhIfYkVfrjxd97v9KaG/A8jO69rPg99/ME=";
+    hash = "sha256-6KnPVIEtguuMHopm2vf6s+KZ3Ymf2rjFE/aXy1Kbn5E=";
   };
-
-  patches = [
-    # TODO: remove at next release
-    # fix build on aarch64/riscv64 with gcc15 but bug exists on all platforms.
-    (fetchpatch2 {
-      name = "fix-uninitialized-small-vector.patch";
-      # https://github.com/WebAssembly/binaryen/pull/8094
-      url = "https://github.com/WebAssembly/binaryen/commit/3ff3762bf7c83edcdfccad522de640f2b0928ae2.patch?full_index=1";
-      hash = "sha256-lhrXQJAaQ/4ofnpyVqhD08IuDxPRc7UPyZ8DoCfM9NE=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -4,6 +4,7 @@
   cmake,
   python3,
   fetchFromGitHub,
+  fetchpatch2,
   emscripten,
   gtest,
   lit,
@@ -28,6 +29,17 @@ stdenv.mkDerivation rec {
     rev = "version_${version}";
     hash = "sha256-tkvO0gNESliRV6FOpXDQd7ZKujGe6q1mGX5V+twcE1o=";
   };
+
+  patches = [
+    # TODO: remove at next release
+    # fix build on aarch64/riscv64 with gcc15 but bug exists on all platforms.
+    (fetchpatch2 {
+      name = "fix-uninitialized-small-vector.patch";
+      # https://github.com/WebAssembly/binaryen/pull/8094
+      url = "https://github.com/WebAssembly/binaryen/commit/3ff3762bf7c83edcdfccad522de640f2b0928ae2.patch?full_index=1";
+      hash = "sha256-lhrXQJAaQ/4ofnpyVqhD08IuDxPRc7UPyZ8DoCfM9NE=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -15,19 +15,19 @@ let
   testsuite = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "testsuite";
-    rev = "e05365077e13a1d86ffe77acfb1a835b7aa78422";
-    hash = "sha256-yvZ5AZTPUA6nsD3xpFC0VLthiu2CxVto66RTXBXXeJM=";
+    rev = "4b24564c844e3d34bf46dfcb3c774ee5163e31cc";
+    hash = "sha256-8VirKLRro0iST58Rfg17u4tTO57KNC/7F/NB43dZ7w4=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "binaryen";
-  version = "124";
+  version = "125";
 
   src = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "binaryen";
     rev = "version_${version}";
-    hash = "sha256-tkvO0gNESliRV6FOpXDQd7ZKujGe6q1mGX5V+twcE1o=";
+    hash = "sha256-QG8ZhvjcTbhIfYkVfrjxd97v9KaG/A8jO69rPg99/ME=";
   };
 
   patches = [


### PR DESCRIPTION
Fixes CVE-2025-14956 and CVE-2025-14957.
    
https://github.com/WebAssembly/binaryen/blob/version_126/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
