### PR TITLE
certspotter: 0.21.0 -> 0.24.0

### DIFF
--- a/pkgs/by-name/ce/certspotter/package.nix
+++ b/pkgs/by-name/ce/certspotter/package.nix
@@ -7,20 +7,26 @@
 
 buildGoModule (finalAttrs: {
   pname = "certspotter";
-  version = "0.21.0";
+  version = "0.24.0";
 
   src = fetchFromGitHub {
     owner = "SSLMate";
     repo = "certspotter";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-cJIjJyWvy/prx97jUvVToJsEdMa0MpqATD9rO8G2biY=";
+    hash = "sha256-OmukbtHOvyfjRb7WdAc3A3I5FlWmQD515dNeJ5JiJ0k=";
   };
 
-  vendorHash = "sha256-CLq/QFnZ5OLv7wT+VYr5SkSgmwt1g6cBYcAlB4Z/3wE=";
+  vendorHash = "sha256-F7qNpvjWqywPPLTKw90bfy6V83/LMQcV+Gml2n1Wd2A=";
 
   ldflags = [
     "-s"
     "-w"
+    "-X main.Version=${finalAttrs.version}"
+    "-X main.Source=software.sslmate.com/src/certspotter"
+  ];
+
+  checkFlags = [
+    "-skip=TestParseFromURL" # requires network access
   ];
 
   nativeBuildInputs = [ lowdown-unsandboxed ];


### PR DESCRIPTION
Diff: https://github.com/SSLMate/certspotter/compare/v0.21.0...v0.24.0
Changelog: https://github.com/SSLMate/certspotter/blob/v0.24.0/CHANGELOG.md

Fixed `certspotter --version` not displaying the version.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
