### PR TITLE
nginx: 1.28.2 -> 1.28.3, nginxMainline: 1.29.5 -> 1.29.7

### DIFF
--- a/pkgs/servers/http/nginx/mainline.nix
+++ b/pkgs/servers/http/nginx/mainline.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.29.5";
-  hash = "sha256-Z0R2ikEUiA83sToEQyROcxvLMTDAoGXX432P1Ymt43Q=";
+  version = "1.29.7";
+  hash = "sha256-Zz+PuMCWHET72UENYWGDFFNgm0QGPT8pSCU/wrVpITk=";
 }

--- a/pkgs/servers/http/nginx/stable.nix
+++ b/pkgs/servers/http/nginx/stable.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.28.2";
-  hash = "sha256-IOXg8skXrPtREg7sL7qaS6Th4Q/ShGUGfMh6fYGoKaM=";
+  version = "1.28.3";
+  hash = "sha256-LJapRr+wiCohdE7UKXcKISOuGCjHxIZlCSmT3e6RqRg=";
 }


### PR DESCRIPTION
https://github.com/nginx/nginx/releases/tag/release-1.28.3
https://github.com/nginx/nginx/releases/tag/release-1.29.7

fixes:
  - CVE-2026-27654
  - CVE-2026-27784
  - CVE-2026-32647
  - CVE-2026-27651
  - CVE-2026-28753
  - CVE-2026-28755

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
