### PR TITLE
opera: init at 129.0.5823.28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14915,7 +14915,7 @@
   laurids = {
     email = "laurids.dechow@gmail.com";
     github = "Laurids33";
-    githubId = 187098082; 
+    githubId = 187098082;
     name = "Laurids Dechow";
   };
   lavafroth = {

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14912,6 +14912,12 @@
     githubId = 621759;
     name = "Lassulus";
   };
+  laurids = {
+    email = "laurids.dechow@gmail.com";
+    github = "Laurids33";
+    githubId = 187098082; 
+    name = "Laurids Dechow";
+  };
   lavafroth = {
     email = "lavafroth@protonmail.com";
     github = "lavafroth";

--- a/pkgs/by-name/op/opera/package.nix
+++ b/pkgs/by-name/op/opera/package.nix
@@ -1,0 +1,131 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  glib,
+  gtk3,
+  libdrm,
+  libnotify,
+  libuuid,
+  mesa,
+  nspr,
+  nss,
+  pango,
+  systemd,
+  wayland,
+  libva,
+  curl,
+  libGL,
+  xorg,
+  vivaldi-ffmpeg-codecs,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "opera";
+  version = "129.0.5823.28";
+
+  src = fetchurl {
+    url = "https://get.geo.opera.com/pub/opera/desktop/${finalAttrs.version}/linux/opera-stable_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-1hIxbv0tU6SnGDFu4fN+syt1sbASfJnZwmQXao/ehIY=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    glib
+    gtk3
+    libdrm
+    libnotify
+    libuuid
+    mesa
+    nspr
+    nss
+    pango
+    systemd
+    wayland
+    libva
+    curl
+    libGL
+    vivaldi-ffmpeg-codecs
+  ]
+  ++ (with xorg; [
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libxcb
+  ]);
+
+  autoPatchelfIgnoreMissingDeps = [
+    "libQt5Widgets.so.5"
+    "libQt5Gui.so.5"
+    "libQt5Core.so.5"
+    "libQt6Widgets.so.6"
+    "libQt6Gui.so.6"
+    "libQt6Core.so.6"
+  ];
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r usr/* $out/
+
+    mkdir -p $out/lib/x86_64-linux-gnu/opera/
+    ln -sf ${vivaldi-ffmpeg-codecs}/lib/libffmpeg.so $out/lib/x86_64-linux-gnu/opera/libffmpeg.so
+
+    wrapProgram $out/bin/opera \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}" \
+      --add-flags "--ffmpeg-directory=${vivaldi-ffmpeg-codecs}/lib" \
+      --add-flags "--password-store=basic"
+
+    substituteInPlace $out/share/applications/opera.desktop \
+      --replace "Exec=opera" "Exec=$out/bin/opera"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Opera web browser";
+    homepage = "https://www.opera.com/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ laurids ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "opera";
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1515,7 +1515,6 @@ mapAliases {
   opensyclWithRocm = throw "'opensyclWithRocm' has been renamed to/replaced by 'adaptivecppWithRocm'"; # Converted to throw 2025-10-27
   opentofu-ls = warnAlias "'opentofu-ls' has been renamed to 'tofu-ls'" tofu-ls; # Added 2025-06-10
   opentracing-cpp = throw "'opentracingc-cpp' has been removed as it was archived upstream in 2024"; # Added 2025-10-19
-  opera = throw "'opera' has been removed due to lack of maintenance in nixpkgs"; # Added 2025-05-19
   opusTools = warnAlias "'opusTools' has been renamed to 'opus-tools'" opus-tools; # Added 2026-02-12
   orogene = throw "'orogene' uses a wasm-specific fork of async-tar that is vulnerable to CVE-2025-62518, which is not supported by its upstream"; # Added 2025-10-24
   ortp = throw "'ortp' has been moved to 'linphonePackages.ortp'"; # Added 2025-09-20


### PR DESCRIPTION
### Opera: init at 129.0.5823.28

This PR adds the Opera web browser to Nixpkgs using the `by-name` structure. 
It also removes the legacy `throw` alias from `aliases.nix` to allow the name to be reused.

- [x] Tested using sandboxing
- [x] Built on platform(s): x86_64-linux
- [x] Tested execution of all binary files (`./result/bin/opera`)
- [x] Verified H.264 video playback (using `vivaldi-ffmpeg-codecs`)
- [x] Meets Nixpkgs contribution standards

I've added myself as a maintainer in a separate commit.