### PR TITLE
postfix: build with lmdb support

### DIFF
--- a/pkgs/by-name/po/postfix/package.nix
+++ b/pkgs/by-name/po/postfix/package.nix
@@ -8,6 +8,7 @@
   openssl,
   cyrus_sasl,
   libnsl,
+  lmdb,
   coreutils,
   findutils,
   gnugrep,
@@ -39,6 +40,7 @@ let
       "-DUSE_CYRUS_SASL"
       "-I${cyrus_sasl'.dev}/include/sasl"
       "-DHAS_DB_BYPASS_MAKEDEFS_CHECK"
+      "-DHAS_LMDB"
       # Fix build with gcc15, no upstream fix for stable releases:
       # https://www.mail-archive.com/postfix-devel@postfix.org/msg01270.html
       "-std=gnu17"
@@ -58,11 +60,12 @@ let
   );
   auxlibs = lib.concatStringsSep " " (
     [
+      "-lcrypto"
       "-ldb"
+      "-llmdb"
       "-lnsl"
       "-lresolv"
       "-lsasl2"
-      "-lcrypto"
       "-lssl"
     ]
     ++ lib.optional withPgSQL "-lpq"
@@ -87,11 +90,12 @@ stdenv.mkDerivation (finalAttrs: {
     m4
   ];
   buildInputs = [
-    db
-    openssl
     cyrus_sasl'
+    db
     icu
     libnsl
+    lmdb
+    openssl
     pcre2
   ]
   ++ lib.optional withPgSQL libpq


### PR DESCRIPTION
Should we eventually remove bdb support, lmdb is the probably a good choice going forward.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
