### PR TITLE
linuxPackages.nvidiaPackages.production: 580.142 -> 595.58.03

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -135,6 +135,8 @@
 
 - `n8n` has been updated to version 2. You can find the breaking changes here: https://docs.n8n.io/2-0-breaking-changes/.
 
+- The default NVIDIA drivers no longer support Maxwell (GTX 1xxx) or older GPUs. Pin the nvidia package to ` config.boot.kernelPackages.nvidiaPackages.legacy_580` for continued support.
+
 - `gurk-rs` has been updated from `0.6.4` to `0.8.0`. Version `0.8.0` includes breaking changes. For more information read the [release notes for 0.8.0](https://github.com/boxdot/gurk-rs/releases/tag/v0.8.0).
 
 - `iroh` has been removed and split up into `iroh-dns-server` and `iroh-relay`.

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -77,12 +77,12 @@ rec {
   stable = if stdenv.hostPlatform.system == "i686-linux" then legacy_390 else production;
 
   production = generic {
-    version = "580.142";
-    sha256_64bit = "sha256-IJFfzz/+icNVDPk7YKBKKFRTFQ2S4kaOGRGkNiBEdWM=";
-    sha256_aarch64 = "sha256-jntr88SpTYR648P1rizQjB/8KleBoa14Ay12vx8XETM=";
-    openSha256 = "sha256-v968LbRqy8jB9+yHy9ceP2TDdgyqfDQ6P41NsCoM2AY=";
-    settingsSha256 = "sha256-BnrIlj5AvXTfqg/qcBt2OS9bTDDZd3uhf5jqOtTMTQM=";
-    persistencedSha256 = "sha256-il403KPFAnDbB+dITnBGljhpsUPjZwmLjGt8iPKuBqw=";
+    version = "595.58.03";
+    sha256_64bit = "sha256-jA1Plnt5MsSrVxQnKu6BAzkrCnAskq+lVRdtNiBYKfk=";
+    sha256_aarch64 = "sha256-hzzIKY1Te8QkCBWR+H5k1FB/HK1UgGhai6cl3wEaPT8=";
+    openSha256 = "sha256-6LvJyT0cMXGS290Dh8hd9rc+nYZqBzDIlItOFk8S4n8=";
+    settingsSha256 = "sha256-2vLF5Evl2D6tRQJo0uUyY3tpWqjvJQ0/Rpxan3NOD3c=";
+    persistencedSha256 = "sha256-AtjM/ml/ngZil8DMYNH+P111ohuk9mWw5t4z7CHjPWw=";
   };
 
   latest = selectHighestVersion production (generic {

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -157,6 +157,16 @@ rec {
   # If you add a legacy driver here, also update `top-level/linux-kernels.nix`,
   # adding to the `nvidia_x11_legacy*` entries.
 
+  # LTSB supported until Aug 2028
+  legacy_580 = generic {
+    version = "580.142";
+    sha256_64bit = "sha256-IJFfzz/+icNVDPk7YKBKKFRTFQ2S4kaOGRGkNiBEdWM=";
+    sha256_aarch64 = "sha256-jntr88SpTYR648P1rizQjB/8KleBoa14Ay12vx8XETM=";
+    openSha256 = "sha256-v968LbRqy8jB9+yHy9ceP2TDdgyqfDQ6P41NsCoM2AY=";
+    settingsSha256 = "sha256-BnrIlj5AvXTfqg/qcBt2OS9bTDDZd3uhf5jqOtTMTQM=";
+    persistencedSha256 = "sha256-il403KPFAnDbB+dITnBGljhpsUPjZwmLjGt8iPKuBqw=";
+  };
+
   # Last one without the bug reported here:
   # https://bbs.archlinux.org/viewtopic.php?pid=2155426#p2155426
   legacy_535 = generic {


### PR DESCRIPTION
- Highlights since R595 Beta Release, 595.45.04
  - Fixed a regression introduced in the 580.119.02 driver release which caused some X11 compositors (e.g. picom, Xfwm) to blink:
    - https://github.com/NVIDIA/open-gpu-kernel-modules/issues/986        
    - https://github.com/yshui/picom/issues/1488
  - Fixed a bug that would prevent kwin_wayland from being able to wake up display under certain scenarios.
    - https://forums.developer.nvidia.com/t/bug-external-monitor-fails-to-wake-up-from-powersave-mode-if-refresh-rate-is-higher-than-30hz/316612        
  - Fixed a bug that causes a kernel crash when display docks or other DisplayPort MST configurations are disconnected from the GPU.
    - https://forums.developer.nvidia.com/t/kernel-null-pointer-dereference-in-nvidia-modeset-during-thunderbolt-dock-disconnect/359280        
  - Fixed a bug that caused kernel panics on Linux kernels configured with CONFIG_RANDSTRUCT_FULL or CONFIG_RANDSTRUCT_PERFORMANCE:
    - https://github.com/NVIDIA/open-gpu-kernel-modules/issues/1033        
  - Improved support for falling back to system memory when available video memory is low, to help prevent Wayland desktop freezes.
  - Fixed a bug that caused nvidia-drm to report errors in the system log and fail to enumerate connectors on some DisplayPort MST configurations.
  - Fixed a bug that could cause a kernel crash on driver initialization on some DisplayPort MST configurations.
  - Fixed a regression introduced in the 575.xx driver series which prevented EGL-X11 applications from starting on SLI Mosaic.
  - Fixed a bug that could cause flickering in VRR on some HDMI displays.
  - Fixed a regression, introduced after the 470.xx release series, that could cause four 4k monitors, driven as separate X11 X screens on one GPU, to fail modeset.
  - Fixed kernel module build issue with Linux kernel v6.19.
  - Fixed a bug that could cause an Xid error to be reported in the system log, along with a VK_DEVICE_LOST API error, when repeatedly resizing Vulkan application windows.
- Highlights from R595 Beta Release, 595.45.04
  - Added support for the VK_EXT_descriptor_heap extension.
  - Fixed a bug that caused GPU hangs and Xid errors in Black Myth: Wukong.
  - Added support for DRI3 version 1.2.
  - Added support for the VK_EXT_present_timing extension.
  - Fixed hang when NVIDIA Smooth Motion is enabled in applications that use VK_KHR_present_id2.
  - Modified nvidia.ko to handle video memory preservation on its own when the open kernel modules are in use if NVreg_UseKernelSuspendNotifiers=1 is enabled. When the proprietary driver is in use, or if kernel suspend notifiers are disabled, video memory preservation requires using the /proc/driver/nvidia/suspend interface for suspend and resume notifications.
  - See the chapter titled "Configuring Power Management Support" in the README for more information.
  - Enabled the nvidia-drm.ko modeset=1 parameter by default.
  - Updated the driver to allow nvidia-smi to reset GPUs while nvidia-drm is loaded with the modeset=1 parameter enabled, as long as no other processes are using the GPU.
  - Added a new application profile - CudaNoStablePerfLimit - that allows CUDA-using apps to reach P0 PState. See the 'Application Profiles' appendix of the driver README for details.
  - Raised the minimum supported Wayland version to 1.20.
  - Fixed a bug that prevented the PowerMizer preferred mode dropdown menu in the nvidia-settings control panel from functioning correctly on Wayland.
  - Raised the minimum supported glibc version to 2.27.
  - Improved the performance of recreating Vulkan swapchains. This helps prevent stuttering when resizing Vulkan application windows.
  - Raised the minimum supported X.Org xserver version to 1.17 (video driver ABI version 19).
  - Fixed a bug that caused adaptive sync displays to go blank when connected with an active USB-C-to-HDMI adapter.
  - Fixed a bug that could cause Vulkan swapchains to stop presenting new frames on X11.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
