### PR TITLE
construo: fix darwin build

### DIFF
--- a/pkgs/by-name/co/construo/package.nix
+++ b/pkgs/by-name/co/construo/package.nix
@@ -11,6 +11,7 @@
   libGLU,
   withLibglut ? !stdenv.hostPlatform.isDarwin,
   libglut,
+  apple-sdk,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -29,12 +30,21 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional withLibGL libGL
   ++ lib.optional withLibGLU libGLU
-  ++ lib.optional withLibglut libglut;
+  ++ lib.optional withLibglut libglut
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk ];
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace configure --replace-fail \
+      '-I/System/Library/Frameworks/GLUT.framework/Headers/' \
+      '-I${apple-sdk}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GLUT.framework/Headers/'
+  '';
 
   preConfigure = ''
     substituteInPlace src/Makefile.in \
       --replace games bin
   '';
+
+  env.CXXFLAGS = "-std=c++98";
 
   meta = {
     description = "Masses and springs simulation game";


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
