### PR TITLE
python3Packages.scalib: init at 0.6.4

### DIFF
--- a/pkgs/development/python-modules/scalib/default.nix
+++ b/pkgs/development/python-modules/scalib/default.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+
+  setuptools,
+  setuptools-scm,
+
+  cargo,
+  rustc,
+  setuptools-rust,
+
+  numpy,
+
+  pytestCheckHook,
+  pytest-cov-stub,
+  scikit-learn,
+  scipy,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "scalib";
+  version = "0.6.4";
+  pyproject = true;
+  src = fetchFromGitHub {
+    owner = "simple-crypto";
+    repo = "SCALib";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DVXb93W0TmOcyGyMN5GmIJNAdbLeeFnNm+3QfTw2j5s=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"setuptools-scm-git-archive",' ""
+  '';
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      cargoRoot
+      ;
+    hash = "sha256-mzzp5EnaBYIbGGxJ9mJ6dqRVcTDS406BRx7hWVZ11SY=";
+  };
+
+  cargoRoot = "src/scalib_ext";
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeBuildInputs = [
+    cargo
+    rustPlatform.cargoSetupHook
+    rustc
+    setuptools-rust
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+    scikit-learn
+    scipy
+    numpy
+  ];
+
+  meta = {
+    description = "Side-Channel Analysis Library";
+    homepage = "https://github.com/simple-crypto/scalib";
+    changelog = "https://github.com/simple-crypto/SCALib/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ d-brasher ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17223,6 +17223,8 @@ self: super: with self; {
 
   scales = callPackage ../development/python-modules/scales { };
 
+  scalib = callPackage ../development/python-modules/scalib { };
+
   scancode-toolkit = callPackage ../development/python-modules/scancode-toolkit { };
 
   scanpy = callPackage ../development/python-modules/scanpy { };


### PR DESCRIPTION
[SCALib](https://github.com/simple-crypto/SCALib) is a Python library that contains state-of-the-art tools for side-channel security evaluation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
