### PR TITLE
[backport-25.11] varnish80: init at 8.0.1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1648,6 +1648,10 @@ in
     imports = [ ./varnish.nix ];
     _module.args.package = pkgs.varnish77;
   };
+  varnish80 = runTest {
+    imports = [ ./varnish.nix ];
+    _module.args.package = pkgs.varnish80;
+  };
   vault = runTest ./vault.nix;
   vault-agent = runTest ./vault-agent.nix;
   vault-dev = runTest ./vault-dev.nix;

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -57,26 +57,32 @@ let
       buildFlags = [ "localstatedir=/var/run" ];
 
       patches =
-        lib.optionals (stdenv.isDarwin && lib.versionAtLeast version "7.7") [
-          # Fix VMOD section attribute on macOS
-          # Unreleased commit on master
-          (fetchpatch2 {
-            url = "https://github.com/varnishcache/varnish-cache/commit/a95399f5b9eda1bfdba6ee6406c30a1ed0720167.patch";
-            hash = "sha256-T7DIkmnq0O+Cr9DTJS4/rOtg3J6PloUo8jHMWoUZYYk=";
-          })
-          # Fix endian.h compatibility on macOS
-          # PR: https://github.com/varnishcache/varnish-cache/pull/4339
-          ./patches/0001-fix-endian-h-compatibility-on-macos.patch
-        ]
+        lib.optionals
+          (stdenv.isDarwin && lib.versionAtLeast version "7.7" && lib.versionOlder version "8.0")
+          [
+            # Fix VMOD section attribute on macOS
+            # Unreleased commit on master
+            (fetchpatch2 {
+              url = "https://github.com/varnishcache/varnish-cache/commit/a95399f5b9eda1bfdba6ee6406c30a1ed0720167.patch";
+              hash = "sha256-T7DIkmnq0O+Cr9DTJS4/rOtg3J6PloUo8jHMWoUZYYk=";
+            })
+            # Fix endian.h compatibility on macOS
+            # PR: https://github.com/varnishcache/varnish-cache/pull/4339
+            ./patches/0001-fix-endian-h-compatibility-on-macos.patch
+          ]
         ++ lib.optionals (stdenv.isDarwin && lib.versionOlder version "7.6") [
           # Fix duplicate OS_CODE definitions on macOS
           # PR: https://github.com/varnishcache/varnish-cache/pull/4347
           ./patches/0002-fix-duplicate-os-code-definitions-on-macos.patch
         ];
 
-      postPatch = ''
-        substituteInPlace bin/varnishtest/vtc_main.c --replace /bin/rm "${coreutils}/bin/rm"
-      '';
+      postPatch =
+        lib.optionalString (lib.versionOlder version "8.0") ''
+          substituteInPlace bin/varnishtest/vtc_main.c --replace /bin/rm "${coreutils}/bin/rm"
+        ''
+        + lib.optionalString (lib.versionAtLeast version "8.0") ''
+          substituteInPlace bin/varnishtest/vtest2/src/vtc_main.c --replace-fail /bin/rm "${coreutils}/bin/rm"
+        '';
 
       postInstall = ''
         wrapProgram "$out/sbin/varnishd" --prefix PATH : "${lib.makeBinPath [ stdenv.cc ]}"
@@ -106,6 +112,7 @@ let
         knownVulnerabilities = lib.optionals (lib.versions.major version == "7") [
           "VSV00018: https://vinyl-cache.org/security/VSV00018.html"
         ];
+        broken = stdenv.isDarwin && version == "8.0.1"; # https://github.com/NixOS/nixpkgs/issues/495368
       };
     };
 in
@@ -119,5 +126,10 @@ in
   varnish77 = common {
     version = "7.7.3";
     hash = "sha256-6W7q/Ez+KlWO0vtU8eIr46PZlfRvjADaVF1YOq74AjY=";
+  };
+  # EOL 2026-09-15
+  varnish80 = common {
+    version = "8.0.1";
+    hash = "sha256-n1oi1YrNvqw3GhY9683TYSG+XuS8hKoYfrfNDDGP5oI=";
   };
 }

--- a/pkgs/servers/varnish/modules.nix
+++ b/pkgs/servers/varnish/modules.nix
@@ -22,7 +22,7 @@ let
       src = fetchFromGitHub {
         owner = "varnish";
         repo = "varnish-modules";
-        rev = version;
+        tag = version;
         inherit hash;
       };
 
@@ -58,5 +58,9 @@ in
   modules26 = common {
     version = "0.26.0";
     hash = "sha256-xKMOkqm6/GoBve0AhPqyVMQv/oh5Rtj6uCeg/yId7BU=";
+  };
+  modules27 = common {
+    version = "0.27.0";
+    hash = "sha256-1hE+AKsC6Td+Al7LFN6bgPicU8dtWd3A8PP7VKZLvYM=";
   };
 }

--- a/pkgs/servers/varnish/packages.nix
+++ b/pkgs/servers/varnish/packages.nix
@@ -3,9 +3,10 @@
   callPackage,
   varnish60,
   varnish77,
+  lib,
 }:
 {
-  varnish60Packages = rec {
+  varnish60Packages = lib.recurseIntoAttrs rec {
     varnish = varnish60;
     modules = (callPackages ./modules.nix { inherit varnish; }).modules15;
     digest = callPackage ./digest.nix {
@@ -19,7 +20,7 @@
       sha256 = "1n94slrm6vn3hpymfkla03gw9603jajclg84bjhwb8kxsk3rxpmk";
     };
   };
-  varnish77Packages = rec {
+  varnish77Packages = lib.recurseIntoAttrs rec {
     varnish = varnish77;
     modules = (callPackages ./modules.nix { inherit varnish; }).modules26;
   };

--- a/pkgs/servers/varnish/packages.nix
+++ b/pkgs/servers/varnish/packages.nix
@@ -3,6 +3,7 @@
   callPackage,
   varnish60,
   varnish77,
+  varnish80,
   lib,
 }:
 {
@@ -23,5 +24,9 @@
   varnish77Packages = lib.recurseIntoAttrs rec {
     varnish = varnish77;
     modules = (callPackages ./modules.nix { inherit varnish; }).modules26;
+  };
+  varnish80Packages = lib.recurseIntoAttrs rec {
+    varnish = varnish80;
+    modules = (callPackages ./modules.nix { inherit varnish; }).modules27;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4159,10 +4159,12 @@ with pkgs;
   inherit (callPackages ../servers/varnish { })
     varnish60
     varnish77
+    varnish80
     ;
   inherit (callPackages ../servers/varnish/packages.nix { })
     varnish60Packages
     varnish77Packages
+    varnish80Packages
     ;
   varnishPackages = varnish77Packages;
   varnish = varnishPackages.varnish;


### PR DESCRIPTION
Backport of #501601 without changing the default package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
