### PR TITLE
xjump-sdl: init at 3.0.5

### DIFF
--- a/pkgs/by-name/xj/xjump-sdl/package.nix
+++ b/pkgs/by-name/xj/xjump-sdl/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  SDL2,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xjump-sdl";
+  version = "3.0.5";
+
+  src = fetchFromGitHub {
+    owner = "hugomg";
+    repo = "xjump-sdl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-a3d9d/Zif8UNUU+Tpgx8U34TpXMEHMg2KSpZR16mOOg=";
+  };
+
+  buildInputs = [ SDL2 ];
+
+  meta = {
+    description = "Jumping game for modern graphical systems";
+    longDescription = ''
+      Xjump is a jumping game where you are in a Falling Tower.
+      The floor you are standing on is sinking with the rest of the building;
+      you will die once the floor gives way (disappears under the bottom of the display).
+      To survive, you have to jump onto the upper floors of the tower.
+      Because the entire tower is sinking, the upper floors will soon collapse too,
+      so you have to keep on jumping!
+
+      This version of Xjump is a re-implementation using SDL instead of Xlib.
+      It features smoother animations (60 FPS with smooth scrolling)
+      and is more compatible with modern graphical systems.
+    '';
+    homepage = "https://github.com/hugomg/xjump-sdl";
+    maintainers = with lib.maintainers; [ marcin-serwin ];
+    mainProgram = "xjump";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2157,7 +2157,7 @@ mapAliases {
   xflux = throw "'xflux' has been removed as it was unmaintained"; # Added 2025-08-22
   xflux-gui = throw "'xflux-gui' has been removed as it was unmaintained"; # Added 2025-08-22
   xinput_calibrator = xinput-calibrator; # Added 2025-08-28
-  xjump = throw "'xjump' has been removed as it is unmaintained"; # Added 2025-08-22
+  xjump = throw "'xjump' has been removed as it is unmaintained, consider using its reimplementation xjump-sdl"; # Added 2025-08-22
   xkeyboardconfig = xkeyboard-config; # Added 2026-02-04
   xkeyboardconfig_custom = xkeyboard-config_custom; # Added 2026-01-19
   xmlada = throw "'xmlada' has been renamed to/replaced by 'gnatPackages.xmlada'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Original xjump was removed in https://github.com/NixOS/nixpkgs/pull/435780, this is an SDL re-implementation by the original author.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
