### PR TITLE
python3Packages.sphinx-autodoc-typehints: 3.9.2 -> 3.9.9

### DIFF
--- a/pkgs/development/python-modules/sphinx-autodoc-typehints/default.nix
+++ b/pkgs/development/python-modules/sphinx-autodoc-typehints/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "sphinx-autodoc-typehints";
-  version = "3.9.2";
+  version = "3.9.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tox-dev";
     repo = "sphinx-autodoc-typehints";
     tag = finalAttrs.version;
-    hash = "sha256-RfeY9i7M+5SoZtJzdORm/ZyCZ+RLyERJFK7I9L1B7ws=";
+    hash = "sha256-TyG63QHuiquofeMkr078FsBVc9TAqPFfzWJ5L9sdqm0=";
   };
 
   build-system = [


### PR DESCRIPTION
https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.3
https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.4
https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.5
https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.6
https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.7
https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.8
https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.9

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
