### PR TITLE
nexttrace: 1.5.0 -> 1.6.1

### DIFF
--- a/pkgs/by-name/ne/nexttrace/package.nix
+++ b/pkgs/by-name/ne/nexttrace/package.nix
@@ -7,15 +7,15 @@
 
 buildGoModule (finalAttrs: {
   pname = "nexttrace";
-  version = "1.5.0";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "nxtrace";
     repo = "NTrace-core";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-Ui3Vm9Q6VJXW9hGDFCuOCUmoSO8SE5ufRYq0niY6ojo=";
+    sha256 = "sha256-EKsOPE5EGkUtgNIf60ojvMJfZwtSwDzVDDEeKPBLWhY=";
   };
-  vendorHash = "sha256-8KxY3KYcaaZZjk+IIKdu8tzGhgGUlJ5nyMMSKhe41kg=";
+  vendorHash = "sha256-fUM2mWbol1lM6moygeCFiGHyYZfaVzz6edZM6zoGrSg=";
 
   buildInputs = [ libpcap ];
 
@@ -25,7 +25,6 @@ buildGoModule (finalAttrs: {
     "-s"
     "-w"
     "-X github.com/nxtrace/NTrace-core/config.Version=v${finalAttrs.version}"
-    "-checklinkname=0" # refers to https://github.com/nxtrace/NTrace-core/issues/247
   ];
 
   postInstall = ''
@@ -34,7 +33,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Open source visual route tracking CLI tool";
-    homepage = "https://mtr.moe";
+    homepage = "https://www.nxtrace.org/";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ sharzy ];
     mainProgram = "nexttrace";


### PR DESCRIPTION
Diff: https://github.com/nxtrace/NTrace-core/compare/v1.5.0...v1.6.1
Changelog: https://github.com/nxtrace/NTrace-core/releases/tag/v1.6.1

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
