### PR TITLE
wolfssl: add `enableJni` option

### DIFF
--- a/pkgs/by-name/ar/art-standalone/package.nix
+++ b/pkgs/by-name/ar/art-standalone/package.nix
@@ -65,19 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     lz4
     openssl
-    (wolfssl.overrideAttrs (oldAttrs: {
-      configureFlags = oldAttrs.configureFlags ++ [
-        "--enable-jni"
-      ];
-      # Disable failing tests when jni enabled
-      postPatch = oldAttrs.postPatch or "" + ''
-        sed -i '/TEST_DECL(test_wolfSSL_Tls13_ECH)/d;
-                /TEST_DECL(test_wolfSSL_Tls13_ECH_HRR)/d;
-                /TEST_DECL(test_TLSX_CA_NAMES_bad_extension)/d' tests/api.c
-        sed -i '/quic/d' tests/include.am
-        sed -i '300,305d' tests/unit.c
-      '';
-    }))
+    (wolfssl.override { enableJni = true; })
     xz
     zlib
   ];

--- a/pkgs/by-name/wo/wolfssl/package.nix
+++ b/pkgs/by-name/wo/wolfssl/package.nix
@@ -10,6 +10,7 @@
   # requiring to build a special variant for that software. Example: 'haproxy'
   variant ? "all",
   extraConfigureFlags ? [ ],
+  enableJni ? false,
   enableARMCryptoExtensions ?
     stdenv.hostPlatform.isAarch64
     && ((builtins.match "^.*\\+crypto.*$" stdenv.hostPlatform.gcc.arch) != null),
@@ -31,6 +32,14 @@ stdenv.mkDerivation (finalAttrs: {
     # ensure test detects musl-based systems too
     substituteInPlace scripts/ocsp-stapling2.test \
       --replace '"linux-gnu"' '"linux-"'
+  ''
+  + lib.optionalString enableJni ''
+    # Some tests fail when JNI is enabled
+    sed -i '/TEST_DECL(test_wolfSSL_Tls13_ECH)/d;
+            /TEST_DECL(test_wolfSSL_Tls13_ECH_HRR)/d;
+            /TEST_DECL(test_TLSX_CA_NAMES_bad_extension)/d' tests/api.c
+    sed -i '/quic/d' tests/include.am
+    sed -i '/WOLFSSL_QUIC/,/#endif/d' tests/unit.c
   '';
 
   configureFlags = [
@@ -64,6 +73,9 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals (stdenv.hostPlatform.isAarch64) [
     # No runtime detection under ARM and no platform function checks like for X86.
     (if enableARMCryptoExtensions then "--enable-armasm=inline" else "--disable-armasm")
+  ]
+  ++ lib.optionals enableJni [
+    "--enable-jni"
   ]
   ++ extraConfigureFlags;
 


### PR DESCRIPTION
Add an `enableJni` parameter that passes `--enable-jni` and patches out failing ECH, CA_NAMES, and QUIC tests.  This replaces the raw `overrideAttrs` in art-standalone with a clean `wolfssl.override`, per the guidance in `pkgs/README.md` § ["overrideAttrs and overridePythonAttrs"](https://github.com/NixOS/nixpkgs/pull/421201).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test