### PR TITLE
suitesparse: 5.13.0 -> 7.10.0

### DIFF
--- a/pkgs/by-name/ce/ceres-solver/package.nix
+++ b/pkgs/by-name/ce/ceres-solver/package.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ceres-solver";
-  version = "2.1.0";
+  version = "2.2.0";
 
   src = fetchurl {
     url = "http://ceres-solver.org/ceres-solver-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-99dO7N4K7XW/xR7EjJHQH+Fqa/FrzhmHpwcyhnAeL8Y=";
+    sha256 = "sha256-SLIwKnmG7OFyiYR3w7zW3rj7XPGbMye8SZaarUzt6C0=";
   };
 
   outputs = [

--- a/pkgs/by-name/ch/cholmod-extra/cholmod-internal-suitesparse7.patch
+++ b/pkgs/by-name/ch/cholmod-extra/cholmod-internal-suitesparse7.patch
@@ -1,0 +1,55 @@
+--- a/Include/cholmod_internal.h
++++ b/Include/cholmod_internal.h
+@@ -38,7 +38,6 @@
+  * CHOLMOD with -DNLARGEFILE.  You must do this for MATLAB 6.5 and earlier,
+  * for example. */
+ 
+-#include "cholmod_io64.h"
+ 
+ /* ========================================================================== */
+ /* === debugging and basic includes ========================================= */
+@@ -129,13 +128,28 @@
+     { \
+ 	return (result) ; \
+     } \
+-    if (Common->itype != ITYPE || Common->dtype != DTYPE) \
++    if (Common->itype != ITYPE) \
+     { \
+ 	Common->status = CHOLMOD_INVALID ; \
+ 	return (result) ; \
+     } \
+ }
+ 
++/* Return if a matrix has an invalid xtype */
++#define RETURN_IF_XTYPE_INVALID(A,xtype1,xtype2,result) \
++{ \
++    if ((A)->xtype < (xtype1) || (A)->xtype > (xtype2) || \
++	((A)->xtype != CHOLMOD_PATTERN && ((A)->x) == NULL) || \
++	((A)->xtype == CHOLMOD_ZOMPLEX && ((A)->z) == NULL)) \
++    { \
++	if (Common->status != CHOLMOD_OUT_OF_MEMORY) \
++	{ \
++	    ERROR (CHOLMOD_INVALID, "invalid xtype") ; \
++	} \
++	return (result) ; \
++    } \
++}
++
+ #define IS_NAN(x)	CHOLMOD_IS_NAN(x)
+ #define IS_ZERO(x)	CHOLMOD_IS_ZERO(x)
+ #define IS_NONZERO(x)	CHOLMOD_IS_NONZERO(x)
+@@ -257,14 +271,11 @@
+ /* === real/complex arithmetic ============================================== */
+ /* ========================================================================== */
+ 
+-#include "cholmod_complexity.h"
+ 
+ /* ========================================================================== */
+ /* === Architecture and BLAS ================================================ */
+ /* ========================================================================== */
+ 
+-#define BLAS_OK Common->blas_ok
+-#include "cholmod_blas.h"
+ 
+ /* ========================================================================== */
+ /* === debugging definitions ================================================ */

--- a/pkgs/by-name/ch/cholmod-extra/package.nix
+++ b/pkgs/by-name/ch/cholmod-extra/package.nix
@@ -18,6 +18,18 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "0hz1lfp0zaarvl0dv0zgp337hyd8np41kmdpz5rr3fc6yzw7vmkg";
   };
 
+  patches = [ ./cholmod-internal-suitesparse7.patch ];
+
+  postPatch = ''
+    substituteInPlace Include/cholmod_extra.h \
+      --replace-fail "#include <cholmod_config.h>" "" \
+      --replace-fail "#include <cholmod_core.h>" "#include <cholmod.h>" \
+      --replace-fail "#include <cholmod_partition.h>" "" \
+      --replace-fail "#include <cholmod_supernodal.h>" ""
+    substituteInPlace Source/cholmod_spinv.c \
+      --replace-fail "#include <cholmod_cholesky.h>" ""
+  '';
+
   nativeBuildInputs = [ gfortran ];
   buildInputs = [
     suitesparse

--- a/pkgs/by-name/su/suitesparse/package.nix
+++ b/pkgs/by-name/su/suitesparse/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  cmake,
   gfortran,
   blas,
   lapack,
@@ -19,9 +20,12 @@ let
   stdenv = throw "Use effectiveStdenv instead";
   effectiveStdenv = if enableCuda then cudaPackages.backendStdenv else inputs.stdenv;
 in
-effectiveStdenv.mkDerivation rec {
+effectiveStdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
   pname = "suitesparse";
-  version = "5.13.0";
+  version = "7.10.0";
 
   outputs = [
     "out"
@@ -32,17 +36,20 @@ effectiveStdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "DrTimothyAldenDavis";
     repo = "SuiteSparse";
-    rev = "v${version}";
-    sha256 = "sha256-Anen1YtXsSPhk8DpA4JtADIz9m8oXFl9umlkb4iImf8=";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-FcEyOvt96FLwCTil4l52ug+faiRlEG+mMUvKWipMxng=";
   };
 
-  nativeBuildInputs =
-    lib.optionals effectiveStdenv.hostPlatform.isDarwin [
-      fixDarwinDylibNames
-    ]
-    ++ lib.optionals enableCuda [
-      cudaPackages.cuda_nvcc
-    ];
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ]
+  ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [
+    fixDarwinDylibNames
+  ]
+  ++ lib.optionals enableCuda [
+    cudaPackages.cuda_nvcc
+  ];
 
   # Use compatible indexing for lapack and blas used
   buildInputs =
@@ -65,46 +72,49 @@ effectiveStdenv.mkDerivation rec {
     ];
 
   preConfigure = ''
-    # Mongoose and GraphBLAS are packaged separately
-    sed -i "Makefile" -e '/GraphBLAS\|Mongoose/d'
+    export GRAPHBLAS_CACHE_PATH="$(mktemp -d)"
   '';
 
-  makeFlags = [
-    "INSTALL=${placeholder "out"}"
-    "INSTALL_INCLUDE=${placeholder "dev"}/include"
-    "JOBS=$(NIX_BUILD_CORES)"
-    "MY_METIS_LIB=-lmetis"
+  cmakeFlags = [
+    (lib.cmakeBool "SUITESPARSE_USE_PYTHON" false)
+    (lib.cmakeFeature "BLAS_LIBRARIES" "${lib.getLib blas}/lib/libblas${effectiveStdenv.hostPlatform.extensions.sharedLibrary}")
+    (lib.cmakeFeature "LAPACK_LIBRARIES" "${lib.getLib lapack}/lib/liblapack${effectiveStdenv.hostPlatform.extensions.sharedLibrary}")
+    (lib.cmakeBool "SUITESPARSE_USE_64BIT_BLAS" blas.isILP64)
   ]
-  ++ lib.optionals blas.isILP64 [
-    "CFLAGS=-DBLAS64"
-  ]
-  ++ lib.optionals enableCuda [
-    "CUDA_PATH=${lib.getBin cudaPackages.cuda_nvcc}"
-    "CUDART_LIB=${lib.getLib cudaPackages.cuda_cudart}/lib/libcudart.so"
-    "CUBLAS_LIB=${lib.getLib cudaPackages.libcublas}/lib/libcublas.so"
-  ]
-  ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [
-    # Unless these are set, the build will attempt to use `Accelerate` on darwin, see:
-    # https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/v5.13.0/SuiteSparse_config/SuiteSparse_config.mk#L368
-    "BLAS=-lblas"
-    "LAPACK=-llapack"
+  ++ lib.optionals (effectiveStdenv.hostPlatform != effectiveStdenv.buildPlatform) [
+    # GraphBLAS JIT builds a native helper binary (grb_jitpackage) but uses
+    # the cross compiler, so it can't execute on the build host.
+    (lib.cmakeBool "GRAPHBLAS_USE_JIT" false)
   ];
 
-  env = {
-    # in GCC14 these two warnings were promoted to error
-    # let's make them warnings again to fix the build failure
-    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types";
-  }
-  // lib.optionalAttrs effectiveStdenv.hostPlatform.isDarwin {
+  env = lib.optionalAttrs effectiveStdenv.hostPlatform.isDarwin {
     # Ensure that there is enough space for the `fixDarwinDylibNames` hook to
     # update the install names of the output dylibs.
     NIX_LDFLAGS = "-headerpad_max_install_names";
   };
 
-  buildFlags = [
-    # Build individual shared libraries, not demos
-    "library"
-  ];
+  # CMAKE build does not automatically provide doc output, so we make it ourselves
+  postInstall = ''
+    docdir=$doc/share/doc/${finalAttrs.pname}-${finalAttrs.version}
+    mkdir -p $docdir
+
+    # Top-level docs
+    cp $src/LICENSE.txt $src/ChangeLog $src/README.md $docdir/
+
+    # Per-component READMEs, licenses, and changelogs
+    for f in $src/*/README.txt $src/*/README.md $src/*/LICENSE $src/*/LICENSE.txt $src/*/ChangeLog; do
+      [ -f "$f" ] || continue
+      component=$(basename $(dirname "$f"))
+      cp "$f" "$docdir/''${component}_$(basename "$f")"
+    done
+
+    # User guides and papers from Doc directories
+    for dir in $src/*/Doc; do
+      [ -d "$dir" ] || continue
+      component=$(basename $(dirname "$dir"))
+      find "$dir" -name '*.pdf' -exec cp {} "$docdir/" \;
+    done
+  '';
 
   meta = {
     homepage = "http://faculty.cse.tamu.edu/davis/suitesparse.html";
@@ -117,4 +127,4 @@ effectiveStdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = with lib.platforms; unix;
   };
-}
+})

--- a/pkgs/by-name/su/suitesparse/package.nix
+++ b/pkgs/by-name/su/suitesparse/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  cmake,
   gfortran,
   blas,
   lapack,
@@ -19,9 +20,12 @@ let
   stdenv = throw "Use effectiveStdenv instead";
   effectiveStdenv = if enableCuda then cudaPackages.backendStdenv else inputs.stdenv;
 in
-effectiveStdenv.mkDerivation rec {
+effectiveStdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
   pname = "suitesparse";
-  version = "5.13.0";
+  version = "7.10.0";
 
   outputs = [
     "out"
@@ -32,17 +36,20 @@ effectiveStdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "DrTimothyAldenDavis";
     repo = "SuiteSparse";
-    rev = "v${version}";
-    sha256 = "sha256-Anen1YtXsSPhk8DpA4JtADIz9m8oXFl9umlkb4iImf8=";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-FcEyOvt96FLwCTil4l52ug+faiRlEG+mMUvKWipMxng=";
   };
 
-  nativeBuildInputs =
-    lib.optionals effectiveStdenv.hostPlatform.isDarwin [
-      fixDarwinDylibNames
-    ]
-    ++ lib.optionals enableCuda [
-      cudaPackages.cuda_nvcc
-    ];
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ]
+  ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [
+    fixDarwinDylibNames
+  ]
+  ++ lib.optionals enableCuda [
+    cudaPackages.cuda_nvcc
+  ];
 
   # Use compatible indexing for lapack and blas used
   buildInputs =
@@ -65,46 +72,55 @@ effectiveStdenv.mkDerivation rec {
     ];
 
   preConfigure = ''
-    # Mongoose and GraphBLAS are packaged separately
-    sed -i "Makefile" -e '/GraphBLAS\|Mongoose/d'
+    export GRAPHBLAS_CACHE_PATH="$(mktemp -d)"
   '';
 
-  makeFlags = [
-    "INSTALL=${placeholder "out"}"
-    "INSTALL_INCLUDE=${placeholder "dev"}/include"
-    "JOBS=$(NIX_BUILD_CORES)"
-    "MY_METIS_LIB=-lmetis"
+  cmakeFlags = [
+    (lib.cmakeBool "SUITESPARSE_USE_PYTHON" false)
+    (lib.cmakeFeature "BLAS_LIBRARIES" "${lib.getLib blas}/lib/libblas${effectiveStdenv.hostPlatform.extensions.sharedLibrary}")
+    (lib.cmakeFeature "LAPACK_LIBRARIES" "${lib.getLib lapack}/lib/liblapack${effectiveStdenv.hostPlatform.extensions.sharedLibrary}")
+    (lib.cmakeBool "SUITESPARSE_USE_64BIT_BLAS" blas.isILP64)
   ]
-  ++ lib.optionals blas.isILP64 [
-    "CFLAGS=-DBLAS64"
-  ]
-  ++ lib.optionals enableCuda [
-    "CUDA_PATH=${lib.getBin cudaPackages.cuda_nvcc}"
-    "CUDART_LIB=${lib.getLib cudaPackages.cuda_cudart}/lib/libcudart.so"
-    "CUBLAS_LIB=${lib.getLib cudaPackages.libcublas}/lib/libcublas.so"
-  ]
-  ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [
-    # Unless these are set, the build will attempt to use `Accelerate` on darwin, see:
-    # https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/v5.13.0/SuiteSparse_config/SuiteSparse_config.mk#L368
-    "BLAS=-lblas"
-    "LAPACK=-llapack"
+  ++ lib.optionals (effectiveStdenv.hostPlatform != effectiveStdenv.buildPlatform) [
+    # GraphBLAS JIT builds a native helper binary (grb_jitpackage) but uses
+    # the cross compiler, so it can't execute on the build host.
+    (lib.cmakeBool "GRAPHBLAS_USE_JIT" false)
   ];
 
-  env = {
-    # in GCC14 these two warnings were promoted to error
-    # let's make them warnings again to fix the build failure
-    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types";
-  }
-  // lib.optionalAttrs effectiveStdenv.hostPlatform.isDarwin {
+  env = lib.optionalAttrs effectiveStdenv.hostPlatform.isDarwin {
     # Ensure that there is enough space for the `fixDarwinDylibNames` hook to
     # update the install names of the output dylibs.
     NIX_LDFLAGS = "-headerpad_max_install_names";
   };
 
-  buildFlags = [
-    # Build individual shared libraries, not demos
-    "library"
-  ];
+  # CMAKE build does not automatically provide doc output, so we make it ourselves
+  postInstall = ''
+    # Versions of SuiteSparse < 6 had a flat structure, which most downstream
+    # consumers can continue to expect.
+    for header in "$dev"/include/suitesparse/*; do
+      ln -s "suitesparse/$(basename "$header")" "$dev/include/$(basename "$header")"
+    done
+
+    docdir=$doc/share/doc/${finalAttrs.pname}-${finalAttrs.version}
+    mkdir -p $docdir
+
+    # Top-level docs
+    cp $src/LICENSE.txt $src/ChangeLog $src/README.md $docdir/
+
+    # Per-component READMEs, licenses, and changelogs
+    for f in $src/*/README.txt $src/*/README.md $src/*/LICENSE $src/*/LICENSE.txt $src/*/ChangeLog; do
+      [ -f "$f" ] || continue
+      component=$(basename $(dirname "$f"))
+      cp "$f" "$docdir/''${component}_$(basename "$f")"
+    done
+
+    # User guides and papers from Doc directories
+    for dir in $src/*/Doc; do
+      [ -d "$dir" ] || continue
+      component=$(basename $(dirname "$dir"))
+      find "$dir" -name '*.pdf' -exec cp {} "$docdir/" \;
+    done
+  '';
 
   meta = {
     homepage = "http://faculty.cse.tamu.edu/davis/suitesparse.html";
@@ -117,4 +133,4 @@ effectiveStdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = with lib.platforms; unix;
   };
-}
+})

--- a/pkgs/by-name/va/vacask/package.nix
+++ b/pkgs/by-name/va/vacask/package.nix
@@ -19,15 +19,6 @@
 }:
 
 let
-  # VACASK includes SuiteSparse headers as <suitesparse/klu.h>, the layout used
-  # by SuiteSparse >= 6. However, our suitesparse is currently at 5.13.0 and
-  # installs headers flat into include/, so here we're fixing that.
-  # TODO: remove when suitesparse is updated
-  suitesparse-include = runCommand "suitesparse-include" { } ''
-    mkdir -p $out/include/suitesparse
-    ln -s ${suitesparse.dev}/include/*.h $out/include/suitesparse/
-  '';
-
   pyEnv = python3.withPackages (
     ps: with ps; [
       numpy
@@ -77,7 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeFeature "FLEX_INCLUDE_DIR" "${flex}/include")
-    (lib.cmakeFeature "SuiteSparse_DIR" "${suitesparse-include}")
     (lib.cmakeFeature "TOMLPP_DIR" "${tomlplusplus}")
   ];
 

--- a/pkgs/development/libraries/science/math/suitesparse/default.nix
+++ b/pkgs/development/libraries/science/math/suitesparse/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  cmake,
   gfortran,
   blas,
   lapack,
@@ -19,9 +20,12 @@ let
   stdenv = throw "Use effectiveStdenv instead";
   effectiveStdenv = if enableCuda then cudaPackages.backendStdenv else inputs.stdenv;
 in
-effectiveStdenv.mkDerivation rec {
+effectiveStdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
   pname = "suitesparse";
-  version = "5.13.0";
+  version = "7.10.0";
 
   outputs = [
     "out"
@@ -32,17 +36,20 @@ effectiveStdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "DrTimothyAldenDavis";
     repo = "SuiteSparse";
-    rev = "v${version}";
-    sha256 = "sha256-Anen1YtXsSPhk8DpA4JtADIz9m8oXFl9umlkb4iImf8=";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-FcEyOvt96FLwCTil4l52ug+faiRlEG+mMUvKWipMxng=";
   };
 
-  nativeBuildInputs =
-    lib.optionals effectiveStdenv.hostPlatform.isDarwin [
-      fixDarwinDylibNames
-    ]
-    ++ lib.optionals enableCuda [
-      cudaPackages.cuda_nvcc
-    ];
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ]
+  ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [
+    fixDarwinDylibNames
+  ]
+  ++ lib.optionals enableCuda [
+    cudaPackages.cuda_nvcc
+  ];
 
   # Use compatible indexing for lapack and blas used
   buildInputs =
@@ -65,46 +72,49 @@ effectiveStdenv.mkDerivation rec {
     ];
 
   preConfigure = ''
-    # Mongoose and GraphBLAS are packaged separately
-    sed -i "Makefile" -e '/GraphBLAS\|Mongoose/d'
+    export GRAPHBLAS_CACHE_PATH="$(mktemp -d)"
   '';
 
-  makeFlags = [
-    "INSTALL=${placeholder "out"}"
-    "INSTALL_INCLUDE=${placeholder "dev"}/include"
-    "JOBS=$(NIX_BUILD_CORES)"
-    "MY_METIS_LIB=-lmetis"
+  cmakeFlags = [
+    (lib.cmakeBool "SUITESPARSE_USE_PYTHON" false)
+    (lib.cmakeFeature "BLAS_LIBRARIES" "${lib.getLib blas}/lib/libblas${effectiveStdenv.hostPlatform.extensions.sharedLibrary}")
+    (lib.cmakeFeature "LAPACK_LIBRARIES" "${lib.getLib lapack}/lib/liblapack${effectiveStdenv.hostPlatform.extensions.sharedLibrary}")
+    (lib.cmakeBool "SUITESPARSE_USE_64BIT_BLAS" blas.isILP64)
   ]
-  ++ lib.optionals blas.isILP64 [
-    "CFLAGS=-DBLAS64"
-  ]
-  ++ lib.optionals enableCuda [
-    "CUDA_PATH=${lib.getBin cudaPackages.cuda_nvcc}"
-    "CUDART_LIB=${lib.getLib cudaPackages.cuda_cudart}/lib/libcudart.so"
-    "CUBLAS_LIB=${lib.getLib cudaPackages.libcublas}/lib/libcublas.so"
-  ]
-  ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [
-    # Unless these are set, the build will attempt to use `Accelerate` on darwin, see:
-    # https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/v5.13.0/SuiteSparse_config/SuiteSparse_config.mk#L368
-    "BLAS=-lblas"
-    "LAPACK=-llapack"
+  ++ lib.optionals (effectiveStdenv.hostPlatform != effectiveStdenv.buildPlatform) [
+    # GraphBLAS JIT builds a native helper binary (grb_jitpackage) but uses
+    # the cross compiler, so it can't execute on the build host.
+    (lib.cmakeBool "GRAPHBLAS_USE_JIT" false)
   ];
 
-  env = {
-    # in GCC14 these two warnings were promoted to error
-    # let's make them warnings again to fix the build failure
-    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types";
-  }
-  // lib.optionalAttrs effectiveStdenv.hostPlatform.isDarwin {
+  env = lib.optionalAttrs effectiveStdenv.hostPlatform.isDarwin {
     # Ensure that there is enough space for the `fixDarwinDylibNames` hook to
     # update the install names of the output dylibs.
     NIX_LDFLAGS = "-headerpad_max_install_names";
   };
 
-  buildFlags = [
-    # Build individual shared libraries, not demos
-    "library"
-  ];
+  # CMAKE build does not automatically provide doc output, so we make it ourselves
+  postInstall = ''
+    docdir=$doc/share/doc/${finalAttrs.pname}-${finalAttrs.version}
+    mkdir -p $docdir
+
+    # Top-level docs
+    cp $src/LICENSE.txt $src/ChangeLog $src/README.md $docdir/
+
+    # Per-component READMEs, licenses, and changelogs
+    for f in $src/*/README.txt $src/*/README.md $src/*/LICENSE $src/*/LICENSE.txt $src/*/ChangeLog; do
+      [ -f "$f" ] || continue
+      component=$(basename $(dirname "$f"))
+      cp "$f" "$docdir/''${component}_$(basename "$f")"
+    done
+
+    # User guides and papers from Doc directories
+    for dir in $src/*/Doc; do
+      [ -d "$dir" ] || continue
+      component=$(basename $(dirname "$dir"))
+      find "$dir" -name '*.pdf' -exec cp {} "$docdir/" \;
+    done
+  '';
 
   meta = {
     homepage = "http://faculty.cse.tamu.edu/davis/suitesparse.html";
@@ -117,4 +127,4 @@ effectiveStdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ ttuegel ];
     platforms = with lib.platforms; unix;
   };
-}
+})


### PR DESCRIPTION
Updating `suitesparse` to v7.10.0. The new version uses `cmake`, so much of the build has changed. Most importantly, the `doc` folder has to be aggregated "manually".

A bunch of stuff is broken on `master` that appears in `nixpkgs-review` (crossed out items are merged since the PR was opened):
- [x] `cloudcompare`: similar problem to `otb`, fixed in https://github.com/NixOS/nixpkgs/pull/555707
- [x] `otb`: fixed in https://github.com/NixOS/nixpkgs/pull/557530.
- [x] `python-control`: `matplotlib` and `numpy` interfaces changed, patched in https://github.com/NixOS/nixpkgs/pull/558603.
- [x] `python-pyprecice`: some version mismatch shenanigans. Fix in https://github.com/NixOS/nixpkgs/pull/558673
- [x] ~~`python-qutip`: looks like something changed in `numpy` or `scipy` maybe? Fixed in https://github.com/NixOS/nixpkgs/pull/558267~~
- [x] `python-pyradiomics`: same version shenanigans as `python-pyprecise`, fixed in https://github.com/NixOS/nixpkgs/pull/558677
- [x] `python-scikits-odes`: same version shenanigans as `python-pyprecise`, fixed in https://github.com/NixOS/nixpkgs/pull/558680
- [x] `python-scikit-survival`: `pytest` shenanigans, updated in https://github.com/NixOS/nixpkgs/pull/558637
- [x] ~~`therion`: `gdal` upgrade fallout, fixed in https://github.com/NixOS/nixpkgs/pull/557609~~
- [x] `vpv`: `gdal` upgrade, updated upstream absorbed in https://github.com/NixOS/nixpkgs/pull/558489
- [ ] `vtk_9_6`: `cmake` target error
- [x] ~~`xfitter`: due to `root` hash mismatch, updated in https://github.com/NixOS/nixpkgs/pull/558633~~

Every package that was broken by this update has been fixed in this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
