### PR TITLE
pdfposter: 0.8.1 -> 0.9.1

### DIFF
--- a/pkgs/by-name/pd/pdfposter/package.nix
+++ b/pkgs/by-name/pd/pdfposter/package.nix
@@ -1,44 +1,26 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchPypi,
 }:
-let
-  localPython = python3.override {
-    self = localPython;
-    packageOverrides = self: super: {
-      # Can be removed once this is merged
-      # https://gitlab.com/pdftools/pdfposter/-/merge_requests/7
-      pypdf2 = super.pypdf2.overridePythonAttrs (oldAttrs: rec {
-        version = "2.11.1";
-        format = "setuptools";
-        pyproject = null;
-        src = fetchPypi {
-          pname = "PyPDF2";
-          inherit version;
-          hash = "sha256-PHut1RLCFxHrF4nC6tv5YnkonA+URS7lSoZHO/vv1zI=";
-        };
-      });
-    };
-  };
-in
-with localPython.pkgs;
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "pdfposter";
-  version = "0.8.1";
-  format = "setuptools";
+  version = "0.9.1";
+  pyproject = true;
 
-  propagatedBuildInputs = [ pypdf2 ];
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [ pypdf ];
 
   src = fetchPypi {
-    pname = "pdftools.pdfposter";
+    pname = "pdfposter";
     inherit version;
-    hash = "sha256-yWFtHgVKAWs4dRlSk8t8cB2KBJeBOa0Frh3BLR9txS0=";
+    hash = "sha256-Y5gUrHI470vsORETxkpf3WH5YXgdIeTZvSb3v/UgD24=";
   };
 
   pythonImportsCheck = [
-    "pdftools.pdfposter"
-    "pdftools.pdfposter.cmd"
+    "pdfposter"
+    "pdfposter.cmd"
   ];
 
   meta = {


### PR DESCRIPTION
- renamed by upstream from pdftools.pdfposter to pdfposter
- no longer depends on old version of pypdf


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
