### PR TITLE
opensmtpd: patch another usage of PATH_LIBEXEC

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -216,6 +216,8 @@
 - `light` has been removed because it was unmaintained.
   `brightnessctl` and `acpilight` provide similar functionality.
 
+- `opensmtpd-filter-dkimsign` is now installed into `libexec/smtpd` instead of `libexec/opensmtpd` so that now it is properly linked into the environment built by `services.opensmtpd.procPackages`. If you hardcoded path to `filter-dkimsign` please consider using this option.
+
 - `services.openssh.settings.AcceptEnv` now explicitly defined as an option that takes a list of strings, to facilitate option merging. Setting it to a string value is no longer supported.
 
 - All Xfce packages have been moved to top level (e.g. if you previously added `pkgs.xfce.xfce4-whiskermenu-plugin` to `environment.systemPackages`, you will need to change it to `pkgs.xfce4-whiskermenu-plugin`). The `xfce` scope will be removed in NixOS 26.11.

--- a/pkgs/by-name/op/opensmtpd/proc_path.diff
+++ b/pkgs/by-name/op/opensmtpd/proc_path.diff
@@ -1,8 +1,8 @@
 diff --git a/usr.sbin/smtpd/smtpd.c b/usr.sbin/smtpd/smtpd.c
-index e049f07c..a1bd03a0 100644
+index 2365b1ee..b1b6bcec 100644
 --- a/usr.sbin/smtpd/smtpd.c
 +++ b/usr.sbin/smtpd/smtpd.c
-@@ -1157,6 +1157,7 @@ fork_proc_backend(const char *key, const char *conf, const char *procname)
+@@ -1224,6 +1224,7 @@ fork_proc_backend(const char *key, const char *conf, const char *procname,
  	char		path[PATH_MAX];
  	char		name[PATH_MAX];
  	char		*arg;
@@ -10,7 +10,7 @@ index e049f07c..a1bd03a0 100644
  
  	if (strlcpy(name, conf, sizeof(name)) >= sizeof(name)) {
  		log_warnx("warn: %s-proc: conf too long", key);
-@@ -1167,7 +1168,12 @@ fork_proc_backend(const char *key, const char *conf, const char *procname)
+@@ -1234,7 +1235,12 @@ fork_proc_backend(const char *key, const char *conf, const char *procname,
  	if (arg)
  		*arg++ = '\0';
  
@@ -24,20 +24,41 @@ index e049f07c..a1bd03a0 100644
  	    (ssize_t)sizeof(path)) {
  		log_warn("warn: %s-proc: exec path too long", key);
  		return (-1);
+@@ -1387,6 +1393,7 @@ fork_filter_process(const char *name, const char *command, const char *user, con
+ 	int		 sp[2], errfd[2];
+ 	struct passwd	*pw;
+ 	struct group	*gr;
++	char		*proc_path;
+ 	char		 exec[_POSIX_ARG_MAX];
+ 	int		 execr;
+ 
+@@ -1455,8 +1462,12 @@ fork_filter_process(const char *name, const char *command, const char *user, con
+ 	if (command[0] == '/')
+ 		execr = snprintf(exec, sizeof(exec), "exec %s", command);
+ 	else
++		proc_path = getenv("OPENSMTPD_PROC_PATH");
++		if (proc_path == NULL) {
++			proc_path = PATH_LIBEXEC;
++		}
+ 		execr = snprintf(exec, sizeof(exec), "exec %s/%s", 
+-		    PATH_LIBEXEC, command);
++		    proc_path, command);
+ 	if (execr >= (int) sizeof(exec))
+ 		fatalx("%s: exec path too long", name);
+ 
 diff --git a/usr.sbin/smtpd/table.c b/usr.sbin/smtpd/table.c
-index 9cfdfb99..24dfcca4 100644
+index e62b47af..2ee186bf 100644
 --- a/usr.sbin/smtpd/table.c
 +++ b/usr.sbin/smtpd/table.c
-@@ -201,6 +201,7 @@ table_create(const char *backend, const char *name, const char *tag,
+@@ -229,17 +229,23 @@ table_create(struct smtpd *conf, const char *backend, const char *name,
+ 	struct table		*t;
  	struct table_backend	*tb;
- 	char			 buf[LINE_MAX];
  	char			 path[LINE_MAX];
 +	const char		*proc_path;
  	size_t			 n;
  	struct stat		 sb;
  
-@@ -215,11 +216,16 @@ table_create(const char *backend, const char *name, const char *tag,
- 	if (name && table_find(name, NULL))
+ 	if (name && table_find(conf, name))
  		fatalx("table_create: table \"%s\" already defined", name);
  
 +	proc_path = getenv("OPENSMTPD_PROC_PATH");


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Patches another usage of `PATH_LIBEXEC` which caused the "no such file or directory" in #475685. #503201 is not needed, thanks.

Accompanied a mention of backward incompatibility with the change in `opensmtpd-filter-dkimsign`. Please tell me if it needs to be another PR.

Tested the patch with an overlay on my server, it works good.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
