### PR TITLE
pyamg: fix build

### DIFF
--- a/pkgs/development/python-modules/pyamg/default.nix
+++ b/pkgs/development/python-modules/pyamg/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchPypi,
   numpy,
@@ -19,6 +20,14 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-UyPQ8aTNmZviRqkNWAyeHptYS5iIf2KY05dhEIfvhgs=";
   };
+
+  # removed by next version, https://github.com/pyamg/pyamg/pull/420
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail \
+        'setuptools_scm[toml]==8.3.0' \
+        'setuptools_scm>=8.3.0' \
+  '';
 
   nativeBuildInputs = [ setuptools-scm ];
 
@@ -51,5 +60,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/pyamg/pyamg/blob/v${version}/changelog.md";
     license = lib.licenses.mit;
     maintainers = [ ];
+    broken = stdenv.hostPlatform.isDarwin && lib.versionAtLeast python.version "3.14";
   };
 }

--- a/pkgs/development/python-modules/pyamg/default.nix
+++ b/pkgs/development/python-modules/pyamg/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/pyamg/pyamg";
     changelog = "https://github.com/pyamg/pyamg/blob/v${version}/changelog.md";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ stephen-huan ];
     broken = stdenv.hostPlatform.isDarwin && lib.versionAtLeast python.version "3.14";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

pyamg fails to build because of the recent setuptools-scm update, see [hydra](https://hydra.nixos.org/build/322464231). Built and tested and works. Note that upstream has already removed this explicit pin in https://github.com/pyamg/pyamg/pull/420.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
