### PR TITLE
sabnzbd: ensure config file exists initially

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -84,7 +84,7 @@ in
       tor = 35;
       cups = 36;
       foldingathome = 37;
-      #sabnzbd = 38; # dropped in 25.11
+      #sabnzbd = 38; # dropped in 26.05
       #kdm = 39; # dropped in 17.03
       #ghostone = 40; # dropped in 18.03
       git = 41;
@@ -570,7 +570,7 @@ in
       lambdabot = 191;
       asterisk = 192;
       plex = 193;
-      #sabnzbd = 194; # dropped in 25.11
+      #sabnzbd = 194; # dropped in 26.05
       #grafana = 196; #unused
       #skydns = 197; #unused
       # ripple-rest = 198; # unused, removed 2017-08-12

--- a/nixos/modules/services/networking/sabnzbd/default.nix
+++ b/nixos/modules/services/networking/sabnzbd/default.nix
@@ -514,10 +514,7 @@ in
     systemd.services.sabnzbd =
       let
         files =
-          if cfg.configFile != null then
-            [ sabnzbdIniPath ]
-          else
-            (lib.optional cfg.allowConfigWrite sabnzbdIniPath) ++ [ publicSettingsIni ] ++ cfg.secretFiles;
+          (lib.optional cfg.allowConfigWrite sabnzbdIniPath) ++ [ publicSettingsIni ] ++ cfg.secretFiles;
         iniPathQuoted = lib.escapeShellArg sabnzbdIniPath;
       in
       {
@@ -532,10 +529,17 @@ in
           StateDirectory = cfg.stateDir;
           ExecStart = "${lib.getExe cfg.package} -d -f ${iniPathQuoted}";
         };
+      }
+      // lib.optionalAttrs (cfg.configFile == null) {
         preStart = ''
           set -euo pipefail
 
           ${lib.toShellVar "files" files}
+
+          # We overwrite this immediately, but the merge script requires that
+          # all files exist
+          # See also: nixpkgs #504224
+          (touch ${iniPathQuoted} 2>/dev/null || true)
 
           tmpfile=$(mktemp)
 

--- a/nixos/modules/services/networking/sabnzbd/default.nix
+++ b/nixos/modules/services/networking/sabnzbd/default.nix
@@ -33,7 +33,7 @@ let
     "__version__" = 19;
     "__encoding__" = "utf-8";
   };
-  allSettings = cfg.settings // mandatoryGlobalSettings;
+  allSettings = mandatoryGlobalSettings // cfg.settings;
 
   # sabnzbd uses configobj type inis, which support
   # nested sections specified by increasing numbers

--- a/nixos/tests/sabnzbd-module.nix
+++ b/nixos/tests/sabnzbd-module.nix
@@ -106,29 +106,16 @@ in
     };
 
   testScript = ''
-    machine.wait_for_unit("sabnzbd.service")
-    machine.wait_until_succeeds(
-        "curl --fail -L http://localhost:8080/"
-    )
+    def wait_for_up(m):
+      m.wait_for_unit("sabnzbd.service")
+      m.wait_until_succeeds("curl --fail -L http://localhost:8080")
+
+    wait_for_up(machine)
+    wait_for_up(with_writeable_config)
+    wait_for_up(with_raw_config_file)
 
     machine.succeed("do_test")
-
-
-
-    with_writeable_config.wait_for_unit("sabnzbd.service")
-    with_writeable_config.wait_until_succeeds(
-        "curl --fail -L http://localhost:8080/"
-    )
-
     with_writeable_config.succeed("do_test")
-
-
-
-    with_raw_config_file.wait_for_unit("sabnzbd.service")
-    with_raw_config_file.wait_until_succeeds(
-        "curl --fail -L http://localhost:8080/"
-    )
-
     with_raw_config_file.succeed("do_test_2")
   '';
 }

--- a/nixos/tests/sabnzbd-module.nix
+++ b/nixos/tests/sabnzbd-module.nix
@@ -1,12 +1,7 @@
 { lib, ... }:
-{
-  name = "sabnzbd";
-  meta.maintainers = with lib.maintainers; [ jojosch ];
-
-  node.pkgsReadOnly = false;
-
-  nodes.machine =
-    { pkgs, lib, ... }:
+let
+  common-config =
+    { pkgs, ... }:
     {
       services.sabnzbd = {
         enable = true;
@@ -62,14 +57,78 @@
       # unrar is unfree
       nixpkgs.config.allowUnfreePackages = [ "unrar" ];
     };
+in
+{
+  name = "sabnzbd";
+  meta.maintainers = with lib.maintainers; [ jojosch ];
+
+  node.pkgsReadOnly = false;
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [ common-config ];
+    };
+  nodes.with_writeable_config =
+    { ... }:
+    {
+      imports = [ common-config ];
+      config.services.sabnzbd.allowConfigWrite = true;
+    };
+  nodes.with_raw_config_file =
+    { pkgs, ... }:
+    {
+      imports = [ common-config ];
+      config = {
+        services.sabnzbd = {
+          configFile = builtins.toFile "config.ini" ''
+            [misc]
+            inet_exposure = 2
+            html_login = 0
+            api_key = abcdef
+            log_dir = /var/lib/sabnzbd
+            admin_dir = /var/lib/sabnzbd
+          '';
+        };
+
+        environment.systemPackages = [
+          pkgs.jq
+          (pkgs.writeScriptBin "do_test_2" ''
+            set -euxo pipefail
+
+            misc_url="http://127.0.0.1:8080/api?mode=get_config&section=misc&output=json&apikey=abcdef"
+
+            [[ $(curl $misc_url | jq .config.misc.inet_exposure) == 2 ]]
+            [[ $(curl $misc_url | jq .config.misc.html_login) == "false" ]]
+          '')
+        ];
+      };
+    };
 
   testScript = ''
-
     machine.wait_for_unit("sabnzbd.service")
     machine.wait_until_succeeds(
         "curl --fail -L http://localhost:8080/"
     )
 
     machine.succeed("do_test")
+
+
+
+    with_writeable_config.wait_for_unit("sabnzbd.service")
+    with_writeable_config.wait_until_succeeds(
+        "curl --fail -L http://localhost:8080/"
+    )
+
+    with_writeable_config.succeed("do_test")
+
+
+
+    with_raw_config_file.wait_for_unit("sabnzbd.service")
+    with_raw_config_file.wait_until_succeeds(
+        "curl --fail -L http://localhost:8080/"
+    )
+
+    with_raw_config_file.succeed("do_test_2")
   '';
 }


### PR DESCRIPTION
## Things done

- Only run sabnzbd config merge if using new config format
- If running config merge, ensure the target file exists since it might get merged
  - I am not entirely happy with the solution, but we can't use `systemd.tmpfiles`: If the old config format is used and points to a store path, the string context prevents us from creating an attrset with the config file as a key.
- Added a regression test for the reported issue

Should fix #504224

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
