### PR TITLE
nixos/redis: add assertion for malloc compat

### DIFF
--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -507,7 +507,21 @@ in
 
   config = lib.mkIf (enabledServers != { }) {
 
-    assertions = lib.concatLists (
+    assertions = [
+      {
+        assertion =
+          !builtins.elem config.environment.memoryAllocator.provider [
+            "graphene-hardened"
+            "graphene-hardened-light"
+          ];
+        message = ''
+          Redis is incompatible with the "${config.environment.memoryAllocator.provider}"
+          memory allocator. Redis requires a working malloc_usable_size() which
+          this allocator does not support. Redis may crash on startup.
+        '';
+      }
+    ]
+    ++ lib.concatLists (
       lib.mapAttrsToList (name: conf: [
         {
           assertion = conf.requirePass != null -> conf.requirePassFile == null;


### PR DESCRIPTION
Redis needs to be able to call `malloc_usable_size` which is intentionally not available on some malloc implementations.

Exact error:
```
fatal allocator error: invalid malloc_usable_size from libhardened_malloc.so.
```

Related: https://github.com/redis/redis/issues/8531


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
