### PR TITLE
python3Packages.looptime: disable failing time-based tests on darwin

### DIFF
--- a/pkgs/development/python-modules/looptime/default.nix
+++ b/pkgs/development/python-modules/looptime/default.nix
@@ -7,6 +7,7 @@
   pytestCheckHook,
   setuptools,
   setuptools-scm,
+  stdenv,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -32,6 +33,20 @@ buildPythonPackage (finalAttrs: {
     async-timeout
     pytest-asyncio
     pytestCheckHook
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Time-based tests that fail pretty predictably on darwin but pass on linux
+    "tests/test_chronometers.py::test_duration_resets_on_reuse"
+    "tests/test_chronometers.py::test_conversion_to_float"
+    "tests/test_chronometers.py::test_sync_context_manager"
+    "tests/test_chronometers.py::test_async_context_manager"
+    "tests/test_plugin.py::test_fixture_chronometer"
+    "tests/test_time_moves.py::test_real_time_is_ignored"
+    "tests/test_time_on_executors.py::test_with_sleep"
+    "tests/test_time_on_io_idle.py::test_end_of_time"
+    "tests/test_time_on_io_idle.py::test_no_idle_configured"
+    "tests/test_time_on_io_idle.py::test_stepping_with_no_limit"
   ];
 
   meta = {


### PR DESCRIPTION
These fail pretty predictably on darwin but pass on linux.

Some data points:

- https://hydra.nixos.org/build/321428246/nixlog/4
- https://hydra.nixos.org/build/321428217/nixlog/4
- https://hydra.nixos.org/build/321466734/nixlog/4
- https://hydra.nixos.org/build/321466717/nixlog/4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
