### PR TITLE
ida-free: add binary patch support

### DIFF
--- a/pkgs/by-name/id/ida-free/package.nix
+++ b/pkgs/by-name/id/ida-free/package.nix
@@ -32,7 +32,7 @@
   libice,
   libxcb,
   zlib,
-  hexPatches ? [],
+  hexPatches ? [ ],
   # hexPatches: hex patterns to substitute in specified files immediately after
   # install. Can be used, for example, to replace the embedded SSL certificates
   # for compatibility with a self-hosted Lumina server.
@@ -40,12 +40,12 @@
   # available to us for interoperability purposes.
 }:
 let
-  patchScript = lib.concatMapStringsSep "\n" (p:
+  patchScript = lib.concatMapStringsSep "\n" (
+    p:
     let
-      forcecntDecl =
-        lib.optionalString (p ? assertCount)
-          "my $forcecnt = ${toString p.assertCount};";
-          in ''
+      forcecntDecl = lib.optionalString (p ? assertCount) "my $forcecnt = ${toString p.assertCount};";
+    in
+    ''
       perl -0777 -pi -e '${forcecntDecl} my $cnt = (s/\Q''${\pack("H*","${p.from}")}\E/''${\pack("H*","${p.to}")}/g) || 0; die "Expected $forcecnt substitutions, did $cnt\n" if defined $forcecnt && $cnt != $forcecnt' "$IDADIR/${p.filename}"
     ''
   ) hexPatches;

--- a/pkgs/by-name/id/ida-free/package.nix
+++ b/pkgs/by-name/id/ida-free/package.nix
@@ -16,6 +16,7 @@
   libxkbcommon,
   makeWrapper,
   openssl,
+  perl,
   stdenv,
   libxcb-wm,
   libxcb-render-util,
@@ -31,7 +32,24 @@
   libice,
   libxcb,
   zlib,
+  hexPatches ? [],
+  # hexPatches: hex patterns to substitute in specified files immediately after
+  # install. Can be used, for example, to replace the embedded SSL certificates
+  # for compatibility with a self-hosted Lumina server.
+  # Since IDA is distributed as a binary, such patching is the only recourse
+  # available to us for interoperability purposes.
 }:
+let
+  patchScript = lib.concatMapStringsSep "\n" (p:
+    let
+      forcecntDecl =
+        lib.optionalString (p ? assertCount)
+          "my $forcecnt = ${toString p.assertCount};";
+          in ''
+      perl -0777 -pi -e '${forcecntDecl} my $cnt = (s/\Q''${\pack("H*","${p.from}")}\E/''${\pack("H*","${p.to}")}/g) || 0; die "Expected $forcecnt substitutions, did $cnt\n" if defined $forcecnt && $cnt != $forcecnt' "$IDADIR/${p.filename}"
+    ''
+  ) hexPatches;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ida-free";
   version = "9.3";
@@ -45,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     autoPatchelfHook
+    perl
   ];
 
   # We just get a runfile in $src, so no need to unpack it.
@@ -110,6 +129,8 @@ stdenv.mkDerivation (finalAttrs: {
     # to copy it to fix permissions and patch the executable.
     $(cat $NIX_CC/nix-support/dynamic-linker) $src \
       --mode unattended --prefix $IDADIR
+
+    ${patchScript}
 
     # Copy the exported libraries to the output.
     cp $IDADIR/libida.so $out/lib


### PR DESCRIPTION
In IDA, connecting to a private third-party Lumina server like [lumen](https://github.com/naim94a/lumen) currently requires you to either:
1. Disable SSL entirely (not very secure)
2. Run a local intercepting proxy (very clunky)
3. Patch the binary to instead use your own SSL certificate (replacing .crt files is no longer enough, as the certificate is embedded in the binary now)

In general, patching the IDA binary is (surprisingly) a workflow with some official support; prior to the migration to Apple Silicon, all platforms would [*mutate the binary*](https://github.com/eset/idapython-src/blob/master/idapyswitch_linux.cpp) to swap out what Python library was used, until this caused too much grief with code signing.

Since IDA is non-free software, and only distributed as a binary file, we are unable to apply e.g. source-level patches to fix it/apply workarounds. This PR thus adds support for the install-time application of user-specified hex patches.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
