### PR TITLE
fflas-ffpack: detect OpenMP

### DIFF
--- a/pkgs/by-name/ff/fflas-ffpack/package.nix
+++ b/pkgs/by-name/ff/fflas-ffpack/package.nix
@@ -31,6 +31,11 @@ stdenv.mkDerivation rec {
       hash = "sha256-COJxb1Y47rLBogJuXzznKHOSs9gAX1BtN+j8pEqOhLY=";
       excludes = [ "benchmarks/*" ];
     })
+    (fetchpatch2 {
+      name = "do-not-use-_mm_permute_ps-for-simd128_float.patch";
+      url = "https://github.com/linbox-team/fflas-ffpack/commit/be33b602ecdef543a30ea494899b08610c7e0a74.patch?full_index=1";
+      hash = "sha256-YWUFnPViXwyyHLXuewX6KQsgUiwgl6vfYnZX2JzgkE4=";
+    })
   ];
 
   nativeCheckInputs = [

--- a/pkgs/by-name/ff/fflas-ffpack/package.nix
+++ b/pkgs/by-name/ff/fflas-ffpack/package.nix
@@ -8,6 +8,7 @@
   blas,
   lapack,
   gmpxx,
+  fetchpatch2,
 }:
 
 assert (!blas.isILP64) && (!lapack.isILP64);
@@ -22,6 +23,15 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-Eztc2jUyKRVUiZkYEh+IFHkDuPIy+Gx3ZW/MsuOVaMc=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "detect-openmp.patch";
+      url = "https://github.com/linbox-team/fflas-ffpack/commit/833bb2fa4e87e51e3f7fa1d97f3b4372c1ee4200.patch?full_index=1";
+      hash = "sha256-COJxb1Y47rLBogJuXzznKHOSs9gAX1BtN+j8pEqOhLY=";
+      excludes = [ "benchmarks/*" ];
+    })
+  ];
 
   nativeCheckInputs = [
     gmpxx

--- a/pkgs/by-name/ff/fflas-ffpack/package.nix
+++ b/pkgs/by-name/ff/fflas-ffpack/package.nix
@@ -55,21 +55,6 @@ stdenv.mkDerivation rec {
     "--with-blas-libs=-lcblas"
     "--with-lapack-libs=-llapacke"
     "--without-archnative"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isx86_64 [
-    # disable SIMD instructions (which are enabled *when available* by default)
-    # for now we need to be careful to disable *all* relevant versions of an instruction set explicitly (https://github.com/linbox-team/fflas-ffpack/issues/284)
-    "--${if stdenv.hostPlatform.sse3Support then "enable" else "disable"}-sse3"
-    "--${if stdenv.hostPlatform.ssse3Support then "enable" else "disable"}-ssse3"
-    "--${if stdenv.hostPlatform.sse4_1Support then "enable" else "disable"}-sse41"
-    "--${if stdenv.hostPlatform.sse4_2Support then "enable" else "disable"}-sse42"
-    "--${if stdenv.hostPlatform.avxSupport then "enable" else "disable"}-avx"
-    "--${if stdenv.hostPlatform.avx2Support then "enable" else "disable"}-avx2"
-    "--${if stdenv.hostPlatform.avx512Support then "enable" else "disable"}-avx512f"
-    "--${if stdenv.hostPlatform.avx512Support then "enable" else "disable"}-avx512dq"
-    "--${if stdenv.hostPlatform.avx512Support then "enable" else "disable"}-avx512vl"
-    "--${if stdenv.hostPlatform.fmaSupport then "enable" else "disable"}-fma"
-    "--${if stdenv.hostPlatform.fma4Support then "enable" else "disable"}-fma4"
   ];
   doCheck = true;
 


### PR DESCRIPTION
As can be seen in e.g. https://hydra.nixos.org/build/323736879/nixlog/1, `fflas-ffpack` is not able to detect OpenMP support.

This patch (part of https://github.com/linbox-team/fflas-ffpack/commit/833bb2fa4e87e51e3f7fa1d97f3b4372c1ee4200) fixes that.

I also cleaned up the SIMD flags which I don't think are needed since https://github.com/linbox-team/fflas-ffpack/pull/293 got merged.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
