### PR TITLE
kasane: init at 0.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30402,6 +30402,12 @@
     githubId = 1866448;
     name = "Eric Bailey";
   };
+  yus314 = {
+    email = "shizhaoyoujie@gmail.com";
+    github = "Yus314";
+    githubId = 91413196;
+    name = "minera";
+  };
   yusdacra = {
     email = "y.bera003.06@protonmail.com";
     matrix = "@yusdacra:nixos.dev";

--- a/pkgs/by-name/ka/kasane/package.nix
+++ b/pkgs/by-name/ka/kasane/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  kakoune,
+  makeBinaryWrapper,
+  versionCheckHook,
+  nix-update-script,
+  withGui ? true,
+  vulkan-loader,
+  wayland,
+  libxkbcommon,
+  libx11,
+  libxcursor,
+  libxrandr,
+  libxi,
+  fontconfig,
+  freetype,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "kasane";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "Yus314";
+    repo = "kasane";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1RyZfIRLviW3PTfQn7uTpt6OEtgrbZu6LFFIUVC+Wwc=";
+  };
+
+  cargoHash = "sha256-WQEpg5+AxpgsldKcYkfMEx0SSXHfnU6H1pXXiXPLQN8=";
+
+  cargoBuildFlags = [
+    "-p"
+    "kasane"
+  ];
+  buildFeatures = lib.optional withGui "gui";
+
+  # gui feature only exists in the kasane crate, not in test targets
+  checkFeatures = [ ];
+
+  # kasane crate tests require a running kakoune process
+  cargoTestFlags = [
+    "-p"
+    "kasane-core"
+    "-p"
+    "kasane-tui"
+  ];
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals (withGui && stdenv.hostPlatform.isLinux) [
+    fontconfig
+    freetype
+    libx11
+    libxcursor
+    libxi
+    libxkbcommon
+    libxrandr
+    vulkan-loader
+    wayland
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/kasane \
+      --prefix PATH : ${lib.makeBinPath [ kakoune ]}
+  '';
+
+  # Vulkan, Wayland, and libxkbcommon are loaded via dlopen at runtime.
+  # Add their paths after shrink-rpath so they are preserved.
+  postFixup = lib.optionalString (withGui && stdenv.hostPlatform.isLinux) ''
+    patchelf --add-rpath ${
+      lib.makeLibraryPath [
+        vulkan-loader
+        wayland
+        libxkbcommon
+      ]
+    } $out/bin/.kasane-wrapped
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Alternative frontend for the Kakoune text editor";
+    homepage = "https://github.com/Yus314/kasane";
+    license = with lib.licenses; [
+      mit # OR
+      asl20
+    ];
+    changelog = "https://github.com/Yus314/kasane/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ yus314 ];
+    mainProgram = "kasane";
+  };
+})


### PR DESCRIPTION
Add [kasane](https://github.com/Yus314/kasane), an alternative frontend
for the Kakoune text editor.

Kasane communicates with Kakoune via JSON-RPC (`kak -ui json`) and
provides a TUI (crossterm) and optional GPU (wgpu/Metal) backend.
Includes a WASM plugin runtime for sandboxed editor plugins.

Two commits:
1. `maintainers: add yus314`
2. `kasane: init at 0.6.0`

**Update 2026-05-08**: Force-pushed to bring this PR up to v0.6.0
(skipped 0.5.0 — apologies for the long pause). Rebased onto
current `master`, history rewritten to 2 clean commits (the previous
"style:" conventional-commit subject is gone). The package
expression preserves the reviewer feedback from the 0.4.0 round
(alphabetical `nativeBuildInputs` / `buildInputs`, no explicit
`platforms` since `buildRustPackage` provides them).

## Things done

- [x] Built on platform(s)
  - [x] aarch64-darwin: `nix-build` against this expression with
        v0.6.0 hashes produces a working `kasane` binary
        (`kasane 0.6.0+gui`, Kakoune wrapped via PATH)
  - [ ] x86_64-linux / aarch64-linux: pending re-run of `nixpkgs-review`
- [x] Tested, as applicable: kasane upstream test suite is ~2828 tests
      at v0.6.0; the Nix expression runs `kasane-core` + `kasane-tui`
      tests (kasane crate tests require a running kakoune process)
- [ ] Tested with `nixpkgs-review` (please re-run @yzhou216 if you
      have cycles, or I can run via `nixpkgs-review-gha`)
- [x] Tested basic functionality of all binary files
- [x] Fits [CONTRIBUTING.md](../CONTRIBUTING.md)

## Hashes

- `src.hash` = `sha256-1RyZfIRLviW3PTfQn7uTpt6OEtgrbZu6LFFIUVC+Wwc=`
- `cargoHash` = `sha256-WQEpg5+AxpgsldKcYkfMEx0SSXHfnU6H1pXXiXPLQN8=`

## Upstream changelog (v0.4.0 → v0.6.0)

- v0.5.0: Declarative widget system, KDL configuration, `kasane init` CLI
- v0.6.0: WIT 3.0 (Composable Lenses, Selection/Time/History first-class
  API), Display Algebra (ADR-034 + ADR-037), Plugin Authoring Path
  Consolidation (ADR-038), Parley closure baseline (56.7 µs warm at 80×24)

See https://github.com/Yus314/kasane/releases/tag/v0.6.0 for details.