### PR TITLE
_4ti2: patch in absolute path to `which`

### DIFF
--- a/pkgs/by-name/_4/_4ti2/package.nix
+++ b/pkgs/by-name/_4/_4ti2/package.nix
@@ -5,6 +5,7 @@
   autoreconfHook,
   glpk,
   gmp,
+  which,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -17,6 +18,12 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "Release_${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     hash = "sha256-bFvq90hLLGty7p6NLxOARVvKdizg3bp2NkP9nZpVFzQ=";
   };
+
+  postPatch = ''
+    substituteInPlace src/{groebner/script.template.in,zsolve/{graver,hilbert}.template} \
+      --replace-fail 'SCRIPT=$(realpath $(which "$0"))' \
+                     'SCRIPT=$(realpath $(${lib.getExe which} "$0"))'
+  '';
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
I ran into this when trying to package Macaulay2 using Nix.
This involved running scripts from `4ti2` during the buildPhase, where `which` is not in `PATH`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
