### PR TITLE
python3Packages.xmlsec: cleanup, skip failing test on `x86_64-darwin`

### DIFF
--- a/pkgs/development/python-modules/xmlsec/default.nix
+++ b/pkgs/development/python-modules/xmlsec/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -68,6 +69,11 @@ buildPythonPackage (finalAttrs: {
   disabledTestPaths = [
     # Full git clone required for test_doc_examples
     "tests/test_doc_examples.py"
+  ];
+
+  disabledTests = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+    # AssertionError: memory leak detected
+    "test_reinitialize_module"
   ];
 
   pythonImportsCheck = [ "xmlsec" ];

--- a/pkgs/development/python-modules/xmlsec/default.nix
+++ b/pkgs/development/python-modules/xmlsec/default.nix
@@ -1,27 +1,40 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  hypothesis,
+  fetchFromGitHub,
+
+  # build-system
+  pkgconfig,
+  setuptools-scm,
+
+  # nativeBuildInputs
+  pkg-config,
+  # pkgconfig,
+
+  # buildInputs
   libtool,
   libxml2,
   libxslt,
-  lxml,
-  pkg-config,
-  pkgconfig,
-  pytestCheckHook,
-  setuptools-scm,
   xmlsec,
+
+  # dependencies
+  lxml,
+
+  # tests
+  hypothesis,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "xmlsec";
   version = "1.3.17";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-8/rJrmefZlhZJcwAxfaDmuNsHQMVdhlXHe4YrMBbnAE=";
+  src = fetchFromGitHub {
+    owner = "xmlsec";
+    repo = "python-xmlsec";
+    tag = finalAttrs.version;
+    hash = "sha256-p3V75DLUI2PKdharP3/0HrKOgma9Kh3lAOZLRAQjo80=";
   };
 
   postPatch = ''
@@ -29,25 +42,27 @@ buildPythonPackage rec {
       --replace-fail "setuptools==" "setuptools>="
   '';
 
-  build-system = [ setuptools-scm ];
+  build-system = [
+    pkgconfig
+    setuptools-scm
+  ];
 
   nativeBuildInputs = [
     pkg-config
-    pkgconfig
   ];
 
   buildInputs = [
-    xmlsec
-    libxslt
-    libxml2
     libtool
+    libxml2
+    libxslt
+    xmlsec
   ];
 
-  propagatedBuildInputs = [ lxml ];
+  dependencies = [ lxml ];
 
   nativeCheckInputs = [
-    pytestCheckHook
     hypothesis
+    pytestCheckHook
   ];
 
   disabledTestPaths = [
@@ -59,9 +74,9 @@ buildPythonPackage rec {
 
   meta = {
     description = "Python bindings for the XML Security Library";
-    homepage = "https://github.com/mehcode/python-xmlsec";
-    changelog = "https://github.com/xmlsec/python-xmlsec/releases/tag/${version}";
+    homepage = "https://github.com/xmlsec/python-xmlsec";
+    changelog = "https://github.com/xmlsec/python-xmlsec/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ zhaofengli ];
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
