### PR TITLE
nixos/mosquitto: write ACL files to StateDirectory instead of /etc

### DIFF
--- a/nixos/modules/services/networking/mosquitto.nix
+++ b/nixos/modules/services/networking/mosquitto.nix
@@ -378,11 +378,22 @@ let
     ++ userAsserts prefix listener.users
     ++ lib.imap0 (i: v: authAsserts "${prefix}.authPlugins.${toString i}" v) listener.authPlugins;
 
+  makeACLFile =
+    idx: listener:
+    pkgs.writeText "mosquitto-acl-${toString idx}.conf" (
+      lib.concatStringsSep "\n" (
+        lib.flatten [
+          listener.acl
+          (lib.mapAttrsToList (n: u: [ "user ${n}" ] ++ map (t: "topic ${t}") u.acl) listener.users)
+        ]
+      )
+    );
+
   formatListener =
     idx: listener:
     [
       "listener ${toString listener.port} ${toString listener.address}"
-      "acl_file /etc/mosquitto/acl-${toString idx}.conf"
+      "acl_file ${cfg.dataDir}/acl-${toString idx}.conf"
     ]
     ++ lib.optional (!listener.omitPasswordAuth) "password_file ${cfg.dataDir}/passwd-${toString idx}"
     ++ formatFreeform { } listener.settings
@@ -762,31 +773,12 @@ in
         UMask = "0077";
       };
       preStart = lib.concatStringsSep "\n" (
-        lib.imap0 (
-          idx: listener:
-          makePasswordFile (listenerScope idx) listener.users "${cfg.dataDir}/passwd-${toString idx}"
-        ) cfg.listeners
+        lib.imap0 (idx: listener: ''
+          ${makePasswordFile (listenerScope idx) listener.users "${cfg.dataDir}/passwd-${toString idx}"}
+          install -m 0700 ${makeACLFile idx listener} ${cfg.dataDir}/acl-${toString idx}.conf
+        '') cfg.listeners
       );
     };
-
-    environment.etc = lib.listToAttrs (
-      lib.imap0 (idx: listener: {
-        name = "mosquitto/acl-${toString idx}.conf";
-        value = {
-          user = config.users.users.mosquitto.name;
-          group = config.users.users.mosquitto.group;
-          mode = "0400";
-          text = (
-            lib.concatStringsSep "\n" (
-              lib.flatten [
-                listener.acl
-                (lib.mapAttrsToList (n: u: [ "user ${n}" ] ++ map (t: "topic ${t}") u.acl) listener.users)
-              ]
-            )
-          );
-        };
-      }) cfg.listeners
-    );
 
     users.users.mosquitto = {
       description = "Mosquitto MQTT Broker Daemon owner";


### PR DESCRIPTION
The ACL file was placed in `/etc` via `environment.etc` with `owner=mosquitto` and `mode=0400`. This breaks when `system.etc.overlay.enable` is set, because the file ownership doesn't map into the service's `PrivateUsers` namespace and mosquitto can't read it.

This PR installs the ACL file into `StateDirectory` during `preStart` instead, alongside the password files. The file ends up owned by the mosquitto user with mode `0700`, satisfying mosquitto's permission checks.

Fixes #474135

This is an alternative to #474136. Rather than adjusting the `/etc` ownership attributes, it sidesteps `/etc` entirely by using the same mechanism the module already uses for password files. This keeps the approach consistent and avoids any future interaction with etc-overlay semantics.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
