### PR TITLE
nixos/fmd-server: create new module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -70,6 +70,8 @@
 
 - [hyprwhspr-rs](https://github.com/better-slop/hyprwhspr-rs), a keybind activated speech-to-text voice dictation utility built for use with Hyprland. Available as `services.hyprwhspr-rs`
 
+- [fmd-server](https://gitlab.com/fmd-foss/fmd-server), a self-hosted server counterpart to the Find My Device android app, an application whose purpose is to remotely fetch GPS information from your smartphone.  Available as [services.fmd-server](#opt-services.fmd-server.enable).
+
 - [DankMaterialShell](https://danklinux.com), a complete desktop shell for Wayland compositors built with Quickshell. Available as [programs.dms-shell](#opt-programs.dms-shell.enable).
 
 - [pyroscope](https://github.com/grafana/pyroscope), a continuous profiling platform. that allows for performance debugging. Available as [services.pyroscope](#opt-services.pyroscope.enable)

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -858,6 +858,7 @@
   ./services/misc/evremap.nix
   ./services/misc/felix.nix
   ./services/misc/flaresolverr.nix
+  ./services/misc/fmd-server.nix
   ./services/misc/forgejo.nix
   ./services/misc/freeswitch.nix
   ./services/misc/fstrim.nix

--- a/nixos/modules/services/misc/fmd-server.nix
+++ b/nixos/modules/services/misc/fmd-server.nix
@@ -1,0 +1,198 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    ;
+  inherit (lib.types)
+    addCheck
+    either
+    enum
+    ints
+    path
+    port
+    str
+    ;
+  inherit (builtins) stringLength;
+  token = addCheck str (s: stringLength s == 32);
+  cfg = config.services.fmd-server;
+  config-file = pkgs.writeText "config.yml" ''
+    DatabaseDir: "${cfg.databaseDir}"
+    PortInsecure: ${toString cfg.port}
+    PortSecure: -1
+    RegistrationToken: "${cfg.registration-token}"
+    RemoteIpHeader: "X-Real-IP"
+    UserIdLength: ${toString cfg.user-id-length}
+    MaxSavedLoc: ${toString cfg.max-saved-loc}
+    MaxSavedPic: ${toString cfg.max-saved-pic}
+    ${
+      if cfg.prometheus.enable then
+        ''MetricsAddrPort: "${cfg.prometheus.address}:${toString cfg.prometheus.port}"''
+      else
+        ""
+    }
+  '';
+in
+{
+  options = {
+    services.fmd-server = {
+      enable = mkEnableOption "Find My Device server";
+      package = mkPackageOption pkgs "fmd-server" { };
+
+      user = mkOption {
+        type = str;
+        default = "fmd";
+        description = "User account under which fmd-server runs.";
+      };
+
+      group = mkOption {
+        type = str;
+        default = "fmd";
+        description = "Group under which fmd-server runs";
+      };
+
+      dataDir = mkOption {
+        type = path;
+        default = "/var/lib/fmd-server";
+        description = "Base path directory";
+      };
+
+      databaseDir = mkOption {
+        type = path;
+        # This is more convoluted that it might seem necessary, but this is to ensure that the
+        # manual builds.  Indeed, when the manual is built, the `config` set doesn't contain a
+        # `services` attribute.
+        default = "${config.services.fmd-server.dataDir or "/var/lib/fmd-server"}/db";
+        description = "Base database directory";
+      };
+
+      port = mkOption {
+        type = port;
+        default = 7893;
+        description = "Port for the web interface";
+      };
+
+      user-id-length = mkOption {
+        type = ints.positive;
+        default = 5;
+        description = "The length for the user IDs that are generated.";
+      };
+
+      max-saved-loc = mkOption {
+        type = ints.positive;
+        default = 500;
+        description = "How many location points FMD server should save per account.";
+      };
+
+      max-saved-pic = mkOption {
+        type = ints.positive;
+        default = 10;
+        description = "How many pictures FMD server should save per account";
+      };
+
+      registration-token = mkOption {
+        type = either (enum [ "public" ]) token;
+        description = "A token required to connect to this instance.  Can be set to `public` if no token is required, or to a 32 character string that should be shared only with applications that are allowed to connect.";
+      };
+
+      prometheus = {
+        enable = mkEnableOption "Run Prometheus metrics on FMD server.";
+        address = mkOption {
+          type = str;
+          example = "[::1]";
+          description = "The address of the Prometheus server.";
+        };
+        port = mkOption {
+          type = port;
+          # See the comment on `databaseDir.default` on why it is needed to have a default value
+          # for `config.services.prometheus.enable`.
+          default =
+            if config.services.prometheus.enable or false then config.services.prometheus.port else 9090;
+          description = "The port the Prometheus server is listening to";
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd = {
+      tmpfiles.settings.fmd-dirs =
+        let
+          dir = {
+            inherit (cfg) user group;
+            mode = "700";
+          };
+        in
+        {
+          "${cfg.dataDir}"."d" = dir;
+          "${cfg.databaseDir}"."d" = dir;
+        };
+      services.fmd-server = {
+        enable = true;
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+        description = "Find My Device server";
+        serviceConfig = {
+          # Follows https://fmd-foss.org/docs/fmd-server/installation/linux/#step-6-manage-with-systemd
+          ExecStart = "${getExe cfg.package} serve --db-dir '${cfg.databaseDir}' --config '${config-file}'";
+          Type = "simple";
+          Restart = "always";
+          User = cfg.user;
+          Group = cfg.group;
+
+          ProtectProc = "invisible";
+          NoNewPrivileges = true;
+          CapabilityBoundingSet = [ "" ];
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          ProtectClock = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectKernelLogs = true;
+          ProtectControlGroups = true;
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+          ];
+          RestrictNamespaces = true;
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          RemoveIPC = true;
+          RuntimeDirectory = "fmd-server";
+          ReadWritePaths = [
+            cfg.dataDir
+            cfg.databaseDir
+          ];
+          SystemCallFilter = "@system-service";
+          SystemCallArchitectures = "native";
+          WorkingDirectory = cfg.dataDir;
+        };
+      };
+    };
+
+    users.users = mkIf (cfg.user == "fmd") {
+      fmd = {
+        inherit (cfg) group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "fmd") {
+      fmd = { };
+    };
+  };
+}

--- a/nixos/modules/services/misc/fmd-server.nix
+++ b/nixos/modules/services/misc/fmd-server.nix
@@ -1,0 +1,195 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  inherit (lib)
+    getExe
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    ;
+  inherit (lib.types)
+    addCheck
+    either
+    enum
+    ints
+    path
+    port
+    str
+    ;
+  inherit (builtins) stringLength;
+  token = addCheck str (s: stringLength s == 32);
+  cfg = config.services.fmd-server;
+  config-file = pkgs.writeText "config.yml" ''
+    DatabaseDir: "${cfg.databaseDir}"
+    PortInsecure: ${toString cfg.port}
+    PortSecure: -1
+    RegistrationToken: "${cfg.registration-token}"
+    RemoteIpHeader: "X-Real-IP"
+    UserIdLength: ${toString cfg.user-id-length}
+    MaxSavedLoc: ${toString cfg.max-saved-loc}
+    MaxSavedPic: ${toString cfg.max-saved-pic}
+    MetricsAddrPort: "${
+      if cfg.prometheus.enable then "${cfg.prometheus.address}:${toString cfg.prometheu.port}" else ""
+    }"
+  '';
+in
+{
+  options = {
+    services.fmd-server = {
+      enable = mkEnableOption "Find My Device server";
+      package = mkPackageOption pkgs "fmd-server" { };
+
+      user = mkOption {
+        type = str;
+        default = "fmd";
+        description = "User account under which fmd-server runs.";
+      };
+
+      group = mkOption {
+        type = str;
+        default = "fmd";
+        description = "Group under which fmd-server runs";
+      };
+
+      dataDir = mkOption {
+        type = path;
+        default = "/var/lib/fmd-server";
+        description = "Base path directory";
+      };
+
+      databaseDir = mkOption {
+        type = path;
+        # This is more convoluted that it might seem necessary, but this is to ensure that the
+        # manual builds.  Indeed, when the manual is built, the `config` set doesn't contain a
+        # `services` attribute.
+        default = "${config.services.fmd-server.dataDir or "/var/lib/fmd-server"}/db";
+        description = "Base database directory";
+      };
+
+      port = mkOption {
+        type = port;
+        default = 7893;
+        description = "Port for the web interface";
+      };
+
+      user-id-length = mkOption {
+        type = ints.positive;
+        default = 5;
+        description = "The length for the user IDs that are generated.";
+      };
+
+      max-saved-loc = mkOption {
+        type = ints.positive;
+        default = 500;
+        description = "How many location points FMD server should save per account.";
+      };
+
+      max-saved-pic = mkOption {
+        type = ints.positive;
+        default = 10;
+        description = "How many pictures FMD server should save per account";
+      };
+
+      registration-token = mkOption {
+        type = either (enum [ "public" ]) token;
+        description = "A token required to connect to this instance.  Can be set to `public` if no token is required, or to a 32 character string that should be shared only with applications that are allowed to connect.";
+      };
+
+      prometheus = {
+        enable = mkEnableOption "Run Prometheus metrics on FMD server.";
+        address = mkOption {
+          type = str;
+          example = "[::1]";
+          description = "The address of the Prometheus server.";
+        };
+        port = mkOption {
+          type = port;
+          # See the comment on `databaseDir.default` on why it is needed to have a default value
+          # for `config.services.prometheus.enable`.
+          default =
+            if config.services.prometheus.enable or false then config.services.prometheus.port else 9090;
+          description = "The port the Prometheus server is listening to";
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd = {
+      tmpfiles.settings.fmd-dirs =
+        let
+          dir = {
+            inherit (cfg) user group;
+            mode = "700";
+          };
+        in
+        {
+          "${cfg.dataDir}"."d" = dir;
+          "${cfg.databaseDir}"."d" = dir;
+        };
+      services.fmd-server = {
+        enable = true;
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+        description = "Find My Device server";
+        serviceConfig = {
+          # Follows https://fmd-foss.org/docs/fmd-server/installation/linux/#step-6-manage-with-systemd
+          ExecStart = "${getExe cfg.package} serve --db-dir '${cfg.databaseDir}' --config '${config-file}'";
+          Type = "simple";
+          Restart = "always";
+          User = cfg.user;
+          Group = cfg.group;
+
+          ProtectProc = "invisible";
+          NoNewPrivileges = true;
+          CapabilityBoundingSet = [ "" ];
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          ProtectClock = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectKernelLogs = true;
+          ProtectControlGroups = true;
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+          ];
+          RestrictNamespaces = true;
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          RemoveIPC = true;
+          RuntimeDirectory = "fmd-server";
+          ReadWritePaths = [
+            cfg.dataDir
+            cfg.databaseDir
+          ];
+          SystemCallFilter = "@system-service";
+          SystemCallArchitectures = "native";
+          WorkingDirectory = cfg.dataDir;
+        };
+      };
+    };
+
+    users.users = mkIf (cfg.user == "fmd") {
+      fmd = {
+        inherit (cfg) group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "fmd") {
+      fmd = { };
+    };
+  };
+}


### PR DESCRIPTION
Find My Device is an android application that allows to remotely turn on GPS, and retrieve its location, among other similar features.  One of the ways to remotely contact a device that has Find My Device is to have it register on a FMD server.  One is publicly available, but there is also the option to self-host it.  The server is already packaged in nixpkgs (`fmd-server`), but until now there was no NixOS module to easily deploy it.

This PR adds a NixOS module to handle a FMD server.

The module added is not complete with respect to all the configuration options available, in the sense that an FMD server can be directly connected to an open port, or it can be served through a reverse-proxy.  Only the reverse-proxy option is implemented in this PR.  Adding the other option would be an easy addition, but I don't see the point of doing so as it's really easy to setup a reverse proxy on NixOS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
