### PR TITLE
yatto: 0.21.7 -> 1.2.0

### DIFF
--- a/pkgs/by-name/ya/yatto/package.nix
+++ b/pkgs/by-name/ya/yatto/package.nix
@@ -2,24 +2,50 @@
   lib,
   fetchFromGitHub,
   buildGoModule,
+  gitMinimal,
+  gitSetupHook,
+  jujutsu,
 }:
 buildGoModule (finalAttrs: {
   pname = "yatto";
-  version = "0.21.7";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "handlebargh";
     repo = "yatto";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WLksvl6BtrtxULxxqdHpAD6oVdefhqo7aZoxqXrFfOA=";
+    hash = "sha256-sso0LlKzE/OJILCf7O5mdPgk6BUTiziQq2tcxcPMtkI=";
   };
 
-  vendorHash = "sha256-I/9Wcwm2rnQxixevtz1i3fhmlM0b8Yq4pb2eieG7bq0=";
+  vendorHash = "sha256-8bCk6c/EyghsHKLinWGIJhbl76j3V/rzTmrCWh+5cIU=";
 
   ldflags = [
     "-s"
     "-w"
   ];
+
+  nativeCheckInputs = [
+    gitMinimal
+    gitSetupHook
+    jujutsu
+  ];
+
+  checkFlags =
+    let
+      # Skip tests that require network access
+      skippedTests = [
+        "TestJjCommit"
+        "TestJjContributors"
+        "TestJjUser"
+        "TestResolver/AllContributors_function_resolves_correctly"
+        "TestResolver"
+        "TestE2E_AddEditDeleteProject"
+        "TestE2E_AddEditDeleteProject/jj"
+        "TestE2E_AddEditDeleteTask"
+        "TestE2E_AddEditDeleteTask/jj"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   meta = {
     description = "Terminal-based to-do application built with Bubble Tea";


### PR DESCRIPTION
Diff: https://github.com/handlebargh/yatto/compare/v0.21.7...v1.2.0

Changelog: https://github.com/handlebargh/yatto/releases/tag/1.2.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
