### PR TITLE
nixos/kine: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -44,6 +44,8 @@
 
 - [knot-resolver](https://www.knot-resolver.cz/) in version 6. Available as `services.knot-resolver`. A module for knot-resolver 5 was already available as `services.kresd`.
 
+- [Kine](https://github.com/k3s-io/kine), an etcd shim that translates the etcd API to SQLite, PostgreSQL, MySQL, or NATS. Available as [services.kine](#opt-services.kine.enable).
+
 - [ImmichFrame](https://immichframe.dev/), display your photos from Immich as a digital photo frame. Available as `services.immichframe`.
 
 - [PdfDing](https://www.pdfding.com/), manage, view and edit your PDFs seamlessly on all your devices wherever you are. Available as [services.pdfding](#opt-services.pdfding.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -533,6 +533,7 @@
   ./services/databases/hbase-standalone.nix
   ./services/databases/influxdb2.nix
   ./services/databases/influxdb.nix
+  ./services/databases/kine.nix
   ./services/databases/lldap.nix
   ./services/databases/memcached.nix
   ./services/databases/monetdb.nix

--- a/nixos/modules/services/databases/kine.nix
+++ b/nixos/modules/services/databases/kine.nix
@@ -1,0 +1,407 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.kine;
+
+  useSqlite = cfg.database.type == "sqlite";
+  usePostgresql = cfg.database.type == "postgres";
+  useMysql = cfg.database.type == "mysql";
+  useNats = cfg.database.type == "nats";
+
+  passwordPlaceholder = "__KINE_DB_PASSWORD__";
+
+  userPart =
+    if cfg.database.passwordFile != null then
+      "${cfg.database.user}:${passwordPlaceholder}"
+    else
+      cfg.database.user;
+
+  useEndpointFile = cfg.endpointFile != null;
+
+  endpointTemplate =
+    if cfg.endpoint != null then
+      cfg.endpoint
+    else if useSqlite then
+      "sqlite://${cfg.database.path}"
+    else if usePostgresql then
+      let
+        hostPart =
+          if cfg.database.socket != null then
+            "/${cfg.database.name}?host=${cfg.database.socket}"
+          else
+            "${cfg.database.host}:${toString cfg.database.port}/${cfg.database.name}";
+      in
+      "postgres://${userPart}@${hostPart}"
+    else if useMysql then
+      let
+        hostPart =
+          if cfg.database.socket != null then
+            "unix(${cfg.database.socket})"
+          else
+            "tcp(${cfg.database.host}:${toString cfg.database.port})";
+      in
+      "mysql://${userPart}@${hostPart}/${cfg.database.name}"
+    else
+      "nats://${cfg.database.host}:${toString cfg.database.port}";
+
+  envFile = "/run/kine/env";
+in
+{
+
+  options.services.kine = {
+    enable = lib.mkEnableOption "kine, an etcdshim that translates etcd API to RDMS";
+
+    package = lib.mkPackageOption pkgs "kine" { };
+
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "0.0.0.0:2379";
+      description = "Address and port on which kine will listen for client connections.";
+    };
+
+    endpoint = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "postgres://user@localhost:5432/kine";
+      description = ''
+        Raw storage backend endpoint URI. When set, this takes precedence over
+        all `database.*` options.
+
+        ::: {.warning}
+        This value is embedded in the Nix store. Do not include credentials here.
+        Use {option}`endpointFile` for endpoints containing secrets.
+        :::
+      '';
+    };
+
+    endpointFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/kine-endpoint";
+      description = ''
+        Path to a file containing the raw storage backend endpoint URI.
+        The file is read at runtime via systemd's `LoadCredential`, keeping
+        secrets out of the Nix store. When set, this takes precedence over
+        {option}`endpoint` and all `database.*` options.
+      '';
+    };
+
+    database = {
+      type = lib.mkOption {
+        type = lib.types.enum [
+          "sqlite"
+          "postgres"
+          "mysql"
+          "nats"
+        ];
+        default = "sqlite";
+        example = "postgres";
+        description = "Database engine to use as kine's storage backend.";
+      };
+
+      host = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        description = "Database host address.";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default =
+          if usePostgresql then
+            config.services.postgresql.settings.port
+          else if useMysql then
+            config.services.mysql.settings.mysqld.port
+          else if useNats then
+            config.services.nats.port
+          else
+            2379;
+        defaultText = lib.literalExpression ''
+          if config.services.kine.database.type == "postgres" then config.services.postgresql.settings.port
+          else if config.services.kine.database.type == "mysql" then config.services.mysql.settings.mysqld.port
+          else if config.services.kine.database.type == "nats" then config.services.nats.port
+          else 2379
+        '';
+        description = "Database host port. Not used for SQLite.";
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "kine";
+        description = "Database name.";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "kine";
+        description = "Database user.";
+      };
+
+      passwordFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/run/secrets/kine-db-pass";
+        description = ''
+          Path to a file containing the database password.
+          The password will be spliced into the endpoint URI at runtime.
+        '';
+      };
+
+      socket = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default =
+          if (cfg.database.createLocally && usePostgresql) then
+            "/run/postgresql"
+          else if (cfg.database.createLocally && useMysql) then
+            "/run/mysqld/mysqld.sock"
+          else
+            null;
+        defaultText = lib.literalExpression "null";
+        example = "/run/mysqld/mysqld.sock";
+        description = ''
+          Path to the Unix socket for database connections.
+          When set, the connection uses the socket instead of host:port.
+          Automatically configured when `createLocally` is enabled for PostgreSQL or MySQL.
+        '';
+      };
+
+      path = lib.mkOption {
+        type = lib.types.str;
+        default = "${cfg.dataDir}/db";
+        defaultText = lib.literalExpression ''"''${config.services.kine.dataDir}/db"'';
+        description = "Path to the SQLite database file.";
+      };
+
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to automatically provision the database locally.
+          When enabled, the appropriate database service (PostgreSQL, MySQL, or NATS)
+          is configured with the necessary database, user, and permissions.
+          For SQLite, no extra provisioning is needed.
+        '';
+      };
+    };
+
+    metricsBindAddress = lib.mkOption {
+      type = lib.types.str;
+      default = ":8080";
+      description = "Bind address for the Prometheus metrics endpoint.";
+    };
+
+    caFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "CA certificate file for backend database TLS.";
+    };
+
+    certFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Client certificate file for backend database TLS.";
+    };
+
+    keyFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "Client key file for backend database TLS.";
+    };
+
+    serverCertFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "TLS certificate file for the kine server (etcd API).";
+    };
+
+    serverKeyFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "TLS key file for the kine server (etcd API).";
+    };
+
+    trustedCaFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = "CA certificate file used to verify client certificates connecting to the kine server.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/kine";
+      description = "Directory for kine state data (used by SQLite backend).";
+    };
+
+    debug = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable trace-level debug logging.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "--compact-interval=10m"
+        "--slow-sql-threshold=2s"
+      ];
+      description = "Extra command-line arguments to pass to kine.";
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.database.createLocally -> useSqlite || useNats || cfg.database.user == "kine";
+        message = "services.kine.database.user must be \"kine\" if the database is to be automatically provisioned";
+      }
+      {
+        assertion = cfg.database.createLocally && usePostgresql -> cfg.database.user == cfg.database.name;
+        message = ''
+          When creating a PostgreSQL database via NixOS, the db user and db name must be equal.
+          If you already have an existing database, set `services.kine.database.createLocally` to `false`.
+        '';
+      }
+      {
+        assertion = !(cfg.endpoint != null && cfg.endpointFile != null);
+        message = "`services.kine.endpoint` and `services.kine.endpointFile` are mutually exclusive.";
+      }
+      {
+        assertion = cfg.database.passwordFile != null -> (cfg.endpoint == null && !useEndpointFile);
+        message = "`services.kine.database.passwordFile` can only be used with structured `database.*` options, not with `endpoint` or `endpointFile`.";
+      }
+      {
+        assertion =
+          (cfg.endpoint != null || useEndpointFile) -> !(cfg.database.createLocally && !useSqlite);
+        message = ''
+          When using a raw endpoint (via `endpoint` or `endpointFile`), set `database.createLocally`
+          to `false` to avoid provisioning a local database that won't be used.
+        '';
+      }
+    ];
+
+    services.postgresql = lib.optionalAttrs (usePostgresql && cfg.database.createLocally) {
+      enable = lib.mkDefault true;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    services.mysql = lib.optionalAttrs (useMysql && cfg.database.createLocally) {
+      enable = lib.mkDefault true;
+      package = lib.mkDefault pkgs.mariadb;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensurePermissions = {
+            "${cfg.database.name}.*" = "ALL PRIVILEGES";
+          };
+        }
+      ];
+    };
+
+    services.nats = lib.optionalAttrs (useNats && cfg.database.createLocally) {
+      enable = lib.mkDefault true;
+      jetstream = lib.mkDefault true;
+    };
+
+    systemd.tmpfiles.settings."10-kine".${cfg.dataDir}.d = {
+      user = "kine";
+      mode = "0700";
+    };
+
+    systemd.services.kine = {
+      description = "Kine - etcd API to RDMS translation layer";
+      after = [
+        "network-online.target"
+      ]
+      ++ lib.optional (cfg.database.createLocally && usePostgresql) "postgresql.service"
+      ++ lib.optional (cfg.database.createLocally && useMysql) "mysql.service"
+      ++ lib.optional (cfg.database.createLocally && useNats) "nats.service";
+      wants = [ "network-online.target" ];
+      requires =
+        lib.optional (cfg.database.createLocally && usePostgresql) "postgresql.service"
+        ++ lib.optional (cfg.database.createLocally && useMysql) "mysql.service"
+        ++ lib.optional (cfg.database.createLocally && useNats) "nats.service";
+      wantedBy = [ "multi-user.target" ];
+
+      preStart = ''
+        umask 0077
+        ${
+          if useEndpointFile then
+            ''
+              endpoint="$(< "$CREDENTIALS_DIRECTORY/endpoint")"
+            ''
+          else
+            ''
+              endpoint=${lib.escapeShellArg endpointTemplate}
+              ${lib.optionalString (cfg.database.passwordFile != null) ''
+                password="$(< "$CREDENTIALS_DIRECTORY/db-password")"
+                endpoint="''${endpoint//${passwordPlaceholder}/$password}"
+              ''}
+            ''
+        }
+        printf '%s' "$endpoint" > ${envFile}
+      '';
+
+      serviceConfig = {
+        ExecStart =
+          let
+            args = [
+              "--listen-address=${cfg.listenAddress}"
+              "--metrics-bind-address=${cfg.metricsBindAddress}"
+            ]
+            ++ lib.optionals (cfg.caFile != null) [ "--ca-file=${cfg.caFile}" ]
+            ++ lib.optionals (cfg.certFile != null) [ "--cert-file=${cfg.certFile}" ]
+            ++ lib.optionals (cfg.keyFile != null) [ "--key-file=${cfg.keyFile}" ]
+            ++ lib.optionals (cfg.serverCertFile != null) [ "--server-cert-file=${cfg.serverCertFile}" ]
+            ++ lib.optionals (cfg.serverKeyFile != null) [ "--server-key-file=${cfg.serverKeyFile}" ]
+            ++ lib.optionals (cfg.trustedCaFile != null) [ "--trusted-ca-file=${cfg.trustedCaFile}" ]
+            ++ lib.optionals cfg.debug [ "--debug" ]
+            ++ cfg.extraArgs;
+          in
+          "${pkgs.writeShellScript "kine-start" ''
+            set -euo pipefail
+            export KINE_ENDPOINT="$(< ${envFile})"
+            exec ${lib.getBin cfg.package}/bin/kine ${lib.escapeShellArgs args}
+          ''}";
+        LoadCredential =
+          lib.optional (cfg.database.passwordFile != null) "db-password:${cfg.database.passwordFile}"
+          ++ lib.optional useEndpointFile "endpoint:${cfg.endpointFile}";
+        RuntimeDirectory = "kine";
+        RuntimeDirectoryMode = "0700";
+        Restart = "on-failure";
+        RestartSec = "15s";
+        User = "kine";
+        WorkingDirectory = cfg.dataDir;
+        StateDirectory = lib.removePrefix "/var/lib/" cfg.dataDir;
+        LimitNOFILE = 40000;
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ReadWritePaths = [ cfg.dataDir ];
+      };
+    };
+
+    users.users.kine = {
+      isSystemUser = true;
+      group = "kine";
+      description = "Kine daemon user";
+      home = cfg.dataDir;
+    };
+    users.groups.kine = { };
+  };
+
+  meta.maintainers = pkgs.kine.meta.maintainers;
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -829,6 +829,7 @@ in
   keyd = handleTest ./keyd.nix { };
   keymap = handleTest ./keymap.nix { };
   kimai = runTest ./kimai.nix;
+  kine = import ./kine/default.nix { inherit pkgs runTest; };
   kismet = runTest ./kismet.nix;
   kiwix-serve = runTest ./kiwix-serve;
   kmonad = runTest ./kmonad.nix;

--- a/nixos/tests/kine/default.nix
+++ b/nixos/tests/kine/default.nix
@@ -1,0 +1,17 @@
+{
+  pkgs,
+  runTest,
+  ...
+}:
+
+let
+  testKine = path: runTest (import path { inherit pkgs; });
+in
+
+{
+  sqlite = testKine ./sqlite.nix;
+  postgres = testKine ./postgres.nix;
+  mariadb = testKine ./mariadb.nix;
+  mysql = testKine ./mysql.nix;
+  nats = testKine ./nats.nix;
+}

--- a/nixos/tests/kine/mariadb.nix
+++ b/nixos/tests/kine/mariadb.nix
@@ -1,0 +1,63 @@
+{ pkgs, ... }:
+
+{
+  name = "kine-mariadb";
+
+  meta = {
+    maintainers = pkgs.kine.meta.maintainers;
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.kine = {
+        enable = true;
+        database = {
+          type = "mysql";
+          createLocally = true;
+        };
+      };
+
+      # Use MariaDB (the default for createLocally)
+      environment.systemPackages = [ pkgs.etcd ];
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("mysql.service")
+    machine.wait_for_unit("kine.service")
+    machine.wait_for_open_port(2379)
+
+    with subtest("should accept etcdctl requests"):
+        machine.wait_until_succeeds(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /health/check ok"
+        )
+
+    with subtest("should write and read key-value pairs"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /test/key 'hello kine mariadb'"
+        )
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'hello kine mariadb'"
+        )
+
+    with subtest("should update existing key-value pairs"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /test/key 'updated value'"
+        )
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'updated value'"
+        )
+        machine.fail(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'hello kine mariadb'"
+        )
+
+    with subtest("should verify data persists in mariadb"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /persist/key 'persistent data'"
+        )
+        machine.succeed(
+            "sudo -u kine mysql kine -e 'SELECT count(*) FROM kine' | grep -E '[0-9]+'"
+        )
+  '';
+}

--- a/nixos/tests/kine/mysql.nix
+++ b/nixos/tests/kine/mysql.nix
@@ -1,0 +1,65 @@
+{ pkgs, ... }:
+
+{
+  name = "kine-mysql";
+
+  meta = {
+    maintainers = pkgs.kine.meta.maintainers;
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.kine = {
+        enable = true;
+        database = {
+          type = "mysql";
+          createLocally = true;
+        };
+      };
+
+      # Override the default MariaDB with MySQL 8.4
+      services.mysql.package = pkgs.mysql84;
+
+      environment.systemPackages = [ pkgs.etcd ];
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("mysql.service")
+    machine.wait_for_unit("kine.service")
+    machine.wait_for_open_port(2379)
+
+    with subtest("should accept etcdctl requests"):
+        machine.wait_until_succeeds(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /health/check ok"
+        )
+
+    with subtest("should write and read key-value pairs"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /test/key 'hello kine mysql'"
+        )
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'hello kine mysql'"
+        )
+
+    with subtest("should update existing key-value pairs"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /test/key 'updated value'"
+        )
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'updated value'"
+        )
+        machine.fail(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'hello kine mysql'"
+        )
+
+    with subtest("should verify data persists in mysql"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /persist/key 'persistent data'"
+        )
+        machine.succeed(
+            "sudo -u kine mysql kine -e 'SELECT count(*) FROM kine' | grep -E '[0-9]+'"
+        )
+  '';
+}

--- a/nixos/tests/kine/nats.nix
+++ b/nixos/tests/kine/nats.nix
@@ -1,0 +1,55 @@
+{ pkgs, ... }:
+
+{
+  name = "kine-nats";
+
+  meta = {
+    maintainers = pkgs.kine.meta.maintainers;
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.kine = {
+        enable = true;
+        database = {
+          type = "nats";
+          createLocally = true;
+        };
+      };
+
+      environment.systemPackages = [ pkgs.etcd ];
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("nats.service")
+    machine.wait_for_open_port(4222)
+    machine.wait_for_unit("kine.service")
+    machine.wait_for_open_port(2379)
+
+    with subtest("should accept etcdctl requests"):
+        machine.wait_until_succeeds(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /health/check ok"
+        )
+
+    with subtest("should write and read key-value pairs"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /test/key 'hello kine nats'"
+        )
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'hello kine nats'"
+        )
+
+    with subtest("should update existing key-value pairs"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /test/key 'updated value'"
+        )
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'updated value'"
+        )
+        machine.fail(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'hello kine nats'"
+        )
+  '';
+}

--- a/nixos/tests/kine/postgres.nix
+++ b/nixos/tests/kine/postgres.nix
@@ -1,0 +1,62 @@
+{ pkgs, ... }:
+
+{
+  name = "kine-postgres";
+
+  meta = {
+    maintainers = pkgs.kine.meta.maintainers;
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.kine = {
+        enable = true;
+        database = {
+          type = "postgres";
+          createLocally = true;
+        };
+      };
+
+      environment.systemPackages = [ pkgs.etcd ];
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("postgresql.service")
+    machine.wait_for_unit("kine.service")
+    machine.wait_for_open_port(2379)
+
+    with subtest("should accept etcdctl requests"):
+        machine.wait_until_succeeds(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /health/check ok"
+        )
+
+    with subtest("should write and read key-value pairs"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /test/key 'hello kine postgres'"
+        )
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'hello kine postgres'"
+        )
+
+    with subtest("should update existing key-value pairs"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /test/key 'updated value'"
+        )
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'updated value'"
+        )
+        machine.fail(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'hello kine postgres'"
+        )
+
+    with subtest("should verify data persists in postgres"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /persist/key 'persistent data'"
+        )
+        machine.succeed(
+            "sudo -u kine psql -d kine -c 'SELECT count(*) FROM kine' | grep -E '^\s+[0-9]+'"
+        )
+  '';
+}

--- a/nixos/tests/kine/sqlite.nix
+++ b/nixos/tests/kine/sqlite.nix
@@ -1,0 +1,50 @@
+{ pkgs, ... }:
+
+{
+  name = "kine-sqlite";
+
+  meta = {
+    maintainers = pkgs.kine.meta.maintainers;
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.kine = {
+        enable = true;
+        database.type = "sqlite";
+      };
+
+      environment.systemPackages = [ pkgs.etcd ];
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("kine.service")
+    machine.wait_for_open_port(2379)
+
+    with subtest("should accept etcdctl requests"):
+        machine.wait_until_succeeds(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /health/check ok"
+        )
+
+    with subtest("should write and read key-value pairs"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /test/key 'hello kine sqlite'"
+        )
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'hello kine sqlite'"
+        )
+
+    with subtest("should update existing key-value pairs"):
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 put /test/key 'updated value'"
+        )
+        machine.succeed(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'updated value'"
+        )
+        machine.fail(
+            "etcdctl --endpoints=http://127.0.0.1:2379 get /test/key | grep 'hello kine sqlite'"
+        )
+  '';
+}

--- a/pkgs/by-name/ki/kine/package.nix
+++ b/pkgs/by-name/ki/kine/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nixosTests,
 }:
 
 buildGoModule (finalAttrs: {
@@ -27,6 +28,8 @@ buildGoModule (finalAttrs: {
   env = {
     "CGO_CFLAGS" = "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_USE_ALLOCA=1";
   };
+
+  passthru.tests = nixosTests.kine;
 
   meta = {
     description = "etcdshim that translates etcd API to RDMS";


### PR DESCRIPTION
## Things done

initialize a module for kine and add some tests to validate it works with its various backends available

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
