### PR TITLE
hyprscratch: init at 0.6.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21751,6 +21751,12 @@
     github = "piegamesde";
     githubId = 14054505;
   };
+  pierreborine = {
+    email = "nixpkgs@thecakeis.top";
+    github = "PierreBorine";
+    githubId = 85021467;
+    name = "Pierre Borine";
+  };
   pierrechevalier83 = {
     email = "pierrechevalier83@gmail.com";
     github = "pierrechevalier83";

--- a/pkgs/by-name/hy/hyprscratch/package.nix
+++ b/pkgs/by-name/hy/hyprscratch/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hyprscratch";
+  version = "0.6.5";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sashetophizika";
+    repo = "hyprscratch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-y3OnhY3GzHhxabxOcXWP5PJ/HZhaNOO0UgYM5Kzqkc8=";
+  };
+
+  cargoHash = "sha256-Sms+Nx2xQilN9IROVyuO1pl7fFGF8LYN6EhFcYQBLQs=";
+
+  nativeBuildInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  checkFlags = [ "skip=scratchpad::tests::test_named_workspace" ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Improved scratchpad functionality for Hyprland";
+    homepage = "https://github.com/sashetophizika/hyprscratch";
+    changelog = "https://github.com/sashetophizika/hyprscratch/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ pierreborine ];
+    mainProgram = "hyprscratch";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Introduce [hyprscratch](https://github.com/sashetophizika/hyprscratch), which adds "Improved scratchpad functionality for Hyprland"

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
