### PR TITLE
qt6Packages.pyotherside: init at 1.6.2

### DIFF
--- a/pkgs/development/libraries/pyotherside/default.nix
+++ b/pkgs/development/libraries/pyotherside/default.nix
@@ -5,11 +5,15 @@
   python3,
   qmake,
   qtbase,
-  qtquickcontrols,
+  qtdeclarative,
+  qtquickcontrols ? null, # Qt6: merged into qtdeclarative
   qtsvg,
   ncurses,
 }:
 
+let
+  withQt6 = lib.strings.versionAtLeast qtbase.version "6";
+in
 stdenv.mkDerivation rec {
   pname = "pyotherside";
   version = "1.6.2";
@@ -25,7 +29,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     python3
     qtbase
-    qtquickcontrols
+    (if withQt6 then qtdeclarative else qtquickcontrols)
     qtsvg
     ncurses
   ];
@@ -36,7 +40,7 @@ stdenv.mkDerivation rec {
   installTargets = [ "sub-src-install_subtargets" ];
 
   meta = {
-    description = "Asynchronous Python 3 Bindings for Qt 5";
+    description = "Asynchronous Python 3 Bindings for Qt ${lib.versions.major qtbase.version}";
     homepage = "https://thp.io/2011/pyotherside/";
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.mic92 ];

--- a/pkgs/development/libraries/pyotherside/default.nix
+++ b/pkgs/development/libraries/pyotherside/default.nix
@@ -75,5 +75,6 @@ stdenv.mkDerivation rec {
     homepage = "https://thp.io/2011/pyotherside/";
     license = lib.licenses.isc;
     maintainers = [ lib.maintainers.mic92 ];
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
   };
 }

--- a/pkgs/development/libraries/pyotherside/default.nix
+++ b/pkgs/development/libraries/pyotherside/default.nix
@@ -25,6 +25,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-2OYVULNW9EzssqodiVtL2EmhTSbefXpLkub3zFvNwNo=";
   };
 
+  postPatch = ''
+    substituteInPlace qtquicktests/run \
+      --replace-fail \
+        '-plugins ../src' \
+        '-plugins ../src -import $out/${qtbase.qtQmlPrefix} -import ${lib.getBin qtdeclarative}/${qtbase.qtQmlPrefix}'
+  '';
+
   nativeBuildInputs = [ qmake ];
   buildInputs = [
     python3
@@ -38,6 +45,30 @@ stdenv.mkDerivation rec {
 
   patches = [ ./qml-path.patch ];
   installTargets = [ "sub-src-install_subtargets" ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  checkPhase = ''
+    runHook preCheck
+
+    export QT_QPA_PLATFORM=minimal
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+    ./tests/tests
+
+    runHook postCheck
+  '';
+
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    pushd qtquicktests
+    ./run
+    popd
+
+    runHook postInstallCheck
+  '';
 
   meta = {
     description = "Asynchronous Python 3 Bindings for Qt ${lib.versions.major qtbase.version}";

--- a/pkgs/development/libraries/pyotherside/default.nix
+++ b/pkgs/development/libraries/pyotherside/default.nix
@@ -28,6 +28,14 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace qtquicktests/run \
       --replace-fail \
+        'exec ./qtquicktests' \
+        'exec ./${
+          if stdenv.hostPlatform.isDarwin then
+            "qtquicktests.app/Contents/MacOS/qtquicktests"
+          else
+            "qtquicktests"
+        }' \
+      --replace-fail \
         '-plugins ../src' \
         '-plugins ../src -import $out/${qtbase.qtQmlPrefix} -import ${lib.getBin qtdeclarative}/${qtbase.qtQmlPrefix}'
   '';

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1738,6 +1738,7 @@ mapAliases {
   pyCA = warnAlias "'pyCA' was renamed to 'pyca'" pyca; # Added 2026-02-12
   pyload-ng = throw "'pyload-ng' has been removed due to vulnerabilities and being unmaintained"; # Added 2026-03-21
   pyo3-pack = throw "'pyo3-pack' has been renamed to/replaced by 'maturin'"; # Converted to throw 2025-10-27
+  pyotherside = warnAlias "'pyotherside' has been renamed to 'libsForQt5.pyotherside'."; # Added 2026-03-27
   pypolicyd-spf = throw "'pypolicyd-spf' has been renamed to/replaced by 'spf-engine'"; # Converted to throw 2025-10-27
   python3Full = throw "python3Full has been removed. Bluetooth support is now enabled by default. The tkinter package is available within the package set."; # Added 2025-08-30
   python311Full = throw "python311Full has been removed. Bluetooth support is now enabled by default. The tkinter package is available within the package set."; # Added 2025-08-30

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1738,7 +1738,7 @@ mapAliases {
   pyCA = warnAlias "'pyCA' was renamed to 'pyca'" pyca; # Added 2026-02-12
   pyload-ng = throw "'pyload-ng' has been removed due to vulnerabilities and being unmaintained"; # Added 2026-03-21
   pyo3-pack = throw "'pyo3-pack' has been renamed to/replaced by 'maturin'"; # Converted to throw 2025-10-27
-  pyotherside = warnAlias "'pyotherside' has been renamed to 'libsForQt5.pyotherside'."; # Added 2026-03-27
+  pyotherside = warnAlias "'pyotherside' has been renamed to 'libsForQt5.pyotherside'. A Qt6 build is available at 'qt6Packages.pyotherside'."; # Added 2026-03-27
   pypolicyd-spf = throw "'pypolicyd-spf' has been renamed to/replaced by 'spf-engine'"; # Converted to throw 2025-10-27
   python3Full = throw "python3Full has been removed. Bluetooth support is now enabled by default. The tkinter package is available within the package set."; # Added 2025-08-30
   python311Full = throw "python311Full has been removed. Bluetooth support is now enabled by default. The tkinter package is available within the package set."; # Added 2025-08-30

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7117,8 +7117,6 @@ with pkgs;
 
   pth = if stdenv.hostPlatform.isMusl then npth else gnupth;
 
-  pyotherside = libsForQt5.callPackage ../development/libraries/pyotherside { };
-
   qbs = libsForQt5.callPackage ../development/tools/build-managers/qbs { };
 
   qdjango = libsForQt5.callPackage ../development/libraries/qdjango { };

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -154,6 +154,8 @@ makeScopeWithSplicing' {
 
         pulseaudio-qt = callPackage ../development/libraries/pulseaudio-qt { };
 
+        pyotherside = callPackage ../development/libraries/pyotherside { };
+
         qca = callPackage ../development/libraries/qca {
           inherit (libsForQt5) qtbase;
         };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -92,6 +92,8 @@ makeScopeWithSplicing' {
 
       maplibre-native-qt = callPackage ../development/libraries/maplibre-native-qt { };
 
+      pyotherside = callPackage ../development/libraries/pyotherside { };
+
       qca = callPackage ../development/libraries/qca {
         inherit (qt6) qtbase qt5compat;
       };


### PR DESCRIPTION
In need of a Qt6 version of this for porting Lomiri Weather App (#381300) to Qt6 (#467662, https://gitlab.com/ubports/development/apps/lomiri-weather-app/-/work_items/121).

Took the liberty to also run the tests, and fix `meta.platforms` being unset.

Only in-tree user of `pyotherside` rn is `pure-maps`, but that has a dependency that hasn't been building since the GCC 15 switch: https://hydra.nixos.org/job/nixpkgs/unstable/libsForQt5.maplibre-native-qt.x86_64-linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
