### PR TITLE
holo-cli: 0.5.0-unstable-2025-09-22 -> 0.5.0-unstable-2026-03-15

### DIFF
--- a/pkgs/by-name/ho/holo-cli/libyang4-sys.patch
+++ b/pkgs/by-name/ho/holo-cli/libyang4-sys.patch
@@ -1,0 +1,12 @@
+--- a/build.rs
++++ b/build.rs
+@@ -62,6 +62,9 @@
+         cmake_config.define("ENABLE_BUILD_TESTS", "OFF");
+         cmake_config.define("CMAKE_BUILD_TYPE", "Release");
+         cmake_config.define("CMAKE_POSITION_INDEPENDENT_CODE", "ON");
++        // https://github.com/CESNET/libyang/blob/3d07c3a71534a580c3960907da17568eff7e5c64/CMakeModules/FindPCRE2.cmake#L9
++        cmake_config.define("PCRE2_INCLUDE_DIRS", "@PCRE2_INCLUDE_DIRS@");
++        cmake_config.define("PCRE2_LIBRARIES", "@PCRE2_LIBRARIES@");
+         let cmake_dst = cmake_config.build();
+         println!("cargo:root={}", env::var("OUT_DIR").unwrap());
+         println!("cargo:rustc-link-search=native={}/lib", cmake_dst.display());

--- a/pkgs/by-name/ho/holo-cli/package.nix
+++ b/pkgs/by-name/ho/holo-cli/package.nix
@@ -2,6 +2,8 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  stdenv,
+  replaceVars,
   cmake,
   pkg-config,
   protobuf,
@@ -11,17 +13,28 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "holo-cli";
-  version = "0.5.0-unstable-2025-09-22";
+  version = "0.5.0-unstable-2026-01-03";
 
   src = fetchFromGitHub {
     owner = "holo-routing";
     repo = "holo-cli";
-    rev = "7d99e7de5eb5226728ee57153c03362c90eb65b2";
-    hash = "sha256-O509LNSpak+MJPQheYLPtJQcNGPyZLMHMasKScoVnls=";
+    rev = "8a8f02fc56f30cca216e9a99029b736fe57b3d59";
+    hash = "sha256-pCupXT4fymydzOpdsMbimAcQZzVUNzfG3VRnrD3q7Xw=";
   };
 
-  cargoHash = "sha256-bsoxWjOMzRRtFGEaaqK0/adhGpDcejCIY0Pzw1HjQ5U=";
+  cargoHash = "sha256-7/OtT2TdLhFVZeuQOg6xQJFnGJNz/G9mna8vIeh86/k=";
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    pushd $cargoDepsCopy/libyang4-sys-*
+    patch -p1 < ${
+      replaceVars ./libyang4-sys.patch {
+        PCRE2_INCLUDE_DIRS = "${lib.getInclude pcre2}/include";
+        PCRE2_LIBRARIES = "${lib.getLib pcre2}/lib/libpcre2-8${stdenv.hostPlatform.extensions.sharedLibrary}";
+      }
+    }
+    popd
+  '';
 
   # Use rust nightly features
   env.RUSTC_BOOTSTRAP = 1;

--- a/pkgs/by-name/ho/holo-cli/package.nix
+++ b/pkgs/by-name/ho/holo-cli/package.nix
@@ -2,31 +2,40 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+
   stdenv,
   replaceVars,
+
   cmake,
   pkg-config,
   protobuf,
+
   pcre2,
+
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "holo-cli";
-  version = "0.5.0-unstable-2026-01-03";
+  version = "0.5.0-unstable-2026-03-15";
 
   src = fetchFromGitHub {
     owner = "holo-routing";
     repo = "holo-cli";
-    rev = "8a8f02fc56f30cca216e9a99029b736fe57b3d59";
-    hash = "sha256-pCupXT4fymydzOpdsMbimAcQZzVUNzfG3VRnrD3q7Xw=";
+    rev = "36fdc13323e384c086da8663f0d510b238fb6e4f";
+    hash = "sha256-5Nvyh9gznMsutu3wHR6gwgKkIm115hbx4R6D/Gm1Rug=";
   };
 
-  cargoHash = "sha256-7/OtT2TdLhFVZeuQOg6xQJFnGJNz/G9mna8vIeh86/k=";
-  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+  cargoPatches = [
+    # cargo lock is outdated
+    # https://github.com/holo-routing/holo-cli/pull/31
+    ./update-cargo-lock.patch
+  ];
+
+  cargoHash = "sha256-77aUfXcnVQLVEKQuUdBZ4k5/3rOoe9PvGC0AlJS0UJc=";
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    pushd $cargoDepsCopy/libyang4-sys-*
+    pushd $cargoDepsCopy/*/libyang4-sys-*
     patch -p1 < ${
       replaceVars ./libyang4-sys.patch {
         PCRE2_INCLUDE_DIRS = "${lib.getInclude pcre2}/include";
@@ -44,17 +53,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pkg-config
     protobuf
   ];
+
   buildInputs = [
     pcre2
   ];
 
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
   meta = {
     description = "Holo` Command Line Interface";
     homepage = "https://github.com/holo-routing/holo-cli";
-    teams = with lib.teams; [ ngi ];
-    maintainers = with lib.maintainers; [ themadbit ];
     license = lib.licenses.mit;
     mainProgram = "holo-cli";
+    maintainers = with lib.maintainers; [ themadbit ];
     platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/by-name/ho/holo-cli/update-cargo-lock.patch
+++ b/pkgs/by-name/ho/holo-cli/update-cargo-lock.patch
@@ -1,0 +1,96 @@
+From 8e282c056f7d3cc00c1f1b544659f94c150e72e9 Mon Sep 17 00:00:00 2001
+From: phanirithvij <phanirithvij2000@gmail.com>
+Date: Sat, 28 Mar 2026 22:01:41 +0530
+Subject: [PATCH] update cargo lock file
+
+Signed-off-by: phanirithvij <phanirithvij2000@gmail.com>
+---
+ Cargo.lock | 28 +++++++++++++++-------------
+ 1 file changed, 15 insertions(+), 13 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index a7279b9b9a339056b625a217a642c50e2fb97780..b1f8b251d1e0d9c3cdfa4f769b690a75c7404624 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -26,12 +26,6 @@ dependencies = [
+  "memchr",
+ ]
+ 
+-[[package]]
+-name = "android-tzdata"
+-version = "0.1.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+-
+ [[package]]
+ name = "android_system_properties"
+ version = "0.1.5"
+@@ -224,15 +218,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+ 
+ [[package]]
+ name = "chrono"
+-version = "0.4.40"
++version = "0.4.44"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
++checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+ dependencies = [
+- "android-tzdata",
+  "iana-time-zone",
++ "js-sys",
+  "num-traits",
+  "serde",
+- "windows-link",
++ "wasm-bindgen",
++ "windows-link 0.2.1",
+ ]
+ 
+ [[package]]
+@@ -537,6 +532,7 @@ checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+ name = "holo-cli"
+ version = "0.5.0"
+ dependencies = [
++ "chrono",
+  "clap",
+  "derive-new",
+  "enum-as-inner",
+@@ -1877,7 +1873,7 @@ checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+ dependencies = [
+  "windows-implement",
+  "windows-interface",
+- "windows-link",
++ "windows-link 0.1.1",
+  "windows-result",
+  "windows-strings",
+ ]
+@@ -1910,13 +1906,19 @@ version = "0.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+ 
++[[package]]
++name = "windows-link"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
++
+ [[package]]
+ name = "windows-result"
+ version = "0.3.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+ dependencies = [
+- "windows-link",
++ "windows-link 0.1.1",
+ ]
+ 
+ [[package]]
+@@ -1925,7 +1927,7 @@ version = "0.4.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+ dependencies = [
+- "windows-link",
++ "windows-link 0.1.1",
+ ]
+ 
+ [[package]]
+


### PR DESCRIPTION
Built on top of #478748

- Supersedes & closes #478748
- Supersedes & closes #473191
- Supersedes & closes #478347
- closes https://github.com/ngi-nix/projects/issues/1012

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
