### PR TITLE
luarocks-nix: mark broken for Lua 5.5

### DIFF
--- a/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
+++ b/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
@@ -1,4 +1,6 @@
 {
+  lib,
+  lua,
   luarocks_bootstrap,
   fetchFromGitHub,
   unstableGitUpdater,
@@ -42,5 +44,10 @@ luarocks_bootstrap.overrideAttrs (old: {
       platforms
       ;
     mainProgram = "luarocks";
+    # luarocks-nix is based on upstream 3.11.0, which predates Lua 5.5 support;
+    # Lua 5.5 makes for-loop variables const, breaking luarocks source code
+    # throughout (e.g. luarocks/core/util.lua:96). Upstream luarocks 3.13.0 has
+    # the fixes, but the nix-community fork has not been rebased yet.
+    broken = lib.versionAtLeast lua.luaversion "5.5";
   };
 })


### PR DESCRIPTION
`luarocks-nix` is based on upstream luarocks 3.11.0, which predates Lua 5.5 support. Lua 5.5 makes for-loop variables const, breaking luarocks source code throughout (e.g. `core/util.lua` reassigns loop variable `k`). Upstream luarocks 3.13.0 has the fixes, but the nix-community fork has not been rebased yet.

CC @teto for https://github.com/nix-community/luarocks-nix

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test