### PR TITLE
beam: add erlang_24 package set for Elixir 1.15 / OTP 24

### DIFF
--- a/pkgs/development/interpreters/erlang/24.nix
+++ b/pkgs/development/interpreters/erlang/24.nix
@@ -1,0 +1,6 @@
+genericBuilder:
+
+genericBuilder {
+  version = "24.3.4.17";
+  hash = "sha256-V26pZEyFo+c+ztDDkjDNFK6LTw5xzF8gQYepWGNlGKg=";
+}

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -50,6 +50,20 @@ in
       inherit wxSupport systemdSupport;
     };
 
+    erlang_24 =
+      (callErlang ../development/interpreters/erlang/24.nix {
+        inherit wxSupport systemdSupport;
+      }).overrideAttrs
+        (old: {
+          # OTP 24 uses `bool` as a variable name in dist.c, which conflicts
+          # with the C23 keyword in GCC 14+.
+          postPatch = (old.postPatch or "") + ''
+            substituteInPlace erts/emulator/beam/dist.c \
+              --replace-fail 'Eterm bool' 'Eterm spawn_monitor_p' \
+              --replace-fail 'ref, bool' 'ref, spawn_monitor_p'
+          '';
+        });
+
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlang_27.elixir`.
@@ -77,5 +91,6 @@ in
     erlang_28 = self.packagesWith self.interpreters.erlang_28;
     erlang_27 = self.packagesWith self.interpreters.erlang_27;
     erlang_26 = self.packagesWith self.interpreters.erlang_26;
+    erlang_24 = self.packagesWith self.interpreters.erlang_24;
   };
 }


### PR DESCRIPTION
## Summary
- Add `beam.packages.erlang_24` with Erlang/OTP 24.3.4.17
- Enables `beam.packages.erlang_24.elixir_1_15` for reproducing Elixir 1.15 / OTP 24 environments
- Includes a minimal GCC 14+ compatibility patch (rename `bool` variable in `erts/emulator/beam/dist.c`)

## Motivation
`elixir_1_15` exists in nixpkgs with `minimumOTPVersion = "24"`, but `beam.packages.erlang_24` was removed when OTP 24 reached EOL. This makes it impossible to use the Elixir 1.15 / OTP 24 combination that some projects still test against in CI (e.g. `wojtekmach/req`).

## Changes
- `pkgs/development/interpreters/erlang/24.nix` — new file, OTP 24.3.4.17 version definition
- `pkgs/top-level/beam-packages.nix` — add `erlang_24` to interpreters and packages, with a `postPatch` to rename a `bool` variable that conflicts with the C23 keyword in GCC 14+

## Testing
- `nix eval` confirms `erlang_24` appears in `beam.packages`
- `nix build .#beam.packages.erlang_24.erlang` builds successfully
- `nix build .#beam.packages.erlang_24.elixir_1_15` builds successfully
- Runtime verification:
```
Erlang/OTP 24 [erts-12.3.2.17] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]
Elixir 1.15.7 (compiled with Erlang/OTP 24)
```