### PR TITLE
nixos/calibre-web: add split book directory to config

### DIFF
--- a/nixos/modules/services/web-apps/calibre-web.nix
+++ b/nixos/modules/services/web-apps/calibre-web.nix
@@ -85,6 +85,14 @@ in
           '';
         };
 
+        calibreSplitBookDirectory = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = ''
+            Path to directory to store ebook files.
+          '';
+        };
+
         enableBookConversion = mkOption {
           type = types.bool;
           default = false;
@@ -150,6 +158,10 @@ in
           ++ optional (
             cfg.options.calibreLibrary != null
           ) "config_calibre_dir = '${cfg.options.calibreLibrary}'"
+          ++ optionals (cfg.options.calibreSplitBookDirectory != null) [
+            "config_calibre_split = true"
+            "config_calibre_split_dir = '${cfg.options.calibreSplitBookDirectory}'"
+          ]
           ++ optionals cfg.options.enableBookConversion [
             "config_converterpath = '${cfg.calibrePackage}/bin/ebook-convert'"
             "config_binariesdir = '${cfg.calibrePackage}/bin/'"
@@ -179,6 +191,9 @@ in
             + optionalString (cfg.options.calibreLibrary != null) ''
               test -f "${cfg.options.calibreLibrary}/metadata.db" || { echo "Invalid Calibre library"; exit 1; }
             ''
+            + optionalString (cfg.options.calibreSplitBookDirectory != null) ''
+              test -d "${cfg.options.calibreSplitBookDirectory}" || { echo "Invalid Calibre split book directory"; exit 1; }
+            ''
           );
 
           ExecStart = "${calibreWebCmd} -i ${cfg.listen.ip}";
@@ -191,7 +206,10 @@ in
           ProtectSystem = "strict";
           ReadWritePaths =
             lib.optional (lib.hasPrefix "/" cfg.dataDir) cfg.dataDir
-            ++ lib.optional (cfg.options.calibreLibrary != null) cfg.options.calibreLibrary;
+            ++ lib.optional (cfg.options.calibreLibrary != null) cfg.options.calibreLibrary
+            ++ lib.optional (
+              cfg.options.calibreSplitBookDirectory != null
+            ) cfg.options.calibreSplitBookDirectory;
           PrivateTmp = true;
           PrivateDevices = true;
           PrivateIPC = true;


### PR DESCRIPTION
calibre-web has a configuration option that allows a user to store books in a different directory than the calibre library. This adds a config option to specify that and adds it to the service's ReadWritePaths.

Resolves #503147  

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
