### PR TITLE
buildRustCrate: remap rustc store path to break rust-src closure leak

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -31,6 +31,12 @@ let
     (if release then "-C opt-level=3" else "-C debuginfo=2")
     "-C codegen-units=${toString codegenUnits}"
     "--remap-path-prefix=$NIX_BUILD_TOP=/"
+    # When the rust-src component is present (common with rust-overlay
+    # toolchains), rustc unvirtualises libstd source paths. Panic
+    # locations from monomorphised generic std code then embed the
+    # toolchain store path in .rodata, pulling the entire toolchain into
+    # the closure. Remap to a stable placeholder to break the reference.
+    "--remap-path-prefix=${rustc}=/rustc"
     (mkRustcDepArgs dependencies crateRenames)
     (mkRustcFeatureArgs crateFeatures)
   ]


### PR DESCRIPTION
When the rust-src component is installed (common with rust-overlay
toolchains via rust-toolchain.toml), rustc unvirtualises libstd source
paths. Panic locations from monomorphised generic std code
(BTreeMap, VecDeque, sync primitives, etc.) then embed the toolchain
store path in .rodata, pulling the entire multi-GB toolchain into the
runtime closure.

This is not an RPATH issue — stdenv's patchelf --shrink-rpath already
cleans that. The reference is a core::panic::Location string.

Remap the rustc store path to /rustc so panic messages stay readable
but no longer create a store-path dependency. This is a no-op for
toolchains without rust-src (the prefix simply never matches).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
