### PR TITLE
buildRustCrate: make --cap-lints configurable

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -842,6 +842,17 @@ general. A number of other parameters can be overridden:
   (hello { }).override { extraRustcOpts = "-Z debuginfo=2"; }
   ```
 
+- The lint level cap passed to `rustc` (`allow` by default, which
+  silences all lints). Because `rustc` only honours the first
+  `--cap-lints` it receives, this cannot be changed via
+  `extraRustcOpts`; use this attribute instead. Useful when overriding
+  the `rust` attribute to point at `clippy-driver`, since clippy lints
+  are also capped by this flag:
+
+  ```nix
+  (hello { }).override { capLints = "warn"; }
+  ```
+
 - Phases, just like in any other derivation, can be specified using
   the following attributes: `preUnpack`, `postUnpack`, `prePatch`,
   `patches`, `postPatch`, `preConfigure` (in the case of a Rust crate,

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -24,6 +24,7 @@
   colors,
   buildTests,
   codegenUnits,
+  capLints,
 }:
 
 let
@@ -73,6 +74,7 @@ in
   LIB_EXT="${stdenv.hostPlatform.extensions.library}"
   LIB_PATH="${libPath}"
   LIB_NAME="${libName}"
+  CAP_LINTS="${capLints}"
 
   CRATE_NAME='${lib.replaceStrings [ "-" ] [ "_" ] libName}'
 

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -29,6 +29,7 @@
   crateVersion,
   extraLinkFlags,
   extraRustcOptsForBuildRs,
+  capLints,
   libName,
   libPath,
   release,
@@ -195,7 +196,7 @@ in
      fi
      noisily rustc --crate-name build_script_build $BUILD --crate-type bin ${rustcOpts} \
        ${mkRustcFeatureArgs crateFeatures} --out-dir target/build/${crateName} --emit=dep-info,link \
-       -L dependency=target/buildDeps ${buildDeps} --cap-lints allow $EXTRA_BUILD_FLAGS --color ${colors}
+       -L dependency=target/buildDeps ${buildDeps} --cap-lints ${capLints} $EXTRA_BUILD_FLAGS --color ${colors}
 
      mkdir -p target/build/${crateName}.out
      export RUST_BACKTRACE=1

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -196,6 +196,16 @@ lib.makeOverridable
       # Example: [ "-Z debuginfo=2" ]
       # Default: []
       extraRustcOptsForBuildRs,
+      # The lint level cap passed to rustc via `--cap-lints`.
+      # See <https://doc.rust-lang.org/rustc/lints/levels.html#capping-lints>.
+      #
+      # rustc honours only the first `--cap-lints` it sees, so appending a
+      # second one via `extraRustcOpts` has no effect. Use this parameter
+      # instead if you need lints to fire (e.g. when running clippy).
+      #
+      # Example: "warn"
+      # Default: "allow"
+      capLints,
       # Whether to enable building tests.
       # Use true to enable.
       # Default: false
@@ -249,12 +259,14 @@ lib.makeOverridable
         "buildTests"
         "codegenUnits"
         "links"
+        "capLints"
       ];
       extraDerivationAttrs = removeAttrs crate processedAttrs;
       nativeBuildInputs_ = nativeBuildInputs;
       buildInputs_ = buildInputs;
       extraRustcOpts_ = extraRustcOpts;
       extraRustcOptsForBuildRs_ = extraRustcOptsForBuildRs;
+      capLints_ = capLints;
       buildTests_ = buildTests;
 
       # crate2nix has a hack for the old bash based build script that did split
@@ -383,6 +395,7 @@ lib.makeOverridable
           lib.optionals (crate ? extraRustcOptsForBuildRs) crate.extraRustcOptsForBuildRs
           ++ extraRustcOptsForBuildRs_
           ++ (lib.optional (edition != null) "--edition ${edition}");
+        capLints = crate.capLints or capLints_;
 
         configurePhase = configureCrate {
           inherit
@@ -403,6 +416,7 @@ lib.makeOverridable
             crateLinks
             extraLinkFlags
             extraRustcOptsForBuildRs
+            capLints
             crateLicense
             crateLicenseFile
             crateReadme
@@ -433,6 +447,7 @@ lib.makeOverridable
             extraRustcOpts
             buildTests
             codegenUnits
+            capLints
             ;
         };
         dontStrip = !release;
@@ -472,6 +487,7 @@ lib.makeOverridable
     verbose = crate_.verbose or true;
     extraRustcOpts = [ ];
     extraRustcOptsForBuildRs = [ ];
+    capLints = "allow";
     features = [ ];
     nativeBuildInputs = [ ];
     buildInputs = [ ];

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -15,7 +15,7 @@ build_lib() {
     $lib_src \
     --out-dir target/lib \
     -L dependency=target/deps \
-    --cap-lints allow \
+    --cap-lints $CAP_LINTS \
     $LINK \
     $EXTRA_LINK_ARGS \
     $EXTRA_LINK_ARGS_LIB \
@@ -52,7 +52,7 @@ build_bin() {
     $EXTRA_LINK_ARGS \
     $EXTRA_LINK_ARGS_BINS \
     $EXTRA_LIB \
-    --cap-lints allow \
+    --cap-lints $CAP_LINTS \
     $BUILD_OUT_DIR \
     $EXTRA_BUILD \
     $EXTRA_FEATURES \


### PR DESCRIPTION
lib.sh previously hardcoded `--cap-lints allow` in both build_lib and
build_bin. Since rustc only honours the first `--cap-lints` it sees,
appending a different level via `extraRustcOpts` had no effect, making
it impossible to run clippy (or any lint-based tooling) through
buildRustCrate without wrapper scripts that strip the argument.

This adds a `capLints` parameter (default `"allow"`, preserving current
behaviour) that can be set per-crate or via `.override`:

    (myCrate { }).override { capLints = "warn"; }


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
