### PR TITLE
python3Packages.xgrammar: 0.1.31 -> 0.1.33

### DIFF
--- a/pkgs/development/python-modules/xgrammar/default.nix
+++ b/pkgs/development/python-modules/xgrammar/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "xgrammar";
-  version = "0.1.31";
+  version = "0.1.33";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     repo = "xgrammar";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-Baa/DiRoNcIv4UOC+msi4PgfRWnwprnZpLG2v7qB2h4=";
+    hash = "sha256-mliAmFBY3eLnUP+2HCRGX36KPUjaxn0Eb+2aKyDwdaM=";
   };
 
   patches = [
@@ -99,6 +99,7 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # Requires internet access
     "tests/python/test_structural_tag_converter.py"
+    "tests/python/test_structural_tag_for_model.py"
   ];
 
   pythonImportsCheck = [ "xgrammar" ];


### PR DESCRIPTION
Fixes #497289 / CVE-2026-25048

https://github.com/mlc-ai/xgrammar/security/advisories/GHSA-7rgv-gqhr-fxg3

https://github.com/mlc-ai/xgrammar/releases/tag/v0.1.33
https://github.com/mlc-ai/xgrammar/releases/tag/v0.1.32


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

No new build failures

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 504820`
Commit: `cdf5c4eb3b70c9b943a9875506e8c8694d6ef414`

---
### `x86_64-linux`
<details>
  <summary>:x: 6 packages failed to build:</summary>
  <ul>
    <li>python313Packages.kserve</li>
    <li>python313Packages.kserve.dist</li>
    <li>python313Packages.torchrl</li>
    <li>python313Packages.torchrl.dist</li>
    <li>vllm (python313Packages.vllm)</li>
    <li>vllm.dist (python313Packages.vllm.dist)</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>python313Packages.xgrammar</li>
    <li>python313Packages.xgrammar.dist</li>
    <li>python314Packages.xgrammar</li>
    <li>python314Packages.xgrammar.dist</li>
  </ul>
</details>

---
<details>
<summary>Error logs: `x86_64-linux`</summary>
<details>
<summary>vllm</summary>
<pre>    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File &quot;/nix/store/jldwaqq2p69ms46wpf74aw5rllnhwz6j-python3.13-setuptools-80.10.1/lib/python3.13/site-packages/setuptools/dist.py&quot;, line 1107, in run_command
    super().run_command(command)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File &quot;/nix/store/jldwaqq2p69ms46wpf74aw5rllnhwz6j-python3.13-setuptools-80.10.1/lib/python3.13/site-packages/setuptools/_distutils/dist.py&quot;, line 1021, in run_command
    cmd_obj.run()
    ~~~~~~~~~~~^^
  File &quot;&lt;string&gt;&quot;, line 370, in run
  File &quot;/nix/store/jldwaqq2p69ms46wpf74aw5rllnhwz6j-python3.13-setuptools-80.10.1/lib/python3.13/site-packages/setuptools/command/build_ext.py&quot;, line 97, in run
    _build_ext.run(self)
    ~~~~~~~~~~~~~~^^^^^^
  File &quot;/nix/store/jldwaqq2p69ms46wpf74aw5rllnhwz6j-python3.13-setuptools-80.10.1/lib/python3.13/site-packages/setuptools/_distutils/command/build_ext.py&quot;, line 368, in run
    self.build_extensions()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File &quot;&lt;string&gt;&quot;, line 339, in build_extensions
  File &quot;/nix/store/pzdalg368npikvpq4ncz2saxnz19v53k-python3-3.13.12/lib/python3.13/subprocess.py&quot;, line 419, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command &#x27;[&#x27;cmake&#x27;, &#x27;--build&#x27;, &#x27;.&#x27;, &#x27;-j=10&#x27;, &#x27;--target=_C&#x27;]&#x27; returned non-zero exit status 1.

ERROR Backend subprocess exited when trying to invoke build_wheel</pre>
</details>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
