### PR TITLE
kermit: fix build

### DIFF
--- a/pkgs/by-name/ke/kermit/package.nix
+++ b/pkgs/by-name/ke/kermit/package.nix
@@ -1,51 +1,59 @@
 {
-  lib,
-  stdenv,
   fetchurl,
-  ncurses,
+  lib,
   libxcrypt,
+  ncurses,
+  stdenv,
+  versionCheckHook,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kermit";
   version = "9.0.302";
 
   src = fetchurl {
-    url = "ftp://ftp.kermitproject.org/kermit/archives/cku302.tar.gz";
-    sha256 = "0487mh6s99ijqf1pfmbm302pa5i4pzmm8s439hdl1ffs5g8jqpqd";
+    url = "ftp://ftp.kermitproject.org/kermit/archives/cku${lib.versions.patch finalAttrs.version}.tar.gz";
+    hash = "sha256-DV8s0SvauUAbTINoVOu/JBZ1BRh1VXeDwzKmpA2sBxE=";
   };
 
-  buildInputs = [
-    ncurses
-    libxcrypt
-  ];
+  sourceRoot = ".";
 
-  unpackPhase = ''
-    mkdir -p src
-    pushd src
-    tar xvzf $src
-  '';
+  strictDeps = true;
+
+  buildInputs = [
+    libxcrypt
+    ncurses
+  ];
 
   postPatch = ''
     sed -i -e 's@-I/usr/include/ncurses@@' \
       -e 's@/usr/local@'"$out"@ makefile
   '';
 
-  buildPhase = "make -f makefile linux KFLAGS='-D_IO_file_flags -std=gnu89' LNKFLAGS='-lcrypt -lresolv'";
-
-  installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/man/man1
-    make -f makefile install
-  '';
-
   env.NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration -Wno-implicit-int";
 
+  buildPhase = ''
+    runHook preBuild
+    make linux KFLAGS='-D_IO_file_flags -std=gnu89' LNKFLAGS='-lcrypt -lresolv'
+    runHook postBuild
+  '';
+
+  preInstall = ''
+    mkdir --parents $out/{bin,man/man1}
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   meta = {
-    homepage = "https://www.kermitproject.org/ck90.html";
+    changelog = "https://www.kermitproject.org/ckupdates.html#ck${
+      lib.replaceStrings [ "." ] [ "" ] finalAttrs.version
+    }";
     description = "Portable Scriptable Network and Serial Communication Software";
+    homepage = "https://www.kermitproject.org/ck90.html";
     license = lib.licenses.bsd3;
+    mainProgram = "kermit";
     maintainers = with lib.maintainers; [ pSub ];
-    platforms = with lib.platforms; linux;
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ke/kermit/package.nix
+++ b/pkgs/by-name/ke/kermit/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
       -e 's@/usr/local@'"$out"@ makefile
   '';
 
-  buildPhase = "make -f makefile linux KFLAGS='-D_IO_file_flags' LNKFLAGS='-lcrypt -lresolv'";
+  buildPhase = "make -f makefile linux KFLAGS='-D_IO_file_flags -std=gnu89' LNKFLAGS='-lcrypt -lresolv'";
 
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
Resolves #504144

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
