### PR TITLE
fix(prometheus): allow setting options unknown to nix

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -59,7 +59,7 @@ let
 
   # This becomes the main config file for Prometheus
   promConfig = {
-    global = filterValidPrometheus cfg.globalConfig;
+    global = filterValidPrometheus (cfg.extraGlobalConfig // cfg.globalConfig);
     scrape_configs = filterValidPrometheus cfg.scrapeConfigs;
     remote_write = filterValidPrometheus cfg.remoteWrite;
     remote_read = filterValidPrometheus cfg.remoteRead;
@@ -1816,6 +1816,16 @@ in
       description = ''
         Parameters that are valid in all  configuration contexts. They
         also serve as defaults for other configuration sections
+      '';
+    };
+
+    extraGlobalConfig = mkOption {
+      type = types.anything;
+      default = { };
+      description = ''
+        Extra global config that which is not type checked by nixos. Options
+        configurable via {option}`services.prometheus.globalConfig` will get
+        overridden and must be configured there.
       '';
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Prometheus has many global config options and allows setting default for more specific config contexts. The nixos module previously was not flexible enough to allow for this. This change adds the ability to optionally configure any prometheus global config option.

For example, previously it was not possible to set the global config `scrape_failure_log_file`, which allows logging scrape failures independently of the log level.

The Prometheus config is defined here:  https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file

## Things done

Add the option `services.prometheus.extraGlobalConfig`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested by cherry picking this commit on top of our our current nixpkgs commit and redeploying our prometheus test instance.   

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
