### PR TITLE
python3Packages.biopython: fix numpy >= 2.4 compatibility

### DIFF
--- a/pkgs/development/python-modules/biopython/default.nix
+++ b/pkgs/development/python-modules/biopython/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch,
   setuptools,
   numpy,
 }:
@@ -15,6 +16,14 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-k6ULWGpNLOxoqy+Z0D71g8V2HY+6VTXLjoHaeB0Nkv8=";
   };
+
+  patches = [
+    # Numpy 2.4 compatibility
+    (fetchpatch {
+      url = "https://github.com/biopython/biopython/pull/5161.patch";
+      hash = "sha256-oN0nNlhvshIgNrmm+tIeCAJx1U/OqhdL4tj51DV2CHU=";
+    })
+  ];
 
   build-system = [ setuptools ];
 
@@ -33,8 +42,6 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    # https://github.com/biopython/biopython/issues/5135
-    broken = lib.versionAtLeast numpy.version "2.4";
     description = "Python library for bioinformatics";
     longDescription = ''
       Biopython is a set of freely available tools for biological computation


### PR DESCRIPTION
Fix biopython compatibility with numpy >= 2.4 as fixed in https://github.com/biopython/biopython/issues/5135

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
