### PR TITLE
 python313Packages.graphql-core: actually execute some tests, avoid big pytest-benchmark dependency

### DIFF
--- a/pkgs/development/python-modules/graphql-core/default.nix
+++ b/pkgs/development/python-modules/graphql-core/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   poetry-core,
-  pytest-benchmark,
   pytest-describe,
   pytest-asyncio,
   pytestCheckHook,
@@ -24,6 +23,10 @@ buildPythonPackage rec {
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail ', "setuptools>=59,<81"' ""
+
+    # avoid big pytest-benchmark dependency
+    substituteInPlace setup.cfg \
+      --replace-fail "addopts = --benchmark-disable" ""
   '';
 
   build-system = [
@@ -32,12 +35,13 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytest-asyncio
-    pytest-benchmark
     pytest-describe
     pytestCheckHook
   ];
 
-  pytestFlags = [ "--benchmark-disable" ];
+  disabledTestPaths = [
+    "tests/benchmarks"
+  ];
 
   pythonImportsCheck = [ "graphql" ];
 

--- a/pkgs/development/python-modules/graphql-core/default.nix
+++ b/pkgs/development/python-modules/graphql-core/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   poetry-core,
   pytest-benchmark,
+  pytest-describe,
   pytest-asyncio,
   pytestCheckHook,
 }:
@@ -32,6 +33,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-asyncio
     pytest-benchmark
+    pytest-describe
     pytestCheckHook
   ];
 


### PR DESCRIPTION
This fell out of #503933 while trying to debug test failures.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
