### PR TITLE
motrix-next: init at 3.6.1

### DIFF
--- a/pkgs/by-name/mo/motrix-next/package.nix
+++ b/pkgs/by-name/mo/motrix-next/package.nix
@@ -1,0 +1,126 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  cargo-tauri,
+  pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  nodejs,
+  pkg-config,
+  jq,
+  moreutils,
+  glib-networking,
+  openssl,
+  webkitgtk_4_1,
+  libayatana-appindicator,
+  wrapGAppsHook4,
+  desktop-file-utils,
+  xdg-utils,
+  nix-update-script,
+}:
+let
+  pnpm = pnpm_10;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "motrix-next";
+  version = "3.6.1";
+
+  src = fetchFromGitHub {
+    owner = "AnInsomniacy";
+    repo = "motrix-next";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DeqHF36iH2kPi4F7RU5Ipde0lnwGWJqHfu4kz3znexg=";
+  };
+
+  cargoHash = "sha256-v+0dWo3w42wglv23Ydj0+Cb5HXF2fZ4Z0DC8EIsN5ww=";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      ;
+    inherit pnpm;
+    hash = "sha256-WvcN4LLRKiOxYEjImZ7VerwHFj33ELJvDKyP3F2UYG8=";
+    fetcherVersion = 3;
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+
+    pnpmConfigHook
+    pnpm
+    nodejs
+
+    pkg-config
+    jq
+    moreutils
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+
+  # we don't want to wrap aria2c
+  dontWrapGApps = true;
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    openssl
+    webkitgtk_4_1
+    libayatana-appindicator
+  ];
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  checkFlags = lib.optional stdenv.hostPlatform.isDarwin "--skip=commands::protocol::tests::macos_tests::get_default_handler_bundle_id_returns_some_for_https";
+
+  # Deactivate the upstream update mechanism
+  postPatch = ''
+    jq '
+      .bundle.createUpdaterArtifacts = false |
+      .plugins.updater = {"active": false, "pubkey": "", "endpoints": []}
+    ' \
+    src-tauri/tauri.conf.json | sponge src-tauri/tauri.conf.json
+  '';
+
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          libayatana-appindicator
+        ]
+      }
+      --suffix PATH : ${
+        lib.makeBinPath [
+          desktop-file-utils
+          xdg-utils
+        ]
+      }
+      # Tricky way to make the protocol handler desktop file point to the wrapper
+      --set-default APPIMAGE $out/bin/motrix-next
+    )
+    wrapGApp $out/bin/motrix-next
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+
+  meta = {
+    description = "Full-featured download manager, rebuilt from scratch with Tauri 2, Vue 3, and Rust";
+    homepage = "https://github.com/AnInsomniacy/motrix-next";
+    changelog = "https://github.com/AnInsomniacy/motrix-next/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      gpl2Plus
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      # ships an upstream-provided aria2c binary (statically linked, max connections increased)
+      # source for this binary: https://github.com/AnInsomniacy/aria2-builder
+      binaryNativeCode
+    ];
+    maintainers = with lib.maintainers; [ ccicnce113424 ];
+    mainProgram = "motrix-next";
+    platforms = with lib.platforms; linux ++ darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/AnInsomniacy/motrix-next
The original motrix have not been updated since 2023, and this is a rewrite with Tauri 2, Vue 3, and Rust.
Based on #506657.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
