### PR TITLE
daktari: init at 0.0.319

### DIFF
--- a/pkgs/by-name/da/daktari/optional-pyclip.patch
+++ b/pkgs/by-name/da/daktari/optional-pyclip.patch
@@ -1,0 +1,33 @@
+diff --git a/daktari/result_printer.py b/daktari/result_printer.py
+--- a/daktari/result_printer.py
++++ b/daktari/result_printer.py
+@@ -1,7 +1,11 @@
+ import re
+ import textwrap
+-import pyclip
+ from typing import Callable, Dict, Optional
+ 
++try:
++    import pyclip
++except ImportError:
++    pyclip = None
++
+ from colors import green, red, underline, yellow
+ 
+ from daktari.check import CheckResult, CheckStatus
+@@ -58,10 +62,13 @@ def copy_to_clipboard(suggestion: Optional[str]):
+         command_regex = re.compile(r"\<cmd\>(.*?)\<\/cmd\>")
+         results = command_regex.findall(suggestion)
+         if len(results) > 0:
+-            try:
+-                pyclip.copy("\n".join(results))
++            if pyclip is not None:
++                try:
++                    pyclip.copy("\n".join(results))
++                    print("ⓘ  Command copied to clipboard")
++                except pyclip.base.ClipboardSetupException:
+                     print("ⓘ  Clipboard not available")
++            else:
++                print("ⓘ  Clipboard not available")
+             return
+     print("ⓘ  No command available to copy to clipboard")

--- a/pkgs/by-name/da/daktari/package.nix
+++ b/pkgs/by-name/da/daktari/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "daktari";
+  version = "0.0.319";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "genio-learn";
+    repo = "daktari";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NxTDyul1BESr/fBow9hwmTLr6jcl4p5RlIKNzFbaJvc=";
+  };
+
+  patches = [ ./optional-pyclip.patch ];
+
+  pythonRelaxDeps = true;
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # pyclip is broken on macOS in nixpkgs
+    substituteInPlace requirements.txt --replace-fail "pyclip==0.7.0" ""
+  '';
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      ansicolors
+      distro
+      pyfiglet
+      importlib-resources
+      packaging
+      requests
+      responses
+      semver
+      python-hosts
+      pyyaml
+      types-pyyaml
+      requests-unixsocket
+      dpath
+      pyopenssl
+      types-pyopenssl
+      urllib3
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      pyclip
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      pyobjc-core
+      pyobjc-framework-Cocoa
+    ];
+
+  pythonImportsCheck = [ "daktari" ];
+
+  meta = {
+    description = "Tool to assist in setting up and maintaining developer environments";
+    homepage = "https://github.com/genio-learn/daktari";
+    changelog = "https://github.com/genio-learn/daktari/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tymscar ];
+    mainProgram = "daktari";
+  };
+})


### PR DESCRIPTION
Add [daktari](https://github.com/genio-learn/daktari), a tool to assist in setting up and maintaining developer environments. It runs environment checks (e.g., verifying required software installation) and suggests fixes when checks fail.

Note: upstream pins exact dependency versions (`==`) in `requirements.txt`, which are relaxed in this package to work with nixpkgs versions. Additionally, `pyclip` is marked broken on macOS in nixpkgs, so clipboard support is made optional on Darwin via a small patch to the import.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test