### PR TITLE
nixos/firewalld: convert bool settings to yes/no

### DIFF
--- a/nixos/modules/services/networking/firewalld/settings.nix
+++ b/nixos/modules/services/networking/firewalld/settings.nix
@@ -1,20 +1,20 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
 let
   cfg = config.services.firewalld;
-  format = pkgs.formats.keyValue { };
   inherit (lib) mkOption;
   inherit (lib.types)
+    attrsOf
     bool
     commas
     either
     enum
     nonEmptyStr
+    oneOf
     separatedString
     submodule
     ;
@@ -27,7 +27,10 @@ in
     '';
     default = { };
     type = submodule {
-      freeformType = format.type;
+      freeformType = attrsOf (oneOf [
+        bool
+        nonEmptyStr
+      ]);
       options = {
         DefaultZone = mkOption {
           type = nonEmptyStr;
@@ -191,8 +194,8 @@ in
       }
     ];
 
-    environment.etc."firewalld/firewalld.conf" = {
-      source = format.generate "firewalld.conf" cfg.settings;
-    };
+    environment.etc."firewalld/firewalld.conf".text = lib.concatMapAttrsStringSep "\n" (
+      k: v: "${k}=${if lib.isBool v then lib.boolToYesNo v else v}"
+    ) cfg.settings;
   };
 }


### PR DESCRIPTION
Resolves #502922.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
