### PR TITLE
hunspell-colorize: init at 0-unstable-2026-01-19

### DIFF
--- a/pkgs/by-name/hu/hunspell-colorize/package.nix
+++ b/pkgs/by-name/hu/hunspell-colorize/package.nix
@@ -1,0 +1,61 @@
+{
+  fetchFromGitHub,
+  hunspell,
+  hunspellDicts,
+  less,
+  lib,
+  makeBinaryWrapper,
+  nix-update-script,
+  pkg-config,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hunspell-colorize";
+  version = "0-unstable-2026-01-19";
+
+  src = fetchFromGitHub {
+    owner = "torvalds";
+    repo = "HunspellColorize";
+    rev = "87c358bfc99454490f1ef3afcb9ecf7590a9367e";
+    hash = "sha256-Tqb9b/1k8AhaaqHVB/4Jrs4os9hilJ2Rgt71tukuPp4=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    hunspell
+    hunspellDicts.en_US
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail gcc cc
+    substituteInPlace huncolor.c \
+      --replace-fail /usr/share/hunspell ${hunspellDicts.en_US}/share/hunspell
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D huncolor "$out"/bin/${finalAttrs.meta.mainProgram}
+    wrapProgram "$_" --prefix PATH : ${lib.makeBinPath [ less ]}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Wrapper around 'less' to colorize spelling mistakes using Hunspell";
+    homepage = "https://github.com/torvalds/HunspellColorize";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "huncolor";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
https://github.com/torvalds/HunspellColorize

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
