### PR TITLE
kdePackages.plasma-workspace: stop accidentally duplicating fontconfig config

### DIFF
--- a/pkgs/kde/plasma/plasma-workspace/default.nix
+++ b/pkgs/kde/plasma/plasma-workspace/default.nix
@@ -37,6 +37,9 @@ mkKdeDerivation {
       # @QtBinariesDir@ only appears in the *removed* lines of the diff
       QtBinariesDir = null;
     })
+
+    # stop accidentally duplicating fontconfig configs
+    ./fontconfig.patch
   ];
 
   outputs = [

--- a/pkgs/kde/plasma/plasma-workspace/fontconfig.patch
+++ b/pkgs/kde/plasma/plasma-workspace/fontconfig.patch
@@ -1,0 +1,15 @@
+diff --git a/kcms/fonts/kxftconfig.cpp b/kcms/fonts/kxftconfig.cpp
+index b67d885de7..d5c469687a 100644
+--- a/kcms/fonts/kxftconfig.cpp
++++ b/kcms/fonts/kxftconfig.cpp
+@@ -310,6 +310,10 @@ bool KXftConfig::apply()
+             m_excludePixelRange.from = (int)point2Pixel(m_excludeRange.from);
+             m_excludePixelRange.to = (int)point2Pixel(m_excludeRange.to);
+ 
++            // Ensure m_doc is the config file we want
++            m_doc.clear();
++            parseConfigFile(m_file);
++
+             FcAtomic *atomic = FcAtomicCreate((const unsigned char *)(QFile::encodeName(m_file).data()));
+ 
+             ok = false;


### PR DESCRIPTION
Upstream PR: https://invent.kde.org/plasma/plasma-workspace/-/merge_requests/6447

Fixes #504527.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
