### PR TITLE
claude-code: 2.1.81 -> 2.1.83

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -8,8 +8,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "claude-code";
     publisher = "anthropic";
-    version = "2.1.81";
-    hash = "sha256-AblL1ChlZ8JKMhKVz/AAV22iyGfWQWXfLY2ntLWg/ik=";
+    version = "2.1.83";
+    hash = "sha256-5Qo2Pm0YWlkesdJPqWp8bsA5nE2kOT7lVhMbUvQVY0I=";
   };
 
   postInstall = ''

--- a/pkgs/by-name/cl/claude-code-bin/manifest.json
+++ b/pkgs/by-name/cl/claude-code-bin/manifest.json
@@ -1,46 +1,46 @@
 {
-  "version": "2.1.81",
-  "buildDate": "2026-03-20T21:31:30Z",
+  "version": "2.1.83",
+  "buildDate": "2026-03-25T05:20:36Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "d014162177fc18bfeb7f93d942130dd964f7424e4101f6ad569de66e6eddca03",
-      "size": 193286000
+      "checksum": "43246a9ff21de27c517f48af52c9d510c9e6e70bd90b115d80b9c690c515ae0d",
+      "size": 199115504
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "3c63d8173d4a86ab3985aead73c4699e42956d10c2f946179274be76ec657099",
-      "size": 199366256
+      "checksum": "bd16eefc5f7ba3d1b791e311f4d5b24ac3174588110a38db1c88c1b51dc88214",
+      "size": 200708688
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "ccfc3845c8d1a2ded9656a3a517694a844a1b7005b87c784a66f7a60cc58012c",
-      "size": 235183215
+      "checksum": "660bddb82c06a69bef8e468ffb8dd2354212bb76de122fe5d67393564b932de9",
+      "size": 233704000
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "047e3f5591d6238b08dd9518729ac335b0e8df1c80fe985e5d7fbda2c18fc281",
-      "size": 237954904
+      "checksum": "ff79cd5d152017326f661309bbffbefc954f02a195fb232ada152d812e476e66",
+      "size": 233863808
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "eab144605b0b0cc7d41325ef4dc9d553cdee853234da8bd7cd8187552b875399",
-      "size": 225718687
+      "checksum": "23396cad38d89cbce1fc739e2443e25a1b9bf9036964f5d2c82ae0d266f0b727",
+      "size": 226822592
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "480a961630459c0790e38d4860a2653fd39ae96aadc38044f669e1c2db686254",
-      "size": 228552392
+      "checksum": "d0c301132fa0a3447c8442fc4a92076e042c2acd849e48d93ccf1192fa03d75e",
+      "size": 228489664
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "6d34836bf4d62f4bd5221fb69899ed5b2edc380d35fb0f23218c62fae94e28b9",
-      "size": 242411680
+      "checksum": "24cd40c12e7d62faef9d1aead2d27bb8e9f45fb3445eaded05010bbf72e637d5",
+      "size": 243462304
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "18352be0d91c690b0fe2ed6841e4908c266c06eb7000555118e91966b67b9ea5",
-      "size": 238605472
+      "checksum": "8c6692a1e83b9baafbe405b11c62003dec03aa606623e59483bac772ab0f4730",
+      "size": 239616160
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/package-lock.json
+++ b/pkgs/by-name/cl/claude-code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.1.81",
+  "version": "2.1.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthropic-ai/claude-code",
-      "version": "2.1.81",
+      "version": "2.1.83",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -15,14 +15,14 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "claude-code";
-  version = "2.1.81";
+  version = "2.1.83";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${finalAttrs.version}.tgz";
-    hash = "sha256-WT+fj9H/5hlr/U8MygiIdE2QZ32kRz6wTjYEABtmBPU=";
+    hash = "sha256-tRrJ1UuolwI9d7ZOvBml0xJ9yZ3u57vGBfvF69artI8=";
   };
 
-  npmDepsHash = "sha256-x8Y1vODjATE6F6r0GhK427J0h2Et7bsqKoDcWaNO+IM=";
+  npmDepsHash = "sha256-ll47m1mgOur+cbx8MkNRttSUCXyKKG5ZlceH1lhC5Y0=";
 
   strictDeps = true;
 


### PR DESCRIPTION
Update claude-code, claude-code-bin, and vscode-extensions.anthropic.claude-code to 2.1.83.

https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
