### PR TITLE
libnl: optionally actually build docs

### DIFF
--- a/pkgs/by-name/li/libnl/package.nix
+++ b/pkgs/by-name/li/libnl/package.nix
@@ -7,14 +7,16 @@
   bison,
   flex,
   pkg-config,
+  pythonSupport ? false,
+  swig ? null,
+  python ? null,
+  enableDocs ? false,
   doxygen,
   graphviz,
   mscgen,
   asciidoc,
   sourceHighlight,
-  pythonSupport ? false,
-  swig ? null,
-  python ? null,
+  python3Packages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -34,9 +36,12 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "man"
   ]
-  ++ lib.optional pythonSupport "py";
+  ++ lib.optional pythonSupport "py"
+  ++ lib.optional enableDocs "doc";
 
   enableParallelBuilding = true;
+
+  configureFlags = [ (lib.enableFeature enableDocs "doc") ];
 
   nativeBuildInputs = [
     autoreconfHook
@@ -44,18 +49,33 @@ stdenv.mkDerivation (finalAttrs: {
     flex
     pkg-config
     file
+  ]
+  ++ lib.optionals pythonSupport [
+    swig
+  ]
+  ++ lib.optionals enableDocs [
     doxygen
     graphviz
     mscgen
     asciidoc
     sourceHighlight
-  ]
-  ++ lib.optional pythonSupport swig;
+    python3Packages.pygments
+  ];
 
   postBuild = lib.optionalString pythonSupport ''
     cd python
     ${python.pythonOnBuildForHost.interpreter} setup.py install --prefix=../pythonlib
     cd -
+  '';
+
+  postInstall = lib.optionalString enableDocs ''
+    patchShebangs doc
+    # See tools/build_release.sh
+    make -C doc
+    make -C doc gendoc
+    make -C doc dist
+    mkdir -p $doc/share/doc/libnl
+    cp doc/libnl-doc-${finalAttrs.version}.tar.gz $doc/share/doc/libnl
   '';
 
   postFixup = lib.optionalString pythonSupport ''


### PR DESCRIPTION
A bunch of big dependencies were pulled in, but the documentation was not actually generated.

See https://github.com/thom311/libnl/issues/422#issuecomment-2671351008 / `tools/build_release.sh` .

Since the docs have been broken and I don't see any issues complaining about it they are now off by default to minimize dependencies.

The doc build also wants pygments.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
