### PR TITLE
apt: 3.1.15 -> 3.1.16, add update script

### DIFF
--- a/pkgs/by-name/ap/apt/package.nix
+++ b/pkgs/by-name/ap/apt/package.nix
@@ -30,18 +30,19 @@
   zstd,
   withDocs ? true,
   withNLS ? true,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "apt";
-  version = "3.1.15";
+  version = "3.1.16";
 
   src = fetchFromGitLab {
     domain = "salsa.debian.org";
     owner = "apt-team";
     repo = "apt";
     rev = finalAttrs.version;
-    hash = "sha256-PnI7Ggqc/Go5p+eXf93d5qhG61TKO2/8ZSjML37pyzY=";
+    hash = "sha256-4n7QocfpAlDtJGpswV0LtwzWV1xtr7dLuLvAF5kBbAk=";
   };
 
   # cycle detection; lib can't be split
@@ -101,13 +102,15 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WITH_DOC" withDocs)
   ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     homepage = "https://salsa.debian.org/apt-team/apt";
     description = "Command-line package management tools used on Debian-based systems";
     changelog = "https://salsa.debian.org/apt-team/apt/-/raw/${finalAttrs.version}/debian/changelog";
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "apt";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ VZstless ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
`apt` has had 3 minor releases in recent 1 month, btw I am ready to adopt this package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compilation)
  ~~- [ ] x86_64-darwin~~
  ~~- [ ] aarch64-darwin~~
  (Linux platform only)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
