### PR TITLE
ansible-doctor: fix version check hook

### DIFF
--- a/pkgs/by-name/an/ansible-doctor/package.nix
+++ b/pkgs/by-name/an/ansible-doctor/package.nix
@@ -4,6 +4,7 @@
   python3Packages,
   fetchFromGitHub,
   versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -45,8 +46,11 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   pythonImportsCheck = [ "ansibledoctor" ];
 
-  # ansible.errors.AnsibleError: Unable to create local directories(/private/var/empty/.ansible/tmp)
-  nativeCheckInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [ versionCheckHook ];
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
 
   meta = {
     description = "Annotation based documentation for your Ansible roles";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`ansible-doctor` requires a writable home directory because it calls Ansible functions directly and Ansible needs to create `$HOME/.ansible/tmp`. Weirdly enough, this build didn't fail in Hydra ([link](https://hydra.nixos.org/build/325031831)), but it does fail when building on my host. I assume that adding a writable home directory also fixes the Darwin build, but I have no system to test this on.

<details>
<summary>Build logs</summary>

```
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Using versionCheckHook
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/i15yzxl56qhmkad8j0vxi0p5v9b38zmi-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/renovate.json"
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing pypaBuildPhase
Setting POETRY_DYNAMIC_VERSIONING_BYPASS to 8.2.2
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
[1m* Getting build dependencies for wheel...[0m
[1m* Building wheel...[0m
[1m[92mSuccessfully built [4mansible_doctor-8.2.2-py3-none-any.whl[0m[1m[92m[0m
Finished creating a wheel...
/build/source/dist /build/source
Unpacking to: unpacked/ansible_doctor-8.2.2...OK
Repacking wheel as ./ansible_doctor-8.2.2-py3-none-any.whl...OK
/build/source
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
@nix { "action": "setPhase", "phase": "pythonRuntimeDepsCheckHook" }
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for ansible_doctor-8.2.2-py3-none-any.whl
Finished executing pythonRuntimeDepsCheck
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Executing pypaInstallPhase
Successfully installed ansible_doctor-8.2.2-py3-none-any.whl
Finished executing pypaInstallPhase
Running phase: pythonOutputDistPhase
@nix { "action": "setPhase", "phase": "pythonOutputDistPhase" }
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/wp8hm33y2qqw7wyx6avji5q4nba6hjl1-ansible-doctor-8.2.2
checking for references to /build/ in /nix/store/wp8hm33y2qqw7wyx6avji5q4nba6hjl1-ansible-doctor-8.2.2...
patching script interpreter paths in /nix/store/wp8hm33y2qqw7wyx6avji5q4nba6hjl1-ansible-doctor-8.2.2
stripping (with command strip and flags -S -p) in  /nix/store/wp8hm33y2qqw7wyx6avji5q4nba6hjl1-ansible-doctor-8.2.2/lib /nix/store/wp8hm33y2qqw7wyx6avji5q4nba6hjl1-ansible-doctor-8.2.2/bin
shrinking RPATHs of ELF executables and libraries in /nix/store/9z2dcnl9prnvqzll279x9zafyz3zn27i-ansible-doctor-8.2.2-dist
checking for references to /build/ in /nix/store/9z2dcnl9prnvqzll279x9zafyz3zn27i-ansible-doctor-8.2.2-dist...
patching script interpreter paths in /nix/store/9z2dcnl9prnvqzll279x9zafyz3zn27i-ansible-doctor-8.2.2-dist
Rewriting #!/nix/store/pzdalg368npikvpq4ncz2saxnz19v53k-python3-3.13.12/bin/python3.13 to #!/nix/store/pzdalg368npikvpq4ncz2saxnz19v53k-python3-3.13.12
wrapping `/nix/store/wp8hm33y2qqw7wyx6avji5q4nba6hjl1-ansible-doctor-8.2.2/bin/ansible-doctor'...
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
Running phase: installCheckPhase
@nix { "action": "setPhase", "phase": "installCheckPhase" }
Executing versionCheckPhase
Did not find version 8.2.2 in the output of the command /nix/store/wp8hm33y2qqw7wyx6avji5q4nba6hjl1-ansible-doctor-8.2.2/bin/ansible-doctor --version
Traceback (most recent call last):
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/utils/path.py", line 86, in makedirs_safe
    os.makedirs(b_rpath, mode, exist_ok=True)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 218, in makedirs
  File "<frozen os>", line 218, in makedirs
  File "<frozen os>", line 218, in makedirs
  File "<frozen os>", line 228, in makedirs
PermissionError: [Errno 13] Permission denied: b'/"'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "{{storeDir}}/bin/.ansible-doctor-wrapped", line 6, in <module>
    from ansibledoctor.cli import main
  File "{{storeDir}}/lib/python3.13/site-packages/ansibledoctor/cli.py", line 13, in <module>
    from ansibledoctor.doc_generator import Generator
  File "{{storeDir}}/lib/python3.13/site-packages/ansibledoctor/doc_generator.py", line 16, in <module>
    from ansibledoctor.doc_parser import Parser
  File "{{storeDir}}/lib/python3.13/site-packages/ansibledoctor/doc_parser.py", line 17, in <module>
    from ansibledoctor.utils.yaml_helper import parse_yaml, parse_yaml_ansible
  File "{{storeDir}}/lib/python3.13/site-packages/ansibledoctor/utils/yaml_helper.py", line 10, in <module>
    from ansible.parsing.yaml.loader import AnsibleLoader
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/parsing/yaml/loader.py", line 5, in <module>
    from ansible._internal._yaml import _loader
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/_internal/_yaml/_loader.py", line 11, in <module>
    from ._constructor import AnsibleConstructor, AnsibleInstrumentedConstructor
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/_internal/_yaml/_constructor.py", line 11, in <module>
    from ansible import constants as C
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/constants.py", line 188, in <module>
    set_constant(setting, config.get_config_value(setting, variables=vars()))
                          ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/config/manager.py", line 545, in get_config_value
    value, _drop = self.get_config_value_and_origin(config, cfile=cfile, plugin_type=plugin_type, plugin_name=plugin_name,
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                    keys=keys, variables=variables, direct=direct)
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/config/manager.py", line 669, in get_config_value_and_origin
    value = ensure_type(value, defs[config].get('type'), origin=origin, origin_ftype=origin_ftype)
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/config/manager.py", line 108, in ensure_type
    value = _ensure_type(value, value_type, origin)
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/config/manager.py", line 179, in _ensure_type
    makedirs_safe(value, 0o700)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/utils/path.py", line 90, in makedirs_safe
    raise AnsibleError(f"Unable to create local directories {rpath!r}.") from ex
ansible.errors.AnsibleError: Unable to create local directories '/"/build"/.ansible/tmp': [Errno 13] Permission denied: b'/"'
Did not find version 8.2.2 in the output of the command /nix/store/wp8hm33y2qqw7wyx6avji5q4nba6hjl1-ansible-doctor-8.2.2/bin/ansible-doctor --help
Traceback (most recent call last):
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/utils/path.py", line 86, in makedirs_safe
    os.makedirs(b_rpath, mode, exist_ok=True)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 218, in makedirs
  File "<frozen os>", line 218, in makedirs
  File "<frozen os>", line 218, in makedirs
  File "<frozen os>", line 228, in makedirs
PermissionError: [Errno 13] Permission denied: b'/"'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "{{storeDir}}/bin/.ansible-doctor-wrapped", line 6, in <module>
    from ansibledoctor.cli import main
  File "{{storeDir}}/lib/python3.13/site-packages/ansibledoctor/cli.py", line 13, in <module>
    from ansibledoctor.doc_generator import Generator
  File "{{storeDir}}/lib/python3.13/site-packages/ansibledoctor/doc_generator.py", line 16, in <module>
    from ansibledoctor.doc_parser import Parser
  File "{{storeDir}}/lib/python3.13/site-packages/ansibledoctor/doc_parser.py", line 17, in <module>
    from ansibledoctor.utils.yaml_helper import parse_yaml, parse_yaml_ansible
  File "{{storeDir}}/lib/python3.13/site-packages/ansibledoctor/utils/yaml_helper.py", line 10, in <module>
    from ansible.parsing.yaml.loader import AnsibleLoader
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/parsing/yaml/loader.py", line 5, in <module>
    from ansible._internal._yaml import _loader
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/_internal/_yaml/_loader.py", line 11, in <module>
    from ._constructor import AnsibleConstructor, AnsibleInstrumentedConstructor
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/_internal/_yaml/_constructor.py", line 11, in <module>
    from ansible import constants as C
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/constants.py", line 188, in <module>
    set_constant(setting, config.get_config_value(setting, variables=vars()))
                          ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/config/manager.py", line 545, in get_config_value
    value, _drop = self.get_config_value_and_origin(config, cfile=cfile, plugin_type=plugin_type, plugin_name=plugin_name,
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                    keys=keys, variables=variables, direct=direct)
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/config/manager.py", line 669, in get_config_value_and_origin
    value = ensure_type(value, defs[config].get('type'), origin=origin, origin_ftype=origin_ftype)
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/config/manager.py", line 108, in ensure_type
    value = _ensure_type(value, value_type, origin)
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/config/manager.py", line 179, in _ensure_type
    makedirs_safe(value, 0o700)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "{{storeDir}}/lib/python3.13/site-packages/ansible/utils/path.py", line 90, in makedirs_safe
    raise AnsibleError(f"Unable to create local directories {rpath!r}.") from ex
ansible.errors.AnsibleError: Unable to create local directories '/"/build"/.ansible/tmp': [Errno 13] Permission denied: b'/"'
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
