### PR TITLE
buildRustCrate: support propagatedBuildInputs in crate overrides

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -325,6 +325,7 @@ lib.makeOverridable
       buildDependencies_ = buildDependencies;
       processedAttrs = [
         "src"
+        "propagatedBuildInputs"
         "nativeBuildInputs"
         "buildInputs"
         "crateBin"
@@ -418,7 +419,8 @@ lib.makeOverridable
         buildInputs =
           lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ]
           ++ (crate.buildInputs or [ ])
-          ++ buildInputs_;
+          ++ buildInputs_
+          ++ completePropagatedBuildInputs;
         dependencies = map lib.getLib dependencies_;
         buildDependencies = map lib.getLib buildDependencies_;
 
@@ -426,6 +428,16 @@ lib.makeOverridable
         completeBuildDeps = lib.unique (
           buildDependencies
           ++ lib.concatMap (dep: dep.completeBuildDeps ++ dep.completeDeps) buildDependencies
+        );
+
+        # Propagated native build inputs from this crate and all transitive Rust
+        # dependencies. Analogous to completeDeps but for native library deps:
+        # a crate can declare `propagatedBuildInputs` in its override and they
+        # will automatically be added to the buildInputs of every crate that
+        # depends on it, without having to repeat them up the dependency tree.
+        completePropagatedBuildInputs = lib.unique (
+          (crate.propagatedBuildInputs or [ ])
+          ++ lib.concatMap (dep: dep.completePropagatedBuildInputs or [ ]) dependencies
         );
 
         # Create a list of features that are enabled by the crate itself and

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -1060,6 +1060,69 @@ rec {
                 test -x '${pkg}/bin/rcgen' && touch $out
               ''
           );
+
+      # Test that propagatedBuildInputs declared in a crate override are
+      # collected by completePropagatedBuildInputs and propagate transitively
+      # to all crates that depend on it.
+      propagatedBuildInputsTest =
+        let
+          fakeNativeLib = runCommand "fake-native-lib" { } "mkdir -p $out/lib && touch $out/lib/libfoo.a";
+
+          # Library crate that declares a native dep via propagatedBuildInputs
+          libCrate = mkHostCrate {
+            crateName = "mylib";
+            src = mkLib "src/lib.rs";
+            propagatedBuildInputs = [ fakeNativeLib ];
+          };
+
+          # Binary crate with a direct dependency on libCrate
+          binCrate = mkHostCrate {
+            crateName = "mybin";
+            src = mkFile "src/main.rs" "fn main() {}";
+            dependencies = [ libCrate ];
+          };
+
+          # Intermediate library that depends on libCrate
+          transitiveLib = mkHostCrate {
+            crateName = "transitivelib";
+            src = mkLib "src/lib.rs";
+            dependencies = [ libCrate ];
+          };
+
+          # Binary crate that only depends on transitiveLib (not libCrate directly)
+          transitiveBin = mkHostCrate {
+            crateName = "transitivebin";
+            src = mkFile "src/main.rs" "fn main() {}";
+            dependencies = [ transitiveLib ];
+          };
+        in
+        runCommand "propagated-build-inputs-test"
+          {
+            libCrateInputs = libCrate.completePropagatedBuildInputs;
+            binCrateInputs = binCrate.completePropagatedBuildInputs;
+            transitiveBinInputs = transitiveBin.completePropagatedBuildInputs;
+          }
+          ''
+            # libCrate itself should have fakeNativeLib in completePropagatedBuildInputs
+            echo "$libCrateInputs" | grep -q "${fakeNativeLib}" || {
+              echo "ERROR: fakeNativeLib not in libCrate.completePropagatedBuildInputs"
+              exit 1
+            }
+
+            # binCrate depends on libCrate, so fakeNativeLib should propagate
+            echo "$binCrateInputs" | grep -q "${fakeNativeLib}" || {
+              echo "ERROR: fakeNativeLib not propagated to binCrate.completePropagatedBuildInputs"
+              exit 1
+            }
+
+            # transitiveBin → transitiveLib → libCrate: fakeNativeLib should propagate transitively
+            echo "$transitiveBinInputs" | grep -q "${fakeNativeLib}" || {
+              echo "ERROR: fakeNativeLib not transitively propagated to transitiveBin.completePropagatedBuildInputs"
+              exit 1
+            }
+
+            touch $out
+          '';
     }
   );
   test = releaseTools.aggregate {


### PR DESCRIPTION
Add completePropagatedBuildInputs that collects propagatedBuildInputs from a crate and all its transitive Rust dependencies, analogous to how completeDeps chains .rlib paths. The collected inputs are appended to buildInputs so native library deps (e.g. boost) declared on a library crate automatically propagate to binary crates that depend on it, without requiring repetition in every downstream crate override.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
