### PR TITLE
python3Packages.nglview: fix build

### DIFF
--- a/pkgs/development/python-modules/nglview/default.nix
+++ b/pkgs/development/python-modules/nglview/default.nix
@@ -1,13 +1,12 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  nodejs,
+  fetchPypi,
+  pythonRelaxDepsHook,
   notebook,
   ipywidgets,
   ipykernel,
   numpy,
-  runCommand,
   jupyter-packaging,
   jupyter-core,
   notebook-shim,
@@ -18,32 +17,24 @@
   pillow,
   ase,
 }:
-let
-  nodeModules = runCommand "nglview-node-modules" { } ''
-    mkdir -p $out/node_modules/@jupyter-widgets/base
-    cat > $out/node_modules/@jupyter-widgets/base/package.json <<EOF
-    {
-      "name": "@jupyter-widgets/base",
-      "version": "4.1.1",
-      "main": "lib/index.js"
-    }
-    EOF
-  '';
-in
 buildPythonPackage rec {
   pname = "nglview";
   version = "4.0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "nglviewer";
-    repo = "nglview";
-    tag = "v${version}";
-    hash = "sha256-Dacsg3+asY0THJ5qrM7+IZCnc2rhCOrbOfN7Xai63Ac=";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-LAz/LFseKgpy4zkwh85ErgMIUkxapflTV4EtPtvCboM=";
   };
 
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  # NGLview demands numpy < 2.3, but nixpkgs ships >= 2.4
+  pythonRelaxDeps = [ "numpy" ];
+
   build-system = [
-    nodejs
     jupyter-packaging
     jupyter-core
     notebook-shim
@@ -57,12 +48,6 @@ buildPythonPackage rec {
     ipykernel
     numpy
   ];
-
-  preBuild = ''
-    cd js
-    cp -r ${nodeModules}/node_modules .
-    cd ..
-  '';
 
   pythonImportsCheck = [ "nglview" ];
 
@@ -80,15 +65,10 @@ buildPythonPackage rec {
     "test_movie_maker"
   ];
 
-  postInstall = ''
-    mkdir -p $out/share/jupyter/nbextensions
-    cp -r nglview/static $out/share/jupyter/nbextensions/nglview-js-widgets
-  '';
-
   meta = {
     description = "IPython/Jupyter widget to interactively view molecular structures and trajectories";
     homepage = "https://github.com/nglviewer/nglview";
-    changelog = "https://github.com/nglviewer/nglview/releases/tag/${src.tag}";
+    changelog = "https://github.com/nglviewer/nglview/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ guelakais ];
   };


### PR DESCRIPTION
Fixes and simplifies the NGLView build, which is missing some frontend logic in the setup. By switching to the PyPi sources, these missing artefacts are included now in the sources.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
