### PR TITLE
rustPlatform.importCargoLock: use structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -283,12 +283,12 @@ let
             mkdir -p $out/.cargo
 
             ${
-              if lockFile != null then
-                "ln -s ${lockFile} $out/Cargo.lock"
-              else
+              if lockFile == null then
                 ''
                   printf "%s" "$lockFileContents" > "$out/Cargo.lock"
                 ''
+              else
+                "ln -s ${lockFile} $out/Cargo.lock"
             }
 
             cat > $out/.cargo/config.toml <<EOF

--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -263,17 +263,21 @@ let
   vendorDir =
     runCommand "cargo-vendor-dir"
       (
-        if lockFile == null then
-          {
-            inherit lockFileContents;
-            passAsFile = [ "lockFileContents" ];
-          }
-        else
-          {
-            passthru = {
-              inherit lockFile;
-            };
-          }
+        {
+          __structuredAttrs = true;
+        }
+        // (
+          if lockFile == null then
+            {
+              inherit lockFileContents;
+            }
+          else
+            {
+              passthru = {
+                inherit lockFile;
+              };
+            }
+        )
       )
       ''
             mkdir -p $out/.cargo
@@ -282,7 +286,9 @@ let
               if lockFile != null then
                 "ln -s ${lockFile} $out/Cargo.lock"
               else
-                "cp $lockFileContentsPath $out/Cargo.lock"
+                ''
+                  printf "%s" "$lockFileContents" > "$out/Cargo.lock"
+                ''
             }
 
             cat > $out/.cargo/config.toml <<EOF


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
