### PR TITLE
tsgolint: 0.17.0 -> 0.17.4

### DIFF
--- a/pkgs/by-name/ts/tsgolint/package.nix
+++ b/pkgs/by-name/ts/tsgolint/package.nix
@@ -3,19 +3,18 @@
   buildGo126Module,
   fetchFromGitHub,
   findutils,
-  go_1_26,
   nix-update-script,
 }:
 
 buildGo126Module (finalAttrs: {
   pname = "tsgolint";
-  version = "0.17.0";
+  version = "0.17.4";
 
   src = fetchFromGitHub {
     owner = "oxc-project";
     repo = "tsgolint";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bY5oDaaKMu4KmGQFT3MyzNNKZWC8PVSRjAgWYhPVE2s=";
+    hash = "sha256-C0n1L1oIQXPWFX27DDoSSHJm7KrZkWObsq50jFAETGM=";
     fetchSubmodules = true;
   };
 
@@ -25,7 +24,7 @@ buildGo126Module (finalAttrs: {
     pushd typescript-go
   '';
 
-  # These patches are applied to the typescript-go submodule in justfile's "init" target upstream.
+  # These patches are applied to the typescript-go submodule in upstream justfile's "init" target.
   patches = [
     (finalAttrs.src + "/patches/0001-Parallel-readDirectory-visitor.patch")
     (finalAttrs.src + "/patches/0002-Adapt-project-service-for-single-run-mode.patch")
@@ -36,25 +35,16 @@ buildGo126Module (finalAttrs: {
   ];
 
   postPatch =
-    # We don't want to build with go.work, so we add the replacement to
-    # the local module to the go.mod instead.
+    # From upstream justfile's "init" target.
     ''
       popd
-      ${lib.getExe go_1_26} mod edit --replace=github.com/microsoft/typescript-go=./typescript-go
-    ''
-    +
-    # From justfile's "init" target upstream.
-    ''
-      rm go.work{,.sum}
       mkdir -p internal/collections && find ./typescript-go/internal/collections -type f ! -name '*_test.go' -exec cp {} internal/collections/ \;
     '';
 
   proxyVendor = true;
-  vendorHash = "sha256-Mb78gEN582QFTRTBefdAz8Yly2vB3zbPyViRnA1V3wI=";
+  vendorHash = "sha256-xSdL+XcnZnKScOnYdmhMaVp4okK7uyLEzcKtANgRXjo=";
 
   subPackages = [ "cmd/tsgolint" ];
-
-  env.GOEXPERIMENT = "greenteagc";
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
Uses upstream's `go.work` file instead of manually replicating its replace directive in `go.mod`. This avoids having to patch `go.mod` and `go.sum` to account for transitive dependency version differences between the tsgolint and typescript-go modules.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
