### PR TITLE
proton-vpn-cli: 0.1.6 -> 0.1.9, python3Packages.proton-vpn-api-core: 4.16.0 -> 4.18.0

### DIFF
--- a/pkgs/by-name/pr/proton-vpn-cli/package.nix
+++ b/pkgs/by-name/pr/proton-vpn-cli/package.nix
@@ -9,14 +9,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "proton-vpn-cli";
-  version = "0.1.6";
+  version = "0.1.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "proton-vpn-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Gx+Jy8oKj7gDqI2MKl7Q5wPpPQXODTMulgSlsqCo9bY=";
+    hash = "sha256-rve97cy4VwZmzZXXj3OiqITDNJgKp9XimtBQ0MFZ8Tk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/proton-vpn-api-core/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-api-core/default.nix
@@ -27,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "proton-vpn-api-core";
-  version = "4.16.0";
+  version = "4.18.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "python-proton-vpn-api-core";
     rev = "v${version}";
-    hash = "sha256-XYyDEAUQ0fzg2J8NJbYlGqd2vG1cUTyfo9YzPisbWSY=";
+    hash = "sha256-dyMSyGkeyYXVKAhkmQpq2w4zCFk3fz1qEVECOVl8jEI=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Changelogs:

- https://github.com/ProtonVPN/python-proton-vpn-api-core/blob/stable/versions.yml
- https://github.com/ProtonVPN/proton-vpn-cli/blob/stable/versions.yml

This PR supersedes: https://github.com/NixOS/nixpkgs/pull/500256


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
