### PR TITLE
gamma-launcher: fix broken version check due to unset $HOME

### DIFF
--- a/pkgs/by-name/ga/gamma-launcher/package.nix
+++ b/pkgs/by-name/ga/gamma-launcher/package.nix
@@ -4,6 +4,7 @@
   _7zz,
   fetchFromGitHub,
   versionCheckHook,
+  writableTmpDirAsHomeHook,
   runCommand,
 }:
 
@@ -40,7 +41,11 @@ python3Packages.buildPythonApplication rec {
     tqdm
   ];
 
-  nativeCheckInputs = [ versionCheckHook ];
+  nativeCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
   doInstallCheck = true;
 
   postFixup = ''


### PR DESCRIPTION
Fixes a failure where the version check fails because the program expects a writable home directory for writing to its config file (`~/.config/gamma-launcher/config.ini`) to. This change ensures there is a writable home directory.

(as an example, setting that directory to read-only gives an error when running `gamma-launcher --version
`)
```
[nix-shell:~/.cache/nixpkgs-review/rev-69e2ddffc97c387dce7d5c1cb98a081b8af085ca-1]$ results/gamma-launcher-x86_64-linux/bin/gamma-launcher --version
usage: gamma-launcher [-h] [--version]
                      {anomaly-install,check-anomaly,check-md5,full-install,gamma-setup,remove-reshade,purge-shader-cache,test-mod-maker,usvfs-workaround} ...
gamma-launcher: error: [Errno 13] Permission denied: '/home/shaun/.config/gamma-launcher/config.ini'
``` 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
