### PR TITLE
yaziPlugins: update on 2026-03-25

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/gvfs/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/gvfs/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "gvfs.yazi";
-  version = "0-unstable-2026-02-16";
+  version = "25.5.31-unstable-2026-03-24";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "gvfs.yazi";
-    rev = "9d64595cd5ba669dda27d41a936e748a795e949a";
-    hash = "sha256-KXx0SDcksaA7cM7UonUGVtm1JJEyC1lGja3R+fsHxtY=";
+    rev = "a908b623aef9c93b9921ce9b16cf50f0f3da0091";
+    hash = "sha256-3BM1XT1Kk0nXBwZ76MPfEHoYW0+4NXvB5o6Nlf+VL9g=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "26.1.22-unstable-2026-03-17";
+  version = "26.1.22-unstable-2026-03-24";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "26a75daabe768347d45aa65be4c75cfb15772ef2";
-    hash = "sha256-tE/ov1lF/bxxVCH00dXuWcjyjYkNpqeiMb0eIZ8Nwj4=";
+    rev = "a7febc034d1a5bef73921d1a2b170224549870bd";
+    hash = "sha256-v/yq7Dyivbf05SJ8Yk3QOkKFixpYkoGMtjuQSrGsN8I=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/starship/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/starship/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "starship.yazi";
-  version = "25.4.8-unstable-2025-12-03";
+  version = "25.4.8-unstable-2026-03-22";
 
   src = fetchFromGitHub {
     owner = "Rolv-Apneseth";
     repo = "starship.yazi";
-    rev = "eca186171c5f2011ce62712f95f699308251c749";
-    hash = "sha256-xcz2+zepICZ3ji0Hm0SSUBSaEpabWUrIdG7JmxUl/ts=";
+    rev = "a83710153ab5625a64ef98d55e6ddad480a3756f";
+    hash = "sha256-CPRVJVunBLwFLCoj+XfoIIwrrwHxqoElbskCXZgFraw=";
   };
 
   meta = {


### PR DESCRIPTION
- gvfs: 0-unstable-2026-02-16 → 25.5.31-unstable-2026-03-24
  Compare: https://github.com/boydaihungst/gvfs.yazi/compare/9d64595cd5ba669dda27d41a936e748a795e949a...a908b623aef9c93b9921ce9b16cf50f0f3da0091
- mediainfo: 26.1.22-unstable-2026-03-17 → 26.1.22-unstable-2026-03-24
  Compare: https://github.com/boydaihungst/mediainfo.yazi/compare/26a75daabe768347d45aa65be4c75cfb15772ef2...a7febc034d1a5bef73921d1a2b170224549870bd
- starship: 25.4.8-unstable-2025-12-03 → 25.4.8-unstable-2026-03-22
  Compare: https://github.com/Rolv-Apneseth/starship.yazi/compare/eca186171c5f2011ce62712f95f699308251c749...a83710153ab5625a64ef98d55e6ddad480a3756f


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
