### PR TITLE
plymouth: add support for building without systemd

### DIFF
--- a/pkgs/by-name/pl/plymouth/package.nix
+++ b/pkgs/by-name/pl/plymouth/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitLab,
+  fetchpatch,
   writeText,
   replaceVars,
   meson,
@@ -19,6 +20,7 @@
   systemd,
   xkeyboard-config,
   fontconfig,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -47,6 +49,13 @@ stdenv.mkDerivation (finalAttrs: {
     (replaceVars ./fix-paths.patch {
       fcmatch = "${fontconfig}/bin/fc-match";
     })
+
+    # fix build without udev, see https://gitlab.freedesktop.org/plymouth/plymouth/-/merge_requests/382 - drop on next release
+    (fetchpatch {
+      name = "fix-build-without-udev.patch";
+      url = "https://gitlab.freedesktop.org/plymouth/plymouth/-/commit/f1ce78764482699b28f60c89af1a071ea0ae13ca.patch";
+      hash = "sha256-t5xt/scO8mVwESU8pFPTSXILd0FhmG/XRZ8O/4baQB8=";
+    })
   ];
 
   strictDeps = true;
@@ -67,8 +76,10 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     libxkbcommon
     pango
-    systemd
     xkeyboard-config
+  ]
+  ++ lib.optionals systemdSupport [
+    systemd
   ];
 
   mesonFlags =
@@ -87,9 +98,12 @@ stdenv.mkDerivation (finalAttrs: {
       "-Dbackground-start-color-stop=0x000000"
       "-Dbackground-end-color-stop=0x000000"
       "-Drelease-file=/etc/os-release"
-      "-Dudev=enabled"
+      "-Dudev=${if systemdSupport then "enabled" else "disabled"}"
       "-Drunstatedir=/run"
       "-Druntime-plugins=true"
+      "-Dsystemd-integration=${lib.boolToString systemdSupport}"
+    ]
+    ++ lib.optionals systemdSupport [
       "--cross-file=${crossFile}"
     ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

modify the `plymouth` package to allow building without `systemd` (and `udev`) - very useful in scenarios where you want to run `plymouth` from `nixpkgs` but aren't running `nixos`

marking as draft because there was a small compilation bug upstream ... ~~we can merge this PR after the next `plymouth` version bump and the included `fetchpatch` will be dropped~~ i didn't realize how long upstream goes between releases... :sweat_smile: the patch is tiny, accepted upstream, and has been [tested](https://private-user-images.githubusercontent.com/7755101/565174816-06fa2081-9854-4907-914f-7aa35507df0c.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzUwOTA0NzEsIm5iZiI6MTc3NTA5MDE3MSwicGF0aCI6Ii83NzU1MTAxLzU2NTE3NDgxNi0wNmZhMjA4MS05ODU0LTQ5MDctOTE0Zi03YWEzNTUwN2RmMGMubXA0P1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI2MDQwMiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNjA0MDJUMDAzNjExWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MDI1MmRlNDFlODE2NTJlM2JjZTVlNzQ2YWYwZjEyMmI1NzVlNzQwN2Q2Y2NhZWEwNmM2NzdkMGIwYmJmNzdmYiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.D9y56nQbC0x6dRbsyceREHkmBXi4mKkm8gWjlWZJVis)... so let's merge this now :+1:

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
