### PR TITLE
frigate: 0.17.0 -> 0.17.1

### DIFF
--- a/pkgs/by-name/fr/frigate/package.nix
+++ b/pkgs/by-name/fr/frigate/package.nix
@@ -11,17 +11,18 @@
   sqlite-vec,
   frigate,
   nixosTests,
+  go2rtc,
 }:
 
 let
-  version = "0.17.0";
+  version = "0.17.1";
 
   src = fetchFromGitHub {
     name = "frigate-${version}-source";
     owner = "blakeblackshear";
     repo = "frigate";
     tag = "v${version}";
-    hash = "sha256-K41tWnj0u+Fw+G++aPFfMa0uFYEvvZ0r6xNPQ7J1cYs=";
+    hash = "sha256-jQQ54By77dOVSIu08YhJn+EUV0D03j1bcMQRk9404RE=";
   };
 
   frigate-web = callPackage ./web.nix {
@@ -250,6 +251,11 @@ python3Packages.buildPythonApplication rec {
   disabledTests = [
     # Test needs network access
     "test_plus_labelmap"
+    # Expects go2rtc on :1984
+    "test_admin_can_access_any_stream"
+    "test_restricted_role_can_access_allowed_camera"
+    "test_stream_alias_allowed_for_owning_camera"
+    "test_unconfigured_role_can_access_any_stream"
   ];
 
   passthru = {


### PR DESCRIPTION
https://github.com/blakeblackshear/frigate/releases/tag/v0.17.1
https://github.com/blakeblackshear/frigate/security/advisories/GHSA-26g3-f8g8-9ffh
https://github.com/blakeblackshear/frigate/security/advisories/GHSA-m2mg-pj9p-2r7g

Fixes: CVE-2026-33469, CVE-2026-33470


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
