### PR TITLE
librelane: 3.0.0rc1 -> 3.0.0

### DIFF
--- a/pkgs/by-name/li/librelane/package.nix
+++ b/pkgs/by-name/li/librelane/package.nix
@@ -23,14 +23,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "librelane";
-  version = "3.0.0rc1";
+  version = "3.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "librelane";
     repo = "librelane";
     tag = finalAttrs.version;
-    hash = "sha256-oEMybXxnOyCbUEsJWtBMuV+6XSg9Y8wKrbR9pm/GI5U=";
+    hash = "sha256-BZmoneeMpnnQ2wUb5sorLFsFZsLaKclhAtCIiMsW8Qc=";
   };
 
   build-system = [

--- a/pkgs/by-name/ma/magic-vlsi/package.nix
+++ b/pkgs/by-name/ma/magic-vlsi/package.nix
@@ -20,15 +20,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "magic-vlsi";
-  version = "8.3.602";
+  version = "8.3.628";
 
   src = fetchFromGitHub {
     owner = "RTimothyEdwards";
     repo = "magic";
     tag = finalAttrs.version;
-    hash = "sha256-jNcuTdBHyVUEvdavIaB2LfMBKhHZkCxFOYyA2kBezqc=";
+    hash = "sha256-Zs9M2UgN+tIty7/DwLKVLjrPZxfd0qpM90F9QjUI6wM=";
     leaveDotGit = true;
   };
+
+  hardeningDisable = [ "fortify" ];
 
   patches = [
     (fetchpatch {


### PR DESCRIPTION
🛠️ Summary of Changes
1. magic-vlsi: 8.3.602 → 8.3.628
    Version Bump: Updated the source to the latest stable revision.
    Hardening Bypass: Added hardeningDisable = [ "fortify" ]; to the Nix derivation.
    Source Integrity: Updated the fetchFromGitHub hash to match the 8.3.628 tag.

2. librelane: 3.0.0rc1 → 3.0.0
    Stable Release: Transitioned the package from the release candidate to the formal 3.0.0 stable version.
    Hash Update: Refreshed the SHA256 to align with the new upstream release tag.

https://github.com/librelane/librelane/releases/tag/3.0.0
https://github.com/librelane/librelane/blob/3.0.0/Changelog.md

https://github.com/RTimothyEdwards/magic/releases/tag/8.3.628

Added hardeningDisable to fix failure in "librelane --smoke-test"

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Ran in nix-shell and made sure "librelane --smoke-test" passes.
