### PR TITLE
cudaPackages.libnvshmem: 3.4.5-0 -> 3.6.5-0

### DIFF
--- a/pkgs/development/cuda-modules/packages/libnvshmem.nix
+++ b/pkgs/development/cuda-modules/packages/libnvshmem.nix
@@ -192,7 +192,10 @@ backendStdenv.mkDerivation (finalAttrs: {
       "aarch64-linux"
       "x86_64-linux"
     ];
-    maintainers = [ maintainers.connorbaker ];
+    maintainers = with maintainers; [
+      connorbaker
+      GaetanLepage
+    ];
     teams = [ teams.cuda ];
   };
 })

--- a/pkgs/development/cuda-modules/packages/libnvshmem.nix
+++ b/pkgs/development/cuda-modules/packages/libnvshmem.nix
@@ -7,6 +7,7 @@
   cuda_cudart,
   cuda_nvcc,
   cuda_nvml_dev,
+  cuda_nvrtc,
   cuda_nvtx,
   cudaAtLeast,
   cudaMajorMinorVersion,
@@ -16,6 +17,7 @@
   gdrcopy,
   lib,
   libfabric,
+  libnvjitlink,
   mpi,
   nccl,
   ninja,
@@ -46,13 +48,13 @@ backendStdenv.mkDerivation (finalAttrs: {
   # NOTE: Depends on the CUDA package set, so use cudaNamePrefix.
   name = "${cudaNamePrefix}-${finalAttrs.pname}-${finalAttrs.version}";
   pname = "libnvshmem";
-  version = "3.4.5-0";
+  version = "3.6.5-0";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "nvshmem";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RHZzjDMYlL7vAVP1/UXM/Pt4bhajeWdCi3ihICeD2mc=";
+    hash = "sha256-2E3/WGbg6srT/e3ykK0qxTy1ZlJ9JGGLlergG0ITwTY=";
   };
 
   outputs = [ "out" ];
@@ -94,9 +96,11 @@ backendStdenv.mkDerivation (finalAttrs: {
     cuda_cccl
     cuda_cudart
     cuda_nvml_dev
+    cuda_nvrtc
     cuda_nvtx
     gdrcopy
     libfabric
+    libnvjitlink
     nccl
     pmix
     rdma-core
@@ -179,6 +183,7 @@ backendStdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Parallel programming interface for NVIDIA GPUs based on OpenSHMEM";
     homepage = "https://github.com/NVIDIA/nvshmem";
+    changelog = "https://github.com/NVIDIA/nvshmem/releases/tag/${finalAttrs.src.tag}";
     broken = _cuda.lib._mkMetaBroken finalAttrs;
     # NOTE: There are many licenses:
     # https://github.com/NVIDIA/nvshmem/blob/7dd48c9fd7aa2134264400802881269b7822bd2f/License.txt


### PR DESCRIPTION
## Things done

Diff: https://github.com/NVIDIA/nvshmem/compare/v3.4.5-0...v3.6.5-0
Changelog: https://github.com/NVIDIA/nvshmem/releases/tag/v3.6.5-0

cc @ConnorBaker @SomeoneSerge @YorikSar @samuela @prusnak

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test