### PR TITLE
nix-user-chroot: init at 2.1.0

### DIFF
--- a/pkgs/by-name/ni/nix-user-chroot/package.nix
+++ b/pkgs/by-name/ni/nix-user-chroot/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  pkgsStatic,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nix-user-chroot";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "nix-community";
+    repo = "nix-user-chroot";
+    tag = finalAttrs.version;
+    hash = "sha256-PU71ulCYaT7vM70ariJAgOXBqfBzWDsMh+l4tcnbGYw=";
+  };
+
+  cargoHash = "sha256-VgwLuR+ZGIZi2aTBAevngTyZLswduFbKzoFgL9TFUj4=";
+
+  passthru.updateScript = nix-update-script { };
+
+  NIX_USER_CHROOT_TEST_BUSYBOX = "${pkgsStatic.busybox}/bin/busybox";
+  checkFlags = [
+    "--skip=run_nix_install" # Test requires network
+  ];
+
+  meta = {
+    description = "Install & Run Nix Programs without root permissions";
+    homepage = "https://github.com/nix-community/nix-user-chroot";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      eveeifyeve
+      mic92
+    ];
+    mainProgram = "nix-user-chroot";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is the rust rewrite of nix-user-chroot just to note.

Homepage: https://github.com/nix-community/nix-user-chroot
Changelog: https://github.com/nix-community/nix-user-chroot/releases/tag/2.0.0

Ref previous pr for the C version: https://github.com/NixOS/nixpkgs/pull/495286 however I think it would be best to have this in rust, more maintainable, easier to get contributors and works well!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

@Mic92 do you want to become a maintainer for this package? Just want your confirmation, before we do merge this pr.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
