### PR TITLE
n8n: 2.10.4 -> 2.13.3, fix 6 CVEs

### DIFF
--- a/pkgs/by-name/n8/n8n/package.nix
+++ b/pkgs/by-name/n8/n8n/package.nix
@@ -25,20 +25,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "n8n";
-  version = "2.10.4";
+  version = "2.13.3";
 
   src = fetchFromGitHub {
     owner = "n8n-io";
     repo = "n8n";
     tag = "n8n@${finalAttrs.version}";
-    hash = "sha256-/UJ6+EpNh+jr8digBFKltxahebAeJKGwj3rbkXO0vm8=";
+    hash = "sha256-ErChLX9bzOABz1hM4YuB2horhTWR4tskItx5rE0zR8g=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-2m5ftzOKzXpRDdeUDfoWkpYY982cyqHB7uTZ3/3dhsk=";
+    hash = "sha256-SyGVhJ1kKH209TQken89RnBpZ7K3agHPN0jSmoFtX6c=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/n8/n8n/update.sh
+++ b/pkgs/by-name/n8/n8n/update.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 new_version="$(curl -s 'https://api.github.com/repos/n8n-io/n8n/releases?per_page=30' | \
   jq -r '
-    map(select(.prerelease | not) | .tag_name | sub("^n8n@"; ""))
+    map(select(.prerelease | not) | .tag_name | select(startswith("n8n@")) | sub("^n8n@"; ""))
     | sort_by(split(".") | map(tonumber)) | last
     ')"
 nix-update n8n --version "$new_version"


### PR DESCRIPTION
Release: https://github.com/n8n-io/n8n/releases/tag/n8n%402.13.3

This should fix a number of security issues: https://github.com/NixOS/nixpkgs/issues/494836


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
