### PR TITLE
proxyman: 3.9.0 -> 3.10.0

### DIFF
--- a/pkgs/by-name/pr/proxyman/package.nix
+++ b/pkgs/by-name/pr/proxyman/package.nix
@@ -3,14 +3,15 @@
   appimageTools,
   fetchurl,
   asar,
+  nix-update-script,
 }:
 let
   pname = "proxyman";
-  version = "3.9.0";
+  version = "3.10.0";
 
   src = fetchurl {
     url = "https://github.com/ProxymanApp/proxyman-windows-linux/releases/download/${version}/Proxyman-${version}.AppImage";
-    hash = "sha256-hv0TYlCHoiWrMRLcPrruI09SC24Pafo9B5kkUpFDyKI=";
+    hash = "sha256-kprkRi50/GASHZ/NiP6tuYiVp0019W4wIjUXL9H4aBg=";
   };
 
   appimageContents = appimageTools.extract {
@@ -41,6 +42,11 @@ appimageTools.wrapAppImage {
     substituteInPlace $out/share/applications/proxyman.desktop \
       --replace-fail "Exec=AppRun" "Exec=proxyman --"
   '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    inherit src; # needed for nix-update to find the GitHub URL
+  };
 
   meta = {
     description = "Capture, inspect, and manipulate HTTP(s) requests/responses with ease";


### PR DESCRIPTION
Changelog: https://github.com/ProxymanApp/proxyman-windows-linux/releases/tag/3.10.0

I also added the update script so the updates are automated in the future. Tested using `nix run nixpkgs#nix-update -- proxyman`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
