### PR TITLE
msolve: guard SIMD instructions

### DIFF
--- a/pkgs/by-name/ms/msolve/package.nix
+++ b/pkgs/by-name/ms/msolve/package.nix
@@ -37,6 +37,35 @@ stdenv.mkDerivation (finalAttrs: {
     llvmPackages.openmp
   ];
 
+  configureFlags =
+    let
+      mkCpuFeatureFlag = acvar: cond: "ax_cv_have_${acvar}_cpu_ext=${lib.boolToYesNo cond}";
+    in
+    [
+      (mkCpuFeatureFlag "sse3" stdenv.hostPlatform.sse3Support)
+      (mkCpuFeatureFlag "ssse3" stdenv.hostPlatform.ssse3Support)
+      (mkCpuFeatureFlag "sse41" stdenv.hostPlatform.sse4_1Support)
+      (mkCpuFeatureFlag "sse42" stdenv.hostPlatform.sse4_2Support)
+      (mkCpuFeatureFlag "sse4a" stdenv.hostPlatform.sse4_aSupport)
+      (mkCpuFeatureFlag "avx" stdenv.hostPlatform.avxSupport)
+      (mkCpuFeatureFlag "avx2" stdenv.hostPlatform.avx2Support)
+    ]
+    ++ map (lib.flip mkCpuFeatureFlag stdenv.hostPlatform.avx512Support) [
+      "avx512f"
+      "avx512cd"
+      "avx512pf"
+      "avx512er"
+      "avx512vl"
+      "avx512bw"
+      "avx512dq"
+      "avx512ifma"
+      "avx512vbmi"
+    ]
+    ++ [
+      (mkCpuFeatureFlag "fma3" stdenv.hostPlatform.fmaSupport)
+      (mkCpuFeatureFlag "fma4" stdenv.hostPlatform.fma4Support)
+    ];
+
   doCheck = true;
 
   meta = {


### PR DESCRIPTION
Running `msolve` [built by Hydra](https://hydra.nixos.org/build/325188535) on my `x86_64-linux` laptop gives an illegal instruction error:

```sh
$ curl -sL https://gitlab.lip6.fr/eder/msolve-examples/-/raw/master/zero-dimensional/cp_d_3_n_4_p_2.ms -o cp_d_3_n_4_p_2.ms
$ nix run github:nixos/nixpkgs/96b35ef7a3cb2b14d7cffc39acb986a66bce3d9e#msolve -- -f ./cp_d_3_n_4_p_2.ms
[1]    537864 illegal hardware instruction (core dumped)  ...
```

As far as I can tell this is because the configure script checks for SSE and AVX support on the builder's CPU, see https://hydra.nixos.org/build/325188535/log (search for `checking whether AVX512-F is supported by the processor`).

Looking at https://github.com/algebraic-solving/msolve/blob/v0.9.5/m4/ax_ext.m4 I figured out the configureFlags to pass to avoid this impure behaviour.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
