### PR TITLE
dness: 0.5.7 -> 0.6.0

### DIFF
--- a/pkgs/by-name/dn/dness/package.nix
+++ b/pkgs/by-name/dn/dness/package.nix
@@ -9,16 +9,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dness";
-  version = "0.5.7";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "nickbabcock";
     repo = "dness";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Vty4ec6aoUh3p2b9vLkNeS5R4pJWzjwYrC5DtVVyhT8=";
+    hash = "sha256-Znlygpq0EetCLjtZC39ksaVFeuwMmqI5FhHxsliw+oE=";
   };
 
-  cargoHash = "sha256-WhSeNukPjgM7Cy8LWi/s1YGa5/UxsFU1NGL7vIUlU58=";
+  cargoHash = "sha256-2NT67tVMI511iISDln3p66Ls8XSLze0JSQZ50/s24tM=";
 
   doCheck = false; # Many tests require network access
 

--- a/pkgs/by-name/dn/dness/package.nix
+++ b/pkgs/by-name/dn/dness/package.nix
@@ -1,8 +1,6 @@
 {
   fetchFromGitHub,
   lib,
-  openssl,
-  pkg-config,
   rustPlatform,
   versionCheckHook,
   nix-update-script,
@@ -21,10 +19,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-2NT67tVMI511iISDln3p66Ls8XSLze0JSQZ50/s24tM=";
 
   doCheck = false; # Many tests require network access
-
-  nativeBuildInputs = [ pkg-config ];
-
-  buildInputs = [ openssl ];
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
Supersedes #503088.

Includes the version bump from the auto-update bot plus drops the
native-tls build inputs (`openssl`, `pkg-config`) since 0.6.0 switched
to `rustls-tls-webpki-roots` upstream.