### PR TITLE
hatch: disable failing tests

### DIFF
--- a/pkgs/by-name/ha/hatch/package.nix
+++ b/pkgs/by-name/ha/hatch/package.nix
@@ -108,6 +108,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # https://github.com/pypa/hatch/issues/2006
     "test_project_location_basic_set_first_project"
     "test_project_location_complex_set_first_project"
+
+    # TypeError: 'int' object is not subscriptable with newer packaging
+    "test_begin"
+    "test_continue"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # This test assumes it is running on macOS with a system shell on the PATH.
@@ -155,6 +159,15 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_license_expression"
     "tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_license_files"
     "tests/backend/metadata/test_spec.py::TestProjectMetadataFromCoreMetadata::test_license_files"
+
+    # Table title centering changed in newer Rich
+    "tests/cli/dep/show/test_table.py"
+    "tests/cli/env/test_show.py"
+    "tests/cli/python/test_show.py"
+
+    # Version scheme failures with newer packaging
+    "tests/backend/version/scheme/test_standard.py::TestWithEpoch::test_correct[minor,dev-1!0.1.0.dev0]"
+    "tests/backend/version/scheme/test_standard.py::TestMultiple::test_correct[minor,dev-0.1.0.dev0]"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # AssertionError: assert [call('test h...2p32/bin/sh')] == [call('test h..., shell=True)]


### PR DESCRIPTION
Disable tests broken by newer Rich (table title centering) and packaging (version scheme handling).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
