### PR TITLE
node-red: fix cross compilation

### DIFF
--- a/pkgs/by-name/no/node-red/package.nix
+++ b/pkgs/by-name/no/node-red/package.nix
@@ -27,7 +27,7 @@ buildNpmPackage rec {
       packageDir = "packages/node_modules/node-red";
     in
     ''
-      ${lib.getExe jq} '. += {"bin": {"node-red": "${packageDir}/red.js", "node-red-pi": "${packageDir}/bin/node-red-pi"}}' package.json > package.json.tmp
+      jq '. += {"bin": {"node-red": "${packageDir}/red.js", "node-red-pi": "${packageDir}/bin/node-red-pi"}}' package.json > package.json.tmp
       mv package.json.tmp package.json
     '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix compile error like `../bin/jq: cannot execute binary file: Exec format error` when doing cross compilation.

The error occurs because `${lib.getExe jq}` gets a host-platform jq, not the build-platform one.

```
legacyPackages.x86_64-linux.pkgsCross.aarch64-multiplatform.node-red.postPatch
"/nix/store/pjxz39hsykjly1dj8vmiwmiw6nbd9k53-jq-aarch64-unknown-linux-gnu-1.8.1-bin/bin/jq '. += {\"bin\": {\"node-red\": \"packages/node_modules/node-red/red.js\", \"node-red-pi\": \"packages/node_modules/node-red/bin/node-red-pi\"}}' package.json > package.json.tmp\nmv package.json.tmp package.json\n"
```

The following packages have been successfully built on an x86-linux machine:
- `node-red`
- `pkgsCross.aarch64-multiplatform.node-red`
- `pkgsCross.riscv64.node-red`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
