### PR TITLE
caesura: 0.26.0 -> 0.27.2

### DIFF
--- a/pkgs/by-name/ca/caesura/package.nix
+++ b/pkgs/by-name/ca/caesura/package.nix
@@ -1,73 +1,48 @@
 {
   lib,
   fetchFromGitHub,
-  fetchzip,
   rustPlatform,
-  eyed3,
   flac,
-  imagemagick,
-  intermodal,
   lame,
   makeBinaryWrapper,
   sox,
-  writableTmpDirAsHomeHook,
 }:
 let
   runtimeDeps = [
-    eyed3
     flac
-    intermodal
-    imagemagick
     lame
     sox
   ];
-
-  testSampleContent = fetchzip {
-    url = "https://archive.org/download/tennyson-discography_/Tennyson%20-%20With%20You%20-%20Lay-by.zip";
-    hash = "sha256-/MgnOgn+OSPPg9wkJ32hq+1MXDdW+Qo9MqLtZMLQYBY=";
-    stripRoot = false;
-  };
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "caesura";
-  version = "0.26.0";
+  version = "0.27.2";
 
   src = fetchFromGitHub {
     owner = "RogueOneEcho";
     repo = "caesura";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-atB7IrG9KchFOc1EXChlsqlrZs7mQ9tiXmdw1SptLI0=";
+    hash = "sha256-ifaZ+rmMmWhn8HM25sRPXJKuXvWE5VG+5hFMi9hqxA0=";
   };
 
-  cargoHash = "sha256-Iz/RYmuCc5XuyktYIN/zDrbyPpRU2eps0yqExPu+5J8=";
+  cargoHash = "sha256-g8Duhl5nZ6umIrAafW7s4vtDS+f06CWnFLoLSw0wa4o=";
 
   nativeBuildInputs = [
     makeBinaryWrapper
   ];
+  nativeCheckInputs = runtimeDeps;
+
+  env = {
+    CAESURA_NIX = "1";
+  };
 
   postPatch = ''
-    substituteInPlace Cargo.toml \
+    substituteInPlace Cargo.toml crates/*/Cargo.toml \
       --replace-fail 'version = "0.0.0"' 'version = "${finalAttrs.version}"'
   '';
 
-  checkFlags = [
-    # Those test need internet access for its `Source` (i.e: tracker)
-    "--skip=commands::spectrogram::tests::spectrogram_command_tests::spectrogram_command"
-    "--skip=commands::transcode::tests::transcode_command_tests::transcode_command"
-    "--skip=utils::source::tests::source_provider_tests::source_provider"
-  ];
-
   preCheck = ''
-    # From samples/download-sample
-    mkdir samples/content/
-    ln -s ${finalAttrs.passthru.testSampleContent} "samples/content/Tennyson - With You (2014) [Digital] "'{'"16-44.1 Bandcamp"'}'" (FLAC)"
-    # Adapted from .github/workflows/on-push.yml
-    tee config.yml <<EOF
-    announce_url: https://flacsfor.me/YOUR_ANNOUNCE_KEY/announce
-    api_key: YOUR_API_KEY
-    content:
-    - samples/content
-    source: $(mktemp -d)
+    cat > config.yml <<EOF
     verbosity: trace
     EOF
   '';
@@ -78,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   passthru = {
-    inherit runtimeDeps testSampleContent;
+    inherit runtimeDeps;
   };
 
   meta = {


### PR DESCRIPTION
Finishing what was started in #495393. 0.27.2 doesn't depend on sox_ng, so it works fine without. Somehow tests are failing with the env var `CAESURA_DETERMINISTIC_TESTS` and not with `CAESURA_NIX`, so I just left `CAESURA_NIX` in. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
