### PR TITLE
dependi-lsp: init at 1.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29457,6 +29457,12 @@
     github = "XBagon";
     githubId = 1523292;
   };
+  xBLACKICEx = {
+    email = "xBLACKICEx@outlook.com";
+    github = "xBLACKICEx";
+    githubId = "51036094";
+    name = "xBLACKICEx";
+  };
   xbreak = {
     email = "xbreak@alphaware.se";
     github = "xbreak";

--- a/pkgs/by-name/de/dependi-lsp/package.nix
+++ b/pkgs/by-name/de/dependi-lsp/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "dependi-lsp";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "mpiton";
+    repo = "zed-dependi";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pqkCgyfyEi83fuJGblOyQHTKsed+44Pa2EzlqaHOHi8=";
+  };
+
+  cargoRoot = "dependi-lsp";
+  buildAndTestSubdir = "dependi-lsp";
+  cargoHash = "sha256-G1CdEZwDb75UHOflUJvyynyF31Nhl5kVHsxNZCarAPA=";
+
+  cargoBuildFlags = [
+    "--bin"
+    "dependi-lsp"
+  ];
+
+  # Integration tests require network access.
+  doCheck = false;
+
+  meta = {
+    description = "LSP backend for the Dependi extension in Zed Editor";
+    homepage = "https://mpiton.github.io/zed-dependi";
+    changelog = "https://github.com/mpiton/zed-dependi/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "dependi-lsp";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ xBLACKICEx ];
+  };
+})


### PR DESCRIPTION
Add `dependi-lsp`, the Language Server Protocol (LSP) backend for the [Dependi extension in Zed](https://zed.dev/extensions/dependi) Editor. It provides dependency update suggestions and vulnerability diagnostics.

Package details:

* Name: `dependi-lsp`
* Version: `1.6.1`
* Source: GitHub tag `v1.6.1` (`mpiton/zed-dependi`)
* Build system: `rustPlatform.buildRustPackage`
* Monorepo layout:

  * `cargoRoot = "dependi-lsp"`
  * `buildAndTestSubdir = "dependi-lsp"`
* Binary: `dependi-lsp`
* Tests: `doCheck = false` (integration tests require network access)

## Things done

* Built on platform:

  * [x] x86_64-linux
  * [ ] aarch64-linux
  * [ ] x86_64-darwin
  * [ ] aarch64-darwin
* Tested, as applicable:

  * [x] NixOS tests
  * [ ] Package tests
  * [ ] lib/tests or pkgs/test
* [x] Ran `nixpkgs-review`.
* [x] Tested basic functionality of binary:

  * `./result/bin/dependi-lsp --help`
* Nixpkgs Release Notes

  * [ ] Package update
* NixOS Release Notes

  * [ ] Module addition
  * [ ] Module update
* [x] Fits CONTRIBUTING.md and pkgs guidelines.

## Testing

Tested locally on **x86_64-linux (NixOS)**.

### 1. Build package

```bash
nix-build -A dependi-lsp
```

### 2. Verify binary

```bash
./result/bin/dependi-lsp --help
```

### 3. Zed integration

Install the Dependi extension in Zed:

https://zed.dev/extensions/dependi

Build and print the store path:

```bash id="5g9p0c"
nix build nixpkgs#dependi-lsp --print-out-paths --no-link
```

Configure LSP override in `settings.json`:

```json id="h0q6pr"
{
  "lsp": {
    "dependi": {
      "binary": {
        "ignore_system_version": false,
        "path": "/nix/store/xxx-dependi-lsp-1.6.1/bin/dependi-lsp",
        "arguments": []
      }
    }
  }
}
```

Then open a supported dependency file (e.g. `Cargo.toml` or `package.json`) to verify diagnostics and completions.