### PR TITLE
buildCrystalPackage: fix env overrides

### DIFF
--- a/pkgs/development/compilers/crystal/build-package.nix
+++ b/pkgs/development/compilers/crystal/build-package.nix
@@ -108,11 +108,12 @@ stdenv.mkDerivation (
         ++ [ "runHook postConfigure" ]
       ));
 
-    env = args.env or { } // {
+    env = {
       CRFLAGS = lib.concatStringsSep " " defaultOptions;
 
       PREFIX = placeholder "out";
-    };
+    }
+    // (args.env or { });
 
     inherit enableParallelBuilding;
     strictDeps = true;
@@ -205,8 +206,9 @@ stdenv.mkDerivation (
         done
       '';
 
-    meta = args.meta or { } // {
-      platforms = args.meta.platforms or crystal.meta.platforms;
-    };
+    meta = {
+      platforms = crystal.meta.platforms;
+    }
+    // (args.meta or { });
   }
 )


### PR DESCRIPTION
Passing variables through `env` was broken for 2 reasons:

1. due to missing parens, no merging of `env` would take place, and
2. it was impossible to override defaults due to the order


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
