### PR TITLE
Adding the `fedora-media-writer-qt` package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2532,6 +2532,11 @@
     name = "Dmitriy";
     keys = [ { fingerprint = "922D A6E7 58A0 FE4C FAB4 E4B2 FD26 6B81 0DF4 8DF2"; } ];
   };
+  atemo-c = {
+    name = "Atemo Cajaku";
+    github = "atemo-c";
+    githubId = "160250128";
+  };
   atemu = {
     name = "Atemu";
     email = "nixpkgs@mail.atemu.net";

--- a/pkgs/by-name/fe/fedora-media-writer-qt/package.nix
+++ b/pkgs/by-name/fe/fedora-media-writer-qt/package.nix
@@ -1,0 +1,45 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  pkg-config,
+  qt6,
+  stdenv,
+  udisks,
+  xz,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fedora-media-writer-qt";
+  version = "5.2.9";
+
+  src = fetchFromGitHub {
+    owner = "FedoraQt";
+    repo = "MediaWriter";
+    rev = finalAttrs.version;
+    hash = "sha256-tZ0GzaEzhklD/FJocnRmet+dvBwZoNYVhJfF1NY6puE=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtsvg
+    udisks
+    xz
+  ];
+
+  meta = {
+    description = "Write Fedora and other distributions images onto portable devices such as flash disks.";
+    homepage = "https://github.com/FedoraQt/MediaWriter";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ atemo-c ];
+    platforms = lib.platforms.linux;
+    mainProgram = "mediawriter";
+  };
+})


### PR DESCRIPTION
Added the `fedora-media-writer-qt` package and myself as a maintainer of said package.
[https://github.com/FedoraQt/MediaWriter](https://github.com/FedoraQt/MediaWriter)

This package allows a user to easily and graphically write various Linux images onto removable medium such as USB flash drives. Despite its name, it can write more than just Fedora, even if it is primarily made for the former. I have found this program to be very simple to use, convenient, and nice, and would like to see it in nixpkgs. If, however, such a distribution-specific package would not fit, I would entirely understand.

This is my very first pull request for a new package here; I may make mistakes or forget/not understand how to do things properly quite yet, but I have tried reading as much as I could. I am unsure if I am fit to be a maintainer, even if it should be fine for that single package; It is very simple, after all. 


Any feedback and help is appreciated!
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
