### PR TITLE
khard: fix build failure caused by sphinx

### DIFF
--- a/pkgs/by-name/kh/khard/khard-sphinx.patch
+++ b/pkgs/by-name/kh/khard/khard-sphinx.patch
@@ -1,0 +1,13 @@
+diff '--color=auto' -u -r khard-0.20.1/doc/source/conf.py new/doc/source/conf.py
+--- khard-0.20.1/doc/source/conf.py	2025-07-29 04:47:18.000000000 +0800
++++ new/doc/source/conf.py	2026-03-29 12:53:42.904389827 +0800
+@@ -52,8 +52,8 @@
+     'sphinx.ext.autodoc',  # https://pypi.org/project/sphinx-autodoc-typehints/
+     'sphinx.ext.autosectionlabel',
+     'sphinx.ext.todo',
+-    'sphinx_autodoc_typehints',  # https://pypi.org/project/sphinx-autodoc-typehints/
+     'sphinxarg.ext',
++    'sphinx_autodoc_typehints',  # https://pypi.org/project/sphinx-autodoc-typehints/
+ ]
+ 
+ autoapi_type = 'python'

--- a/pkgs/by-name/kh/khard/package.nix
+++ b/pkgs/by-name/kh/khard/package.nix
@@ -15,6 +15,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-s+W/rfa11+jxaNDDIMdLlU5NDvQZSyh5EUD+V3pI+Ug=";
   };
 
+  patches = [ ./khard-sphinx.patch ];
+
   build-system = with python3.pkgs; [
     setuptools
     setuptools-scm


### PR DESCRIPTION
reference: https://github.com/sphinx-doc/sphinx/issues/14333#issuecomment-4124118458


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
