### PR TITLE
kicad: 9.0.8 -> 10.0.0

### DIFF
--- a/pkgs/by-name/ki/kicad/base.nix
+++ b/pkgs/by-name/ki/kicad/base.nix
@@ -43,9 +43,11 @@
 
   swig,
   python,
+  poppler,
   wxPython,
   opencascade-occt_7_6,
   libngspice,
+  libspnav,
   valgrind,
   protobuf_29,
   nng,
@@ -171,6 +173,7 @@ stdenv.mkDerivation (finalAttrs: {
     boost
     swig
     python
+    poppler
     unixodbc
     libdeflate
     opencascade-occt
@@ -178,6 +181,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     # This would otherwise cause a linking requirement for mbedtls.
     (nng.override { mbedtlsSupport = false; })
+  ]
+  ++ optionals (stdenv.hostPlatform.isLinux) [
+    libspnav
   ]
   ++ optionals withScripting [ wxPython ]
   ++ optionals withNgspice [ libngspice ]

--- a/pkgs/by-name/ki/kicad/libraries.nix
+++ b/pkgs/by-name/ki/kicad/libraries.nix
@@ -6,6 +6,7 @@
   compressStep,
   stepreduce,
   parallel,
+  python3,
   zip,
 }:
 let
@@ -24,6 +25,9 @@ let
         stepreduce
         parallel
         zip
+      ]
+      ++ lib.optionals (name == "symbols") [
+        python3
       ];
 
       postInstall =

--- a/pkgs/by-name/ki/kicad/package.nix
+++ b/pkgs/by-name/ki/kicad/package.nix
@@ -234,9 +234,9 @@ stdenv.mkDerivation rec {
       "--prefix GIO_EXTRA_MODULES : ${dconf}/lib/gio/modules"
       # required to open a bug report link in firefox-wayland
       "--set-default MOZ_DBUS_REMOTE 1"
-      "--set-default KICAD9_FOOTPRINT_DIR ${footprints}/share/kicad/footprints"
-      "--set-default KICAD9_SYMBOL_DIR ${symbols}/share/kicad/symbols"
-      "--set-default KICAD9_TEMPLATE_DIR ${template_dir}"
+      "--set-default KICAD10_FOOTPRINT_DIR ${footprints}/share/kicad/footprints"
+      "--set-default KICAD10_SYMBOL_DIR ${symbols}/share/kicad/symbols"
+      "--set-default KICAD10_TEMPLATE_DIR ${template_dir}"
     ]
     ++ optionals (addons != [ ]) (
       let
@@ -248,10 +248,10 @@ stdenv.mkDerivation rec {
           ];
         };
       in
-      [ "--set-default NIX_KICAD9_STOCK_DATA_PATH ${stockDataPath}" ]
+      [ "--set-default NIX_KICAD10_STOCK_DATA_PATH ${stockDataPath}" ]
     )
     ++ optionals with3d [
-      "--set-default KICAD9_3DMODEL_DIR ${packages3d}/share/kicad/3dmodels"
+      "--set-default KICAD10_3DMODEL_DIR ${packages3d}/share/kicad/3dmodels"
     ]
     ++ optionals withNgspice [ "--prefix LD_LIBRARY_PATH : ${libngspice}/lib" ]
 

--- a/pkgs/by-name/ki/kicad/runtime_stock_data_path.patch
+++ b/pkgs/by-name/ki/kicad/runtime_stock_data_path.patch
@@ -6,7 +6,7 @@ index a74cdd9..790cc58 100644
  {
      wxString path;
 
-+    if( wxGetEnv( wxT( "NIX_KICAD9_STOCK_DATA_PATH" ), &path ) ) {
++    if( wxGetEnv( wxT( "NIX_KICAD10_STOCK_DATA_PATH" ), &path ) ) {
 +        return path;
 +    }
 +

--- a/pkgs/by-name/ki/kicad/versions.nix
+++ b/pkgs/by-name/ki/kicad/versions.nix
@@ -3,23 +3,23 @@
 {
   "kicad" = {
     kicadVersion = {
-      version = "9.0.8";
+      version = "10.0.0";
       src = {
-        rev = "1b361e77008b6a38253c4d90d7c749f4aef0f07f";
-        sha256 = "1b995p0qb9cjpj0n3x3szbqr6d7fxwmrp2nbx37y7ym2bc1lpxd8";
+        rev = "b0e9d3b0656e3770d11324b15e09b097f7fc33da";
+        sha256 = "1470x1276yvd8li3w25zjg73fkpl2qp4dsx7adanafq5c4l47rmc";
       };
     };
     libVersion = {
-      version = "9.0.8";
+      version = "10.0.0";
       libSources = {
-        symbols.rev = "83b87ce54ef7c17da4cefe45ad99a5f8d375abe6";
-        symbols.sha256 = "08qb4rqxsyhrcvj1k200m2c06jjy7jwjmf9n1qkcm0biqqc5dba4";
-        templates.rev = "319c71222af4205673e0cab9d772a02bbb34c597";
+        symbols.rev = "dc72a484664c0470407113a174f2b5435debbcaf";
+        symbols.sha256 = "0khfnln0f2zsz5hy31nw2rr0nflb2z3s9n9f7g41g03m9l3s43v2";
+        templates.rev = "e703d1e2ab3eb98a209ff402d2b6bf6d02dc1930";
         templates.sha256 = "0zs29zn8qjgxv0w1vyr8yxmj02m8752zagn4vcraqgik46dwg2id";
-        footprints.rev = "384ecd066fcaef6aacdd099ca0bb7c47499a9a4b";
-        footprints.sha256 = "1w7dkb93s84ymi1syxpzacbmkxlnlh0k4z1c62nabspb901nn524";
-        packages3d.rev = "6b3a47da075011b33b6de17aa499690f8c5be4a7";
-        packages3d.sha256 = "1j26dmgz7xfixlqrzclb1wpc6zkd10n1fq7rmdrgwwx083p3c7a8";
+        footprints.rev = "4899503b69ff037ed102ab0fe5a0564ef3d61726";
+        footprints.sha256 = "0ymmd1rzrczpvcqzw1mld9x8xhbka0vvjy3kdqwysg4ri97f5wrm";
+        packages3d.rev = "bc82151111e9edddf4295228e6ceb5e0584c9c3e";
+        packages3d.sha256 = "0k91iw661fpzb7saryjxdcdvk1kis7dhbcpzp7xzjk84i4jvxrp5";
       };
     };
   };


### PR DESCRIPTION
See https://gitlab.com/kicad/code/kicad/-/tree/10.0.0?ref_type=tags and https://www.kicad.org/blog/2026/03/Version-10.0.0-Released/ for further reference.

This PR updates KiCad to its next major version 10. I am unsure whether `libspnav` is in the right place or if it should be a Linux only `buildInput` instead. Please test and give review :) 

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
