### PR TITLE
monkeys-audio: remove redundant NIX_CFLAGS_COMPILE

### DIFF
--- a/pkgs/by-name/mo/monkeys-audio/package.nix
+++ b/pkgs/by-name/mo/monkeys-audio/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "APE codec and decompressor";
-    platforms = lib.platforms.linux;
+    platforms = with lib.platforms; linux ++ windows ++ darwin;
     mainProgram = "mac";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ doronbehar ];

--- a/pkgs/by-name/mo/monkeys-audio/package.nix
+++ b/pkgs/by-name/mo/monkeys-audio/package.nix
@@ -15,11 +15,6 @@ stdenv.mkDerivation (finalAttrs: {
     stripRoot = false;
   };
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    # Otherwise, >> related build errors are encountered
-    "-std=c++11"
-  ];
-
   nativeBuildInputs = [
     cmake
   ];


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test