### PR TITLE
libbase91: init at 0.2.1

### DIFF
--- a/pkgs/by-name/li/libbase91/package.nix
+++ b/pkgs/by-name/li/libbase91/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  llvmPackages,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libbase91";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "douzebis";
+    repo = "base91";
+    rev = "v${version}";
+    hash = "sha256-S5gWC2SmN5lAjfFGK0z31ZL//pRXQG2qLk3RMnzuiys=";
+  };
+
+  sourceRoot = "${src.name}/src";
+
+  nativeBuildInputs = [
+    llvmPackages.clang
+    llvmPackages.bintools
+  ];
+
+  buildPhase = ''
+    clang -O2 -fPIC -shared -o libbase91.so base91.c
+    clang -O2 -c base91.c -o base91.o
+    llvm-ar crs libbase91.a base91.o
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib $out/include $out/share/man/man3
+    cp libbase91.so libbase91.a $out/lib/
+    cp base91.h $out/include/
+    for f in ${src}/rust/base91-cli/man/man3/*.3; do
+      install -Dm444 "$f" $out/share/man/man3/$(basename "$f")
+    done
+  '';
+
+  meta = {
+    description = "basE91 C library";
+    homepage = "https://github.com/douzebis/base91";
+    changelog = "https://github.com/douzebis/base91/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ douzebis ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description

Add `libbase91`, the basE91 C library.

- **Source**: `src/base91.{c,h}` from [douzebis/base91](https://github.com/douzebis/base91)
- **Outputs**: `libbase91.so`, `libbase91.a`, `base91.h`
- **Man pages**: C API reference (`basE91.3`, `basE91_encode.3`, `basE91_decode.3`, etc.)
- **License**: BSD-3-Clause (Joachim Henke's original C implementation)
- Drop-in replacement for the original reference implementation at <http://base91.sourceforge.net/>

## Test plan

- [x] Built on `x86_64-linux`: `nix-build -A libbase91`
- [x] `ls result/lib/` → `libbase91.a libbase91.so`
- [x] `ls result/include/` → `base91.h`
- [x] `man -l result/share/man/man3/basE91.3`