### PR TITLE
kubectx: 0.10.0 -> 0.10.2

### DIFF
--- a/pkgs/by-name/ku/kubectx/package.nix
+++ b/pkgs/by-name/ku/kubectx/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "kubectx";
-  version = "0.10.0";
+  version = "0.10.2";
 
   src = fetchFromGitHub {
     owner = "ahmetb";
     repo = "kubectx";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-LgZz/fRpIf/D3WmRic/P8O+wOrgKbDyAyBWzdOxXjKQ=";
+    hash = "sha256-rbfdqksNqWv2evrCl+2jMft2wBo7iWJoLvCABl1MUgk=";
   };
 
-  vendorHash = "sha256-BbGXJM1RMn7dgd8aaaGxRkqgs398rwpONWUcCcWNZow=";
+  vendorHash = "sha256-6bzTLnT69IdLwgbz/zZhjQYm8WpimJlItutW6fvwACs=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -34,6 +34,9 @@ buildGoModule (finalAttrs: {
     description = "Fast way to switch between clusters and namespaces in kubectl";
     license = lib.licenses.asl20;
     homepage = "https://github.com/ahmetb/kubectx";
-    maintainers = with lib.maintainers; [ jlesquembre ];
+    maintainers = with lib.maintainers; [
+      jlesquembre
+      miniharinn
+    ];
   };
 })


### PR DESCRIPTION
Release: https://github.com/ahmetb/kubectx/releases/tag/v0.10.2
Diff: https://github.com/ahmetb/kubectx/compare/v0.10.0...v0.10.2
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
