### PR TITLE
doc: correct example syntax nix repl

### DIFF
--- a/nixos/doc/manual/configuration/modularity.section.md
+++ b/nixos/doc/manual/configuration/modularity.section.md
@@ -113,7 +113,7 @@ Interactive exploration of the configuration is possible using `nix
   repl`, a read-eval-print loop for Nix expressions. A typical use:
 
 ```ShellSession
-$ nix repl '<nixpkgs/nixos>'
+$ nix repl --expr 'import <nixpkgs/nixos> {}'
 
 nix-repl> config.networking.hostName
 "mandark"
@@ -121,6 +121,10 @@ nix-repl> config.networking.hostName
 nix-repl> map (x: x.hostName) config.services.httpd.virtualHosts
 [ "example.org" "example.gov" ]
 ```
+
+Note that this default to the configuration file paths stored in
+`NIX_PATH`. You may pass a different path as
+`'import <nixpkgs/nixos> { configuration = /path/to/configuration.nix; }'`
 
 While abstracting your configuration, you may find it useful to generate
 modules using code, instead of writing files. The example below would


### PR DESCRIPTION
Correct example syntax of `nix repl`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
