### PR TITLE
autokey-wayland: init at 0.97.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7977,6 +7977,12 @@
     github = "encode42";
     githubId = 34699884;
   };
+  enderbsd = {
+    email = "ender@enderzone.com";
+    github = "enderbsd";
+    githubId = 13617481;
+    name = "enderbsd";
+  };
   enderger = {
     email = "endergeryt@gmail.com";
     github = "enderger";

--- a/pkgs/by-name/au/autokey-wayland/package.nix
+++ b/pkgs/by-name/au/autokey-wayland/package.nix
@@ -85,7 +85,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     description = "Desktop automation utility for Linux with Wayland support";
     homepage = "https://github.com/dlk3/autokey-wayland";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ enderbsd ];
     platforms = lib.platforms.linux;
     mainProgram = "autokey-qt";
   };

--- a/pkgs/by-name/au/autokey-wayland/package.nix
+++ b/pkgs/by-name/au/autokey-wayland/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  zip,
+  wrapGAppsHook3,
+  gobject-introspection,
+  gtksourceview3,
+  libappindicator-gtk3,
+  libnotify,
+  libsForQt5,
+  zenity,
+  wmctrl,
+  kdePackages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "autokey-wayland";
+  version = "0.97.4";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "dlk3";
+    repo = "autokey-wayland";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-aS1X+YKV5VtuMUjkkQIwARPWxoagXHKUFaPuy3qq/fI=";
+  };
+
+  nativeBuildInputs = [
+    zip
+    wrapGAppsHook3
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    gtksourceview3
+    libappindicator-gtk3
+    libnotify
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    # shared with upstream autokey
+    dbus-python
+    pyinotify
+    xlib
+    pygobject3
+    packaging
+    # wayland fork additions
+    python-magic
+    pyasyncore
+    pyqt5
+    qscintilla
+    pydbus
+    pyudev
+    evdev
+  ];
+
+  # build the GNOME Shell extension zip before the Python build
+  preBuild = ''
+    cd autokey-gnome-extension
+    zip --junk-paths autokey-gnome-extension@autokey.shell-extension.zip 46/extension.js 46/metadata.json
+    cd ..
+  '';
+
+  runtimeDeps = [
+    zenity
+    wmctrl
+    kdePackages.kdialog
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix PATH : ${lib.makeBinPath finalAttrs.runtimeDeps}
+      --prefix QT_PLUGIN_PATH : "${libsForQt5.qtbase.bin}/${libsForQt5.qtbase.qtPluginPrefix}"
+      --prefix QT_PLUGIN_PATH : "${libsForQt5.qtwayland.bin}/${libsForQt5.qtbase.qtPluginPrefix}"
+    )
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Desktop automation utility for Linux with Wayland support";
+    homepage = "https://github.com/dlk3/autokey-wayland";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.linux;
+    mainProgram = "autokey-qt";
+  };
+})

--- a/pkgs/by-name/au/autokey-wayland/package.nix
+++ b/pkgs/by-name/au/autokey-wayland/package.nix
@@ -9,6 +9,7 @@
   libappindicator-gtk3,
   libnotify,
   libsForQt5,
+  versionCheckHook,
   zenity,
   wmctrl,
   kdePackages,
@@ -22,7 +23,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "dlk3";
     repo = "autokey-wayland";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-aS1X+YKV5VtuMUjkkQIwARPWxoagXHKUFaPuy3qq/fI=";
   };
 
@@ -79,7 +80,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     )
   '';
 
-  doCheck = false;
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Desktop automation utility for Linux with Wayland support";
@@ -87,6 +89,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ enderbsd ];
     platforms = lib.platforms.linux;
-    mainProgram = "autokey-qt";
+    mainProgram = "autokey-headless";
   };
 })

--- a/pkgs/by-name/au/autokey-wayland/package.nix
+++ b/pkgs/by-name/au/autokey-wayland/package.nix
@@ -54,6 +54,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pydbus
     pyudev
     evdev
+    tkinter
   ];
 
   # build the GNOME Shell extension zip before the Python build

--- a/pkgs/by-name/au/autokey-wayland/package.nix
+++ b/pkgs/by-name/au/autokey-wayland/package.nix
@@ -20,6 +20,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   version = "0.97.4";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "dlk3";
     repo = "autokey-wayland";


### PR DESCRIPTION
Adds autokey-wayland, a fork of autokey with Wayland support via evdev/uinput.

https://github.com/dlk3/autokey-wayland

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test