### PR TITLE
Fix guile hoot binary

### DIFF
--- a/pkgs/by-name/gu/guile-hoot/package.nix
+++ b/pkgs/by-name/gu/guile-hoot/package.nix
@@ -3,7 +3,12 @@
   stdenv,
   fetchFromCodeberg,
   autoreconfHook,
+  makeWrapper,
+  nodejs,
   guile,
+  guile-websocket,
+  guile-fibers,
+  guile-gnutls,
   pkg-config,
   texinfo,
   nix-update-script,
@@ -21,11 +26,30 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
+    makeWrapper
     autoreconfHook
     guile
     pkg-config
     texinfo
+    nodejs
   ];
+  propagatedBuildInputs = [
+    guile-fibers
+    guile-websocket
+    guile-gnutls
+  ];
+
+  postInstall =
+    let
+      libs = [ "$out" ] ++ finalAttrs.propagatedBuildInputs;
+    in
+    ''
+      cp ./repl/repl.js $out/share/guile-hoot/0.8.0/repl/repl.js
+      wrapProgram $out/bin/hoot \
+        --prefix GUILE_LOAD_PATH : ${lib.makeSearchPath guile.siteDir libs} \
+        --prefix GUILE_LOAD_COMPILED_PATH : ${lib.makeSearchPath guile.siteCcacheDir libs}
+    '';
+
   buildInputs = [
     guile
   ];
@@ -41,5 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ jinser ];
     platforms = lib.platforms.unix;
+    mainProgram = "hoot";
   };
 })

--- a/pkgs/by-name/gu/guile-websocket/package.nix
+++ b/pkgs/by-name/gu/guile-websocket/package.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "guile-websocket";
-  version = "0.2.1";
+  version = "0.3.0";
 
   src = fetchurl {
     url = "https://files.dthompson.us/releases/guile-websocket/guile-websocket-${finalAttrs.version}.tar.gz";
-    hash = "sha256-MurFAPXYjp1oq9gNCIH2e8xLmVsMUH0OdCpTVxhffVU=";
+    hash = "sha256-G6bA0dF19KaLWM4AMldHfjkx/qDXBZOIGqcXfLmUg/w=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Hoot 0.8.0 introduced a binary that needed wrapping and extra dependencies to be present at build time. I tried to reproduce the guix package from https://codeberg.org/guix/guix/src/branch/master/gnu/packages/guile-xyz.scm#L4659 and the source code at
https://codeberg.org/spritely/hoot/src/branch/main/guix.scm#L65 to fix the issues
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
