### PR TITLE
luajit*: Fix badPlatforms declarations for 64-bit POWER

### DIFF
--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -172,7 +172,9 @@ stdenv.mkDerivation (finalAttrs: {
       badPlatforms = [
         "loongarch64-linux" # See https://github.com/LuaJIT/LuaJIT/issues/1278
         "riscv64-linux" # See https://github.com/LuaJIT/LuaJIT/issues/628
-        "powerpc64le-linux" # `#error "No support for PPC64"`
+        # `#error "No support for PPC64"`
+        "powerpc64-linux"
+        "powerpc64le-linux"
       ];
       mainProgram = "lua";
       maintainers = with lib.maintainers; [

--- a/pkgs/development/interpreters/luajit/openresty.nix
+++ b/pkgs/development/interpreters/luajit/openresty.nix
@@ -15,5 +15,17 @@ callPackage ./default.nix rec {
     hash = "sha256-SICmM+/dvp/36UAWAH0l7D938iFDimnoKBOjlOodrCY=";
   };
 
+  extraMeta = {
+    badPlatforms = [
+      "loongarch64-linux" # See https://github.com/LuaJIT/LuaJIT/issues/1278
+      "riscv64-linux" # See https://github.com/LuaJIT/LuaJIT/issues/628
+      # 64-bit POWER (LE and BE, either ELF ABI version on the latter) *is* supported, but ELFv1 powerpc64-linux has an
+      # issue with memory allocation
+      # https://github.com/openresty/luajit2/issues/258
+      # Both BE ABI versions use the same double though, so would have to inspect stdenv to differentiate.
+      "powerpc64-linux"
+    ];
+  };
+
   inherit self passthruFun;
 }


### PR DESCRIPTION
Official LuaJIT throws same error on powerpc64 as it does on powerpc64le. OpenResty *does* support powerpc64 and powerpc64le since at least 2.1-20201001, but without a JIT implementation (could still be useful for API compatibility? not super familiar with LuaJIT fork stuff).

powerpc64-linux ELFv1 (which is our default ABI target on that platform) builds on the OpenResty fork, but suffers from an issue with memory allocations (https://github.com/openresty/luajit2/issues/258). Differentiating ELFv1 from ELFv2 would require `stdenv` inspection. Opted to just keep `powerpc64-linux` in `meta.badPlatforms` for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
