### PR TITLE
neovim: move rtp config to lua file

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -126,6 +126,19 @@ let
         rcContent = lib.concatStringsSep "\n" (
           lib.optional (luaDeps != [ ]) luaPathLuaRc
           ++ [ providerLuaRc ]
+          ++ lib.optionals
+              (
+                finalAttrs.packpathDirs.myNeovimPackages.start != [ ]
+                || finalAttrs.packpathDirs.myNeovimPackages.opt != [ ]
+              )
+              [
+                ''if vim.g.nixpkgs_set_rtp /= false then
+                      vim.opt.packpath:prepend("${finalPackdir}")
+                      vim.opt.runtimepath:prepend("${finalPackdir}")
+                  end
+                  ''
+              ]
+
           ++ lib.optional (luaRcContent != "") luaRcContent
           ++ lib.optional (neovimRcContent' != "") ''
             vim.cmd.source "${writeText "init.vim" neovimRcContent'}"
@@ -154,18 +167,6 @@ let
             "--add-flags"
             ''--cmd "lua ${providerLuaRc}"''
           ]
-          ++
-            lib.optionals
-              (
-                finalAttrs.packpathDirs.myNeovimPackages.start != [ ]
-                || finalAttrs.packpathDirs.myNeovimPackages.opt != [ ]
-              )
-              [
-                "--add-flags"
-                ''--cmd "set packpath^=${finalPackdir}"''
-                "--add-flags"
-                ''--cmd "set rtp^=${finalPackdir}"''
-              ]
           ++ lib.optionals finalAttrs.withRuby [
             "--set"
             "GEM_HOME"


### PR DESCRIPTION
instead of wrapping arguments.
Make it possible to ignore via `vim.g.nixpkgs_set_rtp=false`, necessary for HM for instance.

I dont intend to merge this for now. Just testing different approaches to have HM reuse the maximum of nixpkgs wrapper

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
