### PR TITLE
nodejs: add a `slim` passthru helper

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -291,7 +291,7 @@ gnuradioMinimal.override {
 
 - `nodejs-slim` no longer exposes a `corepack` executable, it has been moved to an ad-hoc output; to restore the previous behavior, `nodejs-slim.corepack` must be explicitely included.
 
-- `nodejs` is now a simple wrapper for `nodejs-slim`+`nodejs-slim.npm`+`nodejs-slim.corepack`, meaning it is no longer possible to reference or override its attributes or outputs (e.g. `nodejs.libv8` must be replaced with `nodejs-slim.libv8`, `nodejs.nativeBuildInputs` with `nodejs-slim.nativeBuildInputs`, etc.).
+- `nodejs` is now a simple wrapper for `nodejs-slim`+`nodejs-slim.npm`+`nodejs-slim.corepack`, meaning it is no longer possible to reference or override its attributes or outputs (e.g. `nodejs.libv8` must be replaced with `nodejs-slim.libv8` or `nodejs.slim.libv8`, `nodejs_22.nativeBuildInputs` with `nodejs-slim_22.nativeBuildInputs` or `nodejs_22.slim.nativeBuildInputs`, etc.).
 
 - `mold` is now wrapped by default.
 

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -630,6 +630,7 @@ let
         done
       '';
 
+      passthru.slim = self;
       passthru.tests = {
         version = testers.testVersion {
           package = self;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Helper that helps functions that can accept either of the symlinked or slim versions of `nodejs_*` packages to access the original attributes (e.g. `nodejs.src` -> `nodejs.slim.src`)

Refs: https://github.com/NixOS/nixpkgs/pull/501357

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
