### PR TITLE
hmcl: 3.11.2 -> 3.12.2

### DIFF
--- a/pkgs/by-name/hm/hmcl/package.nix
+++ b/pkgs/by-name/hm/hmcl/package.nix
@@ -49,13 +49,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "hmcl";
-  version = "3.11.2";
+  version = "3.12.2";
 
   src = fetchurl {
     # HMCL has built-in keys, such as the Microsoft OAuth secret and the CurseForge API key.
     # See https://github.com/HMCL-dev/HMCL/blob/refs/tags/release-3.6.12/.github/workflows/gradle.yml#L26-L28
     url = "https://github.com/HMCL-dev/HMCL/releases/download/v${finalAttrs.version}/HMCL-${finalAttrs.version}.jar";
-    hash = "sha256-Db9ly87xt6+S6dgQ0bkVvKwY9t4pMPfnebMKPFrcbhc=";
+    hash = "sha256-CuWueXEq77Nr6aVbXo3BJVsYU+UWwBZRz//zBToLwN0=";
   };
 
   # - HMCL prompts users to download prebuilt Terracotta binary for

--- a/pkgs/by-name/hm/hmcl/update.nix
+++ b/pkgs/by-name/hm/hmcl/update.nix
@@ -18,19 +18,22 @@ writeShellApplication {
   ];
 
   text = ''
-    # get old info
-    oldVersion=$(nix-instantiate --eval --strict -A "hmcl.version" | jq -e -r)
-
     get_latest_release() {
-        curl --fail ''${GITHUB_TOKEN:+ -H "Authorization: bearer $GITHUB_TOKEN"} \
-             -s "https://api.github.com/repos/HMCL-dev/HMCL/releases/latest" | jq -r ".tag_name"
+        curl -fsSL ''${GITHUB_TOKEN:+ -H "Authorization: bearer $GITHUB_TOKEN"} \
+             "https://api.github.com/repos/HMCL-dev/HMCL/releases" | \
+        jq -r 'map(select(.tag_name | test("^v\\d+\\.\\d+\\.\\d+$")))[0].tag_name'
     }
 
     version=$(get_latest_release)
-    version="''${version#v-}"
+    version="''${version#v}"
 
-    if [[ "$oldVersion" == "$version" ]]; then
+    if [[ "$UPDATE_NIX_OLD_VERSION" == "$version" ]]; then
         echo "Already up to date!"
+        exit 0
+    fi
+
+    if ! curl -fsSL "https://docs.hmcl.net/changelog/stable.html" | grep -q "HMCL $version"; then
+        echo "Version $version found on GitHub but not yet listed in stable changelog. Skipping."
         exit 0
     fi
 


### PR DESCRIPTION
Tested on x86_64-linux

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
