### PR TITLE
git-unroll: 0-unstable-2025-08-14 -> 0-unstable-2026-03-25

### DIFF
--- a/pkgs/by-name/gi/git-unroll/package.nix
+++ b/pkgs/by-name/gi/git-unroll/package.nix
@@ -2,11 +2,10 @@
   lib,
   stdenv,
   fetchFromCodeberg,
-  fetchpatch,
   makeWrapper,
   bash,
 
-  git,
+  gitMinimal,
   nix-prefetch-git,
   rWrapper,
   rPackages,
@@ -16,25 +15,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "git-unroll";
-  version = "0-unstable-2025-08-14";
+  version = "0-unstable-2026-03-25";
 
   src = fetchFromCodeberg {
     owner = "gm6k";
     repo = "git-unroll";
-    rev = "a66aad56af0440e1d6e807518af298264861b2c7";
-    hash = "sha256-Mpc2p+W8PqQ6Os9AJJJwvL00a4cjFKBUTBG5bF+IzL4=";
+    rev = "62fc6ff3fcb62b6972182d64b4f3710c2188c082";
+    hash = "sha256-We3nbdZIxk27T2VXoKiwRTrBAZ2qoANpDpUXq+MgvbY=";
   };
-
-  patches = [
-    # Discovered when bumping pytorch to 2.10.0
-    # See https://github.com/NixOS/nixpkgs/pull/484881#issuecomment-3814200207
-    # https://codeberg.org/gm6k/git-unroll/pulls/2
-    (fetchpatch {
-      name = "fix-name-decollision-for-multi-parent-submodules";
-      url = "https://codeberg.org/glepage/git-unroll/commit/3a16e138a6c4bc9d8226f025fb53e281c80fc1ef.patch";
-      hash = "sha256-mHDqpDh6aiQRDgfxeZs/ufa5Af0lDFDRGpSlmD1+kEo=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace unroll \
@@ -60,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     wrapProgram $out/bin/unroll \
       --prefix PATH : ${
         lib.makeBinPath [
-          git
+          gitMinimal
           nix-prefetch-git
           (rWrapper.override {
             packages = with rPackages; [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tested with:
```
nix-build -A python3Packages.torch.unroll-src
./result 2.10.0 > pkgs/development/python-modules/torch/source/src.nix
```

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
