### PR TITLE
cernlib: 2024.06.12.0 -> 2025.09.18.4

### DIFF
--- a/pkgs/by-name/ce/cernlib/package.nix
+++ b/pkgs/by-name/ce/cernlib/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  fetchpatch,
   fetchurl,
   cmake,
   freetype,
@@ -17,7 +16,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "2024.06.12.0";
+  version = "2025.09.18.4";
   pname = "cernlib";
   year = lib.versions.major version;
 
@@ -26,21 +25,17 @@ stdenv.mkDerivation rec {
       "https://ftp.riken.jp/cernlib/download/${year}_source/tar/cernlib-cernlib-${version}-free.tar.gz"
       "https://cernlib.web.cern.ch/download/${year}_source/tar/cernlib-cernlib-${version}-free.tar.gz"
     ];
-    hash = "sha256-SEFgQjPBkmRoaMD/7yXiXO9DZNrRhqZ01kptSDQur84=";
+    hash = "sha256-zhLZlR0CUtPPYr+99JpFnJ1er+L7YcoRLi5hKLERqR4=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/user-attachments/files/16832928/geant321-fix-weak-alias-on-darwin.patch";
-      hash = "sha256-YzaUh4rJBszGdp5s/HDQMI5qQhCGrTt9P6XCgZOFn1I=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace-fail "cmake_minimum_required(VERSION 3.3.0 FATAL_ERROR)" \
-                     "cmake_minimum_required(VERSION 3.10.0 FATAL_ERROR)" \
       --replace-fail "find_program ( SED NAMES gsed" "find_program ( SED NAMES sed"
+
+    # termio.h is not found. Use the POSIX header
+    substituteInPlace packlib/cspack/tcpaw/tcpaw.c \
+      --replace-fail "#include <termio.h>" "#include <termios.h>" \
+      --replace-fail "struct termio" "struct termios"
   '';
 
   # gfortran warning's on iframework messes with CMake's check_fortran_compiler_flag


### PR DESCRIPTION
- #475479
- https://hydra.nixos.org/build/324452694

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
