### PR TITLE
nixos/zram-generator: do not restart on switch

### DIFF
--- a/nixos/modules/services/system/zram-generator.nix
+++ b/nixos/modules/services/system/zram-generator.nix
@@ -36,7 +36,18 @@ in
     ];
 
     systemd.packages = [ cfg.package ];
-    systemd.services."systemd-zram-setup@".path = [ pkgs.util-linux ]; # for mkswap
+    systemd.services."systemd-zram-setup@" = {
+      path = [ pkgs.util-linux ]; # for mkswap
+      # Restart on switch does swapoff -> reset -> reconfigure -> swapon.
+      # Besides risking OOM when swap is in use, the reset races with udev
+      # still holding /dev/zramN open after swapoff: the kernel rejects the
+      # reset with EBUSY (disk_openers > 0), the device stays initialized,
+      # and the following ExecStart fails to write comp_algorithm/disksize
+      # (systemd/zram-generator#226). The unit only "changes" due to store
+      # path churn, so keep the device across switches; real config changes
+      # need a reboot or manual restart.
+      restartIfChanged = false;
+    };
 
     environment.etc."systemd/zram-generator.conf".source =
       settingsFormat.generate "zram-generator.conf" cfg.settings;


### PR DESCRIPTION
Restarting systemd-zram-setup@ does swapoff -> reset -> reconfigure -> swapon. This is undesirable because swapoff can push a loaded system into OOM.
The reset races with udev still holding /dev/zramN open after swapoff; the kernel rejects it with EBUSY (disk_openers > 0), leaving the device initialized so ExecStart then fails to write comp_algorithm/disksize (systemd/zram-generator#226).

The unit only "changes" because store paths in the drop-in churn, so just keep the device across switches. Actual config changes can be applied with a reboot or manual restart.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
