### PR TITLE
gws: 0.22.1 -> 0.22.3

### DIFF
--- a/pkgs/by-name/gw/gws/package.nix
+++ b/pkgs/by-name/gw/gws/package.nix
@@ -39,6 +39,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/googleworkspace/cli/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     mainProgram = "gws";
-    maintainers = with lib.maintainers; [ imalison ];
+    maintainers = with lib.maintainers; [
+      imalison
+      miniharinn
+    ];
   };
 })

--- a/pkgs/by-name/gw/gws/package.nix
+++ b/pkgs/by-name/gw/gws/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gws";
-  version = "0.22.1";
+  version = "0.22.3";
 
   src = fetchFromGitHub {
     owner = "googleworkspace";
     repo = "cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yDgUvFXBhm7SNi51JeOm4+EOowNmY3dS0vF+AM6BygM=";
+    hash = "sha256-7bkTSDX6Mr/QcHkqCAI6oTAjLWdWzNicnvUu0IG/ejQ=";
   };
 
-  cargoHash = "sha256-9Ncn0r3Pih962l/4HKZjyWCvyCPQODIPX/oyroA1kL0=";
+  cargoHash = "sha256-iJ8M7NVqPbtPt1oeyDlh/46bWr5sKxO786sV4szhLCk=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
Release: https://github.com/googleworkspace/cli/releases/tag/v0.22.3
Diff: https://github.com/googleworkspace/cli/compare/v0.22.1...v0.22.3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
