### PR TITLE
gui-for-clash: 1.18.0 -> 1.21.1

### DIFF
--- a/pkgs/by-name/gu/gui-for-clash/package.nix
+++ b/pkgs/by-name/gu/gui-for-clash/package.nix
@@ -18,13 +18,13 @@
 
 let
   pname = "gui-for-clash";
-  version = "1.18.0";
+  version = "1.21.1";
 
   src = fetchFromGitHub {
     owner = "GUI-for-Cores";
     repo = "GUI.for.Clash";
     tag = "v${version}";
-    hash = "sha256-M5M3o7RIXszMW2KGv2UDyR002dNOL3FFj0zM4w4D+U0=";
+    hash = "sha256-eIJYtXa0JdP7hLvBRnWyh0KkdMWvOd2GRXPaqCvP8yE=";
   };
 
   metaCommon = {
@@ -53,8 +53,8 @@ let
         sourceRoot
         ;
       pnpm = pnpm_10;
-      fetcherVersion = 2;
-      hash = "sha256-AHGPAYw/6FRKO2FY1J84NrLcp+bZOclOF6UFY61npFI=";
+      fetcherVersion = 3;
+      hash = "sha256-gr6XIhLKWSOJ4LWiliOvMoA9QbPiohrCPmvObz49/pw=";
     };
 
     buildPhase = ''
@@ -84,7 +84,7 @@ buildGoModule {
 
   patches = [ ./xdg-path-and-restart-patch.patch ];
 
-  vendorHash = "sha256-xQ6TeVoBe8906+/5X1q4e5QHVo+KHymB+yoxM+Obk18=";
+  vendorHash = "sha256-EeIxt0BzSaZh1F38btUXN9kAvj12nlqEerVgWVGkiuk=";
 
   nativeBuildInputs = [
     autoPatchelfHook

--- a/pkgs/by-name/gu/gui-for-clash/xdg-path-and-restart-patch.patch
+++ b/pkgs/by-name/gu/gui-for-clash/xdg-path-and-restart-patch.patch
@@ -1,27 +1,9 @@
 --- a/bridge/bridge.go
 +++ b/bridge/bridge.go
-@@ -55,9 +55,14 @@
- 
- 	app := NewApp()
- 
--	if Env.OS == "darwin" {
--		createMacOSSymlink()
--		createMacOSMenus(app)
-+	if Env.OS == "linux" || Env.OS == "darwin" {
-+		userConfigDir, err := os.UserConfigDir()
-+		if err == nil {
-+			targetPath := filepath.Join(userConfigDir, Env.AppName)
-+			if err := os.MkdirAll(targetPath, 0755); err == nil {
-+				Env.BasePath = targetPath
-+			}
-+		}
- 	}
- 
- 	if Env.OS == "windows" {
-@@ -80,7 +85,10 @@
- }
+@@ -93,7 +93,10 @@
  
  func (a *App) RestartApp() FlagResult {
+ 	log.Printf("RestartApp")
 -	exePath := Env.BasePath + "/" + Env.AppName
 +	exePath, err := os.Executable()
 +	if err != nil {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/GUI-for-Cores/GUI.for.Clash/releases/tag/v1.21.1

Closes: #482742

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
