### PR TITLE
buildLuarocksPackage: fix wrapping lua package binaries

### DIFF
--- a/pkgs/development/interpreters/lua-5/wrap.sh
+++ b/pkgs/development/interpreters/lua-5/wrap.sh
@@ -31,13 +31,15 @@ wrapLuaProgramsIn() {
     if head -n1 "$f" | grep -q '#!.*'; then
         # Cross-compilation hack: exec '/nix/store/...-lua-.../bin/lua' execute
         # the host lua
+        # NOTE: We don't --replace-fail, because this hook is also used
+        # on Lua packages' wrapped binaries.
         substituteInPlace "$f" \
-          --replace-fail "@luaBuild@" "@luaHost@"
+          --replace-quiet "@luaBuild@" "@luaHost@"
         # Build platform's Luarocks writes scripts that reference luarocks
         # itself in them, so we fix these references to reference the host
         # platform's luarocks.
         substituteInPlace "$f" \
-          --replace-fail "@luarocksBuild@" "@luarocksHost@"
+          --replace-quiet "@luarocksBuild@" "@luarocksHost@"
     fi
 
     # wrapProgram creates the executable shell script described
@@ -60,7 +62,7 @@ wrapLuaProgramsIn() {
 
     # Same as above, but now for the wrapper script
     substituteInPlace "$f" \
-      --replace-fail "@luarocksBuild@" "@luarocksHost@"
+      --replace-quiet "@luarocksBuild@" "@luarocksHost@"
 
   done
 }


### PR DESCRIPTION
The changes in #481511 introduced a regression when building Lua packages that have binaries in `bin/` (e.g. `luaPackages.vusted`), because the `wrapLua` hook is used on those, too.

This replaces the `--replace-fail` flag with a `--replace` flag.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
