### PR TITLE
doctest: 2.4.12 -> 2.5.0, clean, adopt

### DIFF
--- a/pkgs/by-name/do/doctest/package.nix
+++ b/pkgs/by-name/do/doctest/package.nix
@@ -2,30 +2,19 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "doctest";
-  version = "2.4.12";
+  version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "doctest";
     repo = "doctest";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Fxs1EWydhqN9whx+Cn4fnZ4fhCEQvFgL5e9TUiXlnq8=";
+    hash = "sha256-7t/eknv7VtHoBgcuJmI07x//HIyqzE9HUuH5u2y7X8A=";
   };
-
-  patches = [
-    # Fix the build with Clang.
-    (fetchpatch {
-      name = "doctest-disable-warnings.patch";
-      url = "https://github.com/doctest/doctest/commit/c8d9ed2398d45aa5425d913bd930f580560df30d.patch";
-      excludes = [ ".github/workflows/main.yml" ];
-      hash = "sha256-kOBy0om6MPM2vLXZjNLXiezZqVgNr/viBI7mXrOZts8=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -37,23 +26,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  # Fix the build with LLVM 21 / GCC 15.
-  #
-  # See:
-  #
-  # * <https://github.com/doctest/doctest/issues/928>
-  # * <https://github.com/doctest/doctest/pull/929>
-  # * <https://github.com/doctest/doctest/issues/950>
-  env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " [
-    "-Wno-error=nrvo"
-    "-Wno-error=missing-noreturn"
-  ];
-
   meta = {
     homepage = "https://github.com/doctest/doctest";
     description = "Fastest feature-rich C++11/14/17/20 single-header testing framework";
     platforms = lib.platforms.all;
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.nim65s ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
