### PR TITLE
flow5: init at 7.55

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12324,6 +12324,12 @@
     githubId = 4599384;
     name = "Jack Baldry";
   };
+  jdelacroix = {
+    email = "jdelacroix@gatech.edu";
+    github = "jdelacroix";
+    githubId = 807477;
+    name = "Jean-Pierre de la Croix";
+  };
   jdelStrother = {
     email = "me@delstrother.com";
     github = "jdelStrother";

--- a/pkgs/by-name/fl/flow5/package.nix
+++ b/pkgs/by-name/fl/flow5/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  qt6,
+  opencascade-occt,
+  openblasCompat,
+  gmsh,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "flow5";
+  version = "7.55";
+
+  src = fetchFromGitHub {
+    owner = "techwinder";
+    repo = "flow5";
+    tag = "v${finalAttrs.version}";
+    sha256 = "5NtYRIthJleYMHy0ZZt0TmCm0tNUqmMnmDd6PzIp6Ns=";
+  };
+
+  env.LC_ALL = "C.UTF-8";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    qt6.qmake
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    opencascade-occt
+    openblasCompat
+    openblasCompat.dev
+    gmsh
+  ];
+
+  preConfigure = ''
+    mkdir include
+    ln -s ${openblasCompat.dev}/include include/openblas
+
+    for f in fl5-lib/fl5-lib.pro fl5-app/fl5-app.pro; do
+
+      sed -i -E "/LIBS \+= -lopenblas$/a\\$(printf '\t')INCLUDEPATH += $PWD/include" $f
+
+      substituteInPlace "$f" \
+        --replace-fail "/usr/local/include/opencascade" "${opencascade-occt}/include/opencascade" \
+        --replace-fail "/usr/local/lib" "${opencascade-occt}/lib" \
+        --replace-fail "LIBS += -lopenblaso" "LIBS += -L${openblasCompat}/lib -lopenblaso" \
+        --replace-fail "LIBS += -lopenblasp" "LIBS += -L${openblasCompat}/lib -lopenblasp" \
+        --replace-fail "LIBS += -lopenblas" "LIBS += -L${openblasCompat}/lib -lopenblas"
+    done
+
+    for f in XFoil-lib/XFoil-lib.pro fl5-lib/fl5-lib.pro fl5-app/fl5-app.pro; do
+      substituteInPlace "$f" \
+        --replace-fail "PREFIX = /usr/local" "PREFIX = $out"
+    done
+
+    substituteInPlace fl5-app/fl5-app.pro \
+      --replace-fail 'desktop.path = $$(HOME)/.local/share/applications' "desktop.path = $out/share/applications"
+  '';
+
+  meta = {
+    description = "Potential flow solver with built-in pre- and post-processing functionalities";
+    homepage = "https://flow5.tech/flow5.html";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "flow5";
+    maintainers = with lib.maintainers; [ jdelacroix ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Added a new package to build flow5, which is described as "a potential flow solver with built-in pre- and post- processing functionalities." Its project page can be found here: https://flow5.tech/flow5.html

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
