### PR TITLE
cewl: fix missing getoptlong gem

### DIFF
--- a/pkgs/by-name/ce/cewl/Gemfile
+++ b/pkgs/by-name/ce/cewl/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+gem 'getoptlong'
 gem 'mime'
 gem 'mime-types', ">=3.3.1"
 gem 'mini_exiftool'

--- a/pkgs/by-name/ce/cewl/Gemfile.lock
+++ b/pkgs/by-name/ce/cewl/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    getoptlong (0.2.1)
     logger (1.7.0)
     mime (0.4.4)
     mime-types (3.7.0)
@@ -25,6 +26,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  getoptlong
   mime
   mime-types (>= 3.3.1)
   mini_exiftool

--- a/pkgs/by-name/ce/cewl/gemset.nix
+++ b/pkgs/by-name/ce/cewl/gemset.nix
@@ -1,4 +1,14 @@
 {
+  getoptlong = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "198vy9dxyzibqdbw9jg8p2ljj9iknkyiqlyl229vz55rjxrz08zx";
+      type = "gem";
+    };
+    version = "0.2.1";
+  };
   logger = {
     groups = [ "default" ];
     platforms = [ ];


### PR DESCRIPTION
Fixes #503826

`getoptlong` isn't installed in CeWL's upstream `Gemfile`, because it was historicaly part of Ruby's standard library. In newer Ruby versions it was extracted into a separate gem, but CeWL's upstream has not updated their `Gemfile`. As a result, the nixpkgs build fails with `Error: getoptlong gem not installed.`

This adds `getoptlong` from [rubygems](https://rubygems.org/gems/getoptlong) to gemset.nix and Gemfile to fix the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
