### PR TITLE
sourcey: init at 3.6.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2608,6 +2608,11 @@
     githubId = 574938;
     name = "Jonathan Glines";
   };
+  auscaster = {
+    github = "auscaster";
+    githubId = 100876;
+    name = "Kam Low";
+  };
   auscyber = {
     email = "ivyp@outlook.com.au";
     github = "auscyber";

--- a/pkgs/by-name/so/sourcey/package.nix
+++ b/pkgs/by-name/so/sourcey/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "sourcey";
+  version = "3.3.10";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sourcey";
+    repo = "sourcey";
+    tag = finalAttrs.version;
+    hash = "sha256-ByvcCxjxNzmQVzNIPZTY/RPrGyd7RDPTpCvYtkaqazs=";
+  };
+
+  npmDepsHash = "sha256-jdzOCeFoUcjmaJz1h4i1utWdFwcfcDmtTkfj+EGXVtI=";
+
+  npmDepsFetcherVersion = 2;
+
+  makeCacheWritable = true;
+
+  npmFlags = [ "--legacy-peer-deps" ];
+
+  dontNpmBuild = true;
+
+  meta = {
+    description = "Open source documentation platform for OpenAPI specs and markdown";
+    homepage = "https://sourcey.com";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "sourcey";
+    maintainers = with lib.maintainers; [ auscaster ];
+  };
+})

--- a/pkgs/by-name/so/sourcey/package.nix
+++ b/pkgs/by-name/so/sourcey/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "sourcey";
+  version = "3.6.5";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sourcey";
+    repo = "sourcey";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-l1MpeJKGlQfiLCtCNMlG6ZEDYYLTMIy+N9sddDkxKXc=";
+  };
+
+  npmDepsHash = "sha256-Wwa7//iSvBmLCogVqk8aAUX9kn9FZsndvX00JBoXI+0=";
+
+  npmDepsFetcherVersion = 2;
+
+  makeCacheWritable = true;
+
+  npmFlags = [ "--legacy-peer-deps" ];
+
+  dontNpmBuild = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source documentation platform for OpenAPI specs and markdown";
+    homepage = "https://sourcey.com";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "sourcey";
+    maintainers = with lib.maintainers; [ auscaster ];
+  };
+})


### PR DESCRIPTION
Adds sourcey, an open source documentation platform for OpenAPI specs and markdown.

Homepage: https://sourcey.com
Source: https://github.com/sourcey/sourcey
License: AGPL-3.0-only

Builds and runs successfully with `nix build github:sourcey/sourcey`.