### PR TITLE
deno: 2.7.4 -> 2.7.9

### DIFF
--- a/pkgs/by-name/de/deno/fetchers.nix
+++ b/pkgs/by-name/de/deno/fetchers.nix
@@ -11,7 +11,7 @@
     args:
     fetchurl {
       name = "librusty_v8-${args.version}";
-      url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+      url = "https://github.com/denoland/rusty_v8/releases/download/v${args.version}/librusty_v8_simdutf_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
       sha256 = args.shas.${stdenv.hostPlatform.system};
       meta = {
         inherit (args) version;

--- a/pkgs/by-name/de/deno/librusty_v8.nix
+++ b/pkgs/by-name/de/deno/librusty_v8.nix
@@ -2,11 +2,11 @@
 { fetchLibrustyV8 }:
 
 fetchLibrustyV8 {
-  version = "146.1.0";
+  version = "147.0.0";
   shas = {
-    x86_64-linux = "sha256-PYCBh8+RY1nvPOKXMCns5mDRo2j0SB3Edw/ut7npjxo=";
-    aarch64-linux = "sha256-EGlTttOowHhoFBy8FQeokCnbPLi4tfkIhSek28TfcGQ=";
-    x86_64-darwin = "sha256-61d4tQ/PcNPUvDuQsMNTNUO43zLZSVEHOjdGFG0u4W8=";
-    aarch64-darwin = "sha256-BMKybPdxP9+7QD/yfbnPnFxD8N7kHPUkMcEEf4P4iSE=";
+    x86_64-linux = "sha256-PXLRowkOBRVWeonQDTN6e4BQlSLK/kobCX7eE0Y1NLY=";
+    aarch64-linux = "sha256-6jaFVmmYYOZNZmk6UHUAGyibSBQn51Ie57hB7CIZBFI=";
+    x86_64-darwin = "sha256-yTrxJ5ABXg1r0myZqy4J3m/ivYdXnsgG089PrD5cMhY=";
+    aarch64-darwin = "sha256-HVr7hNzZk4qQTct2Px7DvSJAnyq1duJCqJawY475SR4=";
   };
 }

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -30,17 +30,17 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "deno";
-  version = "2.7.4";
+  version = "2.7.9";
 
   src = fetchFromGitHub {
     owner = "denoland";
     repo = "deno";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true; # required for tests
-    hash = "sha256-L1dLMcA7YDNMF8uRImHZlQ0mXox3kpGln6MXeB9cMLU=";
+    hash = "sha256-asRSIDpVN8sZgck5cocqfjcFNnP3CekR0lwBi0jr6GM=";
   };
 
-  cargoHash = "sha256-ebozsCns5J95u+C4smysslJB9xVltHeVOdfD2IBuLtI=";
+  cargoHash = "sha256-lL9ZeMUi5cwrqikg+GiR5hQNgWPKlpAN7yQIXSsr93k=";
 
   patches = [
     ./patches/0002-tests-replace-hardcoded-paths.patch

--- a/pkgs/by-name/de/deno/update/librusty_v8.ts
+++ b/pkgs/by-name/de/deno/update/librusty_v8.ts
@@ -26,7 +26,7 @@ const fetchArchShaTasks = (version: string, arches: Architecture[]) =>
     async (arch: Architecture): Promise<PrefetchResult> => {
       log("Fetching:", arch.nix);
       const sha256 = await run("nix-prefetch-url", [
-        `https://github.com/denoland/rusty_v8/releases/download/v${version}/librusty_v8_release_${arch.rust}.a.gz`
+        `https://github.com/denoland/rusty_v8/releases/download/v${version}/librusty_v8_simdutf_release_${arch.rust}.a.gz`
       ]);
       const sha256_sri = await run("nix-hash", ["--type", "sha256", "--to-sri", sha256]);
       log("Done:    ", arch.nix);


### PR DESCRIPTION
The `librusty_v8` change is required to fix a linking error (relevant upstream change: https://github.com/denoland/deno/pull/32743)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
