### PR TITLE
python3Packages.urllib3-future: 2.17.903 -> 2.18.901

### DIFF
--- a/pkgs/development/python-modules/caldav/default.nix
+++ b/pkgs/development/python-modules/caldav/default.nix
@@ -70,6 +70,8 @@ buildPythonPackage rec {
     "test_rfc8764_test_conf"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   pythonImportsCheck = [ "caldav" ];
 
   meta = {

--- a/pkgs/development/python-modules/urllib3-future/default.nix
+++ b/pkgs/development/python-modules/urllib3-future/default.nix
@@ -24,14 +24,14 @@
 
 buildPythonPackage rec {
   pname = "urllib3-future";
-  version = "2.17.903";
+  version = "2.18.901";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jawah";
     repo = "urllib3.future";
     tag = version;
-    hash = "sha256-tgAKjtYuVVjkxI6qC7/iFHv/DE+rGSw0+Dye73WTcis=";
+    hash = "sha256-y6DRN24U2vxLRcVw9w9E4FMlk71W44x7UYSJrS6hfuA=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Diff: https://github.com/jawah/urllib3.future/compare/2.17.903...2.18.901

Changelog: https://github.com/jawah/urllib3.future/blob/2.18.901/CHANGES.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
