### PR TITLE
git-branchless: fix fetchCargoVendor path, add version check, fix license

### DIFF
--- a/pkgs/by-name/gi/git-branchless/package.nix
+++ b/pkgs/by-name/gi/git-branchless/package.nix
@@ -75,7 +75,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Suite of tools to help you visualize, navigate, manipulate, and repair your commit history";
     homepage = "https://github.com/arxanas/git-branchless";
-    license = lib.licenses.gpl2Only;
+    license = [
+      lib.licenses.asl20
+      lib.licenses.mit
+    ];
     mainProgram = "git-branchless";
     maintainers = with lib.maintainers; [
       nh2

--- a/pkgs/by-name/gi/git-branchless/package.nix
+++ b/pkgs/by-name/gi/git-branchless/package.nix
@@ -8,6 +8,7 @@
   rustPlatform,
   sqlite,
   stdenv,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -66,6 +67,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=test_next_ambiguous_interactive"
     "--skip=test_switch_auto_switch_interactive"
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   meta = {
     description = "Suite of tools to help you visualize, navigate, manipulate, and repair your commit history";

--- a/pkgs/by-name/gi/git-branchless/package.nix
+++ b/pkgs/by-name/gi/git-branchless/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # - https://github.com/facebook/sapling/commit/9e27acb84605079bf4e305afb637a4d6801831ac
   postPatch = ''
     (
-      cd ../git-branchless-*-vendor/esl01-indexedlog-*/
+      cd $cargoDepsCopy/*/esl01-indexedlog-*/
       patch -p1 < ${./fix-esl01-indexedlog-for-rust-1_89.patch}
     )
   '';


### PR DESCRIPTION
- Fix the build of `git-branchless`
  - #387337 changed the directory layout of `cargoDeps` such that the vendored dependencies are split by dependency source (e.g., `source-git-0`, `source-git-1`, `source-registry-0`).
- Add `versionCheckHook` as a minimal smoke test for the package
- Fix `meta.license`
  - https://github.com/arxanas/git-branchless/pull/841
  - https://github.com/arxanas/git-branchless/blob/v0.10.0/LICENSE-APACHE
  - https://github.com/arxanas/git-branchless/blob/v0.10.0/LICENSE-MIT

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
