### PR TITLE
readest: fix login and UI issues

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13687,6 +13687,12 @@
     githubId = 15855440;
     name = "Keanu Ashwell";
   };
+  kasifrasi = {
+    name = "Ardit Abrashi";
+    github = "Kasifrasi";
+    githubId = 73264146;
+    email = "ardit.abrashi03@gmail.com";
+  };
   katanallama = {
     github = "katanallama";
     githubId = 70604257;

--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -18,6 +18,10 @@
   moreutils,
   jq,
   gst_all_1,
+  glib-networking,
+  cacert,
+  gsettings-desktop-schemas,
+  adwaita-icon-theme,
 
   # NOTE: this is enabled by default for better compatibility, but it may slow
   # down performance.
@@ -83,6 +87,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     gtk3
     librsvg
     openssl
+    glib-networking
+    cacert
+    gsettings-desktop-schemas
+    adwaita-icon-theme
     # TTS
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
@@ -95,7 +103,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pnpm setup-vendors
   '';
 
-  preFixup = lib.optionalString withNvidiaFix ''
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --set GIO_EXTRA_MODULES "${glib-networking}/lib/gio/modules"
+      --set NIX_SSL_CERT_FILE "${cacert}/etc/ssl/certs/ca-bundle.crt"
+    )
+  ''
+  + lib.optionalString withNvidiaFix ''
     # fix Nvidia issues with Tauri
     # https://github.com/tauri-apps/tauri/issues/9394
     # https://github.com/tauri-apps/tauri/issues/9304
@@ -112,7 +126,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/readest/readest/releases/tag/v${finalAttrs.version}";
     mainProgram = "readest";
     license = lib.licenses.agpl3Plus;
-    maintainers = with lib.maintainers; [ eljamm ];
+    maintainers = with lib.maintainers; [
+      eljamm
+      kasifrasi
+    ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Description

This PR fixes the "TLS support is not available" error in `readest` which prevented users from logging into Supabase. It also ensures that GTK schemas and icons are correctly loaded for a consistent user interface.

### Changes:
- Added `glib-networking` and `cacert` to `buildInputs` and configured them via `gappsWrapperArgs` to enable TLS/SSL support.
- Added `gsettings-desktop-schemas` and `adwaita-icon-theme` to ensure proper UI rendering.
- Added myself (@Kasifrasi) as a maintainer.

---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
