### PR TITLE
python3Packages.pypdf{2,3}: mark insecure

### DIFF
--- a/pkgs/development/python-modules/pypdf2/default.nix
+++ b/pkgs/development/python-modules/pypdf2/default.nix
@@ -29,5 +29,13 @@ buildPythonPackage rec {
     homepage = "https://pypdf2.readthedocs.io/";
     changelog = "https://github.com/py-pdf/PyPDF2/raw/${version}/CHANGELOG.md";
     license = lib.licenses.bsd3;
+    knownVulnerabilities = [
+      "CVE-2026-27024"
+      "CVE-2026-27025"
+      "CVE-2026-27628"
+      "CVE-2026-27888"
+      "CVE-2026-28351"
+      "CVE-2026-33699"
+    ];
   };
 }

--- a/pkgs/development/python-modules/pypdf3/default.nix
+++ b/pkgs/development/python-modules/pypdf3/default.nix
@@ -32,5 +32,13 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/sfneal/PyPDF3";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ ambroisie ];
+    knownVulnerabilities = [
+      "CVE-2026-27024"
+      "CVE-2026-27025"
+      "CVE-2026-27628"
+      "CVE-2026-27888"
+      "CVE-2026-28351"
+      "CVE-2026-33699"
+    ];
   };
 })


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/issues/504451

This disables

* cups-kyocera-3500-4500 (@me-and)
* cups-kyodialog (@steveej)
* odoo{17,18,19} (@mkg20001 @siriobalmelli)
* pdfposter (@wamserma)
* krop
* pdf-quench (@flokli)
* maigret (@fabaff @thtrf)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
