### PR TITLE
oculante: Generated Nix Path Changed

### DIFF
--- a/pkgs/by-name/oc/oculante/package.nix
+++ b/pkgs/by-name/oc/oculante/package.nix
@@ -76,7 +76,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   patchFlags = [
     "-p1"
-    "--directory=../${finalAttrs.pname}-${finalAttrs.version}-vendor"
+    "--directory=../${finalAttrs.pname}-${finalAttrs.version}-vendor/source-registry-0"
   ];
 
   postInstall = ''


### PR DESCRIPTION
Closes #504269

Oculate fails to build with wrong vendor path. 

```
building the system configuration...
warning: Git tree '/home/adriel/.nixos' is dirty
error: Cannot build '/nix/store/7vvyfvjw3bf3dd7hvcq66nb3af908s99-oculante-0.9.2.1-unstable-2025-10-08.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/6vzskhwsvmmwl82pf4wqjhvmmyk3k1fc-oculante-0.9.2.1-unstable-2025-10-08
       Last 18 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/i1m5k0lalyg0306m5w62y28654ydz9x2-source
       > source root is source
       > Executing cargoSetupPostUnpackHook
       > Finished cargoSetupPostUnpackHook
       > Running phase: patchPhase
       > applying patch /nix/store/ls4953cqhgp9jhh07bg6ifg2sixsfj5v-libaom-sys-0.17.2+libaom.3.11.0-cmake-nasm-fix.patch
       > can't find file to patch at input line 3
       > Perhaps you used the wrong -p or --strip option?
       > The text leading up to this was:
       > --------------------------
       > |--- a/libaom-sys-0.17.2+libaom.3.11.0/vendor/build/cmake/aom_optimization.cmake
       > |+++ b/libaom-sys-0.17.2+libaom.3.11.0/vendor/build/cmake/aom_optimization.cmake
       > --------------------------
       > File to patch:
       > Skip this patch? [y]
       > Skipping patch.
       > 2 out of 2 hunks ignored
       For full logs, run:
         nix log /nix/store/7vvyfvjw3bf3dd7hvcq66nb3af908s99-oculante-0.9.2.1-unstable-2025-10-08.drv
error: Cannot build '/nix/store/4p553glnbn36cyb37r21d2fjhkhvqsl5-home-manager-path.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/1ilhcxlprsswrhgk8jiv3sd36dr2wmcz-home-manager-path
error: Cannot build '/nix/store/xr2n32w6vnfxzmiz0rpbqjadhk6fh9sp-home-manager-generation.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/4nk5argcq4922x9n2p749f24q6ha8637-home-manager-generation
error: Cannot build '/nix/store/mjck8hl8v9jc35r1xxn6bhh87kq3z0mn-user-environment.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/0rkc2c5dhnvz1fqa07x37qa8kg8bpxxm-user-environment
error: Cannot build '/nix/store/m24pqjlkr0b8c3xvnxxw4j9ig358lhh3-etc.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/03ml43acb9mzx83vw2f74qzw0nmcz0bn-etc
error: Cannot build '/nix/store/cnbmbklkmi4b6rm0443zc6as1bg001i0-nixos-system-razer14-26.05.20260321.6c9a78c.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/p3jpwfx19apgl1pqyq69d78f00g1yfxc-nixos-system-razer14-26.05.20260321.6c9a78c
Command 'nix --extra-experimental-features 'nix-command flakes' build --print-out-paths '.#nixosConfigurations."razer14".config.system.build.toplevel' --no-link' returned non-zero exit status 1.
error: Recipe `switch` failed with exit code 1
```



```
nixpkgs master*​ 
❯ drv=$(nix eval /home/adriel/.nixos#nixosConfigurations.razer14.pkgs.oculante.cargoDeps.drvPath --raw)
warning: Git tree '/home/adriel/.nixos' is dirty

nixpkgs master*​ 2s 
❯ vendor=$(nix build "${drv}^out" --no-link --print-out-paths)

nixpkgs master*​ 
❯ echo $vendor                                                   
/nix/store/d9is8mlwxizilvpg0i9j8jkyxyjps7s7-oculante-0.9.2.1-unstable-2025-10-08-vendor

nixpkgs master*​ 
❯ rg 'aom_optimization\.cmake' "$vendor"
/nix/store/d9is8mlwxizilvpg0i9j8jkyxyjps7s7-oculante-0.9.2.1-unstable-2025-10-08-vendor/source-registry-0/libaom-sys-0.17.2+libaom.3.11.0/vendor/build/cmake/aom_configure.cmake
20:include("${AOM_ROOT}/build/cmake/aom_optimization.cmake")
```


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
