### PR TITLE
python3Packages.django-sslserver: init at 0.15

### DIFF
--- a/pkgs/development/python-modules/django-sslserver/default.nix
+++ b/pkgs/development/python-modules/django-sslserver/default.nix
@@ -1,0 +1,39 @@
+{
+  buildPythonPackage,
+  django,
+  lib,
+  setuptools-scm,
+  fetchFromGitHub,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "django-sslserver";
+  version = "0.15";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "teddziuba";
+    repo = "django-sslserver";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RIhqvwJQ7fYZT1SAkbcBNl2jX7j7UZND8e5Vra+ibHA=";
+  };
+
+  build-system = [ setuptools-scm ];
+
+  dependencies = [
+    django
+  ];
+
+  # No tests on upstream
+  doCheck = false;
+
+  pythonImportsCheck = [ "sslserver" ];
+
+  meta = {
+    description = "SSL-enabled development server for Django";
+    homepage = "https://github.com/teddziuba/django-sslserver";
+    changelog = "https://github.com/teddziuba/django-sslserver/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kurogeek ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4378,6 +4378,8 @@ self: super: with self; {
 
   django-sql-utils = callPackage ../development/python-modules/django-sql-utils { };
 
+  django-sslserver = callPackage ../development/python-modules/django-sslserver { };
+
   django-statici18n = callPackage ../development/python-modules/django-statici18n { };
 
   django-storages = callPackage ../development/python-modules/django-storages { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
