### PR TITLE
onnxruntime: fix build on darwin with protobuf 34

### DIFF
--- a/pkgs/by-name/on/onnxruntime/protobuf34-nodiscard.patch
+++ b/pkgs/by-name/on/onnxruntime/protobuf34-nodiscard.patch
@@ -99,3 +99,45 @@ index 538f600404..111692d4ca 100644
  
    auto run_model = [&](TransformerLevel level, std::vector<OrtValue>& fetches) {
      SessionOptions session_options;
+diff --git a/onnxruntime/test/ir/graph_test.cc b/onnxruntime/test/ir/graph_test.cc
+index 47a3e87..d3e8e12 100644
+--- a/onnxruntime/test/ir/graph_test.cc
++++ b/onnxruntime/test/ir/graph_test.cc
+@@ -1247,1 +1247,1 @@
+-  model.ToProto().SerializeToString(&s1);
++  ASSERT_TRUE(model.ToProto().SerializeToString(&s1));
+@@ -1316,1 +1316,1 @@
+-  model.ToProto().SerializeToString(&s1);
++  ASSERT_TRUE(model.ToProto().SerializeToString(&s1));
+@@ -1345,1 +1345,1 @@
+-    model_proto.SerializeToString(&s1);
++    ASSERT_TRUE(model_proto.SerializeToString(&s1));
+@@ -1943,1 +1943,1 @@
+-    model_proto.SerializeToString(&s1);
++    ASSERT_TRUE(model_proto.SerializeToString(&s1));
+diff --git a/onnxruntime/test/framework/inference_session_test.cc b/onnxruntime/test/framework/inference_session_test.cc
+index 4566782..8991234 100644
+--- a/onnxruntime/test/framework/inference_session_test.cc
++++ b/onnxruntime/test/framework/inference_session_test.cc
+@@ -1080,1 +1080,1 @@
+-  p_model->ToProto().SerializeToString(&s1);
++  ASSERT_TRUE(p_model->ToProto().SerializeToString(&s1));
+@@ -1113,1 +1113,1 @@
+-  p_model->ToProto().SerializeToString(&s1);
++  ASSERT_TRUE(p_model->ToProto().SerializeToString(&s1));
+diff --git a/onnxruntime/test/providers/compare_provider_test_utils.cc b/onnxruntime/test/providers/compare_provider_test_utils.cc
+index 5678912..6789012 100644
+--- a/onnxruntime/test/providers/compare_provider_test_utils.cc
++++ b/onnxruntime/test/providers/compare_provider_test_utils.cc
+@@ -85,1 +85,1 @@ void CompareProviderTestUtils::Run(const Model& model,
+-  model.ToProto().SerializeToString(&s1);
++  ASSERT_TRUE(model.ToProto().SerializeToString(&s1));
+@@ -106,1 +106,1 @@ void CompareProviderTestUtils::Run(const Model& model,
+-  tp_model.ToProto().SerializeToString(&s2);
++  ASSERT_TRUE(tp_model.ToProto().SerializeToString(&s2));
+@@ -161,1 +161,1 @@ void CompareProviderTestUtils::Run(const Model& model,
+-  model.ToProto().SerializeToString(&s1);
++  ASSERT_TRUE(model.ToProto().SerializeToString(&s1));
+@@ -183,1 +183,1 @@ void CompareProviderTestUtils::Run(const Model& model,
+-    tp_model.ToProto().SerializeToString(&s2);
++    ASSERT_TRUE(tp_model.ToProto().SerializeToString(&s2));


### PR DESCRIPTION
actually with commit https://github.com/NixOS/nixpkgs/commit/512658d41e7a135dc3660251451d38f12078b715 the protobuf34-nodiscard.patch was added. however, for darwin although there is patch build still going to fail because several test files ignored the return values.

in that commit i update protobuf34-nodiscard.patch to include missing checks in:
- graph_test.cc
- inference_session_test.cc
- compare_provider_test_utils.cc
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
