### PR TITLE
python3Packages.kanidm: 1.8.0 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/kanidm/default.nix
+++ b/pkgs/development/python-modules/kanidm/default.nix
@@ -1,18 +1,22 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
 
   # build
   pdm-backend,
 
   # propagates
   aiohttp,
+  aiohttp-retry,
   authlib,
   pydantic,
+  python-dateutil,
   toml,
+  typing-extensions,
 
   # tests
+  openapi-spec-validator,
   pytest-asyncio,
   pytest-mock,
   pytestCheckHook,
@@ -20,34 +24,41 @@
 
 buildPythonPackage rec {
   pname = "kanidm";
-  version = "1.8.5";
+  version = "1.3.0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "kanidm";
-    repo = "kanidm";
-    tag = "v${version}";
-    hash = "sha256-lJX/eObXi468iFOzeFjAnNkPiQ8VbBnfqD1518LDm2s=";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-KlUxW/bJByQnzPdRd9Z5pStH27SpWrCijZc5jlVT5jE=";
   };
-
-  sourceRoot = "${src.name}/pykanidm";
 
   build-system = [ pdm-backend ];
 
   dependencies = [
     aiohttp
+    aiohttp-retry
     authlib
     pydantic
+    python-dateutil
     toml
+    typing-extensions
   ];
 
   nativeCheckInputs = [
+    openapi-spec-validator
     pytest-asyncio
     pytest-mock
     pytestCheckHook
   ];
 
-  disabledTestMarks = [ "network" ];
+  disabledTests = [
+    "test_tokenstuff"
+  ];
+
+  disabledTestMarks = [
+    "network"
+    "openapi"
+  ];
 
   pythonImportsCheck = [ "kanidm" ];
 


### PR DESCRIPTION
Track the PyPi releases. The Git tags are only for Kanidm itself.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
