### PR TITLE
steamcmd: Use stdenvNoCC instead of stdenv

### DIFF
--- a/pkgs/by-name/st/steamcmd/package.nix
+++ b/pkgs/by-name/st/steamcmd/package.nix
@@ -29,7 +29,8 @@ stdenvNoCC.mkDerivation {
   version = "20180104"; # According to steamcmd_linux.tar.gz mtime
 
   src =
-    srcs.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+    srcs.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
 
   # The source tarball does not have a single top-level directory.
   preUnpack = ''
@@ -49,7 +50,9 @@ stdenvNoCC.mkDerivation {
       --subst-var out \
       --subst-var-by coreutils ${coreutils} \
       --subst-var-by steamRoot '${steamRoot}' \
-      --subst-var-by steamRun ${if stdenvNoCC.hostPlatform.isLinux then (lib.getExe steam-run) else "exec"}
+      --subst-var-by steamRun ${
+        if stdenvNoCC.hostPlatform.isLinux then (lib.getExe steam-run) else "exec"
+      }
     chmod 0755 $out/bin/steamcmd
   '';
 

--- a/pkgs/by-name/st/steamcmd/package.nix
+++ b/pkgs/by-name/st/steamcmd/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchurl,
   steam-run,
   coreutils,
@@ -24,12 +24,12 @@ let
       };
     };
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   pname = "steamcmd";
   version = "20180104"; # According to steamcmd_linux.tar.gz mtime
 
   src =
-    srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    srcs.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
 
   # The source tarball does not have a single top-level directory.
   preUnpack = ''
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
       --subst-var out \
       --subst-var-by coreutils ${coreutils} \
       --subst-var-by steamRoot '${steamRoot}' \
-      --subst-var-by steamRun ${if stdenv.hostPlatform.isLinux then (lib.getExe steam-run) else "exec"}
+      --subst-var-by steamRun ${if stdenvNoCC.hostPlatform.isLinux then (lib.getExe steam-run) else "exec"}
     chmod 0755 $out/bin/steamcmd
   '';
 


### PR DESCRIPTION
Compiler and linker are not required, so use stdenvNoCC.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
