### PR TITLE
cwal update v0.8.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19300,12 +19300,6 @@
     githubId = 368712;
     name = "Niels Egberts";
   };
-  nitinbhat972 = {
-    email = "nitinbhat972@gmail.com";
-    github = "nitinbhat972";
-    githubId = 80189191;
-    name = "Nitin Bhat";
-  };
   nigelgbanks = {
     name = "Nigel Banks";
     email = "nigel.g.banks@gmail.com";
@@ -19453,6 +19447,12 @@
     name = "nishimara";
     github = "Nishimara";
     githubId = 59232119;
+  };
+  nitinbhat972 = {
+    email = "nitinbhat972@gmail.com";
+    github = "nitinbhat972";
+    githubId = 80189191;
+    name = "Nitin Bhat";
   };
   nitsky = {
     name = "nitsky";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19300,6 +19300,12 @@
     githubId = 368712;
     name = "Niels Egberts";
   };
+  nitinbhat972 = {
+    email = "nitinbhat972@gmail.com";
+    github = "nitinbhat972";
+    githubId = 80189191;
+    name = "Nitin Bhat";
+  };
   nigelgbanks = {
     name = "Nigel Banks";
     email = "nigel.g.banks@gmail.com";

--- a/pkgs/by-name/cw/cwal/package.nix
+++ b/pkgs/by-name/cw/cwal/package.nix
@@ -7,17 +7,18 @@
   imagemagick,
   libimagequant,
   lua,
+  makeWrapper,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cwal";
-  version = "0.7.0";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "nitinbhat972";
     repo = "cwal";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-2COw5YBa16XzB4h5dfTLDF6LYjb10UC3+hCgTavnnVo=";
+    hash = "sha256-QPPGM22OoPpQfMQ4ZvA0AZc12FjP/p0GmaOTwaFlum8=";
   };
 
   strictDeps = true;
@@ -25,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     pkg-config
+    makeWrapper
   ];
 
   buildInputs = [
@@ -33,12 +35,17 @@ stdenv.mkDerivation (finalAttrs: {
     lua
   ];
 
+  postFixup = ''
+    wrapProgram $out/bin/cwal \
+      --prefix XDG_DATA_DIRS : $out/share
+  '';
+
   meta = {
     description = "Blazing-fast pywal-like color palette generator written in C";
     homepage = "https://github.com/nitinbhat972/cwal";
     license = lib.licenses.gpl3Only;
     mainProgram = "cwal";
-    platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ gustlik501 ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ gustlik501 nitinbhat972];
   };
 })

--- a/pkgs/by-name/cw/cwal/package.nix
+++ b/pkgs/by-name/cw/cwal/package.nix
@@ -46,6 +46,9 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     mainProgram = "cwal";
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ gustlik501 nitinbhat972];
+    maintainers = with lib.maintainers; [
+      gustlik501
+      nitinbhat972
+    ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
Update cwal to 0.8.1.

Add XDG_DATA_DIRS wrapper to ensure themes and templates are discovered correctly at runtime in Nix environments.
Update version and source hash.
Enable unix platforms (tested on macOS).
Add myself as a maintainer.
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
