### PR TITLE
snip: init at 0.8.1

### DIFF
--- a/pkgs/by-name/sn/snip/package.nix
+++ b/pkgs/by-name/sn/snip/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "snip";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "edouard-claude";
+    repo = "snip";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-95CHMKE894IkQONvVKO44/9bEfXzJrNRV+iVIVRx8TA=";
+  };
+
+  vendorHash = "sha256-2MxFZqjNuLzcuu+bsLyOyHIakCxh7j0FUx8LsjZRhrY=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "CLI proxy that reduces LLM token consumption by filtering verbose shell output";
+    homepage = "https://github.com/edouard-claude/snip";
+    changelog = "https://github.com/edouard-claude/snip/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gdifolco ];
+    mainProgram = "snip";
+  };
+})


### PR DESCRIPTION
Introduce [snip](https://github.com/edouard-claude/snip)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
