### PR TITLE
obs-backgroundremoval: 1.1.13 -> 1.3.7

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-backgroundremoval/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-backgroundremoval/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   cmake,
   ninja,
+  pkg-config,
   obs-studio,
   onnxruntime,
   opencv,
@@ -13,19 +14,21 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-backgroundremoval";
-  version = "1.1.13";
+  version = "1.3.7";
 
   src = fetchFromGitHub {
     owner = "occ-ai";
     repo = "obs-backgroundremoval";
-    rev = version;
-    hash = "sha256-QoC9/HkwOXMoFNvcOxQkGCLLAJmsja801LKCNT9O9T0=";
+    tag = version;
+    hash = "sha256-bl0KixfBnBeyidZ4+RJhX4TDy33l9awo0wISMr7XUwk=";
   };
 
   nativeBuildInputs = [
     cmake
     ninja
+    pkg-config
   ];
+
   buildInputs = [
     obs-studio
     onnxruntime
@@ -37,26 +40,19 @@ stdenv.mkDerivation rec {
   dontWrapQtApps = true;
 
   cmakeFlags = [
-    "--preset linux-x86_64"
-    "-DCMAKE_MODULE_PATH:PATH=${src}/cmake"
     "-DUSE_SYSTEM_ONNXRUNTIME=ON"
     "-DUSE_SYSTEM_OPENCV=ON"
-    "-DDISABLE_ONNXRUNTIME_GPU=ON"
+    "-DENABLE_FRONTEND_API=OFF"
+    "-DENABLE_QT=OFF"
   ];
-
-  buildPhase = ''
-    cd ..
-    cmake --build build_x86_64 --parallel
-  '';
-
-  installPhase = ''
-    cmake --install build_x86_64 --prefix "$out"
-  '';
 
   meta = {
     description = "OBS plugin to replace the background in portrait images and video";
-    homepage = "https://github.com/royshil/obs-backgroundremoval";
-    maintainers = with lib.maintainers; [ zahrun ];
+    homepage = "https://github.com/occ-ai/obs-backgroundremoval";
+    maintainers = with lib.maintainers; [
+      randomizedcoder
+      zahrun
+    ];
     license = lib.licenses.mit;
     inherit (obs-studio.meta) platforms;
   };


### PR DESCRIPTION
Really happy to share this update. After bumping obs-backgroundremoval to 1.3.7 and enabling GPU acceleration, background removal on OBS is looking great. On an AMD Radeon W7500, GPU utilization sits at roughly 10%, compared to the previous version (1.1.13) which would saturate all cores on a 24-core machine running CPU-only inference.

- Bump version to 1.3.7 (latest upstream)
- Remove cmake preset and custom build/install phases
- Remove DISABLE_ONNXRUNTIME_GPU flag (no longer exists upstream)
- Add pkg-config to nativeBuildInputs (required for dependency discovery)
- GPU execution providers (ROCm, MIGraphX, CUDA, TensorRT) are now auto-detected at build time via the linked onnxruntime
- Update homepage URL to current GitHub org (occ-ai)
- Add randomizedcoder to maintainers

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test