### PR TITLE
python313Packages.pydicom: 3.0.1 -> 3.0.2

### DIFF
--- a/pkgs/development/python-modules/pydicom/default.nix
+++ b/pkgs/development/python-modules/pydicom/default.nix
@@ -14,6 +14,7 @@
   pyjpegls,
   pylibjpeg,
   pylibjpeg-libjpeg,
+  pyfakefs,
   writableTmpDirAsHomeHook,
 }:
 let
@@ -28,14 +29,14 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "pydicom";
-  version = "3.0.1";
+  version = "3.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydicom";
     repo = "pydicom";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SvRevQehRaSp+vCtJRQVEJiC5noIJS+bGG1/q4p7/XU=";
+    hash = "sha256-d7fFsNKzUoGUDg9E6KVHq64g7p8QzIAAEIk3vLQ+rQ0=";
   };
 
   build-system = [ flit-core ];
@@ -58,6 +59,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pyfakefs
     writableTmpDirAsHomeHook
   ]
   ++ finalAttrs.passthru.optional-dependencies.pixeldata;


### PR DESCRIPTION
Addresses CVE-2026-32711 (nixpkgs issue: #502600) ([NIST](https://nvd.nist.gov/vuln/detail/CVE-2026-32711)).

[changelog](https://github.com/pydicom/pydicom/releases/tag/v3.0.2)
[diff](https://github.com/pydicom/pydicom/compare/v3.0.1...v3.0.2)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
