### PR TITLE
dwproton-bin: init at dwproton-10.0-22

### DIFF
--- a/pkgs/by-name/dw/dwproton-bin/package.nix
+++ b/pkgs/by-name/dw/dwproton-bin/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchzip,
+  writeScript,
+  proton-ge-bin,
+
+  steamDisplayName ? "dwproton",
+}:
+proton-ge-bin.overrideAttrs (
+  finalAttrs: _: {
+    inherit steamDisplayName;
+
+    pname = "dwproton-bin";
+    version = "dwproton-10.0-22";
+
+    src = fetchzip {
+      url = "https://dawn.wine/dawn-winery/dwproton/releases/download/${finalAttrs.version}/${finalAttrs.version}-x86_64.tar.xz";
+      hash = "sha256-U/lLAF/WUxHInBgAt7YuDUM/eGGSv7mkjAACr15iW/0=";
+    };
+
+    passthru.updateScript = writeScript "update-dwproton" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl jq common-updater-scripts
+      version=$(curl -sL "https://dawn.wine/api/v1/repos/dawn-winery/dwproton/tags?page=1\&limit=1" | jq -r .[0].name)
+      update-source-version dwproton-bin "$version"
+    '';
+
+    meta = {
+      description = ''
+        Dawn Winery's custom Proton fork with fixes for various games.
+
+        (This is intended for use in the `programs.steam.extraCompatPackages` option only.)
+      '';
+      homepage = "https://dawn.wine/dawn-winery/dwproton";
+      license = lib.licenses.bsd3;
+      maintainers = with lib.maintainers; [
+        Renna42
+      ];
+      platforms = [ "x86_64-linux" ];
+      sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    };
+  }
+)


### PR DESCRIPTION
Dawn Winery's custom Proton fork with fixes for various games.

Homepage: https://dawn.wine/dawn-winery/dwproton

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
