### PR TITLE
nixos/i18n: allow imperative locale management via localectl

### DIFF
--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -6,6 +6,7 @@
 }:
 let
   cfg = config.console;
+  i18nCfg = config.i18n;
 
   makeColor = i: lib.concatMapStringsSep "," (x: "0x" + lib.substring (2 * i) 2 x);
 
@@ -162,8 +163,10 @@ in
           environment.systemPackages = [ pkgs.kbd ];
 
           # Let systemd-vconsole-setup.service do the work of setting up the
-          # virtual consoles.
-          environment.etc."vconsole.conf".source = vconsoleConf;
+          # virtual consoles. Skip when imperative so localectl can manage it.
+          environment.etc."vconsole.conf" = lib.mkIf (!i18nCfg.imperativeLocale) {
+            source = vconsoleConf;
+          };
           # Provide kbd with additional packages.
           environment.etc.kbd.source = "${consoleEnv pkgs.kbd}/share";
 
@@ -209,13 +212,22 @@ in
             "systemd-vconsole-setup.service"
           ];
 
+          # When imperative, seed /etc/vconsole.conf on first boot from declared
+          # defaults so the keymap isn't lost before localectl is ever used
+          systemd.tmpfiles.rules = lib.mkIf i18nCfg.imperativeLocale [
+            "C /etc/vconsole.conf - - - - ${vconsoleConf}"
+          ];
+
           systemd.services.reload-systemd-vconsole-setup = {
             description = "Reset console on configuration changes";
             wantedBy = [ "multi-user.target" ];
-            restartTriggers = [
-              vconsoleConf
-              (consoleEnv pkgs.kbd)
-            ];
+            restartTriggers =
+              lib.optionals (!i18nCfg.imperativeLocale) [
+                vconsoleConf
+              ]
+              ++ [
+                (consoleEnv pkgs.kbd)
+              ];
             reloadIfChanged = true;
             serviceConfig = {
               RemainAfterExit = true;

--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -5,24 +5,29 @@
   ...
 }:
 let
+  cfg = config.i18n;
+  localeConf = pkgs.writeText "locale.conf" ''
+    LANG=${cfg.defaultLocale}
+    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n}=${v}") cfg.extraLocaleSettings)}
+  '';
   sanitizeUTF8Capitalization =
     lang: (lib.replaceStrings [ "utf8" "utf-8" "UTF8" ] [ "UTF-8" "UTF-8" "UTF-8" ] lang);
   aggregatedLocales =
-    lib.optionals (config.i18n.defaultLocale != "C") [
-      "${config.i18n.defaultLocale}/${config.i18n.defaultCharset}"
+    lib.optionals (cfg.defaultLocale != "C") [
+      "${cfg.defaultLocale}/${cfg.defaultCharset}"
     ]
-    ++ lib.pipe config.i18n.extraLocaleSettings [
+    ++ lib.pipe cfg.extraLocaleSettings [
       # See description of extraLocaleSettings for why is this ignored here.
       (x: lib.removeAttrs x [ "LANGUAGE" ])
       (lib.mapAttrs (n: v: (sanitizeUTF8Capitalization v)))
       # C locales are always installed
       (lib.filterAttrs (n: v: v != "C"))
-      (lib.mapAttrsToList (LCRole: lang: lang + "/" + (config.i18n.localeCharsets.${LCRole} or "UTF-8")))
+      (lib.mapAttrsToList (LCRole: lang: lang + "/" + (cfg.localeCharsets.${LCRole} or "UTF-8")))
     ]
     ++ (map sanitizeUTF8Capitalization (
-      lib.optionals (builtins.isList config.i18n.extraLocales) config.i18n.extraLocales
+      lib.optionals (builtins.isList cfg.extraLocales) cfg.extraLocales
     ))
-    ++ (lib.optional (builtins.isString config.i18n.extraLocales) config.i18n.extraLocales);
+    ++ (lib.optional (builtins.isString cfg.extraLocales) cfg.extraLocales);
 in
 {
   ###### interface
@@ -33,8 +38,8 @@ in
       glibcLocales = lib.mkOption {
         type = lib.types.path;
         default = pkgs.glibcLocales.override {
-          allLocales = lib.elem "all" config.i18n.supportedLocales;
-          locales = config.i18n.supportedLocales;
+          allLocales = lib.elem "all" cfg.supportedLocales;
+          locales = cfg.supportedLocales;
         };
         defaultText = lib.literalExpression ''
           pkgs.glibcLocales.override {
@@ -143,6 +148,16 @@ in
         '';
       };
 
+      imperativeLocale = lib.mkEnableOption ''
+        imperative locale and keyboard management via localectl.
+
+        When enabled, locale and keyboard settings can be changed at runtime
+        using `localectl set-locale` and `localectl set-keymap`.
+        When disabled (the default), these settings are managed declaratively
+        through {option}`i18n.defaultLocale`, {option}`i18n.extraLocaleSettings`,
+        and {option}`console.keyMap`.
+      '';
+
     };
 
   };
@@ -154,8 +169,8 @@ in
       lib.optional
         (
           !(
-            (lib.subtractLists config.i18n.supportedLocales aggregatedLocales) == [ ]
-            || lib.elem "all" config.i18n.supportedLocales
+            (lib.subtractLists cfg.supportedLocales aggregatedLocales) == [ ]
+            || lib.elem "all" cfg.supportedLocales
           )
         )
         ''
@@ -171,25 +186,34 @@ in
 
     environment.systemPackages =
       # We increase the priority a little, so that plain glibc in systemPackages can't win.
-      lib.optional (config.i18n.supportedLocales != [ ]) (lib.setPrio (-1) config.i18n.glibcLocales);
+      lib.optional (cfg.supportedLocales != [ ]) (lib.setPrio (-1) cfg.glibcLocales);
 
     environment.sessionVariables = {
-      LANG = config.i18n.defaultLocale;
       LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
     }
-    // config.i18n.extraLocaleSettings;
+    # When imperative, leave LANG/LC_* to pam_systemd so /etc/set-environment
+    # does not override what localectl wrote to /etc/locale.conf.
+    // lib.optionalAttrs (!cfg.imperativeLocale) (
+      {
+        LANG = cfg.defaultLocale;
+      }
+      // cfg.extraLocaleSettings
+    );
 
-    systemd.globalEnvironment = lib.mkIf (config.i18n.supportedLocales != [ ]) {
-      LOCALE_ARCHIVE = "${config.i18n.glibcLocales}/lib/locale/locale-archive";
+    systemd.globalEnvironment = lib.mkIf (cfg.supportedLocales != [ ]) {
+      LOCALE_ARCHIVE = "${cfg.glibcLocales}/lib/locale/locale-archive";
     };
 
     # ‘/etc/locale.conf’ is used by systemd.
-    environment.etc."locale.conf".source = pkgs.writeText "locale.conf" ''
-      LANG=${config.i18n.defaultLocale}
-      ${lib.concatStringsSep "\n" (
-        lib.mapAttrsToList (n: v: "${n}=${v}") config.i18n.extraLocaleSettings
-      )}
-    '';
+    # If imperative, see below
+    environment.etc."locale.conf" = lib.mkIf (!cfg.imperativeLocale) {
+      source = localeConf;
+    };
 
+    # When imperative, seed /etc/locale.conf on first boot from declared defaults
+    # so the system doesn’t fall back to C.UTF-8
+    systemd.tmpfiles.rules = lib.mkIf cfg.imperativeLocale [
+      "C /etc/locale.conf - - - - ${localeConf}"
+    ];
   };
 }

--- a/nixos/modules/config/locale.nix
+++ b/nixos/modules/config/locale.nix
@@ -86,10 +86,6 @@ in
     # This way services are restarted when tzdata changes.
     systemd.globalEnvironment.TZDIR = tzdir;
 
-    systemd.services.systemd-timedated.environment = lib.optionalAttrs (config.time.timeZone != null) {
-      NIXOS_STATIC_TIMEZONE = "1";
-    };
-
     environment.etc = {
       zoneinfo.source = tzdir;
     }

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -826,10 +826,12 @@ in
     # because either the overlay is mutable (and users can legitimately change
     # values without them being overridden) or it is immutable and systemd will
     # suggest to only make runtime changes.
-    systemd.services."systemd-localed".environment = lib.mkIf (!config.system.etc.overlay.enable) {
-      SYSTEMD_ETC_LOCALE_CONF = "/etc/static/locale.conf";
-      SYSTEMD_ETC_VCONSOLE_CONF = "/etc/static/vconsole.conf";
-    };
+    systemd.services."systemd-localed".environment =
+      lib.mkIf (!config.system.etc.overlay.enable && !config.i18n.imperativeLocale)
+        {
+          SYSTEMD_ETC_LOCALE_CONF = "/etc/static/locale.conf";
+          SYSTEMD_ETC_VCONSOLE_CONF = "/etc/static/vconsole.conf";
+        };
     systemd.services."systemd-timedated".environment =
       lib.mkIf (!config.system.etc.overlay.enable && config.time.timeZone != null)
         {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -374,6 +374,7 @@ in
   collectd = runTest ./collectd.nix;
   commafeed = runTest ./commafeed.nix;
   connman = runTest ./connman.nix;
+  console = runTest ./console.nix;
   console-xkb-and-i18n = runTest ./console-xkb-and-i18n.nix;
   consul = runTest ./consul.nix;
   consul-template = runTest ./consul-template.nix;
@@ -899,6 +900,7 @@ in
   llama-swap = runTest ./web-servers/llama-swap.nix;
   lldap = runTest ./lldap.nix;
   local-content-share = runTest ./local-content-share.nix;
+  locale = runTest ./locale.nix;
   localsend = runTest ./localsend.nix;
   locate = runTest ./locate.nix;
   login = runTest ./login.nix;

--- a/nixos/tests/console.nix
+++ b/nixos/tests/console.nix
@@ -1,0 +1,72 @@
+{ ... }:
+{
+  name = "console";
+  meta.maintainers = [ ];
+
+  nodes =
+    let
+      # Temporary dirty workaround for nixpkgs/issues/286283
+      # Point directly to pkgs.kbd (real files) rather than /etc/kbd/keymaps
+      # (which goes through consoleEnv's buildEnv and contains only symlinks).
+      # systemd-localed follows the directory symlink but not individual file
+      # symlinks inside it, so buildEnv-based paths yield no usable keymaps.
+      missingKeymapsWorkaround =
+        { pkgs, ... }:
+        {
+          systemd.tmpfiles.rules = [
+            "L /usr/share/keymaps - - - - ${pkgs.kbd}/share/keymaps"
+          ];
+        };
+    in
+    {
+      node_static =
+        { ... }:
+        {
+          imports = [ missingKeymapsWorkaround ];
+          console.keyMap = "lt";
+        };
+
+      node_imperative =
+        { ... }:
+        {
+          imports = [ missingKeymapsWorkaround ];
+          console.keyMap = "lt";
+          i18n.imperativeLocale = true;
+        };
+    };
+
+  testScript =
+    { ... }:
+    ''
+      node_static.wait_for_unit("dbus.socket")
+
+      with subtest("static - declared keymap is reported by localectl"):
+          node_static.succeed("localectl status | grep -q 'VC Keymap: lt'")
+
+      with subtest("static - keymap reverts to declared value after reboot"):
+          # Unlike localectl set-locale, vconsole_write_data() in systemd's
+          # localed-util.c writes to a hardcoded /etc/vconsole.conf path rather
+          # than respecting SYSTEMD_ETC_VCONSOLE_CONF, so the set-keymap call
+          # itself always succeeds. The static guarantee is that NixOS activation
+          # restores the symlink on reboot, reverting any runtime changes.
+          node_static.succeed("localectl set-keymap fr")
+          node_static.succeed("localectl status | grep -q 'VC Keymap: fr'")
+          node_static.shutdown()
+          node_static.wait_for_unit("dbus.socket")
+          node_static.succeed("localectl status | grep -q 'VC Keymap: lt'")
+
+      node_imperative.wait_for_unit("dbus.socket")
+
+      with subtest("imperative - declared keymap is reported by localectl on first boot"):
+          node_imperative.succeed("localectl status | grep -q 'VC Keymap: lt'")
+
+      with subtest("imperative - localectl set-keymap changes the keymap"):
+          node_imperative.succeed("localectl set-keymap --no-convert fr")
+          node_imperative.succeed("localectl status | grep -q 'VC Keymap: fr'")
+
+      with subtest("imperative - keymap change persists across reboot"):
+          node_imperative.shutdown()
+          node_imperative.wait_for_unit("dbus.socket")
+          node_imperative.succeed("localectl status | grep -q 'VC Keymap: fr'")
+    '';
+}

--- a/nixos/tests/locale.nix
+++ b/nixos/tests/locale.nix
@@ -1,0 +1,53 @@
+{ ... }:
+{
+  name = "imperative-locale";
+  meta.maintainers = [ ];
+
+  nodes = {
+    node_static =
+      { ... }:
+      {
+        i18n = {
+          defaultLocale = "lt_LT.UTF-8";
+          extraLocales = [ "en_US.UTF-8/UTF-8" ];
+        };
+      };
+
+    node_imperative =
+      { ... }:
+      {
+        i18n = {
+          defaultLocale = "lt_LT.UTF-8";
+          imperativeLocale = true;
+          extraLocales = [ "en_US.UTF-8/UTF-8" ];
+        };
+      };
+  };
+
+  testScript =
+    { ... }:
+    ''
+      node_static.wait_for_unit("dbus.socket")
+
+      with subtest("static - declared locale is reported by localectl"):
+          node_static.succeed("localectl status | grep -q 'System Locale: LANG=lt_LT.UTF-8'")
+
+      with subtest("static - localectl set-locale is blocked"):
+          node_static.fail("localectl set-locale LANG=en_US.UTF-8")
+          node_static.succeed("localectl status | grep -q 'System Locale: LANG=lt_LT.UTF-8'")
+
+      node_imperative.wait_for_unit("dbus.socket")
+
+      with subtest("imperative - declared locale is reported by localectl on first boot"):
+          node_imperative.succeed("localectl status | grep -q 'System Locale: LANG=lt_LT.UTF-8'")
+
+      with subtest("imperative - localectl set-locale changes the locale"):
+          node_imperative.succeed("localectl set-locale LANG=en_US.UTF-8")
+          node_imperative.succeed("localectl status | grep -q 'System Locale: LANG=en_US.UTF-8'")
+
+      with subtest("imperative - locale change persists across reboot"):
+          node_imperative.shutdown()
+          node_imperative.wait_for_unit("dbus.socket")
+          node_imperative.succeed("localectl status | grep -q 'System Locale: LANG=en_US.UTF-8'")
+    '';
+}


### PR DESCRIPTION
This patch introduces a new `i18n.imperativeLocale` option which disables the static path assignments done in `nixos/modules/system/boot/systemd.nix`. This allows `localectl` and `systemd-localed` as a whole to manage locale/keyboard settings at runtime.

To continue respecting `i18n.defaultLocale` and `console.keyMap`, temporary files are created at `/etc/locale.conf` and `/etc/vconsole.conf` respectively.
These will be read by `systemd-localed` at initial boot but immediately overwritten on any imperative change.

Removes the need for certain DEs to use NixOS-specific compilation flags such as https://github.com/pop-os/cosmic-initial-setup/pull/64/changes#diff-294fa088fb0ea271c487889f06cf466f0fa6670fc861e8a45ad1f22881b0309e

Recommend COSMIC module (`nixos/modules/services/desktop-managers/cosmic.nix`) to be adjusted to enable imperative locale and timezone management:
```nix
time.timeZone = null;
i18n.imperativeLocale = true;
```

Can be tested by setting the following:
```nix
  # Enable imperative setting
  i18n.imperativeLocale = true;

  # Due to:
  # https://github.com/NixOS/nixpkgs/issues/267101 and https://github.com/NixOS/nixpkgs/issues/286283
  # `localectl list-locales` and `localectl list-keymaps` both do not work
  # In addition `localectl set-keymap` will also complain about missing keymaps
  # Temporary, dirty alternative to the proper fix https://github.com/NixOS/nixpkgs/pull/445146
  systemd.tmpfiles.rules = [
    "L /usr/lib/locale/locale-archive - - - - /run/current-system/sw/lib/locale/locale-archive"
    "L /usr/share/keymaps - - - - ${pkgs.kbd}/share/keymaps"
  ];
```

Closes: https://github.com/NixOS/nixpkgs/issues/502636

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
