### PR TITLE
cudaPackages.nsight_systems: support flattened directory structure

### DIFF
--- a/pkgs/development/cuda-modules/packages/nsight_systems.nix
+++ b/pkgs/development/cuda-modules/packages/nsight_systems.nix
@@ -69,7 +69,7 @@ buildRedist (
     ];
 
     # NOTE(@connorbaker): nsight-exporter and nsight-sys are deprecated scripts wrapping nsys, it's fine to remove them.
-    prePatch = ''
+    prePatch = lib.optionalString (lib.versionOlder finalAttrs.version "2025.5.2.26") ''
       if [[ -d bin ]]; then
         nixLog "Removing bin wrapper scripts"
         for knownWrapper in bin/{nsys{,-ui},nsight-{exporter,sys}}; do


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes #503856. 

Newer versions of Nsight Systems don't have the same directory structure that requires patching to get everything to the top-level, a simple version check seems to do the job.

Here's the directory structure of the `2025.1.3.140` archive
```
nsight_systems-linux-x86_64-2025.1.3.140-archive
├── bin
│   ├── nsight-sys
│   ├── nsys
│   └── nsys-ui
├── LICENSE
└── nsight-systems
    └── 2025.1.3
        ├── bin
        ├── docs
        ├── host-linux-x64
        └── target-linux-x64
```
and here is the one from `2025.5.2.266` for comparison
```
nsight_systems-linux-x86_64-2025.5.2.266-archive
├── bin
├── documentation
├── host-linux-x64
├── LICENSE
└── target-linux-x64
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
