### PR TITLE
retroarch-bare: use structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/by-name/re/retroarch-bare/package.nix
+++ b/pkgs/by-name/re/retroarch-bare/package.nix
@@ -44,7 +44,7 @@
   retroarch-assets,
   retroarch-bare,
   retroarch-joypad-autoconfig,
-  runCommand,
+  writeText,
   symlinkJoin,
   # params
   enableNvidiaCgToolkit ? false,
@@ -161,7 +161,7 @@ stdenv.mkDerivation (finalAttrs: {
           libretro
           makeBinaryWrapper
           retroarch-bare
-          runCommand
+          writeText
           symlinkJoin
           cores
           ;

--- a/pkgs/by-name/re/retroarch-bare/wrapper.nix
+++ b/pkgs/by-name/re/retroarch-bare/wrapper.nix
@@ -14,10 +14,10 @@ let
     runCommand "declarative-retroarch.cfg"
       {
         value = lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n} = \"${v}\"") settings);
-        passAsFile = [ "value" ];
+        __structuredAttrs = true;
       }
       ''
-        cp "$valuePath" "$out"
+        printf "%s" "$value" > "$out"
       '';
 
   # All cores should be located in the same path after symlinkJoin,

--- a/pkgs/by-name/re/retroarch-bare/wrapper.nix
+++ b/pkgs/by-name/re/retroarch-bare/wrapper.nix
@@ -3,22 +3,16 @@
   libretro,
   makeBinaryWrapper,
   retroarch-bare,
-  runCommand,
+  writeText,
   symlinkJoin,
   cores ? [ ],
   settings ? { },
 }:
 
 let
-  settingsPath =
-    runCommand "declarative-retroarch.cfg"
-      {
-        value = lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n} = \"${v}\"") settings);
-        __structuredAttrs = true;
-      }
-      ''
-        printf "%s" "$value" > "$out"
-      '';
+  settingsPath = writeText "declarative-retroarch.cfg" (
+    lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n} = \"${v}\"") settings)
+  );
 
   # All cores should be located in the same path after symlinkJoin,
   # but let's be safe here


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
