### PR TITLE
build-support/rust/build-rust-crate/configure-crate: fix using features that aren't valid Bash variable names

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -49,7 +49,7 @@ let
   completeDepsDir = lib.concatStringsSep " " completeDeps;
   completeBuildDepsDir = lib.concatStringsSep " " completeBuildDeps;
   envFeatures = lib.concatStringsSep " " (
-    map (f: lib.replaceStrings [ "-" ] [ "_" ] (lib.toUpper f)) crateFeatures
+    map (f: "CARGO_FEATURE_${lib.replaceStrings [ "-" ] [ "_" ] (lib.toUpper f)}=1") crateFeatures
   );
 in
 ''
@@ -206,11 +206,10 @@ in
      (
        # Features should be set as environment variable for build scripts:
        # https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
-       for feature in ${envFeatures}; do
-         export CARGO_FEATURE_$feature=1
-       done
-
-       target/build/${crateName}/build_script_build | tee target/build/${crateName}.opt
+       #
+       # We use `env` instead of `export` because it's possible for a Cargo feature name to contain a character that Bash does
+       # not support for variables.
+       env ${envFeatures} target/build/${crateName}/build_script_build | tee target/build/${crateName}.opt
      )
 
      set +e

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -488,6 +488,8 @@ rec {
                 fn feature_not_visible() {
                   assert!(std::env::var("CARGO_FEATURE_SOME_FEATURE").is_err());
                   assert!(option_env!("CARGO_FEATURE_SOME_FEATURE").is_none());
+                  assert!(std::env::var("CARGO_FEATURE_ANOTHER_FEATURE").is_err());
+                  assert!(option_env!("CARGO_FEATURE_ANOTHER_FEATURE").is_none());
                 }
                 fn main() {}
               '')
@@ -495,6 +497,8 @@ rec {
                 fn main() {
                   assert!(std::env::var("CARGO_FEATURE_SOME_FEATURE").is_ok());
                   assert!(option_env!("CARGO_FEATURE_SOME_FEATURE").is_none());
+                  assert!(std::env::var("CARGO_FEATURE_ANOTHER_FEATURE").is_err());
+                  assert!(option_env!("CARGO_FEATURE_ANOTHER_FEATURE").is_none());
                 }
               '')
             ];

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -477,6 +477,7 @@ rec {
           crateName = "build-script-feature-env";
           features = [
             "some-feature"
+            "some-c++17-thing"
             "crate/another_feature"
           ];
           src = symlinkJoin {
@@ -488,6 +489,8 @@ rec {
                 fn feature_not_visible() {
                   assert!(std::env::var("CARGO_FEATURE_SOME_FEATURE").is_err());
                   assert!(option_env!("CARGO_FEATURE_SOME_FEATURE").is_none());
+                  assert!(std::env::var("CARGO_FEATURE_SOME_C++17_THING").is_err());
+                  assert!(option_env!("CARGO_FEATURE_SOME_C++17_THING").is_none());
                   assert!(std::env::var("CARGO_FEATURE_ANOTHER_FEATURE").is_err());
                   assert!(option_env!("CARGO_FEATURE_ANOTHER_FEATURE").is_none());
                 }
@@ -497,6 +500,8 @@ rec {
                 fn main() {
                   assert!(std::env::var("CARGO_FEATURE_SOME_FEATURE").is_ok());
                   assert!(option_env!("CARGO_FEATURE_SOME_FEATURE").is_none());
+                  assert!(std::env::var("CARGO_FEATURE_SOME_C++17_THING").is_ok());
+                  assert!(option_env!("CARGO_FEATURE_SOME_C++17_THING").is_none());
                   assert!(std::env::var("CARGO_FEATURE_ANOTHER_FEATURE").is_err());
                   assert!(option_env!("CARGO_FEATURE_ANOTHER_FEATURE").is_none());
                 }


### PR DESCRIPTION
`cxx` has feature names like `c++20` [0], which are valid Cargo feature names, but not valid Bash variable names.

[0]: https://docs.rs/crate/cxx/latest/features

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
