### PR TITLE
python3Packages.opentelemetry-api: 1.34.0 -> 1.40.0

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -14,7 +14,7 @@
 let
   self = buildPythonPackage rec {
     pname = "opentelemetry-api";
-    version = "1.34.0";
+    version = "1.40.0";
     pyproject = true;
 
     # to avoid breakage, every package in opentelemetry-python must inherit this version, src, and meta
@@ -22,7 +22,7 @@ let
       owner = "open-telemetry";
       repo = "opentelemetry-python";
       tag = "v${version}";
-      hash = "sha256-fAXcS2VyDMk+UDW3ru5ZvwzXjydsY1uFcT2GvZuiGWw=";
+      hash = "sha256-1KVy9s+zjlB4w7E45PMCWRxPus24bgBmmM3k2R9d+Jg=";
     };
 
     sourceRoot = "${src.name}/opentelemetry-api";

--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -2,70 +2,76 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  deprecated,
+
+  # build-system
   hatchling,
+
+  # dependencies
+  deprecated,
   importlib-metadata,
   typing-extensions,
+
+  # tests
   opentelemetry-test-utils,
   pytestCheckHook,
+
+  # passthru
   writeScript,
+  opentelemetry-api,
 }:
 
-let
-  self = buildPythonPackage rec {
-    pname = "opentelemetry-api";
-    version = "1.40.0";
-    pyproject = true;
+buildPythonPackage (finalAttrs: {
+  pname = "opentelemetry-api";
+  version = "1.40.0";
+  pyproject = true;
 
-    # to avoid breakage, every package in opentelemetry-python must inherit this version, src, and meta
-    src = fetchFromGitHub {
-      owner = "open-telemetry";
-      repo = "opentelemetry-python";
-      tag = "v${version}";
-      hash = "sha256-1KVy9s+zjlB4w7E45PMCWRxPus24bgBmmM3k2R9d+Jg=";
-    };
-
-    sourceRoot = "${src.name}/opentelemetry-api";
-
-    build-system = [ hatchling ];
-
-    dependencies = [
-      deprecated
-      importlib-metadata
-      typing-extensions
-    ];
-
-    pythonRelaxDeps = [ "importlib-metadata" ];
-
-    nativeCheckInputs = [
-      opentelemetry-test-utils
-      pytestCheckHook
-    ];
-
-    pythonImportsCheck = [ "opentelemetry" ];
-
-    doCheck = false;
-
-    passthru = {
-      updateScript = writeScript "update.sh" ''
-        #!/usr/bin/env nix-shell
-        #!nix-shell -i bash -p nix-update
-
-        set -eu -o pipefail
-        nix-update --version-regex 'v(.*)' python3Packages.opentelemetry-api
-        nix-update python3Packages.opentelemetry-instrumentation
-      '';
-      # Enable tests via passthru to avoid cyclic dependency with opentelemetry-test-utils.
-      tests.${self.pname} = self.overridePythonAttrs { doCheck = true; };
-    };
-
-    meta = {
-      homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-api";
-      description = "OpenTelemetry Python API";
-      changelog = "https://github.com/open-telemetry/opentelemetry-python/releases/tag/${src.tag}";
-      license = lib.licenses.asl20;
-      maintainers = [ lib.maintainers.natsukium ];
-    };
+  # to avoid breakage, every package in opentelemetry-python must inherit this version, src, and meta
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1KVy9s+zjlB4w7E45PMCWRxPus24bgBmmM3k2R9d+Jg=";
   };
-in
-self
+
+  sourceRoot = "${finalAttrs.src.name}/opentelemetry-api";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    deprecated
+    importlib-metadata
+    typing-extensions
+  ];
+
+  pythonRelaxDeps = [ "importlib-metadata" ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry" ];
+
+  doCheck = false;
+
+  passthru = {
+    updateScript = writeScript "update.sh" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p nix-update
+
+      set -eu -o pipefail
+      nix-update --version-regex 'v(.*)' python3Packages.opentelemetry-api
+      nix-update python3Packages.opentelemetry-instrumentation
+    '';
+    # Enable tests via passthru to avoid cyclic dependency with opentelemetry-test-utils.
+    tests.pytest = opentelemetry-api.overridePythonAttrs { doCheck = true; };
+  };
+
+  meta = {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-api";
+    description = "OpenTelemetry Python API";
+    changelog = "https://github.com/open-telemetry/opentelemetry-python/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.natsukium ];
+  };
+})

--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -2,33 +2,44 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   hatchling,
+
+  # dependencies
   opentelemetry-api,
-  opentelemetry-test-utils,
-  pytestCheckHook,
+  opentelemetry-semantic-conventions,
   setuptools,
   wrapt,
+
+  # tests
+  opentelemetry-test-utils,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "opentelemetry-instrumentation";
-  version = "0.55b0";
+  version = "0.61b0";
   pyproject = true;
 
   # To avoid breakage, every package in opentelemetry-python-contrib must inherit this version, src, and meta
   src = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-python-contrib";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-UM9ezCh3TVwyj257O0rvTCIgfrddobWcVIgJmBUj/Vo=";
   };
 
-  sourceRoot = "${src.name}/opentelemetry-instrumentation";
+  sourceRoot = "${finalAttrs.src.name}/opentelemetry-instrumentation";
 
   build-system = [ hatchling ];
 
+  pythonRelaxDeps = [
+    "opentelemetry-semantic-conventions"
+  ];
   dependencies = [
     opentelemetry-api
+    opentelemetry-semantic-conventions
     setuptools
     wrapt
   ];
@@ -53,8 +64,8 @@ buildPythonPackage rec {
   meta = {
     description = "Instrumentation Tools & Auto Instrumentation for OpenTelemetry Python";
     homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/opentelemetry-instrumentation";
-    changelog = "https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v${version}";
+    changelog = "https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.natsukium ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.opentelemetry-api: 1.34.0 -> 1.40.0**
- **python3Packages.opentelemetry-api: cleanup**
- **python3Packages.opentelemetry-instrumentation: 0.55b0 -> 0.61b0**

---

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
