### PR TITLE
phpantom-lsp: init at 0.7.0

### DIFF
--- a/pkgs/by-name/ph/phpantom-lsp/package.nix
+++ b/pkgs/by-name/ph/phpantom-lsp/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  _experimental-update-script-combinators,
+  nix-update-script,
+}:
+
+let
+  stubsSrc = fetchFromGitHub {
+    owner = "JetBrains";
+    repo = "phpstorm-stubs";
+    rev = "3327932472f512d2eb9e122b19702b335083fd9d";
+    hash = "sha256-WN5DAvaw4FfHBl2AqSo1OcEthUm3lOpikdB78qy3cyY=";
+  };
+in
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "phpantom-lsp";
+  version = "0.7.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "AJenbo";
+    repo = "phpantom_lsp";
+    tag = finalAttrs.version;
+    hash = "sha256-ZmtOdoxXkwn2IDg7RyQ9KG0RNz5mrGDMcESfcOSR3Ig=";
+  };
+
+  postPatch = ''
+    mkdir -p stubs/jetbrains
+    cp -a ${finalAttrs.passthru.stubsSrc} stubs/jetbrains/phpstorm-stubs
+    chmod u+wx stubs/jetbrains/phpstorm-stubs
+
+    echo "${finalAttrs.passthru.stubsSrc.rev}" \
+      > stubs/jetbrains/phpstorm-stubs/.commit
+  '';
+
+  cargoHash = "sha256-pXP4qItYgmUXVx9XwMdS6WLVc5lP7P4VX9+0TbhYrUc=";
+
+  checkFlags = [
+    "--test"
+    "completion_inheritance"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru = {
+    inherit stubsSrc;
+    updateScript = _experimental-update-script-combinators.sequence [
+      (nix-update-script { })
+      ./update-php-stubs.sh
+    ];
+  };
+
+  meta = {
+    changelog = "https://github.com/AJenbo/phpantom_lsp/releases/tag/${finalAttrs.src.tag}";
+    description = "Fast, lightweight PHP language server written in Rust";
+    homepage = "https://github.com/AJenbo/phpantom_lsp";
+    license = lib.licenses.mit;
+    mainProgram = "phpantom_lsp";
+    maintainers = with lib.maintainers; [ nanoyaki ];
+  };
+})

--- a/pkgs/by-name/ph/phpantom-lsp/update-php-stubs.sh
+++ b/pkgs/by-name/ph/phpantom-lsp/update-php-stubs.sh
@@ -1,0 +1,18 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p bash curl gnused gnugrep nix-prefetch-github jq
+
+file="./pkgs/by-name/ph/phpantom-lsp/package.nix"
+
+version="$(grep -oP 'version = "\K[\d\.]+' "$file")"
+curl -O "https://raw.githubusercontent.com/AJenbo/phpantom_lsp/refs/tags/$version/stubs.lock"
+stubsVersion="$(grep -oP 'commit = "\K[^"]+' ./stubs.lock)"
+rm stubs.lock
+
+stubsHash="$(
+  nix-prefetch-github --rev "$stubsVersion" "JetBrains" "phpstorm-stubs" --json \
+    2> /dev/null \
+    | jq -r '.hash'
+)"
+
+sed -i 's/\(rev = "\)[^"]*/\1'"$stubsVersion"'/' "$file"
+sed -i '/stubsSrc/,/}/ s#\(hash = "\)[^"]*#\1'"$stubsHash"'#' "$file"


### PR DESCRIPTION
Adds phpantom-lsp. I've tested this in personal PHP projects and the binary runs like it's supposed to

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
