### PR TITLE
luxtorpeda: init at 76.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19046,6 +19046,11 @@
     githubId = 1771772;
     name = "Alexander Ben Nasrallah";
   };
+  neovim-btw = {
+    github = "neovim-btw";
+    githubId = 270734577;
+    name = "neovim-btw";
+  };
   nerdypepper = {
     email = "nerdy@peppe.rs";
     github = "oppiliappan";

--- a/pkgs/by-name/lu/luxtorpeda/package.nix
+++ b/pkgs/by-name/lu/luxtorpeda/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  writeScript,
+  autoPatchelfHook,
+  xz,
+  libGL,
+  libx11,
+  libxcursor,
+  libxinerama,
+  libxext,
+  libxrandr,
+  libxrender,
+  libxi,
+  libxfixes,
+  libxkbcommon,
+  vulkan-loader,
+  alsa-lib,
+  libpulseaudio,
+  udev,
+  dbus,
+  speechd,
+  fontconfig,
+  steamDisplayName ? "Luxtorpeda",
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "luxtorpeda";
+  version = "76.2.0";
+
+  src = fetchzip {
+    url = "https://github.com/luxtorpeda-dev/luxtorpeda/releases/download/v${finalAttrs.version}/luxtorpeda-v${finalAttrs.version}.tar.xz";
+    hash = "sha256-l1q+/+5TvSIvyEkVGNRKnGWygRjqXzj4bKfZfk9Zrd4=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    xz
+    libGL
+    libx11
+    libxcursor
+    libxinerama
+    libxext
+    libxrandr
+    libxrender
+    libxi
+    libxfixes
+    libxkbcommon
+    vulkan-loader
+    alsa-lib
+    libpulseaudio
+    udev
+    dbus
+    speechd
+    fontconfig
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  outputs = [
+    "out"
+    "steamcompattool"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    echo "${finalAttrs.pname} should not be installed into environments. Please use programs.steam.extraCompatPackages instead." > $out
+
+    mkdir -p $steamcompattool
+    cp -r . $steamcompattool/
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    substituteInPlace "$steamcompattool/compatibilitytool.vdf" \
+      --replace-fail "Luxtorpeda" "${steamDisplayName}"
+  '';
+
+  passthru.updateScript = writeScript "update-luxtorpeda" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq common-updater-scripts
+    repo="https://api.github.com/repos/luxtorpeda-dev/luxtorpeda/releases"
+    version="$(curl -sL ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "$repo" | jq 'map(select(.prerelease == false)) | .[0].tag_name' --raw-output | sed 's/^v//')"
+    update-source-version luxtorpeda "$version"
+  '';
+
+  meta = {
+    description = "Steam Play compatibility tool to run games using native Linux engines (for use with programs.steam.extraCompatPackages)";
+    homepage = "https://github.com/luxtorpeda-dev/luxtorpeda";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ neovim-btw ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/lu/luxtorpeda/package.nix
+++ b/pkgs/by-name/lu/luxtorpeda/package.nix
@@ -90,7 +90,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Steam Play compatibility tool to run games using native Linux engines (for use with programs.steam.extraCompatPackages)";
-    homepage = "https://github.com/luxtorpeda-dev/luxtorpeda";
+    homepage = "https://luxtorpeda.org";
+    downloadPage = "https://codeberg.org/luxtorpeda/luxtorpeda";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ neovim-btw ];
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
Add [Luxtorpeda](https://github.com/luxtorpeda-dev/luxtorpeda), a Steam Play compatibility tool that runs games using native Linux engines instead of Proton/Wine. Similar to `proton-ge-bin`, it's intended for use with `programs.steam.extraCompatPackages`.                           
                                                                                                                                                                                                                                                                                            
  Supports games like Gothic, Quake, Doom and others that have native engine reimplementations.                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                            
  ## Things done                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                            
  - Built on platform:                                                                                                                                                                                                                                                                      
    - [x] x86_64-linux                                                                                                                                                                                                                                                                      
    - [ ] aarch64-linux                                                                                                                                                                                                                                                                     
    - [ ] x86_64-darwin                                                                                                                                                                                                                                                                     
    - [ ] aarch64-darwin                                                                                                                                                                                                                                                                    
  - Tested, as applicable:                                                                                                                                                                                                                                                                  
    - [ ] [NixOS tests] in [nixos/tests].                                                                                                                                                                                                                                                   
    - [ ] [Package tests] at `passthru.tests`.                                                                                                                                                                                                                                              
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.                                                                                                                                                                                                       
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].                                                                                                                                                                                                                        
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.                                                                                                                                                                                                         
  - Nixpkgs Release Notes                                                                                                                                                                                                                                                                   
    - [ ] Package update: when the change is major or breaking.                                                                                                                                                                                                                             
  - NixOS Release Notes                                                                                                                                                                                                                                                                     
    - [ ] Module addition: when adding a new NixOS module.                                                                                                                                                                                                                                  
    - [ ] Module update: when the change is significant.                                                                                                                                                                                                                                    
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.