### PR TITLE
gh-pr-todo: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26132,6 +26132,12 @@
     githubId = 187109;
     name = "Bjarki Ágúst Guðmundsson";
   };
+  suree33 = {
+    email = "d@sur33.com";
+    github = "Suree33";
+    githubId = 42645594;
+    name = "Daiki Sato";
+  };
   surfaceflinger = {
     email = "nat@nekopon.pl";
     github = "surfaceflinger";

--- a/pkgs/by-name/gh/gh-pr-todo/package.nix
+++ b/pkgs/by-name/gh/gh-pr-todo/package.nix
@@ -1,0 +1,33 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "gh-pr-todo";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "Suree33";
+    repo = "gh-pr-todo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-F1gPI2Qoebm3GdtsV4JyZqBQyJtjgNWV1IjA5RzK04s=";
+  };
+
+  vendorHash = "sha256-a+WKEWXC917SAOuOM6bGZuGHkvbwehNbo1tjhsjoAhE=";
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "GitHub CLI extension to extract TODO comments from pull request diffs";
+    homepage = "https://github.com/Suree33/gh-pr-todo";
+    changelog = "https://github.com/Suree33/gh-pr-todo/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ suree33 ];
+    mainProgram = "gh-pr-todo";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Suree33/gh-pr-todo](https://github.com/Suree33/gh-pr-todo)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
