### PR TITLE
raxml: Add Darwin and introduce AVX and AVX2 builds

### DIFF
--- a/pkgs/by-name/ra/raxml/package.nix
+++ b/pkgs/by-name/ra/raxml/package.nix
@@ -6,6 +6,10 @@
   mpi,
 }:
 
+let
+  mpi_or_pthreads = if useMpi then "MPI" else "PTHREADS";
+  linux_or_darwin = if stdenv.hostPlatform.isDarwin then "mac" else "gcc";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "RAxML${lib.optionalString useMpi "-mpi"}";
   version = "8.2.13";
@@ -19,38 +23,40 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = lib.optionals useMpi [ mpi ];
 
-  # TODO darwin, AVX and AVX2 makefile targets
-  buildPhase =
-    if useMpi then
-      ''
-        make -f Makefile.MPI.gcc
-      ''
-    else
-      ''
-        make -f Makefile.SSE3.PTHREADS.gcc
-      '';
+  buildPhase = ''
+    runHook preBuild
+
+    make -f Makefile.SSE3.${mpi_or_pthreads}.${linux_or_darwin}
+    make -f Makefile.AVX.${mpi_or_pthreads}.${linux_or_darwin}
+    make -f Makefile.AVX2.${mpi_or_pthreads}.${linux_or_darwin}
+
+    runHook postBuild
+  '';
 
   # Fix build with gcc15 (-std=gnu23)
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU "-std=gnu17";
 
-  installPhase =
-    if useMpi then
-      ''
-        mkdir -p $out/bin && cp raxmlHPC-MPI $out/bin
-      ''
-    else
-      ''
-        mkdir -p $out/bin && cp raxmlHPC-PTHREADS-SSE3 $out/bin
-      '';
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp raxmlHPC-${mpi_or_pthreads}-SSE3 $out/bin
+    cp raxmlHPC-${mpi_or_pthreads}-AVX $out/bin
+    cp raxmlHPC-${mpi_or_pthreads}-AVX2 $out/bin
+
+    runHook postInstall
+  '';
 
   meta = {
     description = "Tool for Phylogenetic Analysis and Post-Analysis of Large Phylogenies";
     license = lib.licenses.gpl3;
     homepage = "https://sco.h-its.org/exelixis/web/software/raxml/";
-    maintainers = [ lib.maintainers.unode ];
+    maintainers = with lib.maintainers; [
+      unode
+    ];
     platforms = [
-      "i686-linux"
       "x86_64-linux"
+      "x86_64-darwin"
     ];
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11544,7 +11544,14 @@ with pkgs;
     inherit (perlPackages) perl TextFormat;
   };
 
-  raxml-mpi = raxml.override { useMpi = true; };
+  # raxml MPI is not available on darwin
+  raxml-mpi =
+    (raxml.override {
+      useMpi = true;
+    }).overrideAttrs
+      {
+        meta.platforms = [ "x86_64-linux" ];
+      };
 
   ### SCIENCE/MACHINE LEARNING
 


### PR DESCRIPTION
Add support to building AVX and AVX2 targets in addition to SSE3
Add Darwin support - help testing is welcome since I don't have this platform

Includes #503981

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
