### PR TITLE
nixos-test-driver: Make overridable

### DIFF
--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -64,6 +64,7 @@ let
       eval = nixos-lib.evalTest {
         # Avoid evaluating a NixOS config prototype.
         config.node.type = types.deferredModule;
+        config.hostPkgs = pkgs;
         options._module.args = mkOption { internal = true; };
       };
     in

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -211,6 +211,9 @@
   "test-opt-nodeDefaults": [
     "index.html#test-opt-nodeDefaults"
   ],
+  "test-opt-pythonTestDriverPackage": [
+    "index.html#test-opt-pythonTestDriverPackage"
+  ],
   "test-opt-rawTestDerivationArg": [
     "index.html#test-opt-rawTestDerivationArg"
   ],

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -9,15 +9,10 @@ let
 
   # Reifies and correctly wraps the python test driver for
   # the respective qemu version and with or without ocr support
-  testDriver = hostPkgs.python3Packages.callPackage ../test-driver {
+  testDriver = config.pythonTestDriverPackage.override {
     inherit (config) enableOCR extraPythonPackages;
     qemu_pkg = config.qemu.package;
-    imagemagick_light = hostPkgs.imagemagick_light.override { inherit (hostPkgs) libtiff; };
-    tesseract4 = hostPkgs.tesseract4.override { enableLanguages = [ "eng" ]; };
-
     enableNspawn = config.containers != { };
-    # We want `pkgs.systemd`, *not* `python3Packages.system`.
-    systemd = hostPkgs.systemd;
   };
 
   vlans = map (
@@ -135,6 +130,12 @@ let
 in
 {
   options = {
+    pythonTestDriverPackage = mkOption {
+      description = "Package containing the python NixOS test driver implemetnation";
+      type = types.package;
+      default = hostPkgs.nixos-test-driver;
+      readOnly = true;
+    };
 
     driver = mkOption {
       description = "Package containing a script that runs the test.";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -146,6 +146,14 @@ with pkgs;
 
   inherit (nix-update) nix-update-script;
 
+  nixos-test-driver = pkgs.python3Packages.callPackage ../../nixos/lib/test-driver {
+    qemu_pkg = pkgs.qemu;
+    imagemagick_light = pkgs.imagemagick_light.override { inherit (pkgs) libtiff; };
+    tesseract4 = pkgs.tesseract4.override { enableLanguages = [ "eng" ]; };
+    # We want `pkgs.systemd`, *not* `python3Packages.system`.
+    systemd = pkgs.systemd;
+  };
+
   ### Push NixOS tests inside the fixed point
 
   # See also allTestsForSystem in nixos/release.nix


### PR DESCRIPTION
To be able to inject patches into the python nixos test driver, this change:

- makes it a package `pkgs.nixos-test-driver`
- uses that package as `config.pythonTestDriverPackage` in the test module system 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
