### PR TITLE
connectome-workbench: fix build with gcc15

### DIFF
--- a/pkgs/by-name/co/connectome-workbench/gcc15-cstdint.patch
+++ b/pkgs/by-name/co/connectome-workbench/gcc15-cstdint.patch
@@ -1,0 +1,10 @@
+--- a/Common/CaretRgb.h
++++ b/Common/CaretRgb.h
+@@ -23,6 +23,7 @@
+ 
+ 
+ #include <array>
++#include <cstdint>
+ #include <memory>
+ 
+ namespace caret {

--- a/pkgs/by-name/co/connectome-workbench/package.nix
+++ b/pkgs/by-name/co/connectome-workbench/package.nix
@@ -22,6 +22,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/src";
 
+  patches = [
+    # GCC 15 compatibility: add missing #include <cstdint>
+    ./gcc15-cstdint.patch
+  ];
+
   postPatch = ''
     substituteInPlace kloewe/{cpuinfo,dot}/CMakeLists.txt --replace-fail "cmake_minimum_required(VERSION 3.0)" "cmake_minimum_required(VERSION 3.10)"
   ''


### PR DESCRIPTION
- #475479
- https://hydra.nixos.org/build/324213046

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
