### PR TITLE
usage: 3.0.0 -> 3.2.0

### DIFF
--- a/pkgs/by-name/us/usage/package.nix
+++ b/pkgs/by-name/us/usage/package.nix
@@ -12,16 +12,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "usage";
-  version = "3.0.0";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
     owner = "jdx";
     repo = "usage";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KC3fIfFnXn5K1E1CyHLADaEesXFilCrIe9MYOH/fkrI=";
+    hash = "sha256-0yonwl/2BIkGUs0uOBP+Pjo93NvLVK4QQQj/K4C4NNY=";
   };
 
-  cargoHash = "sha256-RNeHa3V4oCvtiR6/ntTegKl62ByWZbFeliFJVgsHYrQ=";
+  cargoHash = "sha256-jxTN+La7Ye2okRZGAY6niIvvRf2E4vFFHd1nny7JJDo=";
+
+  patches = [
+    ./use-bin-exe-env.patch
+  ];
 
   postPatch = ''
     substituteInPlace ./examples/*.sh \

--- a/pkgs/by-name/us/usage/use-bin-exe-env.patch
+++ b/pkgs/by-name/us/usage/use-bin-exe-env.patch
@@ -1,0 +1,17 @@
+diff --git a/cli/tests/shell_completions_integration.rs b/cli/tests/shell_completions_integration.rs
+index 815c44c..51b5dd9 100644
+--- a/cli/tests/shell_completions_integration.rs
++++ b/cli/tests/shell_completions_integration.rs
+@@ -25,6 +25,13 @@ fn run_complete_word(usage_bin: &Path, shell: &str, spec_file: &Path, words: &[&
+ 
+ /// Build the usage binary and return its path
+ fn build_usage_binary() -> PathBuf {
++    if let Some(usage_path) = std::env::var("CARGO_BIN_EXE_usage")
++        .ok()
++        .filter(|s| !s.is_empty())
++    {
++        return PathBuf::from(usage_path);
++    }
++
+     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+     let workspace_root = manifest_dir.parent().unwrap();


### PR DESCRIPTION
Changelogs: 
- https://github.com/jdx/usage/releases/tag/v3.1.0
- https://github.com/jdx/usage/releases/tag/v3.2.0

Diff: https://github.com/jdx/usage/compare/v3.0.0...v3.2.0

Added `use-bin-exe-env.patch` to make the tests use the correct binary. 
Alternatively, the tests could be fixed by disabling `test_zsh_complete_word_output_format` and `test_complete_path_adds_trailing_slash_for_directories`.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
