### PR TITLE
nixos/autobrr: replace sessionSecret with environmentFile

### DIFF
--- a/nixos/modules/services/misc/autobrr.nix
+++ b/nixos/modules/services/misc/autobrr.nix
@@ -8,10 +8,18 @@
 let
   cfg = config.services.autobrr;
   configFormat = pkgs.formats.toml { };
-  configTemplate = configFormat.generate "autobrr.toml" cfg.settings;
-  templaterCmd = ''${lib.getExe pkgs.dasel} put -f '${configTemplate}' -v "$(${config.systemd.package}/bin/systemd-creds cat sessionSecret)" -o %S/autobrr/config.toml "sessionSecret"'';
+  configFile = configFormat.generate "autobrr.toml" cfg.settings;
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [ "services" "autobrr" "secretFile" ] ''
+      The services.autobrr.secretFile option has been removed.
+      Instead, please provide this secret by setting the
+      AUTOBRR__SESSION_SECRET environment variable using
+      services.autobrr.environmentFile.
+    '')
+  ];
+
   options = {
     services.autobrr = {
       enable = lib.mkEnableOption "Autobrr";
@@ -22,9 +30,17 @@ in
         description = "Open ports in the firewall for the Autobrr web interface.";
       };
 
-      secretFile = lib.mkOption {
-        type = lib.types.path;
-        description = "File containing the session secret for the Autobrr web interface.";
+      environmentFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          Environment file to be passed to the systemd service. Useful for
+          passing secrets to the service.
+
+          Refer to
+          <https://autobrr.com/installation/docker#environment-variables> for a
+          list of environment variables.
+        '';
       };
 
       settings = lib.mkOption {
@@ -57,7 +73,8 @@ in
           Session secrets should not be passed via settings, as
           these are stored in the world-readable nix store.
 
-          Use the secretFile option instead.'';
+          Use the environmentFile option to set the AUTOBRR__SESSION_SECRET
+          variable instead.'';
       }
     ];
 
@@ -73,11 +90,10 @@ in
       serviceConfig = {
         Type = "simple";
         DynamicUser = true;
-        LoadCredential = "sessionSecret:${cfg.secretFile}";
         StateDirectory = "autobrr";
-        ExecStartPre = "${lib.getExe pkgs.bash} -c '${templaterCmd}'";
-        ExecStart = "${lib.getExe cfg.package} --config %S/autobrr";
+        ExecStart = "${lib.getExe cfg.package} --config ${configFile}";
         Restart = "on-failure";
+        EnvironmentFile = cfg.environmentFile;
       };
     };
 

--- a/nixos/tests/autobrr.nix
+++ b/nixos/tests/autobrr.nix
@@ -11,7 +11,7 @@
         enable = true;
         # We create this secret in the Nix store (making it readable by everyone).
         # DO NOT DO THIS OUTSIDE OF TESTS!!
-        secretFile = pkgs.writeText "session_secret" "not-secret";
+        environmentFile = pkgs.writeText "session_secret" "AUTOBRR__SESSION_SECRET=not-secret";
       };
     };
 


### PR DESCRIPTION
The dasel package, which was being used to load the session secret into the config file, had major changes in the interface on v3. This meant that this service has been broken since #494240 got merged.

To fix this, rather than adapt the parameters to the new version, make it even more configurable by using an environmentFile to specify these configuration options, rather than use dasel to patch the config file just for the session secret.

This is also more flexible, since it allows setting other options such as the OIDC secrets with the environment, rather than just the session secret.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
