### PR TITLE
keycloak-config-cli: move to top-level package

### DIFF
--- a/pkgs/by-name/ke/keycloak-config-cli/package.nix
+++ b/pkgs/by-name/ke/keycloak-config-cli/package.nix
@@ -2,6 +2,9 @@
   maven,
   lib,
   fetchFromGitHub,
+  jre_headless,
+  makeWrapper,
+  nix-update-script,
 }:
 maven.buildMavenPackage rec {
   pname = "keycloak-config-cli";
@@ -19,19 +22,28 @@ maven.buildMavenPackage rec {
   # Tests use MockServer which needs to bind to a local port
   __darwinAllowLocalNetworking = true;
 
+  nativeBuildInputs = [ makeWrapper ];
+
   installPhase = ''
     runHook preInstall
-    install -Dm444 -t "$out" target/keycloak-config-cli.jar
+    install -Dm444 target/keycloak-config-cli.jar $out/share/keycloak-config-cli/keycloak-config-cli.jar
+    makeWrapper ${jre_headless}/bin/java $out/bin/keycloak-config-cli \
+      --add-flags "-jar $out/share/keycloak-config-cli/keycloak-config-cli.jar"
     runHook postInstall
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
-    homepage = "https://github.com/adorsys/keycloak-config-cli/";
+    homepage = "https://github.com/adorsys/keycloak-config-cli";
     description = "Import YAML/JSON-formatted configuration files into Keycloak";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       jefferyoo
       anish
+      vitorpavani
     ];
+    mainProgram = "keycloak-config-cli";
+    platforms = jre_headless.meta.platforms;
   };
 }

--- a/pkgs/by-name/ke/keycloak/all-plugins.nix
+++ b/pkgs/by-name/ke/keycloak/all-plugins.nix
@@ -6,7 +6,6 @@
 }:
 {
   keycloak-2fa-sms-authenticator = callPackage ./keycloak-2fa-sms-authenticator { };
-  keycloak-config-cli = callPackage ./keycloak-config-cli { };
   keycloak-discord = callPackage ./keycloak-discord { };
   keycloak-enforce-mfa-authenticator = callPackage ./keycloak-enforce-mfa-authenticator { };
   keycloak-magic-link = callPackage ./keycloak-magic-link { };


### PR DESCRIPTION
## Summary

`keycloak-config-cli` was previously nested under `pkgs.keycloak.plugins`, which made it:
- Invisible on [search.nixos.org](https://search.nixos.org)
- Unusable as a standalone tool via `nix profile install` or `environment.systemPackages`
- Incorrectly categorised alongside Keycloak *server-side* JAR plugins

`keycloak-config-cli` is a **standalone CLI tool** (Spring Boot fat JAR) that manages Keycloak realm configuration from YAML/JSON files — it is not a Keycloak server plugin.

## Changes

- Move `pkgs/by-name/ke/keycloak/keycloak-config-cli/default.nix` → `pkgs/by-name/ke/keycloak-config-cli/package.nix` (top-level `by-name` entry)
- Remove entry from `pkgs/by-name/ke/keycloak/all-plugins.nix`
- Add `makeWrapper` to expose a proper `keycloak-config-cli` executable (wraps `java -jar`)
- Add `meta.mainProgram = "keycloak-config-cli"`
- Add `meta.platforms` (inherited from `jre_headless`)
- Add `passthru.updateScript = nix-update-script { }` for automated updates

## Checklist

- [x] package path fits guidelines (`pkgs/by-name/ke/keycloak-config-cli/package.nix`)
- [x] package name fits guidelines
- [x] package version fits guidelines (`6.4.0`)
- [x] `meta.description` is set and fits guidelines
- [x] `meta.license` fits upstream license (Apache-2.0)
- [x] `meta.platforms` is set
- [x] `meta.maintainers` is set (existing: `jefferyoo`, `anish`)
- [x] `meta.mainProgram` is set (`"keycloak-config-cli"`)
- [x] `nix-instantiate --eval -A keycloak-config-cli.name` evaluates cleanly

## Notes for reviewers

The existing `keycloak.plugins` passthru still works for all remaining server plugins. `keycloak-config-cli` was the only entry that didn't belong there — it has no interaction with the Keycloak server's provider mechanism at all.