### PR TITLE
python3Packages.django-ical: init at 1.9.2

### DIFF
--- a/pkgs/development/python-modules/django-ical/default.nix
+++ b/pkgs/development/python-modules/django-ical/default.nix
@@ -1,0 +1,57 @@
+{
+  buildPythonPackage,
+  django,
+  fetchFromGitHub,
+  lib,
+  pytest-django,
+  pytestCheckHook,
+  setuptools-scm,
+  icalendar,
+  django-recurrence,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "django-ical";
+  version = "1.9.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jazzband";
+    repo = "django-ical";
+    tag = finalAttrs.version;
+    hash = "sha256-DUe0loayGcUS7MTyLn+g0KBxbIY7VsaoQNHGSMbMI3U=";
+  };
+
+  build-system = [ setuptools-scm ];
+
+  dependencies = [
+    django
+    django-recurrence
+    icalendar
+  ];
+
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE=test_settings
+  '';
+
+  disabledTestPaths = [
+    # AssertionError: 'Japan' != 'JST': there seems to be wrong raw data feed
+    "django_ical/tests/test_feed.py::ICal20FeedTest::test_timezone"
+  ];
+
+  pythonImportsCheck = [
+    "django_ical"
+  ];
+
+  nativeCheckInputs = [
+    pytest-django
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "iCal feeds for Django based on Django's syndication feed framework";
+    homepage = "https://github.com/jazzband/django-ical";
+    changelog = "https://github.com/jazzband/django-ical/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kurogeek ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4206,6 +4206,8 @@ self: super: with self; {
 
   django-i18nfield = callPackage ../development/python-modules/django-i18nfield { };
 
+  django-ical = callPackage ../development/python-modules/django-ical { };
+
   django-import-export = callPackage ../development/python-modules/django-import-export { };
 
   django-ipware = callPackage ../development/python-modules/django-ipware { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
