### PR TITLE
luaPackages.lua-https: init at 0-unstable-2025-02-28

### DIFF
--- a/pkgs/development/lua-modules/lua-https/default.nix
+++ b/pkgs/development/lua-modules/lua-https/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildLuaPackage,
+  writeScript,
+  fetchFromGitHub,
+  cmake,
+  lua,
+  curl,
+}:
+
+buildLuaPackage rec {
+  pname = "lua-https";
+  version = "0-unstable-2025-02-28";
+
+  src = fetchFromGitHub {
+    owner = "love2d";
+    repo = "lua-https";
+    rev = "e1b77046dd3cf1a9f61ddeb63cb39d47c844c089";
+    hash = "sha256-NQVB5ncw2bYJEHPQtBXqCdwp6FdQ4SJ/x97fasE5z0A=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    lua
+    curl
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/lib/lua/${lua.luaversion}")
+    (lib.cmakeFeature "LIBRARY_LOADER" "linktime")
+    (lib.cmakeBool "USE_CURL_BACKEND" true) # off by default on darwin
+    (lib.cmakeBool "USE_OPENSSL_BACKEND" false) # on by default on linux, but incompatible with linktime library loader
+    (lib.cmakeBool "USE_NSURL_BACKEND" false) # on by default on darwin
+  ];
+
+  passthru.updateScript = writeScript "update.sh" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq common-updater-scripts
+
+    set -euo pipefail
+
+    response=$(curl ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sL "https://api.github.com/repos/${src.owner}/${src.repo}/commits?per_page=1")
+    rev=$(echo "$response" | jq -r '.[0].sha')
+    date=$(echo "$response" | jq -r '.[0].commit.committer.date' | cut -c1-10)
+    update-source-version luaPackages.lua-https 0-unstable-$date --rev=$rev
+  '';
+
+  meta = {
+    homepage = "https://love2d.org/wiki/lua-https";
+    description = "Simple Lua HTTPS module using native platform backends specifically written for LÖVE 12.0";
+    license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+  };
+}

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -113,6 +113,8 @@ rec {
 
   image-nvim = callPackage ../development/lua-modules/image-nvim { };
 
+  lua-https = callPackage ../development/lua-modules/lua-https { };
+
   lua-pam = callPackage (
     {
       fetchFromGitHub,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tested using this Lua code on LuaJIT:

```lua
print(require("https").request("https://archlinux.org"))
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
