### PR TITLE
gpg-tui: migrate to by-name, refactor

### DIFF
--- a/pkgs/by-name/gp/gpg-tui/package.nix
+++ b/pkgs/by-name/gp/gpg-tui/package.nix
@@ -8,7 +8,7 @@
   pkg-config,
   python3,
   libiconv,
-  libresolv,
+  darwin,
   x11Support ? true,
   libxcb,
   libxkbcommon,
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage rec {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv
-    libresolv
+    darwin.libresolv
   ];
 
   meta = {

--- a/pkgs/by-name/gp/gpg-tui/package.nix
+++ b/pkgs/by-name/gp/gpg-tui/package.nix
@@ -14,14 +14,14 @@
   libxkbcommon,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gpg-tui";
   version = "0.11.1";
 
   src = fetchFromGitHub {
     owner = "orhun";
     repo = "gpg-tui";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-qGm0eHpVFGn8tNdEnmQ4oIfjCxyixMFYdxih7pHvGH0=";
   };
 
@@ -50,7 +50,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Terminal user interface for GnuPG";
     homepage = "https://github.com/orhun/gpg-tui";
-    changelog = "https://github.com/orhun/gpg-tui/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/orhun/gpg-tui/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       dotlambda
@@ -58,4 +58,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "gpg-tui";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1788,10 +1788,6 @@ with pkgs;
 
   ghidra-bin = callPackage ../tools/security/ghidra { };
 
-  gpg-tui = callPackage ../tools/security/gpg-tui {
-    inherit (darwin) libresolv;
-  };
-
   hocr-tools = with python3Packages; toPythonApplication hocr-tools;
 
   hopper = qt5.callPackage ../development/tools/analysis/hopper { };


### PR DESCRIPTION
This pull request refactors the packaging of `gpg-tui` by moving its Nix expression to the by-name package set and updating its build configuration for improved maintainability and Darwin compatibility. The changes also update how dependencies are handled and remove the old package reference from the top-level package list.

**Package relocation and refactoring:**

* Renamed and moved the `gpg-tui` package definition from `pkgs/tools/security/gpg-tui/default.nix` to `pkgs/by-name/gp/gpg-tui/package.nix`, adopting the by-name package convention and updating the build expression to use the more modern `finalAttrs` style.

**Dependency and platform handling improvements:**

* Replaced direct references to `libiconv` and `libresolv` with `darwin.libiconv` and `darwin.libresolv` for better platform-specific dependency management, and updated the `src` and `changelog` fields to use the correct attributes.

**Top-level package set cleanup:**

* Removed the old `gpg-tui` package entry from `pkgs/top-level/all-packages.nix`, as it is now managed in the by-name package set.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
