### PR TITLE
unvanquished: 0.55.3 -> 0.56.1

### DIFF
--- a/pkgs/by-name/un/unvanquished/package.nix
+++ b/pkgs/by-name/un/unvanquished/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchzip,
   fetchFromGitHub,
-  SDL2,
+  sdl3,
   buildFHSEnv,
   cmake,
   copyDesktopItems,
@@ -34,15 +34,15 @@
 }:
 
 let
-  version = "0.55.3";
-  binary-deps-version = "10";
+  version = "0.56.1";
+  binary-deps-version = "11";
 
   src = fetchFromGitHub {
     owner = "Unvanquished";
     repo = "Unvanquished";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-wOFSPPEu7AGsEcqHG7xFWzFlYZRWAIvvfTj5FLZ3HFc=";
+    hash = "sha256-MIsHW56RYkh5xtidHpBOEwQQSsvGMEdAdGt5fQvqXxQ=";
   };
 
   unvanquished-binary-deps = stdenv.mkDerivation rec {
@@ -51,8 +51,8 @@ let
     version = binary-deps-version;
 
     src = fetchzip {
-      url = "https://dl.unvanquished.net/deps/linux-amd64-default_${version}.tar.xz ";
-      hash = "sha256-5n8gRvTuke4e7EaZ/5G+dtCG6qmnawhtA1IXIFQPkzA=";
+      url = "https://dl.unvanquished.net/deps/linux-amd64-default_${version}.tar.xz";
+      hash = "sha256-1PPqQYnMBFR7Jr48qiqQEduEjiFWx3XyvfPBwX/PzIY=";
     };
 
     dontPatchELF = true;
@@ -121,7 +121,7 @@ let
     pname = "unvanquished-assets";
     inherit version src;
 
-    outputHash = "sha256-6v6NO4Ad4rMFziWAO9x22CHtm/nfOuT0ptBEVhCMqZo=";
+    outputHash = "sha256-HnWdOvi7fcKmktLVbdUfMnB8v3iHb1t7jEERUcYcxNg=";
     outputHashMode = "recursive";
 
     nativeBuildInputs = [
@@ -149,7 +149,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    unvanquished-binary-deps
     copyDesktopItems
   ];
 
@@ -162,7 +161,7 @@ stdenv.mkDerivation rec {
     lua5
     nettle
     curl
-    SDL2
+    sdl3
     freetype
     glew
     openal
@@ -177,10 +176,12 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DBUILD_CGAME=NO"
-    "-DBUILD_SGAME=NO"
+    "-DBUILD_CGAME=FALSE"
+    "-DBUILD_SGAME=FALSE"
     "-DUSE_HARDENING=TRUE"
     "-DUSE_LTO=TRUE"
+    "-DUSE_OPENMP=TRUE"
+    "-DUSE_EXTERNAL_DEPS_LIBS=FALSE"
     "-DOpenGL_GL_PREFERENCE=LEGACY" # https://github.com/DaemonEngine/Daemon/issues/474
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (no other platforms)
- Tested, as applicable:
  - [ ] <del>[NixOS tests] in [nixos/tests].</del>
  - [ ] <del>[Package tests] at `passthru.tests`.</del>
  - [ ] <del>Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.</del>
- [ ] <del>Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].</del>
  - tried running `nixpkgs-review`, it crashed because it was killed by the OOM. Note that CI passed and nothing depends on the package.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] <del>Package update: when the change is major or breaking.</del>
- NixOS Release Notes
  - [ ] <del>Module addition: when adding a new NixOS module.</del>
  - [ ] <del>Module update: when the change is significant.</del>
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


This is an update by the maintainer.

This PR should be backported to NixOS stable, since the game is really not fun without the latest version (can't play online). Please add the backport label to this PR.