### PR TITLE
python3Packages.google-cloud-asset: fix broken update

### DIFF
--- a/pkgs/development/python-modules/google-cloud-asset/default.nix
+++ b/pkgs/development/python-modules/google-cloud-asset/default.nix
@@ -18,7 +18,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "google-cloud-asset";
   version = "4.2.0";
   pyproject = true;
@@ -26,11 +26,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "google-cloud-python";
-    tag = "google-cloud-asset-v${version}";
+    tag = "google-cloud-asset-v${finalAttrs.version}";
     sha256 = "sha256-dVgcnnInqjUjySL7wjxGzI33t1YZJ8e9mSsmjAJ+fBI=";
   };
 
-  sourceRoot = "${src.name}/packages/google-cloud-asset";
+  sourceRoot = "${finalAttrs.src.name}/packages/google-cloud-asset";
 
   build-system = [ setuptools ];
 
@@ -83,8 +83,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python Client for Google Cloud Asset API";
     homepage = "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-asset";
-    changelog = "https://github.com/googleapis/google-cloud-python/blob/google-cloud-asset-${src.tag}/packages/google-cloud-asset/CHANGELOG.md";
+    changelog = "https://github.com/googleapis/google-cloud-python/blob/google-cloud-asset-${finalAttrs.src.tag}/packages/google-cloud-asset/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.sarahec ];
   };
-}
+})

--- a/pkgs/development/python-modules/google-cloud-asset/default.nix
+++ b/pkgs/development/python-modules/google-cloud-asset/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  gitUpdater,
   google-api-core,
   google-cloud-access-context-manager,
   google-cloud-org-policy,
@@ -11,6 +10,7 @@
   grpc-google-iam-v1,
   libcst,
   mock,
+  nix-update-script,
   proto-plus,
   protobuf,
   pytest-asyncio,
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "google-cloud-asset";
-  version = "3.31.3";
+  version = "4.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "googleapis";
     repo = "google-cloud-python";
-    tag = "google-cloud-build-v${version}";
-    sha256 = "sha256-qQ+8X6I8lt4OTgbvODsbdab2dYUk0wxWsbaVT2T651U=";
+    tag = "google-cloud-asset-v${version}";
+    sha256 = "sha256-dVgcnnInqjUjySL7wjxGzI33t1YZJ8e9mSsmjAJ+fBI=";
   };
 
   sourceRoot = "${src.name}/packages/google-cloud-asset";
@@ -66,15 +66,17 @@ buildPythonPackage rec {
     "google.cloud.asset_v1"
     "google.cloud.asset_v1p1beta1"
     "google.cloud.asset_v1p2beta1"
-    "google.cloud.asset_v1p4beta1"
     "google.cloud.asset_v1p5beta1"
   ];
 
   passthru = {
     # python updater script sets the wrong tag
     skipBulkUpdate = true;
-    updateScript = gitUpdater {
-      rev-prefix = "google-cloud-asset-v";
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regexp"
+        "^google-cloud-asset: v([0-9.]+)"
+      ];
     };
   };
 


### PR DESCRIPTION
1. Reset tag, version, and hash to the proper value
2. Fix update script to find the right release by removing 
3. Fix broken build by dropping release package that was also dropped in latest.
4. Migrate to `finalAttrs`


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
