### PR TITLE
nixos/locale: emit dbus signal on declarative timezone change

### DIFF
--- a/nixos/modules/config/locale.nix
+++ b/nixos/modules/config/locale.nix
@@ -90,6 +90,25 @@ in
       NIXOS_STATIC_TIMEZONE = "1";
     };
 
+    # When time.timeZone is set declaratively, NixOS patches systemd-timedated
+    # to reject timedatectl set-timezone (via NIXOS_STATIC_TIMEZONE). This means
+    # the PropertiesChanged dbus signal for the Timezone property is never emitted
+    # on activation, so running GUI applications (Thunderbird, Chromium, etc.)
+    # don't pick up timezone changes until restarted. Emit the signal manually
+    # after the etc activation updates the /etc/localtime symlink.
+    system.activationScripts.timezone-notify = lib.mkIf (config.time.timeZone != null) (lib.stringAfter [ "etc" ] ''
+      ${pkgs.systemd}/bin/busctl emit \
+        /org/freedesktop/timedate1 \
+        org.freedesktop.DBus.Properties \
+        PropertiesChanged \
+        "sa{sv}as" \
+        org.freedesktop.timedate1 \
+        1 \
+          Timezone s ${lib.escapeShellArg config.time.timeZone} \
+        0 \
+        2>/dev/null || true
+    '');
+
     environment.etc = {
       zoneinfo.source = tzdir;
     }


### PR DESCRIPTION
## Description

When `time.timeZone` is set declaratively, NixOS patches `systemd-timedated` to reject `timedatectl set-timezone` via the `NIXOS_STATIC_TIMEZONE` environment variable. A side effect is that the `PropertiesChanged` dbus signal for the `Timezone` property is never emitted during activation. Running GUI applications such as Thunderbird, Chromium, and Electron apps don't notice the timezone has changed until they are restarted.

This PR adds an activation script that emits the `PropertiesChanged` signal via `busctl` after the `etc` activation script updates the `/etc/localtime` symlink. This mirrors the signal that upstream `systemd-timedated` would emit in `method_set_timezone()`.

The signal is only emitted when `time.timeZone` is non-null (static/declarative mode). When `time.timeZone = null` (imperative mode), `timedatectl` works normally and emits the signal itself.

## Context

- The NixOS patch to timedated: `pkgs/os-specific/linux/systemd/0006-hostnamed-localed-timedated-disable-methods-that-cha.patch`
- Related: #26469 (allow setting timezone via timedatectl), #26608 (added NIXOS_STATIC_TIMEZONE conditional)
- No existing issue or PR addresses the missing dbus notification

## Testing

After `nixos-rebuild switch` with a changed `time.timeZone` value:

- **Thunderbird**: picks up new timezone on next UI interaction (no restart needed)
- **Chromium**: picks up new timezone on next repaint cycle (no restart needed)  
- **i3status/i3bar**: picks up change on next refresh tick (via glibc re-reading `/etc/localtime`)
- **Terminals**: pick up change immediately (glibc detects mtime change on `/etc/localtime`)

Without this patch, all of the above (except terminals and i3status) require a full application restart to reflect the new timezone.

## Notes

- The `|| true` ensures the activation doesn't fail if dbus isn't running yet (e.g. during initial system installation)
- The signal payload matches what upstream `systemd-timedated` emits
- This affects anyone using `time.timeZone` (the vast majority of NixOS configs) who changes timezones without rebooting