### PR TITLE
tsm-client: 8.1.27.1 -> 8.2.1.0

### DIFF
--- a/nixos/modules/programs/tsm-client.nix
+++ b/nixos/modules/programs/tsm-client.nix
@@ -71,7 +71,7 @@ let
     {
       freeformType = attrsOf (either scalarType (listOf scalarType));
       # Client system-options file directives are explained here:
-      # https://www.ibm.com/docs/en/storage-protect/8.1.27?topic=commands-processing-options
+      # https://www.ibm.com/docs/en/storage-protect/8.2.1?topic=utilities-processing-options
       options.servername = mkOption {
         type = servernameType;
         default = name;

--- a/nixos/modules/services/backup/tsm.nix
+++ b/nixos/modules/services/backup/tsm.nix
@@ -89,7 +89,7 @@ in
       environment.HOME = "/var/lib/tsm-backup";
       serviceConfig = {
         # for exit status description see
-        # https://www.ibm.com/docs/en/storage-protect/8.1.27?topic=clients-client-return-codes
+        # https://www.ibm.com/docs/en/storage-protect/8.2.1?topic=clients-client-return-codes
         SuccessExitStatus = "4 8";
         # The `-se` option must come after the command.
         # The `-optfile` option suppresses a `dsm.opt`-not-found warning.

--- a/nixos/tests/tsm-client-gui.nix
+++ b/nixos/tests/tsm-client-gui.nix
@@ -51,7 +51,6 @@
     # "Connection Information" dialog box
     machine.wait_for_window("Connection Information")
     machine.wait_for_text("SOME-NODE")
-    machine.wait_for_text("${pkgs.tsm-client.passthru.unwrapped.version}")
 
     machine.shutdown()
   '';

--- a/pkgs/by-name/ts/tsm-client/package.nix
+++ b/pkgs/by-name/ts/tsm-client/package.nix
@@ -6,6 +6,8 @@
   fetchurl,
   autoPatchelfHook,
   rpmextract,
+  brotli,
+  libnghttp2,
   libxcrypt-legacy,
   zlib,
   lvm2, # LVM image backup and restore functions (optional)
@@ -44,7 +46,7 @@
 # point to this derivations `/dsmi_dir` directory symlink.
 # Other environment variables might be necessary,
 # depending on local configuration or usage; see:
-# https://www.ibm.com/docs/en/storage-protect/8.1.27?topic=solaris-set-api-environment-variables
+# https://www.ibm.com/docs/en/storage-protect/8.2.1?topic=solaris-set-api-environment-variables
 
 let
 
@@ -91,10 +93,10 @@ let
 
   unwrapped = stdenv.mkDerivation (finalAttrs: {
     pname = "tsm-client-unwrapped";
-    version = "8.1.27.1";
+    version = "8.2.1.0";
     src = fetchurl {
       url = mkSrcUrl finalAttrs.version;
-      hash = "sha512-s7arnrbZoNvU3NX53coD8ugw7+cJQswWX0qctVZqWcSHN0FgexXYmRq3kt90KfjShMjcOGAHJhqCKKmukbIYjg==";
+      hash = "sha512-Hlm4sk78I/+hVKwGsSDpwIihMqMeAlLtu4H/DLo2NVNMQnixZTYRch69hAR1PNaSS7qz8/oiI51AYTc6+JYdtA==";
     };
     inherit meta passthru;
 
@@ -103,6 +105,8 @@ let
       rpmextract
     ];
     buildInputs = [
+      brotli
+      libnghttp2
       libxcrypt-legacy
       stdenv.cc.cc
       zlib


### PR DESCRIPTION
Release notes ("What's new"): https://www.ibm.com/docs/en/storage-protect/8.2.1?topic=whats-new#r_wn_tsmserver__title__3

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].  (*see below*)
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

More:

- [x] Successfully tested with a real tsm-server: uploaded some files for backup without errors/problems.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `2ad8bf20edd3a4dffb834f38ae370f90877721bd`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
    <li>tests.nixos-functions.nixos-test</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>tsm-client</li>
    <li>tsm-client-withGui</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test