### PR TITLE
doc: add documentation for fetcher `fetchMavenArtifact`

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -1027,3 +1027,39 @@ fetchItchIo {
   upload = "13371354";
 }
 ```
+
+## `fetchMavenArtifact` {#fetchmavenartifact}
+
+`fetchMavenArtifact` is a fetcher for downloading Artifacts from the [Maven project](https://maven.apache.org/). It accepts the following arguments:
+
+- `groupId`;
+- `artifactId`;
+- `version`;
+- `hash`;
+- `classifier` (optional);
+- `repos` (optional): Maven repositories to fetch the artifact from;
+- `url` (optional): URL pointing to the JAR file;
+- `urls` (optional): list of alternative URLs pointing to the JAR file;
+- `meta` (optional): the derivation's metadata.
+
+It also accepts any other argument that can be passed to `fetchurl`.
+
+Only one of `url` or `urls` can be specified.
+If neither is provided, `repos` defaults to the most common Maven repositories (see [here](../../pkgs/build-support/fetchmavenartifact/default.nix)).
+If `url` or `urls` is specified, it takes precedence over `repos`.
+
+Once the artifact is fetched, the `.jar` file is stored in the derivation's output directory at `$out/share/java/{fileName}`, where `{fileName}` is the JAR filename.
+It can be accessed programmatically through the `passthru.jar` attribute.
+
+```nix
+{ fetchMavenArtifact }:
+
+fetchMavenArtifact {
+  groupId = "org.apache.httpcomponents";
+  artifactId = "httpclient";
+  version = "4.3.6";
+  classifier = "jdk11";
+  hash = "sha256-eYONnq73PU+FLGOkgIMMOi1LWQ8Ks66BWkiUY+RxQAQ=";
+}
+```
+

--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -1027,3 +1027,38 @@ fetchItchIo {
   upload = "13371354";
 }
 ```
+
+## `fetchMavenArtifact` {#fetchmavenartifact}
+
+`fetchMavenArtifact` is a fetcher for downloading artifacts from the [Maven project](https://maven.apache.org/). It accepts the following arguments:
+
+- `groupId`: The Maven group ID identifying the organization or project.
+- `artifactId`: The Maven artifact ID identifying the specific project.
+- `version`: The version of the Maven artifact to fetch.
+- `hash`: The hash of the downloaded artifact for verification.
+- `classifier` (optional): The Maven classifier to distinguish artifact variants.
+- `repos` (optional): Maven repositories to fetch the artifact from;
+- `url` (optional): URL pointing to the JAR file;
+- `urls` (optional): list of alternative URLs pointing to the JAR file;
+- `meta` (optional): the derivation's metadata.
+
+It also accepts any other argument that can be passed to `fetchurl`.
+
+Only one of `url` or `urls` can be specified.
+If neither `url` or `urls` is provided, `repos` defaults to the most common Maven repositories (see [here](../../pkgs/build-support/fetchmavenartifact/default.nix)).
+
+Once the artifact is fetched, the `.jar` file is stored in the derivation's output directory at `$out/share/java/{fileName}`, where `{fileName}` is the JAR filename.
+It can be accessed programmatically through the `passthru.jar` attribute.
+
+```nix
+{ fetchMavenArtifact }:
+
+fetchMavenArtifact {
+  groupId = "org.apache.httpcomponents";
+  artifactId = "httpclient";
+  version = "4.3.6";
+  classifier = "jdk11";
+  hash = "sha256-eYONnq73PU+FLGOkgIMMOi1LWQ8Ks66BWkiUY+RxQAQ=";
+}
+```
+

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -122,6 +122,9 @@
   "ex-writeShellApplication": [
     "index.html#ex-writeShellApplication"
   ],
+  "fetchmavenartifact": [
+    "index.html#fetchmavenartifact"
+  ],
   "friction-graphics": [
     "index.html#friction-graphics"
   ],


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
