### PR TITLE
{klayout, python3Packages.klayout, python3Packages.kfactory, python3Packages.gdsfactory}: update

### DIFF
--- a/pkgs/applications/misc/klayout/default.nix
+++ b/pkgs/applications/misc/klayout/default.nix
@@ -3,33 +3,44 @@
   stdenv,
   fetchFromGitHub,
   installShellFiles,
+  nix-update-script,
   python3,
+  python3Packages,
   ruby,
   wrapQtAppsHook,
   qtbase,
   qtmultimedia,
+  qtsvg,
   qttools,
   qtxmlpatterns,
+  qmake,
   which,
   perl,
   libgit2,
+  libpng,
+  expat,
+  curl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "klayout";
-  version = "0.30.5";
+  version = "0.30.7";
 
   src = fetchFromGitHub {
     owner = "KLayout";
     repo = "klayout";
-    rev = "v${version}";
-    hash = "sha256-WigRictn6CxOPId2YitlEm43vEw+dSRWdoareD9HtMc=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-W8ry1+wxVOUxg4hXMd0OpcaWcVr6wUBC3eGgDney2Xc=";
   };
+
+  strictDeps = true;
 
   postPatch = ''
     substituteInPlace src/klayout.pri --replace "-Wno-reserved-user-defined-literal" ""
     patchShebangs .
   '';
+
+  dontUseQmakeConfigure = true;
 
   nativeBuildInputs = [
     (python3.withPackages (ps: [ ps.tomli ]))
@@ -38,28 +49,37 @@ stdenv.mkDerivation rec {
     ruby
     which
     wrapQtAppsHook
+    qmake
+    qtbase
+    qtmultimedia
+    qtsvg
+    qttools
+    qtxmlpatterns
   ];
 
   buildInputs = [
     qtbase
     qtmultimedia
+    qtsvg
     qttools
     qtxmlpatterns
     libgit2
+    libpng
+    expat
+    curl
   ];
 
   buildPhase = ''
     runHook preBuild
     mkdir -p $out/lib
 
-    # -qt5: Using Qt5 as per your previous configuration.
-    # -rpath: Ensures the klayout binary can find its internal libraries (tl, db, etc.)
-    #         in the nix store without needing LD_LIBRARY_PATH.
     ./build.sh \
-      -qt5 \
       -prefix $out/lib \
       -option "-j$NIX_BUILD_CORES" \
-      -rpath $out/lib
+      -rpath $out/lib \
+      -libpng \
+      -libcurl \
+      -libexpat
 
     runHook postBuild
   '';
@@ -95,13 +115,20 @@ stdenv.mkDerivation rec {
   # Fix for: "gsiDeclQMessageLogger.cc: error: format not a string literal"
   hardeningDisable = [ "format" ];
 
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      pythonPackage = python3Packages.klayout;
+    };
+  };
+
   meta = {
     description = "High performance layout viewer and editor with support for GDS and OASIS";
     mainProgram = "klayout";
     license = with lib.licenses; [ gpl2Plus ];
     homepage = "https://www.klayout.de/";
-    changelog = "https://www.klayout.de/development.html#${version}";
+    changelog = "https://www.klayout.de/development.html#${finalAttrs.version}";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/gdsfactory/default.nix
+++ b/pkgs/development/python-modules/gdsfactory/default.nix
@@ -48,14 +48,14 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "gdsfactory";
-  version = "9.32.1";
+  version = "9.39.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gdsfactory";
     repo = "gdsfactory";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uXFH+6uZx+fFo1QfozI/JVomchFlnWx805CwbAj7CPQ=";
+    hash = "sha256-WwZ0GikpRfg7wpr08QdqdTvZtsNBnwcC5pxiddfG6rM=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/kfactory/default.nix
+++ b/pkgs/development/python-modules/kfactory/default.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "kfactory";
-  version = "2.3.0";
+  version = "2.4.6";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -45,7 +45,7 @@ buildPythonPackage (finalAttrs: {
     # assert kf.config.project_dir is not None
     # E   AssertionError: assert None is not None
     leaveDotGit = true;
-    hash = "sha256-6z2JlndmuegpCAf74YRa/qVVjFOWv1Xy3dabeWlOmbs=";
+    hash = "sha256-rr4EeTk4+g29kjfbc6tdHt85ZofzAL+kGBWnYMG4J7U=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/klayout/default.nix
+++ b/pkgs/development/python-modules/klayout/default.nix
@@ -6,7 +6,7 @@
   cython,
   expat,
   fixDarwinDylibNames,
-  fetchFromGitHub,
+  klayout,
   libpng,
   qt6,
   setuptools,
@@ -15,17 +15,11 @@
   zlib,
 }:
 
-buildPythonPackage (finalAttrs: {
+buildPythonPackage {
   pname = "klayout";
-  version = "0.30.5";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "KLayout";
-    repo = "klayout";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-WigRictn6CxOPId2YitlEm43vEw+dSRWdoareD9HtMc=";
-  };
+  inherit (klayout) version src;
 
   build-system = [
     cython
@@ -76,4 +70,4 @@ buildPythonPackage (finalAttrs: {
     maintainers = with lib.maintainers; [ fbeffa ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-})
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8295,7 +8295,7 @@ self: super: with self; {
 
   klaus = callPackage ../development/python-modules/klaus { };
 
-  klayout = callPackage ../development/python-modules/klayout { };
+  klayout = callPackage ../development/python-modules/klayout { inherit (pkgs) klayout; };
 
   klein = callPackage ../development/python-modules/klein { };
 


### PR DESCRIPTION
https://github.com/KLayout/klayout/releases/tag/v0.30.7)

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Python was tested with:
```
nix-shell -p "python3.withPackages (ps: [ ps.klayout ])" -I nixpkgs=.   --run "python3 -c 'import klayout.db as db; print(f\"KLayout Module Version: {db.__version__}\")'"
```