### PR TITLE
mppenc: init at 1.16

### DIFF
--- a/pkgs/by-name/mp/mppenc/package.nix
+++ b/pkgs/by-name/mp/mppenc/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchpatch,
+  cmake,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mppenc";
+  version = "1.16";
+
+  src = fetchurl {
+    url = "https://files.musepack.net/source/mppenc-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-+QeBhWynts4exwMzIfrbzQT+Jk0DScILSa0F98smVa0=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://salsa.debian.org/multimedia-team/mppenc/-/raw/c4106cab41261d6228e054a09272d662206c9fe5/debian/patches/kfreebsd-gnu_ftbfs.diff";
+      hash = "sha256-vM9KcS8y0ad3zOSpzqeBRVb2XYwDpqfkhzccpHqoBD8=";
+    })
+    (fetchpatch {
+      url = "https://salsa.debian.org/multimedia-team/mppenc/-/raw/a8e9ac3e110db50f8048f7cc54bace7a0110ea2e/debian/patches/cmake-4.patch";
+      hash = "sha256-zCDZBQ3jFROVKu+3LYkLj6mAqHBceJvMWs/A7kPGnYY=";
+    })
+  ];
+
+  meta = {
+    description = "Musepack lossy audio codec encoder";
+    homepage = "https://www.musepack.net";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [
+      Renna42
+    ];
+    mainProgram = "mppenc";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Musepack lossy audio codec encoder

Homepage: <https://www.musepack.net>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
