### PR TITLE
gdb: fix build for musl

### DIFF
--- a/pkgs/by-name/gd/gdb/package.nix
+++ b/pkgs/by-name/gd/gdb/package.nix
@@ -5,6 +5,7 @@
 
   # Build time
   fetchurl,
+  fetchpatch,
   pkg-config,
   perl,
   texinfo,
@@ -86,6 +87,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./debug-info-from-env.patch
+
+    (fetchurl {
+      name = "musl.patch";
+      url = "https://inbox.sourceware.org/gdb-patches/20260324164527.1446549-2-sunilkumar.dora@windriver.com/raw";
+      hash = "sha256-FC4DDVS4wtE/HXtbUqvkxu9+e7nE3DYi1zIuQP9yQO8=";
+    })
+    (fetchpatch {
+      name = "musl-aarch64.patch";
+      url = "https://sourceware.org/git/?p=binutils-gdb.git;a=patch;h=1ccc3f6a2e28fa1f3357826374cba165b3ba3ff7";
+      hash = "sha256-Q2oTo2b+9yNN3PSsxqgxV4/9/05uFE/JMLe1CPs9Y7I=";
+    })
   ]
   ++ optionals stdenv.hostPlatform.isDarwin [
     ./darwin-target-match.patch


### PR DESCRIPTION
First patch is part of a series that's still being discussed on the list, but the musl fix itself seems to have settled down.

Second patch comes from the GDB 17 branch.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
