### PR TITLE
nixos/rancher: fix warnings/assertions being silently dropped

### DIFF
--- a/nixos/modules/services/cluster/rancher/k3s.nix
+++ b/nixos/modules/services/cluster/rancher/k3s.nix
@@ -115,23 +115,24 @@ in
   # implementation
 
   config = lib.mkIf cfg.enable (
-    lib.recursiveUpdate baseModule.config {
-      warnings = (
-        lib.optional (
-          cfg.disableAgent && cfg.images != [ ]
-        ) "k3s: Images are only imported on nodes with an enabled agent, they will be ignored by this node."
-      );
+    lib.mkMerge [
+      baseModule.config
+      {
+        warnings =
+          lib.optional (cfg.disableAgent && cfg.images != [ ])
+            "k3s: Images are only imported on nodes with an enabled agent, they will be ignored by this node.";
 
-      assertions = [
-        {
-          assertion = cfg.role == "agent" -> !cfg.disableAgent;
-          message = "k3s: disableAgent must be false if role is 'agent'";
-        }
-        {
-          assertion = cfg.role == "agent" -> !cfg.clusterInit;
-          message = "k3s: clusterInit must be false if role is 'agent'";
-        }
-      ];
-    }
+        assertions = [
+          {
+            assertion = cfg.role == "agent" -> !cfg.disableAgent;
+            message = "k3s: disableAgent must be false if role is 'agent'";
+          }
+          {
+            assertion = cfg.role == "agent" -> !cfg.clusterInit;
+            message = "k3s: clusterInit must be false if role is 'agent'";
+          }
+        ];
+      }
+    ]
   );
 }

--- a/nixos/modules/services/cluster/rancher/rke2.nix
+++ b/nixos/modules/services/cluster/rancher/rke2.nix
@@ -121,40 +121,41 @@ in
   # implementation
 
   config = lib.mkIf cfg.enable (
-    lib.recursiveUpdate baseModule.config {
-      warnings = (
-        lib.optional (
+    lib.mkMerge [
+      baseModule.config
+      {
+        warnings = lib.optional (
           cfg.role == "agent" && cfg.cni != null
-        ) "rke2: cni should not be set if role is 'agent'"
-      );
+        ) "rke2: cni should not be set if role is 'agent'";
 
-      # Configure NetworkManager to ignore CNI network interfaces.
-      # See: https://docs.rke2.io/known_issues#networkmanager
-      environment.etc."NetworkManager/conf.d/rke2-canal.conf" = {
-        enable = config.networking.networkmanager.enable;
-        text = ''
-          [keyfile]
-          unmanaged-devices=interface-name:flannel*;interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico;interface-name:wireguard.cali;interface-name:wg-v6.cali
-        '';
-      };
-
-      # CIS hardening
-      # https://docs.rke2.io/security/hardening_guide#kernel-parameters
-      # https://github.com/rancher/rke2/blob/ef0fc7aa9d3bbaa95ce9b1895972488cbd92e302/bundle/share/rke2/rke2-cis-sysctl.conf
-      boot.kernel.sysctl = {
-        "vm.panic_on_oom" = 0;
-        "vm.overcommit_memory" = 1;
-        "kernel.panic" = 10;
-        "kernel.panic_on_oops" = 1;
-      };
-      # https://docs.rke2.io/security/hardening_guide#etcd-is-configured-properly
-      users = lib.mkIf cfg.cisHardening {
-        users.etcd = {
-          isSystemUser = true;
-          group = "etcd";
+        # Configure NetworkManager to ignore CNI network interfaces.
+        # See: https://docs.rke2.io/known_issues#networkmanager
+        environment.etc."NetworkManager/conf.d/rke2-canal.conf" = {
+          enable = config.networking.networkmanager.enable;
+          text = ''
+            [keyfile]
+            unmanaged-devices=interface-name:flannel*;interface-name:cali*;interface-name:tunl*;interface-name:vxlan.calico;interface-name:vxlan-v6.calico;interface-name:wireguard.cali;interface-name:wg-v6.cali
+          '';
         };
-        groups.etcd = { };
-      };
-    }
+
+        # CIS hardening
+        # https://docs.rke2.io/security/hardening_guide#kernel-parameters
+        # https://github.com/rancher/rke2/blob/ef0fc7aa9d3bbaa95ce9b1895972488cbd92e302/bundle/share/rke2/rke2-cis-sysctl.conf
+        boot.kernel.sysctl = {
+          "vm.panic_on_oom" = 0;
+          "vm.overcommit_memory" = 1;
+          "kernel.panic" = 10;
+          "kernel.panic_on_oops" = 1;
+        };
+        # https://docs.rke2.io/security/hardening_guide#etcd-is-configured-properly
+        users = lib.mkIf cfg.cisHardening {
+          users.etcd = {
+            isSystemUser = true;
+            group = "etcd";
+          };
+          groups.etcd = { };
+        };
+      }
+    ]
   );
 }


### PR DESCRIPTION
`lib.recursiveUpdate` overwrites lists instead of merging them, causing base module `warnings` and `assertions` to be silently dropped by `k3s.nix` and `rke2.nix`. Replace with `lib.mkMerge` which properly concatenates lists through the NixOS module system.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test