### PR TITLE
solanum: 0-unstable-2026-02-12 -> 0-unstable-2026-03-22

### DIFF
--- a/nixos/modules/services/networking/solanum.nix
+++ b/nixos/modules/services/networking/solanum.nix
@@ -12,7 +12,6 @@ let
     mkOption
     types
     ;
-  inherit (pkgs) solanum util-linux;
   cfg = config.services.solanum;
 
   configFile = pkgs.writeText "solanum.conf" cfg.config;
@@ -104,12 +103,28 @@ in
             configFile
           ];
           serviceConfig = {
-            ExecStart = "${solanum}/bin/solanum -foreground -logfile /dev/stdout -configfile /etc/solanum/ircd.conf -pidfile /run/solanum/ircd.pid";
-            ExecReload = "${util-linux}/bin/kill -HUP $MAINPID";
+            ExecStart = toString [
+              (lib.getExe pkgs.solanum)
+              "-foreground"
+              "-logfile"
+              "/dev/stdout"
+              "-configfile"
+              "/etc/solanum/ircd.conf"
+              "-pidfile"
+              "/run/solanum/ircd.pid"
+            ];
+            ExecReload = toString [
+              (lib.getExe' pkgs.util-linux "kill")
+              "-HUP"
+              "$MAINPID"
+            ];
             DynamicUser = true;
             User = "solanum";
             StateDirectory = "solanum";
+            StateDiectoryMode = "0750";
             RuntimeDirectory = "solanum";
+            RuntimeDirectoryMode = "0700";
+            UMask = "0027";
             LimitNOFILE = "${toString cfg.openFilesLimit}";
           };
         };

--- a/nixos/modules/services/networking/solanum.nix
+++ b/nixos/modules/services/networking/solanum.nix
@@ -45,6 +45,10 @@ in
             port = 6667;
           };
 
+          class "users" {
+            number_per_ip = 3;
+          };
+
           auth {
             user = "*@*";
             class = "users";

--- a/pkgs/by-name/so/solanum/package.nix
+++ b/pkgs/by-name/so/solanum/package.nix
@@ -1,80 +1,78 @@
 {
   lib,
   stdenv,
-  autoconf,
-  automake,
+  fetchFromGitHub,
+
+  # build
   libtool,
   bison,
-  fetchFromGitHub,
+  meson,
+  ninja,
   flex,
+
+  # runtime
   lksctp-tools,
+  hyperscan,
+  libxcrypt,
   openssl,
   pkg-config,
   sqlite,
-  util-linux,
   unstableGitUpdater,
   nixosTests,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "solanum";
-  version = "0-unstable-2026-02-12";
+  version = "0-unstable-2026-03-22";
 
   src = fetchFromGitHub {
     owner = "solanum-ircd";
     repo = "solanum";
-    rev = "59e35e3f5e0943729f2b55f860416b63c4a0e73f";
-    hash = "sha256-sK0cbVP8IcPhSfBgO70Y7gXYaar6Ua7OZM1HzU0rk9Y=";
+    rev = "6ac4d0e24e4b872b9f30adc743cf743e964d75d1";
+    hash = "sha256-5pW3QkSkmLoRrW/WjsDm4zCJLjwG0KVBKWbQe/iIgnM=";
   };
 
-  patches = [
-    ./dont-create-logdir.patch
-  ];
-
   postPatch = ''
-    substituteInPlace include/defaults.h --replace-fail 'ETCPATH "' '"/etc/solanum'
+    substituteInPlace include/defaults.h \
+      --replace-fail 'ETCPATH "' '"/etc/solanum'
+
+    # fhs path touching in the build sandbox breaks
+    sed -i "/install_emptydir/d" meson.build
   '';
 
-  preConfigure = ''
-    ./autogen.sh
-  '';
-
-  configureFlags = [
-    "--enable-epoll"
-    "--enable-ipv6"
-    "--enable-openssl=${openssl.dev}"
-    "--with-program-prefix=solanum-"
-    "--localstatedir=/var"
-    "--with-rundir=/run"
-    "--with-logdir=/var/log"
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux) [
-    "--enable-sctp=${lksctp-tools.out}/lib"
+  mesonFlags = [
+    # (lib.mesonOption "custom_version" finalAttrs.src.rev)
+    (lib.mesonBool "fhs_paths" true)
+    (lib.mesonOption "localstatedir" "/var")
+    (lib.mesonOption "logdir" "/var/log")
+    (lib.mesonOption "rundir" "/run")
+    (lib.mesonEnable "mbedtls" false)
+    (lib.mesonEnable "openssl" true)
+    (lib.mesonEnable "gnutls" false)
   ];
 
   nativeBuildInputs = [
-    autoconf
-    automake
-    libtool
     bison
     flex
+    libtool
+    meson
+    ninja
     pkg-config
-    util-linux
   ];
 
   buildInputs = [
+    hyperscan
+    libxcrypt
     openssl
     sqlite
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    lksctp-tools
   ];
 
   doCheck = !stdenv.hostPlatform.isDarwin;
 
   enableParallelBuilding = true;
-  # Missing install depends:
-  #   ...-binutils-2.40/bin/ld: cannot find ./.libs/libircd.so: No such file or directory
-  #   collect2: error: ld returned 1 exit status
-  #   make[4]: *** [Makefile:634: solanum] Error 1
-  enableParallelInstalling = false;
 
   passthru = {
     tests = { inherit (nixosTests) solanum; };
@@ -88,4 +86,4 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ hexa ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
The build now uses the meson build system.

Closes: #503313 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
