### PR TITLE
python3Packages.odc-loader: skip failing tests

### DIFF
--- a/pkgs/development/python-modules/odc-loader/default.nix
+++ b/pkgs/development/python-modules/odc-loader/default.nix
@@ -23,7 +23,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "odc-loader";
   version = "0.6.4";
   pyproject = true;
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "opendatacube";
     repo = "odc-loader";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-nJSC93+uPzsZY0ZHmrodPkCIk2FZnZ2ksfJIvr+x0As=";
   };
 
@@ -47,21 +47,22 @@ buildPythonPackage rec {
     xarray
   ];
 
-  optional-dependencies = {
+  optional-dependencies = lib.fix (self: {
     botocore = [ botocore ];
     zarr = [ zarr ];
-    all = lib.concatAttrValues (lib.removeAttrs optional-dependencies [ "all" ]);
-  };
+    all = self.botocore ++ self.zarr;
+  });
 
   nativeCheckInputs = [
     geopandas
     pytestCheckHook
   ]
-  ++ optional-dependencies.all;
+  ++ finalAttrs.passthru.optional-dependencies.all;
 
   disabledTests = [
     # Require internet access
     "test_mem_reader"
+    "test_memreader_aux"
     "test_memreader_zarr"
   ];
 
@@ -72,8 +73,8 @@ buildPythonPackage rec {
   meta = {
     description = "Tools for constructing xarray objects from parsed metadata";
     homepage = "https://github.com/opendatacube/odc-loader/";
-    changelog = "https://github.com/opendatacube/odc-loader/releases/tag/${src.tag}";
+    changelog = "https://github.com/opendatacube/odc-loader/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ daspk04 ];
   };
-}
+})


### PR DESCRIPTION
## Things done

Skips the failing [tests](https://github.com/NixOS/nixpkgs/pull/500241#issuecomment-4106618460) as it needs network access.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
