### PR TITLE
python3Packages.django-stdimage: init at 6.0.2

### DIFF
--- a/pkgs/development/python-modules/django-stdimage/default.nix
+++ b/pkgs/development/python-modules/django-stdimage/default.nix
@@ -1,0 +1,70 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pytest-django,
+  pytestCheckHook,
+  setuptools-scm,
+  pillow,
+  pytest-cov-stub,
+  django,
+  gettext,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "django-stdimage";
+  version = "6.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "codingjoe";
+    repo = "django-stdimage";
+    tag = finalAttrs.version;
+    hash = "sha256-uwVU3Huc5fitAweShJjcMW//GBeIpJcxqKKLGo/EdIs=";
+  };
+
+  build-system = [ setuptools-scm ];
+
+  dependencies = [
+    django
+    pillow
+  ];
+
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE=tests.settings
+  '';
+
+  disabledTestPaths = [
+    # These tests failed on Django 5 or later
+    "tests/test_commands.py"
+    "tests/test_models.py::TestModel::test_variations"
+    "tests/test_models.py::TestModel::test_cropping"
+    "tests/test_models.py::TestModel::test_custom_render_variations"
+    "tests/test_models.py::TestModel::test_defer"
+    "tests/test_models.py::TestModel::test_variations_deepcopy"
+    "tests/test_models.py::TestUtils::test_render_variations_callback"
+    "tests/test_models.py::TestUtils::test_render_variations_overwrite"
+    "tests/test_models.py::TestJPEGField::test_convert"
+    "tests/test_models.py::TestJPEGField::test_convert_multiple"
+  ];
+
+  pythonImportsCheck = [
+    "stdimage"
+    "stdimage.validators"
+    "stdimage.models"
+  ];
+
+  nativeCheckInputs = [
+    gettext
+    pytest-django
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Django Standardized Image Field";
+    homepage = "https://github.com/codingjoe/django-stdimage";
+    changelog = "https://github.com/codingjoe/django-stdimage/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kurogeek ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4376,6 +4376,8 @@ self: super: with self; {
 
   django-statici18n = callPackage ../development/python-modules/django-statici18n { };
 
+  django-stdimage = callPackage ../development/python-modules/django-stdimage { };
+
   django-storages = callPackage ../development/python-modules/django-storages { };
 
   django-stubs = callPackage ../development/python-modules/django-stubs { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
