### PR TITLE
busybox: fix potential build-time buffer overflow

### DIFF
--- a/pkgs/os-specific/linux/busybox/build-system-buffer-overflow.patch
+++ b/pkgs/os-specific/linux/busybox/build-system-buffer-overflow.patch
@@ -1,0 +1,27 @@
+From 3cf1ca7491bd5b6680e80355d76442ae14db681e Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Sun, 29 Mar 2026 13:18:09 +0200
+Subject: [PATCH] build system: fix potential buffer overflow
+
+This could potentially write one byte past the end of line.
+Identified by fortify-headers.
+---
+ scripts/basic/split-include.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/basic/split-include.c b/scripts/basic/split-include.c
+index 6ef29195e..93011d511 100644
+--- a/scripts/basic/split-include.c
++++ b/scripts/basic/split-include.c
+@@ -195,7 +195,7 @@ int main(int argc, const char * argv [])
+ 	ERROR_EXIT( "find" );
+ 
+     line[0] = '\n';
+-    while (fgets(line+1, buffer_size, fp_find))
++    while (fgets(line+1, buffer_size-1, fp_find))
+     {
+ 	if (strstr(list_target, line) == NULL)
+ 	{
+-- 
+2.53.0
+

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -90,6 +90,8 @@ stdenv.mkDerivation rec {
       excludes = [ "networking/httpd_ratelimit_cgi.c" ]; # New since release.
       hash = "sha256-Msm9sDZrVx7ofunnvnTS73SPKUUpR3Tv5xZ/wBd+rts=";
     })
+    # https://lists.busybox.net/pipermail/busybox/2026-March/092010.html
+    ./build-system-buffer-overflow.patch
   ]
   ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ./clang-cross.patch;
 


### PR DESCRIPTION
d8bcd4850391 ("fortify-headers: 1.1 -> 3.0.1") (currently on staging) breaks the musl build by identifying this issue.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
