### PR TITLE
ferrumc: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27577,6 +27577,12 @@
     githubId = 6740669;
     name = "Tom Smeets";
   };
+  tomymartingrinberg-cpu = {
+    email = "tomy.martin.grinberg@gmail.com";
+    github = "tomymartingrinberg-cpu";
+    githubId = 234853832;
+    name = "Tomy Martin Grinberg";
+  };
   tonybanters = {
     email = "tony@tonybtw.com";
     github = "tonybanters";

--- a/pkgs/development/compilers/ferrumc/default.nix
+++ b/pkgs/development/compilers/ferrumc/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ferrumc";
+  version = "0.3.0";
+
+  src = fetchurl (if stdenv.hostPlatform.isLinux then
+    if stdenv.hostPlatform.isAarch64 then {
+      url = "https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-linux-aarch64.tar.gz";
+      hash = "sha256-QySBU3bBO4A4cFhkgFxNWw5EkQtmxSYxEesx+s6Uz5w=";
+    } else {
+      url = "https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-linux-x86_64.tar.gz";
+      hash = "sha256-JzXPcC/5w/O/mtlRQL3iEfPmQlkOkiKAD4GWlyf+YCk=";
+    }
+  else if stdenv.hostPlatform.isDarwin then
+    if stdenv.hostPlatform.isAarch64 then {
+      url = "https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-macos-arm64.tar.gz";
+      hash = "sha256-3Smma7L4Wf8fB/x3SU2N/k6fVo4TIWJTAW2PrShE1g=";
+    } else {
+      url = "https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-macos-x86_64.tar.gz";
+      hash = "sha256-vCL+r5I4KdTI8Y/ytpq07TNptSuC2kJDARZ75IAcUC8=";
+    }
+  else throw "Unsupported platform");
+
+  dontUnpack = false;
+  dontBuild = true;
+
+  installPhase = '
+    install -Dm755 ferrumc $out/bin/ferrumc
+  ';
+
+  meta = {
+    description = "Ferrum-language compiler with compile-time memory safety";
+    longDescription = '
+      Ferrum-language is a systems programming language with C syntax and
+      compile-time memory safety via a borrow checker and ownership model,
+      compiled to native code through LLVM 18.
+    ';
+    homepage = "https://ferrum-language.github.io/Ferrum/";
+    license = lib.licenses.mit;
+    maintainers = [];
+    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "ferrumc";
+  };
+}

--- a/pkgs/development/compilers/ferrumc/default.nix
+++ b/pkgs/development/compilers/ferrumc/default.nix
@@ -1,48 +1,64 @@
-{ lib
-, stdenv
-, fetchurl
+{
+  lib,
+  stdenv,
+  fetchurl,
 }:
 
 stdenv.mkDerivation rec {
   pname = "ferrumc";
   version = "0.3.0";
 
-  src = fetchurl (if stdenv.hostPlatform.isLinux then
-    if stdenv.hostPlatform.isAarch64 then {
-      url = "https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-linux-aarch64.tar.gz";
-      hash = "sha256-QySBU3bBO4A4cFhkgFxNWw5EkQtmxSYxEesx+s6Uz5w=";
-    } else {
-      url = "https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-linux-x86_64.tar.gz";
-      hash = "sha256-JzXPcC/5w/O/mtlRQL3iEfPmQlkOkiKAD4GWlyf+YCk=";
-    }
-  else if stdenv.hostPlatform.isDarwin then
-    if stdenv.hostPlatform.isAarch64 then {
-      url = "https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-macos-arm64.tar.gz";
-      hash = "sha256-3Smma7L4Wf8fB/x3SU2N/k6fVo4TIWJTAW2PrShE1g=";
-    } else {
-      url = "https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-macos-x86_64.tar.gz";
-      hash = "sha256-vCL+r5I4KdTI8Y/ytpq07TNptSuC2kJDARZ75IAcUC8=";
-    }
-  else throw "Unsupported platform");
+  src = fetchurl (
+    if stdenv.hostPlatform.isLinux then
+      if stdenv.hostPlatform.isAarch64 then
+        {
+          url = "https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-linux-aarch64.tar.gz";
+          hash = "sha256-QySBU3bBO4A4cFhkgFxNWw5EkQtmxSYxEesx+s6Uz5w=";
+        }
+      else
+        {
+          url = "https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-linux-x86_64.tar.gz";
+          hash = "sha256-JzXPcC/5w/O/mtlRQL3iEfPmQlkOkiKAD4GWlyf+YCk=";
+        }
+    else if stdenv.hostPlatform.isDarwin then
+      if stdenv.hostPlatform.isAarch64 then
+        {
+          url = "https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-macos-arm64.tar.gz";
+          hash = "sha256-3Smma7L4Wf8fB/x3SU2N/k6fVo4TIWJTAW2PrShE1g=";
+        }
+      else
+        {
+          url = "https://github.com/Ferrum-Language/Ferrum/releases/download/v${version}/ferrumc-v${version}-macos-x86_64.tar.gz";
+          hash = "sha256-vCL+r5I4KdTI8Y/ytpq07TNptSuC2kJDARZ75IAcUC8=";
+        }
+    else
+      throw "Unsupported platform"
+  );
 
-  dontUnpack = false;
   dontBuild = true;
 
-  installPhase = '
+  installPhase = ''
+    runHook preInstall
     install -Dm755 ferrumc $out/bin/ferrumc
-  ';
+    runHook postInstall
+  '';
 
   meta = {
     description = "Ferrum-language compiler with compile-time memory safety";
-    longDescription = '
+    longDescription = ''
       Ferrum-language is a systems programming language with C syntax and
       compile-time memory safety via a borrow checker and ownership model,
       compiled to native code through LLVM 18.
-    ';
+    '';
     homepage = "https://ferrum-language.github.io/Ferrum/";
     license = lib.licenses.gpl3Only;
-    maintainers = [];
-    platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+    maintainers = [ ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     mainProgram = "ferrumc";
   };

--- a/pkgs/development/compilers/ferrumc/default.nix
+++ b/pkgs/development/compilers/ferrumc/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       compiled to native code through LLVM 18.
     ';
     homepage = "https://ferrum-language.github.io/Ferrum/";
-    license = lib.licenses.mit;
+    license = lib.licenses.gpl3Only;
     maintainers = [];
     platforms = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];

--- a/pkgs/development/compilers/ferrumc/default.nix
+++ b/pkgs/development/compilers/ferrumc/default.nix
@@ -52,13 +52,8 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://ferrum-language.github.io/Ferrum/";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "aarch64-darwin"
-      "x86_64-darwin"
-    ];
+    maintainers = with lib.maintainers; [ tomymartingrinberg-cpu ];
+    platforms = lib.platforms.unix;
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     mainProgram = "ferrumc";
   };


### PR DESCRIPTION
## Description
Add `ferrumc` (Ferrum-language compiler) at version 0.3.0.

Ferrum-language is a systems programming language with C syntax and compile-time memory safety via a borrow checker and ownership model, compiled to native code through LLVM 18.

- **License:** MIT
- **Homepage:** https://ferrum-language.github.io/Ferrum/
- **Source:** https://github.com/Ferrum-Language/Ferrum/releases/tag/v0.3.0
- **Platforms:** `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`, `x86_64-darwin`

## Checklist
- [x] Added to `pkgs/development/compilers/ferrumc/default.nix`
- [x] SHA256 hashes verified against GitHub release
- [x] `meta.mainProgram` set
- [x] `meta.sourceProvenance` set to `binaryNativeCode` (prebuilt binary package)