### PR TITLE
librewolf-unwrapped 148.0.2-3 -> 149.0-1

### DIFF
--- a/pkgs/by-name/li/librewolf-unwrapped/librewolf.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/librewolf.nix
@@ -23,6 +23,9 @@ rec {
       patch -p1 < ${source}/$patch_name
     done <${source}/assets/patches.txt
 
+    rm toolkit/components/ml/content/backends/OpenAIPipeline.mjs
+    rm -rf toolkit/components/ml/vendor/openai
+
     cp -r ${source}/themes/browser .
     cp ${source}/assets/search-config.json services/settings/dumps/main/search-config.json
     sed -i '/MOZ_SERVICES_HEALTHREPORT/ s/True/False/' browser/moz.configure
@@ -40,8 +43,8 @@ rec {
     echo "patching appstrings.properties"
     find . -path '*/appstrings.properties' -exec sed -i s/Firefox/LibreWolf/ {} \;
 
-    for fn in $(find "${source}/l10n/en-US/browser" -type f -name '*.inc.ftl'); do
-      target_fn=$(echo "$fn" | sed "s,${source}/l10n,browser/locales," | sed "s,\.inc\.ftl$,.ftl,")
+    for fn in $(find "${source}/l10n/en-US/browser" -type f -name '*.inc.*'); do
+      target_fn=$(echo "$fn" | sed "s,${source}/l10n/en-US/browser,browser/locales/en-US," | sed "s,\.inc,,")
       cat "$fn" >> "$target_fn"
     done
   '';

--- a/pkgs/by-name/li/librewolf-unwrapped/src.json
+++ b/pkgs/by-name/li/librewolf-unwrapped/src.json
@@ -1,11 +1,11 @@
 {
-  "packageVersion": "148.0.2-3",
+  "packageVersion": "149.0-1",
   "source": {
-    "rev": "148.0.2-3",
-    "hash": "sha256-HPmzhmDvM3wccpKT9auKsV3w0tA9wQEs3sxFyBKCfqQ="
+    "rev": "149.0-1",
+    "hash": "sha256-lf9psaFT9PMk8CozjvUqBb6hxHct2kdzcVbQDbID+0U="
   },
   "firefox": {
-    "version": "148.0.2",
-    "hash": "sha512-Vqk65SNfOHBPL1a2JG2t2t07zvHbeXzKECAvuRm6Lw4UWd76qkHPGI8mkQjvrvG3bMv64z1Q7L1SdlF2tDIL7w=="
+    "version": "149.0",
+    "hash": "sha512-zdhxp3OPtw2FpwPonEh00b9EGEtMmyiQGQKty/olwZlnXnRjBrtZ1mgh5uzRfgfJm2akjYJ/OazKbDsBK5U3Gg=="
   }
 }


### PR DESCRIPTION
Diff: https://codeberg.org/librewolf/source/compare/148.0.2-3...149.0-1
Mfsa: https://www.mozilla.org/en-US/security/advisories/mfsa2026-20/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
