### PR TITLE
tree-sitter-grammar.tree-sitter-just: 0-unstable-2026-03-15 -> 0.2.0

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/grammars/grammar-sources.nix
@@ -1329,10 +1329,10 @@
   };
 
   just = {
-    version = "0-unstable-2026-03-15";
+    version = "0.2.0";
     url = "github:casey/tree-sitter-just";
-    rev = "d9da862c156020c1a83d3c6ccdda32be6d8a5d4a";
-    hash = "sha256-YV+vab/QqGHVPV1e3wjd0w1nFskJEIU4ukq/yIlojk0=";
+    rev = "5685543a6e64f66335e25518c9ae8ffa1dae3d01";
+    hash = "sha256-lrW5E+HIqrDSWZ4+KOjIc80/wYm/WV9ZOfdLXxPIbX4=";
     meta = {
       license = lib.licenses.asl20;
       maintainers = with lib.maintainers; [


### PR DESCRIPTION
Upstream is now tagging releases, so we can move away from unstable versions. The only change in this new release is to update all the metadata to point to the new repo.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

<!-- Message of single commit: -->