### PR TITLE
blender: fix segfault when using both HIP and OSL

### DIFF
--- a/pkgs/by-name/bl/blender/llvm-conflict.patch
+++ b/pkgs/by-name/bl/blender/llvm-conflict.patch
@@ -1,0 +1,18 @@
+diff --git a/extern/hipew/src/util.h b/extern/hipew/src/util.h
+index 2aafc4b7f9..b9ed1c0cd3 100644
+--- a/extern/hipew/src/util.h
++++ b/extern/hipew/src/util.h
+@@ -40,11 +40,12 @@
+ #  define dynamic_library_close(lib)         FreeLibrary(lib)
+ #  define dynamic_library_find(lib, symbol)  GetProcAddress(lib, symbol)
+ #else
++#  define _GNU_SOURCE
+ #  include <dlfcn.h>
+ 
+ typedef void* DynamicLibrary;
+ 
+-#  define dynamic_library_open(path)         dlopen(path, RTLD_NOW)
++#  define dynamic_library_open(path)         dlmopen(LM_ID_NEWLM, path, RTLD_NOW)
+ #  define dynamic_library_close(lib)         dlclose(lib)
+ #  define dynamic_library_find(lib, symbol)  dlsym(lib, symbol)
+ #endif

--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -126,7 +126,10 @@ stdenv'.mkDerivation (finalAttrs: {
   };
 
   # Minimal backport of hiprt 3.x support from https://projects.blender.org/blender/blender/pulls/144889
-  patches = lib.optional rocmSupport ./hiprt-3-compat.patch;
+  patches = lib.optionals rocmSupport [
+    ./hiprt-3-compat.patch
+    ./llvm-conflict.patch
+  ];
 
   postPatch =
     (lib.optionalString stdenv.hostPlatform.isDarwin ''


### PR DESCRIPTION
This PR fixes an issue where enabling both ROCm and OpenShadingLanguage in Blender causes Blender to crash when performing a Cycles render.

Blender `dlopen`s HIP, which is dynamically linked to `rocm-comgr`, which in turn links ROCm's libLLVM.
But then, Blender dynamically links OpenShadingLanguage, which links libLLVM 19.
And so, when HIP is invoked, it transitively calls ROCm's libLLVM, which then—due to symbol conflicts—calls functions in libLLVM 19.
One of those functions then dereferences a null pointer, causing a segfault in the process.

Switching out `dlopen` with `dlmopen` separates the namespaces of the two libLLVMs, fixing the issue.

If anyone wants to find a better solution, I'll mention that simply using the same version of LLVM for both ROCm and OpenShadingLanguage causes different issues because then libLLVM is initialized twice.

The bug was also mentioned in https://github.com/NixOS/nixpkgs/pull/502842.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

