### PR TITLE
gnome-extensions-cli: 0.10.8 -> 0.11.0

### DIFF
--- a/pkgs/by-name/gn/gnome-extensions-cli/package.nix
+++ b/pkgs/by-name/gn/gnome-extensions-cli/package.nix
@@ -8,13 +8,13 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gnome-extensions-cli";
-  version = "0.10.8";
+  version = "0.11.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "gnome_extensions_cli";
     inherit (finalAttrs) version;
-    hash = "sha256-Tnf8BbW9u7d19ZtGTdMVHa6azbKekYRGOPEPNiB+y00=";
+    hash = "sha256-5OL0ma17rXA+USDATVQXO3ORWDAwoGB3x85BSIsRapY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Version bump.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)