### PR TITLE
dart-bin: 3.11.0 -> 3.11.4

### DIFF
--- a/pkgs/development/compilers/dart/default.nix
+++ b/pkgs/development/compilers/dart/default.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dart";
-  version = "3.11.0";
+  version = "3.11.4";
 
   src =
     let
@@ -25,10 +25,10 @@ stdenv.mkDerivation (finalAttrs: {
         aarch64-darwin = "macos-arm64";
       };
       hash = selectSystem {
-        x86_64-linux = "sha256-8xcptWe+MYx8wjva/muamX+n3b+CnfUBbwZiJ7aqDJk=";
-        aarch64-linux = "sha256-dr/vXICcCCF332xRu/SADY1NdV8ulvt1Fiv40rAy74M=";
-        x86_64-darwin = "sha256-Wlwpx6g4EmkzKAEyaxHMrc8M/nMB7QGj8G6BdmvLjXQ=";
-        aarch64-darwin = "sha256-IjJFpC6rG4EeUC4VYluGcHX/4BLenrU3Skzd4u4IdTQ=";
+        x86_64-linux = "sha256-UtYvBbAHzLcRfPQcGb7aHIfBRLJ+pgCxa0ycjqj8j9Q=";
+        aarch64-linux = "sha256-w1um8N4fXrvyNQZhK//DR8e6lMOkx1EQyrEVeJIWbTw=";
+        x86_64-darwin = "sha256-GHTjTHJmbIPfsAbF4AmxjDETSw9YD04/6lGecoe1xrA=";
+        aarch64-darwin = "sha256-DwyZtAeZLuaX2MFVPzhERiFeX45wI9sTc4Y2SVopRE8=";
       };
     in
     fetchurl {

--- a/pkgs/development/compilers/dart/update.sh
+++ b/pkgs/development/compilers/dart/update.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 latestVersion=$(curl -sL https://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION | jq --raw-output .version)
-currentVersion=$(nix eval --raw -f . dart.version)
+currentVersion=$(nix eval --raw -f . dart-bin.version)
 
 if [[ "$latestVersion" == "$currentVersion" ]]; then
   exit 0
@@ -12,10 +12,10 @@ fi
 
 MY_PATH=$(dirname $(realpath "$0"))
 
-update-source-version dart $latestVersion --file=$MY_PATH/default.nix
+update-source-version dart-bin $latestVersion --file=$MY_PATH/default.nix
 
-systems=$(nix eval --json -f . dart.meta.platforms | jq --raw-output '.[]')
+systems=$(nix eval --json -f . dart-bin.meta.platforms | jq --raw-output '.[]')
 for system in $systems; do
-  hash=$(nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url $(nix eval --raw -f . dart.src.url --system "$system")))
-  update-source-version dart $latestVersion $hash --file=$MY_PATH/default.nix --system=$system --ignore-same-version --ignore-same-hash
+  hash=$(nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url $(nix eval --raw -f . dart-bin.src.url --system "$system")))
+  update-source-version dart-bin $latestVersion $hash --file=$MY_PATH/default.nix --system=$system --ignore-same-version --ignore-same-hash
 done


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/dart-lang/sdk/blob/3.11.4/CHANGELOG.md#3114
https://github.com/dart-lang/sdk/releases/tag/3.11.4
https://github.com/dart-lang/sdk/compare/3.11.0...3.11.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
