### PR TITLE
kasane: init at 0.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29998,6 +29998,12 @@
     name = "Yusuf Bera Ertan";
     keys = [ { fingerprint = "9270 66BD 8125 A45B 4AC4 0326 6180 7181 F60E FCB2"; } ];
   };
+  yus314 = {
+    email = "shizhaoyoujie@gmail.com";
+    github = "Yus314";
+    githubId = 91413196;
+    name = "minera";
+  };
   yusuf-duran = {
     github = "postgnostic";
     githubId = 37774475;

--- a/pkgs/by-name/ka/kasane/package.nix
+++ b/pkgs/by-name/ka/kasane/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  kakoune,
+  makeWrapper,
+  testers,
+  nix-update-script,
+  withGui ? false,
+  vulkan-loader,
+  wayland,
+  wayland-protocols,
+  libxkbcommon,
+  libX11,
+  libXcursor,
+  libXrandr,
+  libXi,
+  fontconfig,
+  freetype,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kasane";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "Yus314";
+    repo = "kasane";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Vc7gG9xHaKujv7jb2Gn+NDpRaQPDpNLa4e7dr79LbFI=";
+  };
+
+  cargoHash = "sha256-GLl/7PHmsN3cqqTbkN/wFgccQsuV8vqg4iSxh3ihXw4=";
+
+  cargoBuildFlags = [
+    "-p"
+    "kasane"
+  ];
+  buildFeatures = lib.optionals withGui [ "gui" ];
+
+  # kasane crate tests require a running kakoune process
+  cargoTestFlags = [
+    "-p"
+    "kasane-core"
+    "-p"
+    "kasane-tui"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = lib.optionals (withGui && stdenv.hostPlatform.isLinux) [
+    vulkan-loader
+    wayland
+    wayland-protocols
+    libxkbcommon
+    libX11
+    libXcursor
+    libXrandr
+    libXi
+    fontconfig
+    freetype
+  ];
+
+  postInstall =
+    let
+      wrapArgs = lib.concatStringsSep " " (
+        [
+          "--prefix PATH : ${lib.makeBinPath [ kakoune ]}"
+        ]
+        ++ lib.optionals (withGui && stdenv.hostPlatform.isLinux) [
+          "--prefix LD_LIBRARY_PATH : ${
+            lib.makeLibraryPath [
+              vulkan-loader
+              wayland
+              libxkbcommon
+            ]
+          }"
+        ]
+      );
+    in
+    ''
+      wrapProgram $out/bin/kasane ${wrapArgs}
+    '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Alternative frontend for the Kakoune text editor";
+    homepage = "https://github.com/Yus314/kasane";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ yus314 ];
+    mainProgram = "kasane";
+  };
+})


### PR DESCRIPTION
## Description

Add [Kasane](https://github.com/Yus314/kasane), an alternative frontend for the [Kakoune](https://kakoune.org/) text editor written in Rust. It communicates with Kakoune via `kak -ui json` and provides both a TUI (crossterm) and an optional GPU (wgpu) backend.

### Features

- TUI backend using crossterm
- Optional GPU backend via `withGui` parameter (wgpu + glyphon)
- WASM plugin system (wasmtime Component Model)
- Declarative UI architecture (Element tree + TEA)

### Things done

- [x] Built locally with `nix-build`
- [x] Tested with `nix-build -A kasane.tests.version`
- [x] All 1118 cargo tests pass
- [x] Verified both TUI and GUI variants build correctly
- [x] Formatted with `nixfmt`
- [x] Added maintainer entry (`yus314`)
- [x] Uses `finalAttrs` pattern
- [x] Includes `passthru.updateScript` for `nix-update`

### Commits

1. `maintainers: add yus314` — adds maintainer entry to maintainer-list.nix
2. `kasane: init at 0.3.0` — adds the package expression