### PR TITLE
[25.11] fleet: 4.81.0 -> 4.82.2

### DIFF
--- a/pkgs/by-name/fl/fleet/package.nix
+++ b/pkgs/by-name/fl/fleet/package.nix
@@ -7,15 +7,15 @@
 
 buildGo126Module (finalAttrs: {
   pname = "fleet";
-  version = "4.81.0";
+  version = "4.82.2";
   src = fetchFromGitHub {
     owner = "fleetdm";
     repo = "fleet";
     tag = "fleet-v${finalAttrs.version}";
-    hash = "sha256-LPbMcaQ3YIfh5qwIBB7BwJFgMPurCJudrOzUPm5+VcM=";
+    hash = "sha256-Cbn7phhaDcpYm3nV8nLb/2QVQl9mhsRfHa6GG59MNcA=";
   };
 
-  vendorHash = "sha256-kudomUa5c0OJA2LgqLQ2Az0mDH/s9go3jHdyeALGgs8=";
+  vendorHash = "sha256-hgo+j2+gE0ArGRRvxC/0jcpv0Bp3hvBRO7Wl+9xl8io=";
 
   subPackages = [
     "cmd/fleet"


### PR DESCRIPTION
Fixes CVE-2026-34389, CVE-2026-29180, CVE-2026-26060, CVE-2026-34386, CVE-2026-34391, CVE-2026-26061, CVE-2026-34387 and CVE-2026-34388.

Fixes https://github.com/NixOS/nixpkgs/issues/504467
Fixes https://github.com/NixOS/nixpkgs/issues/504468
Fixes https://github.com/NixOS/nixpkgs/issues/504469
Fixes https://github.com/NixOS/nixpkgs/issues/504462
Fixes https://github.com/NixOS/nixpkgs/issues/504463
Fixes https://github.com/NixOS/nixpkgs/issues/504464
Fixes https://github.com/NixOS/nixpkgs/issues/504465
Fixes https://github.com/NixOS/nixpkgs/issues/504466

Changes:
https://github.com/fleetdm/fleet/releases/tag/fleet-v4.82.2
https://github.com/fleetdm/fleet/releases/tag/fleet-v4.82.1
https://github.com/fleetdm/fleet/releases/tag/fleet-v4.82.0 

(cherry picked from commit 9558d0908463fdc277d1301172b6602e50d3d2af)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
