### PR TITLE
tor: 0.4.9.5 -> 0.4.9.6

### DIFF
--- a/pkgs/by-name/to/tor/package.nix
+++ b/pkgs/by-name/to/tor/package.nix
@@ -46,11 +46,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tor";
-  version = "0.4.9.5";
+  version = "0.4.9.6";
 
   src = fetchurl {
     url = "https://dist.torproject.org/tor-${finalAttrs.version}.tar.gz";
-    hash = "sha256-yUnC+Gs0jmSJGXb2seScF3ZVsj35cZMEm/G4zTCZ4Xk=";
+    hash = "sha256-qJq6lwUumWOmVLQN8tRr4H6Ka24k5UN5F/2BrNkKcBc=";
   };
 
   outputs = [


### PR DESCRIPTION
Release notes: https://gitlab.torproject.org/tpo/core/tor/-/raw/tor-0.4.9.6/ReleaseNotes
TROVE: https://gitlab.torproject.org/tpo/core/team/-/wikis/NetworkTeam/TROVE

This release fixes two security issues: TROVE-2026-003 (high severity) and TROVE-2026-004 (medium severity). It also includes several improved defense in depth measures and bug fixes.

Tested by:
- Operating a relay with the NixOS module (aarch64-linux)
- Basic usage via `curl` for both clearnet sites and onion services (x86_64-linux)
	- command: `tor --SocksPort 9052` and then `curl --socks5-hostname localhost:9052 https://check.torproject.org/api/ip`
	- command: `tor --SocksPort 9052` and then `curl --socks5-hostname localhost:9052 http://2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion` (Tor Project homepage)
- Usage with Tor Browser as a managed proxy (x86_64-linux)
	- command: `tor --SocksPort 9050` and then `TOR_PROVIDER=none TOR_SOCKS_PORT=9050 tor-browser`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (picked onto nixos-unstable, since we don't feel like building the kernel)
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 503424`
Commit: `3205377804ef27e8f57df9da8a60373fe1b6fff2`

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 18 packages built:</summary>
  <ul>
    <li>bisq2</li>
    <li>briar-desktop</li>
    <li>carburetor</li>
    <li>cwtch-ui</li>
    <li>cwtch-ui.debug</li>
    <li>cwtch-ui.pubcache</li>
    <li>feather</li>
    <li>onionshare</li>
    <li>onionshare-gui</li>
    <li>onionshare-gui.dist</li>
    <li>onionshare.dist</li>
    <li>sparrow</li>
    <li>tor</li>
    <li>tor.geoip</li>
    <li>tractor</li>
    <li>tractor.dist</li>
    <li>trezor-suite</li>
    <li>wahay</li>
  </ul>
</details>

### `aarch64-linux`
<details>
  <summary>:white_check_mark: 14 packages built:</summary>
  <ul>
    <li>bisq2</li>
    <li>carburetor</li>
    <li>feather</li>
    <li>onionshare</li>
    <li>onionshare-gui</li>
    <li>onionshare-gui.dist</li>
    <li>onionshare.dist</li>
    <li>sparrow</li>
    <li>tor</li>
    <li>tor.geoip</li>
    <li>tractor</li>
    <li>tractor.dist</li>
    <li>trezor-suite</li>
    <li>wahay</li>
  </ul>
</details>
