### PR TITLE
github-copilot-cli 1.0.9 -> 1.0.12 

### DIFF
--- a/pkgs/by-name/gi/github-copilot-cli/sources.json
+++ b/pkgs/by-name/gi/github-copilot-cli/sources.json
@@ -1,19 +1,19 @@
 {
-  "version": "1.0.9",
+  "version": "1.0.12",
   "x86_64-linux": {
     "name": "copilot-linux-x64",
-    "hash": "sha256-FwRLHgibSeqOuq142SRIuPbIw8YVHgSgmwuH41kvWD0="
+    "hash": "sha256-QqFZO9BNWz+8e4BC9KtxYO9M3y5jey5sx7jMpx37WfY="
   },
   "aarch64-linux": {
     "name": "copilot-linux-arm64",
-    "hash": "sha256-YFaVWsztnMBG3xo4DSAPzlEAMTPLRCYUt34G8M7/yls="
+    "hash": "sha256-IBJt89WfdXqT/7txzzvAXcQxwk04Fu3iWwbJOOD0b6w="
   },
   "x86_64-darwin": {
     "name": "copilot-darwin-x64",
-    "hash": "sha256-YdraXVwpfVMPVnzuDCHTdKmuHlgjlAPzwagzDKW5RsE="
+    "hash": "sha256-TGbWhAlLVs3oAPVwgBXQpmB/yPUYNjeZX8k32qcosJ4="
   },
   "aarch64-darwin": {
     "name": "copilot-darwin-arm64",
-    "hash": "sha256-pzXgRrr9dryBVaM2taf1JSidG2zgDa9Sx66Mew4zQZU="
+    "hash": "sha256-mrCdZwv/f0MummttAvMxlJbAfolZaGqIG9Q+UToeYVM="
   }
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
