### PR TITLE
rustPlatform.fetchCargoVendor: Don't recompute internal data

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-vendor.nix
+++ b/pkgs/build-support/rust/fetch-cargo-vendor.nix
@@ -22,6 +22,21 @@ let
     ];
   } (builtins.readFile ./replace-workspace-values.py);
 
+  nix-prefetch-git' = nix-prefetch-git.override {
+    git = gitMinimal;
+    # break loop of nix-prefetch-git -> git-lfs -> asciidoctor -> ruby (yjit) -> fetchCargoVendor -> nix-prefetch-git
+    # Cargo does not currently handle git-lfs: https://github.com/rust-lang/cargo/issues/9692
+    git-lfs = null;
+  };
+
+  removedArgs = [
+    "name"
+    "pname"
+    "version"
+    "nativeBuildInputs"
+    "hash"
+  ];
+
   mkFetchCargoVendorUtil =
     name: src:
     writers.writePython3Bin name {
@@ -57,14 +72,6 @@ in
 # TODO: add asserts about pname version and name
 
 let
-  removedArgs = [
-    "name"
-    "pname"
-    "version"
-    "nativeBuildInputs"
-    "hash"
-  ];
-
   vendorStaging = stdenvNoCC.mkDerivation (
     {
       name = "${name}-vendor-staging";
@@ -74,12 +81,7 @@ let
       nativeBuildInputs = [
         fetchCargoVendorUtilV2
         cacert
-        (nix-prefetch-git.override {
-          git = gitMinimal;
-          # break loop of nix-prefetch-git -> git-lfs -> asciidoctor -> ruby (yjit) -> fetchCargoVendor -> nix-prefetch-git
-          # Cargo does not currently handle git-lfs: https://github.com/rust-lang/cargo/issues/9692
-          git-lfs = null;
-        })
+        nix-prefetch-git'
       ]
       ++ nativeBuildInputs;
 
@@ -108,7 +110,6 @@ let
     // removeAttrs args removedArgs
   );
 in
-
 runCommand "${name}-vendor"
   {
     inherit vendorStaging;


### PR DESCRIPTION
Calling nix-prefetch-git.override on every call to fetchCargoVendor is bad for performance.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
