### PR TITLE
zeroclaw: 0.5.1 -> 0.6.5

### DIFF
--- a/pkgs/by-name/ze/zeroclaw/package.nix
+++ b/pkgs/by-name/ze/zeroclaw/package.nix
@@ -14,13 +14,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zeroclaw";
-  version = "0.5.1";
+  version = "0.6.5";
 
   src = fetchFromGitHub {
     owner = "zeroclaw-labs";
     repo = "zeroclaw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5P+TjAf7i0oUxBCyBtagrmIHPXW2iZ6620PNxVYYjlQ=";
+    hash = "sha256-uBlM5N9+a22HL7CSlpLIapqFFd+MEqhbb94LtiN3FAs=";
   };
 
   postPatch =
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       ln -s ${zeroclaw-web} web/dist
     '';
 
-  cargoHash = "sha256-tpgeRLWyye43fuzw2MRevQx8YKEbyOnIgLzjg8EzwCg=";
+  cargoHash = "sha256-1/s2ijYqanhHIsYSw85c4H3T5phnAfvV7oQeAl/6lxQ=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ze/zeroclaw/package.nix
+++ b/pkgs/by-name/ze/zeroclaw/package.nix
@@ -10,6 +10,8 @@
   gitMinimal,
   versionCheckHook,
   nix-update-script,
+  # makes zeroclaw-web overrideable
+  npmDepsHash ? "sha256-RMiFoPj4cbUYONURsCp4FrNuy9bR1eRWqgAnACrVXsI=",
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -25,7 +27,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postPatch =
     let
-      zeroclaw-web = callPackage ./zeroclaw-web { inherit (finalAttrs) src version; };
+      zeroclaw-web = callPackage ./zeroclaw-web {
+        inherit (finalAttrs) src version;
+        inherit npmDepsHash;
+      };
     in
     ''
       mkdir -p web

--- a/pkgs/by-name/ze/zeroclaw/zeroclaw-web/default.nix
+++ b/pkgs/by-name/ze/zeroclaw/zeroclaw-web/default.nix
@@ -10,7 +10,7 @@ buildNpmPackage (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/web";
 
-  npmDepsHash = "sha256-4+raDJ7+w+RpdeZs2PJL10IWzfoT5B3EpOxsLUnlrRc=";
+  npmDepsHash = "sha256-RMiFoPj4cbUYONURsCp4FrNuy9bR1eRWqgAnACrVXsI=";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ze/zeroclaw/zeroclaw-web/default.nix
+++ b/pkgs/by-name/ze/zeroclaw/zeroclaw-web/default.nix
@@ -2,15 +2,14 @@
   buildNpmPackage,
   src,
   version,
+  npmDepsHash,
   ...
 }:
 buildNpmPackage (finalAttrs: {
   pname = "zeroclaw-web";
-  inherit src version;
+  inherit src version npmDepsHash;
 
   sourceRoot = "${finalAttrs.src.name}/web";
-
-  npmDepsHash = "sha256-RMiFoPj4cbUYONURsCp4FrNuy9bR1eRWqgAnACrVXsI=";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Package bump and made the npmDepsHash for zeroclaw-web overrideable. I had problems when customizing the package. I had to override the postPatchPhase.
The alternative to exposing npmDepsHash was to create a separate package but it doesn't make much sense as the web interface is a tight dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
