### PR TITLE
ocamlPackages.atdml: init at 4.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/atdgen/runtime.nix
+++ b/pkgs/development/ocaml-modules/atdgen/runtime.nix
@@ -9,8 +9,6 @@ buildDunePackage {
   pname = "atdgen-runtime";
   inherit (atdgen-codec-runtime) version src;
 
-  minimalOCamlVersion = "4.08";
-
   propagatedBuildInputs = [
     biniou
     yojson

--- a/pkgs/development/ocaml-modules/atdml/default.nix
+++ b/pkgs/development/ocaml-modules/atdml/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  buildDunePackage,
+  atd,
+  cmdliner,
+}:
+
+buildDunePackage {
+  pname = "atdml";
+  inherit (atd) version src;
+
+  buildInputs = [ cmdliner ];
+
+  propagatedBuildInputs = [ atd ];
+
+  meta = atd.meta // {
+    description = "Simplified OCaml JSON serializers using the Yojson AST";
+    maintainers = [ lib.maintainers.vbgl ];
+    mainProgram = "atdml";
+  };
+}

--- a/pkgs/development/ocaml-modules/testo/default.nix
+++ b/pkgs/development/ocaml-modules/testo/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  testo-util,
+  cmdliner,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "testo";
+  version = "0.4.0";
+
+  src = fetchurl {
+    url = "https://github.com/mjambon/testo/releases/download/${finalAttrs.version}/testo-${finalAttrs.version}.tbz";
+    hash = "sha256-cPm+FSS1fCj3PCyEk37p93lHjpH6NZ3GNkKJjdExaXs=";
+  };
+
+  propagatedBuildInputs = [
+    cmdliner
+    testo-util
+  ];
+
+  meta = {
+    homepage = "https://github.com/mjambon/testo";
+    license = lib.licenses.isc;
+    description = "Test framework for OCaml";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+})

--- a/pkgs/development/ocaml-modules/testo/diff.nix
+++ b/pkgs/development/ocaml-modules/testo/diff.nix
@@ -1,0 +1,17 @@
+{
+  fetchurl,
+  buildDunePackage,
+  testo,
+  ppx_deriving,
+}:
+
+buildDunePackage {
+  pname = "testo-diff";
+  inherit (testo) version src;
+
+  propagatedBuildInputs = [ ppx_deriving ];
+
+  meta = testo.meta // {
+    description = "Pure-OCaml diff implementation";
+  };
+}

--- a/pkgs/development/ocaml-modules/testo/util.nix
+++ b/pkgs/development/ocaml-modules/testo/util.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  testo,
+  testo-diff,
+  fpath,
+  re,
+}:
+
+buildDunePackage {
+  pname = "testo-util";
+  inherit (testo) version src;
+
+  propagatedBuildInputs = [
+    fpath
+    re
+    testo-diff
+  ];
+
+  meta = testo.meta // {
+    description = "Modules shared by testo, testo-lwt, etc";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2104,6 +2104,12 @@ let
 
         terml = callPackage ../development/ocaml-modules/terml { };
 
+        testo = callPackage ../development/ocaml-modules/testo { };
+
+        testo-diff = callPackage ../development/ocaml-modules/testo/diff.nix { };
+
+        testo-util = callPackage ../development/ocaml-modules/testo/util.nix { };
+
         tezos-base58 = callPackage ../development/ocaml-modules/tezos-base58 { };
 
         tezt = callPackage ../development/ocaml-modules/tezt { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -76,6 +76,8 @@ let
 
         atdgen-runtime = callPackage ../development/ocaml-modules/atdgen/runtime.nix { };
 
+        atdml = callPackage ../development/ocaml-modules/atdml { };
+
         augeas = callPackage ../development/ocaml-modules/augeas {
           inherit (pkgs) augeas;
         };


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
