### PR TITLE
waves: 0.1.42 -> 0.1.43

### DIFF
--- a/pkgs/by-name/wa/waves/package.nix
+++ b/pkgs/by-name/wa/waves/package.nix
@@ -10,13 +10,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "waves";
-  version = "0.1.42";
+  version = "0.1.43";
 
   src = fetchFromGitHub {
     owner = "llehouerou";
     repo = "waves";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-UReEoPXVGwBpWs53Dk8iWn2el2+/9PMAJ5KW4M9FjnA=";
+    hash = "sha256-mHA96EijTTUY2yfG5BMnC8NrcpOk4f9QYTTfTL5v93g=";
   };
 
   vendorHash = "sha256-mUifSJ8IalfzqQHeDpFp0jbtZDr7OWPq16st9RJVu7U=";


### PR DESCRIPTION
waves: 0.1.42 -> 0.1.43

[Changelog](https://github.com/llehouerou/waves/releases/tag/v0.1.43)

Show error messages when f-sequence services aren't configured, fix export selection in library browser mode, and add FreeBSD support for Last.fm scrobbling and MPRIS/notifications.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [Built, ran and tested locally](https://nixos.org/manual/nixpkgs/unstable/#sec-building-simple)
- For new packages:
  - [ ] Added to `pkgs/by-name`
- [x] Determined the impact on dependent packages (e.g. by running `nix-build -A nixosTests`)
- [x] Ensured that relevant tests pass with: `nix-build -A tests.waves` or `nix-build -A nixosTests.waves`
- [x] Verified the [code] is in good shape