### PR TITLE
rPackages.*: move env variables into env for structuredAttrs

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1858,7 +1858,9 @@ let
     });
 
     vegan3d = old.vegan3d.overrideAttrs (attrs: {
-      RGL_USE_NULL = "true";
+      env = (attrs.env or { }) // {
+        RGL_USE_NULL = "true";
+      };
     });
 
     # it can happen that the major version of arrow-cpp is ahead of the
@@ -2189,7 +2191,9 @@ let
     });
 
     nanonext = old.nanonext.overrideAttrs (attrs: {
-      NIX_LDFLAGS = "-lnng -lmbedtls -lmbedx509 -lmbedcrypto";
+      env = (attrs.env or { }) // {
+        NIX_LDFLAGS = "-lnng -lmbedtls -lmbedx509 -lmbedcrypto";
+      };
     });
 
     clustermq = old.clustermq.overrideAttrs (attrs: {
@@ -2197,7 +2201,9 @@ let
     });
 
     Cairo = old.Cairo.overrideAttrs (attrs: {
-      NIX_LDFLAGS = "-lfontconfig";
+      env = (attrs.env or { }) // {
+        NIX_LDFLAGS = "-lfontconfig";
+      };
     });
 
     curl = old.curl.overrideAttrs (attrs: {
@@ -2509,7 +2515,9 @@ let
     });
 
     RAppArmor = old.RAppArmor.overrideAttrs (attrs: {
-      LIBAPPARMOR_HOME = pkgs.libapparmor;
+      env = (attrs.env or { }) // {
+        LIBAPPARMOR_HOME = pkgs.libapparmor;
+      };
     });
 
     # Append cargo path to path variable
@@ -2524,17 +2532,21 @@ let
     });
 
     RMySQL = old.RMySQL.overrideAttrs (attrs: {
-      MYSQL_DIR = "${pkgs.libmysqlclient}";
-      PKGCONFIG_CFLAGS = "-I${pkgs.libmysqlclient.dev}/include/mysql";
-      NIX_CFLAGS_LINK = "-L${pkgs.libmysqlclient}/lib/mysql -lmysqlclient";
+      env = (attrs.env or { }) // {
+        MYSQL_DIR = "${pkgs.libmysqlclient}";
+        PKGCONFIG_CFLAGS = "-I${pkgs.libmysqlclient.dev}/include/mysql";
+        NIX_CFLAGS_LINK = "-L${pkgs.libmysqlclient}/lib/mysql -lmysqlclient";
+      };
       preConfigure = ''
         patchShebangs configure
       '';
     });
 
     devEMF = old.devEMF.overrideAttrs (attrs: {
-      NIX_CFLAGS_LINK = "-L${pkgs.libxft.out}/lib -lXft";
-      NIX_LDFLAGS = "-lX11";
+      env = (attrs.env or { }) // {
+        NIX_CFLAGS_LINK = "-L${pkgs.libxft.out}/lib -lXft";
+        NIX_LDFLAGS = "-lX11";
+      };
     });
 
     hdf5r = old.hdf5r.overrideAttrs (attrs: {
@@ -2542,11 +2554,15 @@ let
     });
 
     slfm = old.slfm.overrideAttrs (attrs: {
-      PKG_LIBS = "-L${pkgs.blas}/lib -lblas -L${pkgs.lapack}/lib -llapack";
+      env = (attrs.env or { }) // {
+        PKG_LIBS = "-L${pkgs.blas}/lib -lblas -L${pkgs.lapack}/lib -llapack";
+      };
     });
 
     SamplerCompare = old.SamplerCompare.overrideAttrs (attrs: {
-      PKG_LIBS = "-L${pkgs.blas}/lib -lblas -L${pkgs.lapack}/lib -llapack";
+      env = (attrs.env or { }) // {
+        PKG_LIBS = "-L${pkgs.blas}/lib -lblas -L${pkgs.lapack}/lib -llapack";
+      };
     });
 
     FLAMES = old.FLAMES.overrideAttrs (attrs: {
@@ -2557,13 +2573,17 @@ let
       preConfigure = ''
         patchShebangs configure
       '';
-      PKGCONFIG_CFLAGS = "-I${pkgs.openssl.dev}/include";
-      PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -lssl -lcrypto";
+      env = (attrs.env or { }) // {
+        PKGCONFIG_CFLAGS = "-I${pkgs.openssl.dev}/include";
+        PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -lssl -lcrypto";
+      };
     });
 
     websocket = old.websocket.overrideAttrs (attrs: {
-      PKGCONFIG_CFLAGS = "-I${pkgs.openssl.dev}/include";
-      PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -lssl -lcrypto";
+      env = (attrs.env or { }) // {
+        PKGCONFIG_CFLAGS = "-I${pkgs.openssl.dev}/include";
+        PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -lssl -lcrypto";
+      };
     });
 
     Rserve = old.Rserve.overrideAttrs (attrs: {
@@ -2594,11 +2614,13 @@ let
         patchShebangs configure
       '';
 
-      R_MAKEVARS_SITE = lib.optionalString (pkgs.stdenv.system == "aarch64-linux") (
-        pkgs.writeText "Makevars" ''
-          CXX14PICFLAGS = -fPIC
-        ''
-      );
+      env = (attrs.env or { }) // {
+        R_MAKEVARS_SITE = lib.optionalString (pkgs.stdenv.system == "aarch64-linux") (
+          pkgs.writeText "Makevars" ''
+            CXX14PICFLAGS = -fPIC
+          ''
+        );
+      };
     });
 
     acs = old.acs.overrideAttrs (attrs: {
@@ -2611,7 +2633,9 @@ let
       preConfigure = ''
         patchShebangs configure
       '';
-      NIX_LDFLAGS = "-lfontconfig -lfreetype";
+      env = (attrs.env or { }) // {
+        NIX_LDFLAGS = "-lfontconfig -lfreetype";
+      };
     });
 
     magick = old.magick.overrideAttrs (attrs: {
@@ -2640,7 +2664,9 @@ let
       preConfigure = ''
         export TCLLIBPATH="${pkgs.tclPackages.bwidget}/lib/bwidget${pkgs.tclPackages.bwidget.version}"
       '';
-      TCLLIBPATH = "${pkgs.tclPackages.bwidget}/lib/bwidget${pkgs.tclPackages.bwidget.version}";
+      env = (attrs.env or { }) // {
+        TCLLIBPATH = "${pkgs.tclPackages.bwidget}/lib/bwidget${pkgs.tclPackages.bwidget.version}";
+      };
     });
 
     networkscaleup = old.networkscaleup.overrideAttrs (attrs: {
@@ -2854,8 +2880,10 @@ let
       preConfigure = ''
         patchShebangs configure
       '';
-      PKGCONFIG_CFLAGS = "-I${pkgs.openssl.dev}/include -I${pkgs.cyrus_sasl.dev}/include -I${pkgs.zlib.dev}/include";
-      PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -L${pkgs.cyrus_sasl.out}/lib -L${pkgs.zlib.out}/lib -lssl -lcrypto -lsasl2 -lz";
+      env = (attrs.env or { }) // {
+        PKGCONFIG_CFLAGS = "-I${pkgs.openssl.dev}/include -I${pkgs.cyrus_sasl.dev}/include -I${pkgs.zlib.dev}/include";
+        PKGCONFIG_LIBS = "-Wl,-rpath,${lib.getLib pkgs.openssl}/lib -L${lib.getLib pkgs.openssl}/lib -L${pkgs.cyrus_sasl.out}/lib -L${pkgs.zlib.out}/lib -lssl -lcrypto -lsasl2 -lz";
+      };
     });
 
     ChemmineOB = old.ChemmineOB.overrideAttrs (attrs: {
@@ -3019,7 +3047,9 @@ let
     ChIPXpress = old.ChIPXpress.override { hydraPlatforms = [ ]; };
 
     rgl = old.rgl.overrideAttrs (attrs: {
-      RGL_USE_NULL = "true";
+      env = (attrs.env or { }) // {
+        RGL_USE_NULL = "true";
+      };
     });
 
     Rrdrand = old.Rrdrand.override { platforms = lib.platforms.x86_64 ++ lib.platforms.x86; };
@@ -3051,7 +3081,9 @@ let
     dbarts = old.dbarts.override { platforms = lib.platforms.x86_64 ++ lib.platforms.x86; };
 
     geomorph = old.geomorph.overrideAttrs (attrs: {
-      RGL_USE_NULL = "true";
+      env = (attrs.env or { }) // {
+        RGL_USE_NULL = "true";
+      };
     });
 
     gpuMagic = old.gpuMagic.overrideAttrs (_: {
@@ -3105,9 +3137,11 @@ let
       postPatch = "patchShebangs configure";
     });
 
-    redland = old.redland.overrideAttrs (_: {
-      PKGCONFIG_CFLAGS = "-I${pkgs.redland}/include -I${pkgs.librdf_raptor2}/include/raptor2 -I${pkgs.librdf_rasqal}/include/rasqal";
-      PKGCONFIG_LIBS = "-L${pkgs.redland}/lib -L${pkgs.librdf_raptor2}/lib -L${pkgs.librdf_rasqal}/lib -lrdf -lraptor2 -lrasqal";
+    redland = old.redland.overrideAttrs (attrs: {
+      env = (attrs.env or { }) // {
+        PKGCONFIG_CFLAGS = "-I${pkgs.redland}/include -I${pkgs.librdf_raptor2}/include/raptor2 -I${pkgs.librdf_rasqal}/include/rasqal";
+        PKGCONFIG_LIBS = "-L${pkgs.redland}/lib -L${pkgs.librdf_raptor2}/lib -L${pkgs.librdf_rasqal}/lib -lrdf -lraptor2 -lrasqal";
+      };
     });
 
     textshaping = old.textshaping.overrideAttrs (attrs: {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
