### PR TITLE
python3Packages.steamloop: init at 1.2.1

### DIFF
--- a/pkgs/development/python-modules/steamloop/default.nix
+++ b/pkgs/development/python-modules/steamloop/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  orjson,
+  pytest-cov-stub,
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "steamloop";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hvaclibs";
+    repo = "steamloop";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0uzx1lW34sBWq06dR+ajPZ5VfUSTQHGSB/hoy1fLKLo=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ orjson ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [ "steamloop" ];
+
+  meta = {
+    description = "Local control for choochoo based thermostats";
+    homepage = "https://github.com/hvaclibs/steamloop";
+    changelog = "https://github.com/hvaclibs/steamloop/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -6490,7 +6490,8 @@
       ];
     "trane" =
       ps: with ps; [
-      ]; # missing inputs: steamloop
+        steamloop
+      ];
     "transmission" =
       ps: with ps; [
         transmission-rpc
@@ -8174,6 +8175,7 @@
     "trafikverket_ferry"
     "trafikverket_train"
     "trafikverket_weatherstation"
+    "trane"
     "transmission"
     "transport_nsw"
     "trend"

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -199,6 +199,10 @@ let
       # sandbox doesn't grant access to /sys/class/power_supply
       "tests/components/systemmonitor/test_config_flow.py::test_add_and_remove_processes"
     ];
+    trane = [
+      # TraneConfigFlow doesn't support step reauth
+      "tests/components/trane/test_init.py::test_setup_auth_error"
+    ];
     youtube = [
       # outdated snapshot
       "tests/components/youtube/test_sensor.py::test_sensor"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18533,6 +18533,8 @@ self: super: with self; {
 
   steam = callPackage ../development/python-modules/steam { };
 
+  steamloop = callPackage ../development/python-modules/steamloop { };
+
   steamodd = callPackage ../development/python-modules/steamodd { };
 
   steampy = callPackage ../development/python-modules/steampy { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://www.home-assistant.io/integrations/trane/
- https://pypi.org/project/steamloop/
- https://github.com/hvaclibs/steamloop

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
