### PR TITLE
discord: Expose desktop item in `passthru`

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -78,6 +78,20 @@
 }:
 
 let
+  desktopItem = makeDesktopItem {
+    name = pname;
+    exec = binaryName;
+    icon = pname;
+    inherit desktopName;
+    genericName = meta.description;
+    categories = [
+      "Network"
+      "InstantMessaging"
+    ];
+    mimeTypes = [ "x-scheme-handler/discord" ];
+    startupWMClass = "discord";
+  };
+
   discordMods = [
     withVencord
     withEquicord
@@ -235,23 +249,9 @@ stdenv.mkDerivation (finalAttrs: {
       echo 'require("${moonlight}/injector.js").inject(require("path").join(__dirname, "../_app.asar"));' > $out/opt/${binaryName}/resources/app/injector.js
     '';
 
-  desktopItem = makeDesktopItem {
-    name = pname;
-    exec = binaryName;
-    icon = pname;
-    inherit desktopName;
-    genericName = meta.description;
-    categories = [
-      "Network"
-      "InstantMessaging"
-    ];
-    mimeTypes = [ "x-scheme-handler/discord" ];
-    startupWMClass = "discord";
-  };
-
   passthru = {
     # make it possible to run disableBreakingUpdates standalone
-    inherit disableBreakingUpdates;
+    inherit desktopItem disableBreakingUpdates;
     updateScript = ./update.py;
 
     tests = {


### PR DESCRIPTION
For referencing it in `xdg.mime.defaultApplications` and similar.

Helps with #347835.

Ping @Artturin @FlameFlag @Infinidoge @jopejoe1 @Scrumplex

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
