### PR TITLE
khard: disable man page generation due to upstream issue with sphinx 9

### DIFF
--- a/pkgs/by-name/kh/khard/package.nix
+++ b/pkgs/by-name/kh/khard/package.nix
@@ -39,7 +39,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   '';
 
   preCheck = ''
-    # see https://github.com/scheibler/khard/issues/263
+    # see https://github.com/lucc/khard/issues/263
     export COLUMNS=80
   '';
 
@@ -48,7 +48,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   passthru.tests.version = testers.testVersion { package = khard; };
 
   meta = {
-    homepage = "https://github.com/scheibler/khard";
+    homepage = "https://github.com/lucc/khard";
     description = "Console carddav client";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ matthiasbeyer ];

--- a/pkgs/by-name/kh/khard/package.nix
+++ b/pkgs/by-name/kh/khard/package.nix
@@ -18,13 +18,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   build-system = with python3.pkgs; [
     setuptools
     setuptools-scm
-    sphinxHook
-    sphinx-argparse
-    sphinx-autoapi
-    sphinx-autodoc-typehints
   ];
-
-  sphinxBuilders = [ "man" ];
 
   dependencies = with python3.pkgs; [
     configobj

--- a/pkgs/by-name/kh/khard/package.nix
+++ b/pkgs/by-name/kh/khard/package.nix
@@ -2,8 +2,7 @@
   lib,
   python3,
   fetchPypi,
-  khard,
-  testers,
+  versionCheckHook,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
@@ -45,7 +44,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   pythonImportsCheck = [ "khard" ];
 
-  passthru.tests.version = testers.testVersion { package = khard; };
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
 
   meta = {
     homepage = "https://github.com/lucc/khard";

--- a/pkgs/by-name/kh/khard/package.nix
+++ b/pkgs/by-name/kh/khard/package.nix
@@ -52,7 +52,10 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/lucc/khard";
     description = "Console carddav client";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ matthiasbeyer ];
+    maintainers = with lib.maintainers; [
+      matthiasbeyer
+      doronbehar
+    ];
     mainProgram = "khard";
   };
 })


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test