### PR TITLE
[Backport release-25.11] lrzip: 0.651 -> 0.660

### DIFF
--- a/pkgs/by-name/lr/lrzip/package.nix
+++ b/pkgs/by-name/lr/lrzip/package.nix
@@ -14,25 +14,16 @@
 let
   inherit (stdenv.hostPlatform) isx86;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation(finalAttrs: {
   pname = "lrzip";
-  version = "0.651";
+  version = "0.660";
 
   src = fetchFromGitHub {
     owner = "ckolivas";
     repo = "lrzip";
-    rev = "v${version}";
-    sha256 = "sha256-Mb324ojtLV0S10KhL7Vjf3DhSOtCy1pFMTzvLkTnpXM=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-6nNGmruJBim34EqbgJ+hnLTfylEz6t6jLh3O9RcUY34=";
   };
-
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # Building the ASM/x86 directory creates an empty archive,
-    # which fails on darwin, so remove it
-    # https://github.com/ckolivas/lrzip/issues/193
-    # https://github.com/Homebrew/homebrew-core/pull/85360
-    substituteInPlace lzma/Makefile.am --replace "SUBDIRS = C ASM/x86" "SUBDIRS = C"
-    substituteInPlace configure.ac --replace "-f elf64" "-f macho64"
-  '';
 
   nativeBuildInputs = [
     autoreconfHook
@@ -58,4 +49,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/lr/lrzip/package.nix
+++ b/pkgs/by-name/lr/lrzip/package.nix
@@ -14,7 +14,7 @@
 let
   inherit (stdenv.hostPlatform) isx86;
 in
-stdenv.mkDerivation(finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lrzip";
   version = "0.660";
 


### PR DESCRIPTION
https://github.com/ckolivas/lrzip/compare/v0.651...v0.660
https://github.com/ckolivas/lrzip/blob/v0.660/WHATS-NEW

Fixes https://github.com/NixOS/nixpkgs/issues/490691 / CVE-2025-15571
Fixes https://github.com/NixOS/nixpkgs/issues/489351 / CVE-2025-15570

(cherry picked from commit 8d8c48a7b72e9150795d56def9fa48bf95bb1f9d from PR #494823)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
