### PR TITLE
opensmtpd: fix libexec path inconsistency

### DIFF
--- a/pkgs/by-name/op/opensmtpd/libexec_path.diff
+++ b/pkgs/by-name/op/opensmtpd/libexec_path.diff
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index 2c78868c..4b29744d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -70,6 +70,7 @@ AS_CASE(["$host"],
+ 			supported by bsd-setproctitle.c])
+ ],
+ 	[*-*-linux* | *-gnu* | *-k*bsd*-gnu*], [
++		pkglibexecdir="$libexecdir/smtpd"
+ 		use_pie=auto
+ 		AC_DEFINE([SPT_TYPE], [SPT_REUSEARGV])
+ ],

--- a/pkgs/by-name/op/opensmtpd/package.nix
+++ b/pkgs/by-name/op/opensmtpd/package.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./proc_path.diff # TODO: upstream to OpenSMTPD, see https://github.com/NixOS/nixpkgs/issues/54045
     ./offline.patch
+    ./libexec_path.diff
   ];
 
   postPatch = ''


### PR DESCRIPTION
This may or may not address the report in (https://github.com/NixOS/nixpkgs/pull/497807#issuecomment-4120763696)?

Untested.

Closes: #503163

Cc: @Al2Klimov @alemonmk

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
