### PR TITLE
nixos/autossh-ng: more accurate systemd unit readiness

### DIFF
--- a/nixos/modules/services/networking/autossh-ng.nix
+++ b/nixos/modules/services/networking/autossh-ng.nix
@@ -105,6 +105,8 @@ in
           wantedBy = [ "multi-user.target" ];
 
           serviceConfig = {
+            Type = "notify";
+            NotifyAccess = "all";
             User = "${s.user}";
             # backoff would be nice, but doesn't automatically
             # get reset on successful start yet, so static 10s restart for now:
@@ -117,11 +119,16 @@ in
                     "-o \"UserKnownHostsFile=${s.knownHostsFile}\""
                   else
                     "-o \"UserKnownHostsFile=/dev/null\" -o \"StrictHostKeyChecking=no\"";
+                ready = pkgs.writers.writeBash "systemd-signal-ready" ''
+                  ${pkgs.systemd}/bin/systemd-notify --ready
+                '';
               in
               ''
                 ${pkgs.openssh}/bin/ssh \
                   -o "ServerAliveInterval 30" \
                   -o "ServerAliveCountMax 3" \
+                  -o "PermitLocalCommand=yes" \
+                  -o "LocalCommand ${ready}" \
                   -o ExitOnForwardFailure=yes \
                   ${hostKeyCheckOption} \
                   -N \


### PR DESCRIPTION
This is convenient e.g. if you have another process that wants
to use the connection; that can wait for the unit to become ready
instead of 'blindly' (re)trying the connection.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
