### PR TITLE
krunkit: 1.1.1 -> 1.2.1, libkrun-efi: symlink libkrun-efi.dylib -> libkrun.dylib in output

### DIFF
--- a/pkgs/by-name/kr/krunkit/package.nix
+++ b/pkgs/by-name/kr/krunkit/package.nix
@@ -13,18 +13,18 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "krunkit";
-  version = "1.1.1";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "krunkit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2O2v4etlXN61f8Goog+/e/6FTCtt7xSJnkq+w2KGxUM=";
+    hash = "sha256-T3PbSDaMqR/DLaTe1/tyMx/KseU5ENFzz1Gxd5/hRao=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-ckUunlnyf5BXq/EzFYPF8fI996/NgQaXUuVdOgfj1yk=";
+    hash = "sha256-Yb2jyK4UBJCeVXSKl4UABnlMj+7SKpOIi49tD/itHYo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libkrun-efi/package.nix
+++ b/pkgs/by-name/li/libkrun-efi/package.nix
@@ -128,6 +128,10 @@ stdenv.mkDerivation (finalAttrs: {
     cp ${initBinary}/init init/init
   '';
 
+  postInstall = ''
+    ln -s $out/lib/libkrun-efi.dylib $out/lib/libkrun.dylib
+  '';
+
   passthru = {
     tests.withoutGpu = libkrun-efi.override { withGpu = false; };
     updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- libkrun-efi: symlink libkrun-efi.dylib -> libkrun.dylib in output
- krunkit: 1.1.1 -> 1.2.1

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
