### PR TITLE
lix: fix `installCheckPhase` on Darwin

### DIFF
--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -24,6 +24,7 @@ assert lib.assertMsg (
   closureInfo,
   runCommand,
   meson,
+  bash,
   bison,
   boehmgc,
   boost,
@@ -35,6 +36,7 @@ assert lib.assertMsg (
   cargo,
   curl,
   cmake,
+  darwin,
   doxygen,
   editline,
   flex,
@@ -374,6 +376,19 @@ stdenv.mkDerivation (finalAttrs: {
           ]
         ))
         (lib.mesonOption "build-test-shell" "${pkgsStatic.bash}/bin")
+      ]
+  ++
+    lib.optionals
+      (stdenv.hostPlatform.isDarwin && finalAttrs.doInstallCheck && lib.versionAtLeast version "2.95")
+      [
+        (lib.mesonOption "build-test-env" (
+          lib.makeBinPath [
+            darwin.file_cmds
+            darwin.shell_cmds
+            darwin.text_cmds
+          ]
+        ))
+        (lib.mesonOption "build-test-shell" "${bash}/bin")
       ]
   ++ lib.optionals (lib.versionAtLeast version "2.95") [
     "--${


### PR DESCRIPTION
Set the `build-test-env` and `build-test-shell` Meson flags to ensure that the `BUILD_TEST_ENV` and `BUILD_TEST_SHELL` environment variables are set, as [`test_env_to_env` depends on both of these variables][1].

[1]: https://git.lix.systems/lix-project/lix/commit/22b33b9d080f5220d399596790a5d69fe89add53


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
