### PR TITLE
mactrix: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ma/mactrix/package.nix
+++ b/pkgs/by-name/ma/mactrix/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+  nix-update-script,
+  makeBinaryWrapper,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "mactrix";
+  version = "0.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/viktorstrate/mactrix/releases/download/v${version}/Mactrix.app.zip";
+    hash = "sha256-Y4ydihGSGKNXDatzW/cpJYS1lwjnkIdhVtdr+Y5eaa0=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    unzip
+    makeBinaryWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    cp -R Mactrix.app $out/Applications/
+    mkdir -p $out/bin
+    makeWrapper $out/Applications/Mactrix.app/Contents/MacOS/Mactrix $out/bin/mactrix
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^v([0-9.]+)$"
+    ];
+  };
+
+  meta = {
+    description = "Native Matrix client for macOS";
+    longDescription = ''
+      A native macOS client for Matrix – an open protocol for decentralised, secure communications.
+
+      Mactrix is built with Apple's SwiftUI framework to provide seamless native integration with macOS.
+      It leverages the robust matrix-rust-sdk for stability and performance.
+    '';
+    homepage = "https://github.com/viktorstrate/mactrix";
+    changelog = "https://github.com/viktorstrate/mactrix/releases/tag/v${version}";
+    mainProgram = "mactrix";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ deadbaed ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
Mactrix is a native macOS client for Matrix, built with SwiftUI to have a native feel.

I have been compiling it (not with Nix though) and using it from source for a couple of months, it works great!

I saw the 0.1.0 got tagged, and thought it would be nice to add it to nixpkgs.

For the package I basically copied and pasted what was done for a popular Mac application on nixpkgs: https://github.com/NixOS/nixpkgs/blob/1073dad219cb244572b74da2b20c7fe39cb3fa9e/pkgs/by-name/ne/net-news-wire/package.nix

I also tested the update script with `nix-update`: the regex works correctly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
