### PR TITLE
inkscape-extensions.applytransforms: 0.pre+unstable=2021-05-11 → 0.pre+unstable=2024-12-19

### DIFF
--- a/pkgs/applications/graphics/inkscape/extensions/applytransforms/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/applytransforms/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation {
   pname = "inkscape-applytransforms";
-  version = "0.pre+unstable=2021-05-11";
+  version = "0.pre+unstable=2024-12-19";
 
   src = fetchFromGitHub {
     owner = "Klowner";
     repo = "inkscape-applytransforms";
-    rev = "5b3ed4af0fb66e399e686fc2b649b56db84f6042";
-    sha256 = "XWwkuw+Um/cflRWjIeIgQUxJLrk2DLDmx7K+pMWvIlI=";
+    rev = "979f98dfe199d25ceecff68a86684b941e703e18";
+    hash = "sha256-vRhNsHx5QkJPQgeToh4GRKD7EpMwLnN8QhrAP0WWTjU=";
   };
 
   nativeCheckInputs = [


### PR DESCRIPTION
Changelog:
- Make stroke-width independent from px unit
- Fix an issue with scaling between different units
- Add Rect support
- Update for Inkscape 1.2 deprecations

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
