### PR TITLE
ginkgo: add Go 1.26 compatibility patch

### DIFF
--- a/pkgs/by-name/gi/ginkgo/package.nix
+++ b/pkgs/by-name/gi/ginkgo/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  fetchpatch,
   testers,
   ginkgo,
 }:
@@ -18,6 +19,14 @@ buildGoModule (finalAttrs: {
   };
   vendorHash = "sha256-I3n1FPINb/nhi4QUzRFEspn7REN1dQEPg8Bhb3PemQU=";
 
+  patches = [
+    # Add ArtifactDir() to support Go 1.26 testing.TB interface
+    # https://github.com/onsi/ginkgo/pull/1648
+    (fetchpatch {
+      url = "https://github.com/onsi/ginkgo/pull/1648.patch";
+      hash = "sha256-O8YWPAvf0ukPWSTm6+YKnV/L+qSL0RCoBswmiQVXOKI=";
+    })
+  ];
   # integration tests expect more file changes
   # types tests are missing CodeLocation
   excludedPackages = [


### PR DESCRIPTION
Go 1.26 added ArtifactDir() to the testing.TB interface. Ginkgo 2.28.1 doesn't implement this method yet, causing test failures. Add a patch to implement the missing method.

https://github.com/onsi/ginkgo/pull/1648


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
