### PR TITLE
base91: init at 0.2.1

### DIFF
--- a/pkgs/by-name/ba/base91/package.nix
+++ b/pkgs/by-name/ba/base91/package.nix
@@ -1,38 +1,50 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
+  installShellFiles,
+  rustPlatform,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+rustPlatform.buildRustPackage rec {
   pname = "base91";
-  version = "0.1.0";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "douzebis";
     repo = "base91";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-Lx569OtNU0z884763FSByH0yXIq6GzeXyp5NVvMejco="; # update as needed
+    rev = "v${version}";
+    hash = "sha256-S5gWC2SmN5lAjfFGK0z31ZL//pRXQG2qLk3RMnzuiys=";
   };
 
-  makeFlags = [
-    "CC=cc"
-    "-C"
-    "src"
-    "all"
-  ];
-  installFlags = [
-    "-C"
-    "src"
-    "install"
-    "prefix=$(out)"
-  ];
+  sourceRoot = "${src.name}/rust";
+
+  cargoHash = "sha256-Xxph31cpLJjHA3EzU0541FM0IIkCTA9HHpWM8IiXHkQ=";
+
+  cargoExtraArgs = "-p base91-cli";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    ln -s base91 $out/bin/b91enc
+    ln -s base91 $out/bin/b91dec
+
+    out_dir=$(find . -path "*/build/base91-cli-*/out" -maxdepth 6 | head -1)
+    if [ -n "$out_dir" ]; then
+      install -Dm444 "$out_dir/base91.1" $out/share/man/man1/base91.1
+      installShellCompletion --cmd base91 \
+        --bash "$out_dir/base91.bash" \
+        --zsh "$out_dir/_base91" \
+        --fish "$out_dir/base91.fish"
+    fi
+  '';
 
   meta = {
-    description = "CLI tool for encoding binary data as ASCII characters";
+    description = "basE91 binary-to-text encoder/decoder";
     homepage = "https://github.com/douzebis/base91";
+    changelog = "https://github.com/douzebis/base91/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ douzebis ];
+    mainProgram = "base91";
     platforms = lib.platforms.unix;
   };
-})
+}


### PR DESCRIPTION
## Description

Add `base91`, a basE91 binary-to-text encoder/decoder CLI.

- **Crate**: [`base91-cli`](https://crates.io/crates/base91-cli), backed by [`base91-rs`](https://crates.io/crates/base91-rs)
- **Algorithm**: [basE91](http://base91.sourceforge.net/) by Joachim Henke — encodes binary data using 91 printable ASCII characters (~23% overhead vs ~33% for base64)
- **Binaries**: `base91`, `b91enc` (symlink), `b91dec` (symlink)
- **Man page**: `base91.1` (generated by `clap_mangen`)
- **Shell completions**: bash, zsh, fish (generated by `clap_complete`)
- ~1.35× faster encode, ~1.32× faster decode vs the existing `base91` crate on crates.io

## Test plan

- [x] Built on `x86_64-linux`: `nix-build -A base91`
- [x] `./result/bin/base91 --version`
- [x] `echo hello | ./result/bin/base91 | ./result/bin/base91 -d`
- [x] Man page present: `ls result/share/man/man1/base91.1`
- [x] Shell completions present