### PR TITLE
scantpaper: init at 3.0.6

### DIFF
--- a/pkgs/by-name/sc/scantpaper/package.nix
+++ b/pkgs/by-name/sc/scantpaper/package.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  wrapGAppsHook3,
+
+  # libs
+  gobject-introspection,
+  goocanvas_2,
+  unpaper,
+  djvulibre,
+  libtiff,
+  qpdf,
+
+  # tests
+  writableTmpDirAsHomeHook,
+  xvfb,
+  imagemagickBig,
+  poppler-utils,
+  ghostscript,
+  tesseract,
+}:
+
+let
+  runtimeExecDeps = [
+    unpaper
+    tesseract
+    djvulibre
+    libtiff
+    qpdf
+  ];
+
+in
+python3.pkgs.buildPythonApplication rec {
+  pname = "scantpaper";
+  version = "3.0.6";
+
+  src = fetchFromGitHub {
+    owner = "carygravel";
+    repo = "scantpaper";
+    rev = "v${version}";
+    hash = "sha256-MKO5/MIlgjWrL+xUVBe84PgUXUGR0tTxUrJed8LegZc=";
+  };
+
+  pyproject = true;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontWrapGApps = true;
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  postPatch = ''
+    # disable formatting check, which breaks on Black version change
+    substituteInPlace pyproject.toml \
+      --replace "--black" ""
+  '';
+
+  build-system = with python3.pkgs; [
+    setuptools
+  ];
+
+  dependencies =
+    (with python3.pkgs; [
+      img2pdf
+      ocrmypdf
+      pycairo
+      pygobject3
+      sane
+      tesserocr
+      python-iso639
+    ])
+    ++ [
+      goocanvas_2
+    ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook3
+    gobject-introspection
+    writableTmpDirAsHomeHook
+  ];
+
+  nativeCheckInputs =
+    (with python3.pkgs; [
+      pytestCheckHook
+      pytest-cov # segfault with pytest-cov-stub
+      pytest-mock
+      pytest-xvfb
+      pytest-timeout
+    ])
+    ++ [
+      xvfb
+      imagemagickBig # "big" version needed for text rendering in tests
+      poppler-utils
+      ghostscript
+    ]
+    ++ runtimeExecDeps;
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath runtimeExecDeps)
+  ];
+
+  meta = with lib; {
+    description = "GUI to produce PDFs or DjVus from scanned documents";
+    homepage = "https://github.com/carygravel/scantpaper";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ euxane ];
+    platforms = platforms.linux;
+    mainProgram = "scantpaper";
+  };
+}

--- a/pkgs/by-name/sc/scantpaper/package.nix
+++ b/pkgs/by-name/sc/scantpaper/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  wrapGAppsHook3,
+
+  # libs
+  gobject-introspection,
+  goocanvas_2,
+  unpaper,
+  djvulibre,
+  libtiff,
+  qpdf,
+
+  # tests
+  writableTmpDirAsHomeHook,
+  xvfb,
+  imagemagickBig,
+  poppler-utils,
+  ghostscript,
+  tesseract,
+}:
+
+let
+  runtimeExecDeps = [
+    unpaper
+    tesseract
+    djvulibre
+    libtiff
+    qpdf
+  ];
+
+in
+python3.pkgs.buildPythonApplication rec {
+  pname = "scantpaper";
+  version = "3.0.6";
+
+  src = fetchFromGitHub {
+    owner = "carygravel";
+    repo = "scantpaper";
+    rev = "v${version}";
+    hash = "sha256-MKO5/MIlgjWrL+xUVBe84PgUXUGR0tTxUrJed8LegZc=";
+  };
+
+  pyproject = true;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  postPatch = ''
+    # disable formatting check, which breaks on Black version change
+    substituteInPlace pyproject.toml \
+      --replace "--black" ""
+  '';
+
+  build-system = with python3.pkgs; [
+    setuptools
+  ];
+
+  dependencies =
+    (with python3.pkgs; [
+      img2pdf
+      ocrmypdf
+      pycairo
+      pygobject3
+      sane
+      tesserocr
+      python-iso639
+    ])
+    ++ [
+      goocanvas_2
+    ];
+
+  nativeBuildInputs =
+    (with python3.pkgs; [
+      pytestCheckHook
+    ])
+    ++ [
+      wrapGAppsHook3
+      gobject-introspection
+      writableTmpDirAsHomeHook
+    ];
+
+  nativeCheckInputs =
+    (with python3.pkgs; [
+      pytest-sugar
+      pytest-cov
+      pytest-mock
+      pytest-xvfb
+      pytest-timeout
+    ])
+    ++ [
+      xvfb
+      imagemagickBig # "big" version needed for text rendering in tests
+      poppler-utils
+      ghostscript
+    ]
+    ++ runtimeExecDeps;
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath runtimeExecDeps)
+  ];
+
+  meta = with lib; {
+    description = "GUI to produce PDFs or DjVus from scanned documents";
+    homepage = "https://github.com/carygravel/scantpaper";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ euxane ];
+    platforms = platforms.linux;
+    mainProgram = "scantpaper";
+  };
+}


### PR DESCRIPTION
This introduces a nix package for [scantpaper], a Python rewrite of [Gscan2pdf].

[scantpaper]: https://github.com/carygravel/scantpaper
[Gscan2pdf]: https://sourceforge.net/projects/gscan2pdf/


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
