### PR TITLE
unpackerr: 0.14.5 -> 0.15.2

### DIFF
--- a/pkgs/by-name/un/unpackerr/package.nix
+++ b/pkgs/by-name/un/unpackerr/package.nix
@@ -6,26 +6,28 @@
 
 buildGoModule (finalAttrs: {
   pname = "unpackerr";
-  version = "0.14.5";
+  version = "0.15.2";
 
   src = fetchFromGitHub {
     owner = "davidnewhall";
     repo = "unpackerr";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-uQwpdgV6ksouW9JTuiiuQjxBGOE/ypDW769kNJgWrHw=";
+    sha256 = "sha256-npq0CXsaWaFa6RazQXRKVaqTyK87VhzaF/hd/d952Po=";
   };
 
-  vendorHash = "sha256-wWIw0gNn5tqRq0udzPy/n2OkiIVESpSotOSn2YlBNS4=";
+  vendorHash = "sha256-v0ml1dTIhf79mhlyTrPNhIfg1Yhao27eP0pnI95OvaU=";
 
   ldflags = [
     "-s"
     "-w"
+    "-X golift.io/version.Branch=main"
     "-X golift.io/version.Version=${finalAttrs.version}"
+    "-X golift.io/version.Revision=v${finalAttrs.version}"
   ];
 
   meta = {
     description = "Extracts downloads for Radarr, Sonarr, Lidarr - Deletes extracted files after import";
-    homepage = "https://github.com/davidnewhall/unpackerr";
+    homepage = "https://unpackerr.zip/";
     maintainers = [ ];
     license = lib.licenses.mit;
     mainProgram = "unpackerr";


### PR DESCRIPTION
Diff: https://github.com/Unpackerr/unpackerr/compare/v0.14.5...v0.15.2

Changelogs:
> https://github.com/Unpackerr/unpackerr/releases/tag/v0.15.0
> https://github.com/Unpackerr/unpackerr/releases/tag/v0.15.1
> https://github.com/Unpackerr/unpackerr/releases/tag/v0.15.2

Homepage updated from `https://github.com/davidnewhall/unpackerr` -> `https://unpackerr.zip/`.
Make version command show Revision and Branch.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
