### PR TITLE
fmd-server: 1.13.0 -> 1.14.1

### DIFF
--- a/pkgs/by-name/fm/fmd-server/package.nix
+++ b/pkgs/by-name/fm/fmd-server/package.nix
@@ -2,37 +2,93 @@
   lib,
   buildGoModule,
   fetchFromGitLab,
+  fetchPnpmDeps,
   nix-update-script,
+  nodejs,
+  pnpm,
+  pnpmConfigHook,
+  stdenv,
   versionCheckHook,
 }:
-let
-  version = "0.13.0";
-in
-buildGoModule {
-  pname = "fmd-server";
-  inherit version;
-  src = fetchFromGitLab {
-    owner = "fmd-foss";
-    repo = "fmd-server";
-    tag = "v${version}";
-    hash = "sha256-pIVsdoen45YWG/V8qW/DE/yet4o+8MqpVHgHh70Fty8=";
-  };
+buildGoModule (
+  finalAttrs:
+  let
+    inherit (finalAttrs.finalPackage.passthru) ui;
+  in
+  {
+    pname = "fmd-server";
+    version = "0.14.1";
+    src = fetchFromGitLab {
+      owner = "fmd-foss";
+      repo = "fmd-server";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-UmiYtriLC9qztv7nW+1tFpYv9I0NAOsApAJWP72OINg=";
+    };
 
-  vendorHash = "sha256-d8QP6k7vEX0jBcpIMZymgOFYyKqGhND4Xa+mANg172s=";
+    pnpmDeps = fetchPnpmDeps {
+      inherit (ui) pname;
+      inherit pnpm;
+      sourceRoot = "${finalAttrs.src.name}/${ui.pnpmRoot}";
+      fetcherVersion = 3;
+      hash = "sha256-fgqNaFQ4+uJxXzDJJq+D0+EFaLaYR+WUzi5kGq5ezjs=";
+    };
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgramArg = "version";
+    vendorHash = "sha256-cFIg9mOSQbrYHW4kg4aTeTaF+gy1jNpAlg8qepb81Jc=";
 
-  doInstallCheck = true;
-  passthru.updateScript = nix-update-script { };
+    nativeInstallCheckInputs = [ versionCheckHook ];
+    versionCheckProgramArg = "version";
 
-  meta = {
-    description = "Server to communicate with the FindMyDevice app and save the latest (encrypted) location";
-    homepage = "https://fmd-foss.org/";
-    downloadPage = "https://gitlab.com/fmd-foss/fmd-server";
-    license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ j0hax ];
-    teams = [ lib.teams.ngi ];
-    mainProgram = "fmd-server";
-  };
-}
+    doInstallCheck = true;
+    passthru.updateScript = nix-update-script { };
+
+    passthru.ui = stdenv.mkDerivation {
+      inherit (finalAttrs) version src pnpmDeps;
+      pname = "${finalAttrs.pname}-web-ui";
+
+      pnpmRoot = "web";
+      distRoot = "dist";
+
+      nativeBuildInputs = [
+        nodejs
+        pnpmConfigHook
+        pnpm
+      ];
+
+      buildPhase = ''
+        runHook preBuild
+
+        pushd web
+        pnpm build
+        popd
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        mkdir -p "$out"
+        cp -r '${ui.pnpmRoot}/${ui.distRoot}' "$out"
+
+        runHook postInstall
+      '';
+    };
+
+    postUnpack = ''
+      cp -r ${ui}/${ui.distRoot} /build/source/web/
+    '';
+
+    meta = {
+      description = "Server to communicate with the FindMyDevice app and save the latest (encrypted) location";
+      homepage = "https://fmd-foss.org/";
+      downloadPage = "https://gitlab.com/fmd-foss/fmd-server";
+      license = lib.licenses.gpl3Plus;
+      maintainers = with lib.maintainers; [
+        j0hax
+        jthulhu
+      ];
+      teams = [ lib.teams.ngi ];
+      mainProgram = "fmd-server";
+    };
+  }
+)


### PR DESCRIPTION
Version bump.  The web interface has been improved, and has been moved to its own build unit whose output is then embedded in the server executable.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
