### PR TITLE
cangaroo: init at 0.10.0

### DIFF
--- a/pkgs/by-name/ca/cangaroo/package.nix
+++ b/pkgs/by-name/ca/cangaroo/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  stdenv,
+  pkg-config,
+  libnl,
+  qt6,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cangaroo";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "OpenAutoDiagLabs";
+    repo = "CANgaroo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5RHcnCCz1iQEZgWuONBixIBZnSz2YsbGsiWPvMBI81s=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    qt6.qmake
+    qt6.wrapQtAppsHook
+    qt6.qtcharts
+    qt6.qtserialport
+  ];
+
+  buildInputs = [
+    libnl
+    qt6.qtcharts
+    qt6.qtserialport
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install bin/cangaroo -Dt $out/bin
+    substituteInPlace cangaroo.desktop \
+      --replace-fail "Exec=/usr/bin/cangaroo" "Exec=$out/bin/cangaroo"
+    install cangaroo.desktop -Dt $out/share/applications
+    install src/assets/cangaroo.svg -Dt $out/share/icons/hicolor/scalable/apps
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open-source CAN bus analyzer";
+    homepage = "https://github.com/OpenAutoDiagLabs/CANgaroo";
+    changelog = "https://github.com/OpenAutoDiagLabs/CANgaroo/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    mainProgram = "cangaroo";
+    maintainers = with lib.maintainers; [ swendel ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ca/cangaroo/package.nix
+++ b/pkgs/by-name/ca/cangaroo/package.nix
@@ -25,8 +25,6 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     qt6.qmake
     qt6.wrapQtAppsHook
-    qt6.qtcharts
-    qt6.qtserialport
   ];
 
   buildInputs = [


### PR DESCRIPTION
   Cangaroo is a professional-grade CAN bus analyzer designed for engineers in Automotive, Robotics, and Industrial Automation. It facilitates     
   real-time capture, decoding, and analysis of CAN and CAN‑FD traffic.                                                                            
                                                                                                                                                   
   - Works with SocketCAN (Linux), CANable, Candlelight, and CANblaster for immediate testing and real hardware connections.                       
                                                                                                                                                   
   **Key Features:**                                                                                                                               
   - **Real-time CAN/CAN-FD Decoding**: Support for standard and high-speed flexible data-rate frames.                                             
   - **Wide Hardware Compatibility**: Seamlessly works with SocketCAN (Linux), CANable (SLCAN), Candlelight, and CANblaster (UDP).                 
   - **DBC Database Support**: Load multiple `.dbc` files to instantly decode frames into human-readable signals.                                  
   - **Powerful Data Visualization**: Integrated Graphing tools supporting Time-series, Scatter charts, Text-based monitoring, and interactive     
   Gauge views with zoom and live tooltips.                                                                                                        
   - **Advanced Filtering & Logging**: Isolate critical data with live filters and export captures for offline analysis.                           
   - **UDS/ISO-TP Support**: Seamlessly reassemble and decode UDS (Unified Diagnostic Services) messages over the ISO-TP transport layer.          
   - **J1939 Protocol Analysis**: Robust analysis of J1939 heavy-duty protocols, supporting Multi-frame (BAM) reassembly and PGN identification.   
   - **Modern Workspace**: A clean, dockable user interface optimized for multi-monitor setups.                                                    
                                                                                                                                                   
   Homepage: https://github.com/OpenAutoDiagLabs/CANgaroo                                                                                          
                                                                                                                                                   
   ## Things done                                                                                                                                  
                                                                                                                                                   
   - Built on platform:                                                                                                                            
     - [x] x86_64-linux                                                                                                                            
     - [x] aarch64-linux                                                                                                                           
     - [ ] x86_64-darwin                                                                                                                           
     - [ ] aarch64-darwin                                                                                                                          
   - Tested, as applicable:                                                                                                                        
     - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in                                                    
   [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).                                                                        
     - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.                         
     - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or                                                         
   [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.                                     
   - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).                               
   - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.                                                               
   - Nixpkgs Release Notes                                                                                                                         
     - [ ] Package update: when the change is major or breaking.                                                                                   
   - NixOS Release Notes                                                                                                                           
     - [ ] Module addition: when adding a new NixOS module.                                                                                        
     - [ ] Module update: when the change is significant.                                                                                          
   - [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md),                                                     
   [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md),                                                                  
   [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.          
   
## Note on strictDeps and __structuredAttrs

This package cannot use strictDeps = true because Qt6/qmake requires Qt modules (qtcharts, qtserialport) to be visible during the configure phase for module discovery. With strictDeps, buildInputs are only available at runtime, causing qmake to fail with:

> Project ERROR: Unknown module(s) in QT: charts serialport
> make: *** [Makefile:47: sub-src-make_first-ordered] Error 3

This seems consistent with other Qt6/qmake packages in nixpkgs which also don't use strictDeps.
