### PR TITLE
nufmt: 0-unstable-2025-12-29 -> 0-unstable-2026-03-26

### DIFF
--- a/pkgs/by-name/nu/nufmt/package.nix
+++ b/pkgs/by-name/nu/nufmt/package.nix
@@ -7,29 +7,29 @@
 }:
 rustPlatform.buildRustPackage {
   pname = "nufmt";
-  version = "0-unstable-2025-12-29";
+  version = "0-unstable-2026-03-26";
 
   src = fetchFromGitHub {
     owner = "nushell";
     repo = "nufmt";
-    rev = "c03e166babe7b77f1a80a7916ab1e8e2437bba06";
-    hash = "sha256-VZiRmo9/jxAFCSr2bHrf89qb6o1Obwt2+O3NrIrokZo=";
+    rev = "074930a23bc89a5f720a0d46ac2853f3153817c2";
+    hash = "sha256-XqiUPAVM6OuyNo9HbBKW+OKQrE7QbSjDRtyfmIYQRxs=";
   };
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
   ];
 
-  cargoHash = "sha256-BpKhgF3LUQRL1mNCR5Iq4/Q+eRaOf+JgQCuUfloRhzk=";
+  cargoHash = "sha256-heHFiW1/2qV6BJH7Y0ObSV1sPfVaU0m2KLbASdzca8s=";
 
-  # NOTE: Patch follows similar intention upstream https://github.com/nushell/nufmt/commit/35962223fbd4c1a924b4ccfb8c7ad81fe2863b86
+  # NOTE: Patch follows similar intention upstream https://github.com/nushell/nufmt/commit/074930a23bc89a5f720a0d46ac2853f3153817c2
   postPatch = ''
-    substituteInPlace tests/main.rs --replace-fail \
-      'const TEST_BINARY: &str = "target/debug/nufmt";' \
-      'const TEST_BINARY: &str = "target/${stdenv.hostPlatform.rust.rustcTarget}/release/nufmt";'
     substituteInPlace tests/ground_truth.rs --replace-fail \
-      'const TEST_BINARY: &str = "target/debug/nufmt";' \
-      'const TEST_BINARY: &str = "target/${stdenv.hostPlatform.rust.rustcTarget}/release/nufmt";'
+      '        let path = PathBuf::from(target_dir).join("debug").join(exe_name);' \
+      '        let path = PathBuf::from(target_dir).join("${stdenv.hostPlatform.rust.rustcTarget}/release").join(exe_name);'
+    substituteInPlace tests/ground_truth.rs --replace-fail \
+      '    let default_path = PathBuf::from("target").join("debug").join(exe_name);' \
+      '    let default_path = PathBuf::from("target").join("${stdenv.hostPlatform.rust.rustcTarget}/release").join(exe_name);'
   '';
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

https://github.com/nushell/nufmt/ has got many bug fixes

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
