### PR TITLE
gradle: configure updateScript per major version

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -119,7 +119,7 @@ let
 
       # Put the update script in passthru. Should only be on a single attrpath
       # so that nixpkgs-update doesn't create duplicate PRs.
-      enableUpdateScript ? false,
+      updateScriptMajorVersion ? null,
     }@genArgs:
 
     {
@@ -305,14 +305,15 @@ let
         gradle-unwrapped = mkGradle genArgs;
       };
       passthru.updateScript =
-        if enableUpdateScript then
+        if updateScriptMajorVersion != null then
           nix-update-script {
             extraArgs = [
               "--url=https://github.com/gradle/gradle"
+              "--use-github-releases"
               # Gradle’s .0 releases are tagged as `vX.Y.0`, but the actual
               # release version omits the `.0`, so we’ll wanto to only capture
               # the version up but not including the the trailing `.0`.
-              "--version-regex=^v(\\d+\\.\\d+(?:\\.[1-9]\\d?)?)(\\.0)?$"
+              "--version-regex=^v(${updateScriptMajorVersion}\\.\\d+(?:\\.[1-9]\\d?)?)(\\.0)?$"
             ];
           }
         else
@@ -367,13 +368,13 @@ rec {
     version = "9.4.0";
     hash = "sha256-YOpyM1bYEmPoAC/sD8+eKw7uDAhQx6PXqwpj8szGAfM=";
     defaultJava = jdk21;
+    updateScriptMajorVersion = "9";
   };
   gradle_8 = mkGradle {
     version = "8.14.4";
     hash = "sha256-8XcSmKcPbbWina9iN4xOGKF/wzybprFDYuDN9AYQOA0=";
     defaultJava = jdk21;
-    # Only enable this on *one* version to avoid duplicate PRs.
-    enableUpdateScript = true;
+    updateScriptMajorVersion = "8";
   };
   gradle_7 = mkGradle {
     version = "7.6.6";


### PR DESCRIPTION
Previously the regex for updating Gradle matched any major version, resulting in version bumps like #504857 where gradle_8 was updated to 9.4.1.

After this change, the version regexp is tagged to a specific major version. That way gradle_8 is only updated to versions that start with '8'. At the same time version updates are enabled for gradle_9 if they start with '9'.

Last but not least, `nix-update-script` is now called with `--use-github-releases` because without it the updater defaults to using GitHub's releases Atom feed, and just returns the most recent releases, causing the gradle_8 update to fail because no matching release version could be found.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
