### PR TITLE
direnv: fix build on Darwin with CGO_ENABLED=0 and Go 1.26

### DIFF
--- a/pkgs/by-name/di/direnv/package.nix
+++ b/pkgs/by-name/di/direnv/package.nix
@@ -30,6 +30,10 @@ buildGoModule (finalAttrs: {
 
   # replace the build phase to use the GNUMakefile instead
   buildPhase = ''
+    # Remove -linkmode=external on Darwin as it's incompatible with CGO_ENABLED=0
+    # The original fix (direnv#194) was for macOS 10.10 DYLD_INSERT_LIBRARIES issues
+    # which is no longer relevant
+    substituteInPlace GNUmakefile --replace-fail '-linkmode=external' ""
     make BASH_PATH=$BASH_PATH
   '';
 


### PR DESCRIPTION
Go 1.26 now errors on -linkmode=external when CGO_ENABLED=0, instead of silently ignoring it. The Makefile adds -linkmode=external on Darwin to work around a DYLD_INSERT_LIBRARIES issue from macOS 10.10 (2015), which is no longer relevant. Remove the flag to fix the build.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
