### PR TITLE
[25.11] cryptomator: 1.18.0 -> 1.19.2, fix 3 security issues

### DIFF
--- a/pkgs/by-name/cr/cryptomator/downgrade-fuse.patch
+++ b/pkgs/by-name/cr/cryptomator/downgrade-fuse.patch
@@ -1,0 +1,13 @@
+diff --git a/pom.xml b/pom.xml
+index fdaf9b328..2dbc69fb8 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -39,7 +39,7 @@
+ 		<cryptomator.integrations.win.version>1.6.0</cryptomator.integrations.win.version>
+ 		<cryptomator.integrations.mac.version>1.5.0</cryptomator.integrations.mac.version>
+ 		<cryptomator.integrations.linux.version>1.7.0</cryptomator.integrations.linux.version>
+-		<cryptomator.fuse.version>6.0.1</cryptomator.fuse.version>
++		<cryptomator.fuse.version>5.1.0</cryptomator.fuse.version>
+ 		<cryptomator.webdav.version>3.0.1</cryptomator.webdav.version>
+ 		<cryptomator.webdav-servlet.version>1.2.12</cryptomator.webdav-servlet.version>
+ 

--- a/pkgs/by-name/cr/cryptomator/package.nix
+++ b/pkgs/by-name/cr/cryptomator/package.nix
@@ -17,13 +17,13 @@ let
 in
 maven.buildMavenPackage rec {
   pname = "cryptomator";
-  version = "1.18.0";
+  version = "1.18.1";
 
   src = fetchFromGitHub {
     owner = "cryptomator";
     repo = "cryptomator";
     tag = version;
-    hash = "sha256-UWe9iBgb6eBasHnqfBtOFnZlLF1XCIF0y+ebphYQkQw=";
+    hash = "sha256-C2pvToxIK8gPzmqcRKYCu4B2FBrOGcH2Uzpjdt3nZZs=";
   };
 
   mvnJdk = jdk;

--- a/pkgs/by-name/cr/cryptomator/package.nix
+++ b/pkgs/by-name/cr/cryptomator/package.nix
@@ -17,18 +17,30 @@ let
 in
 maven.buildMavenPackage rec {
   pname = "cryptomator";
-  version = "1.18.1";
+  version = "1.19.2";
 
   src = fetchFromGitHub {
     owner = "cryptomator";
     repo = "cryptomator";
     tag = version;
-    hash = "sha256-C2pvToxIK8gPzmqcRKYCu4B2FBrOGcH2Uzpjdt3nZZs=";
+    hash = "sha256-9JWZaTsL2sfnGQAZI56T2iQnTNhERsFNFFCeLMB7WC0=";
   };
+
+  patches = [
+    # fix for "java.lang.IllegalStateException: No fuse library found at expected path"
+    ./downgrade-fuse.patch
+  ];
 
   mvnJdk = jdk;
   mvnParameters = "-Dmaven.test.skip=true -Plinux";
-  mvnHash = "sha256-dOpvojr6gVtDFE52eghOVZWGspRLQrTDotOMkVGaG9k=";
+  mvnHash = "sha256-IVOcDFW5YKgUHJKX3ZXYVnOevwmOwN5yEU8jfPtCY1I=";
+  mvnFetchExtraArgs.env = {
+    inherit SOURCE_DATE_EPOCH;
+  };
+
+  # fix for "date 1980-01-01T00:00:00Z is not within the valid range 1980-01-01T00:00:02Z to 2099-12-31T23:59:59Z"
+  # this should be in env, but looks like buildMavenPackage doesn't support that
+  SOURCE_DATE_EPOCH = 315532802; # 1980-01-01T00:00:02Z
 
   preBuild = ''
     VERSION=${version}


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/502619
Fixes https://github.com/NixOS/nixpkgs/issues/502616
Fixes https://github.com/NixOS/nixpkgs/issues/502595

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
(cherry picked from commit 73162f9)