### PR TITLE
steamvr-linux-fixes: init at 0.1.3 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14125,6 +14125,13 @@
     githubId = 148352;
     name = "Jim Fowler";
   };
+  Kitsune = {
+    name = "Lunae V";
+    github = "KitsuneDev";
+    githubId = 11809449;
+    email = "kitsune@akitsune.dev";
+    matrix = "@kitsune:akitsune.dev";
+  };
   kitsunoff = {
     github = "kitsunoff";
     githubId = 58953114;

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14426,6 +14426,13 @@
     githubId = 7587245;
     name = "Kit Langton";
   };
+  Kitsune = {
+    name = "Lunae V";
+    github = "KitsuneDev";
+    githubId = 11809449;
+    email = "kitsune@akitsune.dev";
+    matrix = "@kitsune:akitsune.dev";
+  };
   kitsunoff = {
     github = "kitsunoff";
     githubId = 58953114;

--- a/pkgs/by-name/st/steamvr-linux-fixes/package.nix
+++ b/pkgs/by-name/st/steamvr-linux-fixes/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  vulkan-headers,
+  vulkan-loader,
+  python3Packages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "steamvr-linux-fixes";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "BnuuySolutions";
+    repo = "SteamVRLinuxFixes";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pyIEzVGkMWtFPBFGIpxmuFw8a1lbBAOm2BrpqAwD6Hc=";
+
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    vulkan-headers
+    vulkan-loader
+  ];
+
+  env.NIX_CFLAGS_LINK = "-Wl,-z,noexecstack";
+
+  cmakeFlags = [
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_DISTORM" "${python3Packages.distorm3.src}")
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 libsteamvr_linux_fixes.so -t $out/lib
+
+    layerJson="$out/share/vulkan/implicit_layer.d/VkLayer_steamvr_linux_fixes.json"
+
+    install -Dm644 "$src/VkLayer_steamvr_linux_fixes.json" "$layerJson"
+
+    substituteInPlace "$layerJson" \
+      --replace-fail \
+        '"library_path": "./libsteamvr_linux_fixes.so"' \
+        '"library_path": "'"$out"'/lib/libsteamvr_linux_fixes.so"'
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Vulkan layer that patches SteamVR vrcompositor for wired HMDs";
+    longDescription = ''
+      A Vulkan layer that patches SteamVR's vrcompositor to address issues for
+      wired headsets (Vive, Index, Beyond, PSVR2, etc), applying fixes such as correct
+      refresh rate support, frame presentation latency via VK_KHR_present_wait,
+      FIFO_LATEST_READY on NVIDIA, swapchain usage flags for Mesa, and a crash
+      on zero-sized texture allocation.
+
+      Add to programs.steam.extraPackages to use with Steam on NixOS. The layer
+      activates automatically via the Vulkan implicit layer mechanism and can be
+      disabled at runtime by setting DISABLE_STEAMVR_LINUX_FIXES=1.
+    '';
+    homepage = "https://github.com/BnuuySolutions/SteamVRLinuxFixes";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Kitsune ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+})

--- a/pkgs/by-name/st/steamvr-linux-fixes/package.nix
+++ b/pkgs/by-name/st/steamvr-linux-fixes/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  vulkan-headers,
+  vulkan-loader,
+  python3Packages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "steamvr-linux-fixes";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "BnuuySolutions";
+    repo = "SteamVRLinuxFixes";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Zvk7I4df+Y8FsnkNLZ+h3SsdFK9BL35TCJgsSk/G58U=";
+
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    vulkan-headers
+    vulkan-loader
+  ];
+
+  env.NIX_CFLAGS_LINK = "-Wl,-z,noexecstack";
+
+  cmakeFlags = [
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_DISTORM" "${python3Packages.distorm3.src}")
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 libsteamvr_linux_fixes.so -t $out/lib
+
+    layerJson="$out/share/vulkan/implicit_layer.d/VkLayer_steamvr_linux_fixes.json"
+
+    install -Dm644 "$src/VkLayer_steamvr_linux_fixes.json" "$layerJson"
+
+    substituteInPlace "$layerJson" \
+      --replace-fail \
+        '"library_path": "./libsteamvr_linux_fixes.so"' \
+        '"library_path": "'"$out"'/lib/libsteamvr_linux_fixes.so"'
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Vulkan layer that patches SteamVR vrcompositor for wired HMDs";
+    longDescription = ''
+      A Vulkan layer that patches SteamVR's vrcompositor to address issues for
+      wired headsets (Vive, Index, Beyond, PSVR2, etc), applying fixes such as correct
+      refresh rate support, frame presentation latency via VK_KHR_present_wait,
+      FIFO_LATEST_READY on NVIDIA, swapchain usage flags for Mesa, and a crash
+      on zero-sized texture allocation.
+
+      Add to programs.steam.extraPackages to use with Steam on NixOS. The layer
+      activates automatically via the Vulkan implicit layer mechanism and can be
+      disabled at runtime by setting DISABLE_STEAMVR_LINUX_FIXES=1.
+    '';
+    homepage = "https://github.com/BnuuySolutions/SteamVRLinuxFixes";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Kitsune ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+})


### PR DESCRIPTION

**New Package** (And new maintainer 😅 )
**Project Source**: https://github.com/BnuuySolutions/SteamVRLinuxFixes

A Vulkan layer that patches SteamVR's vrcompositor to address issues for wired headsets (Vive, Index, Beyond, PSVR2, etc).

Fixes include:
  *  Patches vrcompositor to allow all refresh rates to work correctly. For example, PSVR2 could only use 90Hz and not 120Hz
  *  Uses VK_KHR_present_wait to wait on the latest frame that was just rendered. This fixes the view lagging behind
  *  Enables VK_PRESENT_MODE_FIFO_LATEST_READY_EXT if supported (NVIDIA only), which ensures the latest frame is always presented
  *  Addresses issue with swapchain missing VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, which causes no image to show in HMD on Mesa 26
   * Fixes a crash that can happen if SteamVR decides to allocate a 0x0 Vulkan texture. Launching Resonite on AMD was one way to cause this issue


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
