### PR TITLE
osquery: move to finalAttrs, bump toolchain from 1.1.0 to 1.2.0

### DIFF
--- a/pkgs/by-name/os/osquery/package.nix
+++ b/pkgs/by-name/os/osquery/package.nix
@@ -35,7 +35,7 @@ let
 
 in
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
 
   pname = "osquery";
 
@@ -68,7 +68,7 @@ stdenvNoCC.mkDerivation rec {
     cmake .. \
       -DCMAKE_INSTALL_PREFIX=$out \
       -DOSQUERY_TOOLCHAIN_SYSROOT=${toolchain} \
-      -DOSQUERY_VERSION=${version} \
+      -DOSQUERY_VERSION=${finalAttrs.version} \
       -DCMAKE_PREFIX_PATH=${toolchain}/usr/lib/cmake \
       -DCMAKE_LIBRARY_PATH=${toolchain}/usr/lib \
       -DOSQUERY_OPENSSL_ARCHIVE_PATH=${opensslSrc} \
@@ -107,4 +107,4 @@ stdenvNoCC.mkDerivation rec {
       lesuisse
     ];
   };
-}
+})

--- a/pkgs/by-name/os/osquery/toolchain-bin.nix
+++ b/pkgs/by-name/os/osquery/toolchain-bin.nix
@@ -6,16 +6,16 @@
 }:
 let
 
-  version = "1.1.0";
+  version = "1.2.0";
 
   dist = {
     "x86_64-linux" = {
       url = "https://github.com/osquery/osquery-toolchain/releases/download/${version}/osquery-toolchain-${version}-x86_64.tar.xz";
-      hash = "sha256-irekR8a0d+T64+ZObgblsLoc4kVBmb6Gv0Qf8dLDCMk=";
+      hash = "sha256-nLwnNsXQ+J0ms75YJHVFT9xb6F3RFJScgFlvuZ4JiYE=";
     };
     "aarch64-linux" = {
       url = "https://github.com/osquery/osquery-toolchain/releases/download/${version}/osquery-toolchain-${version}-aarch64.tar.xz";
-      hash = "sha256-cQlx9AtO6ggIQqHowa+42wQ4YCMCN4Gb+0qqVl2JElw=";
+      hash = "sha256-Vt4LA6H/TsrwJgB03eqrP2WqHbRqwQq5RK4PtGiqsVc=";
     };
   };
 


### PR DESCRIPTION
https://github.com/osquery/osquery-toolchain/releases/tag/1.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
