### PR TITLE
winboat: Fix build by specifying dependency versions

### DIFF
--- a/pkgs/by-name/wi/winboat/guest-server.nix
+++ b/pkgs/by-name/wi/winboat/guest-server.nix
@@ -1,9 +1,10 @@
 {
   lib,
-  buildGoModule,
+  buildGo125Module,
   winboat,
 }:
-buildGoModule {
+
+buildGo125Module {
   inherit (winboat) version src;
   modRoot = "guest_server";
   pname = "winboat-guest-server";

--- a/pkgs/by-name/wi/winboat/package.nix
+++ b/pkgs/by-name/wi/winboat/package.nix
@@ -1,8 +1,7 @@
 {
   lib,
-  electron,
+  electron_40,
   zip,
-  nodejs_24,
   makeWrapper,
   udev,
   usbutils,
@@ -43,7 +42,6 @@ buildNpmPackage (finalAttrs: {
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
   npmDepsHash = "sha256-DLkI9a030uM2X1et94e4nd/HEyw5ugtK8NEAn/J8p9U=";
-  nodejs = nodejs_24;
   makeCacheWritable = true;
 
   guest-server = pkgsCross.mingwW64.callPackage ./guest-server.nix { };
@@ -61,8 +59,8 @@ buildNpmPackage (finalAttrs: {
     node scripts/build.ts
     npm exec electron-builder --linux -- \
       --dir \
-      -c.electronDist=${electron.dist} \
-      -c.electronVersion=${electron.version}
+      -c.electronDist=${electron_40.dist} \
+      -c.electronVersion=${electron_40.version}
   '';
 
   installPhase = ''
@@ -83,7 +81,7 @@ buildNpmPackage (finalAttrs: {
     ln -sf $out/share/winboat/resources/data $out/share/winboat/data
     ln -sf $out/share/winboat/resources/guest_server $out/share/winboat/guest_server
 
-    makeWrapper ${electron}/bin/electron $out/bin/winboat \
+    makeWrapper ${electron_40}/bin/electron $out/bin/winboat \
       --add-flag "$out/share/winboat/resources/app.asar" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --suffix PATH : ${


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes #503112 
The issue listed is specifically for the windows guest server written in go, that broke when go was updated to 1.26. Specifying 1.25 again fixes the issue. Furthermore after successfully compiling the guest server, similar issues happen in the main Winboat package, where electron is updated from 40 to 41, which breaks node-abi, and also nodejs_24 is dropped in nixpkgs.unstable so an update to nodejs_25 is needed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
