### PR TITLE
clippy-clipboard: init at 1.5.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -69,16 +69,16 @@
     github = "0b11stan";
     githubId = 27831931;
   };
-  _0don = {
-    name = "Don";
-    github = "0-don";
-    githubId = 70039285;
-  };
   _0david0mp = {
     email = "davidmrpr@proton.me";
     github = "0david0mp";
     githubId = 54892055;
     name = "David mp";
+  };
+  _0don = {
+    name = "Don";
+    github = "0-don";
+    githubId = 70039285;
   };
   _0nyr = {
     email = "onyr.maintainer@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -69,6 +69,11 @@
     github = "0b11stan";
     githubId = 27831931;
   };
+  _0don = {
+    name = "Don";
+    github = "0-don";
+    githubId = 70039285;
+  };
   _0david0mp = {
     email = "davidmrpr@proton.me";
     github = "0david0mp";

--- a/pkgs/by-name/cl/clippy-clipboard/package.nix
+++ b/pkgs/by-name/cl/clippy-clipboard/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  wrapGAppsHook3,
+  webkitgtk_4_1,
+  gtk3,
+  libayatana-appindicator,
+  openssl,
+  glib-networking,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "clippy-clipboard";
+  version = "1.5.8";
+
+  src = fetchurl {
+    url = "https://github.com/0-don/clippy/releases/download/v${version}/clippy_${version}_amd64.deb";
+    hash = "sha256-w0E2MCpI1ZaMvYKkkPiISAzHjDrILUkUXL58Clesv4I=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    webkitgtk_4_1
+    gtk3
+    libayatana-appindicator
+    openssl
+    glib-networking
+  ];
+
+  unpackPhase = ''
+    dpkg-deb -x $src .
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r usr/* $out/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Clipboard manager built with Rust and TypeScript";
+    homepage = "https://github.com/0-don/clippy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ _0don ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "clippy";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description

Add clippy-clipboard, a clipboard manager built with Rust and TypeScript using Tauri.

- Project homepage: https://github.com/0-don/clippy
- Version: 1.5.8
- License: MIT
- Platform: x86_64-linux (binary .deb repackage)

## Things done

- [x] Built on Linux
- [x] Tested `nix-build`
- [x] Added maintainer entry to `maintainers/maintainer-list.nix`
- [x] Package uses `by-name` convention (`pkgs/by-name/cl/clippy-clipboard/package.nix`)
- [x] `meta.sourceProvenance` includes `binaryNativeCode`