### PR TITLE
mmixware: fix buffer-overflow error, and update

### DIFF
--- a/pkgs/by-name/mm/mmixware/package.nix
+++ b/pkgs/by-name/mm/mmixware/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  tetex,
+  texliveMedium,
 }:
 
 stdenv.mkDerivation {
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
     "-std=gnu17"
   ];
 
-  nativeBuildInputs = [ tetex ];
+  nativeBuildInputs = [ texliveMedium ];
   enableParallelBuilding = true;
 
   makeFlags = [

--- a/pkgs/by-name/mm/mmixware/package.nix
+++ b/pkgs/by-name/mm/mmixware/package.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation {
   pname = "mmixware";
-  version = "1.0-unstable-2021-06-18";
+  version = "1.0-unstable-2025-06-30";
 
   src = fetchFromGitLab {
     domain = "gitlab.lrz.de";
     owner = "mmix";
     repo = "mmixware";
-    rev = "7c790176d50d13ae2422fa7457ccc4c2d29eba9b";
-    sha256 = "sha256-eSwHiJ5SP/Nennalv4QFTgVnM6oan/DWDZRqtk0o6Z0=";
+    rev = "9205420225f4227462e37e298ee482a5c37e9c23";
+    sha256 = "sha256-u6eGc+R9xsr4sMslj1ytgSUY54qSOONEc3QtbY2r+8A=";
   };
 
   hardeningDisable = [ "format" ];


### PR DESCRIPTION
When using `tetex`, there is a buffer-overflow error, so fix it.

Also update to latest unstable commit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test