### PR TITLE
pkgs/by-name/co*: use installFonts hook

### DIFF
--- a/pkgs/by-name/co/comic-mono/package.nix
+++ b/pkgs/by-name/co/comic-mono/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation {
@@ -15,11 +16,10 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-q8NxrluWuH23FfRlntIS0MDdl3TkkGE7umcU2plS6eU=";
   };
 
+  nativeBuildInputs = [ installFonts ];
+
   installPhase = ''
     runHook preInstall
-
-    mkdir -p $out/share/fonts
-    cp *.ttf $out/share/fonts
 
     mkdir -p $out/etc/fonts/conf.d
     ln -s ${./comic-mono-weight.conf} $out/etc/fonts/conf.d/30-comic-mono.conf

--- a/pkgs/by-name/co/comic-neue/package.nix
+++ b/pkgs/by-name/co/comic-neue/package.nix
@@ -2,27 +2,32 @@
   lib,
   stdenv,
   fetchzip,
+  installFonts,
 }:
 
 stdenv.mkDerivation rec {
   pname = "comic-neue";
   version = "2.51";
 
+  outputs = [
+    "out"
+    "webfont"
+    "doc"
+  ];
+
   src = fetchzip {
     url = "https://github.com/crozynski/comicneue/releases/download/${version}/comicneue-master.zip";
     hash = "sha256-Xkw+Yd36ffptKsS8RSEP9BPX6eQI7TZn2NgU49rdo80=";
   };
 
+  nativeBuildInputs = [ installFonts ];
+
   installPhase = ''
-    mkdir -pv $out/share/{doc/${pname}-${version},fonts/{opentype,truetype,WOFF,WOFF2}}
-    cp -v {FONTLOG,OFL-FAQ,OFL}.txt $out/share/doc/
-    cp -v Booklet-ComicNeue.pdf $out/share/doc/
-    cp -v Fonts/OTF/ComicNeue-Angular/*.otf $out/share/fonts/opentype
-    cp -v Fonts/OTF/ComicNeue/*.otf $out/share/fonts/opentype
-    cp -v Fonts/TTF/ComicNeue-Angular/*.ttf $out/share/fonts/truetype
-    cp -v Fonts/TTF/ComicNeue/*.ttf $out/share/fonts/truetype
-    cp -v Fonts/WebFonts/*.woff $out/share/fonts/WOFF
-    cp -v Fonts/WebFonts/*.woff2 $out/share/fonts/WOFF2
+    runHook preInstall
+
+    install -m644 -Dt $doc/share/doc/ {FONTLOG,OFL-FAQ,OFL}.txt Booklet-ComicNeue.pdf
+
+    runHook postInstall
   '';
 
   meta = {

--- a/pkgs/by-name/co/comic-relief/package.nix
+++ b/pkgs/by-name/co/comic-relief/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -14,14 +15,14 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-lvkMfaQvLMZ8F0Q5JnpmMsIAkR+XfihoHIoS4z5QEvA=";
   };
 
+  nativeBuildInputs = [ installFonts ];
+
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/etc/fonts/conf.d
     mkdir -p $out/share/doc/${pname}-${version}
-    mkdir -p $out/share/fonts/truetype
     cp -v ${./comic-sans-ms-alias.conf}     $out/etc/fonts/conf.d/30-comic-sans-ms.conf
-    cp *.ttf      -d $out/share/fonts/truetype
     cp FONTLOG.txt -d $out/share/doc/${pname}-${version}
 
     runHook postInstall

--- a/pkgs/by-name/co/commit-mono/package.nix
+++ b/pkgs/by-name/co/commit-mono/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "commit-mono";
@@ -19,12 +20,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontFixup = true;
   doCheck = false;
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm644 CommitMono-${finalAttrs.version}/*.otf -t $out/share/fonts/opentype
-    install -Dm644 CommitMono-${finalAttrs.version}/ttfautohint/*.ttf -t $out/share/fonts/truetype
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Anonymous and neutral programming typeface focused on creating a better reading experience";

--- a/pkgs/by-name/co/cozette/package.nix
+++ b/pkgs/by-name/co/cozette/package.nix
@@ -5,6 +5,7 @@
   writeText,
   bdf2psf,
   codepoints ? (import ./default-codepoints.nix),
+  installFonts,
 }:
 
 let
@@ -14,6 +15,11 @@ stdenvNoCC.mkDerivation rec {
   pname = "cozette";
   version = "1.30.0";
 
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchzip {
     url = "https://github.com/the-moonwitch/Cozette/releases/download/v.${version}/CozetteFonts-v-${
       builtins.replaceStrings [ "." ] [ "-" ] version
@@ -21,7 +27,10 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-Njh6V5wTBKM/1QKmPwG1qiOYyAJSVQXLTBLN03V6DaE=";
   };
 
-  nativeBuildInputs = [ bdf2psf ];
+  nativeBuildInputs = [
+    bdf2psf
+    installFonts
+  ];
 
   postBuild = ''
     # Confine Powerline left divider symbols to strictly 6 pixels wide
@@ -37,13 +46,6 @@ stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-
-    install -Dm644 *.ttf -t $out/share/fonts/truetype
-    install -Dm644 *.otf -t $out/share/fonts/opentype
-    install -Dm644 *.bdf -t $out/share/fonts/misc
-    install -Dm644 *.otb -t $out/share/fonts/misc
-    install -Dm644 *.woff -t $out/share/fonts/woff
-    install -Dm644 *.woff2 -t $out/share/fonts/woff2
 
     install -Dm644 *.psfu -t "$out/share/consolefonts/"
 


### PR DESCRIPTION
Only one not changed is corefonts, since it had weird issues that I can't be bothered fixing atm. Everything else tested to build properly.

Part of #495640

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
