### PR TITLE
gren: refactor

### DIFF
--- a/pkgs/by-name/gr/gren/package.nix
+++ b/pkgs/by-name/gr/gren/package.nix
@@ -3,8 +3,9 @@
   stdenv,
   fetchFromGitHub,
   makeBinaryWrapper,
-  nodejs,
+  nodejs-slim,
   git,
+  haskell,
   haskellPackages,
   versionCheckHook,
 }:
@@ -20,7 +21,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-eWs2Qsg3jCrBWAP7GAtBkG8RSoljjES6EpdN4IfpxaA=";
   };
 
-  buildInputs = [ nodejs ];
+  buildInputs = [
+    nodejs-slim
+    git
+  ];
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
@@ -32,7 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     wrapProgram $out/bin/gren \
       --set-default GREN_BIN ${lib.getExe finalAttrs.passthru.backend} \
-      --suffix PATH : ${lib.makeBinPath [ git ]}
 
     runHook postInstall
   '';
@@ -42,7 +45,9 @@ stdenv.mkDerivation (finalAttrs: {
   versionCheckProgram = "${placeholder "out"}/bin/gren";
 
   passthru = {
-    backend = haskellPackages.callPackage ./generated-backend-package.nix { };
+    backend = haskell.lib.justStaticExecutables (
+      haskellPackages.callPackage ./generated-backend-package.nix { }
+    );
     updateScript = ./update.sh;
   };
 
@@ -50,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Programming language for simple and correct applications";
     homepage = "https://gren-lang.org";
     license = lib.licenses.bsd3;
-    platforms = lib.intersectLists haskellPackages.ghc.meta.platforms nodejs.meta.platforms;
+    platforms = lib.intersectLists haskellPackages.ghc.meta.platforms nodejs-slim.meta.platforms;
     mainProgram = "gren";
     maintainers = with lib.maintainers; [
       robinheghan


### PR DESCRIPTION
Reduce the size of the derivation by using `nodejs-slim` instead of `nodejs` (gren doesn't require nodejs package management in any way), and by using `haskell.lib.justStaticExecutables` for the backend program.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
