### PR TITLE
sublime-merge: add aarch64-darwin support

### DIFF
--- a/pkgs/applications/version-management/sublime-merge/common.nix
+++ b/pkgs/applications/version-management/sublime-merge/common.nix
@@ -3,22 +3,24 @@
   dev ? false,
   aarch64sha256,
   x64sha256,
+  darwinsha256,
 }:
 
 {
   fetchurl,
   lib,
   stdenv,
-  libx11,
-  glib,
-  libGL,
-  glibcLocales,
-  gtk3,
-  cairo,
-  pango,
-  libredirect,
+  libx11 ? null,
+  glib ? null,
+  libGL ? null,
+  glibcLocales ? null,
+  gtk3 ? null,
+  cairo ? null,
+  pango ? null,
+  libredirect ? null,
   makeWrapper,
-  wrapGAppsHook3,
+  unzip ? null,
+  wrapGAppsHook3 ? null,
   pkexecPath ? "/run/wrappers/bin/pkexec",
   writeShellScript,
   common-updater-scripts,
@@ -44,6 +46,7 @@ let
     if lib.versionAtLeast buildVersion "2086" then "crash_handler" else "crash_reporter";
   downloadUrl =
     arch: "https://download.sublimetext.com/sublime_merge_build_${buildVersion}_${arch}.tar.xz";
+  downloadUrlDarwin = "https://download.sublimetext.com/sublime_merge_build_${buildVersion}_mac.zip";
   versionUrl = "https://www.sublimemerge.com/${if dev then "dev" else "download"}";
   versionFile = toString ./default.nix;
 
@@ -67,19 +70,25 @@ let
 
     src = passthru.sources.${stdenv.hostPlatform.system};
 
+    sourceRoot = lib.optionalString stdenv.hostPlatform.isDarwin "Sublime Merge.app";
     dontStrip = true;
     dontPatchELF = true;
-    buildInputs = [
+    dontFixup = stdenv.hostPlatform.isDarwin;
+    buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
       glib
       # for GSETTINGS_SCHEMAS_PATH
       gtk3
     ];
-    nativeBuildInputs = [
-      makeWrapper
-      wrapGAppsHook3
-    ];
+    nativeBuildInputs =
+      lib.optionals stdenv.hostPlatform.isLinux [
+        makeWrapper
+        wrapGAppsHook3
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        unzip
+      ];
 
-    buildPhase = ''
+    buildPhase = lib.optionalString stdenv.hostPlatform.isLinux ''
       runHook preBuild
 
       for binary in ${builtins.concatStringsSep " " binaries}; do
@@ -95,18 +104,29 @@ let
       runHook postBuild
     '';
 
-    installPhase = ''
-      runHook preInstall
+    installPhase =
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          runHook preInstall
 
-      mkdir -p $out
-      cp -r * $out/
+          mkdir -p "$out/Applications/Sublime Merge.app"
+          cp -r Contents "$out/Applications/Sublime Merge.app/"
 
-      runHook postInstall
-    '';
+          runHook postInstall
+        ''
+      else
+        ''
+          runHook preInstall
+
+          mkdir -p $out
+          cp -r * $out/
+
+          runHook postInstall
+        '';
 
     dontWrapGApps = true; # non-standard location, need to wrap the executables manually
 
-    postFixup = ''
+    postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
       wrapProgram $out/${primaryBinary} \
         --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
         --set NIX_REDIRECTS ${builtins.concatStringsSep ":" redirects} \
@@ -134,6 +154,14 @@ let
           url = downloadUrl "x64";
           sha256 = x64sha256;
         };
+        "aarch64-darwin" = fetchurl {
+          url = downloadUrlDarwin;
+          sha256 = darwinsha256;
+        };
+        "x86_64-darwin" = fetchurl {
+          url = downloadUrlDarwin;
+          sha256 = darwinsha256;
+        };
       };
     };
   };
@@ -144,33 +172,47 @@ stdenv.mkDerivation rec {
 
   dontUnpack = true;
 
-  nativeBuildInputs = [
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     makeWrapper
   ];
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p "$out/bin"
-    makeWrapper "${binaryPackage}/${primaryBinary}" "$out/bin/${primaryBinary}"
-  ''
-  + builtins.concatStringsSep "" (
-    map (binaryAlias: "ln -s $out/bin/${primaryBinary} $out/bin/${binaryAlias}\n") primaryBinaryAliases
-  )
-  + ''
-    mkdir -p "$out/share/applications"
+  installPhase =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        runHook preInstall
 
-    substitute \
-      "${binaryPackage}/${primaryBinary}.desktop" \
-      "$out/share/applications/${primaryBinary}.desktop" \
-      --replace-fail "/opt/${primaryBinary}/${primaryBinary}" "${primaryBinary}"
+        mkdir -p "$out/Applications"
+        ln -s "${binaryPackage}/Applications/Sublime Merge.app" "$out/Applications/Sublime Merge.app"
 
-    for directory in ${binaryPackage}/Icon/*; do
-      size=$(basename $directory)
-      mkdir -p "$out/share/icons/hicolor/$size/apps"
-      ln -s ${binaryPackage}/Icon/$size/* $out/share/icons/hicolor/$size/apps
-    done
-    runHook postInstall
-  '';
+        mkdir -p "$out/bin"
+        ln -s "$out/Applications/Sublime Merge.app/Contents/SharedSupport/bin/smerge" "$out/bin/smerge"
+
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
+        mkdir -p "$out/bin"
+        makeWrapper "${binaryPackage}/${primaryBinary}" "$out/bin/${primaryBinary}"
+      ''
+      + builtins.concatStringsSep "" (
+        map (binaryAlias: "ln -s $out/bin/${primaryBinary} $out/bin/${binaryAlias}\n") primaryBinaryAliases
+      )
+      + ''
+        mkdir -p "$out/share/applications"
+
+        substitute \
+          "${binaryPackage}/${primaryBinary}.desktop" \
+          "$out/share/applications/${primaryBinary}.desktop" \
+          --replace-fail "/opt/${primaryBinary}/${primaryBinary}" "${primaryBinary}"
+
+        for directory in ${binaryPackage}/Icon/*; do
+          size=$(basename $directory)
+          mkdir -p "$out/share/icons/hicolor/$size/apps"
+          ln -s ${binaryPackage}/Icon/$size/* $out/share/icons/hicolor/$size/apps
+        done
+        runHook postInstall
+      '';
 
   passthru = {
     unwrapped = binaryPackage;
@@ -214,7 +256,9 @@ stdenv.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = [
+      "aarch64-darwin"
       "aarch64-linux"
+      "x86_64-darwin"
       "x86_64-linux"
     ];
   };

--- a/pkgs/applications/version-management/sublime-merge/default.nix
+++ b/pkgs/applications/version-management/sublime-merge/default.nix
@@ -8,6 +8,7 @@ in
     buildVersion = "2125";
     aarch64sha256 = "Zs4VKbFKkw4KRViX/QGVtVo4hluJ3HVen39Vq3Xz3KI=";
     x64sha256 = "0Zlv4nZMb2FDUG5KLkHTXJjdRzTa3TuNL54yacFVR/c=";
+    darwinsha256 = "8ddmV31z5Q+EfOWWuGJHqfVS1jV10mf4gNlFXD3cUVY=";
   } { };
 
   sublime-merge-dev = common {
@@ -15,5 +16,6 @@ in
     dev = true;
     aarch64sha256 = "jYd22OPZnC6X2Ceuzz4ZiqqD1pFsmQsrihIqY3A+gAc=";
     x64sha256 = "3Tm9TH+kzTCElFLI44K00CXTuV98+uCswy4auXcY+YY=";
+    darwinsha256 = "RT2pcxAtMtlSNWs1JvsSlPacv8QS3aeEJHhqQ/Baj3I=";
   } { };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
