### PR TITLE
simulide: migrate versions to wrappers

### DIFF
--- a/pkgs/by-name/si/simulide_0_4_15/package.nix
+++ b/pkgs/by-name/si/simulide_0_4_15/package.nix
@@ -1,0 +1,7 @@
+{
+  simulide,
+}:
+
+simulide.override {
+  versionNum = "0.4.15";
+}

--- a/pkgs/by-name/si/simulide_1_0_0/package.nix
+++ b/pkgs/by-name/si/simulide_1_0_0/package.nix
@@ -1,0 +1,8 @@
+{
+  simulide,
+}:
+
+simulide.override {
+  versionNum = "1.0.0";
+
+}

--- a/pkgs/by-name/si/simulide_1_1_0/package.nix
+++ b/pkgs/by-name/si/simulide_1_1_0/package.nix
@@ -1,0 +1,7 @@
+{
+  simulide,
+}:
+
+simulide.override {
+  versionNum = "1.1.0";
+}

--- a/pkgs/by-name/si/simulide_1_2_0/package.nix
+++ b/pkgs/by-name/si/simulide_1_2_0/package.nix
@@ -1,0 +1,7 @@
+{
+  simulide,
+}:
+
+simulide.override {
+  versionNum = "1.2.0";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11796,11 +11796,6 @@ with pkgs;
 
   ### SCIENCE / ELECTRONICS
 
-  simulide_0_4_15 = callPackage ../by-name/si/simulide/package.nix { versionNum = "0.4.15"; };
-  simulide_1_0_0 = callPackage ../by-name/si/simulide/package.nix { versionNum = "1.0.0"; };
-  simulide_1_1_0 = callPackage ../by-name/si/simulide/package.nix { versionNum = "1.1.0"; };
-  simulide_1_2_0 = callPackage ../by-name/si/simulide/package.nix { versionNum = "1.2.0"; };
-
   eagle = libsForQt5.callPackage ../applications/science/electronics/eagle/eagle.nix { };
 
   degate = libsForQt5.callPackage ../applications/science/electronics/degate { };


### PR DESCRIPTION

This pull request refactors the way different versions of the `simulide` package are defined and included in the package set. Instead of defining version-specific variants in the main `all-packages.nix` file, each version now has its own dedicated package file, simplifying maintenance and improving clarity.

**Refactoring and modularization of `simulide` package versions:**

* Added new package files for each version of `simulide` (`0.4.15`, `1.0.0`, `1.1.0`, `1.2.0`) in the `pkgs/by-name/si/` directory, each overriding the base `simulide` package with the appropriate version and name.

* Removed the direct version-specific `simulide` package definitions from `pkgs/top-level/all-packages.nix`, likely in preparation for referencing the new modular package files elsewhere.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
