### PR TITLE
blockbench: 5.0.7 -> 5.1.1

### DIFF
--- a/pkgs/by-name/bl/blockbench/dont-assume-opening-app-asar.patch
+++ b/pkgs/by-name/bl/blockbench/dont-assume-opening-app-asar.patch
@@ -1,0 +1,15 @@
+diff --git a/js/desktop.js b/js/desktop.js
+index f3fcb25..a92a884 100644
+--- a/js/desktop.js
++++ b/js/desktop.js
+@@ -123,7 +123,9 @@ export function loadOpenWithBlockbenchFile() {
+ 	})
+ 	if (electron.process.argv.length >= 2) {
+ 		let path = electron.process.argv.last();
+-		load(path);
++		if (!path.endsWith("app.asar")) {
++			load(path);
++		}
+ 	}
+ }
+ console.log('Electron '+process.versions.electron+', Node '+process.versions.node)

--- a/pkgs/by-name/bl/blockbench/package.nix
+++ b/pkgs/by-name/bl/blockbench/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   buildNpmPackage,
   fetchFromGitHub,
-  fetchpatch,
   makeWrapper,
   imagemagick,
   copyDesktopItems,
@@ -13,14 +12,21 @@
 
 buildNpmPackage rec {
   pname = "blockbench";
-  version = "5.0.7";
+  version = "5.1.1";
 
   src = fetchFromGitHub {
     owner = "JannisX11";
     repo = "blockbench";
     tag = "v${version}";
-    hash = "sha256-JXOO2+UPMOGSuvez8ektbD5waPKatMggKn+MuH9Qkrs=";
+    hash = "sha256-bvstexoBQylLmTMzAhId+1HvC3iiL3tPahGhwZ5Yroo=";
   };
+
+  patches = [
+    # On linux we're running Blockbench by giving the path to the app.asar file to the electron executable,
+    # but Blockbench assumes paths at the and og the argv are files to be opened
+    # This patch disables trying to open the app.asar file
+    ./dont-assume-opening-app-asar.patch
+  ];
 
   nativeBuildInputs = [
     makeWrapper
@@ -30,16 +36,7 @@ buildNpmPackage rec {
     copyDesktopItems
   ];
 
-  patches = [
-    (fetchpatch {
-      # fixes https://github.com/JannisX11/blockbench/issues/3237
-      name = "bump-electron-builder.patch";
-      url = "https://github.com/JannisX11/blockbench/commit/dee9ae271f252d4bb3f98c13c4a1abaaeedd1feb.patch";
-      hash = "sha256-XpdqeCKoWsUieOMWhxVsEQ2r0qR+iiXKnVRfNYERDQs=";
-    })
-  ];
-
-  npmDepsHash = "sha256-T3yenZCkOrGOWJBxqe0RG39jWYfpsXStblf5Jx4dtF0=";
+  npmDepsHash = "sha256-1CCYk3cKFdLhx8oC5XreFCf5sL/7eKjOfXCmHt7hZrM=";
   makeCacheWritable = true;
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;


### PR DESCRIPTION
Changelog: https://github.com/JannisX11/blockbench/releases/tag/v5.1.0
Diff: https://github.com/JannisX11/blockbench/compare/v5.0.7...v5.1.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
