### PR TITLE
vcpkg-tool: use structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/by-name/vc/vcpkg-tool/package.nix
+++ b/pkgs/by-name/vc/vcpkg-tool/package.nix
@@ -53,7 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DVCPKG_DEPENDENCY_CMAKERC=ON"
   ];
 
-  passAsFile = [ "vcpkgWrapper" ];
   vcpkgWrapper =
     let
       # These are the most common binaries used by vcpkg
@@ -173,7 +172,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup = lib.optionalString doWrap ''
     mv "$out/bin/vcpkg" "$out/bin/.vcpkg-wrapped"
-    install -Dm555 "$vcpkgWrapperPath" "$out/bin/vcpkg"
+    printf "%s" "$vcpkgWrapper" | install -Dm555 /dev/stdin "$out/bin/vcpkg"
   '';
 
   passthru.tests = lib.optionalAttrs doWrap {
@@ -190,6 +189,8 @@ stdenv.mkDerivation (finalAttrs: {
       ''}
     '';
   };
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Components of microsoft/vcpkg's binary";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
