### PR TITLE
quill-qr: update github owner of src

### DIFF
--- a/pkgs/by-name/qu/quill-qr/package.nix
+++ b/pkgs/by-name/qu/quill-qr/package.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
   version = "0.1.0";
 
   src = fetchFromGitHub {
-    owner = "IvanMalison";
+    owner = "colonelpanic8";
     repo = "quill-qr";
     rev = "v${version}";
     sha256 = "1kdsq6csmxfvs2wy31bc9r92l5pkmzlzkyqrangvrf4pbk3sk0r6";
@@ -42,7 +42,7 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Print QR codes for use with https://p5deo-6aaaa-aaaab-aaaxq-cai.raw.ic0.app";
     mainProgram = "quill-qr.sh";
-    homepage = "https://github.com/IvanMalison/quill-qr";
+    homepage = "https://github.com/colonelpanic8/quill-qr";
     maintainers = with lib.maintainers; [ imalison ];
     platforms = with lib.platforms; linux;
   };


### PR DESCRIPTION
## Description of changes

Update `fetchFromGitHub.owner` and `meta.homepage` to use the current GitHub owner, `colonelpanic8`.

This is the `quill-qr` split-out requested in https://github.com/NixOS/nixpkgs/pull/251867. The maintainer-account part from that PR is already present on `master`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test