### PR TITLE
bat: genericize shell init for bat-extras packages

### DIFF
--- a/nixos/modules/programs/bat.nix
+++ b/nixos/modules/programs/bat.nix
@@ -5,9 +5,9 @@
   ...
 }:
 let
-  inherit (builtins) isList elem;
+  inherit (builtins) isList;
   inherit (lib)
-    getExe
+    concatMapStrings
     literalExpression
     maintainers
     mapAttrs'
@@ -36,33 +36,6 @@ let
       boolToString value
     else
       toString value;
-
-  initScript =
-    {
-      program,
-      shell,
-      flags ? [ ],
-    }:
-    if (shell != "fish") then
-      ''
-        eval "$(${getExe program} ${toString flags})"
-      ''
-    else
-      ''
-        ${getExe program} ${toString flags} | source
-      '';
-
-  shellInit =
-    shell:
-    optionalString (elem pkgs.bat-extras.batpipe cfg.extraPackages) (initScript {
-      program = pkgs.bat-extras.batpipe;
-      inherit shell;
-    })
-    + optionalString (elem pkgs.bat-extras.batman cfg.extraPackages) (initScript {
-      program = pkgs.bat-extras.batman;
-      inherit shell;
-      flags = [ "--export-env" ];
-    });
 in
 {
   options.programs.bat = {
@@ -112,17 +85,21 @@ in
       );
     };
 
-    programs = {
-      bash = mkIf (!config.programs.fish.enable) {
-        interactiveShellInit = shellInit "bash";
+    programs =
+      let
+        shellInit = shell: concatMapStrings (pkg: pkg.shellInit shell) cfg.extraPackages;
+      in
+      {
+        bash = mkIf (!config.programs.fish.enable) {
+          interactiveShellInit = shellInit "bash";
+        };
+        fish = mkIf config.programs.fish.enable {
+          interactiveShellInit = shellInit "fish";
+        };
+        zsh = mkIf (!config.programs.fish.enable && config.programs.zsh.enable) {
+          interactiveShellInit = shellInit "zsh";
+        };
       };
-      fish = mkIf config.programs.fish.enable {
-        interactiveShellInit = shellInit "fish";
-      };
-      zsh = mkIf (!config.programs.fish.enable && config.programs.zsh.enable) {
-        interactiveShellInit = shellInit "zsh";
-      };
-    };
   };
   meta.maintainers = with maintainers; [ sigmasquadron ];
 }

--- a/pkgs/tools/misc/bat-extras/buildBatExtrasPkg.nix
+++ b/pkgs/tools/misc/bat-extras/buildBatExtrasPkg.nix
@@ -16,12 +16,18 @@ let
     "name"
     "dependencies"
     "meta"
+    "shellInit"
   ];
 in
 {
   name,
   dependencies,
   meta ? { },
+  # Config for the `shellInit` passthru (a `shell -> string`
+  # function returning the shell-specific init snippet for the bat-extras
+  # package). Specified as an attrset with a 'flags' string list argument.
+  # If null, there is no shell init for the package.
+  shellInit ? null,
   ...
 }@args:
 stdenv.mkDerivation (
@@ -75,6 +81,36 @@ stdenv.mkDerivation (
 
     # We have already patched
     dontPatchShebangs = true;
+
+    passthru =
+      let
+        initScript =
+          {
+            program,
+            shell,
+            flags ? [ ],
+          }:
+          if (shell != "fish") then
+            ''
+              eval "$(${lib.getExe program} ${toString flags})"
+            ''
+          else
+            ''
+              ${lib.getExe program} ${toString flags} | source
+            '';
+      in
+      {
+        shellInit =
+          shell:
+          if shellInit == null then
+            ""
+          else
+            initScript {
+              program = finalAttrs.finalPackage;
+              inherit shell;
+              flags = shellInit.flags or [ ];
+            };
+      };
 
     meta = core.meta // { mainProgram = name; } // meta;
   }

--- a/pkgs/tools/misc/bat-extras/modules/batman.nix
+++ b/pkgs/tools/misc/bat-extras/modules/batman.nix
@@ -7,5 +7,8 @@
 buildBatExtrasPkg {
   name = "batman";
   dependencies = lib.optional stdenv.targetPlatform.isLinux util-linux;
+  shellInit = {
+    flags = [ "--export-env" ];
+  };
   meta.description = "Read system manual pages (man) using bat as the manual page formatter";
 }

--- a/pkgs/tools/misc/bat-extras/modules/batpipe.nix
+++ b/pkgs/tools/misc/bat-extras/modules/batpipe.nix
@@ -11,6 +11,9 @@ buildBatExtrasPkg {
     less
     procps
   ];
+  shellInit = {
+    flags = [ ];
+  };
 
   patches = [
     ../patches/batpipe-skip-outdated-test.patch


### PR DESCRIPTION
Moves shell init logic specific to bat-extras packages into the extras packages themselves. The bat package itself is now only reponsible for registering the bat-extras shell inits. Also uses `finalAttrs.finalPackage` to correctly handle overlays on bat-extra packages (if an overlay package was used, it would not be installed with the previous `isElem` checks).

This genericization helps avoid duplicated / 'magic' logic in `bat.nix` here as well as in [home-manager](https://github.com/nix-community/home-manager/pull/8966#discussion_r3004035208).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
