### PR TITLE
nodejs: re-introduce `nodejs.src`

### DIFF
--- a/pkgs/development/web/nodejs/symlink.nix
+++ b/pkgs/development/web/nodejs/symlink.nix
@@ -5,7 +5,12 @@
 }:
 symlinkJoin {
   pname = "nodejs";
-  inherit (nodejs-slim) version passthru meta;
+  inherit (nodejs-slim)
+    version
+    src
+    passthru
+    meta
+    ;
   paths = [
     nodejs-slim
     nodejs-slim.npm


### PR DESCRIPTION
This was always equivalent to nodejs-slim.src.

This is a follow-up on #481461 which has links from a number of downstream projects that hit this.

This is a slightly neater change compared to #501357, but is a mass rebuild so will have to go via staging. We can either merge #501357 first for a 'quick fix' and then this change (the merge conflict should be trivial), or forgo a quick fix and just have this one.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
