### PR TITLE
yaup: unstable-2019-10-16 -> 0-unstable-2026-03-25

### DIFF
--- a/pkgs/by-name/ya/yaup/package.nix
+++ b/pkgs/by-name/ya/yaup/package.nix
@@ -2,33 +2,25 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   intltool,
   pkg-config,
   wrapGAppsHook3,
   gtk3,
   miniupnpc,
+  makeDesktopItem,
+  copyDesktopItems,
 }:
 
 stdenv.mkDerivation {
   pname = "yaup";
-  version = "unstable-2019-10-16";
+  version = "0-unstable-2026-03-25";
 
   src = fetchFromGitHub {
     owner = "Holarse-Linuxgaming";
     repo = "yaup";
-    rev = "7ee3fdbd8c1ecf0a0e6469c47560e26082808250";
-    hash = "sha256-RWnNjpgXRYncz9ID8zirENffy1UsfHD1H6Mmd8DKN4k=";
+    rev = "7135987a17208dab1b980ba5de55114abe217b63";
+    hash = "sha256-1P95cbGy8H+iXs/i7B4eTDzOPXJUJVBTOECsUZX9wG4=";
   };
-
-  patches = [
-    # Fix build with miniupnpc 2.2.8
-    # https://github.com/Holarse-Linuxgaming/yaup/pull/6
-    (fetchpatch2 {
-      url = "https://github.com/Holarse-Linuxgaming/yaup/commit/c92134e305932785a60bd72131388f507b4d1853.patch?full_index=1";
-      hash = "sha256-Exqkfp9VYIf9JpAc10cO8NuEAWvI5Houi7CLXV5zBDY=";
-    })
-  ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     # Replace GNU ld's --export-dynamic with macOS linker equivalent
@@ -37,6 +29,7 @@ stdenv.mkDerivation {
   '';
 
   nativeBuildInputs = [
+    copyDesktopItems
     intltool
     pkg-config
     wrapGAppsHook3
@@ -46,6 +39,28 @@ stdenv.mkDerivation {
     gtk3
     miniupnpc
   ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "yaup";
+      desktopName = "Yaup";
+      genericName = "UPnP Portmapper";
+      comment = "Yet Another UPnP Portmapper";
+      icon = "yaup";
+      exec = "yaup";
+      categories = [
+        "Network"
+        "Utility"
+      ];
+      keywords = [
+        "Port forwarding"
+      ];
+    })
+  ];
+
+  postInstall = ''
+    install -Dm644 src/yaup-dark.png $out/share/icons/hicolor/512x512/apps/yaup.png
+  '';
 
   meta = {
     homepage = "https://github.com/Holarse-Linuxgaming/yaup";


### PR DESCRIPTION
Also unbreaks the package

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
