### PR TITLE
python3Packages.cinemagoer: 2023.5.1 -> 2025.12.31

### DIFF
--- a/pkgs/development/python-modules/cinemagoer/default.nix
+++ b/pkgs/development/python-modules/cinemagoer/default.nix
@@ -1,25 +1,39 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+  setuptools,
   lxml,
   sqlalchemy,
+  python,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "cinemagoer";
-  version = "2023.5.1";
-  format = "setuptools";
+  version = "2025.12.31";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-XOHXeuZUZwFhjxHlsVVqGdGO3srRttfZaXPsNJQbGPI=";
+  src = fetchFromGitHub {
+    owner = "cinemagoer";
+    repo = "cinemagoer";
+    rev = "aca62692b6f0ca7ed9c70871bafd8b558c6ba6ec"; # No tag
+    hash = "sha256-Aelgi+Wz2rxLBkJ3YoHJMfno0QoEKESIpwwrJUzAAF0=";
   };
 
-  propagatedBuildInputs = [
+  pythonRelaxDeps = [
+    "lxml"
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
     lxml
     sqlalchemy
   ];
+
+  preBuild = ''
+    ${python.interpreter} rebuildmo.py
+  '';
 
   # Tests require networking, and https://github.com/cinemagoer/cinemagoer/issues/240
   doCheck = false;


### PR DESCRIPTION
Diff: https://github.com/cinemagoer/cinemagoer/compare/2023.05.01...aca62692b6f0ca7ed9c70871bafd8b558c6ba6ec

This also fixes the build of `python314Packages.cinemagoer`.

Hydra: https://hydra.nixos.org/build/324306261/nixlog/2
Tracking: #475732

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.cinemagoer`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
