### PR TITLE
hk: init at 1.48.0

### DIFF
--- a/pkgs/by-name/hk/hk/package.nix
+++ b/pkgs/by-name/hk/hk/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+  pkg-config,
+  libgit2,
+  openssl,
+  usage,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hk";
+  version = "1.48.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jdx";
+    repo = "hk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jQVEKyFdzeVLBKkX3/zjJBXawxR6ayuf+8wSingESZA=";
+  };
+
+  cargoHash = "sha256-QzjoLnHlGTdnNfsfaRn7ZVeTwQZumN87IOhubLcEDLQ=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    versionCheckHook
+    pkg-config
+    usage
+  ];
+
+  buildInputs = [
+    libgit2
+    openssl
+  ];
+
+  # These tests require external dependencies and are fragile -- skipping.
+  checkFlags = [
+    "--skip=cli::init::detector::tests::test_detect_builtins_with_cargo_toml"
+    "--skip=cli::init::detector::tests::test_detect_builtins_with_package_json"
+    "--skip=cli::init::detector::tests::test_detect_eslint_with_contains"
+    "--skip=cli::init::detector::tests::test_detect_shell_scripts"
+    "--skip=cli::util::python_check_ast::tests::test_invalid_python"
+    "--skip=settings::tests::test_settings_builder_fluent_api"
+    "--skip=settings::tests::test_settings_from_config"
+    "--skip=settings::tests::test_settings_snapshot_caching"
+  ];
+
+  cargoBuildFlags = [
+    "--bin"
+    "hk"
+  ];
+
+  cargoTestFlags = [ "--all-features" ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd hk \
+      --bash <($out/bin/hk completion bash) \
+      --fish <($out/bin/hk completion fish) \
+      --zsh <($out/bin/hk completion zsh)
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for managing git hooks";
+    homepage = "https://hk.jdx.dev";
+    changelog = "https://github.com/jdx/hk/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ typedrat ];
+    mainProgram = "hk";
+  };
+})


### PR DESCRIPTION
[hk](https://hk.jdx.dev/) is a git hook manager and project linting tool written in Rust, by the author of [mise](https://mise.jdx.dev/). It emphasizes performance, using read/write file locks to maximize concurrency while preventing race conditions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test