### PR TITLE
treewide: Take over packages from amesgen, remove them from maintainers

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1532,13 +1532,6 @@
     github = "amerinor01";
     githubId = 22280447;
   };
-  amesgen = {
-    email = "amesgen@amesgen.de";
-    github = "amesgen";
-    githubId = 15369874;
-    name = "Alexander Esgen";
-    matrix = "@amesgen:amesgen.de";
-  };
   ametrine = {
     name = "Matilde Ametrine";
     email = "matilde@diffyq.xyz";

--- a/nixos/modules/programs/bazecor.nix
+++ b/nixos/modules/programs/bazecor.nix
@@ -9,8 +9,6 @@ let
   cfg = config.programs.bazecor;
 in
 {
-  meta.maintainers = with lib.maintainers; [ amesgen ];
-
   options = {
     programs.bazecor = {
       enable = lib.mkEnableOption "Bazecor, the graphical configurator for Dygma Products";

--- a/pkgs/by-name/ba/bazecor/package.nix
+++ b/pkgs/by-name/ba/bazecor/package.nix
@@ -60,7 +60,6 @@ appimageTools.wrapAppImage {
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      amesgen
       gcleroux
     ];
     platforms = [ "x86_64-linux" ];

--- a/pkgs/by-name/cb/cbor-diag/package.nix
+++ b/pkgs/by-name/cb/cbor-diag/package.nix
@@ -36,7 +36,6 @@ bundlerApp {
     maintainers = with lib.maintainers; [
       fdns
       nicknovitski
-      amesgen
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/cd/cddl/package.nix
+++ b/pkgs/by-name/cd/cddl/package.nix
@@ -39,7 +39,6 @@ bundlerApp {
     maintainers = with lib.maintainers; [
       fdns
       nicknovitski
-      amesgen
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/cd/cddlc/package.nix
+++ b/pkgs/by-name/cd/cddlc/package.nix
@@ -17,7 +17,6 @@ bundlerApp {
     description = "CDDL conversion utilities";
     homepage = "https://github.com/cabo/cddlc";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ amesgen ];
     platforms = lib.platforms.unix;
     mainProgram = "cddlc";
   };

--- a/pkgs/by-name/di/diffnav/package.nix
+++ b/pkgs/by-name/di/diffnav/package.nix
@@ -47,7 +47,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/dlvhdr/diffnav";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      amesgen
       matthiasbeyer
     ];
     mainProgram = "diffnav";

--- a/pkgs/by-name/gh/gh-actions-cache/package.nix
+++ b/pkgs/by-name/gh/gh-actions-cache/package.nix
@@ -31,7 +31,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/actions/gh-actions-cache";
     changelog = "https://github.com/actions/gh-actions-cache/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ amesgen ];
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
     mainProgram = "gh-actions-cache";
   };
 })

--- a/pkgs/by-name/gh/gh-dash/package.nix
+++ b/pkgs/by-name/gh/gh-dash/package.nix
@@ -39,7 +39,7 @@ buildGoModule (finalAttrs: {
     description = "Github Cli extension to display a dashboard with pull requests and issues";
     homepage = "https://www.gh-dash.dev";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ amesgen ];
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
     mainProgram = "gh-dash";
   };
 })

--- a/pkgs/by-name/gh/gh-markdown-preview/package.nix
+++ b/pkgs/by-name/gh/gh-markdown-preview/package.nix
@@ -37,7 +37,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/yusukebe/gh-markdown-preview";
     changelog = "https://github.com/yusukebe/gh-markdown-preview/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ amesgen ];
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
     mainProgram = "gh-markdown-preview";
   };
 })

--- a/pkgs/by-name/la/latte-integrale/package.nix
+++ b/pkgs/by-name/la/latte-integrale/package.nix
@@ -38,7 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Software for counting lattice points and integration over convex polytopes";
     homepage = "https://www.math.ucdavis.edu/~latte/";
     license = lib.licenses.gpl2;
-    maintainers = with lib.maintainers; [ amesgen ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/sc/scriv/package.nix
+++ b/pkgs/by-name/sc/scriv/package.nix
@@ -66,7 +66,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/nedbat/scriv";
     changelog = "https://github.com/nedbat/scriv/releases/tag/${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ amesgen ];
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
     mainProgram = "scriv";
   };
 })

--- a/pkgs/by-name/ta/tandem-aligner/package.nix
+++ b/pkgs/by-name/ta/tandem-aligner/package.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/seryrzu/tandem_aligner";
     changelog = "https://github.com/seryrzu/tandem_aligner/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ amesgen ];
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
     platforms = lib.platforms.linux;
     mainProgram = "tandem_aligner";
   };

--- a/pkgs/by-name/wi/wizer/package.nix
+++ b/pkgs/by-name/wi/wizer/package.nix
@@ -48,7 +48,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       lucperkins
-      amesgen
     ];
   };
 }

--- a/pkgs/development/python-modules/pygsl/default.nix
+++ b/pkgs/development/python-modules/pygsl/default.nix
@@ -48,6 +48,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/pygsl/pygsl";
     changelog = "https://github.com/pygsl/pygsl/blob/${src.tag}/ChangeLog";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ amesgen ];
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
   };
 }


### PR DESCRIPTION
They have passed away:

https://www.tweag.io/blog/2025-12-16-in-memoriam-amesgen/

Condolences to family and friends.

This patchset takes over some of the packages and removes them from the maintainers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
