### PR TITLE
python3Packages.tuya-device-handlers: init at 0.0.10

### DIFF
--- a/pkgs/development/python-modules/tuya-device-handlers/default.nix
+++ b/pkgs/development/python-modules/tuya-device-handlers/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  tuya-device-sharing-sdk,
+  pytestCheckHook,
+  syrupy,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "tuya-device-handlers";
+  version = "0.0.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-libs";
+    repo = "tuya-device-handlers";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-W5aSEt8xXxQUcs6+AVVcgXxjm3WppzfCaww8YX+sej0=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ tuya-device-sharing-sdk ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    syrupy
+  ];
+
+  pythonImportsCheck = [ "tuya_device_handlers" ];
+
+  meta = {
+    description = "Tuya quirks library";
+    homepage = "https://github.com/home-assistant-libs/tuya-device-handlers";
+    changelog = "https://github.com/home-assistant-libs/tuya-device-handlers/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/development/python-modules/tuya-device-sharing-sdk/default.nix
+++ b/pkgs/development/python-modules/tuya-device-sharing-sdk/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "tuya-device-sharing-sdk";
-  version = "0.2.9";
+  version = "0.2.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tuya";
     repo = "tuya-device-sharing-sdk";
     tag = finalAttrs.version;
-    hash = "sha256-kNWg+AXISThwK14ByObUr+/4GMntrZgtEEMNpw/HjLw=";
+    hash = "sha256-uD2Lzs08i/01iEksXpYRGB2lU7I15sQrJLfJZ93+oeY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -6527,8 +6527,9 @@
     "tuya" =
       ps: with ps; [
         ha-ffmpeg
+        tuya-device-handlers
         tuya-device-sharing-sdk
-      ]; # missing inputs: tuya-device-handlers
+      ];
     "twentemilieu" =
       ps: with ps; [
         twentemilieu
@@ -8196,6 +8197,7 @@
     "trend"
     "triggercmd"
     "tts"
+    "tuya"
     "twentemilieu"
     "twilio"
     "twinkly"

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -204,6 +204,11 @@ let
       # TraneConfigFlow doesn't support step reauth
       "tests/components/trane/test_init.py::test_setup_auth_error"
     ];
+    tuya = [
+      # entity ordering in diagnostics is non-deterministic; fixed upstream in
+      # https://github.com/home-assistant/core/pull/164819 (landing in HA 2026.4)
+      "tests/components/tuya/test_diagnostics.py"
+    ];
     youtube = [
       # outdated snapshot
       "tests/components/youtube/test_sensor.py::test_sensor"
@@ -236,6 +241,12 @@ let
     shell_command = [
       # tries to retrieve file from github
       "test_non_text_stdout_capture"
+    ];
+    tuya = [
+      # snapshot mismatches: PyPI sdist translations differ from strings.json
+      # ("Power-on behavior" vs "Power on behavior"); expected to resolve in HA 2026.4
+      "test_device_diagnostics[tdq_9htyiowaf5rtdhrv]"
+      "test_platform_setup_and_discovery"
     ];
     zeroconf = [
       # multicast socket bind, not possible in the sandbox

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19758,6 +19758,8 @@ self: super: with self; {
 
   turrishw = callPackage ../development/python-modules/turrishw { };
 
+  tuya-device-handlers = callPackage ../development/python-modules/tuya-device-handlers { };
+
   tuya-device-sharing-sdk = callPackage ../development/python-modules/tuya-device-sharing-sdk { };
 
   tuya-iot-py-sdk = callPackage ../development/python-modules/tuya-iot-py-sdk { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://www.home-assistant.io/integrations/tuya/
- https://pypi.org/project/tuya-device-handlers/
- https://github.com/home-assistant-libs/tuya-device-handlers

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
