### PR TITLE
unblob: 25.5.26 -> 26.3.30

### DIFF
--- a/pkgs/by-name/un/unblob/package.nix
+++ b/pkgs/by-name/un/unblob/package.nix
@@ -46,26 +46,24 @@ let
 in
 python3.pkgs.buildPythonApplication rec {
   pname = "unblob";
-  version = "25.5.26";
+  version = "26.3.30";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "onekey-sec";
     repo = "unblob";
     tag = version;
-    hash = "sha256-vTakXZFAcD3cmd+y4CwYg3X4O4NmtOzuqMLWLMX2Duk=";
+    hash = "sha256-wYWuKvxAagctlmdO5Fi9/WzfJ4zkDgfXejgDTJPHsTI=";
     forceFetchGit = true;
     fetchLFS = true;
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-NirDPuAcKuNquMs9mBZoEkQf+QJ+cMd7JXjj1anB9Zw=";
+    hash = "sha256-wjN4QPOUYFWWYMWL9aAgGqEucM7q+H6YyoS9Mv2dpp4=";
   };
 
   strictDeps = true;
-
-  build-system = with python3.pkgs; [ poetry-core ];
 
   buildInputs = lib.optionals stdenvNoCC.hostPlatform.isDarwin [ libiconv ];
 
@@ -77,10 +75,13 @@ python3.pkgs.buildPythonApplication rec {
     dissect-cstruct
     lark
     lief.py
+    lzallright
     python3.pkgs.lz4 # shadowed by pkgs.lz4
     plotext
     pluggy
+    pydantic
     pyfatfs
+    pymdown-extensions
     pyperscan
     python-magic
     pyzstd
@@ -103,8 +104,6 @@ python3.pkgs.buildPythonApplication rec {
     "ubi-reader"
   ];
 
-  pythonRelaxDeps = [ "lz4" ];
-
   pythonImportsCheck = [ "unblob" ];
 
   makeWrapperArgs = [
@@ -114,19 +113,23 @@ python3.pkgs.buildPythonApplication rec {
   nativeCheckInputs =
     with python3.pkgs;
     [
+      pexpect
+      psutil
+      pytest-cov-stub
       pytestCheckHook
-      pytest-cov # cannot use stub
       versionCheckHook
     ]
     ++ runtimeDeps;
 
   pytestFlags = [
-    "--no-cov"
+    "--with-e2e" # Not that slow: increases test time by ~5s
   ];
 
   disabledTests = [
     # https://github.com/tytso/e2fsprogs/issues/152
     "test_all_handlers[filesystem.extfs]"
+    # regression in erofs-utils 1.9 https://github.com/onekey-sec/unblob/commit/c7c9f20dd871a5694d41a95ca3041eb0c98e257a
+    "test_all_handlers[filesystem.android.erofs]"
   ];
 
   passthru = {

--- a/pkgs/by-name/un/unblob/package.nix
+++ b/pkgs/by-name/un/unblob/package.nix
@@ -3,7 +3,6 @@
   libiconv,
   python3,
   fetchFromGitHub,
-  gitUpdater,
   makeWrapper,
   rustPlatform,
   stdenvNoCC,
@@ -131,7 +130,6 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   passthru = {
-    updateScript = gitUpdater { };
     # helpful to easily add these to a nix-shell environment
     inherit runtimeDeps;
   };


### PR DESCRIPTION
## Things done

- removed pytest-cov from check dependencies, as it is no longer imported from python code
- added new dependencies
- changed updateScript to handle cargoHash updates
- added new end-to-end tests to checkPhase
- needed to disable a test due to an erofs  

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
