### PR TITLE
stockfish: fix build for armv7l

### DIFF
--- a/pkgs/by-name/st/stockfish/package.nix
+++ b/pkgs/by-name/st/stockfish/package.nix
@@ -25,6 +25,8 @@ let
       "x86-32"
     else if stdenv.hostPlatform.isAarch64 then
       "armv8"
+    else if stdenv.hostPlatform.isAarch32 then
+      "armv7"
     else
       "unknown";
 
@@ -66,6 +68,7 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)"
     "ARCH=${arch}"
     "CXX=${stdenv.cc.targetPrefix}c++"
+    "STRIP=${stdenv.cc.targetPrefix}strip"
   ];
   buildFlags = [ "build" ];
 
@@ -121,6 +124,7 @@ stdenv.mkDerivation rec {
       "x86_64-darwin"
       "aarch64-linux"
       "aarch64-darwin"
+      "armv7l-linux"
     ];
     license = lib.licenses.gpl3Only;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

maps aarch32 to stockfish arch armv7 to support builds for armv7l devices

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

maintainers:
@luispedro @siraben @ornicar