### PR TITLE
spidermonkey_140: 140.7.1 -> 140.9.0

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/140.nix
+++ b/pkgs/development/interpreters/spidermonkey/140.nix
@@ -1,4 +1,4 @@
 import ./common.nix {
-  version = "140.7.1";
-  hash = "sha512-fYZ/o8nJSQP2WDvnWtSqjZGPmPdMmcZhWg5AyvIcVFowFJEVIUh2aT7xdYoyDr3M7wF8SENlwZXlWZjM4IhmPA==";
+  version = "140.9.0";
+  hash = "sha512-vAP9KnPQCoi9Cjye6u/mGP+zQib7e8L6xKAiRv8p/gOEI793U4Jz7m+sJfsePk+pi7UiAmrjQnoK1fQdLsa6mA==";
 }


### PR DESCRIPTION
Tested by picking this commit onto master, as I don't have the compute to build the necessary clang/llvm/rust on staging right now.

This seems to fix a few security advisories ([140.8](https://www.mozilla.org/en-US/security/advisories/mfsa2026-15/), [140.9](https://www.mozilla.org/en-US/security/advisories/mfsa2026-22/)):
- [140.9] CVE-2026-4698: JIT miscompilation in the JavaScript Engine: JIT component, likely fix: https://github.com/mozilla-firefox/firefox/commit/7b5c30b335c787c1dfe8e322f123300138f91b6f
- [140.9] CVE-2026-4701: Use-after-free in the JavaScript Engine component, likely fix: https://github.com/mozilla-firefox/firefox/commit/9d9a6875621471d6c8283036d9c2d2c530617dc6
- [140.9] CVE-2026-4702: JIT miscompilation in the JavaScript Engine component, likely fix: https://github.com/mozilla-firefox/firefox/commit/4bdc84018a4b1a3c2d816fa7b5f1dfa04c40caa4
- [140.9] CVE-2026-4716: Incorrect boundary conditions, uninitialized memory in the JavaScript Engine component, likely fix: https://github.com/mozilla-firefox/firefox/commit/059996e56f7901cfa06a48fe6ce6e51056a1756e
- [140.8] CVE-2026-2758: Use-after-free in the JavaScript: GC component, likely fix: https://github.com/mozilla-firefox/firefox/commit/4b8faa68bcc3bfe2d3103f2adc0f0c9500947bfb
- [140.8] CVE-2026-2762: Integer overflow in the JavaScript: Standard Library component, likely fix: https://github.com/mozilla-firefox/firefox/commit/243bc15c0004270cf7244c1c3551bf74bdb022fa
- [140.8] CVE-2026-2763: Use-after-free in the JavaScript Engine component, likely fix: https://github.com/mozilla-firefox/firefox/commit/7777b729fc5bb28924a1b2df985a892e52ef5e6e
- [140.8] CVE-2026-2764: JIT miscompilation, use-after-free in the JavaScript Engine: JIT component, likely fix: https://github.com/mozilla-firefox/firefox/commit/12c49cacb48ca2e5e95e5f29d066901ff4114e8e
- [140.8] CVE-2026-2765: Use-after-free in the JavaScript Engine component, likely fix: https://github.com/mozilla-firefox/firefox/commit/eac910521b1b1279b286d9b3fa65e650e658ae64
- [140.8] CVE-2026-2766: Use-after-free in the JavaScript Engine: JIT component, likely fix: https://github.com/mozilla-firefox/firefox/commit/3f78a4ff83b9c3a313c365b0ac4b991b438443d0
- [140.8] CVE-2026-2783: Information disclosure due to JIT miscompilation in the JavaScript Engine: JIT component, likely fix: https://github.com/mozilla-firefox/firefox/commit/d8ed7cb0b2bc7e0f4ea60025f037fc32b7405515 
- [140.8] CVE-2026-2785: Invalid pointer in the JavaScript Engine component, likely fix: https://github.com/mozilla-firefox/firefox/commit/88809d9c9b3a61684a377d0a5b9b01b83f6f9392
- [140.8] CVE-2026-2786: Use-after-free in the JavaScript Engine component, likely fix: https://github.com/mozilla-firefox/firefox/commit/f45b0dbc08e81c0b81377bb5b8b4fda0528524bd

It should probably be backported to 25.11.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
