### PR TITLE
komorebi: fix by moving to webkitgtk_4_1

### DIFF
--- a/pkgs/by-name/ko/komorebi/package.nix
+++ b/pkgs/by-name/ko/komorebi/package.nix
@@ -8,7 +8,7 @@
   glib,
   gtk3,
   libgee,
-  # webkitgtk_4_0,
+  webkitgtk_4_1,
   clutter-gtk,
   clutter-gst,
   ninja,
@@ -39,16 +39,17 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     gtk3
     libgee
-    # webkitgtk_4_0
+    webkitgtk_4_1
     clutter-gtk
     clutter-gst
   ];
 
+  postPatch = ''
+    substituteInPlace meson.build --replace-fail "webkit2gtk-4.0" "webkit2gtk-4.1"
+  '';
   passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = {
-    # webkitgtk_4_0 was removed
-    broken = true;
     description = "Beautiful and customizable wallpaper manager for Linux";
     homepage = "https://github.com/Komorebi-Fork/komorebi";
     license = lib.licenses.gpl3Only;


### PR DESCRIPTION
Komorebi used `webkitgtk_4_0` and hence was marked broken in #450065.
This is fixed here by using `webkitgtk_4_1` and patching the meson.build to look for this instead.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.