### PR TITLE
wl-find-cursor: init at 0-unstable-2026-02-03

### DIFF
--- a/pkgs/by-name/wl/wl-find-cursor/package.nix
+++ b/pkgs/by-name/wl/wl-find-cursor/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  stdenv,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+}:
+
+stdenv.mkDerivation {
+  pname = "wl-find-cursor";
+  version = "0-unstable-2026-02-03";
+
+  src = fetchFromGitHub {
+    owner = "cjacker";
+    repo = "wl-find-cursor";
+    rev = "ce1a125702b466dc537c5490f7888b4a68dee883";
+    hash = "sha256-IUreWEOWF1loS5SiAh8XPFrKE35Pxv6e8hhvdtNvjiU=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    wayland
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "/usr/share/wayland-protocols" "${wayland-protocols}/share/wayland-protocols" \
+      --replace-fail "gcc" "${stdenv.cc.targetPrefix}cc" \
+      --replace-fail "install: default" "install: all"
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "Highlight and print the mouse cursor position on Wayland";
+    homepage = "https://github.com/cjacker/wl-find-cursor";
+    license = lib.licenses.mit;
+    mainProgram = "wl-find-cursor";
+    maintainers = with lib.maintainers; [ ilkecan ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://github.com/cjacker/wl-find-cursor

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 504085`
Commit: `460bf0c3951714483f14d36dffc519a08d6618e0`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>wl-find-cursor</li>
  </ul>
</details>
