### PR TITLE
google-cloud-sdk: compile pyc at build time

### DIFF
--- a/pkgs/by-name/go/google-cloud-sdk/package.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/package.nix
@@ -88,9 +88,6 @@ stdenv.mkDerivation rec {
     ./gsutil-disable-updates.patch
   ];
 
-  # Prevent Python from writing bytecode to ensure build determinism
-  env.PYTHONDONTWRITEBYTECODE = "1";
-
   installPhase = ''
     runHook preInstall
 
@@ -117,7 +114,7 @@ stdenv.mkDerivation rec {
         binaryPath="$out/bin/$program"
         wrapProgram "$programPath" \
             --set CLOUDSDK_PYTHON "${pythonEnv}/bin/python" \
-            --set CLOUDSDK_PYTHON_ARGS "-S -W ignore" \
+            --set CLOUDSDK_PYTHON_ARGS "-S -B -W ignore" \
             --prefix PYTHONPATH : "${pythonEnv}/${python3.sitePackages}" \
             --prefix PATH : "${openssl.bin}/bin"
 
@@ -166,6 +163,36 @@ stdenv.mkDerivation rec {
     done
 
     runHook postInstall
+  '';
+
+  postInstall = ''
+    # create cached byte-code at build time, see https://docs.python.org/3/library/compileall.html
+    # the excluded files contain python 2 syntax that fails to compile with python 3
+    find $out/google-cloud-sdk -name "*.py" \
+      -not -path "*/lib/third_party/yaml/scanner.py" \
+      -not -path "*/lib/third_party/yaml/error.py" \
+      -not -path "*/lib/third_party/yaml/constructor.py" \
+      -not -path "*/lib/third_party/yaml/parser.py" \
+      -not -path "*/lib/third_party/yaml/reader.py" \
+      -not -path "*/lib/third_party/yaml/loader.py" \
+      -not -path "*/lib/third_party/yaml/resolver.py" \
+      -not -path "*/yaml/lib2/scanner.py" \
+      -not -path "*/yaml/lib2/constructor.py" \
+      -not -path "*/yaml/lib2/reader.py" \
+      -not -path "*/yaml/lib2/resolver.py" \
+      -not -path "*/gcloud_crcmod/python2/crcmod.py" \
+      -not -path "*/gcloud_crcmod/python2/_crcfunpy.py" \
+      -not -path "*/concurrent/python2/concurrent/futures/_base.py" \
+      -not -path "*/third_party/gflags/__init__.py" \
+      -not -path "*/third_party/gflags/setup.py" \
+      -not -path "*/third_party/gflags/gflags2man.py" \
+      -not -path "*/third_party/apitools/setup.py" \
+      -not -path "*/third_party/apitools/ez_setup.py" \
+      -not -path "*/lib/third_party/pytz/lazy.py" \
+      -not -path "*/lib/third_party/fancy_urllib/__init__.py" \
+      -not -path "*/oauth2client/_pkce.py" \
+      -not -path "*/ext-runtime/nodejs/test/runtime_test.py" \
+      -exec ${pythonEnv}/bin/python -OO -m compileall {} +
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
The `google-cloud-sdk` code has quite a few conditional imports. This means we'd corrupt the nix store path _at runtime_ if run with a user that can write to the nix store (e.g. `root`). The behavior can be reproduced using the following:

1. Verify the nix store path:
```
nix store verify /nix/store/<hash>-google-cloud-sdk-<version>
```
2. Count `*.pyc` files in the nix store path
```
/nix/store/<hash>-google-cloud-sdk-<version> -name "*.pyc" | wc -l
```
3. Run some command as `root` (while authenticated, i.e. `gcloud auth list` should show an active command), note that running as non-root/user without write access to the nix store will be fine.
```
sudo /nix/store/<hash>-google-cloud-sdk-<version>/bin/gcloud compute instances list
```
4. Count `*.pyc` files again (will be non-zero)
```
/nix/store/<hash>-google-cloud-sdk-<version> -name "*.pyc" | wc -l
```
5. Verify the nix store path again (will get a hash mismatch):
```
nix store verify /nix/store/<hash>-google-cloud-sdk-<version>
path '/nix/store/<hash>-google-cloud-sdk-<version>' was modified! expected hash 'sha256:19hzap8cfw9d5mlkqyrn004h87pcp2xf5pi8ls9m9clanrwphsg0', got 'sha256:04jcncpqj5mhd0zxvibgp1l95f6qwm0qs61yl07zisbkzhwigksj'
```

This PR does two things, first it sets the `-B` flag in `CLOUDSDK_PYTHON_ARGS`, which prevents writing `*.pyc` files at runtime (see https://docs.python.org/3/using/cmdline.html#cmdoption-B). Second, it runs `compileall` at build time so `google-cloud-sdk` has pre-compiled all cached byte-code at build time to avoid unnecessary runtime overhead (see https://docs.python.org/3/library/compileall.html).

I've also removed the `PYTHONDONTWRITEBYTECODE` environment variable, which only applied here at build time and has no effect at runtime (because environment variables from the build environment are not passed to the python runtime).

This package has quite of a bit of vendored code, some of which is still Python 2, so to avoid failing the build we're ignoring those files when running `compileall`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
