### PR TITLE
python3Packages.{natto-py,openepub,subtitle-parser}: init; lute3: init at 3.10.1

### DIFF
--- a/pkgs/by-name/lu/lute3/package.nix
+++ b/pkgs/by-name/lu/lute3/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "lute3";
+  version = "3.10.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LuteOrg";
+    repo = "lute-v3";
+    tag = finalAttrs.version;
+    hash = "sha256-ZeMXFky/MBW/nce+aUDYerh/9LHBDjl/Eh4f/4obXs8=";
+    fetchSubmodules = true;
+    # The submodule is registered with an SSH URL, which the fetcher cannot
+    # resolve inside the sandbox. Rewrite it to HTTPS.
+    preFetch = ''
+      export GIT_CONFIG_COUNT=1
+      export GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf
+      export GIT_CONFIG_VALUE_0=git@github.com:
+    '';
+  };
+
+  build-system = with python3Packages; [ flit-core ];
+
+  # Upstream caps platformdirs at <4 and waitress at <3, but it only calls
+  # PlatformDirs() and waitress.serve(), neither of which changed in those
+  # major releases.
+  pythonRelaxDeps = [
+    "platformdirs"
+    "waitress"
+  ];
+
+  dependencies = with python3Packages; [
+    ahocorapy
+    beautifulsoup4
+    flask-sqlalchemy
+    flask-wtf
+    jaconv
+    natto-py
+    openepub
+    platformdirs
+    pyparsing
+    pypdf
+    pyyaml
+    requests
+    subtitle-parser
+    toml
+    waitress
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytest-bdd
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    echo "ENV: prod
+    DBNAME: test_lute.db
+    DATAPATH: $(mktemp -d)" > lute/config/config.yml;
+  '';
+
+  meta = {
+    homepage = "https://github.com/LuteOrg/lute-v3";
+    description = "Learn languages through reading";
+    longDescription = ''
+      LUTE (Learning Using Texts) is a standalone web application that you install on your computer and read texts with.
+
+      Lute contains the core features you need for learning through reading:
+
+      * defining languages and dictionaries
+      * creating and editing texts
+      * creating terms and multi-word terms
+    '';
+    changelog = "https://raw.githubusercontent.com/LuteOrg/lute-v3/${finalAttrs.src.tag}/docs/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.imalison ];
+    mainProgram = "lute";
+  };
+})

--- a/pkgs/development/python-modules/natto-py/default.nix
+++ b/pkgs/development/python-modules/natto-py/default.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  cffi,
+  mecab,
+  unittestCheckHook,
+  pyyaml,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "natto-py";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "buruzaemon";
+    repo = "natto-py";
+    tag = finalAttrs.version;
+    hash = "sha256-G7IYv5MNVfsTcTKQIMRAP9apTrMUo9+JnM3OWcV35X8=";
+  };
+
+  # natto-py discovers MeCab at run time by shelling out to `mecab -D` for the
+  # system dictionary's charset and to `mecab-config --libs-only-L` for the
+  # directory containing libmecab. Neither command is on PATH for importers of
+  # this library, so hardcode both. The MECAB_CHARSET and MECAB_PATH
+  # environment variables are still consulted first, so users can point
+  # natto-py at a different MeCab installation.
+  postPatch = ''
+    substituteInPlace natto/environment.py \
+      --replace-fail "['mecab', '-D']" "['${lib.getExe' mecab "mecab"}', '-D']" \
+      --replace-fail "['mecab-config', '--libs-only-L']" "['${lib.getExe' mecab "mecab-config"}', '--libs-only-L']"
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    cffi
+  ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+    # The test suite shells out to a bare `mecab` for `-v`, `-D` and `-P`, and
+    # to `mecab-config`, so it needs them on PATH even though the library
+    # itself no longer looks them up there.
+    mecab
+    pyyaml
+  ];
+
+  # tests/__init__.py refuses to run unless both variables are set; it does not
+  # use the autodetection patched above.
+  preCheck = ''
+    export MECAB_PATH="${lib.getLib mecab}/lib/libmecab${stdenv.hostPlatform.extensions.sharedLibrary}"
+    export MECAB_CHARSET="utf8"
+  '';
+
+  pythonImportsCheck = [ "natto" ];
+
+  meta = {
+    homepage = "https://github.com/buruzaemon/natto-py";
+    changelog = "https://raw.githubusercontent.com/buruzaemon/natto-py/${finalAttrs.src.tag}/CHANGELOG";
+    description = "Python binding to MeCab, the Japanese part-of-speech and morphological analyzer";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.imalison ];
+  };
+})

--- a/pkgs/development/python-modules/openepub/default.nix
+++ b/pkgs/development/python-modules/openepub/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  beautifulsoup4,
+  xmltodict,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "openepub";
+  version = "0.0.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sakolkar";
+    repo = "openepub";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rk9tM2cC78O9icFpVu5ZH5RI4sbZXWlYOGWOSvwqhDU=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  # Upstream caps xmltodict at <1; only xmltodict.parse() is used and its
+  # signature is unchanged in 1.x.
+  pythonRelaxDeps = [ "xmltodict" ];
+
+  dependencies = [
+    beautifulsoup4
+    xmltodict
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # These tests read the EPUB fixtures test/mock/tödliche_lektion.epub and
+  # test/mock/philosophers_stone.epub, which are copyrighted books that
+  # upstream does not redistribute in the repository.
+  disabledTests = [
+    "test_epub_get_text"
+    "test_epub_get_text_2"
+    "test_open_epub_from_stream"
+    "test_open_get_epub_obj_valid_path"
+  ];
+
+  pythonImportsCheck = [ "openepub" ];
+
+  meta = {
+    homepage = "https://github.com/sakolkar/openepub";
+    changelog = "https://github.com/sakolkar/openepub/releases/tag/${finalAttrs.src.tag}";
+    description = "Python library to interact with EPUB files";
+    license = lib.licenses.unlicense;
+    maintainers = [ lib.maintainers.imalison ];
+  };
+})

--- a/pkgs/development/python-modules/subtitle-parser/default.nix
+++ b/pkgs/development/python-modules/subtitle-parser/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  chardet,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "subtitle-parser";
+  version = "2.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "remram44";
+    repo = "subtitle-parser";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uqMedb/WSUaXUHccNTiin3S7V5dDMEaAxla/evIKU1E=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  # Upstream caps chardet at <6; only chardet.UniversalDetector is used and it
+  # is unchanged in 6.x.
+  pythonRelaxDeps = [ "chardet" ];
+
+  dependencies = [
+    chardet
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "tests.py"
+  ];
+
+  pythonImportsCheck = [ "subtitle_parser" ];
+
+  meta = {
+    homepage = "https://github.com/remram44/subtitle-parser";
+    changelog = "https://raw.githubusercontent.com/remram44/subtitle-parser/refs/tags/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Parser for SRT and WebVTT subtitle files";
+    longDescription = "This is a simple Python library for parsing subtitle files in SRT or WebVTT format.";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.imalison ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12254,6 +12254,8 @@ self: super: with self; {
 
   opendal = callPackage ../development/python-modules/opendal { };
 
+  openepub = callPackage ../development/python-modules/openepub { };
+
   openerz-api = callPackage ../development/python-modules/openerz-api { };
 
   openevsewifi = callPackage ../development/python-modules/openevsewifi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11475,6 +11475,8 @@ self: super: with self; {
 
   natsort = callPackage ../development/python-modules/natsort { };
 
+  natto-py = callPackage ../development/python-modules/natto-py { };
+
   natural = callPackage ../development/python-modules/natural { };
 
   naturalsort = callPackage ../development/python-modules/naturalsort { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19697,6 +19697,8 @@ self: super: with self; {
 
   subprocess4 = callPackage ../development/python-modules/subprocess4 { };
 
+  subtitle-parser = callPackage ../development/python-modules/subtitle-parser { };
+
   subzerod = callPackage ../development/python-modules/subzerod { };
 
   succulent = callPackage ../development/python-modules/succulent { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Rebased continuation of #415063 on current `master`.

This keeps the original package additions and includes the minimum follow-up fixes needed to build cleanly on current nixpkgs:
- relax `openepub`'s `xmltodict` upper bound to match nixpkgs' current version
- rewrite `lute3`'s submodule fetch to use HTTPS during fetch so sandboxed builds succeed

[LUTE (Learning Using Texts)](https://github.com/LuteOrg/lute-v3) is a standalone web application that you install on your computer and read texts with.

Lute contains the core features you need for learning through reading:

* defining languages and dictionaries
* creating and editing texts
* creating terms and multi-word terms

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
