### PR TITLE
linuxPackages.amneziawg: 1.0.20251019 -> 1.0.20260322

### DIFF
--- a/pkgs/os-specific/linux/amneziawg/default.nix
+++ b/pkgs/os-specific/linux/amneziawg/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  srcOnly,
   kernel,
   kernelModuleMakeFlags,
   nix-update-script,
@@ -10,28 +9,32 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "amneziawg";
-  version = "1.0.20251009";
+  version = "1.0.20260322";
 
   src = fetchFromGitHub {
     owner = "amnezia-vpn";
     repo = "amneziawg-linux-kernel-module";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OcMlwXOwjxLqHkAQHSwDigK6wuOFCSzoE5spVwybN1M=";
+    hash = "sha256-Y6TETOo5oAr3ZtqsJX909zm38rXq+1fAXiRFSt+g2Gw=";
   };
+
+  patches = [
+    # fix aarch64-linux builds with NEON
+    # upstream PR: https://github.com/amnezia-vpn/amneziawg-linux-kernel-module/pull/159
+    ./neon-619.patch
+  ];
 
   sourceRoot = "${finalAttrs.src.name}/src";
   hardeningDisable = [ "pic" ];
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   buildFlags = [
-    "apply-patches"
     "module"
   ];
 
-  makeFlags =
-    kernelModuleMakeFlags
-    ++ [ "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ]
-    ++ lib.optional (lib.versionAtLeast kernel.version "5.6") "KERNEL_SOURCE_DIR=${srcOnly kernel}";
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/amneziawg/neon-619.patch
+++ b/pkgs/os-specific/linux/amneziawg/neon-619.patch
@@ -1,0 +1,74 @@
+--- a/compat/simd/include/linux/simd.h
++++ b/compat/simd/include/linux/simd.h
+@@ -18,31 +18,42 @@ typedef enum {
+ 	HAVE_NO_SIMD = 1 << 0,
+ 	HAVE_FULL_SIMD = 1 << 1,
+ 	HAVE_SIMD_IN_USE = 1 << 31
++} simd_state_t;
++
++typedef struct {
++	simd_state_t state;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0) && defined(CONFIG_KERNEL_MODE_NEON)
++	struct user_fpsimd_state kstate;
++#endif
+ } simd_context_t;
+ 
+ #define DONT_USE_SIMD ((simd_context_t []){ HAVE_NO_SIMD })
+ 
+ static inline void simd_get(simd_context_t *ctx)
+ {
+-	*ctx = !IS_ENABLED(CONFIG_PREEMPT_RT) && !IS_ENABLED(CONFIG_PREEMPT_RT_BASE) && may_use_simd() ? HAVE_FULL_SIMD : HAVE_NO_SIMD;
++	ctx->state = !IS_ENABLED(CONFIG_PREEMPT_RT) && !IS_ENABLED(CONFIG_PREEMPT_RT_BASE) && may_use_simd() ? HAVE_FULL_SIMD : HAVE_NO_SIMD;
+ }
+ 
+ static inline void simd_put(simd_context_t *ctx)
+ {
+ #if defined(CONFIG_X86_64)
+-	if (*ctx & HAVE_SIMD_IN_USE)
++	if (ctx->state & HAVE_SIMD_IN_USE)
+ 		kernel_fpu_end();
+ #elif defined(CONFIG_KERNEL_MODE_NEON)
+-	if (*ctx & HAVE_SIMD_IN_USE)
++	if (ctx->state & HAVE_SIMD_IN_USE)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++		kernel_neon_end(&ctx->kstate);
++#else
+ 		kernel_neon_end();
+ #endif
+-	*ctx = HAVE_NO_SIMD;
++#endif
++	ctx->state = HAVE_NO_SIMD;
+ }
+ 
+ static inline bool simd_relax(simd_context_t *ctx)
+ {
+ #ifdef CONFIG_PREEMPT
+-	if ((*ctx & HAVE_SIMD_IN_USE) && need_resched()) {
++	if ((ctx->state & HAVE_SIMD_IN_USE) && need_resched()) {
+ 		simd_put(ctx);
+ 		simd_get(ctx);
+ 		return true;
+@@ -53,16 +64,20 @@ static inline bool simd_relax(simd_context_t *ctx)
+ 
+ static __must_check inline bool simd_use(simd_context_t *ctx)
+ {
+-	if (!(*ctx & HAVE_FULL_SIMD))
++	if (!(ctx->state & HAVE_FULL_SIMD))
+ 		return false;
+-	if (*ctx & HAVE_SIMD_IN_USE)
++	if (ctx->state & HAVE_SIMD_IN_USE)
+ 		return true;
+ #if defined(CONFIG_X86_64)
+ 	kernel_fpu_begin();
+ #elif defined(CONFIG_KERNEL_MODE_NEON)
++#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 19, 0)
++	kernel_neon_begin(&ctx->kstate);
++#else
+ 	kernel_neon_begin();
+ #endif
+-	*ctx |= HAVE_SIMD_IN_USE;
++#endif
++	ctx->state |= HAVE_SIMD_IN_USE;
+ 	return true;
+ }
+ 


### PR DESCRIPTION
Include not-yet-merged patch to fix aarch64-linux builds.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
