### PR TITLE
nixos/netbird: fix coturn TURN port for UDP

### DIFF
--- a/nixos/modules/services/networking/netbird/server.nix
+++ b/nixos/modules/services/networking/netbird/server.nix
@@ -56,7 +56,7 @@ in
       }
       // (optionalAttrs cfg.coturn.enable rec {
         turnDomain = cfg.domain;
-        turnPort = config.services.coturn.tls-listening-port;
+        turnPort = config.services.coturn.listening-port;
         # We cannot merge a list of attrsets so we have to redefine the whole list
         settings = {
           TURNConfig.Turns = mkDefault [


### PR DESCRIPTION
## Summary

Fix the netbird server NixOS module's TURN configuration to use the correct coturn UDP port (`listening-port`, default 3478) instead of the TLS port (`tls-listening-port`, default 5349).

Using the TLS port causes TURN relay to not work for NAT'd clients since the UDP entry in `TURNConfig.Turns` was pointing at the TLS port.

Fixes #499137

CC @PatrickDaG. This is my first nixpkgs contribution so just let me know if I missed anything and I'd be happy to fix it. Note that I checked `Tested basic functionality of all binary files, usually in ./result/bin/.` below because I tested the change by overriding the port, but I didn't directly test the change below. I can uncheck if that's not correct.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

