### PR TITLE
lean4: 4.28 -> 4.29

### DIFF
--- a/pkgs/by-name/le/lean4/mimalloc.patch
+++ b/pkgs/by-name/le/lean4/mimalloc.patch
@@ -1,8 +1,8 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -77,12 +77,8 @@
- if (USE_MIMALLOC)
-   ExternalProject_add(mimalloc
+@@ -80,11 +80,7 @@
+   ExternalProject_add(
+     mimalloc
      PREFIX mimalloc
 -    GIT_REPOSITORY https://github.com/microsoft/mimalloc
 -    GIT_TAG v2.2.3
@@ -10,7 +10,8 @@
 -    CONFIGURE_COMMAND ""
 -    BUILD_COMMAND ""
 +    SOURCE_DIR "MIMALLOC-SRC"
-     INSTALL_COMMAND "")
+     INSTALL_COMMAND ""
+   )
    list(APPEND EXTRA_DEPENDS mimalloc)
  endif()
  

--- a/pkgs/by-name/le/lean4/package.nix
+++ b/pkgs/by-name/le/lean4/package.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lean4";
-  version = "4.28.0";
+  version = "4.29.0";
 
   # Using a vendored version rather than nixpkgs' version to match the exact version required by
   # Lean.  Apparently, even a slight version change can impact greatly the final performance.
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "leanprover";
     repo = "lean4";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-K6lWXZ8XVEv91skjCal+hML2Tzr9G804j9Roq+4HXQQ=";
+    hash = "sha256-0v4OTrCLdHBbWJUq7hIjJonqget9SvsG3izGlOwhwyU=";
   };
 
   postPatch =


### PR DESCRIPTION
Release notes: https://lean-lang.org/doc/reference/latest/releases/v4.29.0/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
