### PR TITLE
buildRustCrate: parallelize build_bin via Makefile jobserver

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -238,12 +238,21 @@ in
     export -f build_bin build_bin_test echo_build_heading noisily echo_colored echo_error
     # Generate a Makefile and pipe it to make, which handles parallel execution
     # and the jobserver protocol natively so rustc invocations share a token pool.
+    # Targets use synthetic names (b0, b1, …) and are declared .PHONY so that a
+    # file/dir in the source tree matching a binary name cannot cause make to
+    # skip the build, and so that binary names never collide with make syntax
+    # or the `all` target.
     {
-      printf 'SHELL = %s\nall:' "$BASH"
-      for _n in "''${!BINS[@]}"; do printf ' %s' "$_n"; done
-      printf '\n'
+      printf 'SHELL = %s\n' "$BASH"
+      _i=0
       for _n in "''${!BINS[@]}"; do
-        printf '%s:\n\t${build_bin} "%s" "%s"\n' "$_n" "$_n" "''${BINS[$_n]}"
+        # Escape `$` for make; other metachars are confined to the quoted
+        # recipe string where only `$` is special to make.
+        _en=''${_n//\$/\$\$}
+        _ep=''${BINS[$_n]//\$/\$\$}
+        printf '.PHONY: b%d\nall: b%d\nb%d:\n\t${build_bin} "%s" "%s"\n' \
+          "$_i" "$_i" "$_i" "$_en" "$_ep"
+        _i=$((_i + 1))
       done
     } | make --no-print-directory -j"''${NIX_BUILD_CORES:-1}" -f -
   fi

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -162,6 +162,8 @@ in
     fi
   ''}
 
+  declare -A BINS
+
   ${lib.optionalString (lib.length crateBin > 0) (
     lib.concatMapStringsSep "\n" (
       bin:
@@ -188,7 +190,7 @@ in
                 BIN_PATH='${bin.path}'
               ''
           }
-            ${build_bin} "$BIN_NAME" "$BIN_PATH"
+            BINS["$BIN_NAME"]="$BIN_PATH"
         ''
       else
         ''
@@ -222,13 +224,30 @@ in
   ${lib.optionalString (lib.length crateBin == 0 && !hasCrateBin) ''
     if [[ -e src/main.rs ]]; then
       mkdir -p target/bin
-      ${build_bin} ${crateName} src/main.rs
+      BINS["${crateName}"]="src/main.rs"
     fi
     for i in src/bin/*.rs; do #*/
       mkdir -p target/bin
-      ${build_bin} "$(basename $i .rs)" "$i"
+      BINS["$(basename $i .rs)"]="$i"
     done
   ''}
+
+  if [[ ''${#BINS[@]} -gt 0 ]]; then
+    export BIN_RUSTC_OPTS LINK EXTRA_LINK_ARGS EXTRA_LINK_ARGS_BINS EXTRA_LIB \
+           BUILD_OUT_DIR EXTRA_BUILD EXTRA_FEATURES EXTRA_RUSTC_FLAGS CAP_LINTS
+    export -f build_bin build_bin_test echo_build_heading noisily echo_colored echo_error
+    # Generate a Makefile and pipe it to make, which handles parallel execution
+    # and the jobserver protocol natively so rustc invocations share a token pool.
+    {
+      printf 'SHELL = %s\nall:' "$BASH"
+      for _n in "''${!BINS[@]}"; do printf ' %s' "$_n"; done
+      printf '\n'
+      for _n in "''${!BINS[@]}"; do
+        printf '%s:\n\t${build_bin} "%s" "%s"\n' "$_n" "$_n" "''${BINS[$_n]}"
+      done
+    } | make --no-print-directory -j"''${NIX_BUILD_CORES:-1}" -f -
+  fi
+
   # Remove object files to avoid "wrong ELF type"
   find target -type f -name "*.o" -print0 | xargs -0 rm -f
   runHook postBuild

--- a/pkgs/build-support/rust/build-rust-crate/lib.sh
+++ b/pkgs/build-support/rust/build-rust-crate/lib.sh
@@ -58,7 +58,7 @@ build_bin() {
     $EXTRA_BUILD \
     $EXTRA_FEATURES \
     $EXTRA_RUSTC_FLAGS \
-    --color ${colors} \
+    --color ${colors} || return 1
 
   if [ "$crate_name_" != "$crate_name" ]; then
     if [ -f "$out_dir/$crate_name_.wasm" ]; then


### PR DESCRIPTION
In large Cargo workspaces with many binary targets, `crate2nix` compiled each executable sequentially. For workspaces with dozens of binaries this serialization is a significant bottleneck - parallelizing the builds reduces total build time substantially.

Collect binary targets into a bash associative array (name -> path), then generate a Makefile on the fly and pipe it to `make -j`. Make handles parallel execution and the jobserver protocol natively, so rustc invocations share the same token pool via MAKEFLAGS.

Also fix build_bin error propagation: add `|| return 1` to the rustc invocation so failures are not silently swallowed when the crate name has no hyphens and the mv rename is skipped.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
