### PR TITLE
fluffychat-web: fix build

### DIFF
--- a/pkgs/by-name/fl/fluffychat/vodozemac-wasm.nix
+++ b/pkgs/by-name/fl/fluffychat/vodozemac-wasm.nix
@@ -69,12 +69,12 @@ stdenv.mkDerivation {
 
   cargoDeps = symlinkJoin {
     name = "vodozemac-wasm-cargodeps";
-    paths = [
-      pubSources.flutter_vodozemac.passthru.cargoDeps
-      # Pull in rust vendor so we don't have to vendor rustLibSrc again
-      # This is required because `-Z build-std=std,panic_abort` rebuilds std
-      rustPlatform.rustVendorSrc
-    ];
+    paths = [ pubSources.flutter_vodozemac.passthru.cargoDeps ];
+    # Pull in rust vendor so we don't have to vendor rustLibSrc again
+    # This is required because `-Z build-std=std,panic_abort` rebuilds std
+    postBuild = ''
+      cp -rsn ${rustPlatform.rustVendorSrc}/* $out/*/
+    '';
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Fix https://hydra.nixos.org/build/325045460

I'm not sure why this wasn't an issue before, but dependency lookup actually targets `$cargoDepsCopy/source-registry-0`. I've used `cp -rsn` to link `rustVendorSrc` to that path to resolve build problem.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
