### PR TITLE
vikunja{,-desktop}: use pnpm fetcherVersion 3

### DIFF
--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
   inherit version src;
 
   sourceRoot = "${finalAttrs.src.name}/desktop";
-  pnpmInstallFlags = [ "--shamefully-hoist" ];
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs)
@@ -37,7 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
       version
       src
       sourceRoot
-      pnpmInstallFlags
       ;
     pnpm = pnpm_10_29_2;
     fetcherVersion = 3;

--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -40,8 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
       pnpmInstallFlags
       ;
     pnpm = pnpm_10_29_2;
-    fetcherVersion = 1;
-    hash = "sha256-4+r+1Yi3BS7LHFIY4VOGMhG2RW/KcTy67oqkfXiMW7k=";
+    fetcherVersion = 3;
+    hash = "sha256-/dPjUxD01G1H3nRZfW8x046x33OaiChYuiLhZYOPrTo=";
   };
 
   env = {

--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -36,8 +36,8 @@ let
         sourceRoot
         ;
       pnpm = pnpm_10_29_2;
-      fetcherVersion = 1;
-      hash = "sha256-j84UVbLIqPz56Djy0vafhAOn9ZFM+kuTcBhfYZBYEDI=";
+      fetcherVersion = 3;
+      hash = "sha256-5eTw3W5cmdD8dEfZyJ+2cUBMbkPhF1S5gJMEojJYV2w=";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
Currently I get hash mismatch on master for `vikunja-desktop`:

```console
error: hash mismatch in fixed-output derivation '/nix/store/v5yxg77k1bxrli732fdrmjlj3557g64k-vikunja-desktop-2.2.0-pnpm-deps.drv':
           likely URL: (unknown)
            specified: sha256-4+r+1Yi3BS7LHFIY4VOGMhG2RW/KcTy67oqkfXiMW7k=
                  got: sha256-TRjH0pqBIXqd/XxbY5kQS+TGhfX3encs9bB1YeE55Xg=

```

And recently the hash was broken for `vikunja` too: https://github.com/NixOS/nixpkgs/pull/502218.

[`fetcherVersion`](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/javascript.section.md#pnpm-fetcherversion-javascript-pnpm-fetcherversion) 2 fixed a hash non-determinism. If anyone has the nix store paths with the old hashes, we could compare what has changed and confirm if it will be fixed by this fetcher version bump, or there's yet another pnpm bug that we should resolve.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
