### PR TITLE
metaphlan: init at 4.2.4

### DIFF
--- a/pkgs/by-name/me/metaphlan/package.nix
+++ b/pkgs/by-name/me/metaphlan/package.nix
@@ -38,7 +38,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     description = "Computational tool for profiling the composition of microbial communities from metagenomic shotgun sequencing data";
     homepage = "https://github.com/biobakery/MetaPhlAn";
     license = lib.licenses.mit;
-    changelog = "https://github.com/biobakery/MetaPhlAn/releases/tag/${finalAttrs.tag}";
+    changelog = "https://github.com/biobakery/MetaPhlAn/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "metaphlan";
     maintainers = with lib.maintainers; [ artur-sannikov ];
   };

--- a/pkgs/by-name/me/metaphlan/package.nix
+++ b/pkgs/by-name/me/metaphlan/package.nix
@@ -1,0 +1,45 @@
+{
+  python3Packages,
+  fetchFromGitHub,
+  lib,
+  phylophlan,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "metaphlan";
+  version = "4.2.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "biobakery";
+    repo = "MetaPhlAn";
+    tag = finalAttrs.version;
+    hash = "sha256-qvjC6jozhv1dz/9eC9kEU/3OHMystX0020EyzrP71eQ=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    biom-format
+    biopython
+    dendropy
+    h5py
+    numpy
+    packaging
+    pandas
+    pysam
+    requests
+    scipy
+  ];
+
+  propagateBuildInputs = [ phylophlan ];
+
+  meta = {
+    description = "Computational tool for profiling the composition of microbial communities from metagenomic shotgun sequencing data";
+    homepage = "https://github.com/biobakery/MetaPhlAn";
+    license = lib.licenses.mit;
+    changelog = "https://github.com/biobakery/MetaPhlAn/releases/tag/${finalAttrs.tag}";
+    mainProgram = "metaphlan";
+    maintainers = with lib.maintainers; [ artur-sannikov ];
+  };
+})

--- a/pkgs/by-name/me/metaphlan/package.nix
+++ b/pkgs/by-name/me/metaphlan/package.nix
@@ -1,0 +1,49 @@
+{
+  python3Packages,
+  fetchFromGitHub,
+  lib,
+  bowtie2,
+  phylophlan,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "metaphlan";
+  version = "4.2.4";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "biobakery";
+    repo = "MetaPhlAn";
+    tag = finalAttrs.version;
+    hash = "sha256-qvjC6jozhv1dz/9eC9kEU/3OHMystX0020EyzrP71eQ=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    biom-format
+    biopython
+    dendropy
+    h5py
+    numpy
+    packaging
+    pandas
+    pysam
+    requests
+    scipy
+  ];
+
+  propagatedBuildInputs = [
+    bowtie2
+    phylophlan
+  ];
+  meta = {
+    description = "Computational tool for profiling the composition of microbial communities from metagenomic shotgun sequencing data";
+    homepage = "https://github.com/biobakery/MetaPhlAn";
+    license = lib.licenses.mit;
+    changelog = "https://github.com/biobakery/MetaPhlAn/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "metaphlan";
+    maintainers = with lib.maintainers; [ artur-sannikov ];
+  };
+})


### PR DESCRIPTION
- supercedes: https://github.com/NixOS/nixpkgs/pull/311463

The database is not downloaded as part of the package build.

Users **must** download the database separately by themselves using the `--db_dir` parameter. If they do not use this parameter, and just install it with `metaphlan --install` then it will fail because it tries to download it into `/nix/store` which is read-only.

There is a commit https://github.com/NixOS/nixpkgs/pull/311463/changes/45dec256b8079efff621623cfabc4b3838a6d6b0 that downloads the database, but I frankly do not think it's a good idea to include 50GB of database together with the package. Also because it's possible to download different versions of the database for different purposes.

Pinging @Pandapip1 for feedback.

The package will build successfully once https://github.com/NixOS/nixpkgs/pull/504016, https://github.com/NixOS/nixpkgs/pull/503688, https://github.com/NixOS/nixpkgs/pull/503851 are merged.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

edit: bowtie2db --> db_dir
