### PR TITLE
treewide: plasma-login-manager fixes

### DIFF
--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -300,7 +300,7 @@ in
     services.orca.enable = mkDefault true;
 
     services.displayManager = {
-      sessionPackages = [ kdePackages.plasma-workspace ];
+      sessionPackages = [ kdePackages.plasma-workspace.sessions ];
       defaultSession = mkDefault "plasma";
     };
     services.displayManager.sddm = {

--- a/nixos/modules/services/display-managers/plasma-login-manager.nix
+++ b/nixos/modules/services/display-managers/plasma-login-manager.nix
@@ -65,6 +65,16 @@ in
       path = [ cfg.package ];
       wantedBy = [ "graphical.target" ];
       restartIfChanged = false;
+      environment.XDG_DATA_DIRS = lib.mkIf (
+        dmcfg.sessionPackages != [ ]
+      ) "${dmcfg.sessionData.desktops}/share";
+    };
+
+    systemd.user.services.plasma-login = {
+      overrideStrategy = "asDropin";
+      environment.XDG_DATA_DIRS = lib.mkIf (
+        dmcfg.sessionPackages != [ ]
+      ) "${dmcfg.sessionData.desktops}/share";
     };
 
     systemd.defaultUnit = "graphical.target";

--- a/pkgs/kde/plasma/plasma-workspace/default.nix
+++ b/pkgs/kde/plasma/plasma-workspace/default.nix
@@ -39,6 +39,13 @@ mkKdeDerivation {
     })
   ];
 
+  outputs = [
+    "out"
+    "dev"
+    "devtools"
+    "sessions"
+  ];
+
   postInstall = ''
     # Prevent patching this shell file, it only is used by sourcing it from /bin/sh.
     chmod -x $out/libexec/plasma-sourceenv.sh
@@ -83,6 +90,9 @@ mkKdeDerivation {
   postFixup = ''
     mkdir -p $out/nix-support
     echo "${lsof} ${xmessage} ${xrdb}" > $out/nix-support/depends
+
+    moveToOutput share/xsessions $sessions
+    moveToOutput share/wayland-sessions $sessions
   '';
 
   passthru.providedSessions = [


### PR DESCRIPTION
This should fix #503852.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
