### PR TITLE
fish: 4.5.0 -> 4.6.0

### DIFF
--- a/nixos/tests/fish.nix
+++ b/nixos/tests/fish.nix
@@ -7,7 +7,9 @@
     {
       programs.fish.enable = true;
       environment.systemPackages = with pkgs; [
-        coreutils
+        # coreutils-full (not coreutils) so that man pages are available
+        # for completion generation
+        coreutils-full
         procps # kill collides with coreutils' to test https://github.com/NixOS/nixpkgs/issues/56432
       ];
 
@@ -19,7 +21,7 @@
     #python
     ''
       start_all()
-      machine.wait_for_file("/etc/fish/generated_completions/coreutils.fish")
+      machine.wait_for_file("/etc/fish/generated_completions/chmod.fish")
       machine.wait_for_file("/etc/fish/generated_completions/kill.fish")
       machine.succeed(
           "fish -ic 'echo $fish_complete_path' | grep -q '/share/fish/vendor_completions.d /etc/fish/generated_completions /root/.cache/fish/generated_completions$'"

--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -149,13 +149,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fish";
-  version = "4.5.0";
+  version = "4.6.0";
 
   src = fetchFromGitHub {
     owner = "fish-shell";
     repo = "fish-shell";
     tag = finalAttrs.version;
-    hash = "sha256-9EhvCStAeL+ADkLy9b4gXPx+JrVzUZ5Fdkf+imY3Vw0=";
+    hash = "sha256-lhixotjhD8+xb8Hw6Mu1uJPtCq0zlQsBAXpHRzT+moI=";
   };
 
   env = {
@@ -168,7 +168,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src patches;
-    hash = "sha256-RVg6Zciy9mqZQwM5P3ngJi2NjC0qwFH7XgVEanaKnsg=";
+    hash = "sha256-zua2O3eGi7dXh4w0IoUGL2RxvGIW0O3WpVg/tT8942Q=";
   };
 
   patches = [
@@ -195,37 +195,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Fix FHS paths in tests
   postPatch = ''
-    substituteInPlace src/builtins/test.rs \
-      --replace-fail '"/bin/ls"' '"${lib.getExe' coreutils "ls"}"'
-
     substituteInPlace src/highlight/highlight.rs \
-      --replace-fail '"/bin/c"' '"${lib.getExe' coreutils "c"}"' \
-      --replace-fail '"/bin/ca"' '"${lib.getExe' coreutils "ca"}"'
+      --replace-fail '/usr/bin/e' '${coreutils}/bin/e'
 
     substituteInPlace src/highlight/file_tester.rs \
       --replace-fail '/usr' '/'
-
-    substituteInPlace tests/checks/cd.fish \
-      --replace-fail '/bin/pwd' '${lib.getExe' coreutils "pwd"}'
-
-    substituteInPlace tests/checks/redirect.fish \
-      --replace-fail '/bin/echo' '${lib.getExe' coreutils "echo"}'
 
     substituteInPlace tests/checks/vars_as_commands.fish \
       --replace-fail '/usr/bin' '${coreutils}/bin'
 
     substituteInPlace tests/checks/jobs.fish \
-      --replace-fail 'ps -o' '${lib.getExe' procps "ps"} -o' \
-      --replace-fail '/bin/echo' '${lib.getExe' coreutils "echo"}'
-
-    substituteInPlace tests/checks/job-control-noninteractive.fish \
-      --replace-fail '/bin/echo' '${lib.getExe' coreutils "echo"}'
-
-    substituteInPlace tests/checks/complete.fish \
-      --replace-fail '/bin/ls' '${lib.getExe' coreutils "ls"}'
-
-    substituteInPlace tests/checks/output-buffering.fish \
-      --replace-fail '/bin/echo' '${lib.getExe' coreutils "echo"}'
+      --replace-fail 'ps -o' '${lib.getExe' procps "ps"} -o'
 
     substituteInPlace tests/pexpects/wait.py \
       --replace-fail 'expect_prompt("Job ' 'expect_prompt("fish: Job ' \

--- a/pkgs/by-name/fi/fish/skip-sgr-tests.patch
+++ b/pkgs/by-name/fi/fish/skip-sgr-tests.patch
@@ -1,7 +1,7 @@
 diff --git a/src/terminal.rs b/src/terminal.rs
 --- a/src/terminal.rs
 +++ b/src/terminal.rs
-@@ -787,6 +787,7 @@
+@@ -803,6 +803,7 @@ mod tests {
          SgrTerminalCommand::ExitAttributeMode,
      };
 
@@ -9,7 +9,7 @@ diff --git a/src/terminal.rs b/src/terminal.rs
      #[test]
      fn sgr_combining() {
          // No style, no content
-@@ -823,6 +824,7 @@
+@@ -838,6 +839,7 @@ mod tests {
          assert_eq!(String::from_utf8_lossy(outp.contents()), "\u{1b}[30;40m");
      }
 
@@ -17,3 +17,11 @@ diff --git a/src/terminal.rs b/src/terminal.rs
      #[test]
      fn sgr_max_length() {
          // Cut at max length
+@@ -892,6 +894,7 @@ mod tests {
+         );
+     }
+
++    #[ignore]
+     #[test]
+     fn resettable_style_attribute() {
+         type RS = crate::text_face::ResettableStyle<()>;


### PR DESCRIPTION
https://github.com/fish-shell/fish-shell/releases/tag/4.6.0

Upstream refactored tests in this release, removing many hardcoded FHS paths, so most `substituteInPlace` calls in `postPatch` are no longer needed. The highlight test now uses `/usr/bin/env` instead of `/bin/cat`.

Added the new `resettable_style_attribute` SGR test to `skip-sgr-tests.patch` since it fails in the sandbox like the other SGR tests.

Also fixes the NixOS test which has been broken on Hydra since the coreutils 9.10 update: help2man 1.50 embeds tty hyperlink escape codes in man pages which break fish's `create_manpage_completions.py` parser, so `coreutils.fish` is no longer generated. Switched to `coreutils-full` (the minimal `coreutils` has no man pages) and check for `chmod.fish` which still parses successfully.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
