### PR TITLE
fs-watcher-lsp: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14877,6 +14877,12 @@
     githubId = 61395246;
     name = "Lampros Pitsillos";
   };
+  landreussi = {
+    email = "lucasandreussi@gmail.com";
+    github = "landreussi";
+    githubId = 5938518;
+    name = "Lucas Andreussi";
+  };
   langsjo = {
     name = "langsjo";
     github = "langsjo";

--- a/pkgs/by-name/fs/fs-watcher-lsp/package.nix
+++ b/pkgs/by-name/fs/fs-watcher-lsp/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchCrate,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fs-watcher-lsp";
+  version = "0.1.0";
+
+  src = fetchCrate {
+    version = finalAttrs.version;
+    crateName = "fs_watcher_lsp";
+    hash = "sha256-zahbi8RK8aDHcVOzIk5fCIh57+SjMGAVtUvtKhpMvF0=";
+  };
+
+  cargoHash = "sha256-w1i19IV/tjyl+W0NIjjbB0R9UpGrAUuK/yWbOZUKPUA=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  buildNoDefaultFeatures = false;
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Little file system watcher LSP to reload your editor";
+    changelog = "https://codeberg.org/Zentropivity/fs_watcher_lsp/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = [ ];
+    mainProgram = "fs_watcher_lsp";
+  };
+})

--- a/pkgs/by-name/fs/fs-watcher-lsp/package.nix
+++ b/pkgs/by-name/fs/fs-watcher-lsp/package.nix
@@ -10,6 +10,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "fs-watcher-lsp";
   version = "0.1.0";
 
+  __structuredAttrs = true;
+
   src = fetchCrate {
     version = finalAttrs.version;
     crateName = "fs_watcher_lsp";

--- a/pkgs/by-name/fs/fs-watcher-lsp/package.nix
+++ b/pkgs/by-name/fs/fs-watcher-lsp/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit
       asl20
     ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ landreussi ];
     mainProgram = "fs_watcher_lsp";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This patch adds `fs-watcher-lsp` rust crate to nixpkgs and myself as a maintainer of it.
This package can be used to add buffer auto reload in [helix-editor](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/he/helix/package.nix#L109). 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
