### PR TITLE
nixos/test-driver: fix testScript regressions

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -244,6 +244,8 @@ class Driver:
             serial_stdout_on=self.serial_stdout_on,
             polling_condition=self.polling_condition,
             BaseMachine=BaseMachine,  # for typing
+            QemuMachine=QemuMachine,  # for typing
+            NspawnMachine=NspawnMachine,  # for typing
             t=AssertionTester(),
             debug=self.debug,
         )

--- a/nixos/lib/test-driver/src/test_driver/driver.py
+++ b/nixos/lib/test-driver/src/test_driver/driver.py
@@ -228,6 +228,7 @@ class Driver:
         general_symbols = dict(
             start_all=self.start_all,
             test_script=self.test_script,
+            machines=self.machines,
             machines_qemu=self.machines_qemu,
             machines_nspawn=self.machines_nspawn,
             vlans=self.vlans,

--- a/nixos/lib/test-script-prepend.py
+++ b/nixos/lib/test-script-prepend.py
@@ -45,6 +45,8 @@ subtest: Callable[[str], ContextManager[None]]
 retry: RetryProtocol
 test_script: Callable[[], None]
 machines: List[BaseMachine]
+machines_qemu: List[QemuMachine]
+machines_nspawn: List[NspawnMachine]
 vlans: List[VLan]
 driver: Driver
 log: AbstractLogger

--- a/nixos/tests/garage/common.nix
+++ b/nixos/tests/garage/common.nix
@@ -21,14 +21,14 @@
          node_id: str
          host: str
 
-      def get_node_fqn(machine: Machine) -> GarageNode:
+      def get_node_fqn(machine: BaseMachine) -> GarageNode:
         node_id, host = machine.succeed("garage node id").split('@')
         return GarageNode(node_id=node_id, host=host)
 
-      def get_node_id(machine: Machine) -> str:
+      def get_node_id(machine: BaseMachine) -> str:
         return get_node_fqn(machine).node_id
 
-      def get_layout_version(machine: Machine) -> int:
+      def get_layout_version(machine: BaseMachine) -> int:
         version_data = machine.succeed("garage layout show")
         m = cur_version_regex.search(version_data)
         if m and m.group('ver') is not None:
@@ -36,17 +36,17 @@
         else:
           raise ValueError('Cannot find current layout version')
 
-      def apply_garage_layout(machine: Machine, layouts: List[str]):
+      def apply_garage_layout(machine: BaseMachine, layouts: List[str]):
          for layout in layouts:
             machine.succeed(f"garage layout assign {layout}")
          version = get_layout_version(machine)
          machine.succeed(f"garage layout apply --version {version}")
 
-      def create_api_key(machine: Machine, key_name: str) -> S3Key:
+      def create_api_key(machine: BaseMachine, key_name: str) -> S3Key:
          output = machine.succeed(f"garage key create {key_name}")
          return parse_api_key_data(output)
 
-      def get_api_key(machine: Machine, key_pattern: str) -> S3Key:
+      def get_api_key(machine: BaseMachine, key_pattern: str) -> S3Key:
          output = machine.succeed(f"garage key info {key_pattern}")
          return parse_api_key_data(output)
 

--- a/nixos/tests/incus/incus_machine.py
+++ b/nixos/tests/incus/incus_machine.py
@@ -1,7 +1,7 @@
 import json
 
 
-class IncusHost(Machine):
+class IncusHost(QemuMachine):
     def __init__(self, base):
         with subtest("Wait for startup"):
             base.wait_for_unit("incus.service")

--- a/nixos/tests/networking-proxy.nix
+++ b/nixos/tests/networking-proxy.nix
@@ -72,7 +72,7 @@ in
     from typing import Dict, Optional
 
 
-    def get_machine_env(machine: Machine, user: Optional[str] = None) -> Dict[str, str]:
+    def get_machine_env(machine: BaseMachine, user: Optional[str] = None) -> Dict[str, str]:
         """
         Gets the environment from a given machine, and returns it as a
         dictionary in the form:

--- a/nixos/tests/pacemaker.nix
+++ b/nixos/tests/pacemaker.nix
@@ -86,7 +86,7 @@ rec {
         output = node1.succeed("crm_resource -r cat --locate")
         match = re.search("is running on: (.+)", output)
         if match:
-          for machine in machines:
+          for machine in machines_qemu:
             if machine.name == match.group(1):
               current_node = machine
           break
@@ -96,7 +96,7 @@ rec {
       current_node.crash()
 
       # pick another node that's still up
-      for machine in machines:
+      for machine in machines_qemu:
         if machine.booted:
           check_node = machine
       # find where the service has been started next
@@ -105,7 +105,7 @@ rec {
         match = re.search("is running on: (.+)", output)
         # output will remain the old current_node until the crash is detected by pacemaker
         if match and match.group(1) != current_node.name:
-          for machine in machines:
+          for machine in machines_qemu:
             if machine.name == match.group(1):
               next_node = machine
           break

--- a/nixos/tests/password-option-override-ordering.nix
+++ b/nixos/tests/password-option-override-ordering.nix
@@ -112,22 +112,22 @@ in
       assert stored_hash == pass_hash, f"{username} user password does not match"
 
     with subtest("alice user has correct password"):
-      for machine in machines:
+      for machine in machines_qemu:
         assert_password_sha512crypt_match(machine, "alice", "${password1}")
         assert "${hashed_sha512crypt}" not in machine.succeed("getent shadow alice"), f"{machine}: alice user password is not correct"
 
     with subtest("bob user has correct password"):
-      for machine in machines:
+      for machine in machines_qemu:
         print(machine.succeed("getent shadow bob"))
         assert "${hashed_bcrypt}" in machine.succeed("getent shadow bob"), f"{machine}: bob user password is not correct"
 
     with subtest("cat user has correct password"):
-      for machine in machines:
+      for machine in machines_qemu:
         print(machine.succeed("getent shadow cat"))
         assert "${hashed_bcrypt}" in machine.succeed("getent shadow cat"), f"{machine}: cat user password is not correct"
 
     with subtest("dan user has correct password"):
-      for machine in machines:
+      for machine in machines_qemu:
         print(machine.succeed("getent shadow dan"))
         assert "${hashed_bcrypt}" in machine.succeed("getent shadow dan"), f"{machine}: dan user password is not correct"
 
@@ -138,11 +138,11 @@ in
       assert_password_sha512crypt_match(immutable, "greg", "${password1}")
       assert "${hashed_sha512crypt}" not in immutable.succeed("getent shadow greg"), "greg user password is not correct"
 
-    for machine in machines:
+    for machine in machines_qemu:
       machine.wait_for_unit("multi-user.target")
       machine.wait_until_succeeds("pgrep -f 'agetty.*tty1'")
 
-    def check_login(machine: Machine, tty_number: str, username: str, password: str):
+    def check_login(machine: QemuMachine, tty_number: str, username: str, password: str):
       machine.send_key(f"alt-f{tty_number}")
       machine.wait_until_succeeds(f"[ $(fgconsole) = {tty_number} ]")
       machine.wait_for_unit(f"getty@tty{tty_number}.service")
@@ -158,11 +158,11 @@ in
       assert username in machine.succeed(f"cat /tmp/{tty_number}"), f"{machine}: {username} password is not correct"
 
     with subtest("Test initialPassword override"):
-      for machine in machines:
+      for machine in machines_qemu:
         check_login(machine, "2", "egon", "${password1}")
 
     with subtest("Test initialHashedPassword override"):
-      for machine in machines:
+      for machine in machines_qemu:
         check_login(machine, "3", "fran", "meow")
   '';
 }

--- a/nixos/tests/rtkit.nix
+++ b/nixos/tests/rtkit.nix
@@ -103,7 +103,7 @@
       Result = namedtuple("Result", ["command", "machine", "status", "out", "value"])
       Value = namedtuple("Value", ["type", "data"])
 
-      def busctl(node: Machine, *args: Any, user: Optional[str] = None) -> Result:
+      def busctl(node: BaseMachine, *args: Any, user: Optional[str] = None) -> Result:
           command = f"busctl --json=short {shlex.join(map(str, args))}"
           if user is not None:
               command = f"su - {user} -c {shlex.quote(command)}"
@@ -121,7 +121,7 @@
           if result.status == 0:
               raise Exception(f"command `{result.command}` unexpectedly succeeded")
 
-      def rtkit_make_process_realtime(node: Machine, pid: int, priority: int, user: Optional[str] = None) -> Result:
+      def rtkit_make_process_realtime(node: BaseMachine, pid: int, priority: int, user: Optional[str] = None) -> Result:
           return busctl(node, "call", "org.freedesktop.RealtimeKit1", "/org/freedesktop/RealtimeKit1", "org.freedesktop.RealtimeKit1", "MakeThreadRealtimeWithPID", "ttu", pid, 0, priority, user=user)
 
       def get_max_realtime_priority() -> int:
@@ -133,7 +133,7 @@
       def parse_chrt(out: str, field: str) -> str:
           return next(map(lambda l: l.split(": ")[1], filter(lambda l: field in l, out.splitlines())))
 
-      def get_pid(node: Machine, unit: str, user: Optional[str] = None) -> int:
+      def get_pid(node: BaseMachine, unit: str, user: Optional[str] = None) -> int:
           node.wait_for_unit(unit, user=user)
           (status, out) = node.systemctl(f"show -P MainPID {unit}", user=user)
           if status == 0:
@@ -142,7 +142,7 @@
               node.log(out)
               raise Exception(f"unable to determine MainPID of {unit} (systemctl exit code {status})")
 
-      def assert_sched(node: Machine, pid: int, policy: Optional[str] = None, priority: Optional[int] = None):
+      def assert_sched(node: BaseMachine, pid: int, policy: Optional[str] = None, priority: Optional[int] = None):
           out = node.succeed(f"chrt -p {pid}")
           node.log(out)
           if policy is not None:

--- a/nixos/tests/systemd-journal-upload.nix
+++ b/nixos/tests/systemd-journal-upload.nix
@@ -72,7 +72,7 @@
     server.wait_for_unit("multi-user.target")
     client.wait_for_unit("multi-user.target")
 
-    def copy_pems(machine: Machine, domain: str):
+    def copy_pems(machine: BaseMachine, domain: str):
       machine.succeed("mkdir /run/secrets")
       machine.copy_from_host(
         source=f"{tmpdir}/{domain}/cert.pem",


### PR DESCRIPTION
#478109 introduced some regressions due to breaking changes in the types and symbols provided to lint the test script: https://github.com/NixOS/nixpkgs/pull/478109#issuecomment-4108560093

This PR addresses the commonalities between these regressions by providing a generic `machines` variable to the test script and using the new types (`BaseMachine`, or more specifically `QemuMachine`) where necessary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
