### PR TITLE
sonarlint-ls: 4.8.0.77946 -> 4.15.0.78211

### DIFF
--- a/pkgs/by-name/so/sonarlint-ls/package.nix
+++ b/pkgs/by-name/so/sonarlint-ls/package.nix
@@ -16,17 +16,17 @@
 
 maven.buildMavenPackage rec {
   pname = "sonarlint-ls";
-  version = "4.8.0.77946";
+  version = "4.15.0.78211";
 
   src = fetchFromGitHub {
     owner = "SonarSource";
     repo = "sonarlint-language-server";
     rev = version;
-    hash = "sha256-kwgkRCVcEFGv18zVK9y0JhIx6Cb6XBrnwGbzf2uDdZE=";
+    hash = "sha256-0EFztL1hF1JaYc+6OUvmcPF9x5yA10Sy62f/Drmj4MU=";
   };
 
   mvnJdk = jdk17;
-  mvnHash = "sha256-KyA2/ABdT35DqzEhE5P+aSGJfu60o6T4+ofQNiQTPFg=";
+  mvnHash = "sha256-YG2eQnSCwg24DEp2CJ6awozTVcz8XBUmSSEb65UD7Rw=";
 
   # Disables failing tests which either need network access or are flaky.
   mvnParameters = lib.escapeShellArgs [
@@ -39,6 +39,10 @@ maven.buildMavenPackage rec {
     !JavaMediumTests,
     !OpenNotebooksCacheTests"
   ];
+
+  preBuild = ''
+    echo -n "${version}" > src/main/resources/slls-version.txt
+  '';
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
The version reported by `sonarlint-ls -V` was always `4.15-SNAPSHOT` instead of the actual release version. SonarSource injects the real version through a private CI action that is not reproducible from source, so the fix is to overwrite `slls-version.txt` directly before Maven packages it into the JAR.

[Changelogs](https://github.com/SonarSource/sonarlint-language-server/releases/tag/4.15.0.78211)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
