### PR TITLE
cudaPackages.nsight_compute: include necessary files

### DIFF
--- a/pkgs/development/cuda-modules/packages/nsight_compute.nix
+++ b/pkgs/development/cuda-modules/packages/nsight_compute.nix
@@ -87,18 +87,19 @@ buildRedist (
     postInstall = ''
       moveToOutput 'ncu' "''${!outputBin}/bin"
       moveToOutput 'ncu-ui' "''${!outputBin}/bin"
-      moveToOutput 'host/${archDir}' "''${!outputBin}/bin"
-      moveToOutput 'target/${archDir}' "''${!outputBin}/bin"
+      moveToOutput 'host' "''${!outputBin}/bin"
+      moveToOutput 'target' "''${!outputBin}/bin"
+      moveToOutput 'sections' "''${!outputBin}/bin"
       wrapQtApp "''${!outputBin}/bin/host/${archDir}/ncu-ui.bin"
     ''
     # NOTE(@connorbaker): No idea what this platform is or how to patchelf for it.
     + lib.optionalString (flags.isJetsonBuild && cudaAtLeast "11.8" && cudaOlder "12.9") ''
       nixLog "Removing QNX 700 target directory for Jetson builds"
-      rm -rfv "''${!outputBin}/target/qnx-700-t210-a64"
+      rm -rfv "''${!outputBin}/bin/target/qnx-700-t210-a64"
     ''
     + lib.optionalString (flags.isJetsonBuild && cudaAtLeast "12.8") ''
       nixLog "Removing QNX 800 target directory for Jetson builds"
-      rm -rfv "''${!outputBin}/target/qnx-800-tegra-a64"
+      rm -rfv "''${!outputBin}/bin/target/qnx-800-tegra-a64"
     '';
 
     # lib needs libtiff.so.5, but nixpkgs provides libtiff.so.6


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR addresses the following problems with the current derivation:

- The profiler doesn't start without the `-x86` target directory, so just keep it 
- Section data for metrics is accessed relative to the binaries so that needs to go into `bin` too
- Keep the `aarch64` target directory for `x86_64` hosts so that remote profiling on Grace Hopper/Blackwell systems & GB10 is possible too
- The Jetson targets that get removed live in `bin` when they're being removed, not the top-level target directory

Should fix #423609 and I suppose #288059 since newer versions build just fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
