### PR TITLE
mailutils: 3.19 -> 3.21

### DIFF
--- a/pkgs/by-name/ma/mailutils/package.nix
+++ b/pkgs/by-name/ma/mailutils/package.nix
@@ -25,6 +25,7 @@
   system-sendmail,
   libxcrypt,
   mkpasswd,
+  nss_wrapper,
 
   pythonSupport ? true,
   guileSupport ? true,
@@ -32,11 +33,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mailutils";
-  version = "3.19";
+  version = "3.21";
 
   src = fetchurl {
     url = "mirror://gnu/mailutils/mailutils-${finalAttrs.version}.tar.xz";
-    hash = "sha256-UCMNIANsW4rYyWsNmWF38fEz+6THx+O0YtOe6zCEn0U=";
+    hash = "sha256-5Hwe3GmbjWZ1/bx32zqEroN/GOHyCU/inUi7WKl+9ek=";
   };
 
   separateDebugInfo = true;
@@ -82,11 +83,6 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://lists.gnu.org/archive/html/bug-mailutils/2020-11/txtiNjqcNpqOk.txt";
       hash = "sha256-2rhuopBANngq/PRCboIr+ewdawr8472cYwiLjtHCHz4=";
     })
-    # Avoid hardeningDisable = [ "format" ]; - this patch is from the project's master branch and can be removed at the next version
-    (fetchpatch {
-      url = "https://cgit.git.savannah.gnu.org/cgit/mailutils.git/patch/?id=9379ec9e25ae6bdbd3d6f5ef9930ac2176d2efe7";
-      hash = "sha256-00R1DLMDPsvz3R6UgRO1ZvgMNCiHYS3lfjqAC9VD+Y4=";
-    })
     # https://github.com/NixOS/nixpkgs/issues/223967
     # https://lists.gnu.org/archive/html/bug-mailutils/2023-04/msg00000.html
     ./don-t-use-descrypt-password-in-the-test-suite.patch
@@ -117,7 +113,20 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [
     dejagnu
     mkpasswd
+    nss_wrapper
   ];
+
+  preCheck = ''
+    # The nix sandbox's /etc/passwd has literal quotes around the home directory
+    # (e.g. "/build" instead of /build). imap4d's mu_homedir_assert (new in
+    # 3.21) calls stat() on this path, which fails because no directory named
+    # '"/build"' exists. Use nss_wrapper to provide a fixed passwd to the tests.
+    sed 's/"//g' /etc/passwd > "$TMPDIR/passwd"
+    sed 's/"//g' /etc/group > "$TMPDIR/group" 2>/dev/null || echo "nixbld:x:100:" > "$TMPDIR/group"
+    export LD_PRELOAD="${nss_wrapper}/lib/libnss_wrapper.so"
+    export NSS_WRAPPER_PASSWD="$TMPDIR/passwd"
+    export NSS_WRAPPER_GROUP="$TMPDIR/group"
+  '';
 
   doCheck = !stdenv.hostPlatform.isDarwin; # ERROR: All 46 tests were run, 46 failed unexpectedly.
 


### PR DESCRIPTION
https://git.savannah.gnu.org/cgit/mailutils.git/tree/NEWS

- Remove format string patch (now upstream per commit 9379ec9e)
- Use `nss_wrapper` during tests to fix the nix sandbox's `/etc/passwd` which has literal quotes around the home directory field, causing imap4d's new `mu_homedir_assert` (3.21) to fail `stat()` on `"/build"`

I built the following:
* mailutils
* nixosTests.mailman
* nixosTests.public-inbox
* nixosTests.mailcatcher
* emacs
* smartmontools
* automysqlbackup

Everything came up roses.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test