### PR TITLE
[25.11] various: gnome-circle 2026-03-14 updates

### DIFF
--- a/pkgs/by-name/cl/clairvoyant/package.nix
+++ b/pkgs/by-name/cl/clairvoyant/package.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "clairvoyant";
-  version = "3.1.10";
+  version = "3.1.12";
 
   src = fetchFromGitHub {
     owner = "cassidyjames";
     repo = "clairvoyant";
     rev = finalAttrs.version;
-    hash = "sha256-CSORiNPqzliIpslV28NRPs/+bc9iblsLTPOm1WxxTjc=";
+    hash = "sha256-3TdtSa8RQkeUvw+oesHruyy7S/WnsX7FXWnDLowbEkg=";
   };
 
   nativeBuildInputs = [
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Ask questions, get psychic answers";
     homepage = "https://github.com/cassidyjames/clairvoyant";
     license = lib.licenses.gpl3Plus;
-    mainProgram = "com.github.cassidyjames.clairvoyant";
+    mainProgram = "com.cassidyjames.clairvoyant";
     teams = [ lib.teams.gnome-circle ];
   };
 })

--- a/pkgs/by-name/co/commit/package.nix
+++ b/pkgs/by-name/co/commit/package.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "commit";
-  version = "4.4";
+  version = "4.5";
 
   src = fetchFromGitHub {
     owner = "sonnyp";
     repo = "Commit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ACgt1xZTiHYiCTUvfQ+KP5TYm8tMimGizK1dn9UXzao=";
+    hash = "sha256-PyxByqvTK/B5Kr+uRZTZxsHcfhLqAjZrJ0/hW7m8zVQ=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/cu/curtail/package.nix
+++ b/pkgs/by-name/cu/curtail/package.nix
@@ -22,14 +22,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "curtail";
-  version = "1.13.0";
+  version = "1.14.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "Huluti";
     repo = "Curtail";
     tag = version;
-    sha256 = "sha256-JfioWtd0jGTyaD5uELAqH6J+h04MOrfEqdR7GWgXyMw=";
+    sha256 = "sha256-AxQe7abHZp4SRp90fkFbmXf3ZQH3VmxQVkpxRcit+54=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cu/curtail/package.nix
+++ b/pkgs/by-name/cu/curtail/package.nix
@@ -22,14 +22,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "curtail";
-  version = "1.14.0";
-  format = "other";
+  version = "1.15.0";
+  pyproject = false;
 
   src = fetchFromGitHub {
     owner = "Huluti";
     repo = "Curtail";
     tag = version;
-    sha256 = "sha256-AxQe7abHZp4SRp90fkFbmXf3ZQH3VmxQVkpxRcit+54=";
+    hash = "sha256-1X3isnhl5Lw+iVLM2WdZEaKphLiikBtg5QlSxgQHqy8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/el/elastic/package.nix
+++ b/pkgs/by-name/el/elastic/package.nix
@@ -17,16 +17,16 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "elastic";
-  version = "0.1.9";
+  version = "1.0.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "elastic";
-    rev = version;
-    hash = "sha256-jK9RcZ5U1Dwkpu1mlfq/l4347eRCd3Y/KDYYIIkGytk=";
+    rev = finalAttrs.version;
+    hash = "sha256-ydRKkVYQ1f6Jlymej1Wzoppo6E0FEUvIfrfnDqLRcPY=";
   };
 
   nativeBuildInputs = [
@@ -60,4 +60,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ _0xMRTT ];
     teams = [ lib.teams.gnome-circle ];
   };
-}
+})

--- a/pkgs/by-name/ex/exercise-timer/package.nix
+++ b/pkgs/by-name/ex/exercise-timer/package.nix
@@ -1,24 +1,21 @@
 {
   lib,
   stdenv,
-  alsa-lib,
   appstream-glib,
   blueprint-compiler,
-  cargo,
   desktop-file-utils,
   fetchFromGitHub,
-  json-glib,
   glib,
+  gst_all_1,
   gtk4,
+  json-glib,
   libadwaita,
   meson,
   ninja,
   nix-update-script,
   pkg-config,
-  rustPlatform,
-  rustc,
-  wrapGAppsHook4,
   vala,
+  wrapGAppsHook4,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -36,20 +33,20 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     appstream-glib
     blueprint-compiler
-    cargo
     desktop-file-utils
     glib
     gtk4
     meson
     ninja
     pkg-config
-    rustc
     wrapGAppsHook4
     vala
   ];
 
   buildInputs = [
-    alsa-lib
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gstreamer
     json-glib
     libadwaita
   ];

--- a/pkgs/by-name/ex/exercise-timer/package.nix
+++ b/pkgs/by-name/ex/exercise-timer/package.nix
@@ -3,9 +3,11 @@
   stdenv,
   alsa-lib,
   appstream-glib,
+  blueprint-compiler,
   cargo,
   desktop-file-utils,
   fetchFromGitHub,
+  json-glib,
   glib,
   gtk4,
   libadwaita,
@@ -16,27 +18,24 @@
   rustPlatform,
   rustc,
   wrapGAppsHook4,
+  vala,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "exercise-timer";
-  version = "1.8.5";
+  version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "mfep";
     repo = "exercise-timer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yparZ9XmHkjwvgpnERpi8hvRXdb8R+kAyFOFl+exXb4=";
+    hash = "sha256-81bGX5Oa5z5AbtYDzPcSyFsz0/zWcDw/Ky9n+EfnZNo=";
     fetchLFS = true;
-  };
-
-  cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) pname version src;
-    hash = "sha256-JObzeiQHEGIDjOung3o8dpaXVcOoJS2v1hyrcS1fqcI=";
   };
 
   nativeBuildInputs = [
     appstream-glib
+    blueprint-compiler
     cargo
     desktop-file-utils
     glib
@@ -44,13 +43,14 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    rustPlatform.cargoSetupHook
     rustc
     wrapGAppsHook4
+    vala
   ];
 
   buildInputs = [
     alsa-lib
+    json-glib
     libadwaita
   ];
 

--- a/pkgs/by-name/gn/gnome-decoder/package.nix
+++ b/pkgs/by-name/gn/gnome-decoder/package.nix
@@ -23,14 +23,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-decoder";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "decoder";
     tag = finalAttrs.version;
-    hash = "sha256-O+DXfR9nZ0iz9IX/SZVX6ESI/vRa4ErEPxdgqSyOye0=";
+    hash = "sha256-g3ztQ+wiCDY19bc2/IABzXGSQrZltQgrTZ7rSI0RyFs=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {

--- a/pkgs/by-name/gn/gnome-graphs/package.nix
+++ b/pkgs/by-name/gn/gnome-graphs/package.nix
@@ -19,7 +19,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gnome-graphs";
-  version = "1.8.4";
+  version = "1.8.7";
   pyproject = false;
 
   src = fetchFromGitLab {
@@ -27,7 +27,7 @@ python3Packages.buildPythonApplication rec {
     owner = "World";
     repo = "Graphs";
     rev = "v${version}";
-    hash = "sha256-up4Hv2gndekDQzEnf7kkskDyRGJ/mqEji7dsuLgnUVI=";
+    hash = "sha256-nMcpsYW8/WdCKmHnsObAWhDeo7+1vqBGTTXteh6jBus=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-secrets/package.nix
+++ b/pkgs/by-name/gn/gnome-secrets/package.nix
@@ -23,7 +23,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gnome-secrets";
-  version = "12.0";
+  version = "12.3";
   pyproject = false;
 
   src = fetchFromGitLab {
@@ -31,7 +31,7 @@ python3Packages.buildPythonApplication rec {
     owner = "World";
     repo = "secrets";
     tag = version;
-    hash = "sha256-U+ez/rhaXROcLdXhFY992YzIRBCkR05hxkAYbWIpa/A=";
+    hash = "sha256-ypkzswfX/qdVtMja2oky8Gein2BO1gzDvjbtcd3Javc=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/io/iotas/package.nix
+++ b/pkgs/by-name/io/iotas/package.nix
@@ -20,7 +20,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "iotas";
-  version = "0.12.5";
+  version = "0.12.7";
   pyproject = false;
 
   src = fetchFromGitLab {
@@ -28,7 +28,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "World";
     repo = "iotas";
     tag = version;
-    hash = "sha256-qbUI2hkW3rRiiBWFADuB9KFMf6Maw+WAkdy6dTE+Yo0=";
+    hash = "sha256-LA00Szhjk/tzGnzDGm65SCgH6l2fk+8+p4PhIpB7T1I=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ju/junction/package.nix
+++ b/pkgs/by-name/ju/junction/package.nix
@@ -17,15 +17,15 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "junction";
-  version = "1.9";
+  version = "1.12";
 
   src = fetchFromGitHub {
     owner = "sonnyp";
     repo = "junction";
-    tag = "v${version}";
-    hash = "sha256-gnFig8C46x73gAUl9VVx3Y3hrhEVeP/DvaYHYuv9RTg=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sl/NeElAp/SWHp0BdXycrZYCgm4I4MFx/uHnQf78H8g=";
     fetchSubmodules = true;
   };
 
@@ -77,4 +77,4 @@ stdenv.mkDerivation rec {
     teams = [ lib.teams.gnome-circle ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ko/komikku/package.nix
+++ b/pkgs/by-name/ko/komikku/package.nix
@@ -24,14 +24,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "komikku";
-  version = "1.101.0";
+  version = "1.102.0";
   pyproject = false;
 
   src = fetchFromCodeberg {
     owner = "valos";
     repo = "Komikku";
     tag = "v${version}";
-    hash = "sha256-sDhnG6d77erHO9HS0fL4Fl5qHbeyuLz2TFeic5zLJIE=";
+    hash = "sha256-wxGDy/cM9IBpgPNdun/P9f4447hJaaibBgIgLVaOirY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ko/komikku/package.nix
+++ b/pkgs/by-name/ko/komikku/package.nix
@@ -24,14 +24,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "komikku";
-  version = "1.103.0";
+  version = "1.105.0";
   pyproject = false;
 
   src = fetchFromCodeberg {
     owner = "valos";
     repo = "Komikku";
     tag = "v${version}";
-    hash = "sha256-1RYuaVIdiADAmbzXG8vi1eNoDh8yBL3aVfBsMiGd3h4=";
+    hash = "sha256-Zd+YUFnklu6JbytT/oS8hUU+IcqMfF4f/u6OKmg8uT4=";
   };
 
   nativeBuildInputs = [
@@ -62,6 +62,7 @@ python3.pkgs.buildPythonApplication rec {
     dateparser
     ebooklib
     emoji
+    jxlpy
     keyring
     lxml
     natsort

--- a/pkgs/by-name/ko/komikku/package.nix
+++ b/pkgs/by-name/ko/komikku/package.nix
@@ -24,14 +24,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "komikku";
-  version = "1.105.0";
+  version = "50.0.1";
   pyproject = false;
 
   src = fetchFromCodeberg {
     owner = "valos";
     repo = "Komikku";
     tag = "v${version}";
-    hash = "sha256-Zd+YUFnklu6JbytT/oS8hUU+IcqMfF4f/u6OKmg8uT4=";
+    hash = "sha256-9OxksblhdgGZYgr+lKEt0Kwpoa360ODgdbZrYpiOwkI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ko/komikku/package.nix
+++ b/pkgs/by-name/ko/komikku/package.nix
@@ -24,14 +24,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "komikku";
-  version = "1.102.0";
+  version = "1.103.0";
   pyproject = false;
 
   src = fetchFromCodeberg {
     owner = "valos";
     repo = "Komikku";
     tag = "v${version}";
-    hash = "sha256-wxGDy/cM9IBpgPNdun/P9f4447hJaaibBgIgLVaOirY=";
+    hash = "sha256-1RYuaVIdiADAmbzXG8vi1eNoDh8yBL3aVfBsMiGd3h4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sw/switcheroo/package.nix
+++ b/pkgs/by-name/sw/switcheroo/package.nix
@@ -20,19 +20,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "switcheroo";
-  version = "2.2.0";
+  version = "2.5.2";
 
   src = fetchFromGitLab {
     owner = "adhami3310";
     repo = "Switcheroo";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-AwecOA8HWGimhQyCEG3Z3hhwa9RVWssykUXsdvqqs9U=";
+    hash = "sha256-1SMFkzSH8ekJeP0VOPKxkvUNMh/wRzj31PIy6h051Ng=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
     name = "switcheroo-${finalAttrs.version}";
-    hash = "sha256-Ose1gx6vwKZCdtMDkyM9Y+f6wt7VDKTI3Wc7kep1428=";
+    hash = "sha256-QHdzLlmYCktQCUGZhIcuPhmR4rMUDeneptTdyPrwh1E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ta/tangram/package.nix
+++ b/pkgs/by-name/ta/tangram/package.nix
@@ -25,15 +25,15 @@
   wrapGAppsHook4,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tangram";
-  version = "3.3";
+  version = "3.4";
 
   src = fetchFromGitHub {
     owner = "sonnyp";
     repo = "Tangram";
-    tag = "v${version}";
-    hash = "sha256-OtQN8Iigu92iKa7CAaslIpbS0bqJ9Vus++inrgV/eeM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NTTunlWeS44iUxrfvjwB4NBbYjojVP2SxLDvh+aXvOA=";
     fetchSubmodules = true;
   };
 
@@ -99,4 +99,4 @@ stdenv.mkDerivation rec {
     ];
     teams = [ lib.teams.gnome-circle ];
   };
-}
+})

--- a/pkgs/by-name/ta/tangram/package.nix
+++ b/pkgs/by-name/ta/tangram/package.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tangram";
-  version = "3.4";
+  version = "3.5";
 
   src = fetchFromGitHub {
     owner = "sonnyp";
     repo = "Tangram";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NTTunlWeS44iUxrfvjwB4NBbYjojVP2SxLDvh+aXvOA=";
+    hash = "sha256-aK/oavYQJJYQaQ+PjxSDjSSvEaYz3G8aGXLdumOEXgk=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Backports: 
- #499900
- #479326 and #482375
- #506312
- #489072, #490357 and #502279
- #485757
- Partially 18dc8a95fb9d1378d66e52d67c35e0fad509c58e

Currently `python3.pkgs.buildPythonApplication` doesn't support the `finalAttrs` pattern on `25.11` so we can't fully backport that.

We can't backport `identity` and `shortwave` as `libglycin-gtk4` isn't available on `25.11`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
