### PR TITLE
gdb: let configure auto-detect in-process agent support

### DIFF
--- a/pkgs/by-name/gd/gdb/package.nix
+++ b/pkgs/by-name/gd/gdb/package.nix
@@ -193,10 +193,8 @@ stdenv.mkDerivation (finalAttrs: {
     (withFeatureAs true "auto-load-safe-path" (builtins.concatStringsSep ":" safePaths))
     (withFeature enableDebuginfod "debuginfod")
     (enableFeature (!stdenv.hostPlatform.isMusl) "nls")
-    (enableFeature (
-      !stdenv.hostPlatform.isStatic && !stdenv.hostPlatform.isLoongArch64
-    ) "inprocess-agent")
   ]
+  ++ optional stdenv.hostPlatform.isStatic "--disable-inprocess-agent"
   ++ optional (!hostCpuOnly) "--enable-targets=all"
   # Workaround for Apple Silicon, "--target" must be "faked", see eg: https://github.com/Homebrew/homebrew-core/pull/209753
   ++ optional (


### PR DESCRIPTION
PR #470156 switched the in-process agent flag to use `lib.enableFeature`, which passes `--enable-inprocess-agent` explicitly. That breaks the build on architectures where GDB has no IPA implementation (RISC-V, LoongArch64) because `gdbserver/configure.srv` never sets `ipa_obj` for those targets.

Instead of growing the exclusion list, drop the `enableFeature` call and only pass `--disable-inprocess-agent` for static builds. GDB's configure already defaults to disabling IPA when the target doesn't support it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[1]: https://gitlab.com/gnutools/binutils-gdb/-/blob/master/gdbserver/configure.srv#L284-290