### PR TITLE
fava: 1.30.11 -> 1.30.12

### DIFF
--- a/pkgs/development/python-modules/fava/default.nix
+++ b/pkgs/development/python-modules/fava/default.nix
@@ -25,17 +25,17 @@
 let
   src = buildNpmPackage (finalAttrs: {
     pname = "fava-frontend";
-    version = "1.30.11";
+    version = "1.30.12";
 
     src = fetchFromGitHub {
       owner = "beancount";
       repo = "fava";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-/e3HNAlezqUTt0RYxjrdktM/mwBpZ4CqRuYbLTzww0w=";
+      hash = "sha256-krRkcahikP0ChTCXeS/3MBq4v+VmBLViqaYSSGYt6Mc=";
     };
     sourceRoot = "${finalAttrs.src.name}/frontend";
 
-    npmDepsHash = "sha256-K0XDMTqqSq0wbCqs8HXXP0XgADJQaiYD2AN5ilAXfRM=";
+    npmDepsHash = "sha256-kZAwvyjPZUFJffYsr5917zX+0tMyydcOzfr/TDnoJKw=";
     makeCacheWritable = true;
 
     preBuild = ''


### PR DESCRIPTION
Release: https://github.com/beancount/fava/releases/tag/v1.30.12
Diff: https://github.com/beancount/fava/compare/v1.30.11...v1.30.12

(This is also my first PR in nixpkgs, so apologies if I made a mistake somewhere - feel free to let me know about it and I can fix whatever needs to be changed!)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:x: 2 packages failed to build:</summary>
  <ul>
    <li>fava-investor (python313Packages.fava-investor)</li>
    <li>python314Packages.fava-investor</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>fava (python313Packages.fava)</li>
    <li>python313Packages.fava-dashboards</li>
    <li>python313Packages.fava-portfolio-returns</li>
    <li>python314Packages.fava</li>
    <li>python314Packages.fava-dashboards</li>
    <li>python314Packages.fava-portfolio-returns</li>
  </ul>
</details>

^ (looks like `fava-investor` also failed in #496764 and #491089)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
