### PR TITLE
nixos/rancher: add extraContainerdSettings option

### DIFF
--- a/nixos/modules/services/cluster/rancher/default.nix
+++ b/nixos/modules/services/cluster/rancher/default.nix
@@ -30,6 +30,7 @@ let
       staticContentChartDir = "/var/lib/rancher/${name}/server/static/charts";
 
       manifestFormat = if jsonManifests then pkgs.formats.json { } else pkgs.formats.yaml { };
+      containerdSettingsFormat = pkgs.formats.toml { };
       # Manifests need a valid suffix to be respected
       mkManifestTarget =
         name:
@@ -639,6 +640,28 @@ let
           '';
         };
 
+        extraContainerdSettings = lib.mkOption {
+          type = containerdSettingsFormat.type;
+          default = { };
+          example = lib.literalExpression ''
+            {
+              plugins."io.containerd.grpc.v1.cri".containerd.runtimes."custom" = {
+                runtime_type = "io.containerd.runc.v2";
+              };
+              plugins."io.containerd.grpc.v1.cri".containerd.runtimes."custom".options = {
+                BinaryName = "/path/to/custom-container-runtime";
+              };
+            }
+          '';
+          description = ''
+            Extra structured settings for containerd, converted to TOML and placed at
+            `/var/lib/rancher/${name}/agent/etc/containerd/config.toml.tmpl`.
+            The base containerd config template is automatically included.
+            Mutually exclusive with [](#opt-services.${name}.containerdConfigTemplate).
+            See the docs on [configuring containerd](https://docs.${name}.io/advanced#configuring-containerd).
+          '';
+        };
+
         images = lib.mkOption {
           type = with lib.types; listOf package;
           default = [ ];
@@ -829,6 +852,13 @@ let
             cfg.role == "agent" && !(cfg.agentTokenFile != null || cfg.agentToken != "")
           ) "${name}: agentToken and agentToken should not be set if role is 'agent'");
 
+        assertions = [
+          {
+            assertion = cfg.containerdConfigTemplate == null || cfg.extraContainerdSettings == { };
+            message = "services.${name}.containerdConfigTemplate and services.${name}.extraContainerdSettings are mutually exclusive.";
+          }
+        ];
+
         environment.systemPackages = [ config.services.${name}.package ];
 
         # Use systemd-tmpfiles to activate content
@@ -871,6 +901,16 @@ let
           // (lib.optionalAttrs (cfg.containerdConfigTemplate != null) {
             ${containerdConfigTemplateFile} = {
               "L+".argument = "${pkgs.writeText "config.toml.tmpl" cfg.containerdConfigTemplate}";
+            };
+          })
+          // (lib.optionalAttrs (cfg.extraContainerdSettings != { }) {
+            ${containerdConfigTemplateFile} = {
+              "L+".argument = "${pkgs.runCommand "config.toml.tmpl" { } ''
+                # Include the base containerd config via k3s/rke2's Go template mechanism
+                echo '{{ template "base" . }}' > $out
+                echo >> $out
+                cat ${containerdSettingsFormat.generate "extra-containerd-settings.toml" cfg.extraContainerdSettings} >> $out
+              ''}";
             };
           })
           // (lib.mapAttrs' mkChartRule helmCharts);

--- a/nixos/tests/rancher/default.nix
+++ b/nixos/tests/rancher/default.nix
@@ -99,6 +99,7 @@ let
     {
       auto-deploy = mkTests ./auto-deploy.nix;
       configuration = mkTests ./configuration.nix;
+      extra-containerd-settings = mkTests ./extra-containerd-settings.nix;
       etcd = mkTests ./etcd.nix;
       multi-node = mkTests ./multi-node.nix;
       single-node = mkTests ./single-node.nix;

--- a/nixos/tests/rancher/extra-containerd-settings.nix
+++ b/nixos/tests/rancher/extra-containerd-settings.nix
@@ -1,0 +1,59 @@
+# Tests that extraContainerdSettings generates a valid containerd config template
+{
+  pkgs,
+  lib,
+  rancherDistro,
+  rancherPackage,
+  serviceName,
+  disabledComponents,
+  coreImages,
+  vmResources,
+  ...
+}:
+let
+  nodeName = "test";
+in
+{
+  name = "${rancherPackage.name}-extra-containerd-settings";
+  nodes.machine =
+    { ... }:
+    {
+      environment.systemPackages = with pkgs; [
+        kubectl
+        jq
+      ];
+      environment.sessionVariables.KUBECONFIG = "/etc/rancher/${rancherDistro}/${rancherDistro}.yaml";
+
+      virtualisation = vmResources;
+
+      services.${rancherDistro} = {
+        enable = true;
+        package = rancherPackage;
+        disable = disabledComponents;
+        images = coreImages;
+        inherit nodeName;
+        extraContainerdSettings = {
+          plugins."io.containerd.grpc.v1.cri".containerd.runtimes."test-runtime" = {
+            runtime_type = "io.containerd.runc.v2";
+          };
+        };
+      };
+    };
+
+  testScript = # python
+    ''
+      machine.wait_for_unit("${serviceName}")
+      machine.wait_until_succeeds(r"""kubectl get node ${nodeName} -ojson | jq -e '.status.conditions[] | select(.type == "Ready") | .status == "True"'""")
+
+      with subtest("Containerd config template contains base template and extra settings"):
+        tmpl = machine.succeed("cat /var/lib/rancher/${rancherDistro}/agent/etc/containerd/config.toml.tmpl")
+        t.assertIn('{{ template "base" . }}', tmpl, "the containerd config template does not contain the base template directive")
+        t.assertIn("test-runtime", tmpl, "the containerd config template does not contain the extra runtime")
+
+      with subtest("Containerd config is rendered correctly"):
+        cfg = machine.succeed("cat /var/lib/rancher/${rancherDistro}/agent/etc/containerd/config.toml")
+        t.assertIn("test-runtime", cfg, "the rendered containerd config does not contain the extra runtime")
+    '';
+
+  meta.maintainers = lib.teams.k3s.members ++ pkgs.rke2.meta.maintainers;
+}


### PR DESCRIPTION
Add a structured alternative to `containerdConfigTemplate` that accepts Nix attribute sets and generates TOML containerd config. The base template directive (`{{ template "base" . }}`) is automatically included. This option is mutually exclusive with the existing `containerdConfigTemplate` string option.

Example usage:
```nix
services.k3s.extraContainerdSettings = {
  plugins."io.containerd.grpc.v1.cri".containerd.runtimes."custom" = {
    runtime_type = "io.containerd.runc.v2";
  };
  plugins."io.containerd.grpc.v1.cri".containerd.runtimes."custom".options = {
    BinaryName = "/path/to/custom-container-runtime";
  };
};
```

Depends on #503612 (nixos/rancher: fix warnings/assertions being silently dropped).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] — added `nixos/tests/rancher/extra-containerd-settings.nix`
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test