### PR TITLE
libldac-dec: fix decoder initialization failure

### DIFF
--- a/pkgs/by-name/li/libldac-dec/fix-decode-init.patch
+++ b/pkgs/by-name/li/libldac-dec/fix-decode-init.patch
@@ -1,0 +1,24 @@
+--- a/src/ldacBT_api.o.c
++++ b/src/ldacBT_api.o.c
+@@ -165,6 +165,10 @@
+   // tbl_ldacbt_config[0].frmlen_1ch;
+   // frmlen = 165 * channel - LDACBT_FRMHDRBYTES;
+   frmlen = tbl_ldacbt_config[0].frmlen_1ch * channel - LDACBT_FRMHDRBYTES;
++  hLdacBT->frmlen = frmlen;
++  hLdacBT->cm = cm;
++  hLdacBT->cci = cci;
++  hLdacBT->frm_status = 0;
+   /* Set Configuration Information */
+   result = ldaclib_set_config_info(
+       hLdacBT->hLDAC, hLdacBT->sfid, hLdacBT->cci, hLdacBT->frmlen, hLdacBT->frm_status);
+@@ -174,10 +178,6 @@
+   } else if (result != LDAC_S_OK) {
+     hLdacBT->error_code_api = LDACBT_GET_LDACLIB_ERROR_CODE;
+   }
+-  hLdacBT->frmlen = frmlen;
+-  hLdacBT->cm = cm;
+-  hLdacBT->cci = cci;
+-  hLdacBT->frm_status = 0;
+   hLdacBT->sfid = sfid;
+   result = ldaclib_init_decode(hLdacBT->hLDAC, nshift);
+   if (LDAC_FAILED(result)) {

--- a/pkgs/by-name/li/libldac-dec/package.nix
+++ b/pkgs/by-name/li/libldac-dec/package.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation {
     hash = "sha256-pdeEtQXxL2pd9qTfLOEmPDn3POgo5qxRqbK807WN98s=";
   };
 
+  patches = [
+    # Fix uninitialized struct members passed to ldaclib_set_config_info in decode init
+    ./fix-decode-init.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
 
   # Upstream CMakeLists.txt doesn't have install rules


### PR DESCRIPTION
## Summary

Fix `LDACBT_ERR_FATAL` in `ldacBT_init_handle_decode()` caused by uninitialized struct members being passed to `ldaclib_set_config_info()`.

In `ldacBT_api.o.c`, `hLdacBT->cci`, `hLdacBT->frmlen`, and `hLdacBT->frm_status` are used by `ldaclib_set_config_info()` on line 170 **before** being assigned on lines 177-180. The local variables hold the correct values but the struct fields are zero-initialized from `calloc`, causing the config call to fail.

This breaks PipeWire 1.6+'s LDAC codec entirely — the SPA plugin treats decoder init failure as fatal and refuses to initialize the encoder, so LDAC playback (A2DP sink) doesn't work at all. Arch Linux and Fedora work around this by disabling LDAC decoding at build time (`-D bluez5-codec-ldac-dec=disabled`).

The fix moves the four struct member assignments before the function call that uses them.

## Test plan

- [x] Verified patched library is loaded at runtime via `/proc/<pid>/maps`
- [x] PipeWire 1.6.2 LDAC codec initializes without `LDACBT_ERR_FATAL`
- [x] LDAC A2DP sink profile available and selectable in pwvucontrol
- [x] Audio playback works over LDAC
