### PR TITLE
toybox: use structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/by-name/to/toybox/package.nix
+++ b/pkgs/by-name/to/toybox/package.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = "patchShebangs .";
 
   inherit extraConfig;
-  passAsFile = [ "extraConfig" ];
 
   configurePhase = ''
     make ${
@@ -57,7 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
         "defconfig"
     }
 
-    cat $extraConfigPath .config > .config-
+    printf "%s" "$extraConfig" > .config-
+    cat .config >> .config-
     mv .config- .config
 
     make oldconfig
@@ -86,6 +86,8 @@ stdenv.mkDerivation (finalAttrs: {
   checkTarget = "tests";
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Lightweight implementation of some Unix command line utilities";

--- a/pkgs/by-name/to/toybox/package.nix
+++ b/pkgs/by-name/to/toybox/package.nix
@@ -22,8 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "landley";
     repo = "toybox";
-    rev = finalAttrs.version;
-    sha256 = "sha256-b5sigIxyg4T4wVc5z8Das+RdEXmNBPFsXpWwXxU/ERE=";
+    tag = finalAttrs.version;
+    hash = "sha256-b5sigIxyg4T4wVc5z8Das+RdEXmNBPFsXpWwXxU/ERE=";
   };
 
   depsBuildBuild = optionals (stdenv.hostPlatform != stdenv.buildPlatform) [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
