### PR TITLE
haskellPackages.duckdb: add duckdb C++ library as build dependency

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -843,6 +843,13 @@
     githubId = 209175;
     name = "Alesya Huzik";
   };
+  Ai-Ya-Ya = {
+    email = "spg2500@gmail.com";
+    github = "Ai-Ya-Ya";
+    githubId = 72513839;
+    matrix = "@aiya:catgirl.cloud";
+    name = "aiya";
+  };
   aij = {
     email = "aij+git@mrph.org";
     github = "aij";

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2033,6 +2033,11 @@ with haskellLib;
   # Test suite does not compile.
   feed = dontCheck super.feed;
 
+  # 2026-03-25: one test fails
+  # https://github.com/Tritlo/duckdb-haskell/issues/8
+  # TODO: remove after PR https://github.com/Tritlo/duckdb-haskell/pull/9 is merged
+  duckdb-ffi = dontCheck super.duckdb-ffi;
+
   spacecookie = overrideCabal (old: {
     buildTools = (old.buildTools or [ ]) ++ [ pkgs.buildPackages.installShellFiles ];
     # let testsuite discover the resulting binary

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1515,7 +1515,6 @@ broken-packages:
   - dtw # failure in job https://hydra.nixos.org/build/233198932 at 2023-09-02
   - dual # failure in job https://hydra.nixos.org/build/252724683 at 2024-03-16
   - dualizer # failure in job https://hydra.nixos.org/build/233237592 at 2023-09-02
-  - duckdb-ffi # failure in job https://hydra.nixos.org/build/311300709, https://github.com/Tritlo/duckdb-haskell/issues/2
   - duckdb-haskell # failure in job https://hydra.nixos.org/build/318373036 at 2026-01-10
   - duckling # failure in job https://hydra.nixos.org/build/233247880 at 2023-09-02
   - duet # failure in job https://hydra.nixos.org/build/233219004 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -127,6 +127,8 @@ extra-packages:
 
 # keep-sorted start skip_lines=1 case=no
 package-maintainers:
+  Ai-Ya-Ya:
+    - duckdb-ffi
   alexfmpe:
     - basic-sop
     - commutative-semigroups

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -216,7 +216,6 @@ dont-distribute-packages:
  - bbi
  - bdcs
  - bdcs-api
- - beam-duckdb
  - beam-th
  - beautifHOL
  - bech32-th
@@ -792,7 +791,6 @@ dont-distribute-packages:
  - dsmc-tools
  - DSTM
  - dtd
- - duckdb-simple
  - duoidal-transformers
  - duoids-hedgehog
  - Dust

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -2225,6 +2225,15 @@ builtins.intersectAttrs super {
         }
       );
 
+  duckdb-ffi = overrideCabal (drv: {
+    librarySystemDepends = (drv.librarySystemDepends or [ ]) ++ [ pkgs.duckdb ];
+
+    configureFlags = (drv.configureFlags or [ ]) ++ [
+      "--extra-include-dirs=${lib.getDev pkgs.duckdb}/include"
+      "--extra-lib-dirs=${pkgs.duckdb}/lib"
+    ];
+  }) super.duckdb-ffi;
+
   # Upper bounds of text and bytestring too strict: https://github.com/zsedem/haskell-cpython/pull/24
   cpython = doJailbreak super.cpython;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I added `duckdb`'s C++ libraries as a build dependency for `duckdb-ffi`, in similar manner as `libtorch-ffi`. This should help with https://github.com/Tritlo/duckdb-haskell/issues/4. 

There is a test that fails, that will be fixed upstream (https://github.com/Tritlo/duckdb-haskell/issues/8). Disabled testing for now. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux (wsl2)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable: (not applicable)
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
