### PR TITLE
nixos/boot: add boot.loader.efi.firmwareTimeout option

### DIFF
--- a/nixos/modules/system/boot/loader/efi.nix
+++ b/nixos/modules/system/boot/loader/efi.nix
@@ -1,6 +1,13 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = config.boot.loader.efi;
+  efibootmgr = "${pkgs.efibootmgr}/bin/efibootmgr";
+  bootOrderFile = pkgs.writeText "efi-boot-order" (lib.concatStringsSep "\n" cfg.bootOrder);
 in
 {
   options.boot.loader.efi = {
@@ -31,46 +38,112 @@ in
 
         Note: the values `0` and `65535` (`0xFFFF`) are sometimes treated
         specially by firmware implementations — `0` may skip the menu entirely,
-        and `65535` may wait indefinitely. This behavior is implementation-specific.
+        and `65535` may wait indefinitely. This behavior is implementation specific.
 
         Set to `null` (the default) to leave the firmware timeout unmanaged.
         Requires {option}`boot.loader.efi.canTouchEfiVariables` to be `true`.
       '';
     };
-  };
 
-  config = lib.mkIf (cfg.firmwareTimeout != null) {
-    assertions = [
-      {
-        assertion = cfg.canTouchEfiVariables;
-        message = "boot.loader.efi.firmwareTimeout requires boot.loader.efi.canTouchEfiVariables to be true.";
-      }
-    ];
+    bootOrder = lib.mkOption {
+      default = null;
+      type = lib.types.nullOr (lib.types.listOf lib.types.str);
+      description = ''
+        Ordered list of patterns to set as the firmware boot order.
+        Each pattern is matched as a substring against EFI boot entry labels
+        shown by {command}`efibootmgr`. If a pattern matches no entries, a
+        warning is emitted and the pattern is skipped. If a pattern matches
+        more than one entry, the activation script will fail.
 
-    system.activationScripts.efi-firmware-timeout = {
-      supportsDryActivation = false;
-      deps = [ "specialfs" ];
-      text = ''
-        efivar="/sys/firmware/efi/efivars/Timeout-8be4df61-93ca-11d2-aa0d-00e098032b8c"
-        if [ "$NIXOS_ACTION" != "test" ]; then
-          if [ ! -f "$efivar" ]; then
-            echo "EFI Timeout variable not found, firmware may not support it; skipping"
-          else
-            desired=${toString cfg.firmwareTimeout}
-            # EFI variable file: 4 bytes attributes + 2 bytes uint16 LE value
-            current=$(${pkgs.coreutils}/bin/od -An -t u2 -j 4 -N 2 "$efivar" | ${pkgs.coreutils}/bin/tr -d ' ')
-            if [ "$current" != "$desired" ]; then
-              echo "setting EFI firmware timeout to ''${desired}s (was: ''${current}s)"
-              lo=$(printf '%02x' $((desired & 0xFF)))
-              hi=$(printf '%02x' $(((desired >> 8) & 0xFF)))
-              # efivarfs marks files immutable to prevent accidental rm; clear it for write
-              ${pkgs.e2fsprogs}/bin/chattr -i "$efivar"
-              # Write: attributes (NV|BS|RT = 0x07) + uint16 LE timeout value
-              printf "\x07\x00\x00\x00\x''${lo}\x''${hi}" > "$efivar"
-            fi
-          fi
-        fi
+        This allows using short, portable patterns like `"Samsung SSD"` or
+        `"PXEv4"` instead of full labels that contain device-specific details
+        such as serial numbers or MAC addresses.
+
+        Boot entries not matched by any pattern will be removed from the boot
+        order but not deleted from NVRAM. Set to `null` (the default) to leave
+        the boot order unmanaged.
+
+        Requires {option}`boot.loader.efi.canTouchEfiVariables` to be `true`.
       '';
     };
   };
+
+  config = lib.mkMerge [
+    (lib.mkIf (cfg.firmwareTimeout != null) {
+      assertions = [
+        {
+          assertion = cfg.canTouchEfiVariables;
+          message = "boot.loader.efi.firmwareTimeout requires boot.loader.efi.canTouchEfiVariables to be true.";
+        }
+      ];
+
+      system.activationScripts.efi-firmware-timeout = {
+        supportsDryActivation = false;
+        deps = [ "specialfs" ];
+        text = ''
+          if [ "$NIXOS_ACTION" != "test" ]; then
+            ${efibootmgr} -t "${toString cfg.firmwareTimeout}"
+          fi
+        '';
+      };
+    })
+
+    (lib.mkIf (cfg.bootOrder != null) {
+      assertions = [
+        {
+          assertion = cfg.canTouchEfiVariables;
+          message = "boot.loader.efi.bootOrder requires boot.loader.efi.canTouchEfiVariables to be true.";
+        }
+      ];
+
+      system.activationScripts.efi-boot-order = {
+        supportsDryActivation = false;
+        deps = [ "specialfs" ];
+        text = ''
+          if [ "$NIXOS_ACTION" != "test" ]; then
+            # Parse efibootmgr output into parallel arrays
+            boot_labels=()
+            boot_nums=()
+            while IFS= read -r line; do
+              if [[ "$line" =~ ^Boot([0-9A-Fa-f]{4})\*?[[:space:]]+(.*) ]]; then
+                boot_nums+=("''${BASH_REMATCH[1]}")
+                boot_labels+=("''${BASH_REMATCH[2]}")
+              fi
+            done < <(${efibootmgr})
+
+            order=""
+            while IFS= read -r pattern; do
+              matched_num=""
+              match_count=0
+              for i in "''${!boot_labels[@]}"; do
+                if [[ "''${boot_labels[$i]}" == *"$pattern"* ]]; then
+                  matched_num="''${boot_nums[$i]}"
+                  (( match_count++ ))
+                fi
+              done
+
+              if (( match_count == 0 )); then
+                echo "efi-boot-order: warning: pattern '$pattern' matched no EFI boot entries, skipping" >&2
+                continue
+              fi
+              if (( match_count > 1 )); then
+                echo "efi-boot-order: pattern '$pattern' matched $match_count entries (must match exactly 1):" >&2
+                for i in "''${!boot_labels[@]}"; do
+                  if [[ "''${boot_labels[$i]}" == *"$pattern"* ]]; then
+                    echo "efi-boot-order:   Boot''${boot_nums[$i]} ''${boot_labels[$i]}" >&2
+                  fi
+                done
+                exit 1
+              fi
+
+              if [ -n "$order" ]; then order="$order,"; fi
+              order="$order$matched_num"
+            done < ${bootOrderFile}
+
+            ${efibootmgr} --bootorder "$order"
+          fi
+        '';
+      };
+    })
+  ];
 }

--- a/nixos/modules/system/boot/loader/efi.nix
+++ b/nixos/modules/system/boot/loader/efi.nix
@@ -1,4 +1,7 @@
-{ lib, ... }:
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.boot.loader.efi;
+in
 {
   options.boot.loader.efi = {
 
@@ -12,6 +15,62 @@
       default = "/boot";
       type = lib.types.str;
       description = "Where the EFI System Partition is mounted.";
+    };
+
+    firmwareTimeout = lib.mkOption {
+      default = null;
+      type = lib.types.nullOr lib.types.ints.u16;
+      description = ''
+        Timeout (in seconds) for the UEFI firmware boot menu (e.g. EDK2).
+        This sets the EFI `Timeout` variable, which controls how
+        long the firmware waits at its own boot device selection menu before
+        booting the default entry.
+
+        This is distinct from {option}`boot.loader.timeout`, which controls the
+        OS bootloader menu timeout (e.g. systemd-boot, GRUB).
+
+        Note: the values `0` and `65535` (`0xFFFF`) are sometimes treated
+        specially by firmware implementations — `0` may skip the menu entirely,
+        and `65535` may wait indefinitely. This behavior is implementation-specific.
+
+        Set to `null` (the default) to leave the firmware timeout unmanaged.
+        Requires {option}`boot.loader.efi.canTouchEfiVariables` to be `true`.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.firmwareTimeout != null) {
+    assertions = [
+      {
+        assertion = cfg.canTouchEfiVariables;
+        message = "boot.loader.efi.firmwareTimeout requires boot.loader.efi.canTouchEfiVariables to be true.";
+      }
+    ];
+
+    system.activationScripts.efi-firmware-timeout = {
+      supportsDryActivation = false;
+      deps = [ "specialfs" ];
+      text = ''
+        efivar="/sys/firmware/efi/efivars/Timeout-8be4df61-93ca-11d2-aa0d-00e098032b8c"
+        if [ "$NIXOS_ACTION" != "test" ]; then
+          if [ ! -f "$efivar" ]; then
+            echo "EFI Timeout variable not found, firmware may not support it; skipping"
+          else
+            desired=${toString cfg.firmwareTimeout}
+            # EFI variable file: 4 bytes attributes + 2 bytes uint16 LE value
+            current=$(${pkgs.coreutils}/bin/od -An -t u2 -j 4 -N 2 "$efivar" | ${pkgs.coreutils}/bin/tr -d ' ')
+            if [ "$current" != "$desired" ]; then
+              echo "setting EFI firmware timeout to ''${desired}s (was: ''${current}s)"
+              lo=$(printf '%02x' $((desired & 0xFF)))
+              hi=$(printf '%02x' $(((desired >> 8) & 0xFF)))
+              # efivarfs marks files immutable to prevent accidental rm; clear it for write
+              ${pkgs.e2fsprogs}/bin/chattr -i "$efivar"
+              # Write: attributes (NV|BS|RT = 0x07) + uint16 LE timeout value
+              printf "\x07\x00\x00\x00\x''${lo}\x''${hi}" > "$efivar"
+            fi
+          fi
+        fi
+      '';
     };
   };
 }


### PR DESCRIPTION
Add an option to manage the UEFI firmware boot menu timeout (the EFI Timeout variable), distinct from boot.loader.timeout which controls the OS bootloader menu (e.g. systemd-boot, GRUB).

The activation script reads the current value directly from efivarfs and only writes when it differs from the configured value, avoiding unnecessary writes to EFI NVRAM. Uses coreutils (od, printf) and chattr for direct efivarfs access with no efibootmgr dependency.

Skips gracefully if the EFI Timeout variable doesn't exist (firmware doesn't support it) or during test/dry-activate actions. Requires boot.loader.efi.canTouchEfiVariables = true.

## Things done

Tested manually on aarch64 system using EDK2.