### PR TITLE
parsedmarc: 9.0.10 -> 9.5.4

### DIFF
--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -13,7 +13,6 @@
   boto3,
   dateparser,
   dnspython,
-  elastic-transport,
   elasticsearch-dsl,
   elasticsearch,
   expiringdict,
@@ -32,8 +31,10 @@
   opensearch-py,
   publicsuffixlist,
   pygelf,
+  pyyaml,
   requests,
   tqdm,
+  urllib3,
   xmltodict,
 
   # test
@@ -48,15 +49,20 @@ let
 in
 buildPythonPackage rec {
   pname = "parsedmarc";
-  version = "9.0.10";
+  version = "9.5.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "domainaware";
     repo = "parsedmarc";
     tag = version;
-    hash = "sha256-FrLqR9YTZ75YQDWKdFCVTYiY3wTj0OlKSvMukDwDiHs=";
+    hash = "sha256-Di4ykujzBow1woG0UsH6S1eDu+nuQ8/r6RXcMKLdDF4=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'requires_python = ">=3.10,<3.15"' ""
+  '';
 
   build-system = [
     hatchling
@@ -73,7 +79,6 @@ buildPythonPackage rec {
     boto3
     dateparser
     dnspython
-    elastic-transport
     elasticsearch
     elasticsearch-dsl
     expiringdict
@@ -91,8 +96,10 @@ buildPythonPackage rec {
     opensearch-py
     publicsuffixlist
     pygelf
+    pyyaml
     requests
     tqdm
+    urllib3
     xmltodict
   ];
 


### PR DESCRIPTION
Diff: https://github.com/domainaware/parsedmarc/compare/9.0.10...9.5.4

Changelog: https://github.com/domainaware/parsedmarc/blob/9.5.4/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
