### PR TITLE
ocamlPackages.ppxlib: 0.37.0 → 0.38.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppxlib/default.nix
+++ b/pkgs/development/ocaml-modules/ppxlib/default.nix
@@ -9,7 +9,7 @@
       if lib.versionAtLeast ocaml.version "4.08" then
         if lib.versionAtLeast ocaml.version "4.11" then
           if lib.versionAtLeast ocaml.version "5.03" then
-            if lib.versionAtLeast ocaml.version "5.04" then "0.37.0" else "0.36.2"
+            if lib.versionAtLeast ocaml.version "5.04" then "0.38.0" else "0.36.2"
           else
             "0.34.0"
         else
@@ -100,7 +100,10 @@ let
       };
       "0.37.0" = {
         sha256 = "sha256-LiI4N+fOzDvISkMkMsCnL04dW+kWXJwzdy8VbbhdsLM=";
-        min_version = "4.08";
+        max_version = "5.5";
+      };
+      "0.38.0" = {
+        sha256 = "sha256-ieBJsxAvZnCiE9NNgC6jqw/FMKiVnS8aHo24MAY0KaM=";
       };
     }
     ."${version}";


### PR DESCRIPTION
Compatibility with OCaml 5.5

NB: `cerberus` already fails to build.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
