### PR TITLE
headlamp, headlamp-server, headlamp-frontend: init at 0.41.0

### DIFF
--- a/pkgs/by-name/he/headlamp-frontend/package.nix
+++ b/pkgs/by-name/he/headlamp-frontend/package.nix
@@ -1,0 +1,53 @@
+{
+  buildNpmPackage,
+  headlamp-server,
+}:
+
+buildNpmPackage {
+  pname = "headlamp-frontend";
+  inherit (headlamp-server) version src;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  sourceRoot = "${headlamp-server.src.name}/frontend";
+
+  npmDepsHash = "sha256-cjar6j5Wzh5monp9YxrsrnGDxgjlT+YRFh5mgZcImKI=";
+
+  postPatch = ''
+    chmod -R u+w ../app
+    cp ${headlamp-server.src}/app/package.json ../app/package.json
+    substituteInPlace package.json --replace-fail '"prebuild": "npm run make-version",' ""
+  '';
+
+  preBuild = ''
+    cat > .env <<EOF
+    REACT_APP_HEADLAMP_VERSION=${headlamp-server.version}
+    REACT_APP_HEADLAMP_GIT_VERSION=v${headlamp-server.version}
+    REACT_APP_HEADLAMP_PRODUCT_NAME=Headlamp
+    REACT_APP_ENABLE_REACT_QUERY_DEVTOOLS=false
+    REACT_APP_HEADLAMP_SIDEBAR_DEFAULT_OPEN=true
+    EOF
+  '';
+
+  env = {
+    PUBLIC_URL = "./";
+    NODE_OPTIONS = "--max-old-space-size=8096";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    cp -r build $out
+    runHook postInstall
+  '';
+
+  meta = {
+    inherit (headlamp-server.meta)
+      description
+      homepage
+      changelog
+      license
+      maintainers
+      ;
+  };
+}

--- a/pkgs/by-name/he/headlamp-server/package.nix
+++ b/pkgs/by-name/he/headlamp-server/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "headlamp-server";
+  version = "0.41.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "kubernetes-sigs";
+    repo = "headlamp";
+    tag = "v${version}";
+    hash = "sha256-ZXyE4oPkwimnU2ArOiTCnLxzaI5z/7T/SHS9aqP2DGM=";
+  };
+
+  modRoot = "backend";
+
+  vendorHash = "sha256-JjfB93C97yTbUTUbs7wEB/iFtuRzHzFXGyRHDAec7X8=";
+
+  # Don't embed frontend - Electron serves it directly. This also prevents
+  # the server from auto-opening a browser window.
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig.Version=${version}"
+    "-X github.com/kubernetes-sigs/headlamp/backend/pkg/kubeconfig.AppName=Headlamp"
+  ];
+
+  subPackages = [ "cmd" ];
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/headlamp-server
+  '';
+
+  meta = {
+    description = "An easy-to-use and extensible Kubernetes web UI";
+    homepage = "https://headlamp.dev";
+    changelog = "https://github.com/kubernetes-sigs/headlamp/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dylanmtaylor ];
+    mainProgram = "headlamp-server";
+  };
+}

--- a/pkgs/by-name/he/headlamp/package.nix
+++ b/pkgs/by-name/he/headlamp/package.nix
@@ -1,0 +1,118 @@
+{
+  buildNpmPackage,
+  headlamp-server,
+  headlamp-frontend,
+  electron,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+
+buildNpmPackage {
+  pname = "headlamp";
+  inherit (headlamp-server) version src;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  sourceRoot = "${headlamp-server.src.name}/app";
+
+  npmDepsHash = "sha256-FcV2ORs96Rj/OyCbBCBo/ZmcwvjDLPKkn0i4m+0gXIE=";
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  postPatch = ''
+    chmod u+w ..
+  '';
+
+  npmBuildScript = "compile-electron";
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "headlamp";
+      desktopName = "Headlamp";
+      comment = "An easy-to-use and extensible Kubernetes web UI";
+      exec = "headlamp";
+      icon = "headlamp";
+      categories = [
+        "Network"
+        "System"
+      ];
+      startupWMClass = "Headlamp";
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Electron app
+    install -Dt $out/lib/headlamp/app package.json
+    install -Dt $out/lib/headlamp/app/build build/main.js build/preload.js
+
+    # Production dependencies only
+    npm prune --omit=dev
+    rm -rf node_modules/.bin
+    cp -r node_modules $out/lib/headlamp/app/
+
+    # Resources directory (where process.resourcesPath should point)
+    mkdir -p $out/lib/headlamp/resources
+    cp -r ${headlamp-frontend} $out/lib/headlamp/resources/frontend
+    chmod -R u+w $out/lib/headlamp/resources/frontend
+    ln -s ${headlamp-server}/bin/headlamp-server $out/lib/headlamp/resources/headlamp-server
+    mkdir -p $out/lib/headlamp/resources/.plugins
+    cp ${headlamp-server.src}/app/app-build-manifest.json $out/lib/headlamp/resources/
+
+    # i18n locales
+    mkdir -p $out/lib/headlamp/resources/frontend/i18n
+    cp -r ${headlamp-server.src}/frontend/src/i18n/locales $out/lib/headlamp/resources/frontend/i18n/locales
+
+    # Entry point that sets process.resourcesPath before loading the real main
+    cat > $out/lib/headlamp/app/main.js <<ENTRY
+    const path = require('path');
+    const { app } = require('electron');
+    const resourcesPath = path.resolve(__dirname, '..', 'resources');
+    Object.defineProperty(process, 'resourcesPath', {
+      get: () => resourcesPath,
+      configurable: false,
+    });
+    app.setVersion('${headlamp-server.version}');
+    app.setName('Headlamp');
+    require('./build/main.js');
+    ENTRY
+
+    # Point package.json main at our wrapper
+    substituteInPlace $out/lib/headlamp/app/package.json \
+      --replace-fail '"main": "build/main.js"' '"main": "main.js"'
+
+    # Icons
+    for size in 16 32; do
+      mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
+      cp ${headlamp-server.src}/frontend/public/favicon-''${size}x''${size}.png $out/share/icons/hicolor/''${size}x''${size}/apps/headlamp.png
+    done
+    mkdir -p $out/share/icons/hicolor/192x192/apps
+    cp ${headlamp-server.src}/frontend/public/android-chrome-192x192.png $out/share/icons/hicolor/192x192/apps/headlamp.png
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    cp ${headlamp-server.src}/frontend/public/android-chrome-512x512.png $out/share/icons/hicolor/512x512/apps/headlamp.png
+
+    # Wrapper
+    mkdir -p $out/bin
+    makeWrapper ${electron}/bin/electron $out/bin/headlamp \
+      --add-flags $out/lib/headlamp/app \
+      --prefix PATH : ${headlamp-server}/bin
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    frontend = headlamp-frontend;
+  };
+
+  meta = headlamp-server.meta // {
+    mainProgram = "headlamp";
+  };
+}


### PR DESCRIPTION
## Description

<img width="1920" height="1165" alt="Screenshot From 2026-03-29 15-23-10" src="https://github.com/user-attachments/assets/39b0b051-23a8-4650-af61-72d2729482c1" />


Adds [Headlamp](https://headlamp.dev/), an easy-to-use and extensible Kubernetes web UI. Headlamp is a CNCF Sandbox project under Kubernetes SIG UI.

This PR adds three packages:
- `headlamp-server` — the Go backend, built with `buildGoModule`
- `headlamp-frontend` — the React frontend, built with `buildNpmPackage` using Vite
- `headlamp` — the Electron desktop application with a `.desktop` file and icons, exposing the frontend via `passthru.frontend`

### How it works
- The Go backend (`headlamp-server`) is built with `buildGoModule`
- The React frontend is built with `buildNpmPackage` using Vite
- The Electron app shell is compiled from TypeScript using esbuild
- A wrapper entry point overrides `process.resourcesPath` so Electron finds the frontend and server binary
- The system `electron` package is used instead of bundling Electron

### Note on Kubernetes authentication
Exec-based kubeconfig credential plugins (e.g. `oci-cli`, `aws-cli`, `gcloud`) are expected to be in the user's PATH. Headlamp reads the user's kubeconfig and invokes whatever exec plugin is configured there, so users are responsible for installing the appropriate credential helper for their cluster.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
