### PR TITLE
buildRustCrate: name tests/<dir>/main.rs binaries as <dir> to match cargo

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -87,6 +87,12 @@ build_bin_test_file() {
     # above.
     derived_crate_name=${derived_crate_name#"tests_"}
     derived_crate_name="${derived_crate_name%.rs}"
+    # Cargo names tests/<dir>/main.rs as <dir>, not <dir>_main — strip the
+    # trailing _main that the `/`→`_` substitution produced. Guarded so
+    # a flat-style tests/<name>_main.rs keeps its _main suffix.
+    if [[ "$file" == */main.rs ]]; then
+        derived_crate_name="${derived_crate_name%_main}"
+    fi
     build_bin_test "$derived_crate_name" "$file"
 }
 

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -91,9 +91,15 @@ let
   mkTest =
     crateArgs:
     let
-      crate = mkHostCrate (removeAttrs crateArgs [ "expectedTestOutput" ]);
+      crate = mkHostCrate (
+        removeAttrs crateArgs [
+          "expectedTestOutputs"
+          "expectedTestBinaries"
+        ]
+      );
       hasTests = crateArgs.buildTests or false;
       expectedTestOutputs = crateArgs.expectedTestOutputs or null;
+      expectedTestBinaries = crateArgs.expectedTestBinaries or [ ];
       binaries = map (v: lib.escapeShellArg v.name) (crateArgs.crateBin or [ ]);
       isLib = crateArgs ? libName || crateArgs ? libPath;
       crateName = crateArgs.crateName or "nixtestcrate";
@@ -134,6 +140,10 @@ let
           ''
         else if stdenv.hostPlatform == stdenv.buildPlatform then
           ''
+            ${lib.concatMapStringsSep "\n" (
+              b:
+              "test -x ${crate}/tests/${lib.escapeShellArg b} || { echo 'expected test binary \"${b}\" not found in:'; ls ${crate}/tests; exit 23; }"
+            ) expectedTestBinaries}
             for file in ${crate}/tests/*; do
               $file 2>&1 >> $out
             done
@@ -419,10 +429,32 @@ rec {
             ];
           };
           buildTests = true;
+          # Cargo names tests/<dir>/main.rs as <dir>, not <dir>_main.
+          expectedTestBinaries = [
+            "foo"
+            "bar"
+          ];
           expectedTestOutputs = [
             "test src_main ... ok"
             "test tests_foo ... ok"
             "test tests_bar ... ok"
+          ];
+        };
+        rustBinTestsFlatMainSuffix = {
+          # A flat-style test whose name happens to end in _main must keep
+          # its suffix — only tests/<dir>/main.rs gets the _main stripped.
+          src = symlinkJoin {
+            name = "rust-bin-tests-flat-main-suffix";
+            paths = [
+              (mkTestFileWithMain "src/main.rs" "src_main")
+              (mkTestFile "tests/foo_main.rs" "flat_test")
+            ];
+          };
+          buildTests = true;
+          expectedTestBinaries = [ "foo_main" ];
+          expectedTestOutputs = [
+            "test src_main ... ok"
+            "test flat_test ... ok"
           ];
         };
         linkAgainstRlibCrate = {


### PR DESCRIPTION
`build_bin_test_file` derives the test binary name by replacing `/` with
`_`, stripping the `tests_` prefix and `.rs` suffix. For the
subdirectory integration-test layout `tests/<dir>/main.rs`, this
produces `<dir>_main`, but cargo names that binary `<dir>` per its
auto-discovery rules. Tools that expect the cargo convention
(cargo-nextest binaries-metadata, IDE test runners) cannot find the
binaries.

Strip the trailing `_main` when the source file is `*/main.rs`. The
guard is needed so a flat-style `tests/<name>_main.rs` keeps its
suffix.

Add `expectedTestBinaries` to the test harness so binary naming can be
asserted, and cover both the subdir case (suffix stripped) and the
flat case with a literal `_main` in the filename (suffix kept). Also
fix a typo in `removeAttrs` that leaked `expectedTestOutputs` into the
crate args.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
