### PR TITLE
python3Packages.pymanopt: skip failing tests

### DIFF
--- a/pkgs/development/python-modules/pymanopt/default.nix
+++ b/pkgs/development/python-modules/pymanopt/default.nix
@@ -20,7 +20,7 @@
   torch,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pymanopt";
   version = "2.2.1";
   pyproject = true;
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "pymanopt";
     repo = "pymanopt";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-LOEulticgCWZBCf3qj5KFBHt0lMd4H85368IhG3DQ4g=";
   };
 
@@ -63,11 +63,18 @@ buildPythonPackage rec {
     "tests/manifolds/test_positive_definite.py::TestSingleSpecialHermitianPositiveDefiniteManifold::test_retraction"
   ];
 
+  disabledTests = [
+    # ValueError: setting an array element with a sequence
+    "test_check_gradient"
+    "test_check_hessian"
+    "test_check_retraction"
+  ];
+
   meta = {
     description = "Python toolbox for optimization on Riemannian manifolds with support for automatic differentiation";
     homepage = "https://www.pymanopt.org/";
-    changelog = "https://github.com/pymanopt/pymanopt/releases/tag/${version}";
+    changelog = "https://github.com/pymanopt/pymanopt/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ yl3dy ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

```
        residues = np.zeros(len(x) - window_length)
        polys = np.zeros((2, len(residues)))
        for k in np.arange(len(residues)):
            segment = np.arange(k, k + window_length + 1)
            poly, residuals, *_ = np.polyfit(
                x[segment], y[segment], deg=1, full=True
            )
>           residues[k] = np.sqrt(residuals)
            ^^^^^^^^^^^
E           ValueError: setting an array element with a sequence.
```

cc @yl3dy

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
