### PR TITLE
websocat: 1.14.0 -> 1.14.1

### DIFF
--- a/pkgs/by-name/we/websocat/package.nix
+++ b/pkgs/by-name/we/websocat/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   bash,
   fetchFromGitHub,
-  fetchpatch,
   libiconv,
   makeWrapper,
   openssl,
@@ -14,25 +13,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "websocat";
-  version = "1.14.0";
+  version = "1.14.1";
 
   src = fetchFromGitHub {
     owner = "vi";
     repo = "websocat";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-v5+9cbKe3c12/SrW7mgN6tvQIiAuweqvMIl46Ce9f2A=";
+    hash = "sha256-Ukz7qM6yT6LCdUxew8KhwTeEuz3JF7LOsoHKGM9rBmQ=";
   };
 
-  # Fix build with Rust 1.87
-  # FIXME: remove in next update
-  cargoPatches = [
-    (fetchpatch {
-      url = "https://github.com/vi/websocat/commit/d4455623e777231d69b029d69d7a17c0de2bafe7.diff";
-      hash = "sha256-OUQQ+3eESE3XcGgToErqvF8ItpT8YCMAZhbvRzkFKpc=";
-    })
-  ];
-
-  cargoHash = "sha256-3m7Gg//vjNjYlesEjKsdqjU48dAtgSeugxingr8OJyY=";
+  cargoHash = "sha256-taG+oi+9eh6CnhS7wKSxEzLXOtvVhtLT1D3EuS4AwWY=";
 
   nativeBuildInputs = [
     pkg-config
@@ -47,11 +37,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-
-  buildFeatures = [ "ssl" ];
-
-  # Needed to get openssl-sys to use pkg-config.
-  env.OPENSSL_NO_VENDOR = 1;
 
   # The wrapping is required so that the "sh-c" option of websocat works even
   # if sh is not in the PATH (as can happen, for instance, when websocat is

--- a/pkgs/by-name/we/websocat/package.nix
+++ b/pkgs/by-name/we/websocat/package.nix
@@ -46,6 +46,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --prefix PATH : ${lib.makeBinPath [ bash ]}
   '';
 
+  # Darwin requires local networking for the checks
+  __darwinAllowLocalNetworking = true;
   doInstallCheck = true;
 
   meta = {

--- a/pkgs/by-name/we/websocat/package.nix
+++ b/pkgs/by-name/we/websocat/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   bash,
   fetchFromGitHub,
-  fetchpatch,
   libiconv,
   makeWrapper,
   openssl,
@@ -14,25 +13,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "websocat";
-  version = "1.14.0";
+  version = "1.14.1";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "vi";
     repo = "websocat";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-v5+9cbKe3c12/SrW7mgN6tvQIiAuweqvMIl46Ce9f2A=";
+    hash = "sha256-Ukz7qM6yT6LCdUxew8KhwTeEuz3JF7LOsoHKGM9rBmQ=";
   };
 
-  # Fix build with Rust 1.87
-  # FIXME: remove in next update
-  cargoPatches = [
-    (fetchpatch {
-      url = "https://github.com/vi/websocat/commit/d4455623e777231d69b029d69d7a17c0de2bafe7.diff";
-      hash = "sha256-OUQQ+3eESE3XcGgToErqvF8ItpT8YCMAZhbvRzkFKpc=";
-    })
-  ];
-
-  cargoHash = "sha256-3m7Gg//vjNjYlesEjKsdqjU48dAtgSeugxingr8OJyY=";
+  cargoHash = "sha256-taG+oi+9eh6CnhS7wKSxEzLXOtvVhtLT1D3EuS4AwWY=";
 
   nativeBuildInputs = [
     pkg-config
@@ -46,13 +38,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libiconv
   ];
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
-
-  buildFeatures = [ "ssl" ];
-
-  # Needed to get openssl-sys to use pkg-config.
-  env.OPENSSL_NO_VENDOR = 1;
-
   # The wrapping is required so that the "sh-c" option of websocat works even
   # if sh is not in the PATH (as can happen, for instance, when websocat is
   # started as a systemd service).
@@ -61,6 +46,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --prefix PATH : ${lib.makeBinPath [ bash ]}
   '';
 
+  # Darwin requires local networking for the checks
+  __darwinAllowLocalNetworking = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
   meta = {


### PR DESCRIPTION
Changelog: https://github.com/vi/websocat/releases/tag/v1.14.1
Diff: https://github.com/vi/websocat/compare/v1.14.0...v1.14.1

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
