### PR TITLE
[Backport release-25.11] gotosocial: 0.20.0 -> 0.21.2

### DIFF
--- a/pkgs/by-name/go/gotosocial/package.nix
+++ b/pkgs/by-name/go/gotosocial/package.nix
@@ -10,13 +10,13 @@
 }:
 buildGo124Module (finalAttrs: {
   pname = "gotosocial";
-  version = "0.21.0";
+  version = "0.21.1";
 
   src = fetchFromCodeberg {
     owner = "superseriousbusiness";
     repo = "gotosocial";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ifSm3tV8P435v7WUS2BYXfVS3FHu9Axz3IQWGdTw3Bg=";
+    hash = "sha256-LnxEvOLv+NBjdAbxxtilegW/xqBvMzy3CGM75yJsW0s=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/go/gotosocial/package.nix
+++ b/pkgs/by-name/go/gotosocial/package.nix
@@ -1,28 +1,21 @@
 {
   lib,
-  fetchurl,
-  fetchFromCodeberg,
   buildGo124Module,
+  fetchFromCodeberg,
+  fetchYarnDeps,
+  nodejs,
+  yarn,
+  yarnConfigHook,
   nixosTests,
 }:
-let
-  owner = "superseriousbusiness";
-  repo = "gotosocial";
-
+buildGo124Module (finalAttrs: {
+  pname = "gotosocial";
   version = "0.21.0";
 
-  web-assets = fetchurl {
-    url = "https://codeberg.org/${owner}/${repo}/releases/download/v${version}/${repo}_${version}_web-assets.tar.gz";
-    hash = "sha256-eExVquNTXkvxg0SAR60kXi5mnROp+tHNO3os1K+rWzU=";
-  };
-in
-buildGo124Module rec {
-  inherit version;
-  pname = repo;
-
   src = fetchFromCodeberg {
-    inherit owner repo;
-    tag = "v${version}";
+    owner = "superseriousbusiness";
+    repo = "gotosocial";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ifSm3tV8P435v7WUS2BYXfVS3FHu9Axz3IQWGdTw3Bg=";
   };
 
@@ -31,17 +24,46 @@ buildGo124Module rec {
   ldflags = [
     "-s"
     "-w"
-    "-X main.Version=${version}"
+    "-X main.Version=${finalAttrs.version}"
   ];
 
   tags = [
     "kvformat"
   ];
 
+  nativeBuildInputs = [
+    nodejs
+    yarn
+    yarnConfigHook
+  ];
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/web/source/yarn.lock";
+    hash = "sha256-rfZxslIEoOTufENIvk8Eq5wzdD3rUpUP3wrMjmLH44k=";
+  };
+
+  # manually calling yarnConfigHook in sub-directory
+  dontYarnInstallDeps = true;
+
+  postConfigure = ''
+    pushd ./web/source
+    runHook yarnConfigHook
+    popd
+  '';
+
+  # preparing assets
+  # https://codeberg.org/superseriousbusiness/gotosocial/src/branch/main/.goreleaser.yml#L12
+  preBuild = ''
+    go run ./vendor/github.com/go-swagger/go-swagger/cmd/swagger generate spec --scan-models --exclude-deps -o web/assets/swagger.yaml
+    substituteInPlace web/assets/swagger.yaml --replace-fail "REPLACE_ME" "${finalAttrs.version}"
+    yarn --offline --cwd ./web/source ts-patch install
+    yarn --offline --cwd ./web/source build
+    ./scripts/bundle_licenses.sh
+  '';
+
   postInstall = ''
-    tar xf ${web-assets}
-    mkdir -p $out/share/gotosocial
-    mv web $out/share/gotosocial/
+    mkdir -p $out/share/gotosocial/web
+    mv web/{assets,template} $out/share/gotosocial/web
   '';
 
   # tests are working only on x86_64-linux
@@ -63,7 +85,7 @@ buildGo124Module rec {
 
   meta = {
     homepage = "https://gotosocial.org";
-    changelog = "https://codeberg.org/superseriousbusiness/gotosocial/releases/tag/v${version}";
+    changelog = "https://codeberg.org/superseriousbusiness/gotosocial/releases/tag/v${finalAttrs.version}";
     description = "Fast, fun, ActivityPub server, powered by Go";
     longDescription = ''
       ActivityPub social network server, written in Golang.
@@ -78,4 +100,4 @@ buildGo124Module rec {
     ];
     license = lib.licenses.agpl3Only;
   };
-}
+})

--- a/pkgs/by-name/go/gotosocial/package.nix
+++ b/pkgs/by-name/go/gotosocial/package.nix
@@ -7,6 +7,7 @@
   yarn,
   yarnConfigHook,
   nixosTests,
+  nix-update-script,
 }:
 buildGo124Module (finalAttrs: {
   pname = "gotosocial";
@@ -82,6 +83,7 @@ buildGo124Module (finalAttrs: {
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   passthru.tests.gotosocial = nixosTests.gotosocial;
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://gotosocial.org";

--- a/pkgs/by-name/go/gotosocial/package.nix
+++ b/pkgs/by-name/go/gotosocial/package.nix
@@ -11,13 +11,13 @@
 }:
 buildGo124Module (finalAttrs: {
   pname = "gotosocial";
-  version = "0.21.1";
+  version = "0.21.2";
 
   src = fetchFromCodeberg {
     owner = "superseriousbusiness";
     repo = "gotosocial";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-LnxEvOLv+NBjdAbxxtilegW/xqBvMzy3CGM75yJsW0s=";
+    hash = "sha256-Z3j5/pXnNTHgBmPEfFgjOJuL03LsPtvAwbuoL9wb5bk=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/go/gotosocial/package.nix
+++ b/pkgs/by-name/go/gotosocial/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGo124Module,
+  buildGo125Module,
   fetchFromCodeberg,
   fetchYarnDeps,
   nodejs,
@@ -9,7 +9,7 @@
   nixosTests,
   nix-update-script,
 }:
-buildGo124Module (finalAttrs: {
+buildGo125Module (finalAttrs: {
   pname = "gotosocial";
   version = "0.21.2";
 


### PR DESCRIPTION
Auto-backport failed in https://github.com/NixOS/nixpkgs/pull/502677#issuecomment-4112258818, this backports https://github.com/NixOS/nixpkgs/pull/495006, https://github.com/NixOS/nixpkgs/pull/496884, https://github.com/NixOS/nixpkgs/pull/502677

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
