### PR TITLE
treewide: drop maintainership of many packages

### DIFF
--- a/pkgs/by-name/au/auto-changelog/package.nix
+++ b/pkgs/by-name/au/auto-changelog/package.nix
@@ -49,6 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/cookpete/auto-changelog/blob/master/CHANGELOG.md";
     license = lib.licenses.mit;
     mainProgram = "auto-changelog";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/au/autoprefixer/package.nix
+++ b/pkgs/by-name/au/autoprefixer/package.nix
@@ -63,6 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/postcss/autoprefixer/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     mainProgram = "autoprefixer";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/bl/bluetuith/package.nix
+++ b/pkgs/by-name/bl/bluetuith/package.nix
@@ -44,7 +44,6 @@ buildGoModule (finalAttrs: {
     platforms = lib.platforms.linux;
     mainProgram = "bluetuith";
     maintainers = with lib.maintainers; [
-      pyrox0
       katexochen
     ];
   };

--- a/pkgs/by-name/cd/cdk8s-cli/package.nix
+++ b/pkgs/by-name/cd/cdk8s-cli/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Command-line-interface for CDK for Kubernetes";
     homepage = "https://github.com/cdk8s-team/cdk8s-cli";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "cdk8s";
   };
 })

--- a/pkgs/by-name/co/code-theme-converter/package.nix
+++ b/pkgs/by-name/co/code-theme-converter/package.nix
@@ -38,6 +38,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Convert any Visual Studio Code Theme to Sublime Text 3 or IntelliJ IDEA";
     homepage = "https://github.com/tobiastimm/code-theme-converter";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/commitlint/package.nix
+++ b/pkgs/by-name/co/commitlint/package.nix
@@ -98,6 +98,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://commitlint.js.org/";
     license = lib.licenses.mit;
     mainProgram = "commitlint";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/conventional-changelog-cli/package.nix
+++ b/pkgs/by-name/co/conventional-changelog-cli/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Generate a CHANGELOG from git metadata";
     homepage = "https://github.com/conventional-changelog/conventional-changelog";
     license = lib.licenses.isc;
-    maintainers = [ lib.maintainers.pyrox0 ];
+    maintainers = [ ];
     mainProgram = "conventional-changelog";
   };
 })

--- a/pkgs/by-name/cs/cspell/package.nix
+++ b/pkgs/by-name/cs/cspell/package.nix
@@ -93,6 +93,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/streetsidesoftware/cspell/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     mainProgram = "cspell";
-    maintainers = [ lib.maintainers.pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/di/diagnostic-languageserver/package.nix
+++ b/pkgs/by-name/di/diagnostic-languageserver/package.nix
@@ -40,6 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/iamcco/diagnostic-languageserver/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     mainProgram = "diagnostic-languageserver";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/di/diff2html-cli/package.nix
+++ b/pkgs/by-name/di/diff2html-cli/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Generate pretty HTML diffs from unified and git diff output in your terminal";
     homepage = "https://diff2html.xyz#cli";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "diff2html";
   };
 })

--- a/pkgs/by-name/do/dotenv-cli/package.nix
+++ b/pkgs/by-name/do/dotenv-cli/package.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/entropitor/dotenv-cli/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     mainProgram = "dotenv";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/fa/fauna-shell/package.nix
+++ b/pkgs/by-name/fa/fauna-shell/package.nix
@@ -59,7 +59,7 @@ buildNpmPackage (finalAttrs: {
     description = "Interactive shell for FaunaDB";
     homepage = "https://github.com/fauna/fauna-shell";
     license = lib.licenses.mpl20;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "fauna";
   };
 })

--- a/pkgs/by-name/fi/fixjson/package.nix
+++ b/pkgs/by-name/fi/fixjson/package.nix
@@ -26,6 +26,6 @@ buildNpmPackage {
     homepage = "https://github.com/rhysd/fixjson";
     license = lib.licenses.mit;
     mainProgram = "fixjson";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ga/gatsby-cli/package.nix
+++ b/pkgs/by-name/ga/gatsby-cli/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "The Gatsby command line interface";
     homepage = "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-cli#readme";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "gatsby";
   };
 })

--- a/pkgs/by-name/ge/get-graphql-schema/package.nix
+++ b/pkgs/by-name/ge/get-graphql-schema/package.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/prisma-labs/get-graphql-schema";
     license = lib.licenses.mit;
     mainProgram = "get-graphql-schema";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/gi/git-run/package.nix
+++ b/pkgs/by-name/gi/git-run/package.nix
@@ -37,6 +37,6 @@ buildNpmPackage rec {
     homepage = "https://mixu.net/gr/";
     license = lib.licenses.bsd3;
     mainProgram = "gr";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/gi/gitbeaker-cli/package.nix
+++ b/pkgs/by-name/gi/gitbeaker-cli/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/jdalrymple/gitbeaker/releases/tag/${finalAttrs.version}";
     description = "CLI Wrapper for the @gitbeaker/rest SDK";
     homepage = "https://github.com/jdalrymple/gitbeaker";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "gitbeaker";
   };
 })

--- a/pkgs/by-name/go/goresym/package.nix
+++ b/pkgs/by-name/go/goresym/package.nix
@@ -39,6 +39,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/mandiant/GoReSym";
     changelog = "https://github.com/mandiant/GoReSym/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/gr/gramma/package.nix
+++ b/pkgs/by-name/gr/gramma/package.nix
@@ -45,6 +45,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     changelog = "https://github.com/caderek/gramma/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.isc;
     mainProgram = "gramma";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/jo/joplin-cli/package.nix
+++ b/pkgs/by-name/jo/joplin-cli/package.nix
@@ -115,6 +115,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://joplinapp.org/";
     license = lib.licenses.agpl3Plus;
     mainProgram = "joplin";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/js/js-beautify/package.nix
+++ b/pkgs/by-name/js/js-beautify/package.nix
@@ -43,7 +43,7 @@ buildNpmPackage (finalAttrs: {
     description = "Beautifier for javascript";
     homepage = "https://beautifier.io/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "js-beautify";
   };
 })

--- a/pkgs/by-name/js/jsdoc/package.nix
+++ b/pkgs/by-name/js/jsdoc/package.nix
@@ -45,6 +45,6 @@ buildNpmPackage (finalAttrs: {
     description = "API documentation generator for JavaScript";
     homepage = "https://jsdoc.app";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/js/jshint/package.nix
+++ b/pkgs/by-name/js/jshint/package.nix
@@ -30,7 +30,7 @@ buildNpmPackage (finalAttrs: {
     description = "Tool that helps to detect errors and potential problems in your JavaScript code";
     homepage = "https://jshint.com";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "jshint";
   };
 })

--- a/pkgs/by-name/js/json-diff/package.nix
+++ b/pkgs/by-name/js/json-diff/package.nix
@@ -26,7 +26,7 @@ buildNpmPackage (finalAttrs: {
     description = "Structural diff for JSON files";
     homepage = "https://github.com/andreyvit/json-diff";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "json-diff";
   };
 })

--- a/pkgs/by-name/js/json-server/package.nix
+++ b/pkgs/by-name/js/json-server/package.nix
@@ -24,6 +24,6 @@ buildNpmPackage (finalAttrs: {
     description = "Get a full fake REST API with zero coding in less than 30 seconds";
     homepage = "https://github.com/typicode/json-server";
     license = lib.licenses.fairsource09;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/js/jsonplaceholder/package.nix
+++ b/pkgs/by-name/js/jsonplaceholder/package.nix
@@ -36,6 +36,6 @@ buildNpmPackage {
     description = "Simple online fake REST API server";
     homepage = "https://jsonplaceholder.typicode.com/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ka/kaput-cli/package.nix
+++ b/pkgs/by-name/ka/kaput-cli/package.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Unofficial CLI client for Put.io";
     homepage = "https://kaput.sh/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "kaput";
   };
 })

--- a/pkgs/by-name/ke/keyoxide-cli/package.nix
+++ b/pkgs/by-name/ke/keyoxide-cli/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Command-line interface to locally verify decentralized identities";
     homepage = "https://codeberg.org/keyoxide/keyoxide-cli";
     license = lib.licenses.agpl3Plus;
-    maintainers = [ lib.maintainers.pyrox0 ];
+    maintainers = [ ];
     mainProgram = "keyoxide";
   };
 })

--- a/pkgs/by-name/lo/localtunnel/package.nix
+++ b/pkgs/by-name/lo/localtunnel/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "CLI for localtunnel";
     homepage = "https://localtunnel.me";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "lt";
   };
 })

--- a/pkgs/by-name/lv/lv_font_conv/package.nix
+++ b/pkgs/by-name/lv/lv_font_conv/package.nix
@@ -29,6 +29,6 @@ buildNpmPackage rec {
     mainProgram = "lv_font_conv";
     homepage = "https://lvgl.io/tools/fontconverter";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ma/markdown-link-check/package.nix
+++ b/pkgs/by-name/ma/markdown-link-check/package.nix
@@ -27,6 +27,6 @@ buildNpmPackage rec {
     mainProgram = "markdown-link-check";
     homepage = "https://github.com/tcort/markdown-link-check";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/mo/mocha/package.nix
+++ b/pkgs/by-name/mo/mocha/package.nix
@@ -30,7 +30,7 @@ buildNpmPackage (finalAttrs: {
     description = "Simple, flexible, fun Javascript test framework for Node.js & the browser";
     homepage = "https://mochajs.org";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "mocha";
   };
 })

--- a/pkgs/by-name/no/node-gyp-build/package.nix
+++ b/pkgs/by-name/no/node-gyp-build/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Build tool and bindings loader for node-gyp that supports prebuilds";
     homepage = "https://github.com/prebuild/node-gyp-build";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "node-gyp-build";
   };
 })

--- a/pkgs/by-name/no/nodemon/package.nix
+++ b/pkgs/by-name/no/nodemon/package.nix
@@ -27,6 +27,6 @@ buildNpmPackage rec {
     mainProgram = "nodemon";
     homepage = "https://nodemon.io";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/nr/nrm/package.nix
+++ b/pkgs/by-name/nr/nrm/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Helps you switch between npm registries easily";
     homepage = "https://github.com/Pana/nrm";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "nrm";
   };
 })

--- a/pkgs/by-name/pa/patch-package/package.nix
+++ b/pkgs/by-name/pa/patch-package/package.nix
@@ -40,6 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "patch-package";
     homepage = "https://github.com/ds300/patch-package";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/pe/peerflix-server/package.nix
+++ b/pkgs/by-name/pe/peerflix-server/package.nix
@@ -29,7 +29,7 @@ buildNpmPackage (finalAttrs: {
     description = "Streaming torrent client for Node.js with web ui";
     homepage = "https://github.com/asapach/peerflix-server";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "peerflix-server";
   };
 })

--- a/pkgs/by-name/po/postcss/package.nix
+++ b/pkgs/by-name/po/postcss/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Transforming styles with JS plugins";
     homepage = "https://postcss.org/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/re/remod/package.nix
+++ b/pkgs/by-name/re/remod/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "chmod for human beings";
     homepage = "https://github.com/samuela/remod";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "remod";
   };
 })

--- a/pkgs/by-name/sq/sql-formatter/package.nix
+++ b/pkgs/by-name/sq/sql-formatter/package.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://sql-formatter-org.github.io/sql-formatter";
     license = lib.licenses.mit;
     mainProgram = "sql-formatter";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/sv/svelte-check/package.nix
+++ b/pkgs/by-name/sv/svelte-check/package.nix
@@ -78,6 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/sveltejs/language-tools";
     license = lib.licenses.mit;
     mainProgram = "svelte-check";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/sw/sway-launcher-desktop/package.nix
+++ b/pkgs/by-name/sw/sway-launcher-desktop/package.nix
@@ -55,6 +55,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/Biont/sway-launcher-desktop/releases/tag/v${version}";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ti/tiddlywiki/package.nix
+++ b/pkgs/by-name/ti/tiddlywiki/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Self-contained JavaScript wiki for the browser, Node.js, AWS Lambda etc";
     homepage = "https://tiddlywiki.com";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "tiddlywiki";
   };
 })

--- a/pkgs/by-name/up/uppy-companion/package.nix
+++ b/pkgs/by-name/up/uppy-companion/package.nix
@@ -71,6 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://uppy.io/";
     license = lib.licenses.mit;
     mainProgram = "companion";
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ve/vega-lite/package.nix
+++ b/pkgs/by-name/ve/vega-lite/package.nix
@@ -39,6 +39,6 @@ buildNpmPackage (finalAttrs: {
     description = "Concise grammar of interactive graphics, built on Vega";
     homepage = "https://vega.github.io/vega-lite/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/wa/wasm-text-gen/package.nix
+++ b/pkgs/by-name/wa/wasm-text-gen/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Toolbox for WebAssembly";
     homepage = "https://webassembly.js.org";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "wasmgen";
   };
 })

--- a/pkgs/by-name/wa/wast-refmt/package.nix
+++ b/pkgs/by-name/wa/wast-refmt/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "WAST Reformatter";
     homepage = "https://webassembly.js.org";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "wast-refmt";
   };
 })

--- a/pkgs/by-name/we/webassemblyjs-cli/package.nix
+++ b/pkgs/by-name/we/webassemblyjs-cli/package.nix
@@ -72,6 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Toolbox for WebAssembly";
     homepage = "https://webassembly.js.org";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/we/webassemblyjs-repl/package.nix
+++ b/pkgs/by-name/we/webassemblyjs-repl/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "WebAssembly REPL";
     homepage = "https://webassembly.js.org";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "wasm";
   };
 })

--- a/pkgs/by-name/we/webpack-cli/package.nix
+++ b/pkgs/by-name/we/webpack-cli/package.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Webpack's Command Line Interface";
     homepage = "https://webpack.js.org/api/cli/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "webpack";
   };
 })

--- a/pkgs/by-name/ya/yalc/package.nix
+++ b/pkgs/by-name/ya/yalc/package.nix
@@ -41,6 +41,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mainProgram = "yalc";
     homepage = "https://github.com/wclr/yalc";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/python-modules/aioaquacell/default.nix
+++ b/pkgs/development/python-modules/aioaquacell/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage rec {
     description = "Asynchronous library to retrieve details of your Aquacell water softener device";
     homepage = "https://github.com/Jordi1990/aioaquacell";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/apsystems-ez1/default.nix
+++ b/pkgs/development/python-modules/apsystems-ez1/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "Streamlined interface for interacting with the local API of APsystems EZ1 Microinverters";
     homepage = "https://github.com/SonnenladenGmbH/APsystems-EZ1-API";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/asyncarve/default.nix
+++ b/pkgs/development/python-modules/asyncarve/default.nix
@@ -37,6 +37,6 @@ buildPythonPackage rec {
     description = "Simple Arve library";
     homepage = "https://github.com/arvetech/asyncarve";
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/aws-request-signer/default.nix
+++ b/pkgs/development/python-modules/aws-request-signer/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     description = "Python library to sign AWS requests using AWS Signature V4";
     homepage = "https://github.com/iksteen/aws-request-signer";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-kusto-data/default.nix
+++ b/pkgs/development/python-modules/azure-kusto-data/default.nix
@@ -78,6 +78,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-kusto-python/tree/master/azure-kusto-data";
     changelog = "https://github.com/Azure/azure-kusto-python/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/azure-kusto-ingest/default.nix
+++ b/pkgs/development/python-modules/azure-kusto-ingest/default.nix
@@ -73,6 +73,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Azure/azure-kusto-python/tree/master/azure-kusto-ingest";
     changelog = "https://github.com/Azure/azure-kusto-python/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/bthomehub5-devicelist/default.nix
+++ b/pkgs/development/python-modules/bthomehub5-devicelist/default.nix
@@ -35,6 +35,6 @@ buildPythonPackage rec {
     description = "Returns a list of devices currently connected to a BT Home Hub 5";
     homepage = "https://github.com/ahobsonsayers/bthomehub5-devicelist";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/mozart-api/default.nix
+++ b/pkgs/development/python-modules/mozart-api/default.nix
@@ -52,6 +52,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/bang-olufsen/mozart-open-api";
     changelog = "https://github.com/bang-olufsen/mozart-open-api/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/ofxhome/default.nix
+++ b/pkgs/development/python-modules/ofxhome/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/captin411/ofxhome";
     description = "ofxhome.com financial institution lookup REST client";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/py-ccm15/default.nix
+++ b/pkgs/development/python-modules/py-ccm15/default.nix
@@ -46,6 +46,6 @@ buildPythonPackage rec {
     description = "Python Library to access a Midea CCM15 data converter";
     homepage = "https://github.com/ocalvo/py-ccm15";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pyaprilaire/default.nix
+++ b/pkgs/development/python-modules/pyaprilaire/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "Python library for interacting with Aprilaire thermostats";
     homepage = "https://github.com/chamberlain2007/pyaprilaire";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/rst2pdf/default.nix
+++ b/pkgs/development/python-modules/rst2pdf/default.nix
@@ -78,6 +78,6 @@ buildPythonPackage rec {
     homepage = "https://rst2pdf.org/";
     changelog = "https://github.com/rst2pdf/rst2pdf/blob/${version}/CHANGES.rst";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/xlwt/default.nix
+++ b/pkgs/development/python-modules/xlwt/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage {
       bsd3
       lgpl21Plus
     ];
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
Don't use any of these packages and they take up my more limited bandwidth these days. Cleaning up this list is good for me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
