### PR TITLE
python3Packages.translatehtml: 1.5.2 -> 1.5.3; modernize; disable aarch64 tests

### DIFF
--- a/pkgs/development/python-modules/argos-translate-files/default.nix
+++ b/pkgs/development/python-modules/argos-translate-files/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
@@ -11,6 +12,10 @@
   translatehtml,
 }:
 
+let
+  inherit (stdenv.hostPlatform) isLinux isAarch64;
+  isAarch64Linux = isLinux && isAarch64;
+in
 buildPythonPackage (finalAttrs: {
   pname = "argos-translate-files";
   version = "1.4.4";
@@ -43,15 +48,16 @@ buildPythonPackage (finalAttrs: {
     translatehtml
   ];
 
-  doCheck = true;
-
   nativeCheckInputs = [
     pytestCheckHook
     # pythonImportsCheck needs a home dir for argostranslatefiles
     writableTmpDirAsHomeHook
   ];
 
-  pythonImportsCheck = [ "argostranslatefiles" ];
+  # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox:
+  # terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
+  pythonImportsCheck = lib.optional (!isAarch64Linux) "argostranslatefiles";
+  doCheck = !isAarch64Linux;
 
   meta = {
     description = "Translate files using Argos Translate";

--- a/pkgs/development/python-modules/libretranslate/default.nix
+++ b/pkgs/development/python-modules/libretranslate/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   pkgs,
   buildPythonPackage,
   fetchFromGitHub,
@@ -32,6 +33,10 @@
   lndir,
 }:
 
+let
+  inherit (stdenv.hostPlatform) isLinux isAarch64;
+  isAarch64Linux = isLinux && isAarch64;
+in
 buildPythonPackage (finalAttrs: {
   pname = "libretranslate";
   version = "1.9.5";
@@ -90,7 +95,11 @@ buildPythonPackage (finalAttrs: {
 
   # needed to import the argostranslate module
   nativeCheckInputs = [ writableTmpDirAsHomeHook ];
-  pythonImportsCheck = [ "libretranslate" ];
+
+  # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox:
+  # terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
+  pythonImportsCheck = lib.optional (!isAarch64Linux) "libretranslate";
+  doCheck = !isAarch64Linux;
 
   passthru = {
     static-compressed =

--- a/pkgs/development/python-modules/translatehtml/default.nix
+++ b/pkgs/development/python-modules/translatehtml/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   writableTmpDirAsHomeHook,
@@ -8,6 +9,10 @@
   beautifulsoup4,
 }:
 
+let
+  inherit (stdenv.hostPlatform) isLinux isAarch64;
+  isAarch64Linux = isLinux && isAarch64;
+in
 buildPythonPackage (finalAttrs: {
   pname = "translatehtml";
   version = "1.5.3";
@@ -29,8 +34,11 @@ buildPythonPackage (finalAttrs: {
     beautifulsoup4
   ];
 
-  pythonImportsCheck = [ "translatehtml" ];
+  # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox:
+  # terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
+  pythonImportsCheck = lib.optional (!isAarch64Linux) "translatehtml";
   nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+  doCheck = !isAarch64Linux;
 
   meta = {
     description = "Translate HTML using Beautiful Soup and Argos Translate";

--- a/pkgs/development/python-modules/translatehtml/default.nix
+++ b/pkgs/development/python-modules/translatehtml/default.nix
@@ -1,49 +1,36 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  fetchpatch,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+  setuptools,
   argostranslate,
   beautifulsoup4,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "translatehtml";
-  version = "1.5.2";
+  version = "1.5.3";
+  pyproject = true;
 
-  format = "setuptools";
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "6b30ceb8b6f174917e2660caf2d2ccbaa71d8d24c815316edf56b061d678820d";
+  src = fetchFromGitHub {
+    owner = "argosopentech";
+    repo = "translate-html";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-A94N/nfYSVwi0M3SpNFqlXrRNOCpIi9agOCAlH66QcI=";
   };
 
-  patches = [
-    # https://github.com/argosopentech/translate-html/pull/15
-    (fetchpatch {
-      url = "https://github.com/argosopentech/translate-html/commit/b1c2d210ec1b5fcd0eb79f578bdb5d3ed5c9963a.patch";
-      hash = "sha256-U65vVuRodMS32Aw6PZlLwaCos51P5B88n5hDgJNMZXU=";
-    })
-  ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  pythonRelaxDeps = [ "beautifulsoup4" ];
+
+  dependencies = [
     argostranslate
     beautifulsoup4
   ];
 
-  postPatch = ''
-    ln -s */requires.txt requirements.txt
-
-    substituteInPlace requirements.txt  \
-      --replace "==" ">="
-  '';
-
-  # required for import check to work (argostranslate)
-  env.HOME = "/tmp";
-
   pythonImportsCheck = [ "translatehtml" ];
-
-  doCheck = false; # no tests
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
   meta = {
     description = "Translate HTML using Beautiful Soup and Argos Translate";
@@ -51,4 +38,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ misuzu ];
   };
-}
+})


### PR DESCRIPTION
- Update translatehtml from 1.5.2 -> 1.5.3, modernize the package a bit, and fetch from GitHub instead of pypi.
- Disable the checks on aarch64-linux to fix the remaining build failures in https://github.com/NixOS/nixpkgs/pull/501733#issuecomment-4114371575. These are all caused by a bug in onnxruntime (https://github.com/microsoft/onnxruntime/issues/10038), see https://github.com/NixOS/nixpkgs/pull/481039 for context.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test