### PR TITLE
alvr: use ffmpeg_7 instead of ffmpeg_8

### DIFF
--- a/pkgs/by-name/al/alvr/package.nix
+++ b/pkgs/by-name/al/alvr/package.nix
@@ -11,7 +11,7 @@
   brotli,
   bzip2,
   celt,
-  ffmpeg,
+  ffmpeg_7,
   gmp,
   jack2,
   lame,
@@ -56,7 +56,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   patches = [
     (replaceVars ./fix-finding-libs.patch {
-      ffmpeg = lib.getDev ffmpeg;
+      ffmpeg = lib.getDev ffmpeg_7;
       x264 = lib.getDev x264;
     })
   ];
@@ -107,7 +107,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     brotli
     bzip2
     celt
-    ffmpeg
+    ffmpeg_7
     gmp
     jack2
     lame


### PR DESCRIPTION
Fixes vaapi error messages, as ALVR uses ffmpeg 6, but ffmpeg 7 works fine based on testing.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
