### PR TITLE
kasane: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29998,6 +29998,12 @@
     name = "Yusuf Bera Ertan";
     keys = [ { fingerprint = "9270 66BD 8125 A45B 4AC4 0326 6180 7181 F60E FCB2"; } ];
   };
+  yus314 = {
+    email = "shizhaoyoujie@gmail.com";
+    github = "Yus314";
+    githubId = 91413196;
+    name = "minera";
+  };
   yusuf-duran = {
     github = "postgnostic";
     githubId = 37774475;

--- a/pkgs/by-name/ka/kasane/package.nix
+++ b/pkgs/by-name/ka/kasane/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  kakoune,
+  makeWrapper,
+  testers,
+  withGui ? false,
+  vulkan-loader,
+  wayland,
+  wayland-protocols,
+  libxkbcommon,
+  libX11,
+  libXcursor,
+  libXrandr,
+  libXi,
+  fontconfig,
+  freetype,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kasane";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "Yus314";
+    repo = "kasane";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Vc7gG9xHaKujv7jb2Gn+NDpRaQPDpNLa4e7dr79LbFI=";
+  };
+
+  cargoHash = "sha256-GLl/7PHmsN3cqqTbkN/wFgccQsuV8vqg4iSxh3ihXw4=";
+
+  cargoBuildFlags = [
+    "-p"
+    "kasane"
+  ];
+  buildFeatures = lib.optionals withGui [ "gui" ];
+
+  doCheck = true;
+  cargoTestFlags = [
+    "-p"
+    "kasane-core"
+    "-p"
+    "kasane-tui"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = lib.optionals (withGui && stdenv.hostPlatform.isLinux) [
+    vulkan-loader
+    wayland
+    wayland-protocols
+    libxkbcommon
+    libX11
+    libXcursor
+    libXrandr
+    libXi
+    fontconfig
+    freetype
+  ];
+
+  postInstall =
+    let
+      wrapArgs = lib.concatStringsSep " " (
+        [
+          "--prefix PATH : ${lib.makeBinPath [ kakoune ]}"
+        ]
+        ++ lib.optionals (withGui && stdenv.hostPlatform.isLinux) [
+          "--prefix LD_LIBRARY_PATH : ${
+            lib.makeLibraryPath [
+              vulkan-loader
+              wayland
+              libxkbcommon
+            ]
+          }"
+        ]
+      );
+    in
+    ''
+      wrapProgram $out/bin/kasane ${wrapArgs}
+    '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Alternative frontend for the Kakoune text editor";
+    homepage = "https://github.com/Yus314/kasane";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ yus314 ];
+    mainProgram = "kasane";
+  };
+})


### PR DESCRIPTION
## Description

Add [kasane](https://github.com/Yus314/kasane), an alternative frontend for the [Kakoune](https://kakoune.org/) text editor.

Kasane communicates with Kakoune via JSON-RPC (`kak -ui json`) and provides:
- **TUI backend** (crossterm) — default
- **GPU backend** (wgpu) — optional, via `kasane.override { withGui = true; }`
- **WASM plugin runtime** (wasmtime) — sandboxed, composable editor plugins

### Features
- Declarative UI architecture (Element tree + TEA)
- Plugin system with Contribution/Transform/Annotation/Overlay extension points
- Incremental rendering via Salsa
- ~1100 tests in CI

## Things done

- [x] Built on platform(s): x86_64-linux
- [x] Tested: 1118 tests pass in nix sandbox (`kasane-core`, `kasane-tui`)
- [x] `passthru.tests.version` passes
- [x] Verified binary runs correctly (`kasane --version`, kakoune wrapped in PATH)
- [x] Added myself (`yus314`) to maintainer list (separate commit)
- [x] Closure size: 75.8 MiB (TUI), 103.4 MiB (GUI with override)
- [x] `meta.mainProgram` set
- [x] Formatted with `nixfmt`

## Notes

- Binary wraps `kakoune` in PATH (kasane spawns `kak` via `Command::new("kak")`)
- Tests limited to `kasane-core` and `kasane-tui` crates; the `kasane` crate's tests require a running kakoune instance
- The package includes 5 pre-built WASM plugin files (bundled via `include_bytes!`); source is available in `examples/wasm/` in the same repository