### PR TITLE
kotatogram-desktop: restore tg_owt patches for older version

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/cstring-includes.patch
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/cstring-includes.patch
@@ -1,0 +1,74 @@
+diff --git a/src/api/video/nv12_buffer.cc b/src/api/video/nv12_buffer.cc
+index ca9dcd867..89d28f23c 100644
+--- a/src/api/video/nv12_buffer.cc
++++ b/src/api/video/nv12_buffer.cc
+@@ -16,6 +16,8 @@
+ #include "third_party/libyuv/include/libyuv/convert.h"
+ #include "third_party/libyuv/include/libyuv/scale.h"
+
++#include <cstring>
++
+ namespace webrtc {
+
+ namespace {
+diff --git a/src/audio/utility/channel_mixer.cc b/src/audio/utility/channel_mixer.cc
+index 0f1e66387..33b771b0c 100644
+--- a/src/audio/utility/channel_mixer.cc
++++ b/src/audio/utility/channel_mixer.cc
+@@ -15,6 +15,8 @@
+ #include "rtc_base/logging.h"
+ #include "rtc_base/numerics/safe_conversions.h"
+
++#include <cstring>
++
+ namespace webrtc {
+
+ ChannelMixer::ChannelMixer(ChannelLayout input_layout,
+diff --git a/src/modules/audio_processing/aec3/alignment_mixer.cc b/src/modules/audio_processing/aec3/alignment_mixer.cc
+index 7f076dea8..ffd7242b5 100644
+--- a/src/modules/audio_processing/aec3/alignment_mixer.cc
++++ b/src/modules/audio_processing/aec3/alignment_mixer.cc
+@@ -10,6 +10,7 @@
+ #include "modules/audio_processing/aec3/alignment_mixer.h"
+
+ #include <algorithm>
++#include <cstring>
+
+ #include "rtc_base/checks.h"
+
+diff --git a/src/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc b/src/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+index 7ef1a030e..5b9ab7137 100644
+--- a/src/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
++++ b/src/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc
+@@ -18,6 +18,7 @@
+ #include <spa/param/video/format-utils.h>
+ #include <sys/mman.h>
+
++#include <cstring>
+ #include <vector>
+
+ #include "absl/memory/memory.h"
+diff --git a/src/modules/video_coding/utility/ivf_file_reader.cc b/src/modules/video_coding/utility/ivf_file_reader.cc
+index 4c08ca613..f82f2bfcb 100644
+--- a/src/modules/video_coding/utility/ivf_file_reader.cc
++++ b/src/modules/video_coding/utility/ivf_file_reader.cc
+@@ -10,6 +10,7 @@
+
+ #include "modules/video_coding/utility/ivf_file_reader.h"
+
++#include <cstring>
+ #include <string>
+ #include <vector>
+
+diff --git a/src/net/dcsctp/packet/bounded_byte_writer.h b/src/net/dcsctp/packet/bounded_byte_writer.h
+index d754549e4..bf5e3ed42 100644
+--- a/src/net/dcsctp/packet/bounded_byte_writer.h
++++ b/src/net/dcsctp/packet/bounded_byte_writer.h
+@@ -12,6 +12,7 @@
+ #define NET_DCSCTP_PACKET_BOUNDED_BYTE_WRITER_H_
+
+ #include <algorithm>
++#include <cstring>
+
+ #include "api/array_view.h"
+ 

--- a/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/kotatogram-desktop/default.nix
@@ -31,6 +31,9 @@ let
     };
 
     patches = [
+      # fix build with latest glibc
+      # upstream PR: https://github.com/desktop-app/tg_owt/pull/172
+      ./cstring-includes.patch
       (fetchpatch {
         url = "https://webrtc.googlesource.com/src/+/e7d10047096880feb5e9846375f2da54aef91202%5E%21/?format=TEXT";
         decode = "base64 -d";


### PR DESCRIPTION
### Description

`kotatogram-desktop` overrides `tg_owt` to use version `0-unstable-2024-06-15`, because
>tg_owt's master tracks WebRTC from Chromium 123 while Kotatogram is still based on tdesktop version that was using tgcalls/tg_owt tracking WebRTC from Chromium 108.

which requires two patches that were removed from `telegram-desktop`'s `tg_owt` definition in #503544 after being fixed upstream in newer versions.

Since kotatogram-desktop uses an older `tg_owt` version that doesn't include these upstream fixes, the patches need to be maintained locally.

This PR restores the following patches to the exact state they were before #503544, but now are only applied to `kotatogram-desktop` package:
- `abseil-202508.patch`: fixes build with abseil 202508, based on upstream PR:
desktop-app/tg_owt#164
- `cstring-includes.patch`: fixes build with glibc by adding missing `<cstring>` includes, based on upstream PR: 
desktop-app/tg_owt#172

Resolves #504273

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
