### PR TITLE
repath-studio: fix nixos test

### DIFF
--- a/nixos/tests/repath-studio.nix
+++ b/nixos/tests/repath-studio.nix
@@ -25,8 +25,13 @@
           repath-studio
         ];
 
-        # electron application, give more memory
+        # electron application, give more memory and cpu
         virtualisation.memorySize = 4096;
+        virtualisation.cores = 4;
+        virtualisation.qemu.options = [
+          # Force qemu at 1020x768 resolution for the Save button click
+          "-vga none -device virtio-gpu-pci,xres=1020,yres=768"
+        ];
       };
   };
 
@@ -52,7 +57,9 @@
     machine.sleep(2)
     machine.send_key("ctrl-shift-s")
     machine.sleep(2)
-    machine.send_chars("/tmp/saved.rps\n")
+    machine.send_chars("/tmp/saved.rps")
+    machine.sleep(2)
+    machine.succeed("su - alice -c 'DISPLAY=:0 xdotool mousemove --sync 975 745 click 1'") # Save file dialog
     machine.sleep(2)
     print(machine.succeed("cat /tmp/saved.rps"))
     assert "${pkgs.repath-studio.version}" in machine.succeed("cat /tmp/saved.rps")


### PR DESCRIPTION
We need a better way to test gui applications using some tool like [`dogtail`](https://gitlab.com/dogtail/dogtail). This is not mantainable.

A simple machine.send_key("ret") is not working in icewm file save dialog, it used to work at some point.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
