### PR TITLE
cq: 2024.06.24-12.10 -> 2026.01.09-17.19

### DIFF
--- a/pkgs/by-name/cq/cq/package.nix
+++ b/pkgs/by-name/cq/cq/package.nix
@@ -8,12 +8,12 @@
 
 buildGraalvmNativeImage (finalAttrs: {
   pname = "cq";
-  version = "2024.06.24-12.10";
+  version = "2026.01.09-17.19";
 
   # we need both src (the prebuild jar)
   src = fetchurl {
     url = "https://github.com/markus-wa/cq/releases/download/${finalAttrs.version}/cq.jar";
-    hash = "sha256-iULV+j/AuGVYPYhbOTQTKd3n+VZhWQYBRE6cRiaa1/M=";
+    hash = "sha256-CUErNKworfgKIrOQ7V5vcnudTdZzdVdyA/gsOZUOQBI=";
   };
 
   # and build-src (for the native-image build process)
@@ -21,7 +21,7 @@ buildGraalvmNativeImage (finalAttrs: {
     owner = "markus-wa";
     repo = "cq";
     tag = finalAttrs.version;
-    hash = "sha256-yjAC2obipdmh+JlHzVUTMtTXN2VKe4WKkyJyu2Q93c8=";
+    hash = "sha256-jDhN6eYBOouqBeJ/t5DGA1WELkH1udcuvAGaQKQufiw=";
   };
 
   # copied verbatim from the upstream build script https://github.com/markus-wa/cq/blob/main/package/build-native.sh#L5


### PR DESCRIPTION
Diff: https://github.com/markus-wa/cq/compare/2024.06.24-12.10...2026.01.09-17.19

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
