### PR TITLE
soft-serve: 0.11.5 -> 0.11.6; refactor

### DIFF
--- a/pkgs/by-name/so/soft-serve/package.nix
+++ b/pkgs/by-name/so/soft-serve/package.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  version = "0.11.5";
+  version = "0.11.6";
 in
 buildGoModule {
   pname = "soft-serve";
@@ -18,11 +18,11 @@ buildGoModule {
   src = fetchFromGitHub {
     owner = "charmbracelet";
     repo = "soft-serve";
-    rev = "v${version}";
-    hash = "sha256-6ZPb8qL6E2lJp5uNRWNTcTWcVecGfsoXxshfvTP1UBk=";
+    tag = "v${version}";
+    hash = "sha256-oWZfhB14Yjj3/BKKhowKDKX5v4RvIwjHDCSFfnI+f54=";
   };
 
-  vendorHash = "sha256-BiusDvmXyS0HYx1mTLF1iECmIKPVlkI6B76NVnANEy4=";
+  vendorHash = "sha256-nsrfohr2b6zpbhWVRfOPydCpyUZzbR3YJz5viWGUwmQ=";
 
   doCheck = false;
 

--- a/pkgs/by-name/so/soft-serve/package.nix
+++ b/pkgs/by-name/so/soft-serve/package.nix
@@ -8,17 +8,14 @@
   bash,
 }:
 
-let
-  version = "0.11.6";
-in
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "soft-serve";
-  inherit version;
+  version = "0.11.6";
 
   src = fetchFromGitHub {
     owner = "charmbracelet";
     repo = "soft-serve";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-oWZfhB14Yjj3/BKKhowKDKX5v4RvIwjHDCSFfnI+f54=";
   };
 
@@ -29,7 +26,7 @@ buildGoModule {
   ldflags = [
     "-s"
     "-w"
-    "-X=main.Version=${version}"
+    "-X=main.Version=${finalAttrs.version}"
   ];
 
   nativeBuildInputs = [ makeWrapper ];
@@ -51,9 +48,9 @@ buildGoModule {
   meta = {
     description = "Tasty, self-hosted Git server for the command line";
     homepage = "https://github.com/charmbracelet/soft-serve";
-    changelog = "https://github.com/charmbracelet/soft-serve/releases/tag/v${version}";
+    changelog = "https://github.com/charmbracelet/soft-serve/releases/tag/v${finalAttrs.version}";
     mainProgram = "soft";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/so/soft-serve/package.nix
+++ b/pkgs/by-name/so/soft-serve/package.nix
@@ -51,6 +51,6 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/charmbracelet/soft-serve/releases/tag/v${finalAttrs.version}";
     mainProgram = "soft";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 })


### PR DESCRIPTION
Release: https://github.com/charmbracelet/soft-serve/releases/tag/v0.11.6
Diff: https://github.com/charmbracelet/soft-serve/compare/v0.11.5...v0.11.6
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
