### PR TITLE
neovim[-unwrapped]: 0.11.6 -> 0.12.0

### DIFF
--- a/pkgs/by-name/ne/neovim-unwrapped/package.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/package.nix
@@ -101,7 +101,7 @@ stdenv.mkDerivation (
   in
   {
     pname = "neovim-unwrapped";
-    version = "0.11.6";
+    version = "0.12.0";
 
     __structuredAttrs = true;
 
@@ -109,7 +109,7 @@ stdenv.mkDerivation (
       owner = "neovim";
       repo = "neovim";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-GdfCaKNe/qPaUV2NJPXY+ATnQNWnyFTFnkOYDyLhTNg=";
+      hash = "sha256-uWhrGAwQ2nnAkyJ46qGkYxJ5K1jtyUIQOAVu3yTlquk=";
     };
 
     strictDeps = true;

--- a/pkgs/by-name/ne/neovim-unwrapped/treesitter-parsers.nix
+++ b/pkgs/by-name/ne/neovim-unwrapped/treesitter-parsers.nix
@@ -6,23 +6,23 @@
     hash = "sha256:25dd4bb3dec770769a407e0fc803f424ce02c494a56ce95fedc525316dcf9b48";
   };
   lua.src = fetchurl {
-    url = "https://github.com/tree-sitter-grammars/tree-sitter-lua/archive/v0.4.0.tar.gz";
-    hash = "sha256:b0977aced4a63bb75f26725787e047b8f5f4a092712c840ea7070765d4049559";
+    url = "https://github.com/tree-sitter-grammars/tree-sitter-lua/archive/v0.5.0.tar.gz";
+    hash = "sha256:cf01b93f4b61b96a6d27942cf28eeda4cbce7d503c3bef773a8930b3d778a2d9";
   };
   vim.src = fetchurl {
-    url = "https://github.com/tree-sitter-grammars/tree-sitter-vim/archive/v0.7.0.tar.gz";
-    hash = "sha256:44eabc31127c4feacda19f2a05a5788272128ff561ce01093a8b7a53aadcc7b2";
+    url = "https://github.com/tree-sitter-grammars/tree-sitter-vim/archive/v0.8.1.tar.gz";
+    hash = "sha256:93cafb9a0269420362454ace725a118ff1c3e08dcdfdc228aa86334b54d53c2a";
   };
   vimdoc.src = fetchurl {
-    url = "https://github.com/neovim/tree-sitter-vimdoc/archive/v4.0.0.tar.gz";
-    hash = "sha256:8096794c0f090b2d74b7bff94548ac1be3285b929ec74f839bd9b3ff4f4c6a0b";
+    url = "https://github.com/neovim/tree-sitter-vimdoc/archive/v4.1.0.tar.gz";
+    hash = "sha256:020e8f117f648c8697fca967995c342e92dbd81dab137a115cc7555207fbc84f";
   };
   query.src = fetchurl {
-    url = "https://github.com/tree-sitter-grammars/tree-sitter-query/archive/v0.6.2.tar.gz";
-    hash = "sha256:90682e128d048fbf2a2a17edca947db71e326fa0b3dba4136e041e096538b4eb";
+    url = "https://github.com/tree-sitter-grammars/tree-sitter-query/archive/v0.8.0.tar.gz";
+    hash = "sha256:c2b23b9a54cffcc999ded4a5d3949daf338bebb7945dece229f832332e6e6a7d";
   };
   markdown.src = fetchurl {
-    url = "https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.5.0.tar.gz";
-    hash = "sha256:14c2c948ccf0e9b606eec39b09286c59dddf28307849f71b7ce2b1d1ef06937e";
+    url = "https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.5.3.tar.gz";
+    hash = "sha256:df845b1ab7c7c163ec57d7fa17170c92b04be199bddab02523636efec5224ab6";
   };
 }

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -854,6 +854,16 @@ in
   };
 
   neotest = prev.neotest.overrideAttrs (old: {
+    patches = [
+      (fetchpatch {
+        # fix compatibility with neovim 0.12: iter_matches breaking change
+        # https://github.com/nvim-neotest/neotest/pull/594
+        name = "fix-neovim-0-12-compat";
+        url = "https://github.com/LiamCoop/neotest/commit/2ffca3aefb070e31f1ac00e9fbfd1a83f995c326.patch";
+        hash = "sha256-3+ooC3ZB8pl90FG+kTZxIzmPxrdJTx/XNYE2tPDWO+w=";
+      })
+    ];
+
     doCheck = stdenv.hostPlatform.isLinux;
     nativeCheckInputs = old.nativeCheckInputs ++ [
       final.nlua


### PR DESCRIPTION
## Things done

~~Release is expected to happen on Sunday, March 29.~~

- [x] Updated grammars
- [x] `:checkhealth` report no errors

Diff: https://github.com/neovim/neovim/compare/v0.11.6...v0.12.0
Changelog: https://github.com/neovim/neovim/releases/tag/v0.12.0

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
