### PR TITLE
Revert "[Backport release-25.11] opensmtpd-filter-dkimsign: fix libexec path inconsistency"

### DIFF
--- a/pkgs/by-name/op/opensmtpd-filter-dkimsign/package.nix
+++ b/pkgs/by-name/op/opensmtpd-filter-dkimsign/package.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
     "HAVE_ED25519=1"
     "DESTDIR=$(out)"
     "LOCALBASE="
-    "BINDIR=/libexec/smtpd/"
   ];
 
   meta = {


### PR DESCRIPTION
Reverts NixOS/nixpkgs#497807

Breaks someone's server (https://github.com/NixOS/nixpkgs/pull/497807#issuecomment-4120763696), not certain why, especially since the reporter gave no details whatsoever. @alemonmk do you know why? If not we can just merge this (or a revert against unstable, if that's broken too) and then apply a fixed version later.