### PR TITLE
enpass: set mainProgram to `Enpass`

### DIFF
--- a/pkgs/by-name/en/enpass/package.nix
+++ b/pkgs/by-name/en/enpass/package.nix
@@ -104,6 +104,7 @@ let
         ewok
         dritter
       ];
+      mainProgram = "Enpass";
     };
 
     nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/en/enpass/package.nix
+++ b/pkgs/by-name/en/enpass/package.nix
@@ -101,6 +101,7 @@ let
         "i686-linux"
       ];
       maintainers = with lib.maintainers; [ ewok ];
+      mainProgram = "Enpass";
     };
 
     nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
I set the `mainProgram` of `enpass` to `Enpass`.

>
  ```sh
  $ ls -la $(NIXPKGS_ALLOW_UNFREE=1 nix path-info nixpkgs#enpass --impure)/bin
  total 90384
  dr-xr-xr-x 1 root root      122 Jän  1  1970 .
  dr-xr-xr-x 1 root root       16 Jän  1  1970 ..
  -r-xr-xr-x 2 root root 82098088 Jän  1  1970 .Enpass-wrapped
  -r-xr-xr-x 2 root root     2206 Jän  1  1970 Enpass
  -r-xr-xr-x 2 root root  5232088 Jän  1  1970 importer_enpass
  -r--r--r-- 2 root root      167 Jän  1  1970 qt.conf
  -r-xr-xr-x 2 root root  5206936 Jän  1  1970 wifisyncserver_bin
  ```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
