### PR TITLE
chains: init at 1.6.3

### DIFF
--- a/pkgs/by-name/ch/chains/package.nix
+++ b/pkgs/by-name/ch/chains/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenvNoCC,
+  runCommand,
+  fetchurl,
+  curl,
+  cacert,
+  oath-toolkit,
+  _7zz,
+  love,
+  luajit,
+  makeWrapper,
+  desktopToDarwinBundle,
+  demoSrc ? false,
+}:
+
+let
+  stdenv = stdenvNoCC;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "chains";
+  version = "1.6.3";
+
+  src =
+    if demoSrc then
+      fetchurl {
+        url = "https://web.archive.org/web/20260325231350/https://2dengine.com/files/chains/chains-demo.appimage";
+        hash = "sha256-tFEQFdL+249LPEcJEUSxJ8FWmHzBo9hHMZUrxVcSRuU=";
+      }
+    else
+      runCommand "fetch-chains"
+        {
+          name = "chains.appimage";
+          nativeBuildInputs = [
+            curl
+            cacert
+            oath-toolkit
+          ];
+          impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+            "NIX_2DENGINE_USERNAME"
+            "NIX_2DENGINE_PASSWORD"
+            "NIX_2DENGINE_AUTHENTICATOR_KEY"
+          ];
+          outputHashAlgo = "sha256";
+          outputHashMode = "flat";
+          outputHash = "sha256-gyDQMfwpZ5KF4LMnkpbiZ64aHLeKRszu6rIklXiPDHM=";
+        }
+        ''
+          if [[ -z "$NIX_2DENGINE_USERNAME" || -z "$NIX_2DENGINE_PASSWORD" || -z "$NIX_2DENGINE_AUTHENTICATOR_KEY" ]]; then
+            echo "" >&2
+            echo "***" >&2
+            echo "To authenticate on 2denging.com, set the following environment variables" >&2
+            echo "for the Nix builder process (nix-daemon in the multiuser case):" >&2
+            echo "NIX_2DENGINE_USERNAME, NIX_2DENGINE_PASSWORD, and NIX_2DENGINE_AUTHENTICATOR_KEY." >&2
+            echo "Alternatively, download the game manually on ${finalAttrs.meta.downloadPage}," >&2
+            echo "and then add the downloaded file to the Nix store using" >&2
+            echo "nix-store --add-fixed sha256 ${finalAttrs.src.name}" >&2
+            echo "Alternatively, build `chains.override { demoSrc = true; }` instead." >&2
+            echo "***" >&2
+            echo "" >&2
+            exit 1
+          fi
+
+          cookie_jar=$(mktemp)
+          curl -s -X POST "https://2dengine.com/signin/$NIX_2DENGINE_USERNAME" \
+            -d "username=$NIX_2DENGINE_USERNAME" \
+            -d "password=$NIX_2DENGINE_PASSWORD" \
+            -d "otp=$(oathtool --totp -b "$NIX_2DENGINE_AUTHENTICATOR_KEY")" \
+            -c "$cookie_jar" \
+            -o /dev/null
+          curl -L -b "$cookie_jar" "https://2dengine.com/files/chains/chains.appimage" -o "$out"
+          rm "$cookie_jar"
+        '';
+
+  nativeBuildInputs = [
+    _7zz
+    makeWrapper
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin desktopToDarwinBundle;
+
+  unpackCmd = ''
+    7zz x $curSrc -osource
+    7zz x source/usr/bin/chains -osource/chains.love.dir
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share
+    cp -ar usr/share/{applications,icons} $out/share
+    rm -r $out/share/icons/hicolor/scalable # application-x-love-game.svg
+    cp -ar chains.love.dir $out/share/chains
+    makeWrapper ${lib.getExe (love.override { inherit luajit; })} $out/bin/chains \
+      --add-flags $out/share/chains \
+      --add-flags --fused \
+      --prefix LUA_CPATH ';' "${luajit.pkgs.getLuaCPath luajit.pkgs.lua-https}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Puzzle game with a unique feel and distinctive vector graphics style";
+    homepage = "https://2dengine.com/game/chains";
+    downloadPage = "https://2dengine.com/game/chains";
+    changelog = "https://2dengine.com/notices/chains";
+    platforms = love.meta.platforms;
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    mainProgram = "chains";
+  };
+})

--- a/pkgs/development/lua-modules/lua-https/default.nix
+++ b/pkgs/development/lua-modules/lua-https/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildLuaPackage,
+  writeScript,
+  fetchFromGitHub,
+  cmake,
+  lua,
+  curl,
+}:
+
+buildLuaPackage rec {
+  pname = "lua-https";
+  version = "0-unstable-2025-02-28";
+
+  src = fetchFromGitHub {
+    owner = "love2d";
+    repo = "lua-https";
+    rev = "e1b77046dd3cf1a9f61ddeb63cb39d47c844c089";
+    hash = "sha256-NQVB5ncw2bYJEHPQtBXqCdwp6FdQ4SJ/x97fasE5z0A=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    lua
+    curl
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}/lib/lua/${lua.luaversion}")
+    (lib.cmakeFeature "LIBRARY_LOADER" "linktime")
+    (lib.cmakeBool "USE_CURL_BACKEND" true) # off by default on darwin
+    (lib.cmakeBool "USE_OPENSSL_BACKEND" false) # on by default on linux, but incompatible with linktime library loader
+    (lib.cmakeBool "USE_NSURL_BACKEND" false) # on by default on darwin
+  ];
+
+  passthru.updateScript = writeScript "update.sh" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq common-updater-scripts
+
+    set -euo pipefail
+
+    response=$(curl ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sL "https://api.github.com/repos/${src.owner}/${src.repo}/commits?per_page=1")
+    rev=$(echo "$response" | jq -r '.[0].sha')
+    date=$(echo "$response" | jq -r '.[0].commit.committer.date' | cut -c1-10)
+    update-source-version luaPackages.lua-https 0-unstable-$date --rev=$rev
+  '';
+
+  meta = {
+    homepage = "https://love2d.org/wiki/lua-https";
+    description = "Simple Lua HTTPS module using native platform backends specifically written for LÖVE 12.0";
+    license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+  };
+}

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -113,6 +113,8 @@ rec {
 
   image-nvim = callPackage ../development/lua-modules/image-nvim { };
 
+  lua-https = callPackage ../development/lua-modules/lua-https { };
+
   lua-pam = callPackage (
     {
       fetchFromGitHub,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Waiting for #503542.

Upstream does not have versioned download links, which makes the hash of the paid version unstable. Don't know how to solve this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
