### PR TITLE
nixos/hyperv-guest: add GPU-PV (dxgkrnl) support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -63,6 +63,8 @@
 
 - [Corteza](https://cortezaproject.org/), a low-code platform. Available as [services.corteza](#opt-services.corteza.enable).
 
+- [dxgkrnl](https://github.com/microsoft/WSL2-Linux-Kernel/tree/linux-msft-wsl-6.6.y/drivers/hv/dxgkrnl), Microsoft's Hyper-V GPU paravirtualization (GPU-PV) kernel module, enabling GPU compute (e.g., CUDA) in Hyper-V guests. Available as [virtualisation.hypervGuest.dxgkrnl](#opt-virtualisation.hypervGuest.dxgkrnl.enable).
+
 - [crowdsec](https://www.crowdsec.net/), a free, open-source and collaborative IPS. Available as [services.crowdsec](#opt-services.crowdsec.enable).
 
 - [crowdsec-firewall-bouncer](https://www.crowdsec.net/), the CrowdSec Remediation Component for fetching new and old decisions from a CrowdSec API and adding them to a blocklist used by supported firewalls. Available as [services.crowdsec-firewall-bouncer](#opt-services.crowdsec-firewall-bouncer.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1988,6 +1988,7 @@
   ./virtualisation/docker.nix
   ./virtualisation/ecs-agent.nix
   ./virtualisation/hyperv-guest.nix
+  ./virtualisation/hyperv-guest-gpu.nix
   ./virtualisation/incus-agent.nix
   ./virtualisation/incus.nix
   ./virtualisation/kvmgt.nix

--- a/nixos/modules/virtualisation/hyperv-guest-gpu.nix
+++ b/nixos/modules/virtualisation/hyperv-guest-gpu.nix
@@ -1,0 +1,61 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.virtualisation.hypervGuest.dxgkrnl;
+  wslGpuLib = pkgs.callPackage ../../../pkgs/os-specific/linux/dxgkrnl/gpu-lib.nix { };
+in
+{
+  options = {
+    virtualisation.hypervGuest.dxgkrnl = {
+      enable = lib.mkEnableOption ''
+        Hyper-V GPU paravirtualization (GPU-PV).
+
+        This builds and loads the dxgkrnl kernel module, which exposes
+        {file}`/dev/dxg` for GPU access from a Hyper-V guest via the VMBus.
+        It also installs the WSL GPU libraries (`libdxcore.so`,
+        `libd3d12.so`, `libd3d12core.so`) and adds them to the dynamic
+        linker search path.
+
+        The host VM must have a GPU partition adapter attached
+        (`Add-VMGpuPartitionAdapter` in PowerShell). Vendor-specific
+        driver files (e.g., NVIDIA `.so`/`.bin`) must be copied from
+        the host into {file}`/usr/lib/wsl/lib/` and
+        {file}`/usr/lib/wsl/drivers/<driver-store-name>/`.
+
+        The {file}`/dev/dxg` device is owned by the `video` group.
+        Add users to the `video` group for access:
+        `users.users.<name>.extraGroups = [ "video" ];`
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.virtualisation.hypervGuest.enable;
+        message = "virtualisation.hypervGuest.dxgkrnl requires virtualisation.hypervGuest.enable = true";
+      }
+    ];
+
+    boot = {
+      extraModulePackages = [ config.boot.kernelPackages.dxgkrnl ];
+      kernelModules = [ "dxgkrnl" ];
+    };
+
+    services.udev.extraRules = ''
+      KERNEL=="dxg", MODE="0660", GROUP="video"
+    '';
+
+    # WSL GPU libraries (libdxcore.so, libd3d12.so, libd3d12core.so)
+    environment.sessionVariables.LD_LIBRARY_PATH = [ "${wslGpuLib}/lib" ];
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    lostmsu
+  ];
+}

--- a/pkgs/os-specific/linux/dxgkrnl/default.nix
+++ b/pkgs/os-specific/linux/dxgkrnl/default.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  kernelModuleMakeFlags,
+}:
+
+let
+  # WSL2 kernel source — contains the dxgkrnl driver under drivers/hv/dxgkrnl/
+  # Sparse checkout to avoid cloning the full ~1GB kernel repo.
+  wsl2KernelSrc = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "WSL2-Linux-Kernel";
+    rev = "a07f9ea8a99139913acbcc1c160b132cb2a49c81"; # linux-msft-wsl-6.6.y @ 6.6.123.2
+    sparseCheckout = [
+      "drivers/hv/dxgkrnl"
+      "include/uapi/misc/d3dkmthk.h"
+    ];
+    nonConeMode = true;
+    hash = "sha256-Km0MvRJ3RdoYlsL0XJSaRdBp/bRx/hE7Pbjr7uf+xxI=";
+  };
+
+  # Compatibility patches: adds GPU-PV VMBus channel GUIDs and fixes for
+  # host kernels >= 6.6 (eventfd_signal, get_task_comm, timer API changes).
+  patchSrc = fetchFromGitHub {
+    owner = "staralt";
+    repo = "dxgkrnl-dkms";
+    rev = "a7ce5afa85954e5fa308a17c9aa54d565f9ef453"; # v1.0
+    hash = "sha256-QUiU8BJMrEpT5z/xb1i189mV7ZI/7f4z/fnctSkl/yk=";
+  };
+
+  ksrc = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build/source";
+in
+stdenv.mkDerivation {
+  pname = "dxgkrnl";
+  version = "6.6.123.2-${kernel.version}";
+
+  src = wsl2KernelSrc;
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  patches = [
+    "${patchSrc}/linux-msft-wsl-5.15.y/0001-Add-a-gpu-pv-support.patch"
+    "${patchSrc}/linux-msft-wsl-6.6.y/0002-Fix-eventfd_signal.patch"
+    "${patchSrc}/linux-msft-wsl-6.6.y/0003-Update-get_task_comm-function.patch"
+    "${patchSrc}/linux-msft-wsl-6.6.y/0004-Fix-timer-related-error.patch"
+    "${patchSrc}/linux-msft-wsl-6.6.y/0005-Fix-pointer-casting-error-in-dxgsyncfile.c.patch"
+  ];
+
+  postPatch = ''
+    # Flatten sources into a standalone build directory
+    mkdir -p $TMPDIR/build/include/uapi/misc
+    cp drivers/hv/dxgkrnl/*.c drivers/hv/dxgkrnl/*.h $TMPDIR/build/
+    cp include/uapi/misc/d3dkmthk.h $TMPDIR/build/include/uapi/misc/
+    cat > $TMPDIR/build/Makefile << 'MAKEFILE'
+    obj-m := dxgkrnl.o
+    dxgkrnl-y := dxgmodule.o hmgr.o misc.o dxgadapter.o ioctl.o dxgvmbus.o dxgprocess.o dxgsyncfile.o
+    EXTRA_CFLAGS += -I$(PWD)/include -D_MAIN_KERNEL_
+    EXTRA_CFLAGS += -I${ksrc}/include/linux
+    EXTRA_CFLAGS += -include ${ksrc}/include/linux/vmalloc.h
+    ccflags-y += $(EXTRA_CFLAGS)
+    MAKEFILE
+  '';
+
+  makeFlags = kernelModuleMakeFlags;
+
+  preBuild = ''
+    cd $TMPDIR/build
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build \
+      M=$(pwd) \
+      $makeFlags \
+      modules
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D $TMPDIR/build/dxgkrnl.ko \
+      $out/lib/modules/${kernel.modDirVersion}/extra/dxgkrnl.ko
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Microsoft dxgkrnl - Hyper-V GPU paravirtualization (GPU-PV) kernel module";
+    homepage = "https://github.com/microsoft/WSL2-Linux-Kernel";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [
+      lostmsu
+    ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/os-specific/linux/dxgkrnl/gpu-lib.nix
+++ b/pkgs/os-specific/linux/dxgkrnl/gpu-lib.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+  msitools,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "wsl-gpu-lib";
+  version = "2.6.3";
+
+  src = fetchurl {
+    url = "https://github.com/microsoft/WSL/releases/download/${version}/Microsoft.WSL_${version}.0_x64_ARM64.msixbundle";
+    hash = "sha256-e+etYLgk6bbdiqxhw2woBDaSgc8m+P133ojUPJNoY10=";
+  };
+
+  nativeBuildInputs = [
+    unzip
+    msitools
+  ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # MSIX bundle → x64 MSIX → MSI → .so files
+    unzip -o $src "Microsoft.WSL_${version}.0_x64.msix" -d $TMPDIR
+    unzip -o $TMPDIR/Microsoft.WSL_${version}.0_x64.msix wsl.msi -d $TMPDIR
+    mkdir -p $TMPDIR/msi-out
+    msiextract -C $TMPDIR/msi-out $TMPDIR/wsl.msi
+
+    mkdir -p $out/lib
+    cp $TMPDIR/msi-out/PFiles64/WSL/lib/libdxcore.so $out/lib/
+    cp $TMPDIR/msi-out/PFiles64/WSL/lib/libd3d12.so $out/lib/
+    cp $TMPDIR/msi-out/PFiles64/WSL/lib/libd3d12core.so $out/lib/
+
+    # Case-insensitive symlink needed by some applications
+    ln -s libd3d12core.so $out/lib/libD3D12Core.so
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "DirectX GPU libraries for WSL/Hyper-V GPU paravirtualization";
+    homepage = "https://github.com/microsoft/WSL";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ lostmsu ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -387,6 +387,8 @@ in
 
         dpdk-kmods = callPackage ../os-specific/linux/dpdk-kmods { };
 
+        dxgkrnl = callPackage ../os-specific/linux/dxgkrnl { };
+
         ecapture = callPackage ../by-name/ec/ecapture/package.nix {
           withNonBTF = true;
           inherit kernel;


### PR DESCRIPTION
Add support for Hyper-V GPU paravirtualization (GPU-PV) on NixOS guests.

[GPU-PV](https://learn.microsoft.com/en-us/windows-hardware/drivers/display/gpu-paravirtualization) allows a Hyper-V guest to access the host's GPU via VMBus, enabling GPU compute workloads (e.g., CUDA/PyTorch) without PCIe passthrough. This is the same mechanism WSL2 uses for GPU access, but running on a standard Linux distribution rather than the WSL2 kernel.

The new option `virtualisation.hypervGuest.dxgkrnl.enable` builds and loads the [dxgkrnl](https://github.com/microsoft/WSL2-Linux-Kernel/tree/linux-msft-wsl-6.6.y/drivers/hv/dxgkrnl) out-of-tree kernel module, which exposes `/dev/dxg` for GPU access. Compatibility patches from [staralt/dxgkrnl-dkms](https://github.com/staralt/dxgkrnl-dkms) add the GPU-PV VMBus channel GUIDs (absent from the upstream WSL2 source, which relies on in-tree registration) and fix API changes for kernels >= 6.6.

### Usage

```nix
{
  virtualisation.hypervGuest.enable = true;
  virtualisation.hypervGuest.dxgkrnl.enable = true;
  # /dev/dxg is owned by the video group
  users.users.myuser.extraGroups = [ "video" ];
}
```

### Host setup

The host VM needs a GPU partition adapter with all four resource types configured:

```powershell
Add-VMGpuPartitionAdapter -VMName "YourVM" `
    -MinPartitionVRAM    1          -MaxPartitionVRAM    1000000000 -OptimalPartitionVRAM    1000000000 `
    -MinPartitionEncode  0          -MaxPartitionEncode  1000000000 -OptimalPartitionEncode  1000000000 `
    -MinPartitionDecode  0          -MaxPartitionDecode  1000000000 -OptimalPartitionDecode  1000000000 `
    -MinPartitionCompute 0          -MaxPartitionCompute 1000000000 -OptimalPartitionCompute 1000000000
```

### Copying driver files from the host

Userspace driver files (vendor-specific `.so`/`.bin`) cannot be redistributed and must be copied from the Windows host. The CUDA driver stack uses a two-tier loading architecture:

1. **Stub/dispatcher libraries** in `/usr/lib/wsl/lib/` — enumerate GPU adapters via `/dev/dxg` ioctls, then load the real driver
2. **Real driver files** in `/usr/lib/wsl/drivers/<driver-store-name>/` — the actual GPU driver implementation

Both sets of files are needed. Without the real driver, `cuInit` returns error 100; without `libnvdxgdmal.so.1`, error 500; without `nvcubins.bin`, a segfault.

#### Source directories on the Windows host

| Guest path | Host source | Contents |
|---|---|---|
| `/usr/lib/wsl/lib/` | `C:\Windows\System32\lxss\lib\` | NVIDIA stub libraries (~20 files) |
| `/usr/lib/wsl/lib/` | `C:\Program Files\WSL\lib\` | `libdxcore.so`, `libd3d12.so`, `libd3d12core.so` (from WSL installation, or extractable from [WSL GitHub releases](https://github.com/microsoft/WSL/releases) MSIX bundle) |
| `/usr/lib/wsl/drivers/<name>/` | `C:\Windows\System32\DriverStore\FileRepository\<name>\` | Real driver `.so` and `.bin` files (~22 files, ~1.1 GB). `gsp_*.bin` can be skipped. |

The `<name>` is the driver store directory (e.g., `nv_dispsi.inf_amd64_adf52f3aa9d98326`). Find it with:
```powershell
Get-ChildItem 'C:\Windows\System32\DriverStore\FileRepository\nv_disp*.inf_amd64_*'
```

#### Copy via SCP from the host (elevated PowerShell)

```powershell
$Guest = "root@<guest-ip>"
$Key = "$env:USERPROFILE\.ssh\id_ed25519"
$DSName = "nv_dispsi.inf_amd64_adf52f3aa9d98326"  # your driver store name
$DSPath = "C:\Windows\System32\DriverStore\FileRepository\$DSName"

# Create target directories
ssh -i $Key $Guest "mkdir -p /usr/lib/wsl/lib /usr/lib/wsl/drivers/$DSName"

# Copy stub libraries
Get-ChildItem "C:\Windows\System32\lxss\lib" -File | ForEach-Object {
    scp -i $Key $_.FullName "${Guest}:/usr/lib/wsl/lib/"
}

# Copy WSL core libs (libdxcore.so, libd3d12.so, libd3d12core.so)
Get-ChildItem "C:\Program Files\WSL\lib" -File | ForEach-Object {
    scp -i $Key $_.FullName "${Guest}:/usr/lib/wsl/lib/"
}

# Copy driver store files (skip gsp_*.bin firmware, not needed for CUDA)
Get-ChildItem $DSPath -File | Where-Object {
    ($_.Extension -match '^\.(so|bin)' -or $_.Name -match '\.(so|bin)(\.\d+)*$') -and
    $_.Name -notmatch '^gsp_'
} | ForEach-Object {
    scp -i $Key $_.FullName "${Guest}:/usr/lib/wsl/drivers/${DSName}/"
}
```

Then on the guest, create required symlinks:
```bash
cd /usr/lib/wsl/lib
ln -sf libcuda.so.1.1 libcuda.so.1
ln -sf libcuda.so.1 libcuda.so
ln -sf libd3d12core.so libD3D12Core.so
chmod -R a+rX /usr/lib/wsl
```

#### Verify

```bash
export LD_LIBRARY_PATH=/usr/lib/wsl/lib
python3 -c "import ctypes; c=ctypes.CDLL('libcuda.so'); print('cuInit:', c.cuInit(0))"
# Expected: cuInit: 0
```

### Changes

- **`pkgs/os-specific/linux/dxgkrnl/default.nix`** — new kernel module package. Fetches source from Microsoft's WSL2-Linux-Kernel repo via `fetchFromGitHub` with sparse checkout (~10 MB vs ~1 GB full clone), applies 5 compatibility patches.
- **`pkgs/top-level/linux-kernels.nix`** — register `dxgkrnl` in kernel packages.
- **`nixos/modules/virtualisation/hyperv-guest-gpu.nix`** — new NixOS module under `virtualisation.hypervGuest.dxgkrnl`. Loads dxgkrnl at boot, sets `/dev/dxg` to `root:video 0660` via udev.
- **`nixos/modules/module-list.nix`** — register the new module.
- **`nixos/doc/manual/release-notes/rl-2511.section.md`** — add release note entry.

### Testing

Tested on a Hyper-V Gen2 VM:
- Host: Windows 11 Pro for Workstations (build 26200), NVIDIA RTX 3090 (driver 590.52)
- Guest: NixOS 25.11, kernel 6.12.76
- `nixos-rebuild switch` succeeds, dxgkrnl auto-loads at boot
- `/dev/dxg` created with `root:video 0660` permissions
- CUDA `cuInit()` returns 0 with userspace drivers present
- PyTorch tensor arithmetic on `cuda:0` works
- Package also builds against kernel 6.18.17

Automated NixOS tests are not feasible for this module since GPU-PV requires a Hyper-V host with a physical GPU.

cc @peterhoeg (hyperv-guest maintainer) @patryk27 (kvmgt module maintainer)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test