### PR TITLE
nixos/authelia: add default instance support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5388,6 +5388,12 @@
     name = "Simon Hauser";
     githubId = 15233006;
   };
+  connor-grady = {
+    email = "connor.grady@gmail.com";
+    github = "connor-grady";
+    githubId = 50903811;
+    name = "Connor Grady";
+  };
   connorbaker = {
     email = "ConnorBaker01@gmail.com";
     matrix = "@connorbaker:matrix.org";

--- a/nixos/modules/services/security/authelia.nix
+++ b/nixos/modules/services/security/authelia.nix
@@ -10,9 +10,11 @@ let
 
   format = pkgs.formats.yaml { };
 
+  autheliaName = name: "authelia" + lib.optionalString (name != "") "-${name}";
+
   autheliaOpts =
     with lib;
-    { name, ... }:
+    { name, config, ... }:
     {
       options = {
         enable = mkEnableOption "Authelia instance";
@@ -23,21 +25,28 @@ let
           description = ''
             Name is used as a suffix for the service name, user, and group.
             By default it takes the value you use for `<instance>` in:
-            {option}`services.authelia.<instance>`
+            {option}`services.authelia.instances.<instance>`
+
+            When set to the empty string `""`, the service name, user, and group
+            will be just `authelia` without a suffix.
           '';
         };
 
         package = mkPackageOption pkgs "authelia" { };
 
         user = mkOption {
-          default = "authelia-${name}";
           type = types.str;
+          defaultText = lib.literalExpression ''
+            if name == "" then "authelia" else "authelia-''${name}"
+          '';
           description = "The name of the user for this authelia instance.";
         };
 
         group = mkOption {
-          default = "authelia-${name}";
           type = types.str;
+          defaultText = lib.literalExpression ''
+            if name == "" then "authelia" else "authelia-''${name}"
+          '';
           description = "The name of the group for this authelia instance.";
         };
 
@@ -252,6 +261,11 @@ let
           '';
         };
       };
+
+      config = {
+        user = mkDefault (autheliaName config.name);
+        group = mkDefault (autheliaName config.name);
+      };
     };
 
   writeOidcJwksConfigFile =
@@ -382,7 +396,7 @@ in
             ExecStart = "${execCommand} ${configArg}";
             Restart = "always";
             RestartSec = "5s";
-            StateDirectory = "authelia-${instance.name}";
+            StateDirectory = autheliaName instance.name;
             StateDirectoryMode = "0700";
 
             # Security options:
@@ -431,11 +445,8 @@ in
           };
         };
       mkInstanceUsersConfig = instance: {
-        groups."authelia-${instance.name}" = lib.mkIf (instance.group == "authelia-${instance.name}") {
-          name = "authelia-${instance.name}";
-        };
-        users."authelia-${instance.name}" = lib.mkIf (instance.user == "authelia-${instance.name}") {
-          name = "authelia-${instance.name}";
+        groups.${autheliaName instance.name} = lib.mkIf (instance.group == autheliaName instance.name) { };
+        users.${autheliaName instance.name} = lib.mkIf (instance.user == autheliaName instance.name) {
           isSystemUser = true;
           group = instance.group;
         };
@@ -468,7 +479,7 @@ in
         map (
           instance:
           lib.mkIf instance.enable {
-            "authelia-${instance.name}" = mkInstanceServiceConfig instance;
+            ${autheliaName instance.name} = mkInstanceServiceConfig instance;
           }
         ) instances
       );
@@ -481,5 +492,6 @@ in
     jk
     dit7ya
     nicomem
+    connor-grady
   ];
 }


### PR DESCRIPTION
Add autheliaName helper (matching the redisName pattern from the Redis module) to support using an empty string as an instance name, producing "authelia" without a trailing dash.

- services.authelia.instances."" → service/user/group name authelia
- services.authelia.instances.main → authelia-main (unchanged)

Also moves user/group defaults to a submodule config block so they derive from config.name rather than the attribute key, fixing a pre-existing inconsistency when overriding the name option.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @06kellyjac @dit7ya @nicomem