### PR TITLE
nixosTests.dolibarr: fix test regression

### DIFF
--- a/nixos/tests/dolibarr.nix
+++ b/nixos/tests/dolibarr.nix
@@ -61,9 +61,6 @@
       h2o_postgresql.wait_for_open_port(80)
 
       for machine in (nginx_mysql, h2o_postgresql):
-        # Sanity checks on URLs.
-        machine.succeed("curl -fL http://localhost/index.php")
-        machine.succeed("curl -fL http://localhost/")
         # Perform installation.
         machine.succeed('curl -fL -X POST http://localhost/install/check.php -F selectlang=auto')
         machine.succeed('curl -fL -X POST http://localhost/install/fileconf.php -F selectlang=auto')


### PR DESCRIPTION
I've been seeing this Dolibarr test fail for a while now on zh.fail, so see this PR as an early ZHF PR.

In 401e2b5e843b6a39f90a3649d9289e8cf27101b7, the sanity check `curl` commands were uncommented. Since this scripted install process is rather fragile, these requests change some internal state which in turn breaks the installer, because the `conf.php` file does not get written properly. Note that these lines have always been commented from the first commit (c2563fe47629b32fd3d2505030d6b44ac2f07736) until they were uncommented and broke the test.

CC: @toastal
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
