### PR TITLE
seconlay: init at 0-unstable-2026-03-30

### DIFF
--- a/pkgs/by-name/se/seconlay/package.nix
+++ b/pkgs/by-name/se/seconlay/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  pkg-config,
+  protobuf,
+  openssl,
+  zlib,
+  nix-update-script,
+  cloud-utils,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "seconlay";
+  version = "0-unstable-2026-03-30";
+
+  src = fetchFromGitLab {
+    group = "alasca.cloud";
+    owner = "scl";
+    repo = "scl-management";
+    rev = "ba2bff59916fc3597ebec20c6d0405b888a79c44";
+    hash = "sha256-tJxWdEK+BpVlBeR5z/MsQGgeOp9yt3o1wtSzjA+gHt4=";
+  };
+
+  cargoHash = "sha256-uVccOT0DCHet52Oer3mGzFd/zs9rp4IZCvl5o/JMJgQ=";
+
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+  ];
+
+  buildInputs = [
+    openssl
+    zlib
+  ];
+
+  nativeCheckInputs = [ cloud-utils ];
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Minimal IaaS system with strong tenant separation and small TCB";
+    longDescription = ''
+      Seconlay (commonly abbreviated as SCL) is a minimal IaaS system built in Rust with strong tenant separation and small TCB.
+      It is intended for providing an easy-to-use API to manage a VM-based separation layer underlying to user-facing infrastructure such as tenant-specific Kubernetes clusters.
+    '';
+    homepage = "https://alasca.cloud/projects/seconlay/";
+    license = lib.licenses.eupl12;
+    maintainers = with lib.maintainers; [
+      malik
+      messemar
+    ];
+    mainProgram = "sclctl";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The Separation Control Layer is a minimal IaaS system built in Rust with strong tenant separation and small TCB. It is intended for providing an easy-to-use API to manage a VM-based separation layer underlying to user-facing infrastructure such as tenant-specific Kubernetes clusters.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

@messemar I saw you already packaged this before so I assumed you would be open to take part in maintaining this.