### PR TITLE
harmonoid: 0.3.21 -> 0.3.22, fix update script to update all sources

### DIFF
--- a/pkgs/by-name/ha/harmonoid/package.nix
+++ b/pkgs/by-name/ha/harmonoid/package.nix
@@ -16,7 +16,7 @@
   mpv-unwrapped,
 }:
 let
-  version = "0.3.21";
+  version = "0.3.22";
   url_base = "https://github.com/alexmercerind2/harmonoid-releases/releases/download/v${version}";
   url =
     rec {
@@ -29,9 +29,9 @@ let
       or (throw "${stdenv.hostPlatform.system} is an unsupported platform");
   hash =
     rec {
-      x86_64-linux = "sha256-RZDRb/afXbalNbLBGaQgx5Qd4UEbNrvIsa3h+e6osJE=";
-      aarch64-linux = "sha256-1ys7uyCjXe4IBeXRk8mFjqmP9OottNefQrrtTkxq/qU=";
-      x86_64-darwin = "sha256-mo7Rj6c89KZrsL29i99x4E7b6soWlGUsC6KpSB7y5iY=";
+      x86_64-linux = "sha256-+fEx30uu0rZiORrtE00xG2piJzpFbfxSZw3OjrhLJyg=";
+      aarch64-linux = "sha256-jXN5i+LudsODNZUzb5SXClqgQxYzanrbZCqB8X0pJRQ=";
+      x86_64-darwin = "sha256-YYMKrb7ZilfEztL2JTxSdeoDd8xQMrHFtN9N9fmsm3w=";
       aarch64-darwin = x86_64-darwin;
     }
     .${stdenv.hostPlatform.system};

--- a/pkgs/by-name/ha/harmonoid/package.nix
+++ b/pkgs/by-name/ha/harmonoid/package.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
     inherit url hash;
   };
 
+  passthru.updateScript = ./update.sh;
+
   nativeBuildInputs = [
     makeWrapper
   ]

--- a/pkgs/by-name/ha/harmonoid/update.sh
+++ b/pkgs/by-name/ha/harmonoid/update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl pcre2 jq common-updater-scripts
+
+set -eu -o pipefail
+
+release_data=$(curl https://api.github.com/repos/alexmercerind2/harmonoid-releases/releases/latest)
+version=$(jq -r '.tag_name[1:]' <<< "$release_data")
+
+linux64_hash=$(jq '.assets[] as $item | if $item.name == "harmonoid-linux-x86_64.tar.gz" then $item.digest[7:] else empty end' -r <<< "$release_data")
+linux64_hash=$(nix-hash --to-sri --type sha256 "$linux64_hash")
+
+linux_aarch_hash=$(jq '.assets[] as $item | if $item.name == "harmonoid-linux-aarch64.tar.gz" then $item.digest[7:] else empty end' -r <<< "$release_data")
+linux_aarch_hash=$(nix-hash --to-sri --type sha256 "$linux_aarch_hash")
+
+macos_hash=$(jq '.assets[] as $item | if $item.name == "harmonoid-macos-universal.dmg" then $item.digest[7:] else empty end' -r <<< "$release_data")
+macos_hash=$(nix-hash --to-sri --type sha256 "$macos_hash")
+
+update-source-version harmonoid "$version" "$linux64_hash" --system=x86_64-linux --ignore-same-version
+update-source-version harmonoid "$version" "$linux_aarch_hash" --system=aarch64-linux --ignore-same-version
+update-source-version harmonoid "$version" "$macos_hash" --system=x86_64-darwin --ignore-same-version


### PR DESCRIPTION
version bump to 0.3.22
changelog: https://github.com/harmonoid/harmonoid/releases/tag/v0.3.22

adds update script that fetches and updates hashes for all sources (x86_64-linux, aarch64-linux, x86_64-darwin) as previous automatic package update PRs only updated the x86_64-linux source (e.g. #486825)

tested update script with version update from 0.3.21 -> 0.3.22 using `nix-shell --extra-experimental-features 'flakes nix-command' maintainers/scripts/update.nix --argstr package harmonoid --argstr skip-prompt true`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
