### PR TITLE
nixos/kmscon: revert `hwRender` option

### DIFF
--- a/nixos/modules/services/ttys/kmscon.nix
+++ b/nixos/modules/services/ttys/kmscon.nix
@@ -90,7 +90,7 @@ in
 
       package = mkPackageOption pkgs "kmscon" { };
 
-      hwRender = mkEnableOption "hardware acceleration + DRM backend";
+      hwRender = mkEnableOption "3D hardware acceleration to render the console";
 
       fonts = mkOption {
         description = "Fonts used by kmscon, in order of priority.";
@@ -168,7 +168,6 @@ in
             "--"
             loginScript
           ]
-
         ))
       ];
 
@@ -194,14 +193,10 @@ in
             ) config.services.xserver.xkb
           )
         );
-        render =
-          if cfg.hwRender then
-            [
-              "drm"
-              "hwaccel"
-            ]
-          else
-            [ "no-drm" ];
+        render = optionals cfg.hwRender [
+          "drm"
+          "hwaccel"
+        ];
         fonts =
           optional (cfg.fonts != null)
             "font-name=${lib.concatMapStringsSep ", " (f: f.name) cfg.fonts}";


### PR DESCRIPTION
kmscon uses the [DRM backend by default](https://github.com/kmscon/kmscon/blob/main/docs/man/kmscon.1.xml.in#L518-L524), but #489469 has disabled it by default, which causes kmscon not to render the interface automatically (black screen).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
