### PR TITLE
eliot-tree: 21.0.0 -> 24.0.0

### DIFF
--- a/pkgs/by-name/el/eliot-tree/package.nix
+++ b/pkgs/by-name/el/eliot-tree/package.nix
@@ -1,26 +1,21 @@
 {
   lib,
   python3Packages,
-  fetchPypi,
+  fetchFromGitHub,
   addBinToPathHook,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "eliot-tree";
-  version = "21.0.0";
+  version = "24.0.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-hTl+r+QJPPQ7ss73lty3Wm7DLy2SKGmmgIuJx38ilO8=";
+  src = fetchFromGitHub {
+    owner = "jonathanj";
+    repo = "eliottree";
+    tag = finalAttrs.version;
+    hash = "sha256-4P6eAhX7XBuxu8r/7xvm07u4PZzKP3YLj/5kekgYXG8=";
   };
-
-  # Patch Python 3.12 incompatibilities in versioneer.py.
-  postPatch = ''
-    substituteInPlace versioneer.py \
-      --replace-fail SafeConfigParser ConfigParser \
-      --replace-fail readfp read_file
-  '';
 
   build-system = with python3Packages; [ setuptools ];
 
@@ -29,6 +24,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     eliot
     iso8601
     jmespath
+    six
     toolz
   ];
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Changelog: https://github.com/jonathanj/eliottree/blob/24.0.0/NEWS.rst

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test