### PR TITLE
ryelang: init at 0.2.5

### DIFF
--- a/pkgs/by-name/ry/ryelang/package.nix
+++ b/pkgs/by-name/ry/ryelang/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "ryelang";
+  version = "0.2.5";
+
+  src = fetchFromGitHub {
+    owner = "refaktor";
+    repo = "rye";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6H5PsgORZmSlMDkjqeN/DOhRL/dUWCZ5+kCkVnR6nXA=";
+  };
+
+  vendorHash = "sha256-Jy0250Iv3eif3JMiyjdFv+uInEV5Z2HpOi6hL2/kgKI=";
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "github.com/refaktor/rye/runner.Version=${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "High-level, dynamic programming language inspired by Rebol, Factor, Linux shells, and Go";
+    homepage = "https://ryelang.org/";
+    changelog = "https://github.com/refaktor/rye/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ amadejkastelic ];
+    mainProgram = "rye";
+  };
+})


### PR DESCRIPTION
Adds https://ryelang.org/ which is a high-level, dynamic programming language.

https://github.com/refaktor/rye

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
