### PR TITLE
jai-jail: init at 0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -802,6 +802,13 @@
     githubId = 19290901;
     name = "Andrew Brooks";
   };
+  agentelement = {
+    email = "agentelement@agentelement.net";
+    github = "agentelement";
+    githubId = 38045210;
+    name = "AgentElement";
+    keys = [ { fingerprint = "D37E 581D AD71 2378 A622  5BC0 CD13 9E3B 4354 34F1"; } ];
+  };
   agilesteel = {
     email = "agilesteel@gmail.com";
     github = "agilesteel";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -813,6 +813,13 @@
     githubId = 19290901;
     name = "Andrew Brooks";
   };
+  agentelement = {
+    email = "agentelement@agentelement.net";
+    github = "agentelement";
+    githubId = 38045210;
+    name = "AgentElement";
+    keys = [ { fingerprint = "D37E 581D AD71 2378 A622  5BC0 CD13 9E3B 4354 34F1"; } ];
+  };
   agilesteel = {
     email = "agilesteel@gmail.com";
     github = "agilesteel";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -245,6 +245,7 @@
   ./programs/iio-hyprland.nix
   ./programs/immersed.nix
   ./programs/iotop.nix
+  ./programs/jai-jail.nix
   ./programs/java.nix
   ./programs/joycond-cemuhook.nix
   ./programs/k3b.nix

--- a/nixos/modules/programs/jai-jail.nix
+++ b/nixos/modules/programs/jai-jail.nix
@@ -1,0 +1,45 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.jai-jail;
+
+in
+{
+  options.programs.jai-jail = {
+    enable = lib.mkEnableOption "jai, a sandbox for AI agents";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.jai-jail;
+      defaultText = lib.literalExpression "pkgs.jai-jail";
+      description = "The jai package to use.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    security.wrappers.jai = {
+      setuid = true;
+      owner = "root";
+      group = "root";
+      source = "${cfg.package}/bin/jai";
+    };
+
+    users.users.jai = {
+      isSystemUser = true;
+      group = "jai";
+      home = "/";
+      description = "JAI sandbox untrusted user";
+    };
+
+    users.groups.jai = { };
+
+    environment.systemPackages = [ cfg.package ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ agentelement ];
+}

--- a/pkgs/by-name/ja/jai-jail/package.nix
+++ b/pkgs/by-name/ja/jai-jail/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  gcc15Stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  pandoc,
+  util-linux,
+  acl,
+}:
+
+gcc15Stdenv.mkDerivation (finalAttrs: {
+  pname = "jai";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "stanford-scs";
+    repo = "jai";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BMgWodfo5l/PKOniEYHrUSQJIr3t8BzdLhw9nU0qbOw=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    pandoc
+  ];
+
+  buildInputs = [
+    util-linux # libmount
+    acl
+  ];
+
+  configureFlags = [ "--with-untrusted-user=jai" ];
+
+  meta = {
+    description = "Lightweight jail for AI CLIs";
+    mainProgram = "jai";
+    homepage = "https://jai.scs.stanford.edu";
+    changelog = "https://github.com/stanford-scs/jai/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ agentelement ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ja/jai-jail/package.nix
+++ b/pkgs/by-name/ja/jai-jail/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  gcc15Stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  pandoc,
+  systemd,
+  util-linux,
+  acl,
+}:
+
+gcc15Stdenv.mkDerivation (finalAttrs: {
+  pname = "jai-jail";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "stanford-scs";
+    repo = "jai";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AByC7Xh1FYbQ/4Au396m2zYUxsLqcF1PEbpdz7x6LaQ=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    pandoc
+    systemd
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  buildInputs = [
+    util-linux # libmount
+    acl
+  ];
+
+  configureFlags = [ "--with-untrusted-user=jai" ];
+
+  meta = {
+    description = "Lightweight jail for AI CLIs";
+    mainProgram = "jai";
+    homepage = "https://jai.scs.stanford.edu";
+    changelog = "https://github.com/stanford-scs/jai/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ agentelement ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
I've added jai, a lightweight container marketed for llm-assisted programming tools (opencode, etc). These tools are interesting but insecure in that they allow llms read/write access to files outside your working directory, possibly causing data loss. jai attempts to prevent this by making files outside the working directory read-only or nonexistent to the tools within jai's jail.

github: https://github.com/stanford-scs/jai
homepage: https://jai.scs.stanford.edu/

It's a setuid binary, so there's also a module that sets the correct permissions, otherwise you would have to run it with sudo (I modeled the module off of the firejail module).

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
