### PR TITLE
basedpyright: remove references to nodejs source

### DIFF
--- a/pkgs/by-name/ba/basedpyright/package.nix
+++ b/pkgs/by-name/ba/basedpyright/package.nix
@@ -49,6 +49,8 @@ buildNpmPackage rec {
     mv "$out/bin/pyright-langserver" "$out/bin/basedpyright-langserver"
     # Remove dangling symlinks created during installation (remove -delete to just see the files, or -print '%l\n' to see the target
     find -L $out -type l -print -delete
+    # Remove native module build artifacts that reference nodejs source
+    rm -rf "$out/lib/node_modules/pyright-root/node_modules/keytar/build"
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
The keytar native module's build artifacts contain hardcoded paths to nodejs-slim and nodejs-source, pulling them into the runtime closure. Remove these build artifacts to reduce closure size.

Before (original):
```console
$ nix-store --query --references /nix/store/...basedpyright-1.38.2 | grep node
/nix/store/...-nodejs-slim-24.13.0
/nix/store/...-nodejs-slim-24.13.0-npm
/nix/store/...-nodejs-24.13.0-source
/nix/store/...-nodejs-24.13.0
```
Closure size: 844.6 MiB
After (with PR):
```console
$ nix-store --query --references /nix/store/...basedpyright-1.38.2 | grep node
/nix/store/...-nodejs-24.13.0
```
Closure size: 555.6 MiB

AI disclosure: This PR was created with assistance of opencode. Changes were reviewed and built/tested locally.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
