### PR TITLE
re-plistbuddy,betterdisplay,cyberduck,enpass-mac: add PlistBuddy replacement

### DIFF
--- a/pkgs/by-name/be/betterdisplay/package.nix
+++ b/pkgs/by-name/be/betterdisplay/package.nix
@@ -6,7 +6,7 @@
   nix-update-script,
   versionCheckHook,
   writeShellScript,
-  xcbuild,
+  re-plistbuddy,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -37,7 +37,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = writeShellScript "version-check" ''
-    ${xcbuild}/bin/PlistBuddy -c "Print :CFBundleShortVersionString" "$1"
+    ${lib.getExe' re-plistbuddy "PlistBuddy"} -c "Print :CFBundleShortVersionString" "$1"
   '';
   versionCheckProgramArg = [
     "${placeholder "out"}/Applications/BetterDisplay.app/Contents/Info.plist"

--- a/pkgs/by-name/cy/cyberduck/package.nix
+++ b/pkgs/by-name/cy/cyberduck/package.nix
@@ -6,8 +6,7 @@
   makeBinaryWrapper,
   versionCheckHook,
   writeShellScript,
-  coreutils,
-  xcbuild,
+  re-plistbuddy,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "cyberduck";
@@ -36,8 +35,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = writeShellScript "version-check" ''
-    marketing_version=$(${xcbuild}/bin/PlistBuddy -c "Print :CFBundleShortVersionString" "$1" | ${coreutils}/bin/tr -d '"')
-    build_version=$(${xcbuild}/bin/PlistBuddy -c "Print :CFBundleVersion" "$1")
+    marketing_version=$(${lib.getExe' re-plistbuddy "PlistBuddy"} -c "Print :CFBundleShortVersionString" "$1")
+    build_version=$(${lib.getExe' re-plistbuddy "PlistBuddy"} -c "Print :CFBundleVersion" "$1")
 
     echo $marketing_version.$build_version
   '';

--- a/pkgs/by-name/en/enpass-mac/package.nix
+++ b/pkgs/by-name/en/enpass-mac/package.nix
@@ -12,8 +12,7 @@
   common-updater-scripts,
   versionCheckHook,
   writeShellScript,
-  coreutils,
-  xcbuild,
+  re-plistbuddy,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -71,8 +70,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = writeShellScript "version-check" ''
-    marketing_version=$(${xcbuild}/bin/PlistBuddy -c "Print :CFBundleShortVersionString" "$1" | ${coreutils}/bin/tr -d '"')
-    build_version=$(${xcbuild}/bin/PlistBuddy -c "Print :CFBundleVersion" "$1")
+    marketing_version=$(${lib.getExe' re-plistbuddy "PlistBuddy"} -c "Print :CFBundleShortVersionString" "$1")
+    build_version=$(${lib.getExe' re-plistbuddy "PlistBuddy"} -c "Print :CFBundleVersion" "$1")
 
     echo $marketing_version.$build_version
   '';

--- a/pkgs/by-name/re/re-plistbuddy/package.nix
+++ b/pkgs/by-name/re/re-plistbuddy/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "re-plistbuddy";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "viraptor";
+    repo = "re-plistbuddy";
+    tag = version;
+    hash = "sha256-Iumrj0JLpdrS3cg3jAj/Wrbx7PthlCnTuRMYsYdywyw=";
+  };
+
+  cargoHash = "sha256-RyHM6CMxdhDJrg6mGt8jQCDLVjt0BiLYswelOHoellw=";
+
+  meta = {
+    description = "Open reimplementation of Apple's PlistBuddy and plutil";
+    homepage = "https://github.com/viraptor/re-plistbuddy";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ viraptor ];
+    platforms = lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
The `PlistBuddy` utility provided by xcbuild is incomplete and not fully compatible with the tool present on darwin machines.
This is an issue for two reasons:
- we sometimes need extra patches, like in case or pinentry, or need to do extra processing like stripping quotes
- we rely on xcbuild which is not maintained anymore and provides a number of half-baked tools

I'm trying to replace that dependency with a few tools which have much better compatibility. In this case, `re-plistbuddy` provides `PlistBuddy` and `plutil` which can be used to progressively replace the xcbuild dependency in larger packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
