### PR TITLE
gst_all_1.gst-plugins-good: add patch for CVE-2026-1940

### DIFF
--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -95,6 +95,11 @@ stdenv.mkDerivation (finalAttrs: {
     (replaceVars ./souploader.diff {
       nixLibSoup3Path = "${lib.getLib libsoup_3}/lib";
     })
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10903.patch";
+      hash = "sha256-cXRaK2OjVun5MMlw+MFd6fdUDjxH4NNlYQxu+Hkjgec=";
+      stripLen = 2;
+    })
   ];
 
   strictDeps = true;


### PR DESCRIPTION
Fix for CVE-2026-1940:
- https://nvd.nist.gov/vuln/detail/CVE-2026-1940
- https://gstreamer.freedesktop.org/security/sa-2026-0001.html
- https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10903.patch

Fixes #503018.

Note: The GStreamer security advisory mentions gst-plugins-bad, but the patch applies to wavparse, which is in gst-plugins-good. I am assuming this is an oversight in upstream's post since the 1.28 release notes correctly place the fix in the gst-plugins-good section.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
