### PR TITLE
glycin-thumbnailer: init at 2.1.1

### DIFF
--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -88,6 +88,11 @@ stdenv.mkDerivation (finalAttrs: {
     export XDG_CACHE_HOME=$(mktemp -d)
   '';
 
+  # Thumbnailer files are provided by glycin-thumbnailer
+  postInstall = ''
+    rm -r $out/share/thumbnailers
+  '';
+
   env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
   passthru = {

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -71,11 +71,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    "-Dglycin-loaders=true"
-    "-Dglycin-thumbnailer=false"
-    "-Dlibglycin=false"
-    "-Dlibglycin-gtk4=false"
-    "-Dvapi=false"
+    (lib.mesonBool "glycin-loaders" true)
+    (lib.mesonBool "glycin-thumbnailer" false)
+    (lib.mesonBool "libglycin" false)
+    (lib.mesonBool "libglycin-gtk4" false)
+    (lib.mesonBool "vapi" false)
     (lib.mesonBool "tests" finalAttrs.finalPackage.doCheck)
     (lib.mesonOption "loaders" (
       lib.concatMapStringsSep "," (loader: "glycin-${loader}") enabledLoaders

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -124,10 +124,12 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Glycin loaders for several formats";
     homepage = "https://gitlab.gnome.org/GNOME/glycin";
     teams = [ lib.teams.gnome ];
-    license = with lib.licenses; [
-      mpl20 # or
-      lgpl21Plus
-    ];
+    license =
+      with lib.licenses;
+      OR [
+        mpl20
+        lgpl21Plus
+      ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -20,7 +20,19 @@
   shared-mime-info,
   rustc,
   rustPlatform,
+
+  # List of loaders to build.
+  # https://gitlab.gnome.org/GNOME/glycin/-/blob/2.1.1/meson_options.txt?ref_type=tags#L26-43
+  enabledLoaders ? [
+    "heif"
+    "image-rs"
+    "jxl"
+    "svg"
+  ],
 }:
+
+# Doesn't produce any output if no loaders are enabled
+assert enabledLoaders != [ ];
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glycin-loaders";
@@ -65,6 +77,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dlibglycin-gtk4=false"
     "-Dvapi=false"
     (lib.mesonBool "tests" finalAttrs.finalPackage.doCheck)
+    (lib.mesonOption "loaders" (
+      lib.concatMapStringsSep "," (loader: "glycin-${loader}") enabledLoaders
+    ))
   ];
 
   strictDeps = true;
@@ -91,6 +106,8 @@ stdenv.mkDerivation (finalAttrs: {
   env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
   passthru = {
+    inherit enabledLoaders;
+
     tests = {
       withTests = finalAttrs.finalPackage.overrideAttrs {
         doCheck = true;

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -103,6 +103,11 @@ stdenv.mkDerivation (finalAttrs: {
     export XDG_CACHE_HOME=$(mktemp -d)
   '';
 
+  # Thumbnailer files are provided by glycin-thumbnailer
+  postInstall = ''
+    rm -r $out/share/thumbnailers
+  '';
+
   env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
   passthru = {

--- a/pkgs/by-name/gl/glycin-thumbnailer/package.nix
+++ b/pkgs/by-name/gl/glycin-thumbnailer/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  callPackage,
   cargo,
   fontconfig,
   glib,
@@ -61,6 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
       done
     )
   '';
+
+  passthru.tests.thumbnailer = callPackage ./tests.nix { };
 
   meta = {
     description = "Glycin thumbnailers for several formats";

--- a/pkgs/by-name/gl/glycin-thumbnailer/package.nix
+++ b/pkgs/by-name/gl/glycin-thumbnailer/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  cargo,
+  fontconfig,
+  glib,
+  glycin-loaders,
+  libglycin,
+  libseccomp,
+  meson,
+  ninja,
+  pkg-config,
+  rustc,
+  rustPlatform,
+  wrapGAppsNoGuiHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "glycin-thumbnailer";
+
+  inherit (libglycin) version src cargoDeps;
+
+  nativeBuildInputs = [
+    cargo
+    libglycin.patchVendorHook
+    meson
+    ninja
+    pkg-config
+    rustc
+    rustPlatform.cargoSetupHook
+    wrapGAppsNoGuiHook
+  ];
+
+  buildInputs = [
+    fontconfig
+    glib
+    glycin-loaders
+    libglycin.setupHook
+    libseccomp
+  ];
+
+  mesonFlags = [
+    (lib.mesonBool "glycin-loaders" false)
+    (lib.mesonBool "glycin-thumbnailer" true)
+    (lib.mesonBool "libglycin" false)
+    (lib.mesonBool "libglycin-gtk4" false)
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  # Thumbnailer files are in `glycin-loaders`, but we provide them in this package
+  postInstall = ''
+    mkdir -p $out/share/thumbnailers
+    (
+      shopt -s failglob
+
+      for thumbnailer in ../glycin-loaders/glycin-*/glycin-*.thumbnailer.in; do
+        substitute "$thumbnailer" "$out/share/thumbnailers/$(basename "''${thumbnailer%.in}")" \
+          --subst-var-by "BINDIR" "$out/bin"
+      done
+    )
+  '';
+
+  meta = {
+    description = "Glycin thumbnailers for several formats";
+    homepage = "https://gitlab.gnome.org/GNOME/glycin";
+    changelog = "https://gitlab.gnome.org/GNOME/glycin/-/tags/${finalAttrs.version}";
+    license = with lib.licenses; [
+      mpl20 # or
+      lgpl21Plus
+    ];
+    maintainers = with lib.maintainers; [ thunze ];
+    teams = [ lib.teams.gnome ];
+    platforms = lib.platforms.linux;
+    mainProgram = "glycin-thumbnailer";
+  };
+})

--- a/pkgs/by-name/gl/glycin-thumbnailer/package.nix
+++ b/pkgs/by-name/gl/glycin-thumbnailer/package.nix
@@ -6,6 +6,7 @@
   fontconfig,
   glib,
   glycin-loaders,
+  glycin-thumbnailer,
   libglycin,
   libseccomp,
   meson,
@@ -66,7 +67,20 @@ stdenv.mkDerivation (finalAttrs: {
     )
   '';
 
-  passthru.tests.thumbnailer = callPackage ./tests.nix { };
+  passthru.tests = {
+    all-loaders = glycin-thumbnailer.override {
+      glycin-loaders = glycin-loaders.override {
+        enabledLoaders = [
+          "heif"
+          "image-rs"
+          "jxl"
+          "raw"
+          "svg"
+        ];
+      };
+    };
+    thumbnailer = callPackage ./tests.nix { };
+  };
 
   meta = {
     description = "Glycin thumbnailers for several formats";

--- a/pkgs/by-name/gl/glycin-thumbnailer/package.nix
+++ b/pkgs/by-name/gl/glycin-thumbnailer/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  callPackage,
   cargo,
   fontconfig,
   glib,
@@ -64,6 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
       done
     )
   '';
+
+  passthru.tests.thumbnailer = callPackage ./tests.nix { };
 
   meta = {
     description = "Glycin thumbnailers for several formats";

--- a/pkgs/by-name/gl/glycin-thumbnailer/package.nix
+++ b/pkgs/by-name/gl/glycin-thumbnailer/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  cargo,
+  fontconfig,
+  glib,
+  glycin-loaders,
+  libglycin,
+  libseccomp,
+  meson,
+  ninja,
+  pkg-config,
+  rustc,
+  rustPlatform,
+  wrapGAppsNoGuiHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "glycin-thumbnailer";
+
+  inherit (libglycin) version src cargoDeps;
+
+  nativeBuildInputs = [
+    cargo
+    libglycin.patchVendorHook
+    meson
+    ninja
+    pkg-config
+    rustc
+    rustPlatform.cargoSetupHook
+    wrapGAppsNoGuiHook
+  ];
+
+  buildInputs = [
+    fontconfig
+    glib
+    glycin-loaders
+    libglycin
+    libglycin.setupHook
+    libseccomp
+  ];
+
+  mesonFlags = [
+    (lib.mesonBool "glycin-loaders" false)
+    (lib.mesonBool "glycin-thumbnailer" true)
+    (lib.mesonBool "libglycin" false)
+    (lib.mesonBool "libglycin-gtk4" false)
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  # Thumbnailer files are in `glycin-loaders`, but we provide them in this package
+  postInstall = ''
+    mkdir -p $out/share/thumbnailers
+    (
+      shopt -s failglob
+
+      for loader in ${lib.concatStringsSep " " glycin-loaders.passthru.enabledLoaders}; do
+        substitute \
+          "../glycin-loaders/glycin-$loader/glycin-$loader.thumbnailer.in" \
+          "$out/share/thumbnailers/glycin-$loader.thumbnailer" \
+          --subst-var-by "BINDIR" "$out/bin"
+      done
+    )
+  '';
+
+  meta = {
+    description = "Glycin thumbnailers for several formats";
+    homepage = "https://gitlab.gnome.org/GNOME/glycin";
+    changelog = "https://gitlab.gnome.org/GNOME/glycin/-/tags/${finalAttrs.version}";
+    license = with lib.licenses; [
+      mpl20 # or
+      lgpl21Plus
+    ];
+    maintainers = with lib.maintainers; [ thunze ];
+    teams = [ lib.teams.gnome ];
+    platforms = lib.platforms.linux;
+    mainProgram = "glycin-thumbnailer";
+  };
+})

--- a/pkgs/by-name/gl/glycin-thumbnailer/package.nix
+++ b/pkgs/by-name/gl/glycin-thumbnailer/package.nix
@@ -86,10 +86,12 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Glycin thumbnailers for several formats";
     homepage = "https://gitlab.gnome.org/GNOME/glycin";
     changelog = "https://gitlab.gnome.org/GNOME/glycin/-/tags/${finalAttrs.version}";
-    license = with lib.licenses; [
-      mpl20 # or
-      lgpl21Plus
-    ];
+    license =
+      with lib.licenses;
+      OR [
+        mpl20
+        lgpl21Plus
+      ];
     maintainers = with lib.maintainers; [ thunze ];
     teams = [ lib.teams.gnome ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gl/glycin-thumbnailer/tests.nix
+++ b/pkgs/by-name/gl/glycin-thumbnailer/tests.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  glycin-thumbnailer,
+  shared-mime-info,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "glycin-thumbnailer-test";
+  inherit (glycin-thumbnailer) version;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "sophie-h";
+    repo = "test-images";
+    rev = "b148bcf70847d6f126a8e83e27e1c59d2e474adf";
+    hash = "sha256-dYsUgqjiElRbz3Quy/KxAm/Wu9qAwR5BK94uRrSmQ5s=";
+  };
+
+  # Fix incorrectly detected MIME types
+  preBuild = ''
+    export XDG_DATA_DIRS=${shared-mime-info}/share:$XDG_DATA_DIRS
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    cd images/
+    mkdir -p $out
+
+    for image in color/* icon/*; do
+      for size in 128 256 512 1024; do
+        input="file://$(realpath "$image")"
+        output="$out/$(basename "$image")-$size.png"
+
+        ${lib.getExe glycin-thumbnailer} -i "$input" -o "$output" -s $size
+        file -E "$output"
+      done
+    done
+
+    runHook postBuild
+  '';
+})

--- a/pkgs/by-name/gl/glycin-thumbnailer/tests.nix
+++ b/pkgs/by-name/gl/glycin-thumbnailer/tests.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  glycin-thumbnailer,
+  shared-mime-info,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "glycin-thumbnailer-test";
+  inherit (glycin-thumbnailer) version;
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "sophie-h";
+    repo = "test-images";
+    rev = "f7a06d9131a5686c1b58c56f42f9fda9ea5e620d";
+    hash = "sha256-qoteYmliUha3lY21PRM0FaeYu9aD5MsygBTsTYog9SE=";
+  };
+
+  # Fix incorrectly detected MIME types
+  preBuild = ''
+    export XDG_DATA_DIRS=${shared-mime-info}/share:$XDG_DATA_DIRS
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    cd images/
+    mkdir -p $out
+
+    for image in color/* icon/*; do
+      for size in 128 256 512 1024; do
+        input="file://$(realpath "$image")"
+        output="$out/$(basename "$image")-$size.png"
+
+        ${lib.getExe glycin-thumbnailer} -i "$input" -o "$output" -s $size
+        file -E "$output"
+      done
+    done
+
+    runHook postBuild
+  '';
+})

--- a/pkgs/by-name/li/libglycin-gtk4/package.nix
+++ b/pkgs/by-name/li/libglycin-gtk4/package.nix
@@ -89,10 +89,12 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "C-Bindings to convert glycin frames to GDK Textures";
     homepage = "https://gitlab.gnome.org/GNOME/glycin";
-    license = with lib.licenses; [
-      mpl20 # or
-      lgpl21Plus
-    ];
+    license =
+      with lib.licenses;
+      OR [
+        mpl20
+        lgpl21Plus
+      ];
     teams = [ lib.teams.gnome ];
     platforms = lib.platforms.linux;
     pkgConfigModules = [

--- a/pkgs/by-name/li/libglycin/package.nix
+++ b/pkgs/by-name/li/libglycin/package.nix
@@ -15,6 +15,7 @@
   glib,
   gobject-introspection,
   glycin-loaders,
+  glycin-thumbnailer,
   libglycin-gtk4,
   fontconfig,
   libseccomp,
@@ -146,6 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
     tests = {
       inherit
         glycin-loaders
+        glycin-thumbnailer
         libglycin-gtk4
         ;
     };

--- a/pkgs/by-name/li/libglycin/package.nix
+++ b/pkgs/by-name/li/libglycin/package.nix
@@ -157,10 +157,12 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Sandboxed and extendable image loading library";
     homepage = "https://gitlab.gnome.org/GNOME/glycin";
     changelog = "https://gitlab.gnome.org/GNOME/glycin/-/tags/${finalAttrs.version}";
-    license = with lib.licenses; [
-      mpl20 # or
-      lgpl21Plus
-    ];
+    license =
+      with lib.licenses;
+      OR [
+        mpl20
+        lgpl21Plus
+      ];
     maintainers = [ ];
     teams = [ lib.teams.gnome ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
This PR adds glycin-thumbnailer, a component of [glycin](https://gitlab.gnome.org/GNOME/glycin) that hasn't been packaged yet. It provides thumbnailers for the image formats supported by [glycin-loaders](https://gitlab.gnome.org/GNOME/glycin/-/tree/main/glycin-loaders).

The necessary `.thumbnailer` files are currently installed by the glycin-loaders component, but it's not clear to me why upstream made that choice. These `.thumbnailer` files require the thumbnailer executable they reference to exist, but this excutable is not installed if the Meson flag `glycin-thumbnailer` is set to `false`, which is currently the case. Therefore, the `.thumbnailer` files installed by glycin-loaders are currently not functional.

This PR would change that by

- Not installing the `.thumbnailer` files for glycin-loaders
- Adding glycin-thumbnailer, which builds the required thumbnailer executable, and letting it install the `.thumbnailer` files

This PR also adds a package test for glycin-thumbnailer, which tests the thumbnailer executable on a range of test images. I think that's important because failing thumbnailers are usually not something you immediately notice.

The thumbnailer executable in `$out/bin` can be tested on files of the respective formats using variations of the following command:

```bash
glycin-thumbnailer -i file://<input_file> -o <output_file> -s <size>
```

If you test the thumbnailer directly in a file manager, make sure to clear your thumbnail cache first.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
