### PR TITLE
inshellisense: 0.0.1-rc.21 -> 0.0.1

### DIFF
--- a/pkgs/by-name/in/inshellisense/package.nix
+++ b/pkgs/by-name/in/inshellisense/package.nix
@@ -1,38 +1,26 @@
 {
   lib,
-  stdenv,
   buildNpmPackage,
   fetchFromGitHub,
   nodejs_22,
-  cacert,
 }:
 
 buildNpmPackage rec {
   pname = "inshellisense";
-  version = "0.0.1-rc.21";
+  version = "0.0.1";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "inshellisense";
     tag = version;
-    hash = "sha256-zERwrvioPwGm/351kYuK9S3uOrrzs/6OFPRdNSSr7Tc=";
+    hash = "sha256-X+M4uqWdk5gQvjhqc3tVDOgeI12FpBvsfx8+pO7CHcA=";
   };
 
   # Building against nodejs-24 is not yet supported by upstream.
   # https://github.com/microsoft/inshellisense/issues/369
   nodejs = nodejs_22;
 
-  npmDepsHash = "sha256-iD5SvkVbrHh0Hx44y6VtNerwBA8K7vSe/yfvhgndMEw=";
-
-  # Needed for dependency `@homebridge/node-pty-prebuilt-multiarch`
-  # On Darwin systems the build fails with,
-  #
-  # npm ERR! ../src/unix/pty.cc:413:13: error: use of undeclared identifier 'openpty'
-  # npm ERR!   int ret = openpty(&master, &slave, nullptr, NULL, static_cast<winsi ze*>(&winp));
-  #
-  # when `node-gyp` tries to build the dep. The below allows `npm` to download the prebuilt binary.
-  makeCacheWritable = stdenv.hostPlatform.isDarwin;
-  nativeBuildInputs = lib.optional stdenv.hostPlatform.isDarwin cacert;
+  npmDepsHash = "sha256-670oGCuZhDLKe48hFL+gLMjmHM5YLGEawonG8PZTXpU=";
 
   meta = {
     description = "IDE style command line auto complete";


### PR DESCRIPTION
Update to first stable release. Removed Darwin workaround for `@homebridge/node-pty-prebuilt-multiarch` as that dependency was replaced with `node-pty` upstream, which builds natively on Darwin.

[Diff](https://github.com/microsoft/inshellisense/compare/0.0.1-rc.21...0.0.1)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test