### PR TITLE
python3Packages.pyvlx: 0.2.30 -> 0.2.32

### DIFF
--- a/pkgs/development/python-modules/pyvlx/default.nix
+++ b/pkgs/development/python-modules/pyvlx/default.nix
@@ -1,31 +1,26 @@
 {
   lib,
   buildPythonPackage,
+  deprecated,
   fetchFromGitHub,
   pytestCheckHook,
   pyyaml,
   setuptools,
   setuptools-scm,
-  typing-extensions,
   zeroconf,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pyvlx";
-  version = "0.2.30";
+  version = "0.2.32";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Julius2342";
     repo = "pyvlx";
     tag = finalAttrs.version;
-    hash = "sha256-owrWYBAb/5JAangGwt56gdjJf99C3i04IiKAh1P/MYY=";
+    hash = "sha256-ArNWXvYZ/eZWPUvV8z/+6WsAcm5MTnKblMrUFj51JhM=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "setuptools-scm>=8.0" "setuptools-scm"
-  '';
 
   build-system = [
     setuptools
@@ -33,8 +28,8 @@ buildPythonPackage (finalAttrs: {
   ];
 
   dependencies = [
+    deprecated
     pyyaml
-    typing-extensions
     zeroconf
   ];
 


### PR DESCRIPTION
Diff: https://github.com/Julius2342/pyvlx/compare/0.2.30...0.2.32

Changelog: https://github.com/Julius2342/pyvlx/releases/tag/0.2.32


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
