### PR TITLE
devenv: fix version mismatch (2.0.7 reported instead of 2.0.6)

### DIFF
--- a/pkgs/by-name/de/devenv/package.nix
+++ b/pkgs/by-name/de/devenv/package.nix
@@ -53,6 +53,11 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-p5kI7HlG6RVxCCEb/J0L2gh36jkm/atAV98ny3h4vqo=";
 
+  # Upstream tagged v2.0.6 with Cargo.toml already bumped to 2.0.7
+  postPatch = ''
+    substituteInPlace Cargo.toml --replace-fail 'version = "2.0.7"' 'version = "${version}"'
+  '';
+
   env = {
     RUSTFLAGS = "--cfg tracing_unstable";
     LIBSQLITE3_SYS_USE_PKG_CONFIG = "1";


### PR DESCRIPTION
## Summary
- Upstream tagged `v2.0.6` with the workspace `Cargo.toml` already bumped to `2.0.7`
- This causes the binary to report `devenv 2.0.7` instead of `devenv 2.0.6`, breaking devenv.lock version checks
- Patches the workspace version during build to match the tagged release

Fixes https://github.com/cachix/devenv/issues/2682

## Test plan
- [ ] `nix-build -A devenv` builds successfully
- [ ] `./result/bin/devenv version` reports `2.0.6`
- [ ] `nix-build -A devenv.tests.version` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)