### PR TITLE
various: maintain more figsoda packages

### DIFF
--- a/pkgs/by-name/ba/backdown/package.nix
+++ b/pkgs/by-name/ba/backdown/package.nix
@@ -2,6 +2,8 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -17,10 +19,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-qVE4MOFr0YO+9rAbfnz92h0KocaLu+v2u5ompwY/o6k=";
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "File deduplicator";
     homepage = "https://github.com/Canop/backdown";
-    changelog = "https://github.com/Canop/backdown/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/Canop/backdown/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "backdown";

--- a/pkgs/by-name/ba/backdown/package.nix
+++ b/pkgs/by-name/ba/backdown/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/Canop/backdown";
     changelog = "https://github.com/Canop/backdown/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "backdown";
   };
 })

--- a/pkgs/by-name/bi/binocle/package.nix
+++ b/pkgs/by-name/bi/binocle/package.nix
@@ -49,6 +49,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20 # or
       mit
     ];
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
 })

--- a/pkgs/by-name/bi/binocle/package.nix
+++ b/pkgs/by-name/bi/binocle/package.nix
@@ -9,6 +9,8 @@
   libxcursor,
   libx11,
   vulkan-loader,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -41,10 +43,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
       }
   '';
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Graphical tool to visualize binary data";
     mainProgram = "binocle";
     homepage = "https://github.com/sharkdp/binocle";
+    changelog = "https://github.com/sharkdp/binocle/releases/tag/v0.3.2";
     license = with lib.licenses; [
       asl20 # or
       mit

--- a/pkgs/by-name/cr/crabz/package.nix
+++ b/pkgs/by-name/cr/crabz/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       unlicense # or
       mit
     ];
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "crabz";
   };
 })

--- a/pkgs/by-name/cr/crabz/package.nix
+++ b/pkgs/by-name/cr/crabz/package.nix
@@ -3,6 +3,8 @@
   rustPlatform,
   fetchFromGitHub,
   cmake,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -19,6 +21,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-JzzDkbDVL6az6b/s640KikSNJCwv8hf0aFcmGnvYQu4=";
 
   nativeBuildInputs = [ cmake ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Cross platform, fast, compression and decompression tool";

--- a/pkgs/by-name/cs/csview/package.nix
+++ b/pkgs/by-name/cs/csview/package.nix
@@ -2,6 +2,8 @@
   fetchFromGitHub,
   lib,
   rustPlatform,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -17,10 +19,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-CXIfE1EsNwm4vsybQSdfKewBYpzBh+uQu1jYAm8DDtI=";
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "High performance csv viewer with cjk/emoji support";
     mainProgram = "csview";
     homepage = "https://github.com/wfxr/csview";
+    changelog = "https://github.com/wfxr/csview/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
       mit # or
       asl20

--- a/pkgs/by-name/cs/csview/package.nix
+++ b/pkgs/by-name/cs/csview/package.nix
@@ -25,6 +25,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit # or
       asl20
     ];
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
 })

--- a/pkgs/by-name/dn/dnspeep/package.nix
+++ b/pkgs/by-name/dn/dnspeep/package.nix
@@ -28,6 +28,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "dnspeep";
     homepage = "https://github.com/jvns/dnspeep";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
 })

--- a/pkgs/by-name/dn/dnspeep/package.nix
+++ b/pkgs/by-name/dn/dnspeep/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   libpcap,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -23,10 +24,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     LIBPCAP_VER = libpcap.version;
   };
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Spy on the DNS queries your computer is making";
     mainProgram = "dnspeep";
     homepage = "https://github.com/jvns/dnspeep";
+    changelog = "https://github.com/jvns/dnspeep/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.progrm_jarvis ];
   };

--- a/pkgs/by-name/ez/ezno/package.nix
+++ b/pkgs/by-name/ez/ezno/package.nix
@@ -28,6 +28,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/kaleidawave/ezno";
     changelog = "https://github.com/kaleidawave/ezno/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
 })

--- a/pkgs/by-name/ez/ezno/package.nix
+++ b/pkgs/by-name/ez/ezno/package.nix
@@ -2,31 +2,40 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  pkg-config,
+  openssl,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ezno";
-  version = "0.0.8";
+  version = "0.0.23";
 
   src = fetchFromGitHub {
     owner = "kaleidawave";
     repo = "ezno";
     rev = "release/ezno-${finalAttrs.version}";
-    hash = "sha256-0yLEpNkl7KjBEGxNONtfMjVlWMSKGZ6TbYJMsCeQ3ms=";
+    hash = "sha256-YS0DgRtCy+RJsPMDBvAxjF4vjxfCb5gmQWP7YPUWbWU=";
   };
 
-  cargoHash = "sha256-v4lgHx+sR58CshZJCUYrtaW4EDFBUKFPJJ6V+eyf5Bc=";
+  cargoHash = "sha256-7qTaI8nXH86yIXat584WI6AbJVRZ4PBXdnYDebUrpPA=";
 
   cargoBuildFlags = [
     "--bin"
     "ezno"
   ];
 
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "JavaScript compiler and TypeScript checker with a focus on static analysis and runtime performance";
     mainProgram = "ezno";
     homepage = "https://github.com/kaleidawave/ezno";
-    changelog = "https://github.com/kaleidawave/ezno/releases/tag/${finalAttrs.src.rev}";
+    changelog = "https://github.com/kaleidawave/ezno/releases/tag/release/ezno-${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.progrm_jarvis ];
   };

--- a/pkgs/by-name/im/imagineer/package.nix
+++ b/pkgs/by-name/im/imagineer/package.nix
@@ -5,20 +5,22 @@
   fetchFromGitHub,
   installShellFiles,
   nasm,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "sic-image-cli";
-  version = "0.22.4";
+  pname = "imagineer";
+  version = "0.24.0";
 
   src = fetchFromGitHub {
     owner = "foresterre";
-    repo = "sic";
+    repo = "imagineer";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-PFbHHO3m4mnV5s8DVev/iao9sC3FYht0whTHYzO25Yo=";
+    hash = "sha256-pnnMRRccxSA5F6oIbe9wvdMmuSUMI7Da+NtwyH2psjo=";
   };
 
-  cargoHash = "sha256-HL/KCC8Y42OFL1LXoewmH1Bxp6FICuDjkTnK5DE94Ms=";
+  cargoHash = "sha256-6QMMP6Uss9r6zNd/S6w7yo19IBOQyLmFvcn2o0MkOq4=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -30,9 +32,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   postInstall = ''
-    installShellCompletion sic.{bash,fish}
-    installShellCompletion --zsh _sic
+    installShellCompletion ig.{bash,fish}
+    installShellCompletion --zsh _ig
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Accessible image processing and conversion from the terminal";
@@ -42,8 +49,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20 # or
       mit
     ];
-    maintainers = [ ];
-    mainProgram = "sic";
+    maintainers = [ lib.maintainers.progrm_jarvis ];
+    mainProgram = "ig";
     # The last successful Darwin Hydra build was in 2024
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;
   };

--- a/pkgs/by-name/ma/macchina/package.nix
+++ b/pkgs/by-name/ma/macchina/package.nix
@@ -3,6 +3,8 @@
   rustPlatform,
   fetchFromGitHub,
   installShellFiles,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -26,10 +28,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installManPage doc/macchina.{1,7}
   '';
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Fast, minimal and customizable system information fetcher";
     homepage = "https://github.com/Macchina-CLI/macchina";
-    changelog = "https://github.com/Macchina-CLI/macchina/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/Macchina-CLI/macchina/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [
       _414owen

--- a/pkgs/by-name/ma/macchina/package.nix
+++ b/pkgs/by-name/ma/macchina/package.nix
@@ -33,6 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [
       _414owen
+      progrm_jarvis
     ];
     mainProgram = "macchina";
   };

--- a/pkgs/by-name/no/nomino/package.nix
+++ b/pkgs/by-name/no/nomino/package.nix
@@ -2,6 +2,8 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -17,10 +19,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-daHhCr55RzIHooGXBK831SYD1b8NPEDD6mtDut6nuaQ=";
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Batch rename utility for developers";
     homepage = "https://github.com/yaa110/nomino";
-    changelog = "https://github.com/yaa110/nomino/releases/tag/${finalAttrs.src.rev}";
+    changelog = "https://github.com/yaa110/nomino/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       mit # or
       asl20

--- a/pkgs/by-name/no/nomino/package.nix
+++ b/pkgs/by-name/no/nomino/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit # or
       asl20
     ];
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "nomino";
   };
 })

--- a/pkgs/by-name/wa/wasmer-pack/package.nix
+++ b/pkgs/by-name/wa/wasmer-pack/package.nix
@@ -2,31 +2,38 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wasmer-pack";
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "wasmerio";
     repo = "wasmer-pack";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-+wqgYkdkuhPFkJBdQLnUKAGmUfGBU9mBfMRNBFmiT4E=";
+    hash = "sha256-9dIdwDKQyut2n1hgq4QzNZuGmGb1wUSmTJf9no6XI5A=";
   };
 
-  cargoHash = "sha256-PZudXmdPz6fG7NDC/yN7qG+RQFSzNynXo6SpYJEku9A=";
+  cargoHash = "sha256-Hz+cvi82K9NJrn2yEkrVa29yhDUiE1gXZOwHFPljqqw=";
 
   cargoBuildFlags = [ "-p=wasmer-pack-cli" ];
 
   # requires internet access
   doCheck = false;
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Import your WebAssembly code just like any other dependency";
     mainProgram = "wasmer-pack";
     homepage = "https://github.com/wasmerio/wasmer-pack";
-    changelog = "https://github.com/wasmerio/wasmer-pack/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/wasmerio/wasmer-pack/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.progrm_jarvis ];
   };

--- a/pkgs/by-name/wa/wasmer-pack/package.nix
+++ b/pkgs/by-name/wa/wasmer-pack/package.nix
@@ -28,6 +28,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/wasmerio/wasmer-pack";
     changelog = "https://github.com/wasmerio/wasmer-pack/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1778,6 +1778,7 @@ mapAliases {
   shades-of-gray-theme = throw "'shades-of-gray-theme' has been removed because upstream is a 404"; # Added 2025-12-20
   shared_desktop_ontologies = throw "'shared_desktop_ontologies' has been removed as it had been abandoned upstream"; # Added 2025-11-09
   shipyard = throw "'shipyard' has been renamed to/replaced by 'jumppad'"; # Converted to throw 2025-10-27
+  sic-image-cli = warnAlias "'sic-image-cli' has been renamed to 'imagineer'" imagineer; # Added 2026-03-29
   siduck76-st = throw "'siduck76-st' has been renamed to/replaced by 'st-snazzy'"; # Converted to throw 2025-10-27
   sierra-breeze-enhanced = throw "'sierra-breeze-enhanced' has been removed, as it is only compatible with Plasma 5, which is EOL"; # Added 2025-08-20
   signal-desktop-bin = throw "'signal-desktop-bin' has been replaced by 'signal-desktop' which is built from source"; # Added 2026-03-02


### PR DESCRIPTION
Take maintenance over more figsoda's packages:

* `csview`
* `dnspeep`
* `ezno` (`0.0.8` -> `0.2.3`)
* `sic-image-cli` (`0.22.4` -> `0.24.0`;now named `imagineer` in upstream)
* `binocle`
* `backdown`
* `wasmer-pack` (`0.7.1` -> `0.7.2`)
* `macchina`
* `nomino`
* `crabz`

All updates include the addition of `passthru.updateScript` with `versionCheckHook` where applicable.

Part of #458096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
