### PR TITLE
greetd: remove deprecated attrs, fix license (+ some greeters' licenses)

### DIFF
--- a/pkgs/by-name/gr/greetd/package.nix
+++ b/pkgs/by-name/gr/greetd/package.nix
@@ -49,7 +49,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
     homepage = "https://sr.ht/~kennylevinsen/greetd/";
     mainProgram = "greetd";
-    license = lib.licenses.gpl3Plus;
+    license = lib.licenses.gpl3Only;
     maintainers = [ ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/gr/greetd/package.nix
+++ b/pkgs/by-name/gr/greetd/package.nix
@@ -1,18 +1,11 @@
 {
   rustPlatform,
   lib,
-  config,
   fetchFromSourcehut,
   pam,
   scdoc,
   installShellFiles,
   nix-update-script,
-  # legacy passthrus
-  gtkgreet,
-  qtgreet,
-  regreet,
-  tuigreet,
-  wlgreet,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -45,26 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installManPage man/*
   '';
 
-  # Added 2025-07-23. To be deleted on 26.05
-  passthru =
-    let
-      warnPassthru = name: lib.warnOnInstantiate "`greetd.${name}` was renamed to `${name}`";
-    in
-    lib.mapAttrs warnPassthru (
-      lib.optionalAttrs config.allowAliases {
-        inherit
-          gtkgreet
-          qtgreet
-          regreet
-          tuigreet
-          wlgreet
-          ;
-        greetd = finalAttrs.finalPackage;
-      }
-    )
-    // {
-      updateScript = nix-update-script { };
-    };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Minimal and flexible login manager daemon";

--- a/pkgs/by-name/gt/gtkgreet/package.nix
+++ b/pkgs/by-name/gt/gtkgreet/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "GTK based greeter for greetd, to be run under cage or similar";
     homepage = "https://git.sr.ht/~kennylevinsen/gtkgreet";
-    license = lib.licenses.gpl3Plus;
+    license = lib.licenses.gpl3Only;
     maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "gtkgreet";

--- a/pkgs/by-name/wl/wlgreet/package.nix
+++ b/pkgs/by-name/wl/wlgreet/package.nix
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Raw wayland greeter for greetd, to be run under sway or similar";
     mainProgram = "wlgreet";
     homepage = "https://git.sr.ht/~kennylevinsen/wlgreet";
-    license = lib.licenses.gpl3Plus;
+    license = lib.licenses.gpl3Only;
     maintainers = [ ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Explanations are inside each commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
