### PR TITLE
gradia: fix patch for blueprint-compiler 0.20.4

### DIFF
--- a/pkgs/by-name/gr/gradia/0001-fix-image_stack-action-target-type.patch
+++ b/pkgs/by-name/gr/gradia/0001-fix-image_stack-action-target-type.patch
@@ -1,0 +1,13 @@
+diff --git a/data/ui/image_stack.blp b/data/ui/image_stack.blp
+index 478bc8c..021388b 100644
+--- a/data/ui/image_stack.blp
++++ b/data/ui/image_stack.blp
+@@ -94,7 +94,7 @@ template $GradiaImageStack: Adw.Bin {
+                       icon-name: "sidebar-show-symbolic";
+                       tooltip-text: _("Open Sidebar");
+                       action-name: "win.sidebar-shown";
+-                      action-target: true;
++                      action-target: "true";
+                       visible: false;
+ 
+                       styles [

--- a/pkgs/by-name/gr/gradia/package.nix
+++ b/pkgs/by-name/gr/gradia/package.nix
@@ -55,6 +55,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
     tesseract
   ];
 
+  patches = [
+    ./0001-fix-image_stack-action-target-type.patch
+  ];
+
   postPatch = ''
     substituteInPlace meson.build \
       --replace "/app/bin/tesseract" "${lib.getExe tesseract}"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add patch from this [PR](https://github.com/AlexanderVanhee/Gradia/pull/334) to fix gradia not building with [blueprint-compiler 0.20.4](https://github.com/NixOS/nixpkgs/pull/496793)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
