### PR TITLE
nixos/syncthing: fix unix socket guiAddress handling

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -16,7 +16,7 @@ let
   settingsFormat = pkgs.formats.json { };
   cleanedConfig = converge (filterAttrsRecursive (_: v: v != null && v != { })) cfg.settings;
 
-  isUnixGui = (builtins.substring 0 1 cfg.guiAddress) == "/";
+  isUnixGui = lib.strings.hasPrefix "unix://" cfg.guiAddress;
 
   # Syncthing supports serving the GUI over Unix sockets. If that happens, the
   # API is served over the Unix socket as well.  This function returns the correct
@@ -30,7 +30,7 @@ let
     # note that the dot in front of `${path}` is the hostname, which is
     # required.
     then
-      "--unix-socket ${cfg.guiAddress} http://.${path}"
+      "--unix-socket ${lib.strings.removePrefix "unix://" cfg.guiAddress} http://.${path}"
     # no adjustments are needed if cfg.guiAddress is a network address
     else
       "${cfg.guiAddress}${path}";
@@ -290,7 +290,7 @@ let
               )"
               for id in ''${stale_${conf_type}_ids}; do
                 >&2 echo "Deleting stale device: $id"
-                curl -X DELETE "${s.baseAddress}/$id"
+                curl -X DELETE ${s.baseAddress}/$id
               done
             ''
           ))
@@ -774,6 +774,7 @@ in
       guiAddress = mkOption {
         type = types.str;
         default = "127.0.0.1:8384";
+        apply = x: if lib.strings.hasPrefix "/" x then "unix://${x}" else x;
         description = ''
           The address to serve the web interface at.
         '';
@@ -1000,7 +1001,7 @@ in
               args = lib.escapeShellArgs (
                 (lib.cli.toCommandLineGNU { } {
                   "no-browser" = true;
-                  "gui-address" = (if isUnixGui then "unix://" else "") + cfg.guiAddress;
+                  "gui-address" = cfg.guiAddress;
                   "config" = cfg.configDir;
                   "data" = cfg.databaseDir;
                 })
@@ -1008,6 +1009,7 @@ in
               );
             in
             "${lib.getExe cfg.package} ${args}";
+          RuntimeDirectory = "syncthing";
           MemoryDenyWriteExecute = true;
           NoNewPrivileges = true;
           PrivateDevices = true;

--- a/nixos/tests/syncthing/folders.nix
+++ b/nixos/tests/syncthing/folders.nix
@@ -26,6 +26,7 @@ in
           openDefaultPorts = true;
           cert = "${idA}/cert.pem";
           key = "${idA}/key.pem";
+          guiAddress = "unix:///run/syncthing/syncthing.sock";
           settings = {
             devices.b.id = lib.fileContents "${idB}/id";
             devices.c.id = lib.fileContents "${idC}/id";


### PR DESCRIPTION
This fixes an issue when explicitly setting `services.syncthing.guiAddress` to a `unix://...` socket address would fail to be recognized as a unix socket.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
