### PR TITLE
ocamlPackages.luv: 0.5.12 -> 0.5.14

### DIFF
--- a/pkgs/development/compilers/haxe/default.nix
+++ b/pkgs/development/compilers/haxe/default.nix
@@ -24,7 +24,7 @@ let
         ptmap
         camlp5
         sha
-        luv
+        luv-0-5-12
         extlib
       ]
     else
@@ -37,7 +37,7 @@ let
         ptmap
         camlp5
         sha
-        luv
+        luv-0-5-12
         extlib-1-7-7
       ];
 

--- a/pkgs/development/ocaml-modules/luv/default.nix
+++ b/pkgs/development/ocaml-modules/luv/default.nix
@@ -1,5 +1,3 @@
-# nixpkgs-update: no auto update
-# haxe depends on specific version of luv
 {
   lib,
   buildDunePackage,
@@ -11,51 +9,64 @@
   file,
 }:
 
-buildDunePackage rec {
-  pname = "luv";
-  version = "0.5.12";
+let
+  generic =
+    {
+      version,
+      sha256,
+    }:
+    buildDunePackage rec {
+      pname = "luv";
+      inherit version;
 
-  minimalOCamlVersion = "4.03";
+      minimalOCamlVersion = "4.03";
 
-  src = fetchurl {
-    url = "https://github.com/aantron/luv/releases/download/${version}/luv-${version}.tar.gz";
+      src = fetchurl {
+        url = "https://github.com/aantron/luv/releases/download/${version}/luv-${version}.tar.gz";
+        inherit sha256;
+      };
+
+      patches = lib.optional (lib.versionOlder version "0.5.14") ./incompatible-pointer-type-fix.diff;
+
+      postConfigure = ''
+        for f in src/c/vendor/configure/{ltmain.sh,configure}; do
+          substituteInPlace "$f" --replace /usr/bin/file file
+        done
+      '';
+
+      nativeBuildInputs = [ file ];
+      propagatedBuildInputs = [
+        ctypes
+        result
+      ];
+      checkInputs = [ alcotest ];
+      # Alcotest depends on fmt that needs 4.08 or newer
+      doCheck = lib.versionAtLeast ocaml.version "4.08";
+
+      meta = {
+        homepage = "https://github.com/aantron/luv";
+        description = "Binding to libuv: cross-platform asynchronous I/O";
+        # MIT-licensed, extra licenses apply partially to libuv vendor
+        license = with lib.licenses; [
+          mit
+          bsd2
+          bsd3
+          cc-by-sa-40
+        ];
+        maintainers = with lib.maintainers; [
+          locallycompact
+          sternenseemann
+        ];
+      };
+    };
+in
+{
+  luv-0-5-12 = generic {
+    version = "0.5.12";
     sha256 = "sha256-dp9qCIYqSdROIAQ+Jw73F3vMe7hnkDe8BgZWImNMVsA=";
   };
-
-  patches = [
-    # backport of patch to fix incompatible pointer type. remove next update
-    # https://github.com/aantron/luv/commit/ad7f953fccb8732fe4eb9018556e8d4f82abf8f2
-    ./incompatible-pointer-type-fix.diff
-  ];
-
-  postConfigure = ''
-    for f in src/c/vendor/configure/{ltmain.sh,configure}; do
-      substituteInPlace "$f" --replace /usr/bin/file file
-    done
-  '';
-
-  nativeBuildInputs = [ file ];
-  propagatedBuildInputs = [
-    ctypes
-    result
-  ];
-  checkInputs = [ alcotest ];
-  # Alcotest depends on fmt that needs 4.08 or newer
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
-
-  meta = {
-    homepage = "https://github.com/aantron/luv";
-    description = "Binding to libuv: cross-platform asynchronous I/O";
-    # MIT-licensed, extra licenses apply partially to libuv vendor
-    license = with lib.licenses; [
-      mit
-      bsd2
-      bsd3
-      cc-by-sa-40
-    ];
-    maintainers = with lib.maintainers; [
-      locallycompact
-      sternenseemann
-    ];
+  luv = generic {
+    version = "0.5.14";
+    sha256 = "sha256-jgG0pQyIds3ZjY4kXAaHxNxNiDrtFhrZxazh+x/arpk=";
   };
 }

--- a/pkgs/development/ocaml-modules/luv/default.nix
+++ b/pkgs/development/ocaml-modules/luv/default.nix
@@ -26,9 +26,7 @@ let
       patches = lib.optional (lib.versionOlder version "0.5.14") ./incompatible-pointer-type-fix.diff;
 
       postConfigure = ''
-        for f in src/c/vendor/configure/{ltmain.sh,configure}; do
-          substituteInPlace "$f" --replace /usr/bin/file file
-        done
+        substituteInPlace "src/c/vendor/configure/ltmain.sh" --replace-fail /usr/bin/file file
       '';
 
       nativeBuildInputs = [ file ];

--- a/pkgs/development/ocaml-modules/luv/default.nix
+++ b/pkgs/development/ocaml-modules/luv/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildDunePackage,
-  ocaml,
   fetchurl,
   ctypes,
   result,
@@ -18,8 +17,6 @@ let
     buildDunePackage rec {
       pname = "luv";
       inherit version;
-
-      minimalOCamlVersion = "4.03";
 
       src = fetchurl {
         url = "https://github.com/aantron/luv/releases/download/${version}/luv-${version}.tar.gz";
@@ -40,8 +37,7 @@ let
         result
       ];
       checkInputs = [ alcotest ];
-      # Alcotest depends on fmt that needs 4.08 or newer
-      doCheck = lib.versionAtLeast ocaml.version "4.08";
+      doCheck = true;
 
       meta = {
         homepage = "https://github.com/aantron/luv";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1147,9 +1147,12 @@ let
 
         lutils = callPackage ../development/ocaml-modules/lutils { };
 
-        luv = callPackage ../development/ocaml-modules/luv {
-          inherit (pkgs) file;
-        };
+        inherit
+          (callPackage ../development/ocaml-modules/luv {
+          })
+          luv-0-5-12
+          luv
+          ;
 
         lwd = callPackage ../development/ocaml-modules/lwd { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated luv 0.5.14, but still providing 0.5.12 which is required by older versions of haxe.

This is a prerequisite for #457643, because haxe 4.3.7 needs luv 0.5.14.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
