### PR TITLE
eprover: fix cross compilation

### DIFF
--- a/pkgs/by-name/ep/eprover/fix-cross-toolchains.patch
+++ b/pkgs/by-name/ep/eprover/fix-cross-toolchains.patch
@@ -1,0 +1,25 @@
+--- a/CONTRIB/picosat-965/makefile.in
++++ b/CONTRIB/picosat-965/makefile.in
+@@ -49,8 +49,7 @@ config.h: makefile VERSION mkconfig.sh # and actually picosat.c
+ 	rm -f $@; ./mkconfig.sh > $@
+ 
+ libpicosat.a: picosat.o version.o
+-	ar rc $@ picosat.o version.o
+-	ranlib $@
++	$(AR) $@ picosat.o version.o
+ 
+ SONAME=-Xlinker -soname -Xlinker libpicosat.so
+ libpicosat.so: picosat.o version.o
+--- a/Makefile.vars
++++ b/Makefile.vars
+@@ -160,8 +160,8 @@ LD         = $(CC) $(LDFLAGS)
+ 
+ # Generic
+ #    AR         = sleep 1;ar rcs
+-   AR         = ar rcs
+-   CC         =  gcc
++#    AR         = ar rcs
++#    CC         =  gcc
+ 
+ # Builds with link time optimization
+ #

--- a/pkgs/by-name/ep/eprover/package.nix
+++ b/pkgs/by-name/ep/eprover/package.nix
@@ -17,9 +17,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ which ];
 
-  preConfigure = ''
-    sed -e 's/ *CC *= *gcc$//' -i Makefile.vars
-  '';
+  patches = [
+    ./fix-cross-toolchains.patch
+  ];
+
+  configurePlatforms = [ ];
 
   configureFlags = [
     "--exec-prefix=$(out)"
@@ -28,6 +30,14 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals enableHO [
     "--enable-ho"
   ];
+
+  # need to directly insert into makeFlagsArray as the makefile expects the binary
+  # in the AR variable to already be passed the `rcs` flags, which requires us to
+  # specify them. As this requires spaces, we need makeFlagsArray, as makeFlags
+  # will just make the make script see the `rcs` as a target
+  preBuild = ''
+    makeFlagsArray+=(CC="${stdenv.cc.targetPrefix}cc" AR="${stdenv.cc.targetPrefix}ar rcs")
+  '';
 
   meta = {
     description = "Automated theorem prover for full first-order logic with equality";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fix how toolchains are specified so that the build uses the correct toolchains, even in the case of cross compilation. Tested the build by diffing the output files, and noting that before and after the executables are the same on `x86_64-linux`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
