### PR TITLE
linuxKernel.kernels.linux_zen: fix update script, 6.18.13-zen1 -> 6.19.9-zen1

### DIFF
--- a/pkgs/os-specific/linux/kernel/update-zen.py
+++ b/pkgs/os-specific/linux/kernel/update-zen.py
@@ -64,24 +64,24 @@ def update_file(relpath, version, suffix, sha256):
         for line in f:
             result = line
             result = re.sub(
-                fr'^  version = ".+";',
-                f'  version = "{version}";',
+                r'^(\s*)version = ".+";',
+                fr'\1version = "{version}";',
                 result)
             result = re.sub(
-                fr'^  suffix = ".+";',
-                f'  suffix = "{suffix}";',
+                r'^(\s*)suffix = ".+";',
+                fr'\1suffix = "{suffix}";',
                 result)
             result = re.sub(
-                fr'^    sha256 = ".+";',
-                f'    sha256 = "{sha256}";',
+                r'^(\s*)sha256 = ".+";',
+                fr'\1sha256 = "{sha256}";',
                 result)
             print(result, end='')
 
 
 def read_file(relpath):
     file_path = os.path.join(DIR, relpath)
-    re_version = re.compile(fr'^\s*version = "(.+)";')
-    re_suffix = re.compile(fr'^\s*suffix = "(.+)";')
+    re_version = re.compile(r'^\s*version = "(.+)";')
+    re_suffix = re.compile(r'^\s*suffix = "(.+)";')
     version = None
     suffix = None
     with fileinput.FileInput(file_path, mode='r') as f:

--- a/pkgs/os-specific/linux/kernel/zen-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/zen-kernels.nix
@@ -18,7 +18,7 @@ in
 buildLinux (
   args
   // rec {
-    version = "6.18.13";
+    version = "6.19.9";
     pname = "linux-zen";
     modDirVersion = lib.versions.pad 3 "${version}-${suffix}";
     isZen = true;
@@ -27,7 +27,7 @@ buildLinux (
       owner = "zen-kernel";
       repo = "zen-kernel";
       rev = "v${version}-${suffix}";
-      sha256 = "0x6s3pa7c6zlvr3w2fv6i15v54cy1pschvgk7b4vrzx1bcrjdxf7";
+      sha256 = "09wlnd8ndm4r75ywk2sanmkc0v788rz9faa61hcfschw5pq5yzx6";
     };
 
     # This is based on the following source:
@@ -46,6 +46,7 @@ buildLinux (
       # Preempt (low-latency)
       PREEMPT = mkKernelOverride yes;
       PREEMPT_VOLUNTARY = mkKernelOverride no;
+      PREEMPT_LAZY = mkKernelOverride no;
 
       # Preemptible tree-based hierarchical RCU
       TREE_RCU = yes;

--- a/pkgs/os-specific/linux/kernel/zen-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/zen-kernels.nix
@@ -12,7 +12,7 @@ let
   # override options if they need using lib.mkForce (that has 50 priority)
   mkKernelOverride = lib.mkOverride 90;
 
-  suffix = "zen1"; # zen
+  suffix = "zen1";
 in
 
 buildLinux (


### PR DESCRIPTION
The update script was not working after #499218, so I fixed it (and cleaned up some things) and ran it to update the kernel to the latest version. I had to add PREEMPT_LAZY = no, so that the configure would work (and select full preemption, like upstream zen). This was probably necessary since #497657.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
