### PR TITLE
pwru: 1.0.9 -> 1.0.11

### DIFF
--- a/pkgs/by-name/pw/pwru/package.nix
+++ b/pkgs/by-name/pw/pwru/package.nix
@@ -18,7 +18,7 @@ buildGoModule (finalAttrs: {
   };
 
   vendorHash = null;
-  
+
   subPackages = [ "." ];
 
   nativeBuildInputs = [ clang ];
@@ -45,7 +45,10 @@ buildGoModule (finalAttrs: {
     description = "eBPF-based Linux kernel networking debugger";
     homepage = "https://github.com/cilium/pwru";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ nickcao ];
+    maintainers = with lib.maintainers; [
+      nickcao
+      miniharinn
+    ];
     platforms = lib.platforms.linux;
     mainProgram = "pwru";
   };

--- a/pkgs/by-name/pw/pwru/package.nix
+++ b/pkgs/by-name/pw/pwru/package.nix
@@ -25,6 +25,10 @@ buildGoModule (finalAttrs: {
 
   buildInputs = [ libpcap ];
 
+  ldflags = [
+    "-X github.com/cilium/pwru/internal/pwru.Version=v${finalAttrs.version}"
+  ];
+
   postPatch = ''
     substituteInPlace internal/libpcap/compile.go \
       --replace "-static" ""

--- a/pkgs/by-name/pw/pwru/package.nix
+++ b/pkgs/by-name/pw/pwru/package.nix
@@ -8,16 +8,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "pwru";
-  version = "1.0.9";
+  version = "1.0.11";
 
   src = fetchFromGitHub {
     owner = "cilium";
     repo = "pwru";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-3lIKbzwPX6okJT9CeErX5/innUK3VqnnbWPpvlSN+6U=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-P4CKQOSpRujrgBVVNj1DD1jHoN7DEZ18PrfSOKSd31Y=";
   };
 
   vendorHash = null;
+  
+  subPackages = [ "." ];
 
   nativeBuildInputs = [ clang ];
 


### PR DESCRIPTION
Release: https://github.com/cilium/pwru/releases/tag/v1.0.11
Diff: https://github.com/cilium/pwru/compare/v1.0.9...v1.0.11

This PR also fixes:
```
> ./result/bin/pwru --version
pwru version unknown
```

I've also added myself as a maintainer; I hope you don't mind :D
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
