### PR TITLE
nixos/testing/service-runner: fix build if ExecStartPre or ExecStartPost is a string instead of a list

### DIFF
--- a/nixos/modules/testing/service-runner.nix
+++ b/nixos/modules/testing/service-runner.nix
@@ -3,6 +3,7 @@
 with lib;
 
 let
+  ensureList = x: if builtins.isList x then x else [ x ];
 
   makeScript =
     name: service:
@@ -55,7 +56,7 @@ let
 
       # Run the ExecStartPre program.  FIXME: this could be a list.
       my $preStart = <<END_CMD;
-      ${concatStringsSep "\n" (service.serviceConfig.ExecStartPre or [ ])}
+      ${concatStringsSep "\n" (ensureList (service.serviceConfig.ExecStartPre or [ ]))}
       END_CMD
       if (defined $preStart && $preStart ne "\n") {
           print STDERR "running ExecStartPre: $preStart\n";
@@ -82,7 +83,7 @@ let
 
       # Run the ExecStartPost program.
       my $postStart = <<END_CMD;
-      ${concatStringsSep "\n" (service.serviceConfig.ExecStartPost or [ ])}
+      ${concatStringsSep "\n" (ensureList (service.serviceConfig.ExecStartPost or [ ]))}
       END_CMD
       if (defined $postStart && $postStart ne "\n") {
           print STDERR "running ExecStartPost: $postStart\n";


### PR DESCRIPTION
Without this patch, the `runner` helper would fail to build if `<name>.serviceConfig.ExecStartPre` or `<name>.serviceConfig.ExecStartPre` is set to a single string instead of a list of strings. This happens for many services defined in nixos, here demonstrated with (fairly arbitrarily picked) gitlab-runner:

```
Nix 2.28.5
Type :? for help.
nix-repl> :lf .
Added 19 variables.

nix-repl> :b (lib.nixosSystem { modules = [{ services.gitlab-runner.enable=true; }]; system="x86_64-linux"; }).config.systemd.services.gitlab-runner.runner
evaluation warning: system.stateVersion is not set, defaulting to 26.05. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'gitlab-runner-runner'
         whose name attribute is located at /nix/store/78c4nx1ibhz87y4lq2ar0zmh6bsscjgs-source/pkgs/stdenv/generic/make-derivation.nix:536:13

       … while evaluating attribute 'text' of derivation 'gitlab-runner-runner'
         at /nix/store/78c4nx1ibhz87y4lq2ar0zmh6bsscjgs-source/pkgs/build-support/trivial-builders/default.nix:130:13:
          129|           inherit
          130|             text
             |             ^
          131|             executable

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: expected a list but found a string with context: "!/nix/store/da8mq1wq491blrf25w8n5k7hfrl6z59z-gitlab-runner-configure/bin/gitlab-runner-configure"
```

With this patch, this works as expected:

```
Nix 2.28.5
Type :? for help.
nix-repl> :lf .
warning: Git tree '/home/synthetica/dev/nixpkgs' is dirty
Added 18 variables.

nix-repl> :b (lib.nixosSystem { modules = [{ services.gitlab-runner.enable=true;  }]; system="x86_64-linux"; }).config.systemd.services.gitlab-runner.runner
evaluation warning: system.stateVersion is not set, defaulting to 26.05. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.

This derivation produced the following outputs:
  out -> /nix/store/4xnndwnhh8qis3s6xhrki23hfd85rz69-gitlab-runner-runner
```

There are alternatives possible, but I don't think any of them are a great option:

 - Change `ExecStartPre` and `ExecStartPost` options to wrap into a list if given a string. I don't like this because it would change observable behaviour downstream, so probably quite a few people's setup would break. This is however in my opinion the most disciplined fix for the observed issue.
 - Change all definitions of `ExecStartPre` and `ExecStartPost` to a list in nixos explicitly. This would fix the issue for any built-in services, but not for any downstream users. It would also not prevent this issue from slipping back in to existing or previous modules.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
