### PR TITLE
bitwig-studio6: init at 6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7704,6 +7704,13 @@
     githubId = 103082;
     name = "Ed Brindley";
   };
+  eleina = {
+    email = "ellie@eleina.dev";
+    github = "eleinah";
+    githubId = 129979592;
+    name = "Eleina Mironia";
+    keys = [ { fingerprint = "0A86 5F49 90B1 569C B849  5070 2EF4 8A29 49D6 5978"; } ];
+  };
   eleonora = {
     email = "leonsch@protonmail.com";
     github = "42LoCo42";

--- a/pkgs/by-name/bi/bitwig-studio6/package.nix
+++ b/pkgs/by-name/bi/bitwig-studio6/package.nix
@@ -1,0 +1,157 @@
+{
+  alsa-lib,
+  atk,
+  autoPatchelfHook,
+  bubblewrap,
+  cairo,
+  dpkg,
+  fetchurl,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  harfbuzz,
+  lcms,
+  lib,
+  libglvnd,
+  libjack2,
+  libjpeg8,
+  libnghttp2,
+  libudev-zero,
+  libx11,
+  libxcb,
+  libxcb-util,
+  libxcb-wm,
+  libxcursor,
+  libxkbcommon,
+  libxtst,
+  makeBinaryWrapper,
+  pango,
+  pipewire,
+  stdenv,
+  vulkan-loader,
+  wrapGAppsHook3,
+  writeShellScript,
+  xcb-imdkit,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bitwig-studio6";
+  version = "6.0";
+
+  src = fetchurl {
+    name = "bitwig-studio-${finalAttrs.version}.deb";
+    url = "https://www.bitwig.com/dl/Bitwig%20Studio/${finalAttrs.version}/installer_linux";
+    hash = "sha256-jrCTgaxfeWhfKwLeKLmqTQWS7RVbVnHqJ0InCipmm8k=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeBinaryWrapper
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    atk
+    cairo
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    harfbuzz
+    lcms
+    libglvnd
+    (lib.getLib stdenv.cc.cc)
+    libjack2
+    libjpeg8
+    libnghttp2
+    libudev-zero
+    libx11
+    libxcb
+    libxcb-util
+    libxcb-wm
+    libxcursor
+    libxkbcommon
+    libxtst
+    pango
+    pipewire
+    vulkan-loader
+    xcb-imdkit
+    zlib
+    alsa-lib
+  ];
+
+  dontWrapGApps = true; # we only want $gappsWrapperArgs here
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir "$out"
+    cp -r usr/share "$out"
+    cp -r opt/bitwig-studio "$out"/libexec
+
+    # Bitwig includes a copy of libxcb-imdkit.
+    # Removing it will force it to use our version.
+    rm "$out"/libexec/lib/bitwig-studio/libxcb-imdkit.so.1
+
+    runHook postInstall
+  '';
+
+  postFixup =
+    let
+      wrapper = writeShellScript "bitwig-studio" ''
+        set -e
+
+        currentDir="$(cd "$(dirname "$0")" && pwd)"
+        outDir="$(cd "$currentDir/.." && pwd)"
+
+        TMPDIR="$(mktemp --directory)"
+        cp -r "$outDir"/libexec/resources/VampTransforms "$TMPDIR"
+        chmod -R u+w "$TMPDIR/VampTransforms"
+
+        bwrap \
+          --bind / / \
+          --bind "$TMPDIR"/VampTransforms "$outDir"/libexec/resources/VampTransforms \
+          --dev-bind /dev /dev \
+          "$outDir"/libexec/bitwig-studio \
+          || true
+
+        rm -rf "$TMPDIR"
+      '';
+    in
+    ''
+      for e in "$out"/libexec/bin/*gtk*; do
+        if [ -f "$e" ] && [ -x "$e" ]; then
+          wrapProgram "$e" "''${gappsWrapperArgs[@]}"
+        fi
+      done
+
+      install -D ${wrapper} "$out"/bin/bitwig-studio
+      wrapProgram "$out"/bin/bitwig-studio \
+        --prefix PATH : ${lib.makeBinPath [ bubblewrap ]}
+    '';
+
+  meta = {
+    description = "Digital audio workstation";
+    longDescription = ''
+      Bitwig Studio is a multi-platform music-creation system for
+      production, performance and DJing, with a focus on flexible
+      editing tools and a super-fast workflow.
+    '';
+    homepage = "https://www.bitwig.com/";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [
+      bfortz
+      eleina
+      michalrus
+      mrVanDalo
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "bitwig-studio";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9283,7 +9283,7 @@ with pkgs;
     bitwig-studio-unwrapped = bitwig-studio5-unwrapped;
   };
 
-  bitwig-studio = bitwig-studio5;
+  bitwig-studio = bitwig-studio6;
 
   blucontrol = callPackage ../applications/misc/blucontrol/wrapper.nix {
     inherit (haskellPackages) ghcWithPackages;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bitwig Studio 6.0 was released a couple of weeks ago: https://www.bitwig.com/stories/on-another-level-bitwig-studio-6-is-out-now-416/

Supersedes #498922, which originally bumped Bitwig Studio to 6.0 (thanks @so-lar-is). This PR migrates the package to `pkgs/by-name/bi/bitwig-studio6` and updates the `bitwig-studio` attribute in `pkgs/top-level/all-packages.nix`

I messed around with some old projects, made some new ones, and I also wasn't able to see any obvious defects.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
