### PR TITLE
syncyomi: 1.1.4 -> 1.1.7

### DIFF
--- a/pkgs/by-name/sy/syncyomi/package.nix
+++ b/pkgs/by-name/sy/syncyomi/package.nix
@@ -12,12 +12,12 @@
 let
   lockedEsbuild = esbuild.overrideAttrs (
     finalAttrs: prevAttrs: {
-      version = "0.19.11";
+      version = "0.21.5";
       src = fetchFromGitHub {
         owner = "evanw";
         repo = "esbuild";
-        rev = "v${finalAttrs.version}";
-        hash = "sha256-NUwjzOpHA0Ijuh0E69KXx8YVS5GTnKmob9HepqugbIU=";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-FpvXWIlt67G8w3pBKZo/mcp57LunxDmRUaCU/Ne89B8=";
       };
       vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
     }
@@ -25,16 +25,16 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "syncyomi";
-  version = "1.1.4";
+  version = "1.1.7";
 
   src = fetchFromGitHub {
     owner = "SyncYomi";
     repo = "SyncYomi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pU3zxzixKoYnJsGpfvC/SVWIu0adsaiiVcLn0IZe64w=";
+    hash = "sha256-ot8c7+a/YLhjt9HkcI8QZ2ICgtBj3VGJhxtnhWC0f+0=";
   };
 
-  vendorHash = "sha256-fzPEljXFskr1/qzTsnASFNNc+8vA7kqO21mhMqwT44w=";
+  vendorHash = "sha256-7AySGQBQHaTp2M1uj5581ZqcpzgexI1KvanWMOc6rx0=";
 
   web = stdenvNoCC.mkDerivation (webFinalAttrs: {
     pname = "${finalAttrs.pname}-web";
@@ -50,7 +50,7 @@ buildGoModule (finalAttrs: {
         ;
       pnpm = pnpm_9;
       fetcherVersion = 3;
-      hash = "sha256-hRMHvfzfjOzvcCHFhDLxuq2qZ3mi4/333nEcQANbJ/o=";
+      hash = "sha256-paCYfh7tjDuPm8JCpzhCNjL1ZsyQTNxofW8UNIKjqmE=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/sy/syncyomi/package.nix
+++ b/pkgs/by-name/sy/syncyomi/package.nix
@@ -93,7 +93,10 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/SyncYomi/SyncYomi";
     changelog = "https://github.com/SyncYomi/SyncYomi/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ eriedaberrie ];
+    maintainers = with lib.maintainers; [
+      eriedaberrie
+      miniharinn
+    ];
     mainProgram = "syncyomi";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };

--- a/pkgs/by-name/sy/syncyomi/package.nix
+++ b/pkgs/by-name/sy/syncyomi/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  iana-etc,
+  libredirect,
   buildGoModule,
   nodejs,
   pnpm_9,
@@ -77,6 +79,12 @@ buildGoModule (finalAttrs: {
 
   preConfigure = ''
     cp -r $web/* web/dist
+  '';
+
+  nativeCheckInputs = lib.optionals stdenvNoCC.hostPlatform.isDarwin [ libredirect.hook ];
+
+  preCheck = lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/services=${iana-etc}/etc/services
   '';
 
   ldflags = [

--- a/pkgs/by-name/sy/syncyomi/package.nix
+++ b/pkgs/by-name/sy/syncyomi/package.nix
@@ -8,6 +8,7 @@
   fetchPnpmDeps,
   pnpmConfigHook,
   esbuild,
+  nix-update-script,
 }:
 let
   lockedEsbuild = esbuild.overrideAttrs (
@@ -87,6 +88,8 @@ buildGoModule (finalAttrs: {
   postInstall = lib.optionalString (!stdenvNoCC.hostPlatform.isDarwin) ''
     mv $out/bin/SyncYomi $out/bin/syncyomi
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Open-source project to synchronize Tachiyomi manga reading progress and library across multiple devices";


### PR DESCRIPTION
Release: https://github.com/syncyomi/syncyomi/releases/tag/v1.1.7
Diff: https://github.com/syncyomi/syncyomi/compare/v1.1.4...v1.1.7

Additionally:
- Added myself as a maintainer
- Add  `passthru.updateScript = nix-update-script { };`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
