### PR TITLE
go-tpc: init 1.0.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15480,6 +15480,11 @@
     github = "ljxfstorm";
     githubId = 7077478;
   };
+  lks = {
+    name = "Lukas";
+    github = "1H0";
+    githubId = 37246258;
+  };
   llakala = {
     email = "elevenaka11@gmail.com";
     github = "llakala";

--- a/pkgs/by-name/go/go-tpc/package.nix
+++ b/pkgs/by-name/go/go-tpc/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "go-tpc";
+  version = "1.0.12";
+
+  src = fetchFromGitHub {
+    owner = "pingcap";
+    repo = "go-tpc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-O+zHHSjucFh8T42P/IQAA993DmskJfoo1WdO8T95I88=";
+  };
+
+  vendorHash = "sha256-JInXHnHW5jfKism5OscYSJJjBBB7URYLSVpo4EJ/HAs=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X 'main.version=${finalAttrs.version}'"
+  ];
+
+  meta = {
+    description = "Toolbox to benchmark TPC workloads in Go";
+    homepage = "https://github.com/pingcap/go-tpc";
+    license = lib.licenses.asl20;
+    mainProgram = "go-tpc";
+    maintainers = with lib.maintainers; [ lks ];
+  };
+})


### PR DESCRIPTION
Adding [go-tpc](https://github.com/pingcap/go-tpc), a [TPC](https://tpc.org/) benchmarking tool written in Go.

The latest release is [1.0.12](https://github.com/pingcap/go-tpc/releases/tag/v1.0.12).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
