### PR TITLE
losslesscut-bin: 3.64.0 -> 3.69.0

### DIFF
--- a/pkgs/by-name/lo/losslesscut-bin/build-from-dmg.nix
+++ b/pkgs/by-name/lo/losslesscut-bin/build-from-dmg.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchurl,
-  _7zz,
+  undmg,
   pname,
   version,
   hash,
@@ -20,17 +20,16 @@ stdenvNoCC.mkDerivation {
     inherit hash;
   };
 
-  nativeBuildInputs = [ _7zz ];
+  nativeBuildInputs = [ undmg ];
 
-  sourceRoot = "LosslessCut.app";
+  sourceRoot = ".";
 
   installPhase = ''
     runHook preInstall
     mkdir -p "$out/Applications"
-    cd ..
-    mv "$sourceRoot" "$out/Applications"
+    cp -r LosslessCut.app "$out/Applications"
     mkdir -p "$out/bin"
-    ln -s "$out/Applications/$(basename "$sourceRoot")/Contents/MacOS/LosslessCut" "$out/bin/losslesscut"
+    ln -s "$out/Applications/LosslessCut.app/Contents/MacOS/LosslessCut" "$out/bin/losslesscut"
     runHook postInstall
   '';
 

--- a/pkgs/by-name/lo/losslesscut-bin/package.nix
+++ b/pkgs/by-name/lo/losslesscut-bin/package.nix
@@ -4,10 +4,9 @@
   callPackage,
   buildPackages,
 }:
-
 let
   pname = "losslesscut";
-  version = "3.64.0";
+  version = "3.68.0";
   metaCommon = {
     description = "Swiss army knife of lossless video/audio editing";
     homepage = "https://mifi.no/losslesscut/";
@@ -23,17 +22,17 @@ let
   };
   x86_64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
-    hash = "sha256-BO2KoYAevbVL0Eix1knvaPVBkWucYI89VkueWYRTcXY=";
+    hash = "sha256-K4h5kG65M9vWAzjTV8jxFJdtdEuLCxRr0byMN1SffJk=";
     isAarch64 = false;
   };
   aarch64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
-    hash = "sha256-/M5yafZQDqCoDzHpjZBC80CcL9KMO5lwvyCcq19caRg=";
+    hash = "sha256-5hwzW+0oi8GGmxULvDFCmKKbrYLtq9HjwLLpMj3PnbA=";
     isAarch64 = true;
   };
   x86_64-windows = callPackage ./build-from-windows.nix {
     inherit pname version metaCommon;
-    hash = "sha256-FYrnTiZ5ATT+Y08zceIIHbVM//5Bg2ozIEyC5UxmIno=";
+    hash = "sha256-N3UdnvISjRpiVQXEbpmSs67NCTemqQfRwg2b4rzkUEU=";
   };
 in
 (

--- a/pkgs/by-name/lo/losslesscut-bin/package.nix
+++ b/pkgs/by-name/lo/losslesscut-bin/package.nix
@@ -6,33 +6,36 @@
 }:
 let
   pname = "losslesscut";
-  version = "3.68.0";
+  version = "3.69.0";
   metaCommon = {
     description = "Swiss army knife of lossless video/audio editing";
     homepage = "https://mifi.no/losslesscut/";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ ShamrockLee ];
+    maintainers = with lib.maintainers; [
+      ShamrockLee
+      Br1ght0ne
+    ];
     mainProgram = "losslesscut";
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
   x86_64-appimage = callPackage ./build-from-appimage.nix {
     inherit pname version metaCommon;
-    hash = "sha256-K90cJuJFcIkPuAQusJcOBkZ5PQ8T25q7IFIhtmK+jzc=";
+    hash = "sha256-F56q4nv/viWmVJpKcUR0EmtXwojO/DBwRvycYxOhJnY=";
     inherit (buildPackages) makeWrapper;
   };
   x86_64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
-    hash = "sha256-K4h5kG65M9vWAzjTV8jxFJdtdEuLCxRr0byMN1SffJk=";
+    hash = "sha256-q4KNGmUsiVZhsVtoLYEQZWLg8R+ry4wtHkvyxP3d9ko=";
     isAarch64 = false;
   };
   aarch64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
-    hash = "sha256-5hwzW+0oi8GGmxULvDFCmKKbrYLtq9HjwLLpMj3PnbA=";
+    hash = "sha256-x4AbSC3zvgOErMgXHVp9FsznDRWIhx40SxVarKOfpYs=";
     isAarch64 = true;
   };
   x86_64-windows = callPackage ./build-from-windows.nix {
     inherit pname version metaCommon;
-    hash = "sha256-N3UdnvISjRpiVQXEbpmSs67NCTemqQfRwg2b4rzkUEU=";
+    hash = "sha256-uvcQZXaZnhRg+RgFTjrUrjipVGmJLMahqXtBMfAoGOQ=";
   };
 in
 (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
fixes https://github.com/NixOS/nixpkgs/issues/471862
only tested x86_64-linux.
other hashes fetched with below command
```
nix hash to-sri --type sha256 $(nix-prefetch-url "https://github.com/mifi/lossless-cut/releases/download/v3.68.0/LosslessCut-win-x64.7z")
```
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
