### PR TITLE
crun: enable libkrun support when applicable

### DIFF
--- a/pkgs/by-name/cr/crun/package.nix
+++ b/pkgs/by-name/cr/crun/package.nix
@@ -6,6 +6,8 @@
   go-md2man,
   pkg-config,
   libcap,
+  libkrun,
+  libkrun-sev,
   libseccomp,
   python3,
   systemdMinimal,
@@ -13,6 +15,8 @@
   nixosTests,
   criu,
   versionCheckHook,
+  withLibkrun ? lib.meta.availableOn stdenv.hostPlatform libkrun,
+  withLibkrunSEV ? false,
 }:
 
 let
@@ -70,6 +74,16 @@ stdenv.mkDerivation (finalAttrs: {
     libseccomp
     systemdMinimal
     yajl
+  ]
+  ++ lib.optionals withLibkrun [
+    libkrun
+  ]
+  ++ lib.optionals withLibkrunSEV [
+    libkrun-sev
+  ];
+
+  configureFlags = lib.optionals withLibkrun [
+    "--with-libkrun"
   ];
 
   enableParallelBuilding = true;
@@ -88,6 +102,14 @@ stdenv.mkDerivation (finalAttrs: {
     ${lib.concatMapStringsSep "\n" (
       e: "substituteInPlace Makefile.am --replace-fail 'tests/${e}' ''"
     ) disabledTests}
+  ''
+  + lib.optionalString withLibkrun ''
+    substituteInPlace src/libcrun/handlers/krun.c \
+      --replace-fail '"libkrun.so.1"' '"${libkrun}/lib/libkrun.so.1"'
+  ''
+  + lib.optionalString withLibkrunSEV ''
+    substituteInPlace src/libcrun/handlers/krun.c \
+      --replace-fail '"libkrun-sev.so.1"' '"${libkrun-sev}/lib/libkrun-sev.so.1"'
   '';
 
   doCheck = true;


### PR DESCRIPTION
This patch makes `crun` build with `libkrun` support when applicable, so that `podman` can be used with `--runtime krun` to run containers as `libkrun`-managed microvms out of the box.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
