### PR TITLE
pup: unstable-2022-03-06 -> 0.4.2; add ulysseszhan as maintainer

### DIFF
--- a/pkgs/by-name/pu/pup/package.nix
+++ b/pkgs/by-name/pu/pup/package.nix
@@ -2,26 +2,29 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "pup";
-  version = "unstable-2022-03-06";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
-    owner = "ericchiang";
+    owner = "gromgit";
     repo = "pup";
-    rev = "5a57cf111366c7c08999a34b2afd7ba36d58a96d";
-    hash = "sha256-Ledg3xPbu71L5qUY033bru/lw03jws3s4YlAarIuqaA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FnMPrgALABCQ9WKYEqEvB7guKHyYaXa3nU4jxZILzYw=";
   };
 
-  vendorHash = "sha256-/MDSWIuSYNxKbTslqIooI2qKA8Pye0yJF2dY8g8qbWI=";
+  vendorHash = "sha256-VoCot34BhtrY0bjgm1z6LBbtsiBdw7fjLqVB3/hxTlM=";
+
+  updateScript = nix-update-script { };
 
   meta = {
-    description = "Parsing HTML at the command line";
+    description = "Parsing HTML at the command line (gromgit fork)";
     mainProgram = "pup";
-    homepage = "https://github.com/ericchiang/pup";
+    homepage = "https://github.com/gromgit/pup";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ ulysseszhan ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The old upstream is unmaintained, so I switch it to a new maintained fork.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
