### PR TITLE
liteparse: init at 1.2.0

### DIFF
--- a/pkgs/by-name/li/liteparse/package.nix
+++ b/pkgs/by-name/li/liteparse/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+  makeBinaryWrapper,
+  nix-update-script,
+  versionCheckHook,
+  tesseract,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "liteparse";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "run-llama";
+    repo = "liteparse";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6oG/ajH1roGkzRYAtAuJDniKwpBYF92NL1erYwQ4XPc=";
+  };
+
+  npmDepsHash = "sha256-lgqrXGbFuHbwQMXPbhHFdOabfPdVhghmg5v+aE4Og2k=";
+  npmBuildScript = "build";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/lit \
+      --set TESSDATA_PREFIX "${tesseract}/share/tessdata"
+  '';
+
+  # https://github.com/run-llama/liteparse/blob/270d558441fefdc4a53da258c5ee0cf9d5881286/package-lock.json#L3
+  # lock file needs to be updated
+  #  nativeInstallCheckInputs = [
+  #    versionCheckHook
+  #  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast and lightweight document parser by LlamaIndex";
+    homepage = "https://github.com/run-llama/liteparse";
+    changelog = "https://github.com/run-llama/liteparse/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ daspk04 ];
+    platforms = lib.platforms.all;
+    mainProgram = "lit";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

LiteParse is a standalone OSS PDF parsing tool focused exclusively on fast and light parsing.
Homepage: https://github.com/run-llama/liteparse/

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
