### PR TITLE
granted: 0.38.0 -> 0.39.0

### DIFF
--- a/pkgs/by-name/gr/granted/package.nix
+++ b/pkgs/by-name/gr/granted/package.nix
@@ -88,7 +88,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Easiest way to access your cloud";
     homepage = "https://github.com/fwdcloudsec/granted";
-    changelog = "https://github.com/fwdcloudsec/granted/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/fwdcloudsec/granted/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       jlbribeiro

--- a/pkgs/by-name/gr/granted/package.nix
+++ b/pkgs/by-name/gr/granted/package.nix
@@ -11,16 +11,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "granted";
-  version = "0.38.0";
+  version = "0.39.0";
 
   src = fetchFromGitHub {
     owner = "fwdcloudsec";
     repo = "granted";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-xHpYtHG0fJ/VvJ/4lJ90ept3yGzJRnmtFQFbYxJtxwY=";
+    sha256 = "sha256-/5JP6laC+k+O8GWSl1eo0slqzYzYB86UF3irDX6Z0iQ=";
   };
 
-  vendorHash = "sha256-Y8g5495IYgQ2lvq5qbnQmoxwEYfzzx12KfMS6wF2QXE=";
+  vendorHash = "sha256-L96zj/AEUze/SfuFeK+I1+w2zXcxr5BSW3wGQFbTbJU=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/by-name/gr/granted/package.nix
+++ b/pkgs/by-name/gr/granted/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   version = "0.38.0";
 
   src = fetchFromGitHub {
-    owner = "common-fate";
+    owner = "fwdcloudsec";
     repo = "granted";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-xHpYtHG0fJ/VvJ/4lJ90ept3yGzJRnmtFQFbYxJtxwY=";
@@ -27,11 +27,11 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/common-fate/granted/internal/build.Version=v${finalAttrs.version}"
-    "-X github.com/common-fate/granted/internal/build.Commit=${finalAttrs.src.rev}"
-    "-X github.com/common-fate/granted/internal/build.Date=1970-01-01-00:00:01"
-    "-X github.com/common-fate/granted/internal/build.BuiltBy=Nix"
-    "-X github.com/common-fate/granted/internal/build.ConfigFolderName=.granted"
+    "-X github.com/fwdcloudsec/granted/internal/build.Version=v${finalAttrs.version}"
+    "-X github.com/fwdcloudsec/granted/internal/build.Commit=${finalAttrs.src.rev}"
+    "-X github.com/fwdcloudsec/granted/internal/build.Date=1970-01-01-00:00:01"
+    "-X github.com/fwdcloudsec/granted/internal/build.BuiltBy=Nix"
+    "-X github.com/fwdcloudsec/granted/internal/build.ConfigFolderName=.granted"
   ];
 
   subPackages = [
@@ -87,8 +87,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Easiest way to access your cloud";
-    homepage = "https://github.com/common-fate/granted";
-    changelog = "https://github.com/common-fate/granted/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/fwdcloudsec/granted";
+    changelog = "https://github.com/fwdcloudsec/granted/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       jlbribeiro

--- a/pkgs/by-name/gr/granted/package.nix
+++ b/pkgs/by-name/gr/granted/package.nix
@@ -16,7 +16,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "fwdcloudsec";
     repo = "granted";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-/5JP6laC+k+O8GWSl1eo0slqzYzYB86UF3irDX6Z0iQ=";
   };
 


### PR DESCRIPTION
NB: the project ownership has been transferred to https://github.com/fwdcloudsec/, hence the 2nd commit to reflect this.

ping @jlbribeiro.

1st contribution to nixpkgs, I hope I didn't miss out something important :pray: 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
