### PR TITLE
ghgrab: init at 1.1.0

### DIFF
--- a/pkgs/by-name/gh/ghgrab/package.nix
+++ b/pkgs/by-name/gh/ghgrab/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+}:
+
+# note: upstream has a flake
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ghgrab";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "abhixdd";
+    repo = "ghgrab";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-09+DI1/jKfcbPNB1rUyXtu642TuU7z9UBbQllg9uoQM=";
+  };
+
+  cargoHash = "sha256-9o5AQxe/G5Yc6T/Ogtvq1N32t2eM8jAKt6CIvNBzX70=";
+
+  # fails on darwin
+  # https://github.com/abhixdd/ghgrab/issues/31
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "--skip=agent_tree_invalid_url_returns_json_error"
+  ];
+
+  meta = {
+    changelog = "https://github.com/abhixdd/ghgrab/releases/tag/v${finalAttrs.version}";
+    description = "Simple, pretty terminal tool that lets you search and download files from GitHub without leaving your CLI";
+    homepage = "https://github.com/abhixdd/ghgrab";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ phanirithvij ];
+    mainProgram = "ghgrab";
+  };
+})


### PR DESCRIPTION
Adds https://github.com/abhixdd/ghgrab

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
