### PR TITLE
goupile: 3.12.1 -> 3.12.4

### DIFF
--- a/pkgs/by-name/go/goupile/package.nix
+++ b/pkgs/by-name/go/goupile/package.nix
@@ -12,6 +12,8 @@
   # https://goupile.org/en/build recommends a Paranoid build
   # which is not bit by bit reproducible, whereas others are
   profile ? "Paranoid",
+
+  nix-update-script,
 }:
 
 assert lib.assertOneOf "profile" profile [
@@ -25,14 +27,14 @@ let
 in
 stdenv'.mkDerivation (finalAttrs: {
   pname = "goupile";
-  version = "3.12.1";
+  version = "3.12.4";
 
   # https://github.com/Koromix/rygel/tags
   src = fetchFromGitHub {
     owner = "Koromix";
     repo = "rygel";
     tag = "goupile/${finalAttrs.version}";
-    hash = "sha256-Pn/0tjezVKJedAtqj69avxeIK2l3l9FGioYSyEao12E=";
+    hash = "sha256-2lHCOsvjTZeRkboefIdyh7JoSmes3KgvjFnXKnQ4On4=";
   };
 
   nativeBuildInputs = [
@@ -65,7 +67,10 @@ stdenv'.mkDerivation (finalAttrs: {
   versionCheckProgramArg = "--version";
   nativeInstallCheckInputs = [ versionCheckHook ];
 
-  passthru.tests = { inherit (nixosTests) goupile; };
+  passthru = {
+    tests = { inherit (nixosTests) goupile; };
+    updateScript = nix-update-script { extraArgs = [ "--version-regex=goupile/(.*)" ]; };
+  };
 
   meta = {
     changelog = "https://github.com/Koromix/rygel/blob/${finalAttrs.src.rev}/src/goupile/CHANGELOG.md";


### PR DESCRIPTION
Add missing updateScript

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
