### PR TITLE
python3Packages.pybase91: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/pybase91/default.nix
+++ b/pkgs/development/python-modules/pybase91/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pybase91";
+  version = "0.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "douzebis";
+    repo = "base91";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aul68hDvEriSOUAutJkboeP7rzLcZGC7va39GVqKmig=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/rust";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      sourceRoot
+      ;
+    hash = "sha256-X9hVLZ5+oVsPWihOxaAQQMLOJhejNBQnRQgdk1sp3Lw=";
+  };
+
+  buildAndTestSubdir = "base91";
+
+  nativeBuildInputs = [
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+  ];
+
+  maturinBuildFlags = [
+    "--features"
+    "python"
+  ];
+
+  pythonImportsCheck = [ "pybase91" ];
+
+  meta = {
+    description = "basE91 Python extension (Rust/PyO3)";
+    homepage = "https://github.com/douzebis/base91";
+    changelog = "https://github.com/douzebis/base91/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      bsd3
+      mit
+    ];
+    maintainers = with lib.maintainers; [ douzebis ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13322,6 +13322,8 @@ self: super: with self; {
 
   pybase64 = callPackage ../development/python-modules/pybase64 { };
 
+  pybase91 = callPackage ../development/python-modules/pybase91 { };
+
   pybbox = callPackage ../development/python-modules/pybbox { };
 
   pybcj = callPackage ../development/python-modules/pybcj { };


### PR DESCRIPTION
## Description

Add `python3Packages.pybase91`, a Python extension for basE91
binary-to-text encoding/decoding.

The package is built from the same upstream as `base91` (CLI, v0.2.1)
and `libbase91` (C library, v0.2.1), both submitted in separate PRs.

Implementation: PyO3 bindings compiled via maturin, using
`rustPlatform.maturinBuildHook` + `rustPlatform.cargoSetupHook`.

### API

- `pybase91.encode(data: bytes) -> bytes`
- `pybase91.decode(data: bytes) -> bytes`
- `pybase91.Encoder` / `pybase91.Decoder` streaming classes

### Testing

```
nix-build -A python3Packages.pybase91
```

Builds and imports `pybase91` successfully on x86_64-linux.

## Checklist

- [x] Tested locally
- [x] `pythonImportsCheck` included
- [x] nixfmt-rfc-style applied
- [x] Single signed commit