### PR TITLE
mailutils: revert use of nss_wrapper for tests

### DIFF
--- a/pkgs/by-name/ma/mailutils/package.nix
+++ b/pkgs/by-name/ma/mailutils/package.nix
@@ -25,7 +25,6 @@
   system-sendmail,
   libxcrypt,
   mkpasswd,
-  nss_wrapper,
 
   pythonSupport ? true,
   guileSupport ? true,
@@ -113,20 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeCheckInputs = [
     dejagnu
     mkpasswd
-    nss_wrapper
   ];
-
-  preCheck = ''
-    # The nix sandbox's /etc/passwd has literal quotes around the home directory
-    # (e.g. "/build" instead of /build). imap4d's mu_homedir_assert (new in
-    # 3.21) calls stat() on this path, which fails because no directory named
-    # '"/build"' exists. Use nss_wrapper to provide a fixed passwd to the tests.
-    sed 's/"//g' /etc/passwd > "$TMPDIR/passwd"
-    sed 's/"//g' /etc/group > "$TMPDIR/group" 2>/dev/null || echo "nixbld:x:100:" > "$TMPDIR/group"
-    export LD_PRELOAD="${nss_wrapper}/lib/libnss_wrapper.so"
-    export NSS_WRAPPER_PASSWD="$TMPDIR/passwd"
-    export NSS_WRAPPER_GROUP="$TMPDIR/group"
-  '';
 
   doCheck = !stdenv.hostPlatform.isDarwin; # ERROR: All 46 tests were run, 46 failed unexpectedly.
 


### PR DESCRIPTION
This was introduced because of "the nix sandbox's /etc/passwd which has literal quotes around the home directory field", but this doesn't seem to be a standard configuration.  Using nss_wrapper causes other problems — it's not supported on Darwin or musl.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
