### PR TITLE
findent: init at 4.3.6, ford: init at 7.0.13

### DIFF
--- a/pkgs/by-name/fi/findent/package.nix
+++ b/pkgs/by-name/fi/findent/package.nix
@@ -1,0 +1,30 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "findent";
+  version = "4.3.6";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/findent/findent-${finalAttrs.version}.tar.gz";
+    hash = "sha256-ctg02P8P3R27lCpv3tILSZ5ikn2Va25jHOWIuRfIONQ=";
+  };
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  checkTargets = [ "installcheck" ];
+
+  meta = {
+    description = "Fortran source code formatter";
+    homepage = "https://sourceforge.net/findent/";
+    license = lib.licenses.bsd3;
+    mainProgram = "findent";
+    maintainers = with lib.maintainers; [ sheepforce ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/by-name/fo/ford/package.nix
+++ b/pkgs/by-name/fo/ford/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  gfortran,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "ford";
+  version = "7.0.13";
+
+  src = fetchFromGitHub {
+    owner = "Fortran-FOSS-Programmers";
+    repo = "ford";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+pz4YvMmr7QIqrORJg0F2W7m20FTrItHCC+AmcDp284=";
+  };
+
+  pyproject = true;
+
+  nativeBuildInputs = [ python3Packages.pythonRelaxDepsHook ];
+
+  pythonRelaxDeps = [
+    "markdown"
+    "markdown-include"
+    "toposort"
+    "graphviz"
+  ];
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = with python3Packages; [
+    markdown
+    markdown-include
+    toposort
+    jinja2
+    pygments
+    beautifulsoup4
+    graphviz
+    tqdm
+    tomli
+    rich
+    pcpp
+    python-markdown-math
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    tomli-w
+    pcpp
+    gfortran
+  ];
+
+  meta = {
+    description = "Fortran documentation system";
+    mainProgram = "ford";
+    homepage = "https://github.com/Fortran-FOSS-Programmers/ford";
+    license = [ lib.licenses.gpl3Only ];
+    maintainers = [ lib.maintainers.sheepforce ];
+  };
+})


### PR DESCRIPTION
This adds two programs for fortran development: the formatter [findent](https://sourceforge.net/projects/findent/) and the documentation system [Ford](https://github.com/Fortran-FOSS-Programmers/ford).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
