### PR TITLE
agentgateway: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26346,6 +26346,11 @@
     name = "Tomasz Maciosowski";
     keys = [ { fingerprint = "6866 981C 4992 4D64 D154  E1AC 19E5 A2D8 B1E4 3F19"; } ];
   };
+  t4min0 = {
+    github = "t4min0";
+    githubId = 269137166;
+    name = "t4min0";
+  };
   t4sm5n = {
     email = "t4sm5n@gmail.com";
     github = "t4sm5n";

--- a/pkgs/by-name/ag/agentgateway/package.nix
+++ b/pkgs/by-name/ag/agentgateway/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  cmake,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "agentgateway";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "agentgateway";
+    repo = "agentgateway";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tHz5NwP2oihOObjG/YEeKYk4VU7Ui9WjK2XDvrf/kaI=";
+  };
+
+  cargoHash = "sha256-bVwPCIs8A7TlPX4phc9w8l1UpiPShRTN7n08aS5MA7U=";
+
+  cargoBuildFlags = [
+    "--package"
+    "agentgateway-app"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  postPatch = ''
+    patchShebangs tools/report_build_info.sh
+  '';
+
+  env.VERSION = finalAttrs.version;
+
+  # Tests require network access and external services
+  doCheck = false;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Gateway for Model Context Protocol and Agent-to-Agent protocol servers";
+    homepage = "https://github.com/agentgateway/agentgateway";
+    changelog = "https://github.com/agentgateway/agentgateway/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ t4min0 ];
+    mainProgram = "agentgateway";
+  };
+})


### PR DESCRIPTION
[Agentgateway](https://github.com/agentgateway/agentgateway) is an open source data plane for agentic AI connectivity. It provides security, observability, and governance for agent-to-agent and agent-to-tool communication, supporting Agent2Agent (A2A) and Model Context Protocol (MCP).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - [x] `agentgateway --version` outputs correct version (1.0.1)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test