### PR TITLE
ghidra-extensions.ghidra-mcp: init at 5.1.0

### DIFF
--- a/pkgs/tools/security/ghidra/extensions.nix
+++ b/pkgs/tools/security/ghidra/extensions.nix
@@ -21,6 +21,8 @@ lib.makeScope newScope (self: {
 
   ghidra-golanganalyzerextension = self.callPackage ./extensions/ghidra-golanganalyzerextension { };
 
+  ghidra-mcp = self.callPackage ./extensions/ghidra-mcp { };
+
   ghidraninja-ghidra-scripts = self.callPackage ./extensions/ghidraninja-ghidra-scripts { };
 
   gnudisassembler = self.callPackage ./extensions/gnudisassembler { inherit ghidra; };

--- a/pkgs/tools/security/ghidra/extensions/ghidra-mcp/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/ghidra-mcp/default.nix
@@ -1,0 +1,34 @@
+{
+  fetchFromGitHub,
+  ghidra,
+  lib,
+}:
+
+ghidra.buildGhidraExtension (finalAttrs: {
+  pname = "ghidra-mcp";
+  version = "5.1.0";
+
+  src = fetchFromGitHub {
+    owner = "bethington";
+    repo = "ghidra-mcp";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-L1NldAplskN/3pR0juHNLBcWB39TdhvQ0U82cAL7d18=";
+  };
+
+  postInstall = ''
+    # Upstream ships Module.manifest as simple key/value metadata.
+    # Ghidra expects either an empty manifest or directive-style entries.
+    : > "$out/lib/ghidra/Ghidra/Extensions/GhidraMCP/Module.manifest"
+  '';
+
+  meta = {
+    description = "Model Context Protocol extension for Ghidra";
+    homepage = "https://github.com/bethington/ghidra-mcp";
+    downloadPage = "https://github.com/bethington/ghidra-mcp/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/bethington/ghidra-mcp/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.caverav ];
+    platforms = ghidra.meta.platforms;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+})


### PR DESCRIPTION
Package the published GhidraMCP 5.1.0 release from bethington/ghidra-mcp as a Ghidra extension.

This now builds the extension from the tagged source release using the shared `ghidra.buildGhidraExtension` helper instead of installing the upstream release ZIP asset.

Upstream release notes:
https://github.com/bethington/ghidra-mcp/releases/tag/v5.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
