### PR TITLE
phylophlan: 3.1.1 -> 3.2.1

### DIFF
--- a/pkgs/by-name/ph/phylophlan/package.nix
+++ b/pkgs/by-name/ph/phylophlan/package.nix
@@ -11,14 +11,14 @@
 let
   finalAttrs = {
     pname = "phylophlan";
-    version = "3.1.1";
+    version = "3.2.1";
     pyproject = true;
 
     src = fetchFromGitHub {
       owner = "biobakery";
       repo = "phylophlan";
       tag = finalAttrs.version;
-      hash = "sha256-KlWKt2tH2lQBh/eQ2Hbcu2gXHEFfmFEc6LrybluxINc=";
+      hash = "sha256-rPTEdu0W3LD27tDIWCOQ3K+RJuj97I9aEeYFdM77jOs=";
     };
 
     build-system = with python3Packages; [ setuptools ];
@@ -35,6 +35,8 @@ let
       seaborn
       distutils
       requests
+      scipy
+      tqdm
     ];
 
     # Minimum needed external tools


### PR DESCRIPTION
Changelog: https://github.com/biobakery/phylophlan/releases/tag/3.2.1

## Things done

It will build successfully after https://github.com/NixOS/nixpkgs/pull/503851 and https://github.com/NixOS/nixpkgs/pull/503688 are merged.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
