### PR TITLE
python3Packages.{qcelemental,qcengine}: updates

### DIFF
--- a/pkgs/development/python-modules/qcelemental/default.nix
+++ b/pkgs/development/python-modules/qcelemental/default.nix
@@ -6,6 +6,7 @@
   fetchPypi,
   poetry-core,
   setuptools,
+  setuptools-scm,
   ipykernel,
   networkx,
   numpy,
@@ -18,17 +19,18 @@
 
 buildPythonPackage rec {
   pname = "qcelemental";
-  version = "0.30.1";
+  version = "0.50.0rc3";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-WMNKl4hfW/GIOwHNekZSwguaM64LLerQarEhOgqb2rs=";
+    hash = "sha256-caQmd7zoDzyd4YT9c5J/7oz2eEbhWpirgZHcnOTwz7k=";
   };
 
   build-system = [
     poetry-core
     setuptools
+    setuptools-scm
   ];
 
   dependencies = [
@@ -53,8 +55,25 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "qcelemental" ];
 
+  # These tests require network access
+  disabledTestPaths = [
+    "qcelemental/tests/test_gph_uno_bipartite.py"
+    "qcelemental/tests/test_model_general.py"
+    "qcelemental/tests/test_model_results.py"
+    "qcelemental/tests/test_molecule.py"
+    "qcelemental/tests/test_molparse_align_chiral.py"
+    "qcelemental/tests/test_molparse_from_schema.py"
+    "qcelemental/tests/test_molparse_from_string.py"
+    "qcelemental/tests/test_molparse_pubchem.py"
+    "qcelemental/tests/test_molparse_to_schema.py"
+    "qcelemental/tests/test_molparse_to_string.py"
+    "qcelemental/tests/test_molutil.py"
+    "qcelemental/tests/test_utils.py"
+    "qcelemental/tests/test_zqcschema.py"
+  ];
+
   meta = {
-    broken = stdenv.hostPlatform.isDarwin || pythonAtLeast "3.14"; # https://github.com/MolSSI/QCElemental/issues/375
+    broken = stdenv.hostPlatform.isDarwin;
     description = "Periodic table, physical constants and molecule parsing for quantum chemistry";
     homepage = "https://github.com/MolSSI/QCElemental";
     changelog = "https://github.com/MolSSI/QCElemental/blob/v${version}/docs/changelog.rst";

--- a/pkgs/development/python-modules/qcengine/default.nix
+++ b/pkgs/development/python-modules/qcengine/default.nix
@@ -16,19 +16,24 @@
   qcelemental,
   scipy,
   setuptools,
+  setuptools-scm,
+  pydantic-settings,
 }:
 
 buildPythonPackage rec {
   pname = "qcengine";
-  version = "0.34.0";
+  version = "0.50.0rc2";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-VKULy45bYn5TmxU7TbOVK98r0pRMWAwissmgx0Ee/8w=";
+    hash = "sha256-XIxHFemTXXsqCLAHizzrEt0tVdfp6vY0Pl4CHv+EzDM=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   dependencies = [
     msgpack
@@ -38,6 +43,7 @@ buildPythonPackage rec {
     pydantic
     pyyaml
     qcelemental
+    pydantic-settings
   ];
 
   optional-dependencies = {
@@ -55,12 +61,16 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "qcengine" ];
 
+  # These tests require network access
+  disabledTestPaths = [
+    "qcengine/tests/test_harness_canonical.py"
+  ];
+
   meta = {
     description = "Quantum chemistry program executor and IO standardizer (QCSchema) for quantum chemistry";
     homepage = "https://molssi.github.io/QCElemental/";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ sheepforce ];
     mainProgram = "qcengine";
-    broken = pythonAtLeast "3.14"; # https://github.com/MolSSI/QCEngine/issues/481
   };
 }


### PR DESCRIPTION
This updates the QCElemental and QCEngine packages to their latest release candidates, which are now already being used in the downstream ecosystem:

https://github.com/MolSSI/QCElemental/blob/next2026/docs/changelog.rst#0500rc3--2026-03-10
https://github.com/MolSSI/QCEngine/blob/next2026/docs/source/changelog.rst#v0500rc2--2026-03-13-prerelease

The QCEngine update also requires the NGLView fix #502634 to build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
