### PR TITLE
python3Packages.sphinx-last-updated-by-git: 0.3.8 -> 0.3.8-unstable-2026-03-22

### DIFF
--- a/pkgs/development/python-modules/sphinx-last-updated-by-git/default.nix
+++ b/pkgs/development/python-modules/sphinx-last-updated-by-git/default.nix
@@ -12,14 +12,14 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "sphinx-last-updated-by-git";
-  version = "0.3.8";
+  version = "0.3.8-unstable-2026-03-22";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mgeier";
     repo = "sphinx-last-updated-by-git";
-    rev = "07ac1a98af2a927e773a65c6524ce83067c977b8";
-    hash = "sha256-2TGFR11Ejh/9zpVC/TEdmMNaBt38wE5yeJeYixZSVUE=";
+    rev = "8d4eef2561996319e6f785b4faa914a1e6545476";
+    hash = "sha256-30pZiqWs6Da+O8j08EIHrUoiJfJUPT6FdDiPBjmvRL8=";
     fetchSubmodules = true;
     leaveDotGit = true;
   };


### PR DESCRIPTION
Currently failing on master, updating it to unstable fixes it

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
