### PR TITLE
nerdlog: init at 1.10.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27931,6 +27931,12 @@
     githubId = 1486805;
     name = "Toon Nolten";
   };
+  tophcodes = {
+    email = "toki@toph.so";
+    github = "tophcodes";
+    githubId = 3678770;
+    name = "Christopher Mühl";
+  };
   tornax = {
     email = "tornax@pm.me";
     github = "TornaxO7";

--- a/pkgs/by-name/ne/nerdlog/package.nix
+++ b/pkgs/by-name/ne/nerdlog/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  libx11,
+  nix-update-script,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "nerdlog";
+  version = "1.10.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "dimonomid";
+    repo = "nerdlog";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XlzWNeyd+Ar4ArFcN1wkQ0aod6ckAiIb12odK7cf4+s=";
+  };
+
+  vendorHash = "sha256-hvv0dsE1yz85VLaBOE7RWbux8L8kVTihcA1HyyHRYAM=";
+
+  buildInputs = [ libx11 ];
+
+  subPackages = [ "cmd/nerdlog" ];
+
+  ldflags = [
+    "-X github.com/dimonomid/nerdlog/version.version=${finalAttrs.version}"
+    "-X github.com/dimonomid/nerdlog/version.builtBy=nix"
+  ];
+
+  # e2e tests require SSH connections to test hosts
+  checkFlags = [
+    "-skip"
+    "^TestE2E"
+  ];
+
+  doInstallCheck = true;
+  nativeBuildInputs = [ versionCheckHook ];
+
+  # `nerdlog --version` will fail if $HOME is not defined
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/dimonomid/nerdlog/releases/tag/${finalAttrs.src.tag}";
+    description = "Fast, remote-first, multi-host TUI log viewer with timeline histogram";
+    longDescription = ''
+      Nerdlog is a fast, remote-first, multi-host TUI log viewer with timeline histogram
+      and no central server. Loosely inspired by Graylog/Kibana, but without the bloat.
+      Pretty much no setup needed, either.
+    '';
+    homepage = "https://github.com/dimonomid/nerdlog";
+    license = lib.licenses.bsd2;
+    mainProgram = "nerdlog";
+    maintainers = with lib.maintainers; [ tophcodes ];
+  };
+})


### PR DESCRIPTION
Initializes nerdlog at 1.10.0. Nerdlog is a "fast, remote-first, multi-host TUI log viewer with timeline histogram and no central server". Source at https://github.com/dimonomid/nerdlog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
