### PR TITLE
owntracks-frontend: init at 2.15.3

### DIFF
--- a/pkgs/by-name/ow/owntracks-frontend/package.nix
+++ b/pkgs/by-name/ow/owntracks-frontend/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "owntracks-frontend";
+  version = "2.15.3";
+
+  src = fetchFromGitHub {
+    owner = "owntracks";
+    repo = "frontend";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-omNsCD6sPwPrC+PdyftGDUeZA8nOHkHkRHC+oHFC0eM=";
+  };
+  npmDepsHash = "sha256-sZkOvffpRoUTbIXpskuVSbX4+k1jiwIbqW4ckBwnEHM=";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/owntracks-frontend
+    cp -r dist/* $out/share/owntracks-frontend
+    cp dist/config/config.example.js $out/share/owntracks-frontend/config/config.js
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Web interface for OwnTracks";
+    homepage = "https://github.com/owntracks/frontend";
+    changelog = "https://github.com/owntracks/frontend/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.aionescu ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ow/owntracks-recorder/package.nix
+++ b/pkgs/by-name/ow/owntracks-recorder/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Store and access data published by OwnTracks apps";
     homepage = "https://github.com/owntracks/recorder";
-    changelog = "https://github.com/owntracks/recorder/blob/master/Changelog";
+    changelog = "https://github.com/owntracks/recorder/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.aionescu ];

--- a/pkgs/by-name/ow/owntracks-recorder/package.nix
+++ b/pkgs/by-name/ow/owntracks-recorder/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/owntracks/recorder/blob/master/Changelog";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.aionescu ];
     mainProgram = "ot-recorder";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the [`owntracks-frontend`](https://github.com/owntracks/frontend) package, a Web interface for OwnTracks.

Also adds myself as maintainer for the related `owntracks-recorder` package, which currently has no Nixpkgs maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of ~~all binary files, usually in `./result/bin/`~~ the generated webpage.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
