### PR TITLE
[25.11] gst-thumbnailers: init at 1.0.alpha.1

### DIFF
--- a/pkgs/by-name/gs/gst-thumbnailers/package.nix
+++ b/pkgs/by-name/gs/gst-thumbnailers/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  rustPlatform,
+  meson,
+  ninja,
+  pkg-config,
+  cargo,
+  rustc,
+  wrapGAppsNoGuiHook,
+  gst_all_1,
+  fontconfig,
+  libglycin,
+  glycin-loaders,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gst-thumbnailers";
+  version = "1.0.alpha.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "gst-thumbnailers";
+    tag = finalAttrs.version;
+    hash = "sha256-LOdD8ECSK+QuXkE8jjIg5IfZSQ5FcIi3hmZ2vAaaBKI=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-PIqEEijKe+wsX6idqoIB591h1Yj4mixwXDKDN4caO9I=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+    wrapGAppsNoGuiHook
+  ];
+
+  buildInputs = [
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    fontconfig
+    libglycin
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix XDG_DATA_DIRS : "${glycin-loaders}/share"
+    )
+  '';
+
+  meta = {
+    description = "Generate thumbnailer for video and audio files";
+    homepage = "https://gitlab.gnome.org/GNOME/gst-thumbnailers";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.aleksana ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/gs/gst-thumbnailers/package.nix
+++ b/pkgs/by-name/gs/gst-thumbnailers/package.nix
@@ -51,6 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
     libglycin
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   preFixup = ''
     gappsWrapperArgs+=(
       --prefix XDG_DATA_DIRS : "${glycin-loaders}/share"


### PR DESCRIPTION
Manual backport of 4e5d418a47773e9c804abe3acf39e1b2d9b9252a.

Cannot also backport 737475137dae73433d3762eb27f782fc99455250 because the libglycin setup hook doesn't exist on 25.11.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
