### PR TITLE
rocmPackages: 7.2.0 -> 7.2.1

### DIFF
--- a/pkgs/development/rocm-modules/amdsmi/default.nix
+++ b/pkgs/development/rocm-modules/amdsmi/default.nix
@@ -21,13 +21,18 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "amdsmi";
-  version = "7.2.0";
+  version = "7.2.1";
   src = fetchFromGitHub {
-    owner = "rocm";
-    repo = "amdsmi";
+    owner = "ROCm";
+    repo = "rocm-systems";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-3V3B9+B3cpg0ebvsmX6wwvKoTIHbXtvbpIQHs4tkeWU=";
+    sparseCheckout = [
+      "projects/amdsmi"
+      "shared"
+    ];
+    hash = "sha256-TFi+3txemvV6K827e8S3hZOd9jcj4Qzop6V9CdKrpLg=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/amdsmi";
 
   postPatch = ''
     substituteInPlace goamdsmi_shim/CMakeLists.txt \
@@ -79,13 +84,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "System management interface for AMD GPUs supported by ROCm";
-    homepage = "https://github.com/ROCm/rocm_smi_lib";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/amdsmi";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ lovesegfault ];
     teams = [ lib.teams.rocm ];

--- a/pkgs/development/rocm-modules/amdsmi/default.nix
+++ b/pkgs/development/rocm-modules/amdsmi/default.nix
@@ -82,10 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     ln -sf $out/libexec/amdsmi_cli/amdsmi_cli.py $out/bin/amd-smi
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "System management interface for AMD GPUs supported by ROCm";

--- a/pkgs/development/rocm-modules/aotriton/default.nix
+++ b/pkgs/development/rocm-modules/aotriton/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   rocm-cmake,
   clr,

--- a/pkgs/development/rocm-modules/aqlprofile/default.nix
+++ b/pkgs/development/rocm-modules/aqlprofile/default.nix
@@ -30,10 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     clr
   ];
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "AQLPROFILE library for AMD HSA runtime API extension support";

--- a/pkgs/development/rocm-modules/aqlprofile/default.nix
+++ b/pkgs/development/rocm-modules/aqlprofile/default.nix
@@ -4,18 +4,24 @@
   clr,
   cmake,
   fetchFromGitHub,
+  rocmUpdateScript,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "aqlprofile";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "aqlprofile";
-    tag = "rocm-7.2.0";
-    hash = "sha256-MAZUHo52gb0aZSFnKugMlXxcDkmMwhy1AFF1RDRgRVk=";
+    repo = "rocm-systems";
+    rev = "rocm-${finalAttrs.version}";
+    sparseCheckout = [
+      "projects/aqlprofile"
+      "shared"
+    ];
+    hash = "sha256-74HjB5Ughu17rSRx9mfCCsPJI4TVyXnT4aU7vIbm7ak=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/aqlprofile";
 
   env.CXXFLAGS = "-DROCP_LD_AQLPROFILE=1";
 
@@ -24,11 +30,16 @@ stdenv.mkDerivation {
     clr
   ];
 
+  passthru.updateScript = rocmUpdateScript {
+    name = finalAttrs.pname;
+    inherit (finalAttrs.src) owner repo;
+  };
+
   meta = {
     description = "AQLPROFILE library for AMD HSA runtime API extension support";
-    homepage = "https://github.com/ROCm/aqlprofile/";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/aqlprofile";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/development/rocm-modules/clr/default.nix
+++ b/pkgs/development/rocm-modules/clr/default.nix
@@ -259,10 +259,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     inherit hipClangPath;
 
-    updateScript = rocmUpdateScript {
-      name = finalAttrs.pname;
-      inherit (finalAttrs.src) owner repo;
-    };
+    updateScript = rocmUpdateScript { inherit finalAttrs; };
 
     impureTests = {
       # bash $(nix-build -A rocmPackages.clr.impureTests.rocm-smi)

--- a/pkgs/development/rocm-modules/clr/default.nix
+++ b/pkgs/development/rocm-modules/clr/default.nix
@@ -13,7 +13,6 @@
   rocm-device-libs,
   rocm-comgr,
   rocm-runtime,
-  rocm-toolchain,
   rocm-core,
   roctracer,
   rocminfo,
@@ -70,7 +69,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "clr";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -82,10 +81,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "clr";
+    repo = "rocm-systems";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-zz2O4Qsl1zXMC25L714azsFR2PROAvdpjgKhRolmt1w=";
+    sparseCheckout = [
+      "projects/clr"
+      "shared"
+    ];
+    hash = "sha256-8V2WbyaJZbEcKZpF/xvg0p+3oX9f/zy/45rkKZT9R3o=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/clr";
 
   nativeBuildInputs = [
     makeWrapper
@@ -257,9 +261,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     updateScript = rocmUpdateScript {
       name = finalAttrs.pname;
-      inherit (finalAttrs.src) owner;
-      inherit (finalAttrs.src) repo;
-      page = "tags?per_page=4";
+      inherit (finalAttrs.src) owner repo;
     };
 
     impureTests = {
@@ -324,7 +326,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "AMD Common Language Runtime for hipamd, opencl, and rocclr";
-    homepage = "https://github.com/ROCm/clr";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/clr";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ lovesegfault ];
     teams = [ lib.teams.rocm ];

--- a/pkgs/development/rocm-modules/composable_kernel/base.nix
+++ b/pkgs/development/rocm-modules/composable_kernel/base.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   pname = "composable_kernel_base";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -55,10 +55,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "composable_kernel";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-ABL0MSmWtqAeY5uyw8Ib64npB2v82baUnzLpmrEgDn4=";
+    sparseCheckout = [
+      "projects/composablekernel"
+      "shared"
+    ];
+    hash = "sha256-Zs6wwPmys1kUlgDD4XzKKw273nH/Ur3HtuYxJjvjDs0=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/composablekernel";
 
   nativeBuildInputs = [
     # Deliberately not using ninja
@@ -172,8 +177,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit gpuTargets miOpenReqLibsOnly;
     updateScript = rocmUpdateScript {
       name = finalAttrs.pname;
-      inherit (finalAttrs.src) owner;
-      inherit (finalAttrs.src) repo;
+      inherit (finalAttrs.src) owner repo;
     };
     anyGfx9Target = lib.lists.any (lib.strings.hasPrefix "gfx9") gpuTargets;
     anyMfmaTarget =
@@ -187,7 +191,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Performance portable programming model for machine learning tensor operators";
-    homepage = "https://github.com/ROCm/composable_kernel";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/composablekernel";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/composable_kernel/base.nix
+++ b/pkgs/development/rocm-modules/composable_kernel/base.nix
@@ -175,10 +175,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit gpuTargets miOpenReqLibsOnly;
-    updateScript = rocmUpdateScript {
-      name = finalAttrs.pname;
-      inherit (finalAttrs.src) owner repo;
-    };
+    updateScript = rocmUpdateScript { inherit finalAttrs; };
     anyGfx9Target = lib.lists.any (lib.strings.hasPrefix "gfx9") gpuTargets;
     anyMfmaTarget =
       (lib.lists.intersectLists gpuTargets [

--- a/pkgs/development/rocm-modules/composable_kernel/ck4inductor.nix
+++ b/pkgs/development/rocm-modules/composable_kernel/ck4inductor.nix
@@ -14,7 +14,7 @@ buildPythonPackage {
     setuptools
     setuptools-scm
   ];
-  inherit (composable_kernel) version src;
+  inherit (composable_kernel) version src sourceRoot;
   pythonImportsCheck = [
     "ck4inductor"
     "ck4inductor.universal_gemm.gen_instances"
@@ -34,7 +34,7 @@ buildPythonPackage {
   '';
   meta = {
     description = "Pytorch inductor backend which uses composable_kernel universal GEMM implementations";
-    homepage = "https://github.com/ROCm/composable_kernel";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/composablekernel";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/default.nix
+++ b/pkgs/development/rocm-modules/default.nix
@@ -3,8 +3,6 @@
   config,
   callPackage,
   newScope,
-  symlinkJoin,
-  fetchFromGitHub,
   boost179,
   opencv,
   python3Packages,

--- a/pkgs/development/rocm-modules/half/default.nix
+++ b/pkgs/development/rocm-modules/half/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "half";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
@@ -25,8 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {

--- a/pkgs/development/rocm-modules/half/default.nix
+++ b/pkgs/development/rocm-modules/half/default.nix
@@ -23,10 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     rocm-cmake
   ];
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "C++ library for half precision floating point arithmetics";

--- a/pkgs/development/rocm-modules/hip-common/default.nix
+++ b/pkgs/development/rocm-modules/hip-common/default.nix
@@ -33,10 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "C++ Heterogeneous-Compute Interface for Portability";

--- a/pkgs/development/rocm-modules/hip-common/default.nix
+++ b/pkgs/development/rocm-modules/hip-common/default.nix
@@ -7,14 +7,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hip-common";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "HIP";
+    repo = "rocm-systems";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-eQ+jHc6MlZePPIwJQMB8NKiEcE26i83+U21vKgfGFFM=";
+    sparseCheckout = [
+      "projects/hip"
+      "shared"
+    ];
+    hash = "sha256-orfTXKjcZJ5E73cmXEyltZVYhCQo8FLExVHM3J/rqUM=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/hip";
 
   dontConfigure = true;
   dontBuild = true;
@@ -30,13 +35,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "C++ Heterogeneous-Compute Interface for Portability";
-    homepage = "https://github.com/ROCm/HIP";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/hip";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ lovesegfault ];
     teams = [ lib.teams.rocm ];

--- a/pkgs/development/rocm-modules/hipblas-common/default.nix
+++ b/pkgs/development/rocm-modules/hipblas-common/default.nix
@@ -32,10 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
   meta = {
     description = "Common files shared by hipBLAS and hipBLASLt";
     homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas-common";

--- a/pkgs/development/rocm-modules/hipblas-common/default.nix
+++ b/pkgs/development/rocm-modules/hipblas-common/default.nix
@@ -8,14 +8,19 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipblas-common";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "hipBLAS-common";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-oOelDrk7TLe9/17fzaw6CDPL4MGAoITJL90ahHzhaAE=";
+    sparseCheckout = [
+      "projects/hipblas-common"
+      "shared"
+    ];
+    hash = "sha256-83LgS4I1fMSaNtWdVFf1qhYRMT7a9jVzO3XpUzEipXg=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/hipblas-common";
 
   nativeBuildInputs = [
     cmake
@@ -29,12 +34,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
   meta = {
     description = "Common files shared by hipBLAS and hipBLASLt";
-    homepage = "https://github.com/ROCm/hipBLASlt";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas-common";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/hipblas/default.nix
+++ b/pkgs/development/rocm-modules/hipblas/default.nix
@@ -24,7 +24,7 @@
 # Can also use cuBLAS
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipblas";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -41,10 +41,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "hipBLAS";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-w7myy4FO2vKm91OOfSGWO3bxR8jAvjU68oqI7aJX82c=";
+    sparseCheckout = [
+      "projects/hipblas"
+      "shared"
+    ];
+    hash = "sha256-1+aNDotV5liHBnGddmWtaKYCcsWPxQD3AoEubnghV0M=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/hipblas";
 
   postPatch = ''
     substituteInPlace library/CMakeLists.txt \
@@ -112,8 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
   passthru.tests.hipblas-tested = hipblas.override {
     buildTests = true;
@@ -123,7 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "ROCm BLAS marshalling library";
-    homepage = "https://github.com/ROCm/hipBLAS";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblas";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/hipblas/default.nix
+++ b/pkgs/development/rocm-modules/hipblas/default.nix
@@ -115,10 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
       rmdir $out/bin
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
   passthru.tests.hipblas-tested = hipblas.override {
     buildTests = true;
     buildBenchmarks = true;

--- a/pkgs/development/rocm-modules/hipblaslt/default.nix
+++ b/pkgs/development/rocm-modules/hipblaslt/default.nix
@@ -70,13 +70,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipblaslt${clr.gpuArchSuffix}";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
     repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-+yaOUA8hzRPnz14Cmp2BbfIS5811PgMcHQLY2+FatMU=";
+    hash = "sha256-+xMmPKb32NP9U35dHCXfXWwa6exfiL5TezfXERVDfe4=";
     sparseCheckout = [
       "projects/hipblaslt"
       "shared"
@@ -251,7 +251,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
   meta = {
     description = "Library that provides general matrix-matrix operations with a flexible API";
-    homepage = "https://github.com/ROCm/hipBLASlt";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblaslt";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/hipblaslt/default.nix
+++ b/pkgs/development/rocm-modules/hipblaslt/default.nix
@@ -245,10 +245,7 @@ stdenv.mkDerivation (finalAttrs: {
   # and are fine ignoring it at runtime if it's not supported
   # so we have to support building an empty hipblaslt
   passthru.supportsTargetArches = supportsTargetArches;
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
   meta = {
     description = "Library that provides general matrix-matrix operations with a flexible API";
     homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipblaslt";

--- a/pkgs/development/rocm-modules/hipcub/default.nix
+++ b/pkgs/development/rocm-modules/hipcub/default.nix
@@ -88,10 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
       rmdir $out/bin
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Thin wrapper library on top of rocPRIM or CUB";

--- a/pkgs/development/rocm-modules/hipcub/default.nix
+++ b/pkgs/development/rocm-modules/hipcub/default.nix
@@ -17,7 +17,7 @@
 # CUB can also be used as a backend instead of rocPRIM.
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipcub";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -31,10 +31,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "hipCUB";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-hIIpU1E/X6bPIhFfauNLPnFNBYSwtoxZV335Huw9fCA=";
+    sparseCheckout = [
+      "projects/hipcub"
+      "shared"
+    ];
+    hash = "sha256-geO6LS1osKAlmVRtiZ6keqFHsJccyB7pRZdWPEkue2M=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/hipcub";
 
   nativeBuildInputs = [
     cmake
@@ -85,13 +90,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "Thin wrapper library on top of rocPRIM or CUB";
-    homepage = "https://github.com/ROCm/hipCUB";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipcub";
     license = with lib.licenses; [ bsd3 ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/hipfft/default.nix
+++ b/pkgs/development/rocm-modules/hipfft/default.nix
@@ -109,10 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
       rmdir $out/bin
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "FFT marshalling library";

--- a/pkgs/development/rocm-modules/hipfft/default.nix
+++ b/pkgs/development/rocm-modules/hipfft/default.nix
@@ -21,7 +21,7 @@
 # Can also use cuFFT
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipfft";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -38,11 +38,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "hipFFT";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-5zeL3o/Dfh0iyZOj5CHyfEQdFNehD2BLmllnZRdpsQI=";
+    sparseCheckout = [
+      "projects/hipfft"
+      "shared"
+    ];
     fetchSubmodules = true;
+    hash = "sha256-EtxZuxBPx6trTN9iC7uri2+UR0Eolp919Ry4U1PEqNA=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/hipfft";
 
   nativeBuildInputs = [
     clr
@@ -106,13 +111,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "FFT marshalling library";
-    homepage = "https://github.com/ROCm/hipFFT";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipfft";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/hipfort/default.nix
+++ b/pkgs/development/rocm-modules/hipfort/default.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipfort";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
@@ -52,8 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {

--- a/pkgs/development/rocm-modules/hipfort/default.nix
+++ b/pkgs/development/rocm-modules/hipfort/default.nix
@@ -50,10 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "/bin/ln" "ln"
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Fortran interfaces for ROCm libraries";

--- a/pkgs/development/rocm-modules/hipify/default.nix
+++ b/pkgs/development/rocm-modules/hipify/default.nix
@@ -45,10 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     chmod +x bin/*
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   postInstall = ''
     rm $out/bin/hipify-perl

--- a/pkgs/development/rocm-modules/hipify/default.nix
+++ b/pkgs/development/rocm-modules/hipify/default.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipify";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
@@ -47,8 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   postInstall = ''

--- a/pkgs/development/rocm-modules/hiprand/default.nix
+++ b/pkgs/development/rocm-modules/hiprand/default.nix
@@ -66,10 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     rmdir $out/bin
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "HIP wrapper for rocRAND and cuRAND";

--- a/pkgs/development/rocm-modules/hiprand/default.nix
+++ b/pkgs/development/rocm-modules/hiprand/default.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hiprand";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -25,10 +25,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "hipRAND";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-mhhwYswewcRYKGoVAB/ZTIY8ubFSlTDXKZFoJpoDf2o=";
+    sparseCheckout = [
+      "projects/hiprand"
+      "shared"
+    ];
+    hash = "sha256-bjcwjN1dNukhoDAbiSpATlK6dtAwM8bOJTe3IjhdwwY=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/hiprand";
 
   nativeBuildInputs = [
     cmake
@@ -63,13 +68,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "HIP wrapper for rocRAND and cuRAND";
-    homepage = "https://github.com/ROCm/hipRAND";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/hiprand";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/hipsolver/default.nix
+++ b/pkgs/development/rocm-modules/hipsolver/default.nix
@@ -105,10 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
       rmdir $out/bin
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "ROCm SOLVER marshalling library";

--- a/pkgs/development/rocm-modules/hipsolver/default.nix
+++ b/pkgs/development/rocm-modules/hipsolver/default.nix
@@ -21,7 +21,7 @@
 # Can also use cuSOLVER
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipsolver";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -38,10 +38,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "hipSOLVER";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-xrzRU3X0zlmK6t8Bz4p5ihnJnadrqiW1BW2HLRDpu1M=";
+    sparseCheckout = [
+      "projects/hipsolver"
+      "shared"
+    ];
+    hash = "sha256-ts5wuXHoBFZ1WMAk8Ir5cucP75G0SMOWmn3FEH04ZEQ=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/hipsolver";
 
   nativeBuildInputs = [
     cmake
@@ -102,13 +107,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "ROCm SOLVER marshalling library";
-    homepage = "https://github.com/ROCm/hipSOLVER";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsolver";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/hipsparse/default.nix
+++ b/pkgs/development/rocm-modules/hipsparse/default.nix
@@ -136,10 +136,7 @@ stdenv.mkDerivation (finalAttrs: {
       } $sample/bin/example_*
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "ROCm SPARSE marshalling library";

--- a/pkgs/development/rocm-modules/hipsparse/default.nix
+++ b/pkgs/development/rocm-modules/hipsparse/default.nix
@@ -19,7 +19,7 @@
 # This can also use cuSPARSE as a backend instead of rocSPARSE
 stdenv.mkDerivation (finalAttrs: {
   pname = "hipsparse";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -33,10 +33,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "hipSPARSE";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-DmanHHlDny/SweYrSes4xQeWoF6TV+AoThyDHQpz+hQ=";
+    sparseCheckout = [
+      "projects/hipsparse"
+      "shared"
+    ];
+    hash = "sha256-E1chG+giFtf02fjutoV4yM2XvrQKjgXRSvxs0NBBkvI=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/hipsparse";
 
   nativeBuildInputs = [
     cmake
@@ -133,13 +138,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "ROCm SPARSE marshalling library";
-    homepage = "https://github.com/ROCm/hipSPARSE";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/hipsparse";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/llvm/default.nix
+++ b/pkgs/development/rocm-modules/llvm/default.nix
@@ -13,7 +13,6 @@
   zstd,
   gcc-unwrapped,
   glibc,
-  replaceVars,
   libffi,
   libxml2,
   removeReferencesTo,
@@ -37,7 +36,7 @@
 }:
 
 let
-  version = "7.2.0";
+  version = "7.2.1";
   # major version of this should be the clang version ROCm forked from
   rocmLlvmVersion = "22.0.0-rocm";
   # llvmPackages_base version should match rocmLlvmVersion
@@ -119,7 +118,7 @@ let
     owner = "ROCm";
     repo = "llvm-project";
     rev = "rocm-${version}";
-    hash = "sha256-I/Bxq1JjU9N4h3vXj/tbD3xPYY4+N7QzYA8UTIq1EL0=";
+    hash = "sha256-TwFvQimbax2E37ZC/52lNkHXCgyBNfSGDBaqmas2x/s=";
   };
   llvmMajorVersion = lib.versions.major rocmLlvmVersion;
   # An llvmPackages (pkgs/development/compilers/llvm/) built from ROCm LLVM's source tree
@@ -295,16 +294,6 @@ in
 overrideLlvmPackagesRocm (s: {
   libllvm = (s.prev.libllvm.override { }).overrideAttrs (old: {
     patches = old.patches ++ [
-      (fetchpatch {
-        # Revert of a patch that cause perf regression by pessimising loop unrolling decisions
-        # See PR and issue discussion
-        # https://github.com/ROCm/rocm-systems/issues/2865 https://github.com/ROCm/llvm-project/pull/1349
-        name = "rocm-llvm-revert-unrolling-regression.patch";
-        url = "https://github.com/ROCm/llvm-project/commit/f58b06dce1f9c15707c5f808fd002e18c2accf7e.patch";
-        hash = "sha256-pH+3C7PSDqNfOF014sA5Rvm+sc2IJMQJfysS2bvj/o0=";
-        # stripLen instead of relative to avoid filterdiff mangling /dev/null on the deleted test file
-        stripLen = 1;
-      })
       ./perf-increase-namestring-size.patch
       # v64i8 shuffle lowering inf loop on VBMI targets, hangs whisper-cpp etc
       # https://github.com/NixOS/nixpkgs/issues/497745

--- a/pkgs/development/rocm-modules/migraphx/default.nix
+++ b/pkgs/development/rocm-modules/migraphx/default.nix
@@ -59,7 +59,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "migraphx";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ROCm";
     repo = "AMDMIGraphX";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-FBAVsk4x3ATLDYtfzcPUPnUTwe36maIAY1/FwqG6jD0=";
+    hash = "sha256-2jNdbfDLHqifCst8yPiJy7y2/PIaaVS9101p3VZTvnc=";
   };
 
   nativeBuildInputs = [
@@ -192,8 +192,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {

--- a/pkgs/development/rocm-modules/migraphx/default.nix
+++ b/pkgs/development/rocm-modules/migraphx/default.nix
@@ -190,10 +190,7 @@ stdenv.mkDerivation (finalAttrs: {
       migraphx = finalAttrs.finalPackage;
     };
   };
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "AMD's graph optimization engine";

--- a/pkgs/development/rocm-modules/miopen/default.nix
+++ b/pkgs/development/rocm-modules/miopen/default.nix
@@ -43,7 +43,7 @@
 let
   # FIXME: cmake files need patched to include this properly
   cFlags = "-Wno-documentation-pedantic --offload-compress -I${hipblas-common}/include -I${hipblas}/include -I${roctracer}/include -I${nlohmann_json}/include -I${sqlite.dev}/include -I${rocrand}/include";
-  version = "7.2.0";
+  version = "7.2.1";
 
   # Targets outside this list will get
   # error: use of undeclared identifier 'CK_BUFFER_RESOURCE_3RD_DWORD'
@@ -64,14 +64,6 @@ let
     "gfx1200"
     "gfx1201"
   ] gpuTargets;
-
-  src = fetchFromGitHub {
-    owner = "ROCm";
-    repo = "MIOpen";
-    rev = "rocm-${version}";
-    hash = "sha256-OwBFzUruHHeJD7n3zLs/NsU5cNEjwkwFgim4m2/1hR0=";
-    fetchSubmodules = true;
-  };
 
   latex = lib.optionalAttrs buildDocs (
     texliveSmall.withPackages (
@@ -103,7 +95,9 @@ let
       } > $out
     '';
 
-  kdbs = lib.mapAttrs fetchKdb (import ./kdbs.nix);
+  kdbs = lib.mapAttrs fetchKdb (
+    lib.filterAttrs (name: _: lib.elem name supportedTargets) (import ./kdbs.nix)
+  );
 
   linkKDBsTo =
     targetPath:
@@ -114,8 +108,21 @@ let
     );
 in
 stdenv.mkDerivation (finalAttrs: {
-  inherit version src;
+  inherit version;
   pname = "miopen";
+
+  src = fetchFromGitHub {
+    owner = "ROCm";
+    repo = "rocm-libraries";
+    rev = "rocm-${finalAttrs.version}";
+    sparseCheckout = [
+      "projects/miopen"
+      "shared"
+    ];
+    fetchSubmodules = true;
+    hash = "sha256-plZpBTbEBVMa5CasjfbUsu45xP/BYstrEpWKK2H7QQ4=";
+  };
+  sourceRoot = "${finalAttrs.src.name}/projects/miopen";
 
   env.CFLAGS = cFlags;
   env.CXXFLAGS = cFlags;
@@ -305,7 +312,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Machine intelligence library for ROCm";
-    homepage = "https://github.com/ROCm/MIOpen";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/miopen";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/miopen/update.sh
+++ b/pkgs/development/rocm-modules/miopen/update.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 gh_curl() { curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sf "$@"; }
 
-version="${1:-$(gh_curl "https://api.github.com/repos/ROCm/MIOpen/releases?per_page=4" \
+version="${1:-$(gh_curl "https://api.github.com/repos/ROCm/rocm-libraries/releases?per_page=4" \
   | jq -re 'map(.tag_name // .name)
     | map(select(test("^rocm-[0-9]+\\.[0-9]+(\\.[0-9]+)?$")))
     | first | ltrimstr("rocm-")')}"
@@ -19,7 +19,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 bucket="https://therock-dvc.s3.amazonaws.com/rocm-libraries/files/md5"
 
 # Fetch directory listing; extract name + download_url for .dvc files
-dvc_entries=$(gh_curl "https://api.github.com/repos/ROCm/MIOpen/contents/src/kernels?ref=rocm-${version}" \
+dvc_entries=$(gh_curl "https://api.github.com/repos/ROCm/rocm-libraries/contents/projects/miopen/src/kernels?ref=rocm-${version}" \
   | jq -r '.[] | select(.name | endswith(".kdb.bz2.dvc")) | "\(.name)\t\(.download_url)"')
 
 [[ -n "$dvc_entries" ]] || { echo "No .kdb.bz2.dvc files found, upstream likely changed packaging again" >&2; exit 1; }

--- a/pkgs/development/rocm-modules/mivisionx/default.nix
+++ b/pkgs/development/rocm-modules/mivisionx/default.nix
@@ -125,10 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3 -m sphinx -T -E -b html -d _build/doctrees -D language=en ../docs _build/html
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Set of comprehensive computer vision and machine intelligence libraries, utilities, and applications";

--- a/pkgs/development/rocm-modules/mivisionx/default.nix
+++ b/pkgs/development/rocm-modules/mivisionx/default.nix
@@ -40,13 +40,13 @@ stdenv.mkDerivation (finalAttrs: {
         "cpu"
     );
 
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
     repo = "MIVisionX";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-rdYQt001kFi9FjVL5R8XVzT+Y+rZVeMsbjXCJEB887A=";
+    hash = "sha256-LyiPcZi4vU0R+eI/AbYk8ioewuqET5lCtArtPltJ+Gw=";
   };
 
   patches = [
@@ -127,8 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {

--- a/pkgs/development/rocm-modules/rccl/default.nix
+++ b/pkgs/development/rocm-modules/rccl/default.nix
@@ -40,7 +40,7 @@ in
 # infiniband ib_peer_mem support isn't in the mainline kernel but is carried by some distros
 stdenv.mkDerivation (finalAttrs: {
   pname = "rccl${clr.gpuArchSuffix}";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ROCm";
     repo = "rccl";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-Kpobn0fR7/mXGVWYjNQ35sToRWLfOQTHRbjuSYj1of4=";
+    hash = "sha256-A1IQYIDWqu3JLiPQ70G52s1/0ZweQxFlgMUH81qJWmU=";
   };
 
   requiredSystemFeatures = [ "big-parallel" ]; # Very resource intensive LTO
@@ -140,8 +140,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   # This package with sanitizers + manual integration test binaries built

--- a/pkgs/development/rocm-modules/rccl/default.nix
+++ b/pkgs/development/rocm-modules/rccl/default.nix
@@ -138,10 +138,7 @@ stdenv.mkDerivation (finalAttrs: {
       rmdir $out/bin
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   # This package with sanitizers + manual integration test binaries built
   # must be ran manually

--- a/pkgs/development/rocm-modules/rdc/default.nix
+++ b/pkgs/development/rocm-modules/rdc/default.nix
@@ -49,7 +49,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rdc";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -63,10 +63,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rdc";
+    repo = "rocm-systems";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-gF17mcbsqsL2K9pwTAVG9E6nVY4pi2lC88WyPa0xMes=";
+    sparseCheckout = [
+      "projects/rdc"
+      "shared"
+    ];
+    hash = "sha256-SmySauRxFnEQJVTjGYf4TpmQclTwZG2RZrk3u6ko5Qo=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rdc";
 
   patches = [
     # https://github.com/ROCm/rocm-systems/pull/2423
@@ -135,13 +140,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "Simplifies administration and addresses infrastructure challenges in cluster and datacenter environments";
-    homepage = "https://github.com/ROCm/rdc";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/rdc";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/rdc/default.nix
+++ b/pkgs/development/rocm-modules/rdc/default.nix
@@ -138,10 +138,7 @@ stdenv.mkDerivation (finalAttrs: {
     mv $out/bin/rdctst_tests $test/bin
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Simplifies administration and addresses infrastructure challenges in cluster and datacenter environments";

--- a/pkgs/development/rocm-modules/rocalution/default.nix
+++ b/pkgs/development/rocm-modules/rocalution/default.nix
@@ -110,10 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
       rmdir $out/bin
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Iterative sparse solvers for ROCm";

--- a/pkgs/development/rocm-modules/rocalution/default.nix
+++ b/pkgs/development/rocm-modules/rocalution/default.nix
@@ -22,7 +22,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocalution";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ROCm";
     repo = "rocALUTION";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-7ZlY0GVIsUJE8OOAkQwQ4pXNHKzgCQomQOET9+TKQN4=";
+    hash = "sha256-yPM26e8tGNpPScIriAPRb+6OZfdpX4PgE0E9bmc3FkU=";
   };
 
   nativeBuildInputs = [
@@ -112,8 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {

--- a/pkgs/development/rocm-modules/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/rocblas/default.nix
@@ -192,10 +192,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     amdgpu_targets = gpuTargets';
-    updateScript = rocmUpdateScript {
-      name = finalAttrs.pname;
-      inherit (finalAttrs.src) owner repo;
-    };
+    updateScript = rocmUpdateScript { inherit finalAttrs; };
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/rocm-modules/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/rocblas/default.nix
@@ -40,14 +40,19 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocblas${clr.gpuArchSuffix}";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocBLAS";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-oY6yELFnpnDDksu63Go88TGLAgC64tUaPIbaRgD2qus=";
+    sparseCheckout = [
+      "projects/rocblas"
+      "shared"
+    ];
+    hash = "sha256-wrjcr2ASSF+bk5atjvKfIYSbg+vevo/a2W2ca9Nft/4=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocblas";
 
   outputs = [ "out" ] ++ lib.optional buildBenchmarks "benchmark" ++ lib.optional buildTests "test";
 
@@ -189,8 +194,7 @@ stdenv.mkDerivation (finalAttrs: {
     amdgpu_targets = gpuTargets';
     updateScript = rocmUpdateScript {
       name = finalAttrs.pname;
-      inherit (finalAttrs.src) owner;
-      inherit (finalAttrs.src) repo;
+      inherit (finalAttrs.src) owner repo;
     };
   };
 
@@ -199,7 +203,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "BLAS implementation for ROCm platform";
-    homepage = "https://github.com/ROCm/rocBLAS";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocblas";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/rocdbgapi/default.nix
+++ b/pkgs/development/rocm-modules/rocdbgapi/default.nix
@@ -47,7 +47,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocdbgapi";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -99,8 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {

--- a/pkgs/development/rocm-modules/rocdbgapi/default.nix
+++ b/pkgs/development/rocm-modules/rocdbgapi/default.nix
@@ -97,10 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     rmdir $out/share/html
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Debugger support for control of execution and inspection state of AMD's GPU architectures";

--- a/pkgs/development/rocm-modules/rocfft/default.nix
+++ b/pkgs/development/rocm-modules/rocfft/default.nix
@@ -20,14 +20,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocfft${clr.gpuArchSuffix}";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocFFT";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-AFBV5tlhNYH9+d0KG7mCjSifKfRt+8c1ie5wASTiQXM=";
+    sparseCheckout = [
+      "projects/rocfft"
+      "shared"
+    ];
+    hash = "sha256-RjWMzLX0nBA8ClweJ8YgRTn+Nzt/VUkOoSw3jMQ3IWg=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocfft";
 
   nativeBuildInputs = [
     cmake
@@ -68,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
       pname = "${finalAttrs.pname}-test";
       inherit (finalAttrs) version src;
 
-      sourceRoot = "${finalAttrs.src.name}/clients/tests";
+      sourceRoot = "${finalAttrs.src.name}/projects/rocfft/clients/tests";
 
       nativeBuildInputs = [
         cmake
@@ -97,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
       pname = "${finalAttrs.pname}-benchmark";
       inherit (finalAttrs) version src;
 
-      sourceRoot = "${finalAttrs.src.name}/clients/rider";
+      sourceRoot = "${finalAttrs.src.name}/projects/rocfft/clients/rider";
 
       nativeBuildInputs = [
         cmake
@@ -127,7 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
       pname = "${finalAttrs.pname}-samples";
       inherit (finalAttrs) version src;
 
-      sourceRoot = "${finalAttrs.src.name}/clients/samples";
+      sourceRoot = "${finalAttrs.src.name}/projects/rocfft/clients/samples";
 
       nativeBuildInputs = [
         cmake
@@ -152,8 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     updateScript = rocmUpdateScript {
       name = finalAttrs.pname;
-      inherit (finalAttrs.src) owner;
-      inherit (finalAttrs.src) repo;
+      inherit (finalAttrs.src) owner repo;
     };
   };
 
@@ -161,7 +165,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "FFT implementation for ROCm";
-    homepage = "https://github.com/ROCm/rocFFT";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocfft";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/rocfft/default.nix
+++ b/pkgs/development/rocm-modules/rocfft/default.nix
@@ -155,10 +155,7 @@ stdenv.mkDerivation (finalAttrs: {
       '';
     };
 
-    updateScript = rocmUpdateScript {
-      name = finalAttrs.pname;
-      inherit (finalAttrs.src) owner repo;
-    };
+    updateScript = rocmUpdateScript { inherit finalAttrs; };
   };
 
   requiredSystemFeatures = [ "big-parallel" ];

--- a/pkgs/development/rocm-modules/rocgdb/default.nix
+++ b/pkgs/development/rocm-modules/rocgdb/default.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocgdb";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
@@ -103,8 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {

--- a/pkgs/development/rocm-modules/rocgdb/default.nix
+++ b/pkgs/development/rocm-modules/rocgdb/default.nix
@@ -101,10 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
   env.CFLAGS = "-Wno-switch -Wno-format-nonliteral -I${zstd.dev}/include -I${zlib.dev}/include -I${expat.dev}/include -I${ncurses.dev}/include";
   env.CXXFLAGS = finalAttrs.env.CFLAGS;
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "ROCm source-level debugger for Linux, based on GDB";

--- a/pkgs/development/rocm-modules/rocm-cmake/default.nix
+++ b/pkgs/development/rocm-modules/rocm-cmake/default.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-cmake";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
@@ -24,8 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {

--- a/pkgs/development/rocm-modules/rocm-cmake/default.nix
+++ b/pkgs/development/rocm-modules/rocm-cmake/default.nix
@@ -22,10 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ rocm-core ];
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "CMake modules for common build tasks for the ROCm stack";

--- a/pkgs/development/rocm-modules/rocm-core/default.nix
+++ b/pkgs/development/rocm-modules/rocm-core/default.nix
@@ -83,10 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   passthru.ROCM_LIBPATCH_VERSION = finalAttrs.env.ROCM_LIBPATCH_VERSION;
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Utility for getting the ROCm release version";

--- a/pkgs/development/rocm-modules/rocm-core/default.nix
+++ b/pkgs/development/rocm-modules/rocm-core/default.nix
@@ -17,14 +17,19 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-core";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocm-core";
+    repo = "rocm-systems";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-AqD6MByFAtY6IzAFXdCrCANPXqROaGHybdKixv3NbXE=";
+    sparseCheckout = [
+      "projects/rocm-core"
+      "shared"
+    ];
+    hash = "sha256-Y3WuDwruD5zKN2epwfUCZAGq5vgxCT27awJN8JxmOsY=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocm-core";
 
   patches = [
     ./env-rocm-path.patch
@@ -80,14 +85,12 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.ROCM_LIBPATCH_VERSION = finalAttrs.env.ROCM_LIBPATCH_VERSION;
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
-    page = "tags?per_page=4";
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "Utility for getting the ROCm release version";
-    homepage = "https://github.com/ROCm/rocm-core";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/rocm-core";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/rocm-device-libs/default.nix
+++ b/pkgs/development/rocm-modules/rocm-device-libs/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  fetchpatch,
   cmake,
   ninja,
   zlib,

--- a/pkgs/development/rocm-modules/rocm-docs-core/default.nix
+++ b/pkgs/development/rocm-modules/rocm-docs-core/default.nix
@@ -24,14 +24,14 @@
 # FIXME: Move to rocmPackages_common
 buildPythonPackage rec {
   pname = "rocm-docs-core";
-  version = "1.31.3";
+  version = "1.33.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ROCm";
     repo = "rocm-docs-core";
     rev = "v${version}";
-    hash = "sha256-N9wqu83fPQGgOSDdb4yXmfxfDxkevk6QA31vLl5sYHo=";
+    hash = "sha256-eHX5Vz3MmIHi6n90hgBm4Ik+MGhxmniw2Me6pyZVC+k=";
   };
 
   buildInputs = [ setuptools ];

--- a/pkgs/development/rocm-modules/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/rocm-runtime/default.nix
@@ -94,10 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     export HIP_DEVICE_LIB_PATH="${rocm-device-libs}/amdgcn/bitcode"
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Platform runtime for ROCm";

--- a/pkgs/development/rocm-modules/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/rocm-runtime/default.nix
@@ -16,14 +16,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-runtime";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "ROCR-Runtime";
+    repo = "rocm-systems";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-6xELKQ/uqAoorsCR/H7d8iNK7LsVNsW2DRRZo5cU7UM=";
+    sparseCheckout = [
+      "projects/rocr-runtime"
+      "shared"
+    ];
+    hash = "sha256-hcyjOLMtoBX/p6r6R9Bl9635DuvI6rTn1KziHMeyYM0=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocr-runtime";
 
   cmakeBuildType = "RelWithDebInfo";
   separateDebugInfo = true;
@@ -67,19 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/ROCm/ROCR-Runtime/commit/41bfc66aef437a5b349f71105fa4b907cc7e17d5.patch";
       hash = "sha256-A7VhPR3eSsmjq2cTBSjBIz9i//WiNjoXm0EsRKtF+ns=";
     })
-    (fetchpatch {
-      # [PATCH] hsakmt: Expose and use CWSR and Control stack sizes (#2200)
-      # Fixes potential mismatches between stack sizes configured in amdgpu kernel module
-      # and userspace by relying on kernel value when available
-      # Falls back to hardcoded size based on ISA if kernel is too old. For gfx1151, also prints:
-      # WARNING: KFD ABI 1.20+ is recommended … This may result in faults, crashes and other application instability
-      # This allows new kernels to work with this runtime detection mechanism
-      # Only gfx1151 warns loudly because only it has had the size updated in kernel…
-      name = "rocr-runtime-kernel-stack-size.patch";
-      url = "https://github.com/ROCm/rocm-systems/commit/7037a71f311c021974fafd13727dfefd8a1cc79d.patch";
-      relative = "projects/rocr-runtime";
-      hash = "sha256-EbDxuEvNu0fyQJZmqq0fbcCdNtaEWUbmyPLvcfqDPjc=";
-    })
     # This causes a circular dependency, aqlprofile relies on hsa-runtime64
     # which is part of rocm-runtime
     # Worked around by having rocprofiler load aqlprofile directly
@@ -104,13 +96,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "Platform runtime for ROCm";
-    homepage = "https://github.com/ROCm/ROCR-Runtime";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/rocr-runtime";
     license = with lib.licenses; [ ncsa ];
     maintainers = with lib.maintainers; [ lovesegfault ];
     teams = [ lib.teams.rocm ];

--- a/pkgs/development/rocm-modules/rocm-smi/default.nix
+++ b/pkgs/development/rocm-modules/rocm-smi/default.nix
@@ -11,14 +11,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocm-smi";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocm_smi_lib";
+    repo = "rocm-systems";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-IeOutA/Mpt/75VpdcfPnZrWvx6GG/JLaQNfBrNKb+Mw=";
+    sparseCheckout = [
+      "projects/rocm-smi-lib"
+      "shared"
+    ];
+    hash = "sha256-Si8SbeVKUBtqk6h2QJ9ssQV68bLq6TvESrYXJuArHd8=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocm-smi-lib";
 
   propagatedBuildInputs = [
     libdrm
@@ -57,13 +62,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "System management interface for AMD GPUs supported by ROCm";
-    homepage = "https://github.com/ROCm/rocm_smi_lib";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/rocm-smi-lib";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ lovesegfault ];
     teams = [ lib.teams.rocm ];

--- a/pkgs/development/rocm-modules/rocm-smi/default.nix
+++ b/pkgs/development/rocm-modules/rocm-smi/default.nix
@@ -60,10 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
       ln -s ${libdrm.dev}/include/libdrm/ $out/include/
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "System management interface for AMD GPUs supported by ROCm";

--- a/pkgs/development/rocm-modules/rocminfo/default.nix
+++ b/pkgs/development/rocm-modules/rocminfo/default.nix
@@ -43,10 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     sed 's,lsmod | grep ,${busybox}/bin/lsmod | ${gnugrep}/bin/grep ,' -i rocminfo.cc
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "ROCm Application for Reporting System Info";

--- a/pkgs/development/rocm-modules/rocminfo/default.nix
+++ b/pkgs/development/rocm-modules/rocminfo/default.nix
@@ -12,15 +12,20 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "7.2.0";
+  version = "7.2.1";
   pname = "rocminfo";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocminfo";
+    repo = "rocm-systems";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-Md91iH2YWU7ziNE//xxKuk2RrXdujO9mY6SZY5R9TqA=";
+    sparseCheckout = [
+      "projects/rocminfo"
+      "shared"
+    ];
+    hash = "sha256-0esRBEXVibC2uzyonpc0ABNNHQ2NAWZrBmmg6p1zP0c=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocminfo";
 
   strictDeps = true;
 
@@ -40,13 +45,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "ROCm Application for Reporting System Info";
-    homepage = "https://github.com/ROCm/rocminfo";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/rocminfo";
     license = lib.licenses.ncsa;
     mainProgram = "rocminfo";
     maintainers = with lib.maintainers; [ lovesegfault ];

--- a/pkgs/development/rocm-modules/rocmlir/default.nix
+++ b/pkgs/development/rocm-modules/rocmlir/default.nix
@@ -146,11 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
       patchelf --set-rpath $out/lib:$external/lib:${libPath} $out/{bin/*,lib/*.so*}
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-    page = "tags?per_page=4";
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "MLIR-based convolution and GEMM kernel generator";

--- a/pkgs/development/rocm-modules/rocmlir/default.nix
+++ b/pkgs/development/rocm-modules/rocmlir/default.nix
@@ -148,8 +148,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
     page = "tags?per_page=4";
   };
 

--- a/pkgs/development/rocm-modules/rocprim/default.nix
+++ b/pkgs/development/rocm-modules/rocprim/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocprim";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -29,10 +29,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocPRIM";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-/6x4S8W4MbWY+M2b46Tmebj2echBIs31OnKq+50M21M=";
+    sparseCheckout = [
+      "projects/rocprim"
+      "shared"
+    ];
+    hash = "sha256-e0mZ27OXyblcnXQGv2ex/CvWx9smw6nBbHZIijj7lP8=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocprim";
 
   nativeBuildInputs = [
     cmake
@@ -82,13 +87,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "ROCm parallel primitives";
-    homepage = "https://github.com/ROCm/rocPRIM";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocprim";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/rocprim/default.nix
+++ b/pkgs/development/rocm-modules/rocprim/default.nix
@@ -85,10 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
       rmdir $out/bin
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "ROCm parallel primitives";

--- a/pkgs/development/rocm-modules/rocprofiler-register/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler-register/default.nix
@@ -18,15 +18,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocprofiler-register";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocprofiler-register";
+    repo = "rocm-systems";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-6jr6dfmCjeP5PCNfLDMmh8IO9Hxz6RvLlacNwIWQduQ=";
+    sparseCheckout = [
+      "projects/rocprofiler-register"
+      "shared"
+    ];
     fetchSubmodules = true;
+    hash = "sha256-2u5rLLT4Aif0jwAqqlIzrzh9kICJG15nZAslbiL7H9g=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocprofiler-register";
 
   nativeBuildInputs = [
     cmake
@@ -66,13 +71,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = "rocprofiler-register";
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "Profiling with perf-counters and derived metrics";
-    homepage = "https://github.com/ROCm/rocprofiler";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprofiler-register";
     license = with lib.licenses; [ mit ]; # mitx11
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/rocprofiler-register/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler-register/default.nix
@@ -69,10 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
   ];
 
-  passthru.updateScript = rocmUpdateScript {
-    name = "rocprofiler-register";
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Profiling with perf-counters and derived metrics";

--- a/pkgs/development/rocm-modules/rocprofiler/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler/default.nix
@@ -44,15 +44,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocprofiler";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocprofiler";
+    repo = "rocm-systems";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-W32VAdtZdFmkHeUwyHIIHk8yRnABq6gUaHLZ9Bj8kYI=";
+    sparseCheckout = [
+      "projects/rocprofiler"
+      "shared"
+    ];
     fetchSubmodules = true;
+    hash = "sha256-Wo0pymD8LsrdczdIUEEVe5x2Id//KIFkh40kliAQgWo=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocprofiler";
 
   nativeBuildInputs = [
     cmake
@@ -125,14 +130,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
   passthru.rocmtoolkit-merged = rocmtoolkit-merged;
 
   meta = {
     description = "Profiling with perf-counters and derived metrics";
-    homepage = "https://github.com/ROCm/rocprofiler";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprofiler";
     license = with lib.licenses; [ mit ]; # mitx11
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/rocprofiler/default.nix
+++ b/pkgs/development/rocm-modules/rocprofiler/default.nix
@@ -128,10 +128,7 @@ stdenv.mkDerivation (finalAttrs: {
       --add-needed libhsa-amd-aqlprofile64.so
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
   passthru.rocmtoolkit-merged = rocmtoolkit-merged;
 
   meta = {

--- a/pkgs/development/rocm-modules/rocr-debug-agent/default.nix
+++ b/pkgs/development/rocm-modules/rocr-debug-agent/default.nix
@@ -12,7 +12,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocr-debug-agent";
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
@@ -45,8 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {

--- a/pkgs/development/rocm-modules/rocr-debug-agent/default.nix
+++ b/pkgs/development/rocm-modules/rocr-debug-agent/default.nix
@@ -43,10 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     rm -rf $out/src
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Library that provides some debugging functionality for ROCr";

--- a/pkgs/development/rocm-modules/rocrand/default.nix
+++ b/pkgs/development/rocm-modules/rocrand/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocrand${clr.gpuArchSuffix}";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -29,10 +29,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocRAND";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-BX1A74ZBXE0fqYqA7WijezCezUOpEciUm6k2vhFQlA4=";
+    sparseCheckout = [
+      "projects/rocrand"
+      "shared"
+    ];
+    hash = "sha256-tl++h7LSEXf0jWe007+RIRwYHdB6TKPDpzipj1Emew8=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocrand";
 
   nativeBuildInputs = [
     cmake
@@ -83,13 +88,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "Generate pseudo-random and quasi-random numbers";
-    homepage = "https://github.com/ROCm/rocRAND";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocrand";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/rocrand/default.nix
+++ b/pkgs/development/rocm-modules/rocrand/default.nix
@@ -86,10 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
       rmdir $out/bin
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Generate pseudo-random and quasi-random numbers";

--- a/pkgs/development/rocm-modules/rocsolver/default.nix
+++ b/pkgs/development/rocm-modules/rocsolver/default.nix
@@ -37,7 +37,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocsolver${clr.gpuArchSuffix}";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -51,10 +51,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocSOLVER";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-aCmNTF8P0Y7piPkRnu/+DWFhTd7X8mDcaQpotfw/4hM=";
+    sparseCheckout = [
+      "projects/rocsolver"
+      "shared"
+    ];
+    hash = "sha256-n+Y8RheA0UYeSfpvOw5zfwe4VAW5hsKjlCXtBceGhf0=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocsolver";
 
   nativeBuildInputs = [
     cmake
@@ -124,7 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "ROCm LAPACK implementation";
-    homepage = "https://github.com/ROCm/rocSOLVER";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocsolver";
     license = with lib.licenses; [ bsd2 ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/rocsolver/default.nix
+++ b/pkgs/development/rocm-modules/rocsolver/default.nix
@@ -120,10 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
       rmdir $out/bin
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = "rocsolver";
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   requiredSystemFeatures = [ "big-parallel" ];
 

--- a/pkgs/development/rocm-modules/rocsparse/default.nix
+++ b/pkgs/development/rocm-modules/rocsparse/default.nix
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocsparse${clr.gpuArchSuffix}";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -34,10 +34,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocSPARSE";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-jmrX1a09DlQTkuXwkrInt9pKX5pk3oCO88S0pKXXhO0=";
+    sparseCheckout = [
+      "projects/rocsparse"
+      "shared"
+    ];
+    hash = "sha256-hkfBTcLig39al2w8zFTSQQnouaou9wlD6VlvIyFTNMg=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocsparse";
 
   nativeBuildInputs = [
     cmake
@@ -143,14 +148,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     updateScript = rocmUpdateScript {
       name = finalAttrs.pname;
-      inherit (finalAttrs.src) owner;
-      inherit (finalAttrs.src) repo;
+      inherit (finalAttrs.src) owner repo;
     };
   };
 
   meta = {
     description = "ROCm SPARSE implementation";
-    homepage = "https://github.com/ROCm/rocSPARSE";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocsparse";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/rocsparse/default.nix
+++ b/pkgs/development/rocm-modules/rocsparse/default.nix
@@ -146,10 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
       mirror2 = "https://www.cise.ufl.edu/research/sparse/MM";
     };
 
-    updateScript = rocmUpdateScript {
-      name = finalAttrs.pname;
-      inherit (finalAttrs.src) owner repo;
-    };
+    updateScript = rocmUpdateScript { inherit finalAttrs; };
   };
 
   meta = {

--- a/pkgs/development/rocm-modules/rocthrust/default.nix
+++ b/pkgs/development/rocm-modules/rocthrust/default.nix
@@ -81,10 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
       rm -rf $out/bin
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "ROCm parallel algorithm library";

--- a/pkgs/development/rocm-modules/rocthrust/default.nix
+++ b/pkgs/development/rocm-modules/rocthrust/default.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocthrust";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -29,10 +29,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocThrust";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-BDxFeCR2FfZI+TGMi2jBDHORCoAnFwk8WGGKMckCkmU=";
+    sparseCheckout = [
+      "projects/rocthrust"
+      "shared"
+    ];
+    hash = "sha256-wHEgpmBZCYtvp+OyebrRyfoFz3WQyKWfHPrdzQVL8lY=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocthrust";
 
   nativeBuildInputs = [
     cmake
@@ -78,13 +83,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "ROCm parallel algorithm library";
-    homepage = "https://github.com/ROCm/rocThrust";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocthrust";
     license = with lib.licenses; [ asl20 ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/roctracer/default.nix
+++ b/pkgs/development/rocm-modules/roctracer/default.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "roctracer";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -33,10 +33,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "roctracer";
+    repo = "rocm-systems";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-LCtdPnE+rJU/ccI1PTFDMPNXxgl1GrRgc5z7LjOw3zA=";
+    sparseCheckout = [
+      "projects/roctracer"
+      "shared"
+    ];
+    hash = "sha256-KUNLX5ZonE0bW/xOacD3k3hCcg7M3Vk1dM3WQSDYMvM=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/roctracer";
 
   nativeBuildInputs = [
     cmake
@@ -103,13 +108,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "Tracer callback/activity library";
-    homepage = "https://github.com/ROCm/roctracer";
+    homepage = "https://github.com/ROCm/rocm-systems/tree/develop/projects/roctracer";
     license = with lib.licenses; [ mit ]; # mitx11
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/roctracer/default.nix
+++ b/pkgs/development/rocm-modules/roctracer/default.nix
@@ -106,10 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
       rm -rf $out/test
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Tracer callback/activity library";

--- a/pkgs/development/rocm-modules/rocwmma/default.nix
+++ b/pkgs/development/rocm-modules/rocwmma/default.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rocwmma";
-  version = "7.2.0";
+  version = "7.2.1";
 
   outputs = [
     "out"
@@ -36,10 +36,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "rocWMMA";
+    repo = "rocm-libraries";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-O+P+pobPnlKnmJQylFp/qUQLE1kJKbxjMWyGS6lc3Mo=";
+    sparseCheckout = [
+      "projects/rocwmma"
+      "shared"
+    ];
+    hash = "sha256-eoF8a7zknpgvDOSDzolOrdtszUJ5tC7Ur2sRShiQEO0=";
   };
+  sourceRoot = "${finalAttrs.src.name}/projects/rocwmma";
 
   patches = lib.optionals (buildTests || buildBenchmarks) [
     ./0000-dont-fetch-googletest.patch
@@ -101,13 +106,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {
     description = "Mixed precision matrix multiplication and accumulation";
-    homepage = "https://github.com/ROCm/rocWMMA";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/projects/rocwmma";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/rocwmma/default.nix
+++ b/pkgs/development/rocm-modules/rocwmma/default.nix
@@ -104,10 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
       rm -rf $out/bin
     '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Mixed precision matrix multiplication and accumulation";

--- a/pkgs/development/rocm-modules/rpp/default.nix
+++ b/pkgs/development/rocm-modules/rpp/default.nix
@@ -65,10 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3 -m sphinx -T -E -b html -d _build/doctrees -D language=en ../docs _build/html
   '';
 
-  passthru.updateScript = rocmUpdateScript {
-    name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "Comprehensive high-performance computer vision library for AMD processors";

--- a/pkgs/development/rocm-modules/rpp/default.nix
+++ b/pkgs/development/rocm-modules/rpp/default.nix
@@ -19,13 +19,13 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "rpp-${if useCPU then "cpu" else "hip"}";
 
-  version = "7.2.0";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "ROCm";
     repo = "rpp";
     rev = "rocm-${finalAttrs.version}";
-    hash = "sha256-mET9nZReO3BrNZkcNeB7hOwIQaVZ8OD7lPD3b1Jot2k=";
+    hash = "sha256-6e4JHKFC2dvtSGo9xbQKzIdUwlHB09pr5C/5xHwP3l4=";
   };
 
   nativeBuildInputs = [
@@ -67,8 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
-    inherit (finalAttrs.src) owner;
-    inherit (finalAttrs.src) repo;
+    inherit (finalAttrs.src) owner repo;
   };
 
   meta = {

--- a/pkgs/development/rocm-modules/tensile/default.nix
+++ b/pkgs/development/rocm-modules/tensile/default.nix
@@ -18,15 +18,20 @@
 
 buildPythonPackage rec {
   pname = "tensile";
-  version = "7.2.0";
+  version = "7.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ROCm";
-    repo = "Tensile";
+    repo = "rocm-libraries";
     rev = "rocm-${version}";
-    hash = "sha256-pTuEeu+0E+RlpdeFho0mJmx/V/tou/ZRLYX9KoWEPpA=";
+    sparseCheckout = [
+      "shared/tensile"
+      "shared"
+    ];
+    hash = "sha256-sYudPiEPGeZLmf6+3XfQDZqRXiKgRsGPucApzYwlGV8=";
   };
+  sourceRoot = "${src.name}/shared/tensile";
 
   # TODO: It should be possible to run asm caps test ONCE for all supported arches
   # We currently disable the test because it's slow and runs each time tensile launches
@@ -83,7 +88,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "GEMMs and tensor contractions";
-    homepage = "https://github.com/ROCm/Tensile";
+    homepage = "https://github.com/ROCm/rocm-libraries/tree/develop/shared/tensile";
     license = with lib.licenses; [ mit ];
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/rocm-modules/tensile/default.nix
+++ b/pkgs/development/rocm-modules/tensile/default.nix
@@ -16,7 +16,7 @@
   rich,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "tensile";
   version = "7.2.1";
   pyproject = true;
@@ -24,14 +24,14 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ROCm";
     repo = "rocm-libraries";
-    rev = "rocm-${version}";
+    rev = "rocm-${finalAttrs.version}";
     sparseCheckout = [
       "shared/tensile"
       "shared"
     ];
     hash = "sha256-sYudPiEPGeZLmf6+3XfQDZqRXiKgRsGPucApzYwlGV8=";
   };
-  sourceRoot = "${src.name}/shared/tensile";
+  sourceRoot = "${finalAttrs.src.name}/shared/tensile";
 
   # TODO: It should be possible to run asm caps test ONCE for all supported arches
   # We currently disable the test because it's slow and runs each time tensile launches
@@ -81,10 +81,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "Tensile" ];
 
-  passthru.updateScript = rocmUpdateScript {
-    name = pname;
-    inherit (src) owner repo;
-  };
+  passthru.updateScript = rocmUpdateScript { inherit finalAttrs; };
 
   meta = {
     description = "GEMMs and tensor contractions";
@@ -93,4 +90,4 @@ buildPythonPackage rec {
     teams = [ lib.teams.rocm ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/development/rocm-modules/update.nix
+++ b/pkgs/development/rocm-modules/update.nix
@@ -4,10 +4,11 @@
 }:
 
 {
-  name ? "",
-  owner ? "",
-  repo ? "",
-  page ? "releases",
+  finalAttrs ? { },
+  name ? finalAttrs.pname,
+  owner ? finalAttrs.src.owner,
+  repo ? finalAttrs.src.repo,
+  page ? "releases?per_page=10",
   # input: array of [ { tag_name: "rocm-6.x.x", }, ... ]. some entries may have bad names like rocm-test-date we want to skip
   # output: first tag_name/name that's a proper version if any
   filter ? "map(.tag_name // .name) | map(select(test(\"^rocm-[0-9]+\\\\.[0-9]+(\\\\.[0-9]+)?$\"))) | first | ltrimstr(\"rocm-\")",
@@ -34,7 +35,7 @@ let
     find_valid_version() {
       local releases="$1"
       >&2 echo "$releases"
-      # Wrap in array if not already an array to make handline specific release or tags page the same
+      # Wrap in array if not already an array to make handling specific release or tags page the same
       >&2 echo jq -r 'if type == "array" then . else [.] end | ${filter}'
       echo "$releases" | jq -r 'if type == "array" then . else [.] end | ${filter}'
     }


### PR DESCRIPTION
Release notes: https://rocm.docs.amd.com/en/latest/about/release-notes.html

Relatively simple patch bump.

Dropped some upstreamed patches, migrated fetchers to point at the rocm-systems and rocm-libraries repos where applicable.

rocmlir hasn't been tagged yet, will leave it at 7.2.0 for now and will bump if they tag it before this is ready for merge, otherwise we can catch it later.

Update script continues to work fine with the repo migration, have swapped it to infer configuration from finalAttrs alone for the in-tree usecases to avoid repeating that.

```
nix-shell maintainers/scripts/update.nix --argstr path rocmPackages --argstr max-workers 2 --show-trace
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
