### PR TITLE
ffmpreg: init at 0.1.2-unstable-2026-03-25

### DIFF
--- a/pkgs/by-name/ff/ffmpreg/package.nix
+++ b/pkgs/by-name/ff/ffmpreg/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "ffmpreg";
+  version = "0.1.2-unstable-2026-03-25";
+
+  src = fetchFromGitHub {
+    owner = "yazaldefilimone";
+    repo = "ffmpreg";
+    rev = "a6fca970b98357ccd275acd797673ef7cf4ca02f";
+    hash = "sha256-p2dtNmJ7fXFzgsfg32Tmr6xr1wuZAHziNgMeUOfyjgw=";
+  };
+
+  cargoHash = "sha256-GxUBhFWoAq6zCDHWTiZ/pC6BWu4JcW71Sh9Du2H36wg=";
+
+  meta = {
+    description = "Experimental safe Rust-native multimedia toolkit for decoding, transforming, and encoding audio and video";
+    homepage = "https://github.com/yazaldefilimone/ffmpreg";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ aprl ];
+    mainProgram = "ffmpreg";
+  };
+}


### PR DESCRIPTION
Experimental safe Rust-native multimedia toolkit for decoding, transforming, and encoding audio and video

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
