### PR TITLE
bulwark: init at 1.9.0, nixos/bulwark: init, nixos/tests/bulwark: add bulwark test

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -88,6 +88,8 @@
 
 - [LXMD](https://github.com/markqvist/LXMF), a universal, distributed and secure messaging protocol for Reticulum. Available as [services.lxmd](#opt-services.lxmd.enable).
 
+- [bulwark](https://github.com/bulwarkmail/webmail), a modern, self-hosted webmail client for Stalwart Mail Server. Available as [services.bulwark](#opt-services.bulwark.enable).
+
 - [Entropy](https://github.com/ergohaven/entropy), a configurator for programmable keyboards and input devices running Vial-QMK/RMK firmware. Available as [programs.entropy](#opt-programs.entropy.enable).
 
 - [Kvrocks](https://kvrocks.apache.org/), a distributed key value NoSQL database compatible with the Redis protocol. Available as [services.kvrocks](#opt-services.kvrocks.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1657,6 +1657,7 @@
   ./services/web-apps/bluemap.nix
   ./services/web-apps/bluesky-pds.nix
   ./services/web-apps/bookstack.nix
+  ./services/web-apps/bulwark.nix
   ./services/web-apps/c2fmzq-server.nix
   ./services/web-apps/calibre-web.nix
   ./services/web-apps/castopod.nix

--- a/nixos/modules/services/web-apps/bulwark.nix
+++ b/nixos/modules/services/web-apps/bulwark.nix
@@ -787,6 +787,9 @@ in
         PORT = toString cfg.port;
         ADMIN_STATE_DIR = cfg.admin_state_dir;
         VERSION_CHECK_DATA_DIR = cfg.version_check_data_dir;
+        # Read (and created) even with telemetry off to resolve consent state;
+        # otherwise falls back to <package>/data/telemetry in the store.
+        TELEMETRY_DATA_DIR = cfg.telemetry.data_dir;
         BULWARK_UPDATE_CHECK = if cfg.updateCheck.enabled then "on" else "off";
         BULWARK_TELEMETRY = if cfg.telemetry.enabled then "on" else "off";
       }
@@ -799,9 +802,6 @@ in
       }
       // optionalAttrs cfg.updateCheck.enabled {
         BULWARK_UPDATE_CHECK_URL = cfg.updateCheck.url;
-      }
-      // optionalAttrs cfg.telemetry.enabled {
-        TELEMETRY_DATA_DIR = cfg.telemetry.data_dir;
       };
     };
   };

--- a/nixos/modules/services/web-apps/bulwark.nix
+++ b/nixos/modules/services/web-apps/bulwark.nix
@@ -146,6 +146,8 @@ in
           };
           jmapServers = mkOption {
             type = attrsOf (submodule {
+              freeformType = format.type;
+
               options = {
                 label = mkOption {
                   type = str;
@@ -188,16 +190,10 @@ in
             '';
           };
 
-          searchEngineIndexing = mkOption {
-            type = bool;
-            default = false;
-            description = ''
-              Allow search engines to index this webmail. Off (the default) sends noindex/nofollow in the page head, recommended for private deployments.
-            '';
-          };
-
           oauth = mkOption {
             type = submodule {
+              freeformType = format.type;
+
               options = {
                 enabled = mkOption {
                   type = bool;
@@ -252,30 +248,13 @@ in
               config = mkIf config.enabled { };
             };
             default = { };
-            description = "OAuth / OpenID Connect";
+            description = "OAuth / OpenID Connect. Options are prefixed with `oauth` and the `oauth` submodule is flattened, so `oauth.clientId` turns to `oauthClientId`.";
           };
 
           autoSsoEnabled = mkOption {
             type = bool;
             default = false;
             description = "Automatically redirect to SSO provider on load.";
-          };
-          cookieSameSite = mkOption {
-            type = enum [
-              "lax"
-              "strict"
-              "none"
-            ];
-            default = "lax";
-            description = "Value of the `SameSite` attribute for the session cookie.";
-          };
-          allowedFrameAncestors = mkOption {
-            type = nullOr str;
-            description = "Specifiy the CSP `frame-ancestors` directive.";
-          };
-          parentOrigin = mkOption {
-            type = nullOr str;
-            description = "Parent Origin for embedded mode communication";
           };
 
           sessionSecretFile = mkOption {
@@ -369,11 +348,13 @@ in
         };
       };
       default = { };
-      description = "Bulwark configuration";
+      description = "Bulwark configuration. Check [the example env configuration](https://github.com/bulwarkmail/webmail/blob/1.8.1/.env.example) for more configuration options, keys are written in camel case. ";
     };
 
     admin = mkOption {
       type = nullOr (submodule {
+        freeformType = format.type;
+
         options = {
           passwordHashFile = mkOption {
             type = str;

--- a/nixos/modules/services/web-apps/bulwark.nix
+++ b/nixos/modules/services/web-apps/bulwark.nix
@@ -51,158 +51,6 @@ let
       default = "Webmail";
       description = "App name displayed in the UI, browser tab title, and PWA manifest.";
     };
-    appShortName = mkOption {
-      type = nullOr str;
-      description = ''
-        Short name for the app, used in contexts where space is limited
-        (e.g. home screen label on mobile). Defaults to `settings.appName` if not set.
-      '';
-    };
-    appDescription = mkOption {
-      type = str;
-      default = "Your personal webmail";
-      description = "Description shown in the PWA manifest (displayed by the OS during install).";
-    };
-    faviconUrl = mkOption {
-      type = str;
-      default = "/branding/Bulwark_Favicon.svg";
-      description = ''
-        Custom favicon shown in the browser tab.
-        Supported formats: SVG (recommended), PNG, ICO.
-        Can be an absolute URL (https://...) or a path relative to the public/ directory.
-      '';
-    };
-    pwaIconUrl = mkOption {
-      type = nullOr str;
-      description = ''
-        Source image used to auto-generate PWA icons (192×192 and 512×512 PNG).
-        Supported formats: SVG (recommended for best quality) or PNG (≥512×512px recommended).
-        Can be an absolute URL (https://...) or a path relative to the public/ directory.
-        Falls back to `settings.branding.faviconUrl` if not set, and to the default Bulwark icons if neither is set.
-      '';
-    };
-    pwaScreenshotMobileUrl = mkOption {
-      type = nullOr str;
-      description = ''
-        PWA Screenshot (Mobile)
-        Supported formats: PNG, JPG, WebP.
-        Can be absolute URLs or paths relative to the public/ directory.
-      '';
-    };
-    pwaScreenshotDesktopUrl = mkOption {
-      type = nullOr str;
-      description = ''
-        PWA Screenshot (Desktop)
-        Supported formats: PNG, JPG, WebP.
-        Can be absolute URLs or paths relative to the public/ directory.
-      '';
-    };
-    pwaThemeColor = mkOption {
-      type = str;
-      default = "#ffffff";
-      description = ''
-        Color applied to the browser UI chrome when the app is installed as a PWA
-        (address bar, status bar on Android).
-      '';
-    };
-    pwaBackgroundColor = mkOption {
-      type = str;
-      default = "#ffffff";
-      description = ''
-        Background color shown on the PWA splash screen while the app is loading.
-        Should match your app's main background color.
-      '';
-    };
-    appLogoLightUrl = mkOption {
-      type = nullOr str;
-      default = "/branding/Bulwark_Logo_Color.svg";
-      description = ''
-        Logos shown in the sidebar (main app, after login).
-        Supported formats: SVG (recommended), PNG, WebP.
-        Recommended size: min 24×24px, max 128×128px.
-        Can be absolute URLs or paths relative to the public/ directory.
-        If not set, no logo is shown in the sidebar.
-      '';
-    };
-    appLogoDarkUrl = mkOption {
-      type = nullOr str;
-      default = "/branding/Bulwark_Logo_White.svg";
-      description = ''
-        Logos shown in the sidebar (main app, after login).
-        Supported formats: SVG (recommended), PNG, WebP.
-        Recommended size: min 24×24px, max 128×128px.
-        Can be absolute URLs or paths relative to the public/ directory.
-        If not set, no logo is shown in the sidebar.
-      '';
-    };
-
-    loginLogoLightUrl = mkOption {
-      type = str;
-      default = "/branding/Bulwark_Logo_Color.svg";
-      description = ''
-        Logos shown on the login page.
-        Supported formats: SVG (recommended), PNG, WebP.
-        Recommended size: min 32×32px, max 512×512px.
-        Can be absolute URLs or paths relative to the public/ directory.
-        Light mode logo (shown on light backgrounds).
-      '';
-    };
-    loginLogoDarkUrl = mkOption {
-      type = str;
-      default = "/branding/Bulwark_Logo_White.svg";
-      description = ''
-        Logos shown on the login page.
-        Supported formats: SVG (recommended), PNG, WebP.
-        Recommended size: min 32×32px, max 512×512px.
-        Can be absolute URLs or paths relative to the public/ directory.
-        Dark mode logo (shown on dark backgrounds).
-      '';
-    };
-    loginCompanyName = mkOption {
-      type = nullOr str;
-      description = "Company name shown above the version number on the login page.";
-    };
-    loginImprintUrl = mkOption {
-      type = nullOr str;
-      description = "URL for the imprint / legal notice link on the login page.";
-    };
-    loginPrivacyPolicyUrl = mkOption {
-
-      type = nullOr str;
-      description = "URL for the privacy policy link on the login page.";
-    };
-    loginWebsiteUrl = mkOption {
-      type = nullOr str;
-      description = "URL for the company website link on the login page.";
-    };
-    loginLogoMaxHeight = mkOption {
-      type = nullOr str;
-      description = "Maximum height of the logo on the login page.";
-    };
-    loginLogoMaxWidth = mkOption {
-      type = nullOr str;
-      description = "Maximum width of the logo on the login page.";
-    };
-    loginShowHeading = mkOption {
-      type = bool;
-      default = true;
-      description = "Whether the heading is shown on the login page.";
-    };
-    loginShowSubtitle = mkOption {
-      type = bool;
-      default = true;
-      description = "Whether the subtitle is shown on the login page.";
-    };
-    loginShowTotp = mkOption {
-      type = bool;
-      default = true;
-      description = "Whether the \"I have a 2FA code\" toggle is shown on the login page.";
-    };
-    loginShowVersion = mkOption {
-      type = bool;
-      default = true;
-      description = "Whether the build version is shown on the login page.";
-    };
   };
 in
 {
@@ -484,10 +332,20 @@ in
             description = "Log level: `error`, `warn`, `info`, or `debug`";
           };
 
-          branding = brandingModule;
+          branding = mkOption {
+            type = submodule {
+              freeformType = format.type;
+
+              options = brandingModule;
+            };
+            default = { };
+            description = "Branding configuration. Check [the example env configuration](https://github.com/bulwarkmail/webmail/blob/1.8.1/.env.example#L191), keys are written in camel case.";
+          };
 
           domainBranding = mkOption {
             type = attrsOf (submodule {
+              freeformType = format.type;
+
               options = brandingModule;
             });
             default = { };

--- a/nixos/modules/services/web-apps/bulwark.nix
+++ b/nixos/modules/services/web-apps/bulwark.nix
@@ -1,0 +1,971 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    attrsToList
+    elem
+    filter
+    literalExpression
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    nameValuePair
+    optionalAttrs
+    recursiveUpdate
+    trivial
+    ;
+
+  inherit (lib.types)
+    attrsOf
+    bool
+    enum
+    int
+    listOf
+    nullOr
+    package
+    port
+    str
+    submodule
+    ;
+
+  cfg = config.services.bulwark;
+  format = pkgs.formats.json { };
+
+  flattenAttrSet =
+    key: keyName: value:
+    nameValuePair key (map (it: { "${keyName}" = it.name; } // it.value) (attrsToList value));
+  renameOptions =
+    parent:
+    lib.mapAttrs' (
+      name: value: lib.nameValuePair (lib.strings.toCamelCase "${parent}_${name}") value
+    ) cfg.settings."${parent}";
+
+  brandingModule = {
+    appName = mkOption {
+      type = str;
+      default = "Webmail";
+      description = "App name displayed in the UI, browser tab title, and PWA manifest.";
+    };
+    appShortName = mkOption {
+      type = nullOr str;
+      description = ''
+        Short name for the app, used in contexts where space is limited
+        (e.g. home screen label on mobile). Defaults to `settings.appName` if not set.
+      '';
+    };
+    appDescription = mkOption {
+      type = str;
+      default = "Your personal webmail";
+      description = "Description shown in the PWA manifest (displayed by the OS during install).";
+    };
+    faviconUrl = mkOption {
+      type = str;
+      default = "/branding/Bulwark_Favicon.svg";
+      description = ''
+        Custom favicon shown in the browser tab.
+        Supported formats: SVG (recommended), PNG, ICO.
+        Can be an absolute URL (https://...) or a path relative to the public/ directory.
+      '';
+    };
+    pwaIconUrl = mkOption {
+      type = nullOr str;
+      description = ''
+        Source image used to auto-generate PWA icons (192×192 and 512×512 PNG).
+        Supported formats: SVG (recommended for best quality) or PNG (≥512×512px recommended).
+        Can be an absolute URL (https://...) or a path relative to the public/ directory.
+        Falls back to `settings.branding.faviconUrl` if not set, and to the default Bulwark icons if neither is set.
+      '';
+    };
+    pwaScreenshotMobileUrl = mkOption {
+      type = nullOr str;
+      description = ''
+        PWA Screenshot (Mobile)
+        Supported formats: PNG, JPG, WebP.
+        Can be absolute URLs or paths relative to the public/ directory.
+      '';
+    };
+    pwaScreenshotDesktopUrl = mkOption {
+      type = nullOr str;
+      description = ''
+        PWA Screenshot (Desktop)
+        Supported formats: PNG, JPG, WebP.
+        Can be absolute URLs or paths relative to the public/ directory.
+      '';
+    };
+    pwaThemeColor = mkOption {
+      type = str;
+      default = "#ffffff";
+      description = ''
+        Color applied to the browser UI chrome when the app is installed as a PWA
+        (address bar, status bar on Android).
+      '';
+    };
+    pwaBackgroundColor = mkOption {
+      type = str;
+      default = "#ffffff";
+      description = ''
+        Background color shown on the PWA splash screen while the app is loading.
+        Should match your app's main background color.
+      '';
+    };
+    appLogoLightUrl = mkOption {
+      type = nullOr str;
+      default = "/branding/Bulwark_Logo_Color.svg";
+      description = ''
+        Logos shown in the sidebar (main app, after login).
+        Supported formats: SVG (recommended), PNG, WebP.
+        Recommended size: min 24×24px, max 128×128px.
+        Can be absolute URLs or paths relative to the public/ directory.
+        If not set, no logo is shown in the sidebar.
+      '';
+    };
+    appLogoDarkUrl = mkOption {
+      type = nullOr str;
+      default = "/branding/Bulwark_Logo_White.svg";
+      description = ''
+        Logos shown in the sidebar (main app, after login).
+        Supported formats: SVG (recommended), PNG, WebP.
+        Recommended size: min 24×24px, max 128×128px.
+        Can be absolute URLs or paths relative to the public/ directory.
+        If not set, no logo is shown in the sidebar.
+      '';
+    };
+
+    loginLogoLightUrl = mkOption {
+      type = str;
+      default = "/branding/Bulwark_Logo_Color.svg";
+      description = ''
+        Logos shown on the login page.
+        Supported formats: SVG (recommended), PNG, WebP.
+        Recommended size: min 32×32px, max 512×512px.
+        Can be absolute URLs or paths relative to the public/ directory.
+        Light mode logo (shown on light backgrounds).
+      '';
+    };
+    loginLogoDarkUrl = mkOption {
+      type = str;
+      default = "/branding/Bulwark_Logo_White.svg";
+      description = ''
+        Logos shown on the login page.
+        Supported formats: SVG (recommended), PNG, WebP.
+        Recommended size: min 32×32px, max 512×512px.
+        Can be absolute URLs or paths relative to the public/ directory.
+        Dark mode logo (shown on dark backgrounds).
+      '';
+    };
+    loginCompanyName = mkOption {
+      type = nullOr str;
+      description = "Company name shown above the version number on the login page.";
+    };
+    loginImprintUrl = mkOption {
+      type = nullOr str;
+      description = "URL for the imprint / legal notice link on the login page.";
+    };
+    loginPrivacyPolicyUrl = mkOption {
+
+      type = nullOr str;
+      description = "URL for the privacy policy link on the login page.";
+    };
+    loginWebsiteUrl = mkOption {
+      type = nullOr str;
+      description = "URL for the company website link on the login page.";
+    };
+    loginLogoMaxHeight = mkOption {
+      type = nullOr str;
+      description = "Maximum height of the logo on the login page.";
+    };
+    loginLogoMaxWidth = mkOption {
+      type = nullOr str;
+      description = "Maximum width of the logo on the login page.";
+    };
+    loginShowHeading = mkOption {
+      type = bool;
+      default = true;
+      description = "Whether the heading is shown on the login page.";
+    };
+    loginShowSubtitle = mkOption {
+      type = bool;
+      default = true;
+      description = "Whether the subtitle is shown on the login page.";
+    };
+    loginShowTotp = mkOption {
+      type = bool;
+      default = true;
+      description = "Whether the \"I have a 2FA code\" toggle is shown on the login page.";
+    };
+    loginShowVersion = mkOption {
+      type = bool;
+      default = true;
+      description = "Whether the build version is shown on the login page.";
+    };
+  };
+in
+{
+  options.services.bulwark = {
+    enable = mkEnableOption "Bulwark, a modern, self-hosted webmail client for Stalwart Mail Server.";
+    package = mkPackageOption pkgs "bulwark" { };
+
+    hostname = mkOption {
+      type = str;
+      default = "::";
+      description = "Hostname the server binds to.";
+    };
+    port = mkOption {
+      type = port;
+      default = 3000;
+      description = "Port the server listens on.";
+    };
+
+    settings_data_dir = mkOption {
+      type = str;
+      default = "/var/lib/bulwark/settings";
+      description = "Directory for storing encrypted settings files.";
+    };
+    admin_state_dir = mkOption {
+      type = str;
+      default = "/var/lib/bulwark/admin-state";
+      description = ''
+        State dir - runtime mutations. Holds admin-state.json (login timestamps),
+        audit.log, and the bootstrap setup token. Always read-write.
+      '';
+    };
+    version_check_data_dir = mkOption {
+      type = str;
+      default = "/var/lib/bulwark/version-check";
+      description = ''
+        Version check dir - necessary to perform version checks.
+      '';
+    };
+
+    updateCheck = mkOption {
+      type = submodule {
+        options = {
+          enabled = mkOption {
+            type = bool;
+            default = true;
+            description = "Whether to enable update checks";
+          };
+          url = mkOption {
+            type = nullOr str;
+            description = "Override the endpoint it checks. Takes priority over the on-disk state file.";
+          };
+        };
+        config = mkIf config.enabled { };
+      };
+      default = { };
+      description = "The app periodically checks for new releases and shows a notice";
+    };
+
+    telemetry = mkOption {
+      type = submodule {
+        options = {
+          enabled = mkOption {
+            type = bool;
+            default = false;
+            description = ''
+              Anonymous instance telemetry is OPT-IN and disabled by default. Enabling it
+              helps us understand how Bulwark is used so we can make the product better.
+              Heartbeats contain no PII: version, platform, bucketed account counts, and
+              feature toggles only - never email addresses, hostnames, or IPs. See
+              https://bulwarkmail.org/docs/legal/privacy/telemetry for the full schema.
+            '';
+          };
+          data_dir = mkOption {
+            type = str;
+            default = "/var/lib/bulwark/telemetry";
+            description = "Directory for telemetry state: instance id, consent, login HMACs.";
+          };
+        };
+        config = mkIf config.enabled { };
+      };
+      default = { };
+      description = "Anonymous Telemetry";
+    };
+
+    settings = mkOption {
+      type = submodule {
+        freeformType = format.type;
+
+        options = {
+          jmapServerUrl = mkOption {
+            type = nullOr str;
+            description = "URL of your JMAP-compatible mail server (required unless `settings.allowCustomJmapEndpoint` is set).";
+          };
+          jmapServers = mkOption {
+            type = attrsOf (submodule {
+              options = {
+                label = mkOption {
+                  type = str;
+                  description = "Server label";
+                };
+                url = mkOption {
+                  type = str;
+                  description = "JMAP URL";
+                };
+                domains = mkOption {
+                  type = listOf str;
+                  description = "Email domains";
+                };
+              };
+            });
+            default = { };
+            description = "Allow users to connect to multiple JMAP servers.";
+          };
+          jmapServerAutoPickByDomain = mkOption {
+            type = bool;
+            default = false;
+            description = "When users type their email, automatically select the matching server from `settings.jmapServers`.";
+          };
+          allowCustomJmapEndpoint = mkOption {
+            type = bool;
+            default = false;
+            description = ''
+              Allow users to specify a custom JMAP server URL on the login form.
+              When enabled, a "JMAP Server" field appears on the login page.
+              Users can connect to any JMAP-compatible server.
+            '';
+          };
+
+          stalwartFeaturesEnabled = mkOption {
+            type = bool;
+            default = true;
+            description = ''
+              Enable Stalwart-specific features (password change, sieve filters, etc.).
+              Set to `false` to disable if using a non-Stalwart JMAP server.
+            '';
+          };
+
+          searchEngineIndexing = mkOption {
+            type = bool;
+            default = false;
+            description = ''
+              Allow search engines to index this webmail. Off (the default) sends noindex/nofollow in the page head, recommended for private deployments.
+            '';
+          };
+
+          oauth = mkOption {
+            type = submodule {
+              options = {
+                enabled = mkOption {
+                  type = bool;
+                  default = false;
+                  description = "Set to `true` to use OAuth instead of basic JMAP authentication.";
+                };
+                only = mkOption {
+                  type = bool;
+                  default = false;
+                  description = "Set to `true` to only allow OAuth login (hides username/password form).";
+                };
+                clientId = mkOption {
+                  type = str;
+                  description = "OAuth client ID registered with your identity provider.";
+                };
+                clientSecretFile = mkOption {
+                  type = nullOr str;
+                  description = "Path to a file containing the OAuth client secret (server-side only, never exposed to the browser).";
+                };
+                issuerUrl = mkOption {
+                  type = str;
+                  description = "OpenID Connect issuer URL for discovery.";
+                };
+                authorizeUrl = mkOption {
+                  type = nullOr str;
+                  description = ''
+                    Overrides only the user-facing authorize endpoint (e.g. a per-brand login
+                    host). Discovery, token exchange and refresh keep using `settings.oauth.issuerUrl`.
+                    Leave unset to use the authorization_endpoint from discovery.
+                  '';
+                };
+                scopes = mkOption {
+                  type = str;
+                  default = "openid email profile";
+                  description = "OpenID Connect scopes.";
+                };
+                extraScopes = mkOption {
+                  type = str;
+                  default = "";
+                  description = "Additional OpenID Connect scopes (urn:ietf:params:oauth:...).";
+                };
+                allowPrivateEndpoints = mkOption {
+                  type = bool;
+                  default = false;
+                  description = ''
+                    Allow OAuth discovery to resolve to private (RFC-1918 / loopback) addresses.
+                    Off by default as an SSRF guard. Enable for split-DNS deployments where the
+                    OAuth issuer's public hostname resolves to an internal IP from this server.
+                  '';
+                };
+              };
+              config = mkIf config.enabled { };
+            };
+            default = { };
+            description = "OAuth / OpenID Connect";
+          };
+
+          autoSsoEnabled = mkOption {
+            type = bool;
+            default = false;
+            description = "Automatically redirect to SSO provider on load.";
+          };
+          cookieSameSite = mkOption {
+            type = enum [
+              "lax"
+              "strict"
+              "none"
+            ];
+            default = "lax";
+            description = "Value of the `SameSite` attribute for the session cookie.";
+          };
+          allowedFrameAncestors = mkOption {
+            type = nullOr str;
+            description = "Specifiy the CSP `frame-ancestors` directive.";
+          };
+          parentOrigin = mkOption {
+            type = nullOr str;
+            description = "Parent Origin for embedded mode communication";
+          };
+
+          sessionSecretFile = mkOption {
+            type = nullOr str;
+            description = ''
+              Path to a file containing the secret key for encrypting "Remember me" sessions and settings sync data.
+              Required for both "Remember me" and settings sync features.
+              Generate with: openssl rand -base64 32
+            '';
+          };
+
+          settingsSyncEnabled = mkOption {
+            type = bool;
+            default = false;
+            description = ''
+              Enable server-side settings persistence (requires `settings.sessionSecretFile`).
+              When enabled, user settings are encrypted and stored on the server,
+              allowing them to sync across browsers and devices.
+            '';
+          };
+
+          stalwartAdminAccess = mkOption {
+            type = enum [
+              "auto"
+              "password"
+              "off"
+            ];
+            default = "auto";
+            description = ''
+              What a Stalwart admin account grants in the Bulwark admin dashboard.
+
+              auto     - Stalwart admins see the admin shield and are signed into /admin without the Bulwark admin password.
+              password - Stalwart admins see the shield, but must enter the Bulwark admin password.
+              off      - Stalwart admin status is ignored: no shield, and /admin is reachable only via /admin/login with the admin password.
+            '';
+          };
+
+          logFormat = mkOption {
+            type = enum [
+              "text"
+              "json"
+            ];
+            default = "text";
+            description = "Log format: `text` (colored, human-readable) or `json` (structured, for log aggregation)";
+          };
+          logLevel = mkOption {
+            type = enum [
+              "error"
+              "warn"
+              "info"
+              "debug"
+            ];
+            default = "info";
+            description = "Log level: `error`, `warn`, `info`, or `debug`";
+          };
+
+          branding = brandingModule;
+
+          domainBranding = mkOption {
+            type = attrsOf (submodule {
+              options = brandingModule;
+            });
+            default = { };
+            description = ''
+              When you serve the webmail on multiple hostnames, each hostname can override
+              a subset of branding fields. Unset fields fall back to the global values.
+              Match is on the request's Host (or X-Forwarded-Host) header.
+
+              Use "*." to match any subdomain (e.g. "*.example.com"
+              matches mail.example.com and any deeper subdomain, but NOT example.com).
+              Exact matches always win over wildcards; the longest wildcard suffix wins
+              among multiple wildcard matches.
+            '';
+          };
+
+          extensionDirectoryUrl = mkOption {
+            type = str;
+            default = "https://extensions.bulwarkmail.org";
+            description = "URL of the BulwarkMail extension directory for the admin marketplace.";
+          };
+        };
+      };
+      default = { };
+      description = "Bulwark configuration";
+    };
+
+    admin = mkOption {
+      type = nullOr (submodule {
+        options = {
+          passwordHashFile = mkOption {
+            type = str;
+            description = ''
+              File containing the admin password hash
+
+              Generate with
+              ```
+              SALT=$(openssl rand -hex 32)
+              HASH64=$(openssl kdf \
+                -kdfopt pass:"YOUR-PASSWORD" \
+                -kdfopt hexsalt:$SALT \
+                -keylen 64 -kdfopt n:16384 -kdfopt r:8 -kdfopt p:1 \
+                -binary SCRYPT | base64)
+              SALT64=$(echo $SALT | xxd -r -p | base64)
+
+              echo "\$scrypt\$N=16384,r=8,p=1\$$SALT64\$$HASH64"
+              ```
+            '';
+          };
+          sessionTTL = mkOption {
+            type = int;
+            default = 3600;
+            description = "Admin session lifetime in seconds";
+          };
+          trustedProxyDepth = mkOption {
+            type = int;
+            default = 1;
+            description = "Number of `X-Forwarded-For` hops to trust when resolving the client IP for admin sessions and audit logs.";
+          };
+        };
+      });
+      default = null;
+      description = "Bulwark Admin configuration";
+    };
+
+    policies = mkOption {
+      type = submodule {
+        freeformType = format.type;
+
+        options = {
+          features =
+            let
+              feature =
+                description:
+                mkOption {
+                  type = bool;
+                  default = true;
+                  description = description;
+                };
+            in
+            {
+              pluginsEnabled = feature "Allow the plugin system to load and run plugins for users.";
+              requirePluginApproval = feature "User-uploaded plugins must be approved by an admin before they can be enabled.";
+              themesEnabled = feature "Allow users to select and apply themes.";
+              sidebarAppsEnabled = feature "Allow custom web apps in navigation rail.";
+              settingsExportEnabled = feature "Allow users to export and import settings JSON.";
+              customKeywordsEnabled = feature "Allow user-created labels and tags.";
+              templatesEnabled = feature "Allow email template creation and library.";
+              calendarTasksEnabled = feature "Show task panel in calendar view.";
+              smimeEnabled = feature "Enable certificate management and email signing.";
+              externalContentEnabled = feature "Allow users to choose external content loading policy.";
+              debugModeEnabled = feature "Allow users to enable debug/diagnostic mode.";
+              folderIconsEnabled = feature "Allow custom folder icon picker.";
+              hoverActionsConfigEnabled = feature "Allow users to customize email hover actions.";
+              filesEnabled = feature "Enable file storage via WebDAV. WARNING: Large uploads can cause Stalwart/RocksDB instability. Not recommended for production.";
+              contactsEnabled = feature "Enable contacts/address book features.";
+              crossUnreadViewEnabled = feature ''
+                Allow an Unread entry in the Unified Mailbox section that lists unread mail across the account and its shared folders
+                (or every account when the cross-account sub-option is on). Honors the user's folder selection.
+                Requires the matching per-user toggle in Settings → Appearance.
+              '';
+              crossStarredViewEnabled = feature ''
+                Allow a Starred entry in the Unified Mailbox section that lists flagged/starred mail across the account and its shared folders
+                (or every account when the cross-account sub-option is on). Honors the user's folder selection.
+                Requires the matching per-user toggle in Settings → Appearance.
+              '';
+              crossAllViewEnabled = feature ''
+                Allow an All mail entry in the Unified Mailbox section that lists all mail across the account and its shared folders
+                (or every account when the cross-account sub-option is on).
+                Honors the user's folder selection. Requires the matching per-user toggle in Settings → Appearance.
+              '';
+              unifiedCrossAccountEnabled = feature ''
+                Allow users to expand the Unified Mailbox beyond the active account boundary so its lists merge across every logged-in account.
+                When off, the Unified Mailbox stays within the active account and its shared folders.
+              '';
+            };
+          restrictions =
+            let
+              restricted =
+                description:
+                mkOption {
+                  type = submodule {
+                    options = {
+                      locked = mkOption {
+                        type = bool;
+                        default = false;
+                        description = "Whether this option is locked.";
+                      };
+                      hidden = mkOption {
+                        type = bool;
+                        default = false;
+                        description = "Whether this option is hidden.";
+                      };
+                    };
+                  };
+                  default = { };
+                  description = description;
+                };
+            in
+            {
+              fontSize = restricted "Appearance: Font Size";
+              density = restricted "Appearance: Density";
+              animationsEnabled = restricted "Appearance: Animations";
+              markAsReadDelay = restricted "Email: Mark as Read Delay";
+              deleteAction = restricted "Email: Delete Action";
+              showPreview = restricted "Email: Show Preview";
+              mailLayout = restricted "Email: Mail Layout";
+              emailsPerPage = restricted "Email: Emails Per Page";
+              externalContentPolicy = restricted "Email: External Content Policy";
+              sendConfirmation = restricted "Composer: Send Confirmation";
+              defaultReplyMode = restricted "Composer: Default Reply Mode";
+              autoSelectReplyIdentity = restricted "Composer: Auto-select Reply Identity";
+              plainTextMode = restricted "Composer: Plain Text Only";
+              sessionTimeout = restricted "Privacy: Session Timeout";
+              emailNotificationsEnabled = restricted "Notifications: Email Notifications";
+              calendarNotificationsEnabled = restricted "Notifications: Calendar Notifications";
+              debugMode = restricted "Advanced: Debug Mode";
+            };
+
+          pushRelayUrl = mkOption {
+            type = str;
+            default = "";
+            description = "Override the Web Push relay URL shown in user notification settings.";
+          };
+          pushRelayUrlLocked = mkOption {
+            type = bool;
+            default = false;
+            description = "Whether the Web Push relay URL is locked.";
+          };
+
+          themePolicy =
+            let
+              builtinThemes = [
+                "builtin-qui"
+                "builtin-nord"
+                "builtin-catppuccin"
+                "builtin-solarized"
+                "builtin-roundcube-elastic"
+                "builtin-aurora-glass"
+              ];
+            in
+            {
+              disabledBuiltinThemes = mkOption {
+                type = listOf (enum builtinThemes);
+                default = [ ];
+                description = "Disabled builtin Themes";
+              };
+              disabledThemes = mkOption {
+                type = listOf str;
+                default = [ ];
+                description = "Disabled Themes";
+              };
+              defaultThemeId = mkOption {
+                type = nullOr (enum builtinThemes);
+                description = "Theme applied when users have not chosen one.";
+              };
+            };
+
+          forceEnabledPlugins = mkOption {
+            type = listOf str;
+            default = map (plugin: plugin.package.pluginName) (
+              filter (plugin: plugin.forceEnabled) cfg.plugins
+            );
+            defaultText = literalExpression ''
+              map (plugin: plugin.package.pluginName) (
+                filter (plugin: plugin.forceEnabled) config.services.bulwark.plugins
+              );
+            '';
+            description = "Force-enabled Plugins";
+          };
+          approvedPlugins = mkOption {
+            type = listOf str;
+            default = [ ];
+            description = "Approved Plugins";
+          };
+          forceEnabledThemes = mkOption {
+            type = listOf str;
+            default = [ ];
+            description = "Force-enabled Themes";
+          };
+        };
+      };
+      default = { };
+      description = "Bulwark Policy configuration";
+    };
+
+    plugins = mkOption {
+      type = listOf (submodule {
+        options = {
+          package = mkOption {
+            type = package;
+            description = "Plugin package";
+          };
+          forceEnabled = mkOption {
+            type = bool;
+            default = false;
+            description = "Whether this plugin is force-enabled (users cannot disable).";
+          };
+          config = mkOption {
+            type = submodule {
+              freeformType = format.type;
+            };
+            default = { };
+            description = "Plugin configuration";
+          };
+        };
+      });
+      default = [ ];
+      example = literalExpression ''
+        with pkgs.bulwark-plugins; [
+          {
+            package = calendar-agenda;
+          }
+          {
+            package = spam-score;
+            forceEnabled = true;
+          }
+          {
+            package = external-link-warning;
+            config.trustedDomains = "example.com";
+          }
+        ] ++ [
+          {
+            package = mkBulwarkPlugin {
+              name = "gravatar";
+              version = "1.3.1";
+              hash = "sha256-Rz+xgBw4mfQcdGvQnPLrrW5i4nDQYwMt5Y37gZ2WxyE=";
+            };
+          }
+        ]
+      '';
+      description = "Additional plugins to be used.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.settings.jmapServerUrl != null || cfg.settings.allowCustomJmapEndpoint == true;
+        message = ''
+          <option>services.bulwark.settings.jmapServerUrl</option> needs to be set when <option>services.bulwark.settings.allowCustomJmapEndpoint</option> is `false`.
+        '';
+      }
+      {
+        assertion = cfg.settings.settingsSyncEnabled == false || cfg.settings.sessionSecretFile != null;
+        message = ''
+          <option>services.bulwark.settings.sessionSecretFile</option> needs to be set when <option>services.bulwark.settingsSyncEnabled</option> is `true`.
+        '';
+      }
+      {
+        assertion =
+          !elem cfg.policies.themePolicy.defaultThemeId cfg.policies.themePolicy.disabledBuiltinThemes;
+        message = ''
+          The default theme specified in <option>services.bulwark.policies.themePolicy.defaultThemeId</option> cannot be disabled via <option>services.bulwark.policies.themePolicy.disabledBuiltinThemes</option>.
+        '';
+      }
+      {
+        assertion =
+          lib.lists.intersectLists cfg.policies.themePolicy.disabledThemes cfg.policies.forceEnabledThemes
+          == [ ];
+        message = ''
+          The themes disabled via <option>services.bulwark.policies.themePolicy.disabledThemes</option> cannot be enabled at the same time through <option>services.bulwark.policies.forceEnabledThemes</option>.
+        '';
+      }
+    ];
+
+    users.users.bulwark = {
+      isSystemUser = true;
+      group = "bulwark";
+    };
+    users.groups.bulwark = { };
+
+    systemd.services.bulwark = {
+      description = "bulwark service";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "network-online.target"
+      ];
+      wants = [
+        "network-online.target"
+      ];
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
+        User = "bulwark";
+        Group = "bulwark";
+        DynamicUser = true;
+
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        StateDirectory = "bulwark";
+        BindReadOnlyPaths = [
+          "/nix/store"
+        ];
+        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateUsers = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        DevicePolicy = "closed";
+        ProcSubset = "pid";
+        ProtectSystem = "strict";
+        ProtectClock = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+        ];
+      };
+
+      environment = {
+        ADMIN_CONFIG_DIR = toString (
+          pkgs.linkFarm "bulwark-admin-config-dir" (
+            [
+              {
+                name = "config.json";
+                path = format.generate "config.json" (
+                  lib.mapAttrs'
+                    (
+                      name: value:
+                      if name == "jmapServers" then
+                        flattenAttrSet name "id" value
+                      else if name == "domainBranding" then
+                        flattenAttrSet name "host" value
+                      else
+                        nameValuePair name value
+                    )
+                    (
+                      removeAttrs
+                        (
+                          cfg.settings
+                          // cfg.settings.branding
+                          // optionalAttrs cfg.settings.oauth.enabled (renameOptions "oauth")
+                        )
+                        [
+                          "branding"
+                          "oauth"
+                        ]
+                    )
+
+                  // {
+                    setupComplete = true;
+                  }
+                );
+              }
+              {
+                name = "policy.json";
+                path = format.generate "policy.json" (
+                  recursiveUpdate cfg.policies {
+                    features.pluginsUploadEnabled = false;
+                    features.userThemesEnabled = false;
+                  }
+                );
+              }
+              {
+                name = "plugins";
+                path = toString (
+                  pkgs.linkFarm "bulwark-plugins" (
+                    [
+                      {
+                        name = "registry.json";
+                        path = format.generate "registry.json" {
+                          plugins = map (
+                            plugin:
+                            (trivial.importJSON "${plugin.package.outPath}/manifest.json")
+                            // {
+                              enabled = true;
+                              forceEnabled = plugin.forceEnabled;
+                            }
+                          ) cfg.plugins;
+                        };
+                      }
+                    ]
+                    ++ (map (plugin: {
+                      name = "${plugin.package.pluginName}.js";
+                      path = "${plugin.package.outPath}/index.js";
+                    }) cfg.plugins)
+                  )
+                );
+              }
+              {
+                name = "plugin-config";
+                path = toString (
+                  pkgs.linkFarm "bulwark-plugin-config" (
+                    map (plugin: {
+                      name = "${plugin.package.pluginName}.json";
+                      path = format.generate "${plugin.package.pluginName}.json" plugin.config;
+                    }) (filter (plugin: plugin.config != { }) cfg.plugins)
+                  )
+                );
+              }
+            ]
+            ++ lib.optionals (cfg.admin != null) [
+              {
+                name = "admin.json";
+                path = format.generate "admin.json" cfg.admin;
+              }
+            ]
+          )
+        );
+        ADMIN_CONFIG_READONLY = "true";
+
+        HOSTNAME = cfg.hostname;
+        PORT = toString cfg.port;
+        ADMIN_STATE_DIR = cfg.admin_state_dir;
+        VERSION_CHECK_DATA_DIR = cfg.version_check_data_dir;
+        BULWARK_UPDATE_CHECK = if cfg.updateCheck.enabled then "on" else "off";
+        BULWARK_TELEMETRY = if cfg.telemetry.enabled then "on" else "off";
+      }
+      // optionalAttrs cfg.settings.settingsSyncEnabled {
+        SETTINGS_DATA_DIR = cfg.settings_data_dir;
+      }
+      // optionalAttrs (cfg.admin != null) {
+        ADMIN_SESSION_TTL = toString cfg.admin.sessionTTL;
+        TRUSTED_PROXY_DEPTH = toString cfg.admin.trustedProxyDepth;
+      }
+      // optionalAttrs cfg.updateCheck.enabled {
+        BULWARK_UPDATE_CHECK_URL = cfg.updateCheck.url;
+      }
+      // optionalAttrs cfg.telemetry.enabled {
+        TELEMETRY_DATA_DIR = cfg.telemetry.data_dir;
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ Cameo007 ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -320,6 +320,7 @@ in
   budgie = runTest ./budgie.nix;
   buildbot = runTest ./buildbot.nix;
   buildkite-agents = runTest ./buildkite-agents.nix;
+  bulwark = runTest ./bulwark.nix;
   c2fmzq = runTest ./c2fmzq.nix;
   caddy = runTest ./caddy.nix;
   cadvisor = runTestOn [ "x86_64-linux" ] ./cadvisor.nix;

--- a/nixos/tests/bulwark.nix
+++ b/nixos/tests/bulwark.nix
@@ -1,0 +1,26 @@
+{ pkgs, ... }:
+{
+  name = "bulwark";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [
+      Cameo007
+    ];
+  };
+
+  nodes.machine = {
+    services.bulwark = {
+      enable = true;
+      settings.allowCustomJmapEndpoint = true;
+    };
+  };
+
+  testScript = ''
+    import json
+
+    machine.wait_for_unit("bulwark")
+    machine.wait_for_open_port(3000)
+
+    status = machine.succeed("curl -f http://localhost:3000/api/health")
+    assert json.loads(status)["status"] == "healthy", "The fetched config does not match"
+  '';
+}

--- a/nixos/tests/bulwark.nix
+++ b/nixos/tests/bulwark.nix
@@ -22,5 +22,8 @@
 
     status = machine.succeed("curl -f http://localhost:3000/api/health")
     assert json.loads(status)["status"] == "healthy", "The fetched config does not match"
+
+    machine.wait_until_succeeds("journalctl -u bulwark | grep -q 'scheduler not started'")
+    machine.fail("journalctl -u bulwark | grep -q 'init skipped'")
   '';
 }

--- a/pkgs/by-name/bu/bulwark/01-localfont.patch
+++ b/pkgs/by-name/bu/bulwark/01-localfont.patch
@@ -1,0 +1,31 @@
+diff --git a/app/(main)/layout.tsx b/app/(main)/layout.tsx
+index a8af157f..9d54eb7b 100644
+--- a/app/(main)/layout.tsx
++++ b/app/(main)/layout.tsx
+@@ -1,6 +1,6 @@
+ import type { Metadata, Viewport } from "next";
+ import { getLocaleDirection } from "@/i18n/direction";
+-import { Geist, Geist_Mono } from "next/font/google";
++import localFont from "next/font/local";
+ import { headers } from "next/headers";
+ import { getLocale, getTranslations } from "next-intl/server";
+ import { ServiceWorkerRegistration } from "@/components/service-worker-registration";
+@@ -26,14 +26,14 @@ async function resolveRequestLocale(): Promise<string> {
+   return seg ?? (await getLocale());
+ }
+ 
+-const geistSans = Geist({
++const geistSans = localFont({
++  src: '../fonts/Geist.ttf',
+   variable: "--font-geist-sans",
+-  subsets: ["latin"],
+ });
+ 
+-const geistMono = Geist_Mono({
++const geistMono = localFont({
++  src: '../fonts/Geist.ttf',
+   variable: "--font-geist-mono",
+-  subsets: ["latin"],
+ });
+ 
+ export const viewport: Viewport = {

--- a/pkgs/by-name/bu/bulwark/package.nix
+++ b/pkgs/by-name/bu/bulwark/package.nix
@@ -5,6 +5,7 @@
   google-fonts,
   nodejs,
   nix-update-script,
+  nixosTests,
 }:
 buildNpmPackage (finalAttrs: {
   pname = "bulwark";
@@ -68,7 +69,12 @@ buildNpmPackage (finalAttrs: {
 
   __structuredAttrs = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit (nixosTests) bulwark;
+    };
+  };
 
   meta = {
     description = "Modern, self-hosted webmail client for Stalwart Mail Server";

--- a/pkgs/by-name/bu/bulwark/package.nix
+++ b/pkgs/by-name/bu/bulwark/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  google-fonts,
+  nodejs,
+  nix-update-script,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "bulwark";
+  version = "1.9.2";
+
+  src = fetchFromGitHub {
+    owner = "bulwarkmail";
+    repo = "webmail";
+    tag = finalAttrs.version;
+    hash = "sha256-HWDBwOZ84wbT+tUBTeSyD/4y8RJUbdL15BofXPdIT1Q=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse --short HEAD > $out/COMMIT
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+  npmDepsHash = "sha256-pNA8Kl1ZsblsMRZyqiLx07MPec4fPnJJqJs0gbLfNaA=";
+
+  strictDeps = true;
+
+  patches = [ ./01-localfont.patch ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    mkdir -p app/fonts
+    cp "${
+      google-fonts.override { fonts = [ "Geist" ]; }
+    }/share/fonts/truetype/Geist[wght].ttf" app/fonts/Geist.ttf
+    cp "${
+      google-fonts.override { fonts = [ "GeistMono" ]; }
+    }/share/fonts/truetype/GeistMono[wght].ttf" app/fonts/GeistMono.ttf
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    NEXT_TELEMETRY_DISABLED=1 GIT_COMMIT=$(cat COMMIT) node_modules/.bin/next build --webpack
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp -R .next/standalone/. $out/
+    cp -R public $out/public
+    cp -R .next/static $out/.next/static
+
+    makeWrapper ${nodejs}/bin/node $out/bin/bulwark \
+      --add-flags "$out/server.js" \
+      --set NODE_ENV production \
+      --set NEXT_TELEMETRY_DISABLED 1
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern, self-hosted webmail client for Stalwart Mail Server";
+    homepage = "https://bulwarkmail.org";
+    changelog = "https://github.com/bulwarkmail/webmail/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ Cameo007 ];
+    mainProgram = "bulwark";
+  };
+})

--- a/pkgs/by-name/bu/bulwark/plugins.nix
+++ b/pkgs/by-name/bu/bulwark/plugins.nix
@@ -204,7 +204,7 @@ in
     meta = {
       description = "End-to-end OpenPGP for webmail";
       homepage = "https://github.com/paulhenry46/pgp-plugin";
-      license = lib.licenses.gpl3OrLater;
+      license = lib.licenses.gpl3Plus;
       maintainers = with lib.maintainers; [ Cameo007 ];
     };
   });

--- a/pkgs/by-name/bu/bulwark/plugins.nix
+++ b/pkgs/by-name/bu/bulwark/plugins.nix
@@ -1,36 +1,60 @@
 {
   lib,
   stdenvNoCC,
+  buildNpmPackage,
   fetchFromGitHub,
   fetchzip,
+  nix-update,
   nix-update-script,
+  writeShellScript,
+  curl,
+  jq,
+  coreutils,
 }:
 let
+  # Store bundles ship a prebuilt index.js. Source checkouts (with
+  # npmDepsHash) need to be built with npm first.
   mkBulwarkPlugin =
     f:
-    stdenvNoCC.mkDerivation (
+    let
+      fromSource = (lib.fix f) ? npmDepsHash;
+      builder = if fromSource then buildNpmPackage else stdenvNoCC.mkDerivation;
+    in
+    builder (
       finalAttrs:
       let
-        inherit (f finalAttrs) pname version src;
+        attrs = f finalAttrs;
       in
-      {
-        pluginName = lib.removePrefix "bulwark-plugin-" pname;
+      attrs
+      // rec {
+        pluginName = lib.removePrefix "bulwark-plugin-" attrs.pname;
 
-        inherit pname version src;
-
-        __structuredAttrs = true;
         strictDeps = true;
 
         installPhase = ''
           runHook preInstall
 
-          mkdir -p $out
-          cp -r * $out
+          install -Dm644 -t $out manifest.json ${if fromSource then "dist/" else ""}index.js
+          if [ -d media ]; then
+            cp -r media $out/
+          fi
 
           runHook postInstall
         '';
 
-        passthru.updateScript = nix-update-script { };
+        # nix-update cannot discover versions on the extension store, so ask
+        # its API for the latest one and let nix-update fix the hashes.
+        passthru.updateScript =
+          if fromSource then
+            nix-update-script { }
+          else
+            writeShellScript "update-${attrs.pname}" ''
+              set -euo pipefail
+              version=$(${lib.getExe curl} -sSf https://extensions.bulwarkmail.org/api/v1/extension/${pluginName} \
+                | ${lib.getExe jq} -r '.data.versions[].version' \
+                | ${coreutils}/bin/sort -V | ${coreutils}/bin/tail -n1)
+              exec ${lib.getExe nix-update} bulwark-plugins.${pluginName} --version="$version"
+            '';
       }
     );
 in
@@ -159,6 +183,7 @@ in
       tag = "v${finalAttrs.version}";
       hash = "sha256-/n5FroXla8MvkVZJvPDIZcxm498hIInCJRIbAt9/LMQ=";
     };
+    npmDepsHash = "sha256-rIPl4HIETiZjnfDwORf/lauqN/nbVjLy0a29nm3+bHo=";
     meta = {
       description = "End-to-end OpenPGP (GnuPG-compatible) for webmail";
       homepage = "https://github.com/samuelmiller36/bulwark-gpg";
@@ -175,6 +200,7 @@ in
       tag = finalAttrs.version;
       hash = "sha256-VFX6kiOf0UclAT1Tntg3vmfBUK5Kevh0Vq57XEizcWA=";
     };
+    npmDepsHash = "sha256-O84i5VyIJ+MlhQAJhXRjmlzmwPl910HTFwFWg/vzrUE=";
     meta = {
       description = "End-to-end OpenPGP for webmail";
       homepage = "https://github.com/paulhenry46/pgp-plugin";
@@ -207,9 +233,8 @@ in
       extension = "zip";
       stripRoot = false;
     };
-    hash = "sha256-BGOOkZu3EHCo4uM+g4B81B+6BoXGLlq++hfbevfpWVc=";
     meta = {
-      description = "End-to-end S/MIME for webmail:";
+      description = "End-to-end S/MIME for webmail";
       homepage = "https://extensions.bulwarkmail.org/extension/smime";
       license = lib.licenses.agpl3Only;
       maintainers = with lib.maintainers; [ Cameo007 ];
@@ -224,7 +249,6 @@ in
       extension = "zip";
       stripRoot = false;
     };
-    hash = "sha256-JmT/r4Xhn9NiiAnPfya6EqWvpW3wpJFXjNpzmznMDcE=";
     meta = {
       description = "Adds a Spam Analysis section to a message's \"More details\" panel";
       homepage = "https://extensions.bulwarkmail.org/extension/spam-score";

--- a/pkgs/by-name/bu/bulwark/plugins.nix
+++ b/pkgs/by-name/bu/bulwark/plugins.nix
@@ -1,0 +1,235 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchzip,
+  nix-update-script,
+}:
+let
+  mkBulwarkPlugin =
+    f:
+    stdenvNoCC.mkDerivation (
+      finalAttrs:
+      let
+        inherit (f finalAttrs) pname version src;
+      in
+      {
+        pluginName = lib.removePrefix "bulwark-plugin-" pname;
+
+        inherit pname version src;
+
+        __structuredAttrs = true;
+        strictDeps = true;
+
+        installPhase = ''
+          runHook preInstall
+
+          mkdir -p $out
+          cp -r * $out
+
+          runHook postInstall
+        '';
+
+        passthru.updateScript = nix-update-script { };
+      }
+    );
+in
+{
+
+  inherit mkBulwarkPlugin;
+
+  calendar-agenda = mkBulwarkPlugin (finalAttrs: {
+    pname = "bulwark-plugin-calendar-agenda";
+    version = "1.2.1";
+    src = fetchzip {
+      url = "https://extensions.bulwarkmail.org/api/v1/bundle/calendar-agenda/${finalAttrs.version}";
+      hash = "sha256-p6RIndNGifU70JadAbWmTT5RE2kOgEVmXKCaa6CkFp0=";
+      extension = "zip";
+      stripRoot = false;
+    };
+    meta = {
+      description = "Shows an agenda of your upcoming calendar events in the sidebar";
+      homepage = "https://extensions.bulwarkmail.org/extension/calendar-agenda";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ Cameo007 ];
+    };
+  });
+  external-link-warning = mkBulwarkPlugin (finalAttrs: {
+    pname = "bulwark-plugin-external-link-warning";
+    version = "1.2.1";
+    src = fetchzip {
+      url = "https://extensions.bulwarkmail.org/api/v1/bundle/external-link-warning/${finalAttrs.version}";
+      hash = "sha256-FHq3l5yhVpwcgzbXMI7L5l6+wVwRODm56SJSFQuaRAY=";
+      extension = "zip";
+      stripRoot = false;
+    };
+    meta = {
+      description = "Warns before opening external links to unknown domains";
+      homepage = "https://extensions.bulwarkmail.org/extension/external-link-warning";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ Cameo007 ];
+    };
+  });
+  external-mail-warning = mkBulwarkPlugin (finalAttrs: {
+    pname = "bulwark-plugin-external-mail-warning";
+    version = "1.3.1";
+    src = fetchzip {
+      url = "https://extensions.bulwarkmail.org/api/v1/bundle/external-mail-warning/${finalAttrs.version}";
+      hash = "sha256-J0+WCqc8GGw8txZ1g/4JhnivcLA5iuZOQdlXuUSJMxA=";
+      extension = "zip";
+      stripRoot = false;
+    };
+    meta = {
+      description = "Warns before sending email to recipients outside your safe-domain list";
+      homepage = "https://extensions.bulwarkmail.org/extension/external-mail-warning";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ Cameo007 ];
+    };
+  });
+  gravatar = mkBulwarkPlugin (finalAttrs: {
+    pname = "bulwark-plugin-gravatar";
+    version = "1.3.1";
+    src = fetchzip {
+      url = "https://extensions.bulwarkmail.org/api/v1/bundle/gravatar/${finalAttrs.version}";
+      hash = "sha256-Rz+xgBw4mfQcdGvQnPLrrW5i4nDQYwMt5Y37gZ2WxyE=";
+      extension = "zip";
+      stripRoot = false;
+    };
+    meta = {
+      description = "Resolves Gravatar profile pictures for email contacts via the avatar transform hook";
+      homepage = "https://extensions.bulwarkmail.org/extension/gravatar";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ Cameo007 ];
+    };
+  });
+  impersonation-notice = mkBulwarkPlugin (finalAttrs: {
+    pname = "bulwark-plugin-impersonation-notice";
+    version = "1.2.5";
+    src = fetchzip {
+      url = "https://extensions.bulwarkmail.org/api/v1/bundle/impersonation-notice/${finalAttrs.version}";
+      hash = "sha256-BuE+51gOAMFAsfrRK8O+1SNJ2G/L1NQ9WBYZZq7tlko=";
+      extension = "zip";
+      stripRoot = false;
+    };
+    meta = {
+      description = "Shows a persistent top-of-app banner when the active session is a Stalwart master-user impersonation";
+      homepage = "https://extensions.bulwarkmail.org/extension/impersonation-notice";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ Cameo007 ];
+    };
+  });
+  jitsi-meet = mkBulwarkPlugin (finalAttrs: {
+    pname = "bulwark-plugin-jitsi-meet";
+    version = "1.0.1";
+    src = fetchzip {
+      url = "https://extensions.bulwarkmail.org/api/v1/bundle/jitsi-meet/${finalAttrs.version}";
+      hash = "sha256-8HYA5Ihi3D9ia4RxxM/J3lfB1qxB3LDyVYx4TDTNSJo=";
+      extension = "zip";
+      stripRoot = false;
+    };
+    meta = {
+      description = "Adds a 'Add Jitsi Meeting' button to calendar events";
+      homepage = "https://extensions.bulwarkmail.org/extension/jitsi-meet";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ Cameo007 ];
+    };
+  });
+  libravatar = mkBulwarkPlugin (finalAttrs: {
+    pname = "bulwark-plugin-libravatar";
+    version = "1.0.0";
+    src = fetchzip {
+      url = "https://extensions.bulwarkmail.org/api/v1/bundle/libravatar/${finalAttrs.version}";
+      hash = "sha256-R0AfJJv6IjeFyFUN4L4JA25VvrkLYb1FFAo5IMqxQzU=";
+      extension = "zip";
+      stripRoot = false;
+    };
+    meta = {
+      description = "Resolves Libravatar profile pictures for email contacts via the avatar transform hook";
+      homepage = "https://extensions.bulwarkmail.org/extension/libravatar";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ Cameo007 ];
+    };
+  });
+  openpgp = mkBulwarkPlugin (finalAttrs: {
+    pname = "bulwark-plugin-openpgp";
+    version = "1.1.6";
+    src = fetchFromGitHub {
+      owner = "samuelmiller36";
+      repo = "bulwark-gpg";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-/n5FroXla8MvkVZJvPDIZcxm498hIInCJRIbAt9/LMQ=";
+    };
+    meta = {
+      description = "End-to-end OpenPGP (GnuPG-compatible) for webmail";
+      homepage = "https://github.com/samuelmiller36/bulwark-gpg";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ Cameo007 ];
+    };
+  });
+  pgp-true-end-to-end = mkBulwarkPlugin (finalAttrs: {
+    pname = "bulwark-plugin-pgp-true-end-to-end";
+    version = "2.0.0";
+    src = fetchFromGitHub {
+      owner = "paulhenry46";
+      repo = "pgp-plugin";
+      tag = finalAttrs.version;
+      hash = "sha256-VFX6kiOf0UclAT1Tntg3vmfBUK5Kevh0Vq57XEizcWA=";
+    };
+    meta = {
+      description = "End-to-end OpenPGP for webmail";
+      homepage = "https://github.com/paulhenry46/pgp-plugin";
+      license = lib.licenses.gpl3OrLater;
+      maintainers = with lib.maintainers; [ Cameo007 ];
+    };
+  });
+  quick-notes = mkBulwarkPlugin (finalAttrs: {
+    pname = "bulwark-plugin-quick-notes";
+    version = "1.0.0";
+    src = fetchzip {
+      url = "https://extensions.bulwarkmail.org/api/v1/bundle/quick-notes/${finalAttrs.version}";
+      hash = "sha256-Hh9tTuL0OGSxZWUj2seYD6038ny1DubInpSdtAntOgU=";
+      extension = "zip";
+      stripRoot = false;
+    };
+    meta = {
+      description = "Per-email sticky notes in the sidebar — jot notes while reading emails";
+      homepage = "https://extensions.bulwarkmail.org/extension/quick-notes";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ Cameo007 ];
+    };
+  });
+  smime = mkBulwarkPlugin (finalAttrs: {
+    pname = "bulwark-plugin-smime";
+    version = "1.0.2";
+    src = fetchzip {
+      url = "https://extensions.bulwarkmail.org/api/v1/bundle/smime/${finalAttrs.version}";
+      hash = "sha256-BGOOkZu3EHCo4uM+g4B81B+6BoXGLlq++hfbevfpWVc=";
+      extension = "zip";
+      stripRoot = false;
+    };
+    hash = "sha256-BGOOkZu3EHCo4uM+g4B81B+6BoXGLlq++hfbevfpWVc=";
+    meta = {
+      description = "End-to-end S/MIME for webmail:";
+      homepage = "https://extensions.bulwarkmail.org/extension/smime";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ Cameo007 ];
+    };
+  });
+  spam-score = mkBulwarkPlugin (finalAttrs: {
+    pname = "bulwark-plugin-spam-score";
+    version = "1.0.0";
+    src = fetchzip {
+      url = "https://extensions.bulwarkmail.org/api/v1/bundle/spam-score/${finalAttrs.version}";
+      hash = "sha256-JmT/r4Xhn9NiiAnPfya6EqWvpW3wpJFXjNpzmznMDcE=";
+      extension = "zip";
+      stripRoot = false;
+    };
+    hash = "sha256-JmT/r4Xhn9NiiAnPfya6EqWvpW3wpJFXjNpzmznMDcE=";
+    meta = {
+      description = "Adds a Spam Analysis section to a message's \"More details\" panel";
+      homepage = "https://extensions.bulwarkmail.org/extension/spam-score";
+      license = lib.licenses.agpl3Only;
+      maintainers = with lib.maintainers; [ Cameo007 ];
+    };
+  });
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7201,6 +7201,8 @@ with pkgs;
 
   appdaemon = callPackage ../servers/home-assistant/appdaemon.nix { };
 
+  bulwark-plugins = recurseIntoAttrs (callPackage ../by-name/bu/bulwark/plugins.nix { });
+
   cassandra_4 = callPackage ../servers/nosql/cassandra/4.nix {
     # Effective Cassandra 4.0.2 there is full Java 11 support
     #  -- https://cassandra.apache.org/doc/latest/cassandra/new/java11.html


### PR DESCRIPTION
This PR adds [Bulwark Webmail](https://github.com/bulwarkmail/webmail), a modern webmail client for Stalwart, using JMAP.

For specifying secrest we need to wait for bulwarkmail/webmail#165 which adds `_FILE` env vars, allowing us to specifiy a file containing them.

## April 09 UPDATE

bulwarkmail/webmail#165 is now merged, it’s just a matter of time until the next release

## April 12 UPDATE

`v1.4.13` now includes it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
