### PR TITLE
wayle: init at 0.2.1

### DIFF
--- a/pkgs/by-name/wa/wayle/package.nix
+++ b/pkgs/by-name/wa/wayle/package.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  copyDesktopItems,
+  fetchFromGitHub,
+  fftw,
+  glib,
+  gtk4-layer-shell,
+  gtksourceview5,
+  installShellFiles,
+  libpulseaudio,
+  libxkbcommon,
+  makeDesktopItem,
+  nix-update-script,
+  pipewire,
+  pixman,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+  udev,
+  wrapGAppsHook4,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wayle";
+  version = "0.2.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "wayle-rs";
+    repo = "wayle";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YzDrvCTPuCOCkq0A79IHP+LYZ7ev3IpmWkk6sHuwDts=";
+  };
+
+  cargoHash = "sha256-KYYuB2TsHmHqYDXggWbj6HI0iZ0bepdMVDSQcocfXj4=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    glib
+    installShellFiles
+    pkg-config
+    rustPlatform.bindgenHook
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4-layer-shell.dev
+    gtksourceview5
+    # Not sure why ".dev" is needed here, but CMake doesn't find libxkbcommon otherwise
+    libxkbcommon.dev
+    pixman
+    udev
+
+    # for generating libcava bindings
+    fftw.dev
+    libpulseaudio
+    pipewire.dev
+  ];
+
+  cargoBuildFlags = [
+    "--bin=wayle"
+    "--bin=wayle-settings"
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  checkFlags = [
+    # GTK4 failed to initialize (requires GUI?)
+    "--skip=tests::css_loads_into_gtk4"
+  ];
+
+  preInstall = ''
+    mkdir -p "$out/share/icons/hicolor/scalable/apps"
+    cp -r resources/icons "$out/share"
+    cp resources/wayle-settings.svg "$out/share/icons/hicolor/scalable/apps"
+  '';
+
+  postInstall =
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+      # bash
+      ''
+        installShellCompletion --cmd wayle \
+          --bash <($out/bin/wayle completions bash) \
+          --fish <($out/bin/wayle completions fish) \
+          --zsh <($out/bin/wayle completions zsh)
+      '';
+
+  preFixup = ''
+    # so wayle could access wayle-settings binary
+    gappsWrapperArgs+=( --suffix PATH : $out/bin )
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "com.wayle.settings.desktop";
+      type = "Application";
+      desktopName = "Wayle Settings";
+      genericName = "Shell Settings";
+      comment = "Configure the Wayle desktop shell";
+      exec = "wayle-settings";
+      icon = "wayle-settings";
+      terminal = false;
+      categories = [
+        "Settings"
+        "DesktopSettings"
+        "GTK"
+      ];
+      keywords = [
+        "wayle"
+        "settings"
+        "shell"
+        "bar"
+        "wayland"
+        "config"
+      ];
+      startupNotify = true;
+      startupWMClass = "com.wayle.settings";
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Wayland Elements - A compositor agnostic shell with extensive customization";
+    homepage = "https://github.com/wayle-rs/wayle/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ PerchunPak ];
+    mainProgram = "wayle";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Wayland Elements - A compositor agnostic shell with extensive customization (successor of [HyprPanel](https://github.com/Jas-SinghFSU/HyprPanel)) (NOTE: currently it only supports hyprland)
https://github.com/wayle-rs/wayle/

Home-manager PR: https://github.com/nix-community/home-manager/pull/8998

I have been daily driving Wayle since 2026-03-10 and constantly updating this PR, it is very well tested, including the cava module (which vendors libcava).

# This PR got merged

For instructions on how to use Wayle, go to https://github.com/PerchunPak/wayle/blob/0585dc87e247bcf218b8ea0461b2cfc97761297d/docs/guide/getting-started-nixos.md

## How to try it out

In your home-manager config, create a new folder with these files:

- `package.nix` - copy file from this PR ([link](https://raw.githubusercontent.com/PerchunPak/nixpkgs/refs/heads/wayle/pkgs/by-name/wa/wayle/package.nix))
- `module.nix` - copy home-manager PR ([link](https://raw.githubusercontent.com/isaacST08/home-manager/refs/heads/module/wayle/modules/services/wayle.nix))
- `default.nix`, this is where you can configure wayle, put this there:

```nix
# put this into your home-manager config
{ pkgs, lib, ... }:
{
  imports = [
    ./module.nix
    # if you are on 25.11, also add this
    # (lib.mkAliasOptionModule [ "services" "swww" ] [ "services" "awww" ])
  ];

  # then you can use it as a normal program
  services.wayle = {
    enable = true;
    package = pkgs.callPackage ./package.nix { };
    # tip: you can automatically translate your TOML config to Nix by running
    # nix-instantiate --eval --expr 'builtins.fromTOML (builtins.readFile ./config.toml)' | nixfmt
    settings = {
      modules = {
        clock = {
          format = "%H:%M:%S";
          dropdown-show-seconds = false;
        };
      };
    };
  };
}
```

Then you can import the folder as a usual module (`imports = [ ./wayle ];` where `./wayle` is the path to the folder you created before)

### Configuration

You can configure Wayle using its GUI settings menu using the `wayle-settings` command. After you configured everything, there should be a new `.config/wayle/runtime.toml` file. To automatically convert it to nix, run
```sh
nix-instantiate --eval --expr '(builtins.fromTOML (builtins.readFile ./config.toml)) // (builtins.fromTOML (builtins.readFile ./runtime.toml))' | nixfmt
```
Or if one of the files does not exist (you can replace `config.toml` with `runtime.toml`):
```sh
nix-instantiate --eval --expr 'builtins.fromTOML (builtins.readFile ./config.toml)' | nixfmt
```

If you want to edit the raw `config.toml` file: Wayle does not have documentation for config options yet, but you can use [tombi](https://github.com/tombi-toml/tombi) for word completion in `~/.config/wayle/config.toml` (note that it doesn't work when config is symlinked to `/nix/store`, you need to create a normal file first). Install it using [Neovim](https://github.com/neovim/nvim-lspconfig/blob/16812abf0e8d8175155f26143a8504e8253e92b0/doc/configs.txt#L9877) or [VSCode](https://marketplace.visualstudio.com/items?itemName=tombi-toml.tombi)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
