### PR TITLE
pythonPackages: make disabled python packages enable-able via overrides

### DIFF
--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -157,9 +157,9 @@ let
 
   disabled =
     drv:
-    throw "${
-      removePythonPrefix (drv.pname or drv.name)
-    } not supported for interpreter ${python.executable}";
+    drv.overridePythonAttrs (_: {
+      disabled = true;
+    });
 
   disabledIf = x: drv: if x then disabled drv else drv;
 


### PR DESCRIPTION
I find it very hard to re-enable disabled Python packages for those defined in `pkgs/top-level/python2-packages.nix`. You cannot even get their `name`! With this patch, those packages throw the same error message as before if you try to instantiate them, but now you can easily re-enable them with an override if you really want to:

```nix
import <nixpkgs> {
	config.permittedInsecurePackages = [ "python-2.7.18.12" ];

	overlays = [ (pkgs: pkgsSuper: {
		python2 = pkgsSuper.python2.override {
			packageOverrides = pythonPackages: pythonPackagesSuper: {

				six = pythonPackagesSuper.six.overridePythonAttrs {
					disabled = false;
					doCheck = false;
				};

			};
		};
	}) ];
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
