### PR TITLE
igf: init at 1.1.2

### DIFF
--- a/pkgs/by-name/fr/frida-node-prebuilds/package.nix
+++ b/pkgs/by-name/fr/frida-node-prebuilds/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+
+let
+  # These native bindings must match the Frida npm versions locked by igf.
+  fridaVersion = "17.8.3";
+  frida16Version = "16.7.19";
+
+  assetSystems = {
+    aarch64-darwin = "darwin-arm64";
+    x86_64-darwin = "darwin-x64";
+    aarch64-linux = "linux-arm64";
+    x86_64-linux = "linux-x64";
+  };
+
+  hashes = {
+    aarch64-darwin = {
+      frida = "sha256-YUeJ1dRoeraX5ln3dqt4u/rGbs2DR8wiPs8rCG5zBj4=";
+      frida16 = "sha256-KmDxDXGA6FxFhGY3SNvRriU/SJfXw6XkNOX6O0CtNpY=";
+    };
+    x86_64-darwin = {
+      frida = "sha256-vnCIHUobOGfI83YgVQa6Ke9XUY07xHhCYUxCrONYvEw=";
+      frida16 = "sha256-bnRd2BLK7XJFZvL1aJFNQ/2eI5QrMaKD4o++1/XrE6c=";
+    };
+    aarch64-linux = {
+      frida = "sha256-nl7SbaiJIKc2qM99oNB+J/eHMGYML7LTOya5jAzc5So=";
+      frida16 = "sha256-OImdJ/VGEkPi63TVf08T8N+qo/qxYCofdnatiocMDCc=";
+    };
+    x86_64-linux = {
+      frida = "sha256-MTl8KGSMhJmi8TUXe4gF/YRysnPxOJL+hya4/WAS0ew=";
+      frida16 = "sha256-5+dDsi/3lnyoV4kdwp2r3+/AbdhdUE4HByTDY1tJgok=";
+    };
+  };
+
+  mkSource =
+    version: assetSystem: hash:
+    fetchurl {
+      url = "https://github.com/frida/frida/releases/download/${version}/frida-v${version}-napi-v8-${assetSystem}.tar.gz";
+      inherit hash;
+    };
+
+  sources = lib.mapAttrs (system: assetSystem: {
+    frida = mkSource fridaVersion assetSystem hashes.${system}.frida;
+    frida16 = mkSource frida16Version assetSystem hashes.${system}.frida16;
+  }) assetSystems;
+
+  prebuilds =
+    sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+in
+stdenvNoCC.mkDerivation {
+  pname = "frida-node-prebuilds";
+  version = "${fridaVersion}-${frida16Version}";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/frida/build" "$out/frida16/build"
+
+    tar -xOf ${prebuilds.frida} build/frida_binding.node > "$out/frida/build/frida_binding.node"
+    tar -xOf ${prebuilds.frida16} build/frida_binding.node > "$out/frida16/build/frida_binding.node"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit fridaVersion frida16Version sources;
+    updateScript = ./update.py;
+  };
+
+  meta = {
+    description = "Frida Node.js N-API prebuilt bindings for v17 and v16";
+    homepage = "https://frida.re/";
+    license = with lib.licenses; [
+      lgpl2Only
+      wxWindowsException31
+    ];
+    maintainers = with lib.maintainers; [ caverav ];
+    platforms = lib.attrNames sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/fr/frida-node-prebuilds/update.py
+++ b/pkgs/by-name/fr/frida-node-prebuilds/update.py
@@ -1,0 +1,122 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 -p cacert nix python3
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from urllib.request import urlopen
+
+
+ASSETS = {
+    "aarch64-darwin": "darwin-arm64",
+    "x86_64-darwin": "darwin-x64",
+    "aarch64-linux": "linux-arm64",
+    "x86_64-linux": "linux-x64",
+}
+
+VERSION_KEYS = {
+    "frida": "fridaVersion",
+    "frida16": "frida16Version",
+}
+
+
+def run(args):
+    return subprocess.run(args, check=True, stdout=subprocess.PIPE, text=True).stdout.strip()
+
+
+def igf_version(repo_root):
+    return json.loads(
+        run(
+            [
+                "nix-instantiate",
+                "--eval",
+                "--strict",
+                "--json",
+                str(repo_root),
+                "-A",
+                "igf.version",
+            ]
+        )
+    )
+
+
+def locked_versions(repo_root):
+    url = f"https://raw.githubusercontent.com/ChiChou/grapefruit/v{igf_version(repo_root)}/package-lock.json"
+    with urlopen(url, timeout=30) as response:
+        lock = json.load(response)
+
+    return {
+        "frida": lock["packages"]["node_modules/frida"]["version"],
+        "frida16": lock["packages"]["node_modules/frida16"]["version"],
+    }
+
+
+def current_versions(package_nix):
+    return {
+        name: re.search(rf'{key} = "([^"]+)";', package_nix).group(1)
+        for name, key in VERSION_KEYS.items()
+    }
+
+
+def source_hash(url):
+    raw_hash = run(["nix-prefetch-url", "--type", "sha256", url])
+    return run(
+        [
+            "nix",
+            "--extra-experimental-features",
+            "nix-command",
+            "hash",
+            "convert",
+            "--hash-algo",
+            "sha256",
+            "--to",
+            "sri",
+            raw_hash,
+        ]
+    )
+
+
+def release_url(version, asset_system):
+    return f"https://github.com/frida/frida/releases/download/{version}/frida-v{version}-napi-v8-{asset_system}.tar.gz"
+
+
+def replace_version(package_nix, name, version):
+    key = VERSION_KEYS[name]
+    package_nix, count = re.subn(rf'{key} = "[^"]+";', f'{key} = "{version}";', package_nix, count=1)
+    if count != 1:
+        raise RuntimeError(f"Could not update {key}")
+    return package_nix
+
+
+def replace_hash(package_nix, system, name, hash_):
+    pattern = re.compile(rf'({re.escape(system)} = \{{.*?{name} = ")[^"]+(";)', re.DOTALL)
+    package_nix, count = pattern.subn(rf"\1{hash_}\2", package_nix, count=1)
+    if count != 1:
+        raise RuntimeError(f"Could not update {system}.{name}")
+    return package_nix
+
+
+def main():
+    package_path = Path(__file__).with_name("package.nix")
+    repo_root = package_path.parents[4]
+    package_nix = package_path.read_text()
+    current = current_versions(package_nix)
+
+    for name, version in locked_versions(repo_root).items():
+        if current[name] == version:
+            print(f"{name} is up-to-date: {version}")
+            continue
+
+        package_nix = replace_version(package_nix, name, version)
+
+        for system, asset_system in ASSETS.items():
+            url = release_url(version, asset_system)
+            print(f"Prefetching {system}.{name}: {url}")
+            package_nix = replace_hash(package_nix, system, name, source_hash(url))
+
+    package_path.write_text(package_nix)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/by-name/ig/igf/package.nix
+++ b/pkgs/by-name/ig/igf/package.nix
@@ -1,0 +1,191 @@
+{
+  cctools,
+  buildNpmPackage,
+  curl,
+  fetchFromGitHub,
+  fetchurl,
+  fetchzip,
+  frida-node-prebuilds,
+  lib,
+  node-gyp,
+  nodejs_22,
+  python3,
+  removeReferencesTo,
+  stdenv,
+  srcOnly,
+}:
+
+let
+  fridaVersion = frida-node-prebuilds.fridaVersion;
+  frida16Version = frida-node-prebuilds.frida16Version;
+  nodeSources = srcOnly nodejs_22;
+  radare2Version = "6.1.2";
+
+  grapefruitSrc = fetchFromGitHub {
+    owner = "ChiChou";
+    repo = "grapefruit";
+    rev = "v1.1.2";
+    hash = "sha256-5zd9QNuumNJ3EU0Cx7YU8LIEqP50U820S0UnE9AksBc=";
+  };
+
+  radare2Wasm = fetchzip {
+    url = "https://github.com/radareorg/radare2/releases/download/${radare2Version}/radare2-${radare2Version}-wasi-api.zip";
+    hash = "sha256-HLXTG3gSAamN3BYxYshdOZgYjhtfYUaUW+QMJp+FB3w=";
+    stripRoot = false;
+  };
+in
+buildNpmPackage (finalAttrs: {
+  pname = "igf";
+  version = "1.1.2";
+
+  __structuredAttrs = true;
+
+  nodejs = nodejs_22;
+
+  # The npm release ships the built CLI and web assets that are absent from the Git tag.
+  src = fetchurl {
+    url = "https://registry.npmjs.org/igf/-/igf-${finalAttrs.version}.tgz";
+    hash = "sha256-sR5Jscjp7SySGnSVXKB7NJfn9HOZTfAMJmj1qXWqB0k=";
+  };
+  sourceRoot = "package";
+
+  npmDepsHash = "sha256-9tkptyaLCogmjeokULdt0zxrXA/wSuMm+Mf6WM714Vo=";
+  npmRebuildFlags = [ "--ignore-scripts" ];
+
+  nativeBuildInputs = [
+    node-gyp
+    python3
+    removeReferencesTo
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin cctools.libtool;
+
+  nativeInstallCheckInputs = [
+    curl
+    python3
+  ];
+
+  dontNpmBuild = true;
+
+  postPatch = ''
+    # With __structuredAttrs, npmDeps is declared without -x so subprocesses (prefetchNpmDeps) can't see it.
+    export npmDeps
+
+    # The published npm tarball omits the lockfile, but the dependency graph is still defined upstream.
+    cp ${grapefruitSrc}/package-lock.json package-lock.json
+
+    mkdir -p externals/radare/r2hermes.wasm/dist
+    cp -r ${grapefruitSrc}/externals/radare/r2hermes.wasm/. externals/radare/r2hermes.wasm/
+    install -Dm444 gui/dist/hbc.wasm externals/radare/r2hermes.wasm/dist/hbc.wasm
+  '';
+
+  preBuild = ''
+    mkdir -p node_modules/frida/build node_modules/frida16/build
+
+    # Upstream supports runtime selection between Frida 17 and 16 depending on target compatibility.
+    cp ${frida-node-prebuilds}/frida/build/frida_binding.node node_modules/frida/build/frida_binding.node
+    cp ${frida-node-prebuilds}/frida16/build/frida_binding.node node_modules/frida16/build/frida_binding.node
+
+    pushd node_modules/better-sqlite3
+    npm run build-release --offline --nodedir="${nodeSources}"
+    rm -r build/Release/{.deps,obj,obj.target,sqlite3.a,test_extension.node}
+    find build -type f -exec remove-references-to -t "${nodeSources}" {} \;
+    popd
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    packageOut=$out/lib/node_modules/igf
+    mkdir -p "$packageOut"
+
+    npm prune --omit=dev --no-save --ignore-scripts
+    find node_modules -maxdepth 1 -type d -empty -delete
+
+    cp -r \
+      agent \
+      dist \
+      drizzle \
+      externals \
+      gui \
+      skills \
+      "$packageOut/"
+    install -Dm444 LICENSE "$packageOut/LICENSE"
+    install -Dm444 README.md "$packageOut/README.md"
+    install -Dm444 package.json "$packageOut/package.json"
+    cp -r node_modules "$packageOut/"
+
+    nodejsInstallExecutables package.json
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    install -Dm444 ${radare2Wasm}/radare2-${radare2Version}-wasi-api/radare2.wasm \
+      $out/lib/node_modules/igf/radare2.wasm
+  '';
+
+  # The installCheck starts the igf server and polls its HTTP API, which requires loading
+  # the frida native binding (.node). On Darwin, macOS Hardened Runtime blocks unsigned
+  # native binaries from loading in non-interactive build contexts, so the server never
+  # becomes ready. The package itself installs correctly on Darwin.
+  doInstallCheck = stdenv.hostPlatform.isLinux;
+  installCheckPhase = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    runHook preInstallCheck
+
+    export HOME="$TMPDIR"
+    export PROJECT_DIR="$TMPDIR/igf"
+
+    checkVersion() {
+      local fridaMajor="$1"
+      local expectedFridaVersion="$2"
+      local port="$3"
+      local versionJson="version-$fridaMajor.json"
+
+      (
+        $out/bin/igf --frida "$fridaMajor" --host 127.0.0.1 --port "$port" >"server-$fridaMajor.log" 2>&1 &
+        pid=$!
+
+        cleanup() {
+          kill "$pid" 2>/dev/null || true
+          wait "$pid" 2>/dev/null || true
+        }
+        trap cleanup EXIT
+
+        for _ in $(seq 1 30); do
+          if curl --silent --fail "http://127.0.0.1:$port/api/version" >"$versionJson"; then
+            break
+          fi
+          if ! kill -0 "$pid" 2>/dev/null; then
+            cat "server-$fridaMajor.log"
+            exit 1
+          fi
+          sleep 1
+        done
+
+        test -f "$versionJson"
+
+        python3 -c 'import json, pathlib, sys; data = json.loads(pathlib.Path(sys.argv[1]).read_text()); assert data["frida"] == sys.argv[2]; assert data["igf"] == sys.argv[3]' \
+          "$versionJson" "$expectedFridaVersion" "${finalAttrs.version}"
+      )
+    }
+
+    checkVersion 17 "${fridaVersion}" 43137
+    checkVersion 16 "${frida16Version}" 43138
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Runtime mobile application instrumentation toolkit powered by Frida";
+    homepage = "https://github.com/ChiChou/grapefruit";
+    changelog = "https://github.com/ChiChou/grapefruit/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ caverav ];
+    mainProgram = "igf";
+    platforms = frida-node-prebuilds.meta.platforms;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
+  };
+})


### PR DESCRIPTION
## Summary
- add `frida-node-prebuilds` for the pinned Frida Node.js N-API bindings used by `igf`
- add `igf` 1.1.2, the Grapefruit dynamic instrumentation server for Frida-based mobile application analysis
- package the published npm release because it ships the built CLI and web assets that are absent from the upstream `v1.1.2` tag
- build `r2hermes-wasm` and `better-sqlite3` locally, while sourcing the matching upstream Frida bindings from the reusable helper package

Homepage: https://github.com/ChiChou/grapefruit
npm package: https://www.npmjs.com/package/igf
Upstream release: https://github.com/ChiChou/grapefruit/releases/tag/v1.1.2

## Notes for reviewers
- `igf` intentionally ships both `frida` (17.x) and `frida16` (16.x) because upstream supports runtime selection between them and older targets still commonly require Frida 16 compatibility

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test