### PR TITLE
[Backport release-25.11] rmg: patch includes that cause errors

### DIFF
--- a/pkgs/by-name/rm/rmg/package.nix
+++ b/pkgs/by-name/rm/rmg/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   gitUpdater,
   boost,
   cmake,
@@ -38,6 +39,20 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-XMYHzPE5h9gD1fpN8b5YwOpY5zYCsYYQnof2MHDHa3E=";
   };
+
+  # Fixes include errors from including minizip libraries
+  patches = [
+    (fetchpatch2 {
+      name = "0000-fix-minizip-include-archive";
+      url = "https://github.com/Rosalie241/RMG/commit/7e4e402f277803d3a998e96ea04064063bd1551a.patch";
+      hash = "sha256-uyEYv2r7J2nou9AHkezEX0LS/mOnIa6lbQqhxHY9ibo=";
+    })
+    (fetchpatch2 {
+      name = "0001-fix-minizip-include-mupen64plus-core";
+      url = "https://github.com/Rosalie241/RMG/commit/8ee3410680c247dcfee806562073626a0b7bf46b.patch";
+      hash = "sha256-29zg90ScPNizWq3BzNuM6yfCwmMXRYFfbjOg3YpCrGI=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Backport of the build fixing commit from #503038

Closes #504723

(cherry picked from commit 28923d5072f76ef8296ce1165b626ac654ba5a3b)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
