### PR TITLE
google-cloud-sdk: CVE-2026-27459

### DIFF
--- a/pkgs/by-name/go/google-cloud-sdk/package.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/package.nix
@@ -26,24 +26,8 @@
 
 let
   python3 = python312;
-  # include a compatible pyopenssl version: https://github.com/NixOS/nixpkgs/issues/379291
-  # remove ASAP: https://github.com/googleapis/google-api-python-client/issues/2554
-  pythonCustom = python3.override {
-    self = pythonCustom;
-    packageOverrides = _: super: {
-      pyopenssl = super.pyopenssl.overridePythonAttrs (old: rec {
-        version = "24.2.1";
-        src = old.src.override {
-          tag = version;
-          hash = "sha256-/TQnDWdycN4hQ7ZGvBhMJEZVafmL+0wy9eJ8hC6rfio=";
-        };
-        # 36 failed tests
-        doCheck = false;
-      });
-    };
-  };
 
-  pythonEnv = pythonCustom.withPackages (
+  pythonEnv = python3.withPackages (
     p:
     with p;
     [


### PR DESCRIPTION

pyopenssl is pinned, the pinning is no longer required and necessary to get removed due to CVE-2026-27459

It is required to backport this to 25.11 too

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
