### PR TITLE
[release-25.11] halloy: patch CVE-2026-32810 and CVE-2026-32733

### DIFF
--- a/pkgs/by-name/ha/halloy/package.nix
+++ b/pkgs/by-name/ha/halloy/package.nix
@@ -14,6 +14,7 @@
   wayland,
   xorg,
   alsa-lib,
+  fetchpatch2,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -28,6 +29,19 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoHash = "sha256-lxRLTVtc2Gu3x3bt4po4q5/sfmRXb7CslEQIP8hX0+Q=";
+
+  patches = [
+    (fetchpatch2 {
+      name = "CVE-2026-32733.patch";
+      url = "https://github.com/squidowl/halloy/commit/0f77b2cfc5f822517a256ea5a4b94bad8bfe38b6.patch?full_index=1";
+      hash = "sha256-hi3idb7obz7cGDzG9hdNMOjolGsEEZhjgc6T61Gee+Q=";
+    })
+    (fetchpatch2 {
+      name = "CVE-2026-32810.patch";
+      url = "https://github.com/squidowl/halloy/commit/f180e41061db393acf65bc99f5c5e7397586d9cb.patch?full_index=1";
+      hash = "sha256-1S+xSwx/PANs8HSzQvXTAmzFJkZCw5BRUEttcl5v0pM=";
+    })
+  ];
 
   nativeBuildInputs = [
     copyDesktopItems


### PR DESCRIPTION
- Resolves https://github.com/NixOS/nixpkgs/issues/502608 for 25.11
  ([CVE-2026-32733](https://nvd.nist.gov/vuln/detail/CVE-2026-32733))
- Resolves https://github.com/NixOS/nixpkgs/issues/502532 for 25.11
  ([CVE-2026-32810](https://nvd.nist.gov/vuln/detail/CVE-2026-32810))

Unable to just update to 2026.5 to resolve these two vulnerabilities as done in #502763 on the `master` branch due to newer dependencies requiring `rustc 1.92`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
