### PR TITLE
fceux: fix build failure (minizip)

### DIFF
--- a/pkgs/by-name/fc/fceux/0001-fix-build-with-minizip-1.3.2.patch
+++ b/pkgs/by-name/fc/fceux/0001-fix-build-with-minizip-1.3.2.patch
@@ -1,0 +1,39 @@
+From 8c648b4a68e5ebadb4d0f08728e44078954cebae Mon Sep 17 00:00:00 2001
+From: kuflierl <41301536+kuflierl@users.noreply.github.com>
+Date: Fri, 27 Mar 2026 01:28:17 +0100
+Subject: [PATCH] fix: build with minizip 1.3.2
+
+---
+ src/drivers/Qt/AboutWindow.cpp | 2 +-
+ src/drivers/Qt/fceuWrapper.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/drivers/Qt/AboutWindow.cpp b/src/drivers/Qt/AboutWindow.cpp
+index 025cf360..5638a3c1 100644
+--- a/src/drivers/Qt/AboutWindow.cpp
++++ b/src/drivers/Qt/AboutWindow.cpp
+@@ -23,7 +23,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <string>
+-#include <unzip.h>
++#include <minizip/unzip.h>
+ 
+ #ifdef _S9XLUA_H
+ #include <lua.h>
+diff --git a/src/drivers/Qt/fceuWrapper.cpp b/src/drivers/Qt/fceuWrapper.cpp
+index 8d241258..5e48eaf7 100644
+--- a/src/drivers/Qt/fceuWrapper.cpp
++++ b/src/drivers/Qt/fceuWrapper.cpp
+@@ -23,7 +23,7 @@
+ #include <stdlib.h>
+ #include <stdint.h>
+ #include <limits.h>
+-#include <unzip.h>
++#include <minizip/unzip.h>
+ 
+ #include <QFileInfo>
+ #include <QStyleFactory>
+-- 
+2.51.2
+

--- a/pkgs/by-name/fc/fceux/package.nix
+++ b/pkgs/by-name/fc/fceux/package.nix
@@ -40,6 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-2QDiAk2HO9oQ1gNvc7QFZSCbWkCDYW5OJWT8f4bmXyg=";
   };
 
+  patches = [
+    ./0001-fix-build-with-minizip-1.3.2.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/500611
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
