### PR TITLE
fooyin: 0.9.2 -> 0.11.1

### DIFF
--- a/pkgs/by-name/fo/fooyin/package.nix
+++ b/pkgs/by-name/fo/fooyin/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   alsa-lib,
@@ -12,24 +11,30 @@
   pipewire,
   taglib,
   libebur128,
-  libvgm,
   libsndfile,
   libarchive,
   libopenmpt,
+  soundtouch,
+  soxr,
   game-music-emu,
   SDL2,
   icu,
+  zlib,
+  # Select bundled plugins to build. Leave empty for the default set, use none for no plugins, or use a semicolon/comma-separated list of plugin names to include or -name entries to exclude
+  pluginSelection ? "",
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fooyin";
-  version = "0.9.2";
+  version = "0.11.1";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "ludouzi";
+    owner = "fooyin";
     repo = "fooyin";
-    tag = "v" + finalAttrs.version;
-    hash = "sha256-sQ1zsQ/6OHGPkofiKhusCrpW2XnO+PpMvH1M2OG5Huw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-228hxjKkxE0ILzP8dnIS21R3AW9Y0+wutgcYlQdCgXc=";
   };
 
   buildInputs = [
@@ -41,17 +46,19 @@ stdenv.mkDerivation (finalAttrs: {
     ffmpeg
     icu
     kdsingleapplication
+    zlib
     # output plugins
     alsa-lib
     pipewire
     SDL2
     # input plugins
     libebur128
-    libvgm
     libsndfile
     libarchive
     libopenmpt
     game-music-emu
+    soundtouch
+    soxr
   ];
 
   nativeBuildInputs = [
@@ -66,29 +73,15 @@ stdenv.mkDerivation (finalAttrs: {
     # we need INSTALL_FHS to be true as the various artifacts are otherwise just dumped in the root
     # of $out and the fixupPhase cleans things up anyway
     (lib.cmakeBool "INSTALL_FHS" true)
+    (lib.cmakeFeature "PLUGIN_SELECTION" pluginSelection)
   ];
 
   env.LANG = "C.UTF-8";
 
-  # Remove after next release
-  patches = [
-    (fetchpatch {
-      name = "add-missing-header.patch";
-      url = "https://github.com/fooyin/fooyin/commit/7b171c0da2b9289468696424fe51f76e1c365bb5.patch";
-      hash = "sha256-Uvggz2F6DuWYAg20qi8uHkshzCnTLrchambQ/yDyIfA=";
-    })
-  ];
-
-  # Fix compatibility with Qt 6.10.1 - should be fixed in next release
-  postPatch = ''
-    substituteInPlace src/utils/starrating.cpp \
-      --replace-fail '.arg(alignment);' '.arg(alignment.toInt());'
-  '';
-
   meta = {
     description = "Customisable music player";
     homepage = "https://www.fooyin.org/";
-    changelog = "https://github.com/fooyin/fooyin/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/fooyin/fooyin/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     downloadPage = "https://github.com/fooyin/fooyin";
     mainProgram = "fooyin";
     license = lib.licenses.gpl3Only;


### PR DESCRIPTION
Closes: #504440
    
Diff: https://github.com/fooyin/fooyin/compare/v0.9.2...v0.11.1
Changelog: https://github.com/fooyin/fooyin/blob/v0.11.1/CHANGELOG.md

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
