### PR TITLE
base91: init at 0.2.2

### DIFF
--- a/pkgs/by-name/ba/base91/package.nix
+++ b/pkgs/by-name/ba/base91/package.nix
@@ -1,38 +1,52 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
+  installShellFiles,
+  rustPlatform,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "base91";
-  version = "0.1.0";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "douzebis";
     repo = "base91";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-Lx569OtNU0z884763FSByH0yXIq6GzeXyp5NVvMejco="; # update as needed
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aul68hDvEriSOUAutJkboeP7rzLcZGC7va39GVqKmig=";
   };
 
-  makeFlags = [
-    "CC=cc"
-    "-C"
-    "src"
-    "all"
-  ];
-  installFlags = [
-    "-C"
-    "src"
-    "install"
-    "prefix=$(out)"
-  ];
+  sourceRoot = "${finalAttrs.src.name}/rust";
+
+  cargoHash = "sha256-X9hVLZ5+oVsPWihOxaAQQMLOJhejNBQnRQgdk1sp3Lw=";
+
+  cargoExtraArgs = "-p base91-cli";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    ln -s base91 $out/bin/b91enc
+    ln -s base91 $out/bin/b91dec
+
+    out_dir=$(find . -maxdepth 6 -path "*/build/base91-cli-*/out" | head -1)
+    if [ -z "$out_dir" ]; then
+      echo "base91: could not locate cargo OUT_DIR" >&2
+      exit 1
+    fi
+    install -Dm444 "$out_dir/base91.1" $out/share/man/man1/base91.1
+    installShellCompletion --cmd base91 \
+      --bash "$out_dir/base91.bash" \
+      --zsh "$out_dir/_base91" \
+      --fish "$out_dir/base91.fish"
+  '';
 
   meta = {
-    description = "CLI tool for encoding binary data as ASCII characters";
+    description = "basE91 binary-to-text encoder/decoder";
     homepage = "https://github.com/douzebis/base91";
+    changelog = "https://github.com/douzebis/base91/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ douzebis ];
+    mainProgram = "base91";
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
## Description

Update `base91` from the original C implementation (v0.1.0) to the Rust CLI (v0.2.2).

- **Crates**: [`base91-cli`](https://crates.io/crates/base91-cli) backed by [`base91-rs`](https://crates.io/crates/base91-rs)
- **Binaries**: `base91`, `b91enc` (symlink), `b91dec` (symlink)
- **Man page**: `base91.1` generated at build time via `clap_mangen`
- **Shell completions**: bash, zsh, fish via `clap_complete`
- Wire-format compatible with Joachim Henke's C reference; ~1.35× faster encode, ~1.32× faster decode

## Test plan

- [x] Built on `x86_64-linux`: `nix-build -A base91`
- [x] `./result/bin/base91 --version`
- [x] `echo hello | ./result/bin/base91 | ./result/bin/base91 -d`
- [x] Man page present: `ls result/share/man/man1/base91.1`
- [x] Shell completions present