### PR TITLE
{pkgsCross.aarch64-darwin.,}discord*: update

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -15,9 +15,9 @@
     "version": "0.0.183"
   },
   "linux-stable": {
-    "hash": "sha256-90XmXUbkzwiMXh1UGpeO8xqkXb589+dwUlt7iHGEwQU=",
-    "url": "https://stable.dl2.discordapp.net/apps/linux/0.0.128/discord-0.0.128.tar.gz",
-    "version": "0.0.128"
+    "hash": "sha256-FMIM/CWPk3Kcqp8iIg+gxiCpjD2DNk7dSBqnCBvzn5w=",
+    "url": "https://stable.dl2.discordapp.net/apps/linux/0.0.130/discord-0.0.130.tar.gz",
+    "version": "0.0.130"
   },
   "osx-canary": {
     "hash": "sha256-cK3Yo7NT7MIUJYzaatO9qxNeAFwEDikPsv4CQPUZKZQ=",

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -20,9 +20,9 @@
     "version": "0.0.130"
   },
   "osx-canary": {
-    "hash": "sha256-cK3Yo7NT7MIUJYzaatO9qxNeAFwEDikPsv4CQPUZKZQ=",
-    "url": "https://canary.dl2.discordapp.net/apps/osx/0.0.1007/DiscordCanary.dmg",
-    "version": "0.0.1007"
+    "hash": "sha256-ZLsg7pjWc6MZtcJ6BeH+wrPteyoSQtxKpBUagNFeJwQ=",
+    "url": "https://canary.dl2.discordapp.net/apps/osx/0.0.1038/DiscordCanary.dmg",
+    "version": "0.0.1038"
   },
   "osx-development": {
     "hash": "sha256-UWZYRgykAiYPXPQ63cRIRiPdvG3a8lml84zgNABd0/E=",

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -10,9 +10,9 @@
     "version": "0.0.99"
   },
   "linux-ptb": {
-    "hash": "sha256-Oywm/ckDY3Mhoy3rbW5PdBSQVsPG4vzR/zHXBFfda4c=",
-    "url": "https://ptb.dl2.discordapp.net/apps/linux/0.0.182/discord-ptb-0.0.182.tar.gz",
-    "version": "0.0.182"
+    "hash": "sha256-vnzEamdX8pCzFtYLoWHvxcznHD1FCcgKnwQOx8BkWu0=",
+    "url": "https://ptb.dl2.discordapp.net/apps/linux/0.0.183/discord-ptb-0.0.183.tar.gz",
+    "version": "0.0.183"
   },
   "linux-stable": {
     "hash": "sha256-90XmXUbkzwiMXh1UGpeO8xqkXb589+dwUlt7iHGEwQU=",

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -25,9 +25,9 @@
     "version": "0.0.1038"
   },
   "osx-development": {
-    "hash": "sha256-UWZYRgykAiYPXPQ63cRIRiPdvG3a8lml84zgNABd0/E=",
-    "url": "https://development.dl2.discordapp.net/apps/osx/0.0.116/DiscordDevelopment.dmg",
-    "version": "0.0.116"
+    "hash": "sha256-gQL2ibCxqHsSbMu5Cor+RbioNdbuupJo8JoP4PWmJyA=",
+    "url": "https://development.dl2.discordapp.net/apps/osx/0.0.119/DiscordDevelopment.dmg",
+    "version": "0.0.119"
   },
   "osx-ptb": {
     "hash": "sha256-jnzl9VXIH0AlTtt8BKfVlIRVxAPUBq6iyxECjpE/c+E=",

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -30,9 +30,9 @@
     "version": "0.0.119"
   },
   "osx-ptb": {
-    "hash": "sha256-jnzl9VXIH0AlTtt8BKfVlIRVxAPUBq6iyxECjpE/c+E=",
-    "url": "https://ptb.dl2.discordapp.net/apps/osx/0.0.214/DiscordPTB.dmg",
-    "version": "0.0.214"
+    "hash": "sha256-SV6ZdD0CCnNNkSWyIDqCmg9dpdQr4JLbrD3+k8943PQ=",
+    "url": "https://ptb.dl2.discordapp.net/apps/osx/0.0.226/DiscordPTB.dmg",
+    "version": "0.0.226"
   },
   "osx-stable": {
     "hash": "sha256-zMIBZtvmncIAR3IEYblss7oP7miyRpmCkqao/NSA67k=",

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -1,8 +1,8 @@
 {
   "linux-canary": {
-    "hash": "sha256-0/A5x/5F60fGN/V6n+OZh6dqsi7D2zuSNABflXK0zF4=",
-    "url": "https://canary.dl2.discordapp.net/apps/linux/0.0.902/discord-canary-0.0.902.tar.gz",
-    "version": "0.0.902"
+    "hash": "sha256-byxxEliSZCecwxzsAP5GvrS5tz+fCj0/erBDC9hToug=",
+    "url": "https://canary.dl2.discordapp.net/apps/linux/0.0.925/discord-canary-0.0.925.tar.gz",
+    "version": "0.0.925"
   },
   "linux-development": {
     "hash": "sha256-Xe5PjHDWXU+eIAcBID34gjuADmAl1JAQLmXUAi/p4tg=",

--- a/pkgs/applications/networking/instant-messengers/discord/sources.json
+++ b/pkgs/applications/networking/instant-messengers/discord/sources.json
@@ -35,8 +35,8 @@
     "version": "0.0.226"
   },
   "osx-stable": {
-    "hash": "sha256-zMIBZtvmncIAR3IEYblss7oP7miyRpmCkqao/NSA67k=",
-    "url": "https://stable.dl2.discordapp.net/apps/osx/0.0.380/Discord.dmg",
-    "version": "0.0.380"
+    "hash": "sha256-vBadXUHrYhvkqzkCvGnKf25A19TKcFs5D0tzC54E0Hk=",
+    "url": "https://stable.dl2.discordapp.net/apps/osx/0.0.382/Discord.dmg",
+    "version": "0.0.382"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/503361

Commit messages written from the perspective of Linux, which made the most sense to me since this org is called NixOS after all...

Only built and ran the linux executables, don't have a mac, sorry.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
