### PR TITLE
nixos/linkwarden: depend on postgresql.target instead of .service

### DIFF
--- a/nixos/modules/services/web-apps/linkwarden.nix
+++ b/nixos/modules/services/web-apps/linkwarden.nix
@@ -240,11 +240,11 @@ in
       requires = [
         "network-online.target"
       ]
-      ++ lib.optionals cfg.database.createLocally [ "postgresql.service" ];
+      ++ lib.optionals cfg.database.createLocally [ "postgresql.target" ];
       after = [
         "network-online.target"
       ]
-      ++ lib.optionals cfg.database.createLocally [ "postgresql.service" ];
+      ++ lib.optionals cfg.database.createLocally [ "postgresql.target" ];
       wantedBy = [ "multi-user.target" ];
       environment = cfg.environment // {
         # Required, otherwise chrome dumps core
@@ -262,12 +262,12 @@ in
         "network-online.target"
         "linkwarden.service"
       ]
-      ++ lib.optionals cfg.database.createLocally [ "postgresql.service" ];
+      ++ lib.optionals cfg.database.createLocally [ "postgresql.target" ];
       after = [
         "network-online.target"
         "linkwarden.service"
       ]
-      ++ lib.optionals cfg.database.createLocally [ "postgresql.service" ];
+      ++ lib.optionals cfg.database.createLocally [ "postgresql.target" ];
       wantedBy = [ "multi-user.target" ];
       environment = cfg.environment // {
         # Required, otherwise chrome dumps core


### PR DESCRIPTION
Depending on postgresql.service only ensures the database is at least in read-only mode, while postgresql.target ensures read-write operation.

See https://nixos.org/manual/nixos/unstable/#module-services-postgresql-target-vs-service


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
