### PR TITLE
quill, quill-qr: fix packages and update quill to 0.5.4

### DIFF
--- a/pkgs/build-support/rust/replace-workspace-values.py
+++ b/pkgs/build-support/rust/replace-workspace-values.py
@@ -53,11 +53,14 @@ def replace_key(
             local_default_features = local_dep.pop(
                 "default-features", local_dep.pop("default_features", None)
             )
+            local_no_default_features = local_dep.pop("no-default-features", None)
             workspace_default_features = workspace_dep.get(
                 "default-features", workspace_dep.get("default_features")
             )
 
-            if not workspace_default_features and local_default_features:
+            if local_no_default_features:
+                final["default-features"] = False
+            elif not workspace_default_features and local_default_features:
                 final["default-features"] = True
 
             optional = local_dep.pop("optional", False)

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/crate_no_default_features.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/crate_no_default_features.toml
@@ -1,0 +1,7 @@
+[package]
+name = "im_using_workspaces"
+version = { workspace = true }
+publish = false
+
+[dependencies]
+foo = { workspace = true, no-default-features = true }

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/default.nix
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/default.nix
@@ -12,4 +12,8 @@ runCommand "git-dependency-workspace-inheritance-test" { } ''
   cp --no-preserve=mode ${./crate_missing_field.toml} "$out"
   ${replaceWorkspaceValues} "$out" ${./workspace.toml}
   diff -u "$out" ${./want_missing_field.toml}
+
+  cp --no-preserve=mode ${./crate_no_default_features.toml} "$out"
+  ${replaceWorkspaceValues} "$out" ${./workspace.toml}
+  diff -u "$out" ${./want_no_default_features.toml}
 ''

--- a/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/want_no_default_features.toml
+++ b/pkgs/build-support/rust/test/import-cargo-lock/git-dependency-workspace-inheritance/want_no_default_features.toml
@@ -1,0 +1,11 @@
+[package]
+name = "im_using_workspaces"
+version = "1.0.0"
+publish = false
+
+[dependencies.foo]
+version = "1.0.0"
+features = [
+    "meow",
+]
+default-features = false

--- a/pkgs/by-name/qu/quill-qr/package.nix
+++ b/pkgs/by-name/qu/quill-qr/package.nix
@@ -5,19 +5,20 @@
   jq,
   lib,
   makeWrapper,
+  ncurses,
   qrencode,
   stdenvNoCC,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "quill-qr";
   version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "IvanMalison";
     repo = "quill-qr";
-    rev = "v${version}";
-    sha256 = "1kdsq6csmxfvs2wy31bc9r92l5pkmzlzkyqrangvrf4pbk3sk0r6";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JoOpx1yXuLyfVRn7+emv8xYqUk5sheG50Nv1qpnBus0=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -26,24 +27,25 @@ stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp -a quill-qr.sh $out/bin/quill-qr.sh
+    cp -a quill-qr.sh $out/bin/quill-qr
     patchShebangs $out/bin
 
-    wrapProgram $out/bin/quill-qr.sh --prefix PATH : "${
+    wrapProgram $out/bin/quill-qr --prefix PATH : "${
       lib.makeBinPath [
         qrencode
         coreutils
         jq
         gzip
+        ncurses
       ]
     }"
   '';
 
   meta = {
     description = "Print QR codes for use with https://p5deo-6aaaa-aaaab-aaaxq-cai.raw.ic0.app";
-    mainProgram = "quill-qr.sh";
+    mainProgram = "quill-qr";
     homepage = "https://github.com/IvanMalison/quill-qr";
-    maintainers = with lib.maintainers; [ imalison ];
-    platforms = with lib.platforms; linux;
+    maintainers = [ lib.maintainers.imalison ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/qu/quill/package.nix
+++ b/pkgs/by-name/qu/quill/package.nix
@@ -11,22 +11,23 @@
   buildPackages,
 }:
 
-rustPlatform.buildRustPackage rec {
+let
+  ic = fetchFromGitHub {
+    owner = "dfinity";
+    repo = "ic";
+    rev = "c7993fa049275b6700df8dfcc02f90d0fca82f24";
+    hash = "sha256-eGdBEcp2gxMz2SoRiBRANAvpg3qMgnpSSAED4jzt7bo=";
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "quill";
-  version = "0.5.3";
+  version = "0.5.4";
 
   src = fetchFromGitHub {
     owner = "dfinity";
     repo = "quill";
-    rev = "v${version}";
-    hash = "sha256-lCDKM9zzGcey4oWp6imiHvGSNRor0xhlmlhRkSXFLlU=";
-  };
-
-  ic = fetchFromGitHub {
-    owner = "dfinity";
-    repo = "ic";
-    rev = "2f9ae6bf5eafed03599fd29475100aca9f78ae81";
-    hash = "sha256-QWJFsWZ9miWN4ql4xFXMQM1Y71nzgGCL57yAa0j7ch4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RXYn5QsRRi1888Iec4Q+e3ielkKBdgouHXlFCphZqnk=";
   };
 
   registry = "file://local-registry";
@@ -36,15 +37,15 @@ rustPlatform.buildRustPackage rec {
     export IC_BASE_TYPES_PROTO_INCLUDES=${ic}/rs/types/base_types/proto
     export IC_PROTOBUF_PROTO_INCLUDES=${ic}/rs/protobuf/def
     export IC_NNS_COMMON_PROTO_INCLUDES=${ic}/rs/nns/common/proto
-    export IC_ICRC1_ARCHIVE_WASM_PATH=${ic}/rs/rosetta-api/icrc1/wasm/ic-icrc1-archive.wasm.gz
-    export LEDGER_ARCHIVE_NODE_CANISTER_WASM_PATH=${ic}/rs/rosetta-api/icp_ledger/wasm/ledger-archive-node-canister.wasm
-    cp ${ic}/rs/rosetta-api/icp_ledger/ledger.did /build/quill-${version}-vendor/ledger.did
+    export IC_ICRC1_ARCHIVE_WASM_PATH=${ic}/rs/ledger_suite/icrc1/wasm/ic-icrc1-archive.wasm.gz
+    export LEDGER_ARCHIVE_NODE_CANISTER_WASM_PATH=${ic}/rs/ledger_suite/icp/wasm/ledger-archive-node-canister.wasm
+    cp ${ic}/rs/ledger_suite/icp/ledger.did /build/quill-${finalAttrs.version}-vendor/ledger.did
     export PROTOC=${buildPackages.protobuf}/bin/protoc
     export OPENSSL_DIR=${openssl.dev}
     export OPENSSL_LIB_DIR=${lib.getLib openssl}/lib
   '';
 
-  cargoHash = "sha256-rpsbQYA6RBYSo2g+YhYG02CYlboRQvIwMqPAybayCOs=";
+  cargoHash = "sha256-oV+0yP2EHTjiCb3LK8xAp+8jPZs6m5J7EdFFNDlYujA=";
 
   nativeBuildInputs = [
     pkg-config
@@ -60,10 +61,10 @@ rustPlatform.buildRustPackage rec {
 
   meta = {
     homepage = "https://github.com/dfinity/quill";
-    changelog = "https://github.com/dfinity/quill/releases/tag/v${version}";
+    changelog = "https://github.com/dfinity/quill/releases/tag/v${finalAttrs.version}";
     description = "Minimalistic ledger and governance toolkit for cold wallets on the Internet Computer";
     mainProgram = "quill";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ imalison ];
+    maintainers = [ lib.maintainers.imalison ];
   };
-}
+})


### PR DESCRIPTION
This updates `quill` to the latest upstream release, adjusts it for the current `dfinity/ic` layout, and fixes `quill-qr` runtime packaging so the installed wrapper works correctly.

`quill` 0.5.4 also exposed a gap in the Rust workspace inheritance helper: git dependencies can set `no-default-features = true` while inheriting the rest of their dependency metadata from the workspace. This PR teaches `replace-workspace-values.py` to preserve that flag and adds a focused regression test.

Upstream release notes:
- https://github.com/dfinity/quill/releases/tag/v0.5.4

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test