### PR TITLE
mbedtls: build with -fzero-init-padding-bits=unions

### DIFF
--- a/pkgs/development/libraries/mbedtls/generic.nix
+++ b/pkgs/development/libraries/mbedtls/generic.nix
@@ -54,6 +54,23 @@ stdenv.mkDerivation rec {
     # the repository and do not need to be regenerated. See:
     # https://github.com/Mbed-TLS/mbedtls/releases/tag/v3.3.0 below "Requirement changes".
     "-DGEN_FILES=off"
+  ]
+  ++ lib.optionals stdenv.cc.isGNU [
+    # mbedtls widely uses a pattern of starting unions with an
+    # unsigned int dummy member, and then initializing those unions to
+    # { 0 }.  The problem with this is that it only initializes that
+    # first union member, so in the common case where the non-dummy
+    # members are larger than the dummy member, they will only be
+    # partially initialized since GCC 15[1].  Upstream has added
+    # ad-hoc memset calls to mitigate this issue, but initializers are
+    # also still widely used.  To avoid the risk of using
+    # uninitialized memory, force the compiler to zero all bits of
+    # unions, not just the first element, until upstream has a
+    # systemic fix in place[2].
+    #
+    # [1]: https://gcc.gnu.org/gcc-15/changes.html
+    # [2]: https://github.com/Mbed-TLS/mbedtls/issues/9885
+    "-DCMAKE_C_FLAGS=-fzero-init-padding-bits=unions"
   ];
 
   doCheck = true;


### PR DESCRIPTION
This fixes a test failure that shows up for us with musl on x86_64, but it's doing the wrong thing on all architectures and [upstream doesn't seem in a hurry to fix the test][1].  It's also not clear to me that they have a robust way to even identify these widespread issues to apply the workarounds, so let's err on the safe side and make the compiler work in the way the codebase has been written to expect.  ([Upstream does not set this flag because they don't want to rely on non-standard compiler options.][2])

[1]: https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/585
[2]: https://github.com/Mbed-TLS/mbedtls/issues/9885#issuecomment-2736295388


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
