### PR TITLE
obs-studio-plugins: update 6 plugins to latest

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/advanced-scene-switcher/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/advanced-scene-switcher/default.nix
@@ -36,13 +36,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "advanced-scene-switcher";
-  version = "1.32.6";
+  version = "1.32.9";
 
   src = fetchFromGitHub {
     owner = "WarmUpTill";
     repo = "SceneSwitcher";
     rev = version;
-    hash = "sha256-BQnu7zRk1zOsEqFjmRrOeK/jE+rmnsB1ktW+OfH+L3I=";
+    hash = "sha256-IActG+roG+nm8GpqNQltp7upogRBDIfAW8JOM2pQmD4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/video/obs-studio/plugins/obs-livesplit-one/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-livesplit-one/default.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "obs-livesplit-one";
-  version = "0.4.1";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner = "LiveSplit";
     repo = "obs-livesplit-one";
-    rev = "v${version}";
-    sha256 = "sha256-4Ar4ChSl226BVFyAnqpWDLxsZF63bxl++sWD+6aENW8=";
+    tag = "v${version}";
+    sha256 = "sha256-ClOvpa8tTR+BQ6tx5ihnfoIJJ7oVAHDllZ7ryzFe5RY=";
   };
 
-  cargoHash = "sha256-e0FDa72vzRb5AMVmtkvAkiQ5GUXsq0LekqF+wDYDsr8=";
+  cargoHash = "sha256-sRMFl09AW4VBT0oOIsVsCYdYlXUINnNjThYnySkSK+Q=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/video/obs-studio/plugins/obs-move-transition.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-move-transition.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-move-transition";
-  version = "3.1.5";
+  version = "3.2.1";
 
   src = fetchFromGitHub {
     owner = "exeldro";
     repo = "obs-move-transition";
-    rev = version;
-    sha256 = "sha256-MelIMAy+9LiSlYwDdS8mbgttyZ6rvGFS5TKMas8LzCM=";
+    tag = version;
+    sha256 = "sha256-YA66qSCchZbA5TowOqn1FNvAtPzxREIChVJleoaImxk=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/video/obs-studio/plugins/obs-multi-rtmp/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-multi-rtmp/default.nix
@@ -5,28 +5,18 @@
   obs-studio,
   cmake,
   qtbase,
-  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
   pname = "obs-multi-rtmp";
-  version = "0.6.0.1";
+  version = "0.7.3.2";
 
   src = fetchFromGitHub {
     owner = "sorayuki";
     repo = "obs-multi-rtmp";
-    rev = version;
-    sha256 = "sha256-MRBQY9m6rj8HVdn58mK/Vh07FSm0EglRUaP20P3FFO4=";
+    tag = version;
+    sha256 = "sha256-edhJU06sT+pPovGcMJu4gAYbyaBKZBwSNifvXW06Ui8=";
   };
-
-  patches = [
-    # Fix finding QT. Remove after next release.
-    (fetchpatch {
-      url = "https://github.com/sorayuki/obs-multi-rtmp/commit/a1289fdef404b08a7acbbf0d6d0f93da4c9fc087.patch";
-      hash = "sha256-PDkR315y0iem1+LAqGmiqBFUiMBeEgnFW/xd1W2bAu4=";
-      includes = [ "CMakeLists.txt" ];
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
@@ -42,12 +32,8 @@ stdenv.mkDerivation rec {
 
   dontWrapQtApps = true;
 
-  # install dirs changed after 0.5.0.3-OBS30
   postInstall = ''
-    mkdir -p $out/{lib,share/obs/obs-plugins/}
-    mv $out/dist/obs-multi-rtmp/data $out/share/obs/obs-plugins/obs-multi-rtmp
-    mv $out/dist/obs-multi-rtmp/bin/64bit $out/lib/obs-plugins
-    rm -rf $out/dist
+    rm -rf $out/obs-plugins $out/data
   '';
 
   meta = {

--- a/pkgs/applications/video/obs-studio/plugins/obs-source-clone.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-source-clone.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "obs-source-clone";
-  version = "0.2.1";
+  version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "exeldro";
     repo = "obs-source-clone";
     tag = finalAttrs.version;
-    hash = "sha256-It/TF7vAVzuANcNUG9whK9ZDLXpRHzwpGvV5I/YTVdo=";
+    hash = "sha256-jJC3rbDfmeqE1LoPzfpXSSSX+PZeEU6FC9XBIbBAbck=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/video/obs-studio/plugins/obs-stroke-glow-shadow.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-stroke-glow-shadow.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-stroke-glow-shadow";
-  version = "v1.5.2";
+  version = "1.5.3";
 
   src = fetchFromGitHub {
     owner = "FiniteSingularity";
     repo = "obs-stroke-glow-shadow";
-    rev = version;
-    sha256 = "sha256-+2hb4u+6UG7IV9pAvPjp4wvDYhYnxe98U5QQjUcdD/k=";
+    tag = "v${version}";
+    sha256 = "sha256-PbN6Wdb6MzPe5918Y31UuYY49yuJp4W/2kfAOVJTMdo=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Happy to contribute a batch of OBS Studio plugin updates. All 6 have been built, installed on NixOS, and verified working in OBS Studio 32.1.0. I manually launched OBS, confirmed all plugins loaded in the Plugin Manager, and tested that filters (e.g. Glow from obs-stroke-glow-shadow, Move Transition override) are functioning correctly.

- obs-move-transition: 3.1.5 -> 3.2.1
- obs-source-clone: 0.2.1 -> 0.2.3
- obs-stroke-glow-shadow: v1.5.2 -> v1.5.3
- obs-multi-rtmp: 0.6.0.1 -> 0.7.3.2 (removed merged Qt fix patch, updated install layout)
- advanced-scene-switcher: 1.32.6 -> 1.32.9
- obs-livesplit-one: 0.4.1 -> 0.4.2

Note: obs-advanced-masks, obs-color-monitor, obs-scene-as-transition, and obs-transition-table also have upstream updates available but their new versions link `Qt::GuiPrivate` which is not currently resolved by the nixpkgs Qt6 packaging. Those are left for a follow-up.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test