### PR TITLE
shed: init at 2025.6.1

### DIFF
--- a/pkgs/by-name/co/com2ann/package.nix
+++ b/pkgs/by-name/co/com2ann/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.com2ann

--- a/pkgs/by-name/sh/shed/package.nix
+++ b/pkgs/by-name/sh/shed/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  git,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "shed";
+  version = "2025.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Zac-HD";
+    repo = "shed";
+    tag = finalAttrs.version;
+    hash = "sha256-VF9AsF+hEO4W2lsuZvPQRtJGx2NcRQqjiijSWgQ9kVo=";
+  };
+
+  postUnpack = ''
+    # Tests depend on the source being in a directory named `shed`
+    mv "$sourceRoot" shed
+    sourceRoot=shed
+  '';
+
+  build-system = with python3Packages; [ setuptools ];
+  dependencies = with python3Packages; [
+    black
+    com2ann
+    libcst
+    pyupgrade
+    ruff
+  ];
+
+  nativeCheckInputs =
+    (with python3Packages; [
+      pytestCheckHook
+      pytest-cov
+      flake8-comprehensions
+      hypothesis
+      hypothesmith
+      ruff
+    ])
+    ++ [ git ];
+  preCheck = ''
+    git -c advice.defaultBranchName=false init
+  '';
+  disabledTests = [
+    # Formatting differs with current versions of dependencies.
+    "test_saved_examples[C413-"
+  ];
+  pythonImportsCheck = [ "shed" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Canonicalises Python code";
+    homepage = "https://github.com/Zac-HD/shed";
+    changelog = "https://github.com/Zac-HD/shed/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "shed";
+    maintainers = with lib.maintainers; [ winter ];
+  };
+})

--- a/pkgs/development/python-modules/com2ann/default.nix
+++ b/pkgs/development/python-modules/com2ann/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "com2ann";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ilevkivskyi";
+    repo = "com2ann";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-f84IXuA6d9TPBWUyxxr4NYjf7a5MUKbY59ne3K2Yx1s=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "com2ann" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for translation type comments to type annotations in Python";
+    homepage = "https://github.com/ilevkivskyi/com2ann";
+    license = lib.licenses.mit;
+    mainProgram = "com2ann";
+    maintainers = with lib.maintainers; [ winter ];
+  };
+})

--- a/pkgs/development/python-modules/flake8-comprehensions/default.nix
+++ b/pkgs/development/python-modules/flake8-comprehensions/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  flake8,
+  pytestCheckHook,
+  pytest-flake8-path,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "flake8-comprehensions";
+  version = "3.17.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "adamchainz";
+    repo = "flake8-comprehensions";
+    tag = finalAttrs.version;
+    hash = "sha256-czSMAUO+dOC3WNQi/P8duu/wlNtiPlRpI65VZ8wOfSc=";
+  };
+
+  build-system = [ setuptools ];
+  dependencies = [ flake8 ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-flake8-path
+  ];
+  pythonImportsCheck = [ "flake8_comprehensions" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "flake8 plugin to help you write better list/set/dict comprehensions";
+    homepage = "https://github.com/adamchainz/flake8-comprehensions";
+    changelog = "https://github.com/adamchainz/flake8-comprehensions/blob/${finalAttrs.version}/CHANGELOG.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ winter ];
+  };
+})

--- a/pkgs/development/python-modules/pytest-flake8-path/default.nix
+++ b/pkgs/development/python-modules/pytest-flake8-path/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  flake8,
+  pytestCheckHook,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytest-flake8-path";
+  version = "1.7.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "adamchainz";
+    repo = "pytest-flake8-path";
+    tag = finalAttrs.version;
+    hash = "sha256-YdXrFz4yOL37e7wtfxcjNfeL54WQTa4a61qF2kuoNBU=";
+  };
+
+  build-system = [ setuptools ];
+  dependencies = [ flake8 ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "pytest_flake8_path" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "pytest fixture for testing flake8 plugins";
+    homepage = "https://github.com/adamchainz/pytest-flake8-path";
+    changelog = "https://github.com/adamchainz/pytest-flake8-path/blob/main/CHANGELOG.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ winter ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15266,6 +15266,8 @@ self: super: with self; {
 
   pytest-flake8 = callPackage ../development/python-modules/pytest-flake8 { };
 
+  pytest-flake8-path = callPackage ../development/python-modules/pytest-flake8-path { };
+
   pytest-flakes = callPackage ../development/python-modules/pytest-flakes { };
 
   pytest-flask = callPackage ../development/python-modules/pytest-flask { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5579,6 +5579,8 @@ self: super: with self; {
 
   flake8-class-newline = callPackage ../development/python-modules/flake8-class-newline { };
 
+  flake8-comprehensions = callPackage ../development/python-modules/flake8-comprehensions { };
+
   flake8-debugger = callPackage ../development/python-modules/flake8-debugger { };
 
   flake8-deprecated = callPackage ../development/python-modules/flake8-deprecated { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3068,6 +3068,8 @@ self: super: with self; {
 
   columnize = callPackage ../development/python-modules/columnize { };
 
+  com2ann = callPackage ../development/python-modules/com2ann { };
+
   comet-ml = callPackage ../development/python-modules/comet-ml { };
 
   cometblue-lite = callPackage ../development/python-modules/cometblue-lite { };


### PR DESCRIPTION
[`shed`](https://github.com/Zac-HD/shed) canonicalizes Python code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
