### PR TITLE
chickenPackages_5.chickenEggs.{fuse,isaac,mdh,xlib}: fix build with gcc15

### DIFF
--- a/pkgs/development/compilers/chicken/5/overrides.nix
+++ b/pkgs/development/compilers/chicken/5/overrides.nix
@@ -78,7 +78,29 @@ in
       ];
     };
   freetype = addToBuildInputsWithPkgConfig pkgs.freetype;
-  fuse = addToBuildInputsWithPkgConfig pkgs.fuse;
+  fuse =
+    old:
+    (addToBuildInputsWithPkgConfig pkgs.fuse old)
+    // {
+      env.NIX_CFLAGS_COMPILE = toString [
+        (
+          if stdenv.cc.isClang then
+            "-Wno-error=incompatible-function-pointer-types"
+          else
+            "-Wno-error=incompatible-pointer-types"
+        )
+      ];
+    };
+  isaac =
+    old:
+    (addToBuildInputsWithPkgConfig pkgs.libffi old)
+    // {
+      postPatch = ''
+        substituteInPlace rand.h \
+          --replace-fail '/*_ randctx *r, word flag _*/' 'randctx *r, word flag' \
+          --replace-fail '/*_ randctx *r _*/' 'randctx *r'
+      '';
+    };
   gl-math = old: {
     env.NIX_CFLAGS_COMPILE = toString [
       "-Wno-error=incompatible-pointer-types"
@@ -111,10 +133,13 @@ in
     old:
     (addToBuildInputs pkgs.pcre old)
     // {
-      env.NIX_CFLAGS_COMPILE = toString [
-        "-Wno-error=implicit-function-declaration"
-        "-Wno-error=implicit-int"
-      ];
+      postPatch = ''
+        substituteInPlace bmgsubs.c \
+          --replace-fail "char   *gotamatch();" "char *gotamatch(char *, int, int (*)(char *, int));" \
+          --replace-fail "int bmg_search(char *, int, int (*)());" "int bmg_search(char *, int, int (*)(char *, int));" \
+          --replace-fail "int	(*action)();" "int (*action)(char *, int);" \
+          --replace-fail "int (*action)();" "int (*action)(char *, int);"
+      '';
     };
   # missing dependency in upstream egg
   mistie = addToPropagatedBuildInputs (with chickenEggs; [ srfi-1 ]);
@@ -193,7 +218,19 @@ in
     );
   uuid-lib = addToBuildInputs pkgs.libuuid;
   ws-client = addToBuildInputs pkgs.zlib;
-  xlib = addToPropagatedBuildInputs pkgs.libx11;
+  xlib =
+    old:
+    (addToPropagatedBuildInputs pkgs.libx11 old)
+    // {
+      env.NIX_CFLAGS_COMPILE = toString [
+        (
+          if stdenv.cc.isClang then
+            "-Wno-error=incompatible-function-pointer-types"
+          else
+            "-Wno-error=incompatible-pointer-types"
+        )
+      ];
+    };
   yaml = addToBuildInputs pkgs.libyaml;
   zlib = addToBuildInputs pkgs.zlib;
   zmq = addToBuildInputs pkgs.zeromq;


### PR DESCRIPTION
- #475479
- `fuse`: https://hydra.nixos.org/build/324453807
- `isaac`: https://hydra.nixos.org/build/324454025
- `mdh`: https://hydra.nixos.org/build/324454226
- `xlib`: https://hydra.nixos.org/build/324455529

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
