### PR TITLE
protontricks: add freetype to steam-run fhs

### DIFF
--- a/pkgs/by-name/pr/protontricks/package.nix
+++ b/pkgs/by-name/pr/protontricks/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   replaceVars,
   writeShellScript,
-  steam-run-free,
+  steam,
   fetchpatch2,
   winetricks,
   yad,
@@ -12,6 +12,17 @@
   extraCompatPaths ? "",
 }:
 
+let
+  steam-run =
+    (steam.override {
+      extraLibraries =
+        p: with p; [
+          # Fixes installing vcrun2022
+          # https://github.com/Matoking/protontricks/issues/461
+          freetype
+        ];
+    }).run-free;
+in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "protontricks";
   version = "1.14.0";
@@ -27,9 +38,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
   patches = [
     # Use steam-run to run Proton binaries
     (replaceVars ./steam-run.patch {
-      steamRun = lib.getExe steam-run-free;
+      steamRun = lib.getExe steam-run;
       bash = writeShellScript "steam-run-bash" ''
-        exec ${lib.getExe steam-run-free} bash "$@"
+        exec ${lib.getExe steam-run} bash "$@"
       '';
     })
 


### PR DESCRIPTION
Fixes installing vcrun2022: (closes #479497)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
