### PR TITLE
python3Packages.apache-tvm-ffi: build torch-c-dlpack-ext C extension

### DIFF
--- a/pkgs/development/python-modules/apache-tvm-ffi/default.nix
+++ b/pkgs/development/python-modules/apache-tvm-ffi/default.nix
@@ -9,9 +9,12 @@
   ninja,
   scikit-build-core,
   setuptools-scm,
+  python,
+  build,
 
   # dependencies
   typing-extensions,
+  torch,
 
   # tests
   numpy,
@@ -43,6 +46,8 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     typing-extensions
+    # runtime dependency for torch_c_dlpack_ext
+    torch
   ];
 
   optional-dependencies = {
@@ -58,6 +63,19 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
     writableTmpDirAsHomeHook
   ];
+
+  nativeBuildInputs = [
+    build
+  ];
+
+  # The torch_c_dlpack_ext extension requires tvm-ffi to be installed
+  # before it can be built
+  postInstall = ''
+    pushd addons/torch_c_dlpack_ext
+    pyproject-build --no-isolation --outdir dist/ --wheel
+    ${python.interpreter} -m installer --prefix $out dist/*.whl
+    popd
+  '';
 
   meta = {
     description = "Open ABI and FFI for Machine Learning Systems";


### PR DESCRIPTION
Adds building the torch-c-dlpack-ext extension required by quack-kernels for vLLM 0.17+ CUDA support.

This is work split out from https://github.com/NixOS/nixpkgs/pull/498040 to update vllm from 0.16 to 0.17.
I have tested this integrated with other changes by running vllm 0.17 on cuda and qwen 3.5.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
