### PR TITLE
rofi-systemd: update github owner of src

### DIFF
--- a/pkgs/by-name/ro/rofi-systemd/package.nix
+++ b/pkgs/by-name/ro/rofi-systemd/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   version = "1.1.0";
 
   src = fetchFromGitHub {
-    owner = "IvanMalison";
+    owner = "colonelpanic8";
     repo = "rofi-systemd";
     tag = "v${version}";
     sha256 = "1zwbw119mblp5b6dj4h92fi0y2ymimlgh4bawi5ks2051hpq6c1a";
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Control your systemd units using rofi";
-    homepage = "https://github.com/IvanMalison/rofi-systemd";
+    homepage = "https://github.com/colonelpanic8/rofi-systemd";
     maintainers = with lib.maintainers; [ imalison ];
     license = lib.licenses.gpl3;
     platforms = with lib.platforms; linux;


### PR DESCRIPTION
## Description of changes

Update `fetchFromGitHub.owner` and `meta.homepage` to use the current GitHub owner, `colonelpanic8`.

This is the `rofi-systemd` split-out requested in https://github.com/NixOS/nixpkgs/pull/251867. The maintainer-account part from that PR is already present on `master`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test