### PR TITLE
stdenv: Don't copy dependency input lists when type checking

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -25,7 +25,7 @@ let
     filterAttrs
     getDev
     head
-    imap1
+    foldl'
     isAttrs
     isBool
     isDerivation
@@ -44,6 +44,8 @@ let
     toFunction
     unique
     zipAttrsWith
+    isPath
+    seq
     ;
 
   inherit (import ../../build-support/lib/cmake.nix { inherit lib stdenv; }) makeCMakeFlags;
@@ -436,17 +438,17 @@ let
       checkDependencyList = checkDependencyList' [ ];
       checkDependencyList' =
         positions: name: deps:
-        imap1 (
+        seq (foldl' (
           index: dep:
-          if dep == null || isDerivation dep || isString dep || builtins.isPath dep then
-            dep
+          if dep == null || isDerivation dep || isString dep || isPath dep then
+            index + 1
           else if isList dep then
-            checkDependencyList' ([ index ] ++ positions) name dep
+            seq (checkDependencyList' ([ index ] ++ positions) name dep) (index + 1)
           else
             throw "Dependency is not of a valid type: ${
               concatMapStrings (ix: "element ${toString ix} of ") ([ index ] ++ positions)
             }${name} for ${attrs.name or attrs.pname}"
-        ) deps;
+        ) 1 deps) deps;
     in
     if erroneousHardeningFlags != [ ] then
       abort (


### PR DESCRIPTION
## Things done

A small performance optimisation.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
