### PR TITLE
haskellPackages.mkDerivation: prepare for structuredAttrs

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -121,6 +121,7 @@ in
   haddockFlags ? [ ],
   description ? null,
   doCheck ? !isCross,
+  checkFlags ? [ ],
   doBenchmark ? false,
   doHoogle ? true,
   doHaddockQuickjump ? doHoogle,
@@ -663,6 +664,10 @@ let
       + lib.optionalString (env ? NIX_CFLAGS_COMPILE) (" " + env.NIX_CFLAGS_COMPILE);
   };
 
+  # Do not use escapeShellArgs because flags can contain $var
+  # that actually need to be expanded in the bash code
+  toBashArray = flags: "(${concatStringsSep " " (map (f: ''"${f}"'') flags)})";
+
 in
 lib.fix (
   drv:
@@ -745,8 +750,11 @@ lib.fix (
         packageConfDir="$builddir/package.conf.d"
         mkdir -p $packageConfDir
 
-        setupCompileFlags="${concatStringsSep " " setupCompileFlags}"
-        configureFlags="${concatStringsSep " " defaultConfigureFlags} $configureFlags"
+        setupCompileFlags=${toBashArray setupCompileFlags}
+        configureFlags=${toBashArray (defaultConfigureFlags ++ configureFlags)}
+        buildFlags=${toBashArray buildFlags}
+        checkFlags=${toBashArray checkFlags}
+        haddockFlags=${toBashArray haddockFlags}
       ''
       # We build the Setup.hs on the *build* machine, and as such should only add
       # dependencies for the build machine.
@@ -836,15 +844,14 @@ lib.fix (
           test -f $i && break
         done
 
-        echo setupCompileFlags: $setupCompileFlags
-        ${nativeGhcCommand} $setupCompileFlags --make -o Setup -odir $builddir -hidir $builddir $i
+        echo setupCompileFlags: "''${setupCompileFlags[@]}"
+        ${nativeGhcCommand} "''${setupCompileFlags[@]}" --make -o Setup -odir $builddir -hidir $builddir $i
 
         runHook postCompileBuildDriver
       '';
 
       # Cabal takes flags like `--configure-option=--host=...` instead
       configurePlatforms = [ ];
-      inherit configureFlags buildFlags;
 
       # Note: the options here must be always added, regardless of whether the
       # package specifies `hardeningDisable`.
@@ -857,8 +864,8 @@ lib.fix (
       configurePhase = ''
         runHook preConfigure
 
-        echo configureFlags: $configureFlags
-        ${setupCommand} configure $configureFlags 2>&1 | ${coreutils}/bin/tee "$NIX_BUILD_TOP/cabal-configure.log"
+        echo configureFlags: "''${configureFlags[@]}"
+        ${setupCommand} configure "''${configureFlags[@]}" 2>&1 | ${coreutils}/bin/tee "$NIX_BUILD_TOP/cabal-configure.log"
         ${lib.optionalString (!allowInconsistentDependencies) ''
           if grep -E -q -z 'Warning:.*depends on multiple versions' "$NIX_BUILD_TOP/cabal-configure.log"; then
             echo >&2 "*** abort because of serious configure-time warning from Cabal"
@@ -880,14 +887,15 @@ lib.fix (
         find dist/build -exec touch -d '1970-01-01T00:00:00Z' {} +
       ''
       + ''
-        ${setupCommand} build ${buildTarget} $buildFlags
+        echo buildFlags: "''${buildFlags[@]}"
+        ${setupCommand} build ${buildTarget} "''${buildFlags[@]}"
         runHook postBuild
       '';
 
       inherit doCheck;
 
-      # Run test suite(s) and pass `checkFlags` as well as `checkFlagsArray`.
-      # `testFlags` are added to `checkFlagsArray` each prefixed with
+      # Run test suite(s) and pass `checkFlags`.
+      # `testFlags` are added to `checkFlags` each prefixed with
       # `--test-option`, so Cabal passes it to the underlying test suite binary.
       #
       # We also take care of setting GHC_PACKAGE_PATH during test suite execution,
@@ -899,26 +907,25 @@ lib.fix (
       #   plus GHC's core packages.
       checkPhase = ''
         runHook preCheck
-        checkFlagsArray+=(
-          "--show-details=streaming"
-          "--test-wrapper=${testWrapperScript}"
-          ${lib.escapeShellArgs (map (opt: "--test-option=${opt}") testFlags)}
-        )
+        appendToVar checkFlags "--show-details=streaming" "--test-wrapper=${testWrapperScript}"
+        appendToVar checkFlags ${lib.escapeShellArgs (map (opt: "--test-option=${opt}") testFlags)}
         export NIX_GHC_PACKAGE_PATH_FOR_TEST="''${NIX_GHC_PACKAGE_PATH_FOR_TEST:-$packageConfDir:}"
-        ${setupCommand} test ${testTargetsString} $checkFlags ''${checkFlagsArray:+"''${checkFlagsArray[@]}"}
+        echo checkFlags: "''${checkFlags[@]}"
+        ${setupCommand} test ${testTargetsString} "''${checkFlags[@]}"
         runHook postCheck
       '';
 
       haddockPhase = ''
         runHook preHaddock
         ${optionalString (doHaddock && isLibrary) ''
+          echo haddockFlags: "''${haddockFlags[@]}"
           ${setupCommand} haddock --html \
             ${optionalString doHoogle "--hoogle"} \
             ${optionalString doHaddockQuickjump "--quickjump"} \
             ${optionalString (isLibrary && hyperlinkSource) "--hyperlink-source"} \
             ${optionalString enableParallelBuilding "--haddock-option=-j$NIX_BUILD_CORES"} \
             --haddock-option=--no-tmp-comp-dir \
-            ${lib.concatStringsSep " " haddockFlags}
+            "''${haddockFlags[@]}"
         ''}
         runHook postHaddock
       '';

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -343,6 +343,8 @@ let
     END { print "" }
   '';
 
+  makeGhcOptions = opts: map (opt: "--ghc-option=${opt}") opts;
+
   crossCabalFlags = [
     "--with-ghc=${ghcCommand}"
     "--with-ghc-pkg=${ghc.targetPrefix}ghc-pkg"
@@ -355,27 +357,30 @@ let
     "--with-hsc2hs=${ghc.targetPrefix}hsc2hs"
     "--with-strip=${stdenv.cc.bintools.targetPrefix}strip"
   ]
-  ++ optionals (!isHaLVM) [
-    "--hsc2hs-option=--cross-compile"
-    (optionalString enableHsc2hsViaAsm "--hsc2hs-option=--via-asm")
+  ++ optionals (!isHaLVM) (
+    [
+      "--hsc2hs-option=--cross-compile"
+    ]
+    ++ optionals enableHsc2hsViaAsm [
+      "--hsc2hs-option=--via-asm"
+    ]
+  )
+  ++ optionals (allPkgconfigDepends != [ ]) [
+    "--with-pkg-config=${pkg-config.targetPrefix}pkg-config"
   ]
-  ++ optional (allPkgconfigDepends != [ ]) "--with-pkg-config=${pkg-config.targetPrefix}pkg-config"
-
   ++ optionals enableExternalInterpreter (
-    map (opt: "--ghc-option=${opt}") (
+    makeGhcOptions (
       [
         "-fexternal-interpreter"
         "-pgmi"
         crossSupport.iservWrapper
       ]
-      ++ lib.optionals stdenv.hostPlatform.isWindows [
+      ++ optionals stdenv.hostPlatform.isWindows [
         "-L${windows.pthreads}/bin"
         "-L${windows.pthreads}/lib"
       ]
     )
   );
-
-  makeGhcOptions = opts: lib.concatStringsSep " " (map (opt: "--ghc-option=${opt}") opts);
 
   defaultConfigureFlags = [
     "--verbose"
@@ -383,38 +388,48 @@ let
     # Note: This must be kept in sync manually with mkGhcLibdir
     ("--libdir=\\$prefix/lib/\\$compiler" + lib.optionalString (ghc ? hadrian) "/lib")
     "--libsubdir=\\$abi/\\$libname"
-    (optionalString enableSeparateDataOutput "--datadir=$data/share/${ghcNameWithPrefix}")
-    (optionalString enableSeparateDocOutput "--docdir=${docdir "$doc"}")
+  ]
+  ++ optionals enableSeparateDataOutput [
+    "--datadir=$data/share/${ghcNameWithPrefix}"
+  ]
+  ++ optionals enableSeparateDocOutput [
+    "--docdir=${docdir "$doc"}"
   ]
   ++ optionals stdenv.hasCC [
     "--with-gcc=$CC" # Clang won't work without that extra information.
   ]
   ++ [
     "--package-db=$packageConfDir"
-    (optionalString (
-      enableSharedExecutables && stdenv.hostPlatform.isLinux
-    ) "--ghc-option=-optl=-Wl,-rpath=$out/${ghcLibdir}/${pname}-${version}")
-    (optionalString (
-      enableSharedExecutables && stdenv.hostPlatform.isDarwin
-    ) "--ghc-option=-optl=-Wl,-headerpad_max_install_names")
-    (optionalString enableParallelBuilding (makeGhcOptions [
-      "-j$NIX_BUILD_CORES"
-      "+RTS"
-      "-A64M"
-      "-RTS"
-    ]))
-    (optionalString useCpphs (
-      "--with-cpphs=${cpphs}/bin/cpphs "
-      + (makeGhcOptions [
-        "-cpp"
-        "-pgmP${cpphs}/bin/cpphs"
-        "-optP--cpp"
-      ])
-    ))
+  ]
+  ++ optionals (enableSharedExecutables && stdenv.hostPlatform.isLinux) [
+    "--ghc-option=-optl=-Wl,-rpath=$out/${ghcLibdir}/${pname}-${version}"
+  ]
+  ++ optionals (enableSharedExecutables && stdenv.hostPlatform.isDarwin) [
+    "--ghc-option=-optl=-Wl,-headerpad_max_install_names"
+  ]
+  ++ optionals enableParallelBuilding (makeGhcOptions [
+    "-j$NIX_BUILD_CORES"
+    "+RTS"
+    "-A64M"
+    "-RTS"
+  ])
+  ++ optionals useCpphs (
+    [
+      "--with-cpphs=${cpphs}/bin/cpphs"
+    ]
+    ++ (makeGhcOptions [
+      "-cpp"
+      "-pgmP${cpphs}/bin/cpphs"
+      "-optP--cpp"
+    ])
+  )
+  ++ [
     (enableFeature enableLibraryProfiling "library-profiling")
-    (optionalString (
-      enableExecutableProfiling || enableLibraryProfiling
-    ) "--profiling-detail=${profilingDetail}")
+  ]
+  ++ optionals (enableExecutableProfiling || enableLibraryProfiling) [
+    "--profiling-detail=${profilingDetail}"
+  ]
+  ++ [
     (enableFeature enableExecutableProfiling "profiling")
     (enableFeature enableSharedLibraries "shared")
     (enableFeature doCoverage "coverage")
@@ -444,12 +459,17 @@ let
     "--ghc-option=-haddock"
   ];
 
-  postPhases = optional doInstallIntermediates "installIntermediatesPhase";
-
-  setupCompileFlags = [
-    (optionalString (!coreSetup) "-package-db=$setupPackageConfDir")
-    "-threaded" # https://github.com/haskell/cabal/issues/2398
+  postPhases = optionals doInstallIntermediates [
+    "installIntermediatesPhase"
   ];
+
+  setupCompileFlags =
+    optionals (!coreSetup) [
+      "-package-db=$setupPackageConfDir"
+    ]
+    ++ [
+      "-threaded" # https://github.com/haskell/cabal/issues/2398
+    ];
 
   isHaskellPkg = x: x ? isHaskellLibrary;
 
@@ -513,7 +533,7 @@ let
   ]
   # CC_FOR_BUILD may be necessary if we have no C preprocessor for the host
   # platform. See crossCabalFlags above for more details.
-  ++ lib.optionals (!stdenv.hasCC) [ buildPackages.stdenv.cc ];
+  ++ optionals (!stdenv.hasCC) [ buildPackages.stdenv.cc ];
   collectedToolDepends =
     buildTools
     ++ libraryToolDepends
@@ -524,13 +544,17 @@ let
     ghc
     removeReferencesTo
   ]
-  ++ optional (allPkgconfigDepends != [ ]) (
-    assert pkg-config != null;
-    pkg-config
-  )
+  ++ optionals (allPkgconfigDepends != [ ]) [
+    (
+      assert pkg-config != null;
+      pkg-config
+    )
+  ]
   ++ setupHaskellDepends
   ++ collectedToolDepends
-  ++ optional stdenv.hostPlatform.isGhcjs nodejs;
+  ++ optionals (stdenv.hostPlatform.isGhcjs) [
+    nodejs
+  ];
   propagatedBuildInputs =
     buildDepends ++ libraryHaskellDepends ++ executableHaskellDepends ++ libraryFrameworkDepends;
   otherBuildInputsHaskell =
@@ -650,10 +674,18 @@ lib.fix (
       outputs = [
         "out"
       ]
-      ++ (optional enableSeparateDataOutput "data")
-      ++ (optional enableSeparateDocOutput "doc")
-      ++ (optional enableSeparateBinOutput "bin")
-      ++ (optional enableSeparateIntermediatesOutput "intermediates");
+      ++ optionals enableSeparateDataOutput [
+        "data"
+      ]
+      ++ optionals enableSeparateDocOutput [
+        "doc"
+      ]
+      ++ optionals enableSeparateBinOutput [
+        "bin"
+      ]
+      ++ optionals enableSeparateIntermediatesOutput [
+        "intermediates"
+      ];
 
       setOutputFlags = false;
 
@@ -817,8 +849,10 @@ lib.fix (
       # Note: the options here must be always added, regardless of whether the
       # package specifies `hardeningDisable`.
       hardeningDisable =
-        lib.optionals (args ? hardeningDisable) hardeningDisable
-        ++ lib.optional (ghc.isHaLVM or false) "all";
+        optionals (args ? hardeningDisable) hardeningDisable
+        ++ optionals (ghc.isHaLVM or false) [
+          "all"
+        ];
 
       configurePhase = ''
         runHook preConfigure
@@ -1063,7 +1097,7 @@ lib.fix (
               buildHaskellPackages.ghcWithPackages (_: setupHaskellDepends);
 
             ghcEnv = withPackages (
-              _: otherBuildInputsHaskell ++ propagatedBuildInputs ++ lib.optionals (!isCross) setupHaskellDepends
+              _: otherBuildInputsHaskell ++ propagatedBuildInputs ++ optionals (!isCross) setupHaskellDepends
             );
 
             ghcCommandCaps = lib.toUpper ghcCommand';
@@ -1071,11 +1105,15 @@ lib.fix (
           runCommandCC name {
             inherit shellHook;
 
-            depsBuildBuild = lib.optional isCross ghcEnvForBuild;
+            depsBuildBuild = optionals isCross [
+              ghcEnvForBuild
+            ];
             nativeBuildInputs = [
               ghcEnv
             ]
-            ++ optional (allPkgconfigDepends != [ ]) pkg-config
+            ++ optionals (allPkgconfigDepends != [ ]) [
+              pkg-config
+            ]
             ++ collectedToolDepends;
             buildInputs = otherBuildInputsSystem;
 


### PR DESCRIPTION
Replaces https://github.com/NixOS/nixpkgs/pull/473813 .

Tested with `structuredAttrsByDefault` enabled on a full nixosConfiguration, alsotesting a build of `pandoc` without explicitly setting `structuredAttrs` so it is false.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
