### PR TITLE
engelsystem: 3.6.0 -> 3.7.0, adopt

### DIFF
--- a/nixos/tests/engelsystem.nix
+++ b/nixos/tests/engelsystem.nix
@@ -2,7 +2,10 @@
 {
   name = "engelsystem";
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ talyz ];
+    maintainers = [
+      talyz
+      tmarkus
+    ];
   };
 
   nodes.engelsystem =

--- a/pkgs/by-name/en/engelsystem/package.nix
+++ b/pkgs/by-name/en/engelsystem/package.nix
@@ -11,25 +11,25 @@
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "engelsystem";
-  version = "3.6.0";
+  version = "3.7.0";
 
   src = fetchFromGitHub {
     owner = "engelsystem";
     repo = "engelsystem";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Pi+nowImUvENx2c4gsku1KkFb3pLM84oT8WevI6ImQg=";
+    hash = "sha256-hnTkeSqxkvO2Prop0VaBAV/4opr46wjEaJ5ptd5zQ34=";
   };
 
   inherit php;
 
   composerNoDev = true;
   composerStrictValidation = false;
-  vendorHash = "sha256-JRd5FJviNf5NUI9PwRcMqdDXYBlMoBB6o5yx7dvostE=";
+  vendorHash = "sha256-oGpgtkX0UVSdVceQ8pD3PuGBITifQzaMIb4QRdc7WeY=";
 
   yarnOfflineCache = fetchYarnDeps {
     pname = "${finalAttrs.pname}-yarn-deps";
     yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-nyCLM9OF2qwlW+VK38kiRMo6jMlupNFG+91N3Fb/WLY=";
+    hash = "sha256-IMg1AoqCiQEvMHeqXgonIY2J0nmBHLW2Drz/Vb0rD48=";
   };
 
   strictDeps = true;
@@ -66,7 +66,7 @@ php.buildComposerProject2 (finalAttrs: {
     homepage = "https://engelsystem.de";
     license = lib.licenses.gpl2Only;
     mainProgram = "migrate";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ tmarkus ];
     platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
I'll adopt Engelsystem so this supersedes #498771.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
