### PR TITLE
below: 0.9.0 -> 0.11.0

### DIFF
--- a/pkgs/by-name/be/below/package.nix
+++ b/pkgs/by-name/be/below/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch,
   rustPlatform,
   clang,
   pkg-config,
@@ -12,24 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "below";
-  version = "0.9.0";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "facebookincubator";
     repo = "below";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tPweJFqhZMOL+M08bDjW6HPmtuhr9IXJNP0c938O7Cg=";
+    hash = "sha256-Paf3+aVsJpC8wyNqszCp3y5qQS8LEAyXvJBp9VG4uFM=";
   };
 
-  cargoPatches = [
-    (fetchpatch {
-      name = "update-Cargo.lock.patch";
-      url = "https://github.com/facebookincubator/below/commit/f46f9936ac29fa23f5cb02cafe93ae724649bafc.patch";
-      hash = "sha256-J+M8FIuo8ToT3+9eZi5qfwfAW98XcNRqTIJd6O8z1Ig=";
-    })
-  ];
-
-  cargoHash = "sha256-JrSSIwREHSg5YJivSdBIPjOkOtdw8qGCsa4yE7rJz/E=";
+  cargoHash = "sha256-8+8mBbQSFPcjfBB7y+dgyno+EW82ojhPNxx836gCMik=";
 
   prePatch = ''
     sed -i "s,ExecStart=.*/bin,ExecStart=$out/bin," etc/below.service


### PR DESCRIPTION
https://github.com/facebookincubator/below/releases/tag/v0.11.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
