### PR TITLE
python3Packages.meson-python: set `build-dir` in setup hook

### DIFF
--- a/pkgs/development/python-modules/dbus-python/default.nix
+++ b/pkgs/development/python-modules/dbus-python/default.nix
@@ -63,11 +63,6 @@ lib.fix (
       dbus-glib
     ];
 
-    pypaBuildFlags = [
-      # Don't discard meson build directory, still needed for tests!
-      "-Cbuild-dir=_meson-build"
-    ];
-
     mesonFlags = [ (lib.mesonBool "tests" finalPackage.doInstallCheck) ];
 
     # workaround bug in meson-python
@@ -87,7 +82,7 @@ lib.fix (
     checkPhase = ''
       runHook preCheck
 
-      meson test -C _meson-build --no-rebuild --print-errorlogs --timeout-multiplier 0
+      meson test -C build --no-rebuild --print-errorlogs --timeout-multiplier 0
 
       runHook postCheck
     '';

--- a/pkgs/development/python-modules/meson-python/add-build-flags.sh
+++ b/pkgs/development/python-modules/meson-python/add-build-flags.sh
@@ -11,13 +11,15 @@ mesonPythonBuildFlagsHook() {
   appendToVar pypaBuildFlags "-Cbuild-dir=$mesonBuildDir"
   appendToVar pipBuildFlags "-Cbuild-dir=$mesonBuildDir"
 
-  # Add all of mesonFlags to -Csetup-args for pypa builds
+  # Add all of mesonFlags to `setup-args`
   local flagsArray=()
   concatTo flagsArray mesonFlags mesonFlagsArray
   for f in "${flagsArray[@]}"; do
     appendToVar pypaBuildFlags "-Csetup-args=$f"
-    # This requires pip>23.0.1, see: https://meson-python.readthedocs.io/en/latest/how-to-guides/config-settings.html
-    appendToVar pipBuildFlags "--config-settings=setup-args=$f"
+
+    # Using the same config key multiple times requires pip>=23.1, see:
+    # https://meson-python.readthedocs.io/en/latest/how-to-guides/config-settings.html
+    appendToVar pipBuildFlags "-Csetup-args=$f"
   done
 }
 

--- a/pkgs/development/python-modules/meson-python/add-build-flags.sh
+++ b/pkgs/development/python-modules/meson-python/add-build-flags.sh
@@ -1,4 +1,16 @@
 mesonPythonBuildFlagsHook() {
+  # Use a build directory with a deterministic path by setting `build-dir` [1]
+  # and allow consumers to override it via `mesonBuildDir`.
+  # Setting `build-dir` also causes the build directory to be _persistent_,
+  # i.e., it won't be deleted after the build [2].
+  #
+  # [1] https://github.com/mesonbuild/meson-python/issues/671
+  # [2] https://mesonbuild.com/meson-python/how-to-guides/config-settings.html#using-a-persistent-build-directory
+  #
+  : ${mesonBuildDir:=build}
+  appendToVar pypaBuildFlags "-Cbuild-dir=$mesonBuildDir"
+  appendToVar pipBuildFlags "-Cbuild-dir=$mesonBuildDir"
+
   # Add all of mesonFlags to -Csetup-args for pypa builds
   local flagsArray=()
   concatTo flagsArray mesonFlags mesonFlagsArray


### PR DESCRIPTION
The meson-python build directory path is nondeterministic if `build-dir` is not set because it is [generated by `tempfile.TemporaryDirectory`](https://github.com/mesonbuild/meson-python/blob/0.19.0/mesonpy/__init__.py#L1121) by default. This can cause irreproducible builds as seen in #482107.

Proposed solution: Let meson-python use a build directory with a deterministic path by explicitly setting `build-dir` and allow consumers to override it via the already established `mesonBuildDir`.

Setting `build-dir` also [causes the build directory to be _persistent_](https://mesonbuild.com/meson-python/how-to-guides/config-settings.html#using-a-persistent-build-directory), i.e., it won't be deleted after the build.

Reference: https://mesonbuild.com/meson-python/reference/config-settings.html
Upstream issues: https://github.com/mesonbuild/meson-python/issues/671, https://github.com/mesonbuild/meson-python/issues/703

Fixes #482107

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
    - Under both `python313Packages` and `python314Packages`:
      - `contourpy`
      - `dbus-python`
      - `matplotlib`
      - `meson-python`
      - `numpy`
      - `pandas`
      - `scikit-learn`
      - `scipy`
    - `sage`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
