### PR TITLE
various: gnome-circle 2026-03-28 updates

### DIFF
--- a/pkgs/by-name/de/deja-dup/package.nix
+++ b/pkgs/by-name/de/deja-dup/package.nix
@@ -28,14 +28,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "deja-dup";
-  version = "49.2";
+  version = "50.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "deja-dup";
     tag = finalAttrs.version;
-    hash = "sha256-yH4XX1MwPxTmKh6p27pYQBQDyeGIT+Ed9E0Y508EF7s=";
+    hash = "sha256-sdUyKRksi0ZvheivQVcDRBh7t6PoFeQ1mf4ygSTk4b4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-decoder/package.nix
+++ b/pkgs/by-name/gn/gnome-decoder/package.nix
@@ -23,19 +23,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-decoder";
-  version = "0.8.1";
+  version = "0.9.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "decoder";
     tag = finalAttrs.version;
-    hash = "sha256-g3ztQ+wiCDY19bc2/IABzXGSQrZltQgrTZ7rSI0RyFs=";
+    hash = "sha256-ssbqtDuUpHDT0Q91YCWsvYS8T9cMl4ukOKuaIvnGg44=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-lYbJN5XliFATZVoZqiTDD3wzKPTfpFHk24iLh7ctjG4=";
+    hash = "sha256-Ue89/U4OXQVftuGtiYF2cr4UuFzrfz6DT52EQM1wd7s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-graphs/package.nix
+++ b/pkgs/by-name/gn/gnome-graphs/package.nix
@@ -19,7 +19,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gnome-graphs";
-  version = "1.8.7";
+  version = "1.8.8";
   pyproject = false;
 
   src = fetchFromGitLab {
@@ -27,7 +27,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "World";
     repo = "Graphs";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-nMcpsYW8/WdCKmHnsObAWhDeo7+1vqBGTTXteh6jBus=";
+    hash = "sha256-XsdrXdIZmAngS52KmjcNbOWwYJsnhNGELSd0p3h/XWE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/io/iotas/package.nix
+++ b/pkgs/by-name/io/iotas/package.nix
@@ -20,7 +20,7 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "iotas";
-  version = "0.12.7";
+  version = "2026.4";
   pyproject = false;
 
   src = fetchFromGitLab {
@@ -28,7 +28,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     owner = "World";
     repo = "iotas";
     tag = finalAttrs.version;
-    hash = "sha256-LA00Szhjk/tzGnzDGm65SCgH6l2fk+8+p4PhIpB7T1I=";
+    hash = "sha256-PLKKV6FNYvhvb1Kp2tYu7jXkzxfN/W0C618o5+/tenY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vi/video-trimmer/package.nix
+++ b/pkgs/by-name/vi/video-trimmer/package.nix
@@ -20,19 +20,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "video-trimmer";
-  version = "25.03";
+  version = "26.03";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "YaLTeR";
     repo = "video-trimmer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pJCXL0voOoc8KpYECYRWGefYMrsApNPST4wv8SQlH34=";
+    hash = "sha256-ro7yOl+OZ4IZxIkRMjYf4IqOxfCAB4PdIlWUEuymOc8=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-3ycc4jXneGsz9Jp9Arzf224JPAKM+PxUkitWcIXre8Y=";
+    hash = "sha256-nYPVRTMY0XA3VDclid7+w6SMFl0i4Ra6HYKJtTTC1y0=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/wa/warp/package.nix
+++ b/pkgs/by-name/wa/warp/package.nix
@@ -24,14 +24,14 @@
 
 stdenv.mkDerivation rec {
   pname = "warp";
-  version = "0.9.2";
+  version = "1.0.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "warp";
     tag = "v${version}";
-    hash = "sha256-60FhXIO1etcMhZJuSQjO2UWrkwV+AJOFmaAIi3uLpzY=";
+    hash = "sha256-cFMIMNAVrP3rF7UQeKgSdaRZmJT8XcERR4BSLYqxSoI=";
   };
 
   postPatch = ''
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-sQFJ+eR/Ywl3KPN50P2RVHKAjxtOUb6YRoThRb5aMe8=";
+    hash = "sha256-CFe6Hg1cSz59agZ/eCL7PfnMe/N0vJvAs3gzfjZCwlY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Diffs:
- deja-dup: https://gitlab.gnome.org/World/deja-dup/-/compare/49.2...50.0
- gnome-decoder: https://gitlab.gnome.org/World/decoder/-/compare/0.8.1...0.9.0
- gnome-graphs: https://gitlab.gnome.org/World/Graphs/-/compare/v1.8.7...v1.8.8
- iotas: https://gitlab.gnome.org/World/iotas/-/compare/0.12.7...2026.4
- video-trimmer: https://gitlab.gnome.org/YaLTeR/video-trimmer/-/compare/v25.03...v26.03
- warp: https://gitlab.gnome.org/World/warp/-/compare/v0.9.2...v1.0.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
