### PR TITLE
libcupsfilters: patch to work on Darwin

### DIFF
--- a/pkgs/by-name/li/libcupsfilters/execve.patch
+++ b/pkgs/by-name/li/libcupsfilters/execve.patch
@@ -1,0 +1,11 @@
+--- a/cupsfilters/ghostscript.c
++++ b/cupsfilters/ghostscript.c
+@@ -629,7 +629,7 @@ gs_spawn (const char *filename,
+     }
+ 
+     // Execute Ghostscript command line ...
+-    execvpe(filename, gsargv, envp);
++    execve(filename, gsargv, envp);
+     if (log) log(ld, CF_LOGLEVEL_ERROR,
+ 		 "cfFilterGhostscript: Unable to launch Ghostscript: %s: %s",
+ 		 filename, strerror(errno));

--- a/pkgs/by-name/li/libcupsfilters/package.nix
+++ b/pkgs/by-name/li/libcupsfilters/package.nix
@@ -61,7 +61,9 @@ stdenv.mkDerivation {
       url = "https://github.com/OpenPrinting/libcupsfilters/commit/b69dfacec7f176281782e2f7ac44f04bf9633cfa.patch";
       hash = "sha256-rPUbgtTu7j3uUZrtUhUPO1vFbV6naxIWsHf6x3JhS74=";
     })
-  ];
+  ]
+  # build on platforms without execvpe
+  ++ lib.optional stdenv.hostPlatform.isDarwin ./execve.patch;
 
   nativeBuildInputs = [
     autoreconfHook
@@ -89,7 +91,9 @@ stdenv.mkDerivation {
     "--with-ippfind-path=${lib.getExe' cups "ippfind"}"
     "--enable-imagefilters"
     "--with-test-font-path=${dejavu_fonts}/share/fonts/truetype/DejaVuSans.ttf"
-  ];
+  ]
+  # build on platforms without execvpe (path to Ghostscript must be absolute)
+  ++ lib.optional stdenv.hostPlatform.isDarwin "--with-gs-path=${lib.getExe ghostscript}";
   makeFlags = [
     "CUPS_SERVERBIN=$(out)/lib/cups"
     "CUPS_DATADIR=$(out)/share/cups"

--- a/pkgs/by-name/li/libcupsfilters/package.nix
+++ b/pkgs/by-name/li/libcupsfilters/package.nix
@@ -32,6 +32,18 @@ stdenv.mkDerivation {
     hash = "sha256-WEcg+NSsny/N1VAR1ejytM+3nOF3JlNuIUPf4w6N2ew=";
   };
 
+  # Undefined symbols for architecture x86_64:
+  #   "_iconv", referenced from:
+  #       _cfFilterTextToText in libcupsfilters_la-texttotext.o
+  #   "_iconv_close", referenced from:
+  #       _cfFilterTextToText in libcupsfilters_la-texttotext.o
+  #   "_iconv_open", referenced from:
+  #       _cfFilterTextToText in libcupsfilters_la-texttotext.o
+  # ld: symbol(s) not found for architecture x86_64
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = "-liconv";
+  };
+
   patches = [
     (fetchpatch {
       # https://github.com/OpenPrinting/cups-filters/security/advisories/GHSA-893j-2wr2-wrh9

--- a/pkgs/by-name/li/libcupsfilters/package.nix
+++ b/pkgs/by-name/li/libcupsfilters/package.nix
@@ -104,6 +104,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/OpenPrinting/libcupsfilters";
     description = "Backends, filters, and other software that was once part of the core CUPS distribution but is no longer maintained by Apple Inc";
     license = lib.licenses.asl20;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
Simple patch to make libcupsfilters compile on Darwin:
- replace `execvpe` with `execve` in ghostscript.c (this *requires* that the full path to `gs` is known at compile time)
- link explicitly to iconv (I copied the solutions from #445598)

**I have not tested if it works.** I was only interested in making it compile, because I was not able to test auto-multiple-choice which depends on it.

## Things done
- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
