### PR TITLE
terminusdb: fix fetchCargoVendor path

### DIFF
--- a/pkgs/by-name/te/terminusdb/package.nix
+++ b/pkgs/by-name/te/terminusdb/package.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix MAKEFLAGS order in vendored tikv-jemalloc-sys
     # TODO: remove when tikv-jemalloc-sys 0.6.2+ is released
     # equivalent to https://github.com/tikv/jemallocator/pull/152
-    substituteInPlace $cargoDepsCopy/tikv-jemalloc-sys-*/build.rs \
+    substituteInPlace $cargoDepsCopy/*/tikv-jemalloc-sys-*/build.rs \
       --replace-fail 'format!("{orig_makeflags} {makeflags}")' \
                      'format!("{makeflags} {orig_makeflags}")'
   '';


### PR DESCRIPTION
#387337 changed the directory layout of `cargoDeps` such that the vendored dependencies are split by dependency source (e.g., `source-git-0`, `source-git-1`, `source-registry-0`).

This fixes the build of `terminusdb`.

Hydra: https://hydra.nixos.org/build/324679189/nixlog/2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
