### PR TITLE
pinnwand: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/by-name/pi/pinnwand/package.nix
+++ b/pkgs/by-name/pi/pinnwand/package.nix
@@ -1,24 +1,24 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   nixosTests,
 }:
 
-with python3.pkgs;
+with python3Packages;
 buildPythonApplication (finalAttrs: {
   pname = "pinnwand";
-  version = "1.6.0";
+  version = "1.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "supakeen";
     repo = "pinnwand";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oB7Dd1iVzGqr+5nG7BfZuwOQUgUnmg6ptQDZPGH7P5E=";
+    hash = "sha256-Abj68lJn2qjL1jb+cVzkoc/RYKA6d5tYOPlEwqST0tY=";
   };
 
-  build-system = [ pdm-pep517 ];
+  build-system = [ pdm-backend ];
 
   dependencies = [
     click
@@ -27,6 +27,7 @@ buildPythonApplication (finalAttrs: {
     pygments-better-html
     python-dotenv
     sqlalchemy
+    sqlalchemy-utc
     token-bucket
     tomli
     tornado
@@ -39,7 +40,7 @@ buildPythonApplication (finalAttrs: {
     pytest-html
     pytest-playwright
     pytestCheckHook
-    toml
+    tomli-w
     urllib3
   ];
 

--- a/pkgs/development/python-modules/sqlalchemy-utc/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-utc/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  sqlalchemy,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "sqlalchemy-utc";
+  version = "0.14.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "spoqa";
+    repo = "sqlalchemy-utc";
+    tag = finalAttrs.version;
+    hash = "sha256-ZtUuwUDgd/ngOQoWu8IgOldTbTGoFbv5Y0Hyha1KTrE=";
+  };
+
+  patches = [
+    # https://github.com/spoqa/sqlalchemy-utc/pull/20
+    ./sqlalchemy2-compat.patch
+  ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    sqlalchemy
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "sqlalchemy_utc"
+  ];
+
+  meta = {
+    description = "SQLAlchemy type to store aware datetime values";
+    homepage = "https://github.com/spoqa/sqlalchemy-utc";
+    changelog = "https://github.com/spoqa/sqlalchemy-utc/blob/${finalAttrs.src.rev}/CHANGES.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+})

--- a/pkgs/development/python-modules/sqlalchemy-utc/sqlalchemy2-compat.patch
+++ b/pkgs/development/python-modules/sqlalchemy-utc/sqlalchemy2-compat.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/test_now.py b/tests/test_now.py
+index 93470e5..8ea9ee6 100644
+--- a/tests/test_now.py
++++ b/tests/test_now.py
+@@ -28,7 +28,7 @@ def fx_connection(fx_engine):
+ 
+ def test_utcnow_timezone(fx_connection):
+     fx_connection.execute(TABLE.insert(), [{}])
+-    rows = fx_connection.execute(select([TABLE])).fetchall()
++    rows = fx_connection.execute(select(TABLE)).fetchall()
+     server_now = rows[0].time
+     local_now = datetime.datetime.now(utc)
+     assert server_now.tzinfo is not None

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18344,6 +18344,8 @@ self: super: with self; {
 
   sqlalchemy-mixins = callPackage ../development/python-modules/sqlalchemy-mixins { };
 
+  sqlalchemy-utc = callPackage ../development/python-modules/sqlalchemy-utc { };
+
   sqlalchemy-utils = callPackage ../development/python-modules/sqlalchemy-utils { };
 
   sqlalchemy_1_3 = callPackage ../development/python-modules/sqlalchemy/1_3.nix { };


### PR DESCRIPTION
https://github.com/supakeen/pinnwand/releases/tag/v1.6.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
