### PR TITLE
bibtool: fix build with GCC >= 14

### DIFF
--- a/pkgs/by-name/bi/bibtool/package.nix
+++ b/pkgs/by-name/bi/bibtool/package.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation (finalAttrs: {
   # Perl for running test suite.
   buildInputs = [ perl ];
 
+  # Uses K&R function definitions, which are not supported by GCC >= 14.
+  # https://github.com/ge-ne/bibtool/pull/96
+  env.NIX_CFLAGS_COMPILE = "-std=gnu89";
+
   installTargets = [
     "install"
     "install.man"


### PR DESCRIPTION
## Description

`bibtool` uses K&R-style (old-style) C function definitions, which GCC 14 no longer accepts by default (see [-Werror=old-style-definition](https://gcc.gnu.org/gcc-14/porting_to.html)). This causes the build to fail on Linux with the current toolchain.

The fix compiles bibtool with `-std=gnu89` to restore compatibility until upstream merges the proper fix: https://github.com/ge-ne/bibtool/pull/96

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
