### PR TITLE
kubo: no IFD

### DIFF
--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -10,29 +10,22 @@ let
 
   settingsFormat = pkgs.formats.json { };
 
-  rawDefaultConfig = lib.importJSON (
+  defaultConfig =
     pkgs.runCommand "kubo-default-config"
       {
-        nativeBuildInputs = [ cfg.package ];
+        nativeBuildInputs = [
+          cfg.package
+          pkgs.jq
+        ];
       }
       ''
         export IPFS_PATH="$TMPDIR"
         ipfs init --empty-repo --profile=${profile}
-        ipfs --offline config show > "$out"
-      ''
-  );
+        # Remove the variable key to make the result deterministic.
+        ipfs --offline config show | jq 'del(.Identity)' > $out
+      '';
 
-  # Remove the PeerID (an attribute of "Identity") of the temporary Kubo repo.
-  # The "Pinning" section contains the "RemoteServices" section, which would prevent
-  # the daemon from starting as that setting can't be changed via ipfs config replace.
-  defaultConfig = removeAttrs rawDefaultConfig [
-    "Identity"
-    "Pinning"
-  ];
-
-  customizedConfig = lib.recursiveUpdate defaultConfig cfg.settings;
-
-  configFile = settingsFormat.generate "kubo-config.json" customizedConfig;
+  configFile = settingsFormat.generate "kubo-config.json" cfg.settings;
 
   # Create a fake repo containing only the file "api".
   # $IPFS_PATH will point to this directory instead of the real one.
@@ -392,8 +385,20 @@ in
       ''
       + ''
         fi
+
+        # We need the Identity and Pinning configuration from the current settings.
         ipfs --offline config show |
-          ${pkgs.jq}/bin/jq -s '.[0].Pinning as $Pinning | .[0].Identity as $Identity | .[1] + {$Identity,$Pinning}' - '${configFile}' |
+          ${lib.getExe pkgs.jq} '{ Identity, Pinning, }' |
+
+          # Now we deep-merge all configuration sources (later data wins):
+          # 1. the default configuration
+          # 2. the user-provided configuration
+          # 3. the dynamic keys from the existing configuration
+          ${lib.getExe pkgs.jq} -s 'reduce .[] as $config ({}; . * $config)' \
+            ${defaultConfig} \
+            ${configFile} \
+            - \
+          |
 
           # This command automatically injects the private key and other secrets from
           # the old config file back into the new config file.

--- a/nixos/tests/kubo/kubo.nix
+++ b/nixos/tests/kubo/kubo.nix
@@ -56,7 +56,7 @@
 
     with subtest("Socket activation for the Gateway"):
         machine.succeed(
-            f"curl 'http://127.0.0.1:8080/ipfs/{ipfs_hash.strip()}' | grep fnord2"
+            f"curl -s 'http://127.0.0.1:8080/ipfs/{ipfs_hash.strip()}' | grep fnord2"
         )
 
     with subtest("Setting dataDir works properly with the hardened systemd unit"):


### PR DESCRIPTION
No more IFD for the defaults.
Specifically the merging with the config values is now done at runtime.
The output of the command for generating the defaults is also specifically stripped of the generated credentials, making it reproducible.

This introduces caveats in terms of overwriting as it is now dependent on jq's merge behaviour.

A cleaner solution would probably move from specifying a single JSON-esque datastructure to specifying an attrset with keys and values being those of `ipfs config set` respectively.
This would allow setting individual keys to objects, removing entries, and more fine grained control in general.
However that would introduce severe backwards incompatibilities, so this commit is merely a "minimum viable fix" so to say.

---

Above is the commit message verbatim.

- It should be noted that I merely ran the NixOS tests and have not performed deeper testing or debugging.
- There is also the issue of #502938, meaning that *kubo* does not compile without the below patch (on my end at least).

<details><summary>hotfix patch to compile kubo</summary>

```patch
diff --git a/pkgs/by-name/ku/kubo/package.nix b/pkgs/by-name/ku/kubo/package.nix
index 6f3265922f2d..59cf3b905b89 100644
--- a/pkgs/by-name/ku/kubo/package.nix
+++ b/pkgs/by-name/ku/kubo/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGoModule,
+  buildGo125Module,
   fetchurl,
   nixosTests,
   stdenv,
@@ -8,7 +8,7 @@
   installShellFiles,
 }:

-buildGoModule rec {
+buildGo125Module rec {
   pname = "kubo";
   version = "0.39.0"; # When updating, also check if the repo version changed and adjust repoVersion below
   rev = "v${version}";
```

</details>

@Luflosi: as the maintainer, does this require release notes in your judgement?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
