### PR TITLE
librice: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2807,6 +2807,12 @@
     github = "azazak123";
     githubId = 50211158;
   };
+  azban = {
+    name = "azban";
+    matrix = "azban@matrix.org";
+    github = "azban";
+    githubId = 714931;
+  };
   azd325 = {
     email = "tim.kleinschmidt@gmail.com";
     github = "Azd325";

--- a/pkgs/by-name/li/librice/package.nix
+++ b/pkgs/by-name/li/librice/package.nix
@@ -1,0 +1,60 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  buildPackages,
+  cargo-c,
+  openssl,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "librice";
+  # Cannot bump to 0.4.0 because it breaks webkitgtk_4_1's enableExperimental build.
+  # /build/webkitgtk-2.52.1/Source/WebCore/platform/rice/GRefPtrRice.h:34:47: error: use of undeclared identifier 'rice_turn_config_ref'; did you mean 'rice_turn_config_free'?
+  # 34 | WTF_DEFINE_GREF_TRAITS_INLINE(RiceTurnConfig, rice_turn_config_ref, rice_turn_config_unref)
+  #    |                                               ^~~~~~~~~~~~~~~~~~~~
+  #    |                                               rice_turn_config_free
+  # Unpin when https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/gnome-50/elements/sdk/librice.bst moves to newer version.
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "ystreet";
+    repo = "librice";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CM+YoeVdWfnT/RjkHP0ILwMOkFEylFaN83B71r+S5Ik=";
+  };
+
+  cargoHash = "sha256-GNqzAFAnOYP5tCE4qb9F9XAlinX1xV4QyBWJjqXb5VE=";
+
+  nativeBuildInputs = [
+    cargo-c
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  postInstall = ''
+    for p in rice-proto rice-io; do
+      ${buildPackages.rust.envVars.setEnv} cargo cinstall -p ''${p} -j $NIX_BUILD_CORES --release \
+        --frozen --prefix=${placeholder "out"} --target ${stdenv.hostPlatform.rust.rustcTarget}
+    done
+  '';
+
+  # All tests require network calls
+  doCheck = false;
+
+  meta = {
+    description = "A (sans-IO) implementation of ICE (RFC8445) protocol written in Rust";
+    homepage = "https://github.com/ystreet/librice";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ azban ];
+  };
+})

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -51,6 +51,7 @@
   libintl,
   lcms2,
   libmanette,
+  librice,
   geoclue2,
   flite,
   fontconfig,
@@ -197,6 +198,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals enableExperimental [
     # For ENABLE_WEB_RTC
     openssl
+    librice
     # For ENABLE_WEBXR
     openxr-loader
   ]


### PR DESCRIPTION
This package is needed as a dependency to enable experimental features for webkitgtk.

Closes #504443 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
