### PR TITLE
nixos/lvm: add option for adding lvresize_fs_helper to config

### DIFF
--- a/nixos/modules/profiles/bashless.nix
+++ b/nixos/modules/profiles/bashless.nix
@@ -35,6 +35,8 @@
   users.manageLingering = lib.mkDefault false;
   # Relies on the gzip command which depends on bash
   services.logrotate.enable = lib.mkDefault false;
+  # The resize helper pulls in bash
+  services.lvm.resizeHelper.enable = false;
 
   # Check that the system does not contain a Nix store path that contains the
   # string "bash".

--- a/nixos/modules/tasks/lvm.nix
+++ b/nixos/modules/tasks/lvm.nix
@@ -22,6 +22,10 @@ in
       '';
     };
 
+    resizeHelper.enable = mkEnableOption "lvresize_fs_helper" // {
+      default = true;
+    };
+
     package = mkOption {
       type = types.package;
       default = pkgs.lvm2;
@@ -60,7 +64,7 @@ in
 
       services.udev.packages = [ cfg.package.out ];
       environment.etc."lvm/lvm.conf".text =
-        "global/lvresize_fs_helper_executable = ${pkgs.lvm2.scripts}/libexec/lvresize_fs_helper";
+        mkIf cfg.resizeHelper.enable "global/lvresize_fs_helper_executable = ${pkgs.lvm2.scripts}/libexec/lvresize_fs_helper";
     })
     (mkIf config.boot.initrd.services.lvm.enable {
       # We need lvm2 for the device-mapper rules


### PR DESCRIPTION
Adding `lvresize_fs_helper` unconditionally to the config pulls in bash and thus defeats the efforts of enabling lvm without pulling in bash.

See https://github.com/NixOS/nixpkgs/commit/8c8d4b0eea464f661faaa53283de3f9a6b96c3e0 and https://github.com/NixOS/nixpkgs/pull/475280/changes/a0eed32cb5d8d38a801ea040b3e0a9ea92381a12

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
