### PR TITLE
python3Packages.inject: 5.3.0 -> 5.3.0-unstable-2026-01-05

### DIFF
--- a/pkgs/development/python-modules/inject/default.nix
+++ b/pkgs/development/python-modules/inject/default.nix
@@ -4,21 +4,24 @@
   hatch-vcs,
   hatchling,
   lib,
-  nix-update-script,
   pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "inject";
-  version = "5.3.0";
+  version = "5.3.0-unstable-2026-01-05";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ivankorobkov";
     repo = "python-inject";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-c/OpEsT9KF7285xfD+VRorrNHn3r9IPp/ts9JHyGK9s=";
+    rev = "2ca60abc5370cd91d87e5a21ac373d0ca710f76d";
+    hash = "sha256-FumossBUGwp1XxWthx3gpIietvZsmPpkd52y9jjVKjQ=";
   };
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION =
+    assert lib.hasInfix "unstable" finalAttrs.version;
+    builtins.head (lib.splitString "-" finalAttrs.version);
 
   build-system = [
     hatchling
@@ -31,12 +34,10 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "inject" ];
 
-  passthru.updateScript = nix-update-script { };
-
   meta = {
     description = "Python dependency injection framework";
     homepage = "https://github.com/ivankorobkov/python-inject";
-    changelog = "https://github.com/ivankorobkov/python-inject/blob/${finalAttrs.src.tag}/CHANGES.md";
+    changelog = "https://github.com/ivankorobkov/python-inject/blob/${finalAttrs.src.rev}/CHANGES.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ PerchunPak ];
   };


### PR DESCRIPTION
Bump to upstream master to fix test failures on Python 3.14, where the implicit event loop from `asyncio.get_event_loop()` was removed. The upstream fix (commit 3d525d0) is not part of any release yet.

Since v5.3.0 the library code changes are:

1. Ruff formatting (87c6496) - purely cosmetic (string quotes, type hints style, noqa comments). This is what made the patch context not match when I tried to cherry-pick 3d525d0.
2. `allow_override=True` for `Hashables` (3d19a2e) - bug fix, additive
3. Type hint updates (0e8ee5c) - cosmetic
4. attr descriptor rewrite + attr_dc alias (476bebf, b14f45d, b0fabaf) — new/changed feature
5. inject.attr auto-discovery (29714bb) - new feature
6. CI/test/linting/directory rename - non-functional

Removed the update script to avoid having package reverts from the updater.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
