### PR TITLE
gather_v1/v2: initi gather [darwin-only]

### DIFF
--- a/pkgs/by-name/ga/gatherv1/package.nix
+++ b/pkgs/by-name/ga/gatherv1/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+  writeShellApplication,
+  curl,
+  common-updater-scripts,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "gatherv1";
+  version = "1.35.1";
+
+  src = fetchurl {
+    url = "https://downloads.gather.town/desktop/Gather-${finalAttrs.version}-universal.dmg";
+    hash = "sha256-3EPNd+UmafpVlNSeejqTXdvv3WsezZHF6upfs9ji2no=";
+  };
+
+  dontBuild = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [ _7zz ];
+
+  sourceRoot = "Gather.app";
+
+  unpackPhase = ''
+    runHook preUnpack
+    7zz x -sns- "$src"
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications/Gather.app"
+    cp -R . "$out/Applications/Gather.app"
+    mkdir -p "$out/bin"
+    ln -s "$out/Applications/Gather.app/Contents/MacOS/Gather" "$out/bin/gatherv1"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "gatherv1-update-script";
+    runtimeInputs = [
+      curl
+      common-updater-scripts
+    ];
+    text = ''
+      version=$(
+        curl -sI https://api.v2.gather.town/api/v2/releases/latest/macos/v1 \
+          | grep -i '^location:' \
+          | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
+      )
+      update-source-version gatherv1 "$version" --file=./pkgs/by-name/ga/gatherv1/package.nix
+    '';
+  });
+
+  meta = {
+    description = "Virtual office and event space for remote collaboration (legacy v1 client)";
+    homepage = "https://www.gather.town";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ kaynetik ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+    mainProgram = "gatherv1";
+  };
+})

--- a/pkgs/by-name/ga/gatherv2/package.nix
+++ b/pkgs/by-name/ga/gatherv2/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+  writeShellApplication,
+  curl,
+  common-updater-scripts,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "gatherv2";
+  version = "0.39.1";
+
+  src = fetchurl {
+    url = "https://downloads.gather.town/desktop-v2/GatherV2-${finalAttrs.version}-universal.dmg";
+    hash = "sha256-+nNuObbzG4S8WztN6i5U5ZDM+wXSWRxs4XiTyG7sNDs=";
+  };
+
+  dontBuild = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [ _7zz ];
+
+  sourceRoot = ".";
+
+  unpackPhase = ''
+    runHook preUnpack
+    7zz x -sns- "$src"
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R GatherV2*/GatherV2.app "$out/Applications/GatherV2.app"
+    mkdir -p "$out/bin"
+    ln -s "$out/Applications/GatherV2.app/Contents/MacOS/GatherV2" "$out/bin/gatherv2"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "gatherv2-update-script";
+    runtimeInputs = [
+      curl
+      common-updater-scripts
+    ];
+    text = ''
+      version=$(
+        curl -sI https://api.v2.gather.town/api/v2/releases/latest/macos/v2 \
+          | grep -i '^location:' \
+          | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
+      )
+      update-source-version gatherv2 "$version" --file=./pkgs/by-name/ga/gatherv2/package.nix
+    '';
+  });
+
+  meta = {
+    description = "Virtual office and event space for remote collaboration (v2 client)";
+    homepage = "https://www.gather.town";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ kaynetik ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+    mainProgram = "gatherv2";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the Gather Town desktop clients for macOS:
- `gatherv1` (legacy v1 client, 1.35.1)  
- `gatherv2` (current v2 client, 0.39.1)

Both are Darwin-only unfree binary packages installed from upstream DMGs.
Update scripts hit the Gather releases API redirect to discover new versions.
Homepage: https://www.gather.town

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
