### PR TITLE
rauthy: build against rust-jemalloc-sys-unprefixed

### DIFF
--- a/pkgs/by-name/ra/rauthy/package.nix
+++ b/pkgs/by-name/ra/rauthy/package.nix
@@ -11,6 +11,7 @@
   wasm-bindgen-cli_0_2_108,
   binaryen,
   lld,
+  rust-jemalloc-sys-unprefixed,
 }:
 let
   version = "0.34.3";
@@ -97,6 +98,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pkg-config
     perl
   ];
+
+  buildInputs = [ rust-jemalloc-sys-unprefixed ];
 
   preBuild = ''
     cp -r ${frontend}/lib/node_modules/frontend/dist/templates/html/ templates/html


### PR DESCRIPTION
Required to fix rauthy on ARM systems with a 16 KiB page size.

rauthy uses unprefixed jemalloc:
https://github.com/sebadob/rauthy/blob/v0.34.3/Cargo.toml#L132




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
