### PR TITLE
levin: init at 0.0.3

### DIFF
--- a/pkgs/by-name/le/levin/package.nix
+++ b/pkgs/by-name/le/levin/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  openssl,
+  boost,
+  curl,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "levin";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "bjesus";
+    repo = "levin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Nzob0xD/02gFmfm86BW9joCWIl+DO3PtP4Ok/GIRm9M=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    boost
+    curl
+  ];
+
+  # require network access
+  cmakeFlags = [ "-DLEVIN_BUILD_TESTS=off" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp platforms/linux/levin $out/bin/levin
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Levin is the easiest way to support Anna's Archive and spread human knowledge";
+    homepage = "https://github.com/bjesus/levin";
+    changelog = "https://github.com/bjesus/levin/releases/tag/${finalAttrs.src.tag}";
+    maintainers = with lib.maintainers; [ chillcicada ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+    mainProgram = "levin";
+  };
+})


### PR DESCRIPTION
init [levin](https://github.com/bjesus/levin)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
