### PR TITLE
doomrunner: 1.9.1 -> 1.9.2

### DIFF
--- a/pkgs/by-name/do/doomrunner/package.nix
+++ b/pkgs/by-name/do/doomrunner/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   kdePackages,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -41,6 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
     + ''
       rm -rf $out/usr
     '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Preset-oriented graphical launcher of various ported Doom engines";

--- a/pkgs/by-name/do/doomrunner/package.nix
+++ b/pkgs/by-name/do/doomrunner/package.nix
@@ -1,27 +1,31 @@
 {
   lib,
   stdenv,
-  kdePackages,
+  qt6,
+  minizip,
   fetchFromGitHub,
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "doomrunner";
-  version = "1.9.1";
+  version = "1.9.2";
 
   src = fetchFromGitHub {
     owner = "Youda008";
     repo = "DoomRunner";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-N5kj2Z3QW29kOw2khET6Z4E9nFBBjNTgKw2xbCQrWKY=";
+    hash = "sha256-YkLW3og51e2sydWUiMDr2DOr1uHxzv4Z3rr/WRys5bY=";
   };
 
-  buildInputs = [ kdePackages.qtbase ];
+  buildInputs = [
+    minizip
+    qt6.qtbase
+  ];
 
   nativeBuildInputs = [
-    kdePackages.qmake
-    kdePackages.wrapQtAppsHook
+    qt6.qmake
+    qt6.wrapQtAppsHook
   ];
 
   makeFlags = [
@@ -46,12 +50,12 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Preset-oriented graphical launcher of various ported Doom engines";
-    mainProgram = "DoomRunner";
-    homepage = "https://github.com/Youda008/DoomRunner";
     changelog = "https://github.com/Youda008/DoomRunner/blob/${finalAttrs.src.rev}/changelog.txt";
+    description = "Preset-oriented graphical launcher of various ported Doom engines";
+    homepage = "https://github.com/Youda008/DoomRunner";
     license = lib.licenses.gpl3Only;
-    platforms = lib.platforms.all;
+    mainProgram = "DoomRunner";
     maintainers = with lib.maintainers; [ keenanweaver ];
+    platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
Changelog: https://github.com/Youda008/DoomRunner/releases/tag/v1.9.2
Diff: https://github.com/Youda008/DoomRunner/compare/v1.9.1...v1.9.2

- Bumped to 1.9.2, added new `minizip` dependency
- Added nix-update-script
- Swapped from `kdePackages` to `qt6`
- Minor `meta` cleanup

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
