### PR TITLE
nix-required-mounts: fix eval errors due to builtins.toFile

### DIFF
--- a/pkgs/by-name/ni/nix-required-mounts/closure.nix
+++ b/pkgs/by-name/ni/nix-required-mounts/closure.nix
@@ -8,6 +8,7 @@
   runCommand,
   python3Packages,
   allowedPatterns,
+  formats,
 }:
 runCommand "allowed-patterns.json"
   {
@@ -30,7 +31,7 @@ runCommand "allowed-patterns.json"
     ) (builtins.attrNames allowedPatterns);
     env = {
       storeDir = "${builtins.storeDir}/";
-      shallowConfigPath = builtins.toFile "shallow-config.json" (builtins.toJSON allowedPatterns);
+      shallowConfigPath = (formats.json { }).generate "shallow-config.json" allowedPatterns;
     };
   }
   ''


### PR DESCRIPTION
`nix-instantiate -A nix-required-mounts.tests` now passes (again)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
