### PR TITLE
maintainers: remove farcaller

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8516,12 +8516,6 @@
     name = "Fang-Pen Lin";
     keys = [ { fingerprint = "7130 3454 A7CD 0F0A 941A  F9A3 2A26 9964 AD29 2131"; } ];
   };
-  farcaller = {
-    name = "Vladimir Pouzanov";
-    email = "farcaller@gmail.com";
-    github = "farcaller";
-    githubId = 693;
-  };
   fare = {
     email = "fahree@gmail.com";
     github = "fare";

--- a/pkgs/by-name/al/ali/package.nix
+++ b/pkgs/by-name/al/ali/package.nix
@@ -24,7 +24,7 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/nakabonne/ali/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    maintainers = with lib.maintainers; [ farcaller ];
+    maintainers = [ ];
     mainProgram = "ali";
     # Broken on darwin for Go toolchain > 1.22, with error:
     # 'link: golang.org/x/net/internal/socket: invalid reference to syscall.recvmsg'

--- a/pkgs/by-name/ba/badger/package.nix
+++ b/pkgs/by-name/ba/badger/package.nix
@@ -26,6 +26,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/dgraph-io/badger";
     license = lib.licenses.asl20;
     mainProgram = "badger";
-    maintainers = with lib.maintainers; [ farcaller ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/cq/cq/package.nix
+++ b/pkgs/by-name/cq/cq/package.nix
@@ -37,7 +37,7 @@ buildGraalvmNativeImage (finalAttrs: {
     homepage = "https://github.com/markus-wa/cq";
     changelog = "https://github.com/markus-wa/cq/releases/releases/tag/${finalAttrs.version}";
     license = lib.licenses.epl20;
-    maintainers = with lib.maintainers; [ farcaller ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "cq";
   };

--- a/pkgs/by-name/ov/ov/package.nix
+++ b/pkgs/by-name/ov/ov/package.nix
@@ -73,9 +73,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://noborus.github.io/ov";
     changelog = "https://github.com/noborus/ov/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      farcaller
-    ];
+    maintainers = [ ];
     mainProgram = "ov";
   };
 })

--- a/pkgs/by-name/pr/prometheus-libvirt-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-libvirt-exporter/package.nix
@@ -29,6 +29,6 @@ buildGoModule (finalAttrs: {
     description = "Prometheus metrics exporter for libvirt";
     homepage = "https://github.com/Tinkoff/libvirt-exporter";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ farcaller ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/re/resgate/package.nix
+++ b/pkgs/by-name/re/resgate/package.nix
@@ -21,7 +21,7 @@ buildGoModule (finalAttrs: {
     description = "Realtime API Gateway used with NATS to build REST, real time, and RPC APIs";
     homepage = "https://resgate.io";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ farcaller ];
+    maintainers = [ ];
     mainProgram = "resgate";
   };
 })

--- a/pkgs/by-name/tu/tubekit-unwrapped/package.nix
+++ b/pkgs/by-name/tu/tubekit-unwrapped/package.nix
@@ -23,6 +23,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/reconquest/tubekit";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    maintainers = with lib.maintainers; [ farcaller ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [May 2025](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Afarcaller)
- Hasn't created any PRs / Issues since [July 2024](https://github.com/NixOS/nixpkgs/issues?q=author%3Afarcaller)
- About 31 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Afarcaller%20-commenter%3Afarcaller%20-author%3Afarcaller%20-reviewed-by%3Afarcaller) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages 

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] ali
- [ ] badger
- [ ] cq
- [ ] ov
- [ ] prometheus-libvirt-exporter
- [ ] resgate
- [ ] tubekit-unwrapped
