### PR TITLE
[Backport release-25.11] tautulli: 2.16.0 -> 2.17.0, refactors

### DIFF
--- a/pkgs/by-name/ta/tautulli/package.nix
+++ b/pkgs/by-name/ta/tautulli/package.nix
@@ -7,7 +7,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "Tautulli";
-  version = "2.16.1";
+  version = "2.17.0";
   pyproject = false;
 
   pythonPath = [ python3Packages.setuptools ];
@@ -20,7 +20,7 @@ python3Packages.buildPythonApplication rec {
     owner = "Tautulli";
     repo = "Tautulli";
     tag = "v${version}";
-    sha256 = "sha256-Zct7EhnU5LROO23Joz6OxQTtC9uGZhtceSG+aX6MI2c=";
+    sha256 = "sha256-1NslfaQLQvYM0WeAxzAmZVHTgVbFB2XK/8T+EoCMK1k=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/ta/tautulli/package.nix
+++ b/pkgs/by-name/ta/tautulli/package.nix
@@ -1,20 +1,18 @@
 {
   lib,
   fetchFromGitHub,
-  buildPythonApplication,
-  setuptools,
-  wrapPython,
+  python3Packages,
   makeWrapper,
 }:
 
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "Tautulli";
   version = "2.16.1";
   pyproject = false;
 
-  pythonPath = [ setuptools ];
+  pythonPath = [ python3Packages.setuptools ];
   nativeBuildInputs = [
-    wrapPython
+    python3Packages.wrapPython
     makeWrapper
   ];
 

--- a/pkgs/servers/tautulli/default.nix
+++ b/pkgs/servers/tautulli/default.nix
@@ -37,7 +37,7 @@ buildPythonApplication rec {
     # Can't just symlink to the main script, since it uses __file__ to
     # import bundled packages and manage the service
     makeWrapper $out/libexec/tautulli/Tautulli.py $out/bin/tautulli
-    wrapPythonProgramsIn "$out/libexec/tautulli" "$pythonPath"
+    wrapPythonProgramsIn "$out/libexec/tautulli" "''${pythonPath[*]}"
 
     # Creat backwards compatibility symlink to bin/plexpy
     ln -s $out/bin/tautulli $out/bin/plexpy

--- a/pkgs/servers/tautulli/default.nix
+++ b/pkgs/servers/tautulli/default.nix
@@ -20,7 +20,7 @@ buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "Tautulli";
-    repo = pname;
+    repo = "Tautulli";
     tag = "v${version}";
     sha256 = "sha256-nqSqWRst+gx9aZ2Ko+/tKzpQX7wuU4Bn3vLR5F87aJA=";
   };

--- a/pkgs/servers/tautulli/default.nix
+++ b/pkgs/servers/tautulli/default.nix
@@ -10,7 +10,7 @@
 buildPythonApplication rec {
   pname = "Tautulli";
   version = "2.16.0";
-  format = "other";
+  pyproject = false;
 
   pythonPath = [ setuptools ];
   nativeBuildInputs = [

--- a/pkgs/servers/tautulli/default.nix
+++ b/pkgs/servers/tautulli/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonApplication rec {
   pname = "Tautulli";
-  version = "2.16.0";
+  version = "2.16.1";
   pyproject = false;
 
   pythonPath = [ setuptools ];
@@ -22,7 +22,7 @@ buildPythonApplication rec {
     owner = "Tautulli";
     repo = "Tautulli";
     tag = "v${version}";
-    sha256 = "sha256-nqSqWRst+gx9aZ2Ko+/tKzpQX7wuU4Bn3vLR5F87aJA=";
+    sha256 = "sha256-Zct7EhnU5LROO23Joz6OxQTtC9uGZhtceSG+aX6MI2c=";
   };
 
   installPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3715,8 +3715,6 @@ with pkgs;
 
   tabview = with python3Packages; toPythonApplication tabview;
 
-  tautulli = python3Packages.callPackage ../servers/tautulli { };
-
   plfit = callPackage ../by-name/pl/plfit/package.nix {
     python = null;
   };


### PR DESCRIPTION
Manual backport to `release-25.11` of:
- #479499 (partial)
- #460756 (partial)
- #483072 (partial)
- #491157
- #486114 (partial)
- #504386

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
