### PR TITLE
python3Packages.nltk: patch CVE-2025-33231 and CVE-2026-33236

### DIFF
--- a/pkgs/development/python-modules/nltk/default.nix
+++ b/pkgs/development/python-modules/nltk/default.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   fetchPypi,
+  fetchpatch,
   buildPythonPackage,
   click,
   joblib,
@@ -28,6 +29,24 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-D0CemwacpBd8GQPD6EPu+Qx+kpkvpJMa5gfabeSeFBk=";
   };
+
+  patches = [
+    # https://github.com/nltk/nltk/security/advisories/GHSA-jm6w-m3j8-898g
+    # https://github.com/NixOS/nixpkgs/issues/502599
+    (fetchpatch {
+      name = "fix-unauthed-shutdown";
+      url = "https://github.com/nltk/nltk/commit/bbaae83db86a0f49e00f5b0db44a7254c268de9b.patch";
+      hash = "sha256-1ZzOQXiNxZ6o7JQs0b9FpsUjZtuUAjXEmDkc9mV3dYU=";
+    })
+
+    # https://github.com/nltk/nltk/security/advisories/GHSA-469j-vmhf-r6v7
+    # https://github.com/NixOS/nixpkgs/issues/502535
+    (fetchpatch {
+      name = "fix-downloader-path-traversal";
+      url = "https://github.com/nltk/nltk/commit/89fe2ec2c6bae6e2e7a46dad65cc34231976ed8a.patch";
+      hash = "sha256-hQJmVEDDcio4Ew+Y10WzMV53mpYZuuDsFcEZKEzl7nk=";
+    })
+  ];
 
   dependencies = [
     click


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/502535
Closes https://github.com/NixOS/nixpkgs/issues/502599

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
