### PR TITLE
[25.11] fmt_12: 12.0.0 -> 12.1.0

### DIFF
--- a/pkgs/development/libraries/fmt/default.nix
+++ b/pkgs/development/libraries/fmt/default.nix
@@ -99,7 +99,7 @@ in
   };
 
   fmt_12 = generic {
-    version = "12.0.0";
-    hash = "sha256-AZDmIeU1HbadC+K0TIAGogvVnxt0oE9U6ocpawIgl6g=";
+    version = "12.1.0";
+    hash = "sha256-ZmI1Dv0ZabPlxa02OpERI47jp7zFfjpeWCy1WyuPYZ0=";
   };
 }


### PR DESCRIPTION
## Description

Backport of #473178 (commit c0d952e0dbf3) to `release-25.11`.

Update `fmt_12` from 12.0.0 to 12.1.0. This fixes a clang-tidy failure when processing files that include `fmt/std.h` with clang 19+ ([fmtlib/fmt#4552](https://github.com/fmtlib/fmt/issues/4552)).

Changelog: https://github.com/fmtlib/fmt/releases/tag/12.1.0

## Things done

- [x] Built on x86_64-linux
- [x] All 21 upstream tests pass
- [x] Verified commit exists on `master`