### PR TITLE
nixos/incus: add useACMEHost option

### DIFF
--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -7,6 +7,9 @@
 
 let
   cfg = config.virtualisation.incus;
+
+  acmeHostDir = config.security.acme.certs."${cfg.useACMEHost}".directory;
+
   preseedFormat = pkgs.formats.yaml { };
 
   nvidiaEnabled = (lib.elem "nvidia" config.services.xserver.videoDrivers);
@@ -292,6 +295,17 @@ in
 
         package = lib.mkPackageOption pkgs [ "incus-ui-canonical" ] { };
       };
+      useACMEHost = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "incus.example.com";
+        description = ''
+          Host of an existing Let's Encrypt certificate to use for TLS.
+          *Note that this option does not create any certificates and it
+          doesn't add subdomains to existing ones – you will need to create
+          them manually using {option}`security.acme.certs`.*
+        '';
+      };
     };
   };
 
@@ -391,6 +405,10 @@ in
       '';
     };
 
+    security.acme.certs = lib.mkIf (cfg.useACMEHost != null) {
+      "${cfg.useACMEHost}".reloadServices = [ "incus.service" ];
+    };
+
     systemd.services.incus = {
       description = "Incus Container and Virtual Machine Management Daemon";
 
@@ -402,7 +420,8 @@ in
         "lxcfs.service"
         "incus.socket"
       ]
-      ++ lib.optionals config.virtualisation.vswitch.enable [ "ovs-vswitchd.service" ];
+      ++ lib.optionals config.virtualisation.vswitch.enable [ "ovs-vswitchd.service" ]
+      ++ lib.optionals (cfg.useACMEHost != null) [ "acme-${cfg.useACMEHost}.service" ];
 
       requires = [
         "lxcfs.service"
@@ -410,7 +429,10 @@ in
       ]
       ++ lib.optionals config.virtualisation.vswitch.enable [ "ovs-vswitchd.service" ];
 
-      wants = [ "network-online.target" ];
+      wants = [
+        "network-online.target"
+      ]
+      ++ lib.optionals (cfg.useACMEHost != null) [ "acme-${cfg.useACMEHost}.service" ];
 
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/incusd --group incus-admin";
@@ -427,6 +449,11 @@ in
         Restart = "on-failure";
         TimeoutStartSec = "${cfg.startTimeout}s";
         TimeoutStopSec = "30s";
+
+        BindReadOnlyPaths = lib.mkIf (cfg.useACMEHost != null) [
+          "${acmeHostDir}/fullchain.pem:/var/lib/incus/server.crt"
+          "${acmeHostDir}/key.pem:/var/lib/incus/server.key"
+        ];
       };
     };
 


### PR DESCRIPTION
This adds the tooling to use the acme module together with incus.

Unfortunately incus doesn't seem to support a reload but needs a restart and the cert paths aren't configurable: https://github.com/lxc/incus/issues/2790

Tested this patch on top of nixos-25.11.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
