### PR TITLE
lakectl: 1.79.0 -> 1.80.0

### DIFF
--- a/pkgs/by-name/la/lakectl/package.nix
+++ b/pkgs/by-name/la/lakectl/package.nix
@@ -1,24 +1,24 @@
 {
   lib,
-  buildGoModule,
+  buildGo126Module,
   fetchFromGitHub,
   nix-update-script,
 }:
 
-buildGoModule (finalAttrs: {
+buildGo126Module (finalAttrs: {
   pname = "lakectl";
-  version = "1.79.0";
+  version = "1.80.0";
 
   src = fetchFromGitHub {
     owner = "treeverse";
     repo = "lakeFS";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-UL9JvrNvtHADI0POguLXMDNNvO1oKHXXwfr8tOyvFYc=";
+    hash = "sha256-fco+t73cmoXc3Irf6owloxtldAVfBHCNfYRMitiGeTY=";
   };
 
   subPackages = [ "cmd/lakectl" ];
   proxyVendor = true;
-  vendorHash = "sha256-6XOJBDdAERD6mcneQ7UFqAPGq+pXroNlzQGNvycpVBc=";
+  vendorHash = "sha256-7sQMvpY+1RT2m1B14UPGCb60HQ9De5rErvoyj95Fkbc=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
## Summary
- update lakectl from 1.79.0 to 1.80.0
- switch to buildGo126Module because upstream now requires Go >= 1.25.8 via go.work
- refresh vendorHash for the new release and toolchain

## Testing
- `nix build -L --no-link .#lakectl`
- `/nix/store/pg139sncfwjvj82yq5fxy1bklpscqgjy-lakectl-1.80.0/bin/lakectl --version`
- `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD --branch master --no-shell -p lakectl --print-result"`