### PR TITLE
maintainers: drop khushraj

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13968,13 +13968,6 @@
     githubId = 788813;
     name = "Bryan Gardiner";
   };
-  khushraj = {
-    email = "khushraj.rathod@gmail.com";
-    github = "khrj";
-    githubId = 44947946;
-    name = "Khushraj Rathod";
-    keys = [ { fingerprint = "1988 3FD8 EA2E B4EC 0A93  1E22 B77B 2A40 E770 2F19"; } ];
-  };
   kiara = {
     name = "kiara";
     email = "cinereal@riseup.net";

--- a/pkgs/by-name/bo/bootstrap-studio/package.nix
+++ b/pkgs/by-name/bo/bootstrap-studio/package.nix
@@ -30,7 +30,7 @@ appimageTools.wrapType2 {
     description = "Drag-and-drop designer for bootstrap";
     homepage = "https://bootstrapstudio.io/";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ khushraj ];
+    maintainers = [ ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/by-name/dp/dprint/package.nix
+++ b/pkgs/by-name/dp/dprint/package.nix
@@ -92,7 +92,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://dprint.dev";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      khushraj
       kachick
       phanirithvij
     ];


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/issues?q=sort%3Aupdated-desc+commenter%3Akhrj+) since July 2023, despite 60+ review requests in the [past year](https://github.com/NixOS/nixpkgs/pulls?q=sort%3Aupdated-desc+is%3Apr+created%3A%3E%3D2025-05-01+user-review-requested%3Akhrj+). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@khrj if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!