### PR TITLE
coqPackages_9_1.verified-extraction: fix `meta` eval

### DIFF
--- a/pkgs/development/coq-modules/verified-extraction/default.nix
+++ b/pkgs/development/coq-modules/verified-extraction/default.nix
@@ -59,7 +59,6 @@ mkCoqDerivation {
     homepage = "https://metarocq.github.io/";
     description = "Verified Extraction from Rocq to OCaml. Including a bootstrapped extraction plugin";
     maintainers = with maintainers; [
-      mattam82
       _4ever2
     ];
   };


### PR DESCRIPTION
Without the change the eval fails as:

    $ nix eval --impure --expr 'with import <nixpkgs> {}; coqPackages_9_1.verified-extraction.meta.maintainers'
    error:
       … while evaluating the attribute 'verified-extraction.meta.maintainers'
         at pkgs/stdenv/generic/check-meta.nix:558:7:
          557|       # if you add a new maintainer or team attribute please ensure that this expectation is still met.
          558|       maintainers = unique (
             |       ^
          559|         attrs.meta.maintainers or [ ] ++ concatMap (team: team.members or [ ]) attrs.meta.teams or [ ]

       … while calling the 'foldl'' builtin
         at pkgs/stdenv/generic/check-meta.nix:558:21:
          557|       # if you add a new maintainer or team attribute please ensure that this expectation is still met.
          558|       maintainers = unique (
             |                     ^
          559|         attrs.meta.maintainers or [ ] ++ concatMap (team: team.members or [ ]) attrs.meta.teams or [ ]

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: undefined variable 'mattam82'
       at pkgs/development/coq-modules/verified-extraction/default.nix:62:7:
           61|     maintainers = with maintainers; [
           62|       mattam82
             |       ^
           63|       _4ever2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
