### PR TITLE
python3Packages.pybase91: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/pybase91/default.nix
+++ b/pkgs/development/python-modules/pybase91/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  rustPlatform,
+  cargo,
+  rustc,
+}:
+
+buildPythonPackage rec {
+  pname = "pybase91";
+  version = "0.2.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.11";
+
+  src = fetchFromGitHub {
+    owner = "douzebis";
+    repo = "base91";
+    rev = "v${version}";
+    hash = "sha256-S5gWC2SmN5lAjfFGK0z31ZL//pRXQG2qLk3RMnzuiys=";
+  };
+
+  buildAndTestSubdir = "rust/base91";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    pname = "pybase91";
+    inherit version;
+    sourceRoot = "source/rust";
+    hash = "sha256-Xxph31cpLJjHA3EzU0541FM0IIkCTA9HHpWM8IiXHkQ=";
+  };
+
+  nativeBuildInputs = [
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  maturinBuildFlags = [
+    "--features"
+    "python"
+  ];
+
+  pythonImportsCheck = [ "pybase91" ];
+
+  meta = {
+    description = "basE91 Python extension (Rust/PyO3)";
+    homepage = "https://github.com/douzebis/base91";
+    changelog = "https://github.com/douzebis/base91/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ douzebis ];
+  };
+}


### PR DESCRIPTION
## Description

Add `python3Packages.pybase91`, a PyO3/maturin Python extension for basE91 encoding.

- **PyPI**: [`pybase91`](https://pypi.org/project/pybase91/)
- **API**: `encode(data: bytes) -> bytes`, `decode(data: bytes) -> bytes`, streaming `Encoder`/`Decoder` classes
- **Backend**: Rust via PyO3 and maturin
- **Requires**: Python ≥ 3.11

## Test plan

- [x] Built on `x86_64-linux`: `nix-build -A python3Packages.pybase91`
- [x] `python3 -c "import pybase91; print(pybase91.decode(pybase91.encode(b'hello')))"`