### PR TITLE
nixos-rebuild-ng: redirect switch-to-configuration stdout to stderr

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -717,6 +717,12 @@ def switch_to_configuration(
         },
         remote=target_host,
         sudo=sudo,
+        # switch-to-configuration is not expected to produce meaningful
+        # stdout, but if it (or any of its children) does, it would leak
+        # into our stdout and break the "only the store path on stdout"
+        # contract documented in services.py (see print_result). Redirect
+        # its stdout to our stderr defensively.
+        stdout=sys.stderr,
     )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -249,6 +249,7 @@ def test_execute_nix_boot(mock_run: Mock, tmp_path: Path) -> None:
                     "boot",
                 ],
                 check=True,
+                stdout=ANY,
                 **(
                     DEFAULT_RUN_KWARGS
                     | {
@@ -547,6 +548,7 @@ def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
                     "switch",
                 ],
                 check=True,
+                stdout=ANY,
                 **DEFAULT_RUN_KWARGS,
             ),
         ]
@@ -795,6 +797,7 @@ def test_execute_nix_switch_build_target_host(
                     "switch",
                 ],
                 check=True,
+                stdout=ANY,
                 **DEFAULT_RUN_KWARGS,
             ),
         ]
@@ -920,6 +923,7 @@ def test_execute_nix_switch_flake_target_host(
                     "switch",
                 ],
                 check=True,
+                stdout=ANY,
                 **DEFAULT_RUN_KWARGS,
             ),
         ]
@@ -1047,6 +1051,7 @@ def test_execute_nix_switch_flake_build_host(
                     "switch",
                 ],
                 check=True,
+                stdout=ANY,
                 **DEFAULT_RUN_KWARGS,
             ),
         ]
@@ -1132,6 +1137,7 @@ def test_execute_switch_rollback(mock_run: Mock, tmp_path: Path) -> None:
                     "switch",
                 ],
                 check=True,
+                stdout=ANY,
                 **DEFAULT_RUN_KWARGS,
             ),
         ]
@@ -1307,6 +1313,7 @@ def test_execute_test_flake(mock_run: Mock, tmp_path: Path) -> None:
             call(
                 [config_path / "bin/switch-to-configuration", "test"],
                 check=True,
+                stdout=ANY,
                 **DEFAULT_RUN_KWARGS,
             ),
         ]
@@ -1372,6 +1379,7 @@ def test_execute_test_rollback(
                     "test",
                 ],
                 check=True,
+                stdout=ANY,
                 **DEFAULT_RUN_KWARGS,
             ),
         ]
@@ -1433,6 +1441,7 @@ def test_execute_switch_store_path(mock_run: Mock, tmp_path: Path) -> None:
                     "switch",
                 ],
                 check=True,
+                stdout=ANY,
                 **(
                     DEFAULT_RUN_KWARGS
                     | {
@@ -1551,6 +1560,7 @@ def test_execute_switch_store_path_target_host(
                     "switch",
                 ],
                 check=True,
+                stdout=ANY,
                 **DEFAULT_RUN_KWARGS,
             ),
         ]

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -770,6 +770,7 @@ def test_switch_to_configuration_without_systemd_run(
         },
         sudo=False,
         remote=None,
+        stdout=sys.stderr,
     )
 
     with pytest.raises(m.NixOSRebuildError) as e:
@@ -811,6 +812,7 @@ def test_switch_to_configuration_without_systemd_run(
         },
         sudo=True,
         remote=target_host,
+        stdout=sys.stderr,
     )
 
 
@@ -846,6 +848,7 @@ def test_switch_to_configuration_with_systemd_run(
         },
         sudo=False,
         remote=None,
+        stdout=sys.stderr,
     )
 
     target_host = m.Remote("user@localhost", [], None, "ssh")
@@ -875,6 +878,7 @@ def test_switch_to_configuration_with_systemd_run(
         },
         sudo=True,
         remote=target_host,
+        stdout=sys.stderr,
     )
 
 


### PR DESCRIPTION
nixos-rebuild-ng intentionally prints only the resulting store path to stdout so callers can script against it:

https://github.com/NixOS/nixpkgs/blob/bca49d857b913fdb7b4c8f25fe1de76848e86e61/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py#L223-L227

However, switch-to-configuration's stdout was inherited unredirected, so any output from it or its children leaked into ours and mixed with the store path.

See #503032 which accidentally broke this.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
