### PR TITLE
squashfsTools: fix darwin build

### DIFF
--- a/pkgs/by-name/sq/squashfsTools/package.nix
+++ b/pkgs/by-name/sq/squashfsTools/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   help2man,
   lz4,
   lzo,
@@ -22,6 +23,15 @@ stdenv.mkDerivation (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-rQ69sXvi6wY8yRyuQzcJZ6MvVGBbIw7vG+kYVHvfQQ8=";
   };
+
+  patches =
+    # Fixes a build failure introduced in 4.7.5. Merged upstream, drop in the next update.
+    # https://github.com/plougher/squashfs-tools/pull/356
+    lib.optional stdenv.hostPlatform.isDarwin (fetchpatch2 {
+      name = "fix-macos-build.patch";
+      url = "https://github.com/plougher/squashfs-tools/commit/f88f4a659d6ab432a57e90fe2f6191149c6b343f.patch?full_index=1";
+      hash = "sha256-NyMIlL+8aU11HPH/7jTEFAQYhgMkVCgdtKytdhplCkg=";
+    });
 
   strictDeps = true;
   nativeBuildInputs = [


### PR DESCRIPTION
Apply upstream patch for a build failure in mksquashfs.c, introduced in 4.7.5.

Problem found and fix tested through CI of https://github.com/marienz/nix-doom-emacs-unstraightened (which does not directly use squashfsTools, just an indirect dependency). CI started failing after upgrading from nixpkgs 9cf7092bdd603554bd8b63c216e8943cf9b12512 to fdc7b8f7b30fdbedec91b71ed82f36e1637483ed with:

<details>
<summary>build log</summary>

```
error: build of '/nix/store/p3vqp1q712kpdc67638l21l7vw45ws4q-squashfs-4.7.5.drv^*' failed: Cannot build '/nix/store/p3vqp1q712kpdc67638l21l7vw45ws4q-squashfs-4.7.5.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/cvy8186hbsk2aq0ksrhkframppp0h5iw-squashfs-4.7.5
       Last 21 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/h0np4v5vnxn209kznh1jlypnjdfzip48-source
       > source root is source
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > build flags: SHELL=/nix/store/s0psayl7zvkvwdcqc8fy1sbv8rlf1yq8-bash-5.3p9/bin/bash XZ_SUPPORT=1 ZSTD_SUPPORT=1 LZ4_SUPPORT=1 LZMA_XZ_SUPPORT=1 LZO_SUPPORT=1
       > clang -O2  -I. -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_GNU_SOURCE -DCOMP_DEFAULT=\"gzip\" -Wall -DGZIP_SUPPORT -DLZO_SUPPORT -DLZ4_SUPPORT -DXZ_SUPPORT -DZSTD_SUPPORT -DLZMA_SUPPORT -DXATTR_SUPPORT -DXATTR_DEFAULT -DXATTR_OS_SUPPORT -DMAX_READER_THREADS=1024 -DSMALL_READER_THREADS=4 -DBLOCK_READER_THREADS=4 -DVERSION=\"4.7.5\" -DDATE=\"2026/03/01\" -DYEAR=\"2026\"   -c -o mksquashfs.o mksquashfs.c
       > mksquashfs.c:3376:16: error: no member named 'st_atim' in 'struct stat'
       >  3376 |                 memset(&buf->st_atim, 0, sizeof(buf->st_atim));
       >       |                         ~~~  ^
       > mksquashfs.c:3376:40: error: no member named 'st_atim' in 'struct stat'
       >  3376 |                 memset(&buf->st_atim, 0, sizeof(buf->st_atim));
       >       |                                                 ~~~  ^
       > mksquashfs.c:3376:16: error: no member named 'st_atim' in 'struct stat'
       >  3376 |                 memset(&buf->st_atim, 0, sizeof(buf->st_atim));
       >       |                         ~~~  ^
       > 3 errors generated.
       > make: *** [<builtin>: mksquashfs.o] Error 1
```

</details>

CI succeeds (on both x86_64-linux and aarch64-darwin) with this patch applied. (I also built squashfsTools locally on x86_64-linux, but I can't easily test basic functionality on darwin myself due to lack of hardware...)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
