### PR TITLE
onnxruntime: fix cross-compilation

### DIFF
--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -21,7 +21,7 @@
   protobuf,
   microsoft-gsl,
   darwinMinVersionHook,
-  pythonSupport ? true,
+  pythonSupport ? (stdenv.buildPlatform.canExecute stdenv.hostPlatform),
   cudaSupport ? config.cudaSupport,
   ncclSupport ? cudaSupport && cudaPackages.nccl.meta.available,
   rocmSupport ? config.rocmSupport,
@@ -165,6 +165,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     libpng
     nlohmann_json
     microsoft-gsl
+    protobuf
     zlib
   ]
   ++ lib.optionals (lib.meta.availableOn effectiveStdenv.hostPlatform cpuinfo) [
@@ -313,6 +314,8 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     !(
       cudaSupport
       || rocmSupport
+      # cross-compiled test binaries can't execute on the build platform
+      || (effectiveStdenv.hostPlatform != effectiveStdenv.buildPlatform)
       || builtins.elem effectiveStdenv.buildPlatform.system [
         # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox
         "aarch64-linux"


### PR DESCRIPTION
Fix cross-compilation of onnxruntime (tested with `pkgsCross.riscv64`). Three things were broken:

  1. `doCheck` was true, so CMake tried to build unit tests and fetch GTest. `FETCHCONTENT_FULLY_DISCONNECTED` blocks the download, and the test binaries can't run on the build machine anyway.
  2. `pythonSupport` defaulted to `true`, but CMake's `FindPython` runs the build-platform Python, which can't find target-platform NumPy headers.
  3. `protobuf` was only in `nativeBuildInputs` (for `protoc`), so the linker found the build-platform `libprotobuf-lite.so` instead of the target's.

   Fixes:
   - Disable `doCheck` when `hostPlatform != buildPlatform`
   - Default `pythonSupport` to `stdenv.buildPlatform.canExecute stdenv.hostPlatform`
   - Add `protobuf` to `buildInputs`

Resolves #462791 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
