### PR TITLE
[Backport staging-25.11] Various (spyder): Move to Qt6 #500663

### DIFF
--- a/pkgs/development/python-modules/qtawesome/default.nix
+++ b/pkgs/development/python-modules/qtawesome/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pyqt5,
+  pyqt6,
   pytestCheckHook,
   pythonOlder,
   qtpy,
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    pyqt5
+    pyqt6
     qtpy
   ];
 

--- a/pkgs/development/python-modules/qtconsole/default.nix
+++ b/pkgs/development/python-modules/qtconsole/default.nix
@@ -11,7 +11,7 @@
   jupyter-core,
   jupyter-client,
   pygments,
-  pyqt5,
+  pyqt6,
   qtpy,
   traitlets,
 
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     jupyter-core
     jupyter-client
     pygments
-    pyqt5
+    pyqt6
     qtpy
     traitlets
   ];

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -4,7 +4,7 @@
   fetchPypi,
 
   # nativeBuildInputs
-  pyqtwebengine,
+  pyqt6-webengine,
 
   # build-system
   setuptools,
@@ -36,6 +36,7 @@
   pylint-venv,
   pyls-spyder,
   pyopengl,
+  pyqt6,
   python-lsp-black,
   python-lsp-ruff,
   python-lsp-server,
@@ -55,6 +56,7 @@
   three-merge,
   watchdog,
   yarl,
+  qt6,
 }:
 
 buildPythonPackage rec {
@@ -69,13 +71,18 @@ buildPythonPackage rec {
 
   patches = [ ./dont-clear-pythonpath.patch ];
 
-  nativeBuildInputs = [ pyqtwebengine.wrapQtAppsHook ];
+  nativeBuildInputs = [ qt6.wrapQtAppsHook ];
 
   build-system = [ setuptools ];
 
   pythonRelaxDeps = [
     "ipython"
     "python-lsp-server"
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtwayland
   ];
 
   dependencies = [
@@ -105,7 +112,7 @@ buildPythonPackage rec {
     pylint-venv
     pyls-spyder
     pyopengl
-    pyqtwebengine
+    pyqt6-webengine
     python-lsp-black
     python-lsp-ruff
     python-lsp-server
@@ -125,11 +132,14 @@ buildPythonPackage rec {
     three-merge
     watchdog
     yarl
+    pyqt6
   ]
   ++ python-lsp-server.optional-dependencies.all;
 
   # There is no test for spyder
   doCheck = false;
+
+  env.SPYDER_QT_BINDING = "pyqt6";
 
   postInstall = ''
     # Add Python libs to env so Spyder subprocesses

--- a/pkgs/development/python-modules/superqt/default.nix
+++ b/pkgs/development/python-modules/superqt/default.nix
@@ -37,7 +37,6 @@ buildPythonPackage rec {
 
   dependencies = [
     pygments
-    pyqt5
     qtpy
     typing-extensions
   ];
@@ -47,6 +46,7 @@ buildPythonPackage rec {
     pyside2 = [ pyside2 ];
     pyside6 = [ pyside6 ];
     pyqt6 = [ pyqt6 ];
+    pyqt5 = [ pyqt5 ];
   };
 
   nativeCheckInputs = [ pytestCheckHook ];


### PR DESCRIPTION
Update of https://github.com/NixOS/nixpkgs/pull/500663.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
