### PR TITLE
maintainers: remove arnoldfarkas

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2247,12 +2247,6 @@
     githubId = 1291396;
     name = "Arnar Ingason";
   };
-  arnoldfarkas = {
-    email = "arnold.farkas@gmail.com";
-    github = "arnoldfarkas";
-    githubId = 59696216;
-    name = "Arnold Farkas";
-  };
   arnoutkroeze = {
     email = "nixpkgs@arnoutkroeze.nl";
     github = "ArnoutKroeze";

--- a/pkgs/development/python-modules/atlassian-python-api/default.nix
+++ b/pkgs/development/python-modules/atlassian-python-api/default.nix
@@ -49,6 +49,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/atlassian-api/atlassian-python-api";
     changelog = "https://github.com/atlassian-api/atlassian-python-api/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ arnoldfarkas ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/djangorestframework-simplejwt/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-simplejwt/default.nix
@@ -44,6 +44,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/davesque/django-rest-framework-simplejwt";
     changelog = "https://github.com/jazzband/djangorestframework-simplejwt/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ arnoldfarkas ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/flower/default.nix
+++ b/pkgs/development/python-modules/flower/default.nix
@@ -44,6 +44,6 @@ buildPythonPackage rec {
     description = "Real-time monitor and web admin for Celery distributed task queue";
     homepage = "https://github.com/mher/flower";
     license = lib.licenses.bsdOriginal;
-    maintainers = with lib.maintainers; [ arnoldfarkas ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/nbconflux/default.nix
+++ b/pkgs/development/python-modules/nbconflux/default.nix
@@ -64,6 +64,6 @@ buildPythonPackage rec {
     mainProgram = "nbconflux";
     homepage = "https://github.com/Valassis-Digital-Media/nbconflux";
     license = lib.licenses.bsd3;
-    maintainers = [ lib.maintainers.arnoldfarkas ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sanic-auth/default.nix
+++ b/pkgs/development/python-modules/sanic-auth/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     description = "Simple Authentication for Sanic";
     homepage = "https://github.com/pyx/sanic-auth/";
     license = lib.licenses.bsdOriginal;
-    maintainers = with lib.maintainers; [ arnoldfarkas ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/sqlitedict/default.nix
+++ b/pkgs/development/python-modules/sqlitedict/default.nix
@@ -41,6 +41,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/RaRe-Technologies/sqlitedict";
     changelog = "https://github.com/piskvorky/sqlitedict/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ arnoldfarkas ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/untangle/default.nix
+++ b/pkgs/development/python-modules/untangle/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     description = "Convert XML documents into Python objects";
     homepage = "https://github.com/stchris/untangle";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.arnoldfarkas ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/vertica-python/default.nix
+++ b/pkgs/development/python-modules/vertica-python/default.nix
@@ -45,6 +45,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/vertica/vertica-python";
     changelog = "https://github.com/vertica/vertica-python/releases/tag/${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ arnoldfarkas ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/zstandard/default.nix
+++ b/pkgs/development/python-modules/zstandard/default.nix
@@ -50,6 +50,6 @@ buildPythonPackage rec {
     description = "Zstandard bindings for Python";
     homepage = "https://github.com/indygreg/python-zstandard";
     license = lib.licenses.bsdOriginal;
-    maintainers = with lib.maintainers; [ arnoldfarkas ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Reasons
* Last commented in [March 2021](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aarnoldfarkas)
* Hasn't created any PRs / Issues since [August 2020](https://github.com/NixOS/nixpkgs/issues?q=author%3Aarnoldfarkas)
* About 97 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aarnoldfarkas%20-commenter%3Aarnoldfarkas%20-author%3Aarnoldfarkas%20-reviewed-by%3Aarnoldfarkas) PRs / Issues
* No GitHub activity since [March 2021](https://github.com/arnoldfarkas?tab=overview&from=2021-03-01&to=2021-04-31)

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. @arnoldfarkas, you have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages
Those packages only have them as their maintainer and would need at least one new maintainer.

* [ ]  python3Packages.atlassian-python-api
* [ ]  python3Packages.djangorestframework-simplejwt
* [ ]  python3Packages.flower
* [ ]  python3Packages.nbconflux
* [ ]  python3Packages.sanic-auth
* [ ]  python3Packages.sqlitedict
* [ ]  python3Packages.untangle
* [ ]  python3Packages.vertica-python
* [ ]  python3Packages.zstandard