### PR TITLE
mythic: init at 0.6.0

### DIFF
--- a/pkgs/by-name/my/mythic/package.nix
+++ b/pkgs/by-name/my/mythic/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+  curl,
+  gnused,
+  xmlstarlet,
+  common-updater-scripts,
+  writeShellScript,
+}:
+
+let
+  # Mythic distributes via Sparkle; the UUID changes with each release.
+  # Appcast: https://dl.getmythic.app/updates/update.xml
+  uuid = "92033dfd-7a35-4629-9ca5-60d66576fb65";
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "mythic";
+  version = "0.6.0";
+
+  src = fetchurl {
+    url = "https://dl.getmythic.app/updates/${uuid}/Mythic.zip";
+    hash = "sha256-vNtUPVbnHmrj4QL/W+u73s2xBmVJIo1MXxo8XPqCyBY=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ unzip ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -R ./Mythic.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = writeShellScript "update-mythic" ''
+    set -euo pipefail
+    export PATH="${
+      lib.makeBinPath [
+        curl
+        gnused
+        xmlstarlet
+        common-updater-scripts
+      ]
+    }"
+
+    xml=$(curl -s "https://dl.getmythic.app/updates/update.xml")
+    version=$(echo "$xml" | xmlstarlet sel -t -v '(//item)[1]/enclosure/@sparkle:shortVersionString')
+    url=$(echo "$xml" | xmlstarlet sel -t -v '(//item)[1]/enclosure/@url')
+    uuid=$(echo "$url" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
+
+    sed -i "s/uuid = \"[^\"]*\"/uuid = \"$uuid\"/" pkgs/by-name/my/mythic/package.nix
+    update-source-version mythic "$version"
+  '';
+
+  meta = {
+    description = "Open-source macOS game launcher";
+    homepage = "https://getmythic.app/";
+    changelog = "https://github.com/MythicApp/Mythic/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ delafthi ];
+    platforms = [ "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
https://getmythic.app/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
