### PR TITLE
onefetch: 2.26.1 -> 2.27.1

### DIFF
--- a/pkgs/by-name/on/onefetch/package.nix
+++ b/pkgs/by-name/on/onefetch/package.nix
@@ -16,16 +16,16 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "onefetch";
-  version = "2.26.1";
+  version = "2.27.1";
 
   src = fetchFromGitHub {
     owner = "o2sh";
     repo = "onefetch";
-    rev = finalAttrs.version;
-    hash = "sha256-JT7iQRKOK/2Zh/IDMv1FM1szITeBaaMy+WuXHjpPkfY=";
+    tag = finalAttrs.version;
+    hash = "sha256-aeVLlYDrX7FfZmx30k6hCcihdMUyZm7j72l540+PZJo=";
   };
 
-  cargoHash = "sha256-VBbiOA/+SPcIvmhNQ71gUBOIWEWV1A86rljBfdAfhZM=";
+  cargoHash = "sha256-WR8T/spHZqvwzQxwkQI81yMLBA6s6ral97rTmIW+vpg=";
 
   cargoPatches = [
     # enable pkg-config feature of zstd

--- a/pkgs/by-name/on/onefetch/zstd-pkg-config.patch
+++ b/pkgs/by-name/on/onefetch/zstd-pkg-config.patch
@@ -1,8 +1,8 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index 839cdbc..9622d04 100644
+index 7f0f5c9..4eb062f 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -2819,6 +2819,7 @@ dependencies = [
+@@ -2595,6 +2595,7 @@ dependencies = [
   "tokei",
   "typetag",
   "winres",
@@ -11,14 +11,14 @@ index 839cdbc..9622d04 100644
  
  [[package]]
 diff --git a/Cargo.toml b/Cargo.toml
-index 79cbb8c..410a969 100644
+index 99340b3..75957a3 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -68,6 +68,7 @@ time = { version = "0.3.37", features = ["formatting"] }
+@@ -58,6 +58,7 @@ time = { version = "0.3.47", features = ["formatting"] }
  time-humanize = { version = "0.1.3", features = ["time"] }
- tokei = "13.0.0-alpha.7"
- typetag = "0.2"
+ tokei = "14.0.0"
+ typetag = "0.2.21"
 +zstd = { version = "*", features = ["pkg-config"] }
  
  [dev-dependencies]
- criterion = "0.5.1"
+ criterion = "0.8.2"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>onefetch</li>
  </ul>
</details>

---

cc @kloenk as package maintainer


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
