### PR TITLE
everforest-gtk-theme: 0-unstable-2025-10-15 -> 0-unstable-2025-10-23, build themes

### DIFF
--- a/pkgs/by-name/ev/everforest-gtk-theme/package.nix
+++ b/pkgs/by-name/ev/everforest-gtk-theme/package.nix
@@ -4,21 +4,28 @@
   fetchFromGitHub,
   gnome-themes-extra,
   gtk-engine-murrine,
+  jdupes,
+  sassc,
 }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation rec {
   pname = "everforest-gtk-theme";
-  version = "0-unstable-2025-10-15";
+  version = "0-unstable-2025-10-23";
 
   src = fetchFromGitHub {
     owner = "Fausto-Korpsvart";
     repo = "Everforest-GTK-Theme";
-    rev = "930a5dc57f7a06e8c6538d531544e41c56dbb27a";
-    hash = "sha256-mlJE7gVElWUjJIZnAL5ztchphmaU82llol+YdKqnSxg=";
+    rev = "9b8be4d6648ae9eaae3dd550105081f8c9054825";
+    hash = "sha256-XHO6NoXJwwZ8gBzZV/hJnVq5BvkEKYWvqLBQT00dGdE=";
   };
 
   propagatedUserEnvPkgs = [
     gtk-engine-murrine
+  ];
+
+  nativeBuildInputs = [
+    jdupes
+    sassc
   ];
 
   buildInputs = [
@@ -29,9 +36,27 @@ stdenvNoCC.mkDerivation {
 
   installPhase = ''
     runHook preInstall
+
+    pushd themes/release
+    patchShebangs make-release.sh
+    # don't run last line of make-release.sh
+    # that packs all the theme variants into tarballs
+    sed -i '$d' make-release.sh
+    ./make-release.sh
+    # fix theme names to start with Everforest-
+    # rather than pname and version
+    for f in "${pname}-${version}-"*; do
+      mv "$f" "Everforest-''${f#${pname}-${version}-}"
+    done
+    popd
+
     mkdir -p "$out/share/"{themes,icons}
     cp -a icons/* "$out/share/icons/"
-    cp -a themes/* "$out/share/themes/"
+    mv themes/release/Everforest* "$out/share/themes/"
+
+    # hard link when possible
+    jdupes -L -r $out/share
+
     runHook postInstall
   '';
 
@@ -39,7 +64,10 @@ stdenvNoCC.mkDerivation {
     description = "Everforest colour palette for GTK";
     homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ jn-sena ];
+    maintainers = with lib.maintainers; [
+      jn-sena
+      elnudev
+    ];
     platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
I've updated to the latest commit. Also, the current derivation for everforest-gtk-theme doesn't really actually build the themes in the repository to make them usable, so I've quickly extended the `installPhase` to actually run make-release.sh to build out all of the available theme variants, of which there are many, and then finally run jdupes to hard link some of the duplicate files.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
