### PR TITLE
wprs: 0-unstable-2025-09-05 -> 0-unstable-2026-03-23, add NixOS module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18707,7 +18707,7 @@
     name = "nadir-ishiguro";
   };
   nadja-y = {
-    email = "git@njy.dev";
+    email = "nadja@njy.dev";
     github = "nadja-y";
     githubId = 255079535;
     name = "Nadja Yang";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1447,6 +1447,7 @@
   ./services/networking/wireguard-networkd.nix
   ./services/networking/wireguard.nix
   ./services/networking/wpa_supplicant.nix
+  ./services/networking/wprs.nix
   ./services/networking/wstunnel.nix
   ./services/networking/wvdial.nix
   ./services/networking/x2goserver.nix

--- a/nixos/modules/services/networking/wprs.nix
+++ b/nixos/modules/services/networking/wprs.nix
@@ -1,0 +1,105 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    getExe'
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+  cfg = config.services.wprs;
+
+  # Build CLI args from the settings attrset.
+  mkArgs =
+    settings:
+    lib.concatLists (
+      lib.mapAttrsToList (
+        name: value:
+        let
+          v = if lib.isBool value then lib.boolToString value else toString value;
+        in
+        [
+          "--${name}=${v}"
+        ]
+      ) settings
+    );
+in
+{
+  options.services.wprs = {
+    enable = mkEnableOption "wprs, rootless remote desktop for Wayland";
+
+    package = mkPackageOption pkgs "wprs" { };
+
+    autoStart = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether wprsd should start automatically for logged-in users.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.attrsOf (
+        types.oneOf [
+          types.str
+          types.int
+          types.bool
+        ]
+      );
+      default = { };
+      example = {
+        framerate = 30;
+        enable-xwayland = false;
+      };
+      description = ''
+        Settings passed as CLI flags to wprsd.
+        See `wprsd --help` for available options.
+      '';
+    };
+
+    tuneNetworkBuffers = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to increase socket buffer limits for improved throughput.
+        See <https://wiki.archlinux.org/title/sysctl#Increase_the_memory_dedicated_to_the_network_interfaces>.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    # https://wiki.archlinux.org/title/sysctl#Increase_the_memory_dedicated_to_the_network_interfaces
+    boot.kernel.sysctl = mkIf cfg.tuneNetworkBuffers {
+      "net.core.rmem_default" = mkDefault 1048576;
+      "net.core.rmem_max" = mkDefault 16777216;
+      "net.core.wmem_default" = mkDefault 1048576;
+      "net.core.wmem_max" = mkDefault 16777216;
+    };
+
+    systemd.user.services.wprsd = {
+      description = "wprs rootless remote desktop daemon";
+      wantedBy = mkIf cfg.autoStart [ "default.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = lib.concatStringsSep " " ([ (getExe' cfg.package "wprsd") ] ++ mkArgs cfg.settings);
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+
+      environment = {
+        RUST_BACKTRACE = "1";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/wp/wprs/package.nix
+++ b/pkgs/by-name/wp/wprs/package.nix
@@ -7,16 +7,17 @@
   python3,
   runCommand,
   wprs,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage {
   pname = "wprs";
-  version = "0-unstable-2025-09-05";
+  version = "0-unstable-2026-03-23";
 
   src = fetchFromGitHub {
     owner = "wayland-transpositor";
     repo = "wprs";
-    rev = "1eb482e0f80cc84a3ee55f7cda99df9bea6573af";
-    hash = "sha256-+m0gXQQa2NkUFNXfGPCwHTlyTFOw1nfjrUBgSD5iGMo=";
+    rev = "309ab853cc09cf7fef0370e245367726ea51121f";
+    hash = "sha256-2hgIsGt0z+p8dwb7bCJQvxMISr6vQ5cnU0d4jqkif5Y=";
   };
 
   nativeBuildInputs = [
@@ -28,23 +29,29 @@ rustPlatform.buildRustPackage {
     (python3.withPackages (pp: with pp; [ psutil ]))
   ];
 
-  cargoHash = "sha256-krrVgdoCcW3voSiQAoWsG+rPf1HYKbuGhplhn21as2c=";
+  cargoHash = "sha256-KiZzAhcuqG/+aFzr1u6Rw7LOr1q2PWDe559gQ5g5YqA=";
 
-  env.RUSTFLAGS = "-C target-feature=+avx2"; # only works on x86 systems supporting AVX2
-
-  preFixup = ''
-    cp  wprs "$out/bin/wprs"
+  postInstall = ''
+    install -Dm755 wprs "$out/bin/wprs"
   '';
 
-  passthru.tests.sanity = runCommand "wprs-sanity" { nativeBuildInputs = [ wprs ]; } ''
-    ${wprs}/bin/wprs -h > /dev/null && touch $out
-  '';
+  passthru = {
+    tests.sanity = runCommand "wprs-sanity" { nativeBuildInputs = [ wprs ]; } ''
+      ${wprs}/bin/wprs -h > /dev/null && touch $out
+    '';
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch=master" ];
+    };
+  };
 
   meta = {
     description = "Rootless remote desktop access for remote Wayland";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ mksafavi ];
-    platforms = [ "x86_64-linux" ]; # The aarch64-linux support is not implemented in upstream yet. Also, the darwin platform is not supported as it requires wayland.
+    maintainers = with lib.maintainers; [
+      mksafavi
+      nadja-y
+    ];
+    platforms = lib.platforms.linux;
     homepage = "https://github.com/wayland-transpositor/wprs";
     mainProgram = "wprs";
   };


### PR DESCRIPTION
aarch64 support landed upstream ([wayland-transpositor/wprs#146](https://github.com/wayland-transpositor/wprs/pull/146), closing [wayland-transpositor/wprs#31](https://github.com/wayland-transpositor/wprs/issues/31)). Remove hardcoded x86 `RUSTFLAGS` — upstream `.cargo/config.toml` handles architecture-specific target selection. Enable `aarch64-linux`.

Add `services.wprs` NixOS module: systemd user service for `wprsd`, freeform settings passed as CLI flags, optional socket buffer tuning per the [Arch Wiki recommendation](https://wiki.archlinux.org/title/sysctl#Increase_the_memory_dedicated_to_the_network_interfaces) cited in the upstream README.

Add `nix-update-script` (`branch=master`, no tagged releases). Add `nadja-y` as co-maintainer.

Supersedes draft [#474946](https://github.com/NixOS/nixpkgs/pull/474946).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
  - [x] Module addition: when adding a new NixOS module.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test