### PR TITLE
fflogs: fix invalid icon cache

### DIFF
--- a/pkgs/by-name/ff/fflogs/package.nix
+++ b/pkgs/by-name/ff/fflogs/package.nix
@@ -18,11 +18,13 @@ appimageTools.wrapType2 {
 
   extraInstallCommands = ''
     mkdir -p $out/share/applications
-    cp -r ${extracted}/usr/share/icons $out/share/
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    cp -r ${extracted}/usr/share/icons/hicolor/512x512/apps/'FF Logs Uploader.png' $out/share/icons/hicolor/512x512/apps/fflogs.png
     chmod -R +w $out/share/
     test ! -e $out/share/icons/hicolor/0x0 # check for regression of https://github.com/electron-userland/electron-builder/issues/5294
     cp ${extracted}/'FF Logs Uploader.desktop' $out/share/applications/fflogs.desktop
     sed -i 's@^Exec=AppRun --no-sandbox@Exec=fflogs@g' $out/share/applications/fflogs.desktop
+    sed -i 's@^Icon=FF Logs Uploader@Icon=fflogs@g' $out/share/applications/fflogs.desktop
   '';
 
   meta = {


### PR DESCRIPTION
Previously, fflogs was causing system-path to fail with:

  > gtk-update-icon-cache: The generated cache was invalid.

This seems to be caused by the icon containing spaces. This patch renames the icon to remove the spaces, allowing system-path to build properly.

Note: I'm not 100% sure if this is really the best way to fix this, so I'm open to feedback from reviewers if there might be a better way.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
