### PR TITLE
nixos/tests: respect meta.hydraPlatforms

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -59,7 +59,7 @@ let
         callTest =
           config:
           if attrNamesOnly then
-            hydraJob config.test
+            hydraJob config.driver
           else
             {
               ${system} = hydraJob config.driver;

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -43,12 +43,17 @@ let
       pkgs = import ./.. { inherit system; };
       callTest =
         config:
-        if attrNamesOnly then
-          hydraJob config.test
-        else
-          {
-            ${system} = hydraJob config.test;
-          };
+        let
+          inherit (config) test;
+        in
+        lib.optionalAttrs (builtins.elem system (getPlatforms test)) (
+          if attrNamesOnly then
+            hydraJob test
+          else
+            {
+              ${system} = hydraJob test;
+            }
+        );
     }
     // {
       # for typechecking of the scripts and evaluation of
@@ -58,12 +63,17 @@ let
         pkgs = import ./.. { inherit system; };
         callTest =
           config:
-          if attrNamesOnly then
-            hydraJob config.driver
-          else
-            {
-              ${system} = hydraJob config.driver;
-            };
+          let
+            inherit (config) driver;
+          in
+          lib.optionalAttrs (builtins.elem system (getPlatforms driver)) (
+            if attrNamesOnly then
+              hydraJob driver
+            else
+              {
+                ${system} = hydraJob driver;
+              }
+          );
       };
     };
 

--- a/nixos/tests/nixos-test-driver/containers.nix
+++ b/nixos/tests/nixos-test-driver/containers.nix
@@ -2,6 +2,8 @@
 {
   name = "containers";
   meta.maintainers = with pkgs.lib.maintainers; [ jfly ];
+  # https://github.com/NixOS/infra/issues/987
+  meta.hydraPlatforms = [ ];
 
   nodes = {
     n1 = {

--- a/nixos/tests/test-containers-bittorrent.nix
+++ b/nixos/tests/test-containers-bittorrent.nix
@@ -51,6 +51,8 @@ in
     maintainers = [
       lib.maintainers.kmein
     ];
+    # https://github.com/NixOS/infra/issues/987
+    hydraPlatforms = [ ];
   };
 
   containers = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Motivation is to not build nspawn tests on hydra.nixos.org for the time being.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
