### PR TITLE
fcitx5: fix updateScript

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/update.py
+++ b/pkgs/tools/inputmethods/fcitx5/update.py
@@ -23,21 +23,26 @@ REPOS = [
         ( "fcitx", "fcitx5-table-extra" ),
         ( "fcitx", "fcitx5-table-other" ),
         ( "fcitx", "fcitx5-unikey" ),
-        ( "fcitx", "fcitx5-unikey" )
+        ( "fcitx", "fcitx5-unikey" ),
 
         ( "ray2501", "fcitx5-array" )
         ]
 
-OWNER = "fcitx"
+QT_REPOS = [
+        "fcitx5-chinese-addons",
+        "fcitx5-configtool",
+        "fcitx5-qt",
+        "fcitx5-unikey",
+        ]
 
-def get_latest_tag(repo, owner=OWNER):
+def get_latest_tag(repo, owner):
     r = requests.get('https://api.github.com/repos/{}/{}/tags'.format(owner,repo))
     return r.json()[0].get("name")
 
 def main():
     for (owner, repo) in REPOS:
         rev = get_latest_tag(repo, owner)
-        if repo == "fcitx5-qt":
+        if repo in QT_REPOS:
             subprocess.run(["nix-update", "--commit", "--version", rev, "qt6Packages.{}".format(repo)])
         else:
             subprocess.run(["nix-update", "--commit", "--version", rev, repo])


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The old updateScript doesn't handle packages that are now in the qt6Packages namespace. This PR fixes that.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
