### PR TITLE
python3Packages.bson: fix build with python 3.14; several improvements

### DIFF
--- a/pkgs/development/python-modules/bson/default.nix
+++ b/pkgs/development/python-modules/bson/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   python-dateutil,
   six,
   pytestCheckHook,
@@ -18,6 +19,16 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-mirRpo27RoOBlwxVOKnHaDIzJOErp7c2VxCOunUm/u4=";
   };
+
+  patches = [
+    # Upstream PR: https://github.com/py-bson/bson/pull/140
+    (fetchpatch {
+      name = "python-3.14.patch";
+      url = "https://github.com/py-bson/bson/commit/4e6b4c206f7204034ef74bff8ae84a95d76d1684.patch";
+      includes = [ "setup.py" ];
+      hash = "sha256-JOmW/KMqzFdXKH4TMR/PG1YU3SvLTBc3L3E9kXag3bQ=";
+    })
+  ];
 
   postPatch = ''
     find . -type f -name '*.py' -exec sed -i 's|assertEquals|assertEqual|g' {} +

--- a/pkgs/development/python-modules/bson/default.nix
+++ b/pkgs/development/python-modules/bson/default.nix
@@ -3,20 +3,21 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
+  setuptools,
   python-dateutil,
   six,
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "bson";
   version = "0.5.10";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "py-bson";
     repo = "bson";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-mirRpo27RoOBlwxVOKnHaDIzJOErp7c2VxCOunUm/u4=";
   };
 
@@ -36,7 +37,9 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     python-dateutil
     six
   ];
@@ -51,4 +54,4 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/bson/default.nix
+++ b/pkgs/development/python-modules/bson/default.nix
@@ -51,7 +51,10 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "BSON codec for Python";
     homepage = "https://github.com/py-bson/bson";
-    license = lib.licenses.asl20;
+    license = [
+      lib.licenses.asl20
+      lib.licenses.bsd3
+    ];
     maintainers = with lib.maintainers; [ fab ];
   };
 })

--- a/pkgs/development/python-modules/bson/default.nix
+++ b/pkgs/development/python-modules/bson/default.nix
@@ -21,6 +21,12 @@ buildPythonPackage rec {
   };
 
   patches = [
+    # Upstream PR: https://github.com/py-bson/bson/pull/113
+    (fetchpatch {
+      name = "python-3.11.patch";
+      url = "https://github.com/py-bson/bson/commit/5346e73124de8a1f9e2a1960501416529e4cee02.patch";
+      hash = "sha256-kNs00j/FDjb2av+0WMORrCo75NcuaJXUl4SbYlksnfo=";
+    })
     # Upstream PR: https://github.com/py-bson/bson/pull/140
     (fetchpatch {
       name = "python-3.14.patch";
@@ -29,10 +35,6 @@ buildPythonPackage rec {
       hash = "sha256-JOmW/KMqzFdXKH4TMR/PG1YU3SvLTBc3L3E9kXag3bQ=";
     })
   ];
-
-  postPatch = ''
-    find . -type f -name '*.py' -exec sed -i 's|assertEquals|assertEqual|g' {} +
-  '';
 
   propagatedBuildInputs = [
     python-dateutil


### PR DESCRIPTION
- Fix build with Python 3.14
  - Upstream PR: https://github.com/py-bson/bson/pull/140
  - Hydra: https://hydra.nixos.org/build/324305930/nixlog/2
  - Tracking: #475732
- Move Python 3.11 compatibility patch to `patches`, maybe a bit cleaner than the search and replace in `postPatch`
  - Upstream PR: https://github.com/py-bson/bson/pull/113
- Fix `meta.license`
  - There are [two](https://github.com/py-bson/bson/blob/4e6b4c206f7204034ef74bff8ae84a95d76d1684/LICENSE) [licenses](https://github.com/py-bson/bson/blob/4e6b4c206f7204034ef74bff8ae84a95d76d1684/LICENSE_APACHE) upstream
- Use `pyproject = true;`
- Use `finalAttrs`
- `propagatedBuildInputs` → `dependencies`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.bson`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
