### PR TITLE
sftpgo-plugin-auth: init at 1.0.14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5388,6 +5388,12 @@
     name = "Simon Hauser";
     githubId = 15233006;
   };
+  connor-grady = {
+    email = "connor.grady@gmail.com";
+    github = "connor-grady";
+    githubId = 50903811;
+    name = "Connor Grady";
+  };
   connorbaker = {
     email = "ConnorBaker01@gmail.com";
     matrix = "@connorbaker:matrix.org";

--- a/pkgs/by-name/sf/sftpgo-plugin-auth/package.nix
+++ b/pkgs/by-name/sf/sftpgo-plugin-auth/package.nix
@@ -1,0 +1,40 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "sftpgo-plugin-auth";
+  version = "1.0.14";
+
+  src = fetchFromGitHub {
+    owner = "sftpgo";
+    repo = "sftpgo-plugin-auth";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Aw9n4CBmsWEqhNol5Ge/Ae5uaZn4zp6sIc8N6L724H4=";
+  };
+
+  vendorHash = "sha256-ZCkKr0hpHx37T9DfaYev9jxkpNcDPF9R0YsCkw2/pA8=";
+
+  env.CGO_ENABLED = "0";
+
+  ldflags = [
+    "-s"
+    "-X github.com/sftpgo/sftpgo-plugin-auth/cmd.commitHash=${finalAttrs.src.rev}"
+  ];
+
+  subPackages = [ "." ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/sftpgo/sftpgo-plugin-auth";
+    changelog = "https://github.com/sftpgo/sftpgo-plugin-auth/releases/tag/${finalAttrs.src.tag}";
+    description = "LDAP/Active Directory authentication for SFTPGo";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ connor-grady ];
+    mainProgram = "sftpgo-plugin-auth";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
LDAP/Active Directory authentication plugin for SFTPGo.

https://github.com/sftpgo/sftpgo-plugin-auth

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
