### PR TITLE
curlconverter: init at 4.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12521,6 +12521,11 @@
     name = "Jonathan Hult";
     keys = [ { fingerprint = "DEE7 054C 5D43 ABEA C0F9  8BE4 3512 C8F8 2E2F 2A16"; } ];
   };
+  jiamingc = {
+    name = "Jiaming Chen";
+    github = "jiamingc";
+    githubId = 21327067;
+  };
   jiegec = {
     name = "Jiajie Chen";
     email = "c@jia.je";

--- a/pkgs/by-name/cu/curlconverter/package.nix
+++ b/pkgs/by-name/cu/curlconverter/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+buildNpmPackage (final: {
+  pname = "curlconverter";
+  version = "4.12.0";
+
+  src = fetchFromGitHub {
+    owner = "curlconverter";
+    repo = "curlconverter";
+    tag = "v${final.version}";
+    hash = "sha256-eJ8D5HkYSkWqQt/4UTv6/X6coLwcODde6xGEPQXgJRo=";
+  };
+
+  npmDepsHash = "sha256-UIbMvw8hkZxtSGInV2+Fjm4DZahrdGtSxi0Unhb5lh8=";
+
+  # Prevent the dependency tree-sitter-cli from running its install script, which has an impure network request: https://github.com/tree-sitter/tree-sitter/blob/fd77bda97a0ca05d124590833312e4103f985543/crates/cli/npm/install.js#L63
+  npmFlags = [ "--ignore-scripts" ];
+
+  npmBuildScript = "compile";
+
+  meta = {
+    description = "Convert curl commands to Python, JavaScript and more";
+    homepage = "https://curlconverter.com/";
+    license = lib.licenses.mit;
+    mainProgram = "curlconverter";
+    maintainers = with lib.maintainers; [ jiamingc ];
+  };
+})


### PR DESCRIPTION
[Curlconverter](https://github.com/curlconverter/curlconverter) is a tool for converting curl command lines into other formats, such as a Python script. I'm packaging it so that I can install and use its command line interface.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
