### PR TITLE
tree-sitter-grammars.tree-sitter-go-template-helm: init at 0-unstable-2026-03-21

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
@@ -910,10 +910,16 @@
   };
 
   go-template = {
-    version = "0-unstable-2025-12-12";
+    version = "0-unstable-2026-03-21";
     url = "github:ngalaiko/tree-sitter-go-template";
-    rev = "c59999dc449c29549f5735eaac31b938a13b6c14";
-    hash = "sha256-YKqpNkCRLX+89Ottw4KVXxrEsIPRUsWs0UwIgucHwdo=";
+    rev = "aa71f63de226c5592dfbfc1f29949522d7c95fac";
+    hash = "sha256-QSzUyRDGdBH9TaG3YCHnJp12WcR8kdbsZFIk8I+JW1Y=";
+    meta = {
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        azahi
+      ];
+    };
   };
 
   godot-resource = {

--- a/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
@@ -922,6 +922,20 @@
     };
   };
 
+  go-template-helm = {
+    version = "0-unstable-2026-03-21";
+    url = "github:ngalaiko/tree-sitter-go-template";
+    rev = "aa71f63de226c5592dfbfc1f29949522d7c95fac";
+    hash = "sha256-QSzUyRDGdBH9TaG3YCHnJp12WcR8kdbsZFIk8I+JW1Y=";
+    location = "dialects/helm";
+    meta = {
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        azahi
+      ];
+    };
+  };
+
   godot-resource = {
     language = "godot_resource";
     version = "0.7.0";


### PR DESCRIPTION
- **tree-sitter-grammars.tree-sitter-go-template: 0-unstable-2025-12-12 -> 0-unstable-2026-03-21**
- **tree-sitter-grammars.tree-sitter-go-template-helm: init at 0-unstable-2026-03-21**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
