### PR TITLE
jogl: remove not required xcbuild

### DIFF
--- a/pkgs/by-name/jo/jogl/package.nix
+++ b/pkgs/by-name/jo/jogl/package.nix
@@ -7,7 +7,6 @@
   git,
   xmlstarlet,
   stripJavaArchivesHook,
-  xcbuild,
   udev,
   libxxf86vm,
   libxt,
@@ -76,9 +75,6 @@ stdenv.mkDerivation {
     git
     xmlstarlet
     stripJavaArchivesHook
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    xcbuild
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
I wanted to find out what is xcbuild used for in this package, but it doesn't seem to be required in any way. Builds fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
