### PR TITLE
{tor,mullvad}-browser: 15.0.7 -> 15.0.8

### DIFF
--- a/pkgs/by-name/mu/mullvad-browser/package.nix
+++ b/pkgs/by-name/mu/mullvad-browser/package.nix
@@ -97,7 +97,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg_7 ]
   );
 
-  version = "15.0.7";
+  version = "15.0.8";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -109,7 +109,7 @@ let
         "https://tor.eff.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-Uj2H6ONVpn3EtzMNl8xqOAf6UeO6FGAKtyH9DKh976U=";
+      hash = "sha256-EuyDwgNoVECEko66xFnmteVNnPsn2POlXRU9iS9VPlo=";
     };
   };
 

--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -102,7 +102,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg_7 ]
   );
 
-  version = "15.0.7";
+  version = "15.0.8";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -112,7 +112,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-/zUA3o9zPdZ/MZan5Uc2puGN+S8QvB42QtXDo8MucVM=";
+      hash = "sha256-m/WZa1O9MTeE8YUku/BAbcl9Dx77yVkt44C5qe/1fP0=";
     };
 
     i686-linux = fetchurl {
@@ -122,7 +122,7 @@ let
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
       ];
-      hash = "sha256-GZ2MT8bSVMKLwgTZGYYegdW94e6mJ97+oMBeZJMlHvY=";
+      hash = "sha256-QMv59Tj2voJAvBF/UM0xNe1byx8qZZtZhWqt2yGjdM4=";
     };
   };
 


### PR DESCRIPTION
Changelog (TB): https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/raw/tbb-15.0.8-build1/projects/browser/Bundle-Data/Docs-TBB/ChangeLog.txt
Changelog (MB): https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/raw/mb-15.0.8-build1/projects/browser/Bundle-Data/Docs-MB/ChangeLog.txt
Firefox ESR: https://www.firefox.com/en-US/firefox/140.9.0/releasenotes/
Firefox security advisories: https://www.mozilla.org/en-US/security/advisories/mfsa2026-22/

We've bundled these updates together for convenience since they're largely the same browser with the same changeset, but we can split them if that's preferable.

We've also tested both of these changes when picked to release-25.11, and they both appear to work fine.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] i686-linux (TB only) 
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
