### PR TITLE
 euro-office-documentserver: init at 9.3.3

### DIFF
--- a/nixos/modules/services/web-apps/onlyoffice.nix
+++ b/nixos/modules/services/web-apps/onlyoffice.nix
@@ -271,7 +271,7 @@ in
         serviceConfig = {
           # needs to be ran wrapped in FHS for now
           # because the default config refers to many FHS paths
-          ExecStart = "${cfg.package.fhs}/bin/onlyoffice-wrapper ${cfg.package.fileconverter}/bin/fileconverter";
+          ExecStart = "${lib.getExe cfg.package.fhs} ${cfg.package.fileconverter}/bin/fileconverter";
           Group = "onlyoffice";
           Restart = "always";
           RuntimeDirectory = "onlyoffice";
@@ -361,7 +361,7 @@ in
             NODE_ENV = "production-linux";
           };
           serviceConfig = {
-            ExecStart = "${cfg.package.fhs}/bin/onlyoffice-wrapper ${cfg.package.docservice}/bin/docservice";
+            ExecStart = "${lib.getExe cfg.package.fhs} ${cfg.package.docservice}/bin/docservice";
             ExecStartPre = [ onlyoffice-prestart ];
             Group = "onlyoffice";
             Restart = "always";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1176,7 +1176,9 @@ in
   ombi = runTest ./ombi.nix;
   omnom = runTest ./omnom;
   oncall = runTest ./web-apps/oncall.nix;
-  onlyoffice = runTest ./onlyoffice.nix;
+  onlyoffice = runTest (import ./onlyoffice.nix { }) // {
+    passthru.override = args: runTest (import ./onlyoffice.nix args);
+  };
   open-web-calendar = runTest ./web-apps/open-web-calendar.nix;
   open-webui = runTest ./open-webui.nix;
   openafs = runTest ./openafs.nix;

--- a/nixos/tests/onlyoffice.nix
+++ b/nixos/tests/onlyoffice.nix
@@ -1,3 +1,6 @@
+{
+  package ? null,
+}:
 let
   port = 8000;
 in
@@ -5,7 +8,7 @@ in
   name = "onlyoffice";
 
   nodes.machine =
-    { pkgs, ... }:
+    { pkgs, lib, ... }:
     {
       services.onlyoffice = {
         enable = true;
@@ -14,7 +17,8 @@ in
         securityNonceFile = "${pkgs.writeText "nixos-test-onlyoffice-nonce.conf" ''
           set $secure_link_secret "nixostest";
         ''}";
-      };
+      }
+      // lib.optionalAttrs (package != null) { inherit package; };
 
       networking.hosts = {
         "::1" = [ "office.example.com" ];

--- a/pkgs/by-name/eu/euro-office-documentserver/package.nix
+++ b/pkgs/by-name/eu/euro-office-documentserver/package.nix
@@ -1,0 +1,226 @@
+{
+  buildFHSEnv,
+  buildNpmPackage,
+  dpkg,
+  fetchFromGitHub,
+  fetchurl,
+  gcc-unwrapped,
+  lib,
+  lndir,
+  nixosTests,
+  pkg-config,
+  runCommand,
+  stdenvNoCC,
+  vips,
+  writeScript,
+  x2t,
+
+  extra-fonts ? [ ],
+}:
+
+let
+  version = "0-unstable-2026-04-08";
+  server-src = fetchFromGitHub {
+    owner = "Euro-Office";
+    repo = "server";
+    rev = "f4afd0efaab0ed64406db3188d4c47d4fe2c6a0a";
+    hash = "sha256-97MTQDt1YUUnlAw8j6v79vUTicSgn0Wm1Cg+O1dDZEo=";
+  };
+  common = buildNpmPackage (finalAttrs: {
+    name = "euro-office-server-Common";
+    src = server-src;
+    sourceRoot = "${finalAttrs.src.name}/Common";
+    npmDepsHash = "sha256-zFGqDtnNFzXCwp6uvK04GDMRG6BATv6ti3Wi8ikLjBU=";
+    dontNpmBuild = true;
+    postPatch = ''
+      # https://github.com/ONLYOFFICE/build_tools/blob/ef8153c053bed41909ceb0762b124f8fe7faa0a7/scripts/build_server.py#L34
+      sed -e "s/^const buildVersion = '[0-9.]*'/const buildVersion = '${version}'/" -i sources/commondefines.js
+    '';
+    postInstall = ''
+      ln -s $out/lib/node_modules/common $out/lib/node_modules/Common
+    '';
+  });
+  docservice = buildNpmPackage (finalAttrs: {
+    name = "euro-office-server-DocService";
+    src = server-src;
+    sourceRoot = "${finalAttrs.src.name}/DocService";
+    nativeBuildInputs = [
+      pkg-config
+    ];
+    buildInputs = [
+      vips.dev
+    ];
+    npmDepsHash = "sha256-EKrMv1AIbdgMbXvZrqdSWP1j+s8UhEsXFdPTcJyCl1w=";
+    npmFlags = [ "--loglevel=verbose" ];
+    dontNpmBuild = true;
+    postInstall = ''
+      # it would be neater if this were a 'ln -s', but this is not possible
+      # because common/sources/notificationService.js has a circular dependency
+      # back on DocService
+      cp -r ${common}/lib/node_modules/common $out/lib/node_modules/Common
+      ln -s $out/lib/node_modules/coauthoring $out/lib/node_modules/DocService
+    '';
+  });
+  fileconverter = buildNpmPackage (finalAttrs: {
+    name = "euro-office-server-FileConverter";
+    src = server-src;
+
+    sourceRoot = "${finalAttrs.src.name}/FileConverter";
+
+    npmDepsHash = "sha256-zGLZBbQYV2z0HgQKISKVhclRKbMB8RYEX13H0mB6qJw=";
+
+    dontNpmBuild = true;
+
+    postInstall = ''
+      ln -s ${common}/lib/node_modules/common $out/lib/node_modules/Common
+      ln -s ${docservice}/lib/node_modules/coauthoring $out/lib/node_modules/DocService
+    '';
+  });
+
+  # https://github.com/ONLYOFFICE/document-server-package/blob/master/common/documentserver/bin/documentserver-generate-allfonts.sh.m4
+  x2t-with-fonts-and-themes = runCommand "x2t-with-fonts-and-themes" { } ''
+    mkdir -p $out/{web,converter,images,fonts}
+
+    echo "Generating fonts"
+    export CUSTOM_FONTS_PATHS=${lib.concatStringsSep ":" extra-fonts}
+    ${x2t.components.allfontsgen}/bin/allfontsgen \
+      --input=${x2t.components.core-fonts} \
+      --allfonts-web=$out/web/AllFonts.js \
+      --allfonts=$out/converter/AllFonts.js \
+      --images=$out/images \
+      --selection=$out/converter/font_selection.bin \
+      --output-web=$out/fonts \
+      --use-system=true
+
+    mkdir -p $out/bin
+    cp ${lib.getExe x2t} $out/bin
+    cat >$out/bin/DoctRenderer.config <<EOF
+      <Settings>
+        <file>${x2t.components.sdkjs}/common/Native/native.js</file>
+        <file>${x2t.components.sdkjs}/common/Native/jquery_native.js</file>
+        <allfonts>$out/converter/AllFonts.js</allfonts>
+        <file>${x2t.components.web-apps}/vendor/xregexp/xregexp-all-min.js</file>
+        <sdkjs>${x2t.components.sdkjs}</sdkjs>
+        <dictionaries>${x2t.components.dictionaries}</dictionaries>
+      </Settings>
+    EOF
+
+    echo Generating presentation themes
+    # creates temporary files next to sources...
+    mkdir working
+    cp ${x2t.components.sdkjs}/slide/themes/src/* working
+    ${x2t.components.allthemesgen}/bin/allthemesgen \
+      --converter-dir="$out/bin"\
+      --src="working"\
+      --output="$out/images"
+    ${x2t.components.allthemesgen}/bin/allthemesgen \
+      --converter-dir="$out/bin"\
+      --src="working"\
+      --output="$out/images"\
+      --postfix="ios"\
+      --params="280,224"
+    ${x2t.components.allthemesgen}/bin/allthemesgen \
+      --converter-dir="$out/bin"\
+      --src="working"\
+      --output="$out/images"\
+      --postfix="android"\
+      --params="280,224"
+  '';
+  # var/www/onlyoffice/documentserver/server/DocService/docservice
+  euro-office-documentserver = stdenvNoCC.mkDerivation {
+    pname = "euro-office-documentserver";
+    version = "0-unstable-2026-04-02";
+
+    src = fetchFromGitHub {
+      owner = "Euro-Office";
+      repo = "document-server-package";
+      rev = "7a1406507c0ddfc25ae1dc7b7dfbc365c39d3fa5";
+      hash = "sha256-ee8HG5QQKAYoYg9mAif+OGR9L9NDdjXy6CxEw9vbnBc=";
+    };
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      mkdir -p $out/etc/onlyoffice/documentserver/log4js
+      cp ${server-src}/Common/config/default.json $out/etc/onlyoffice/documentserver
+      cp ${server-src}/Common/config/production-linux.json $out/etc/onlyoffice/documentserver
+      cp ${server-src}/Common/config/log4js/production.json $out/etc/onlyoffice/documentserver/log4js
+
+      mkdir -p $out/var/www/onlyoffice/documentserver-example
+      cp -r common/documentserver-example/welcome $out/var/www/onlyoffice/documentserver-example
+
+      mkdir -p $out/var/www/onlyoffice/documentserver
+
+      # equivalent of usr/bin/documentserver-flush-cache.sh,
+      # busts cache also when fonts collection changes
+      mkdir $out/var/www/onlyoffice/documentserver/web-apps
+      ${lndir}/bin/lndir -silent ${x2t.components.web-apps} $out/var/www/onlyoffice/documentserver/web-apps
+      mv $out/var/www/onlyoffice/documentserver/web-apps/apps/api/documents/api.js{,.orig}
+      sed -e "s/{{HASH_POSTFIX}}/$(basename $out | cut -d '-' -f 1)/" $out/var/www/onlyoffice/documentserver/web-apps/apps/api/documents/api.js.orig > $out/var/www/onlyoffice/documentserver/web-apps/apps/api/documents/api.js
+
+      ln -s ${x2t-with-fonts-and-themes}/fonts $out/var/www/onlyoffice/documentserver/fonts
+
+      mkdir -p $out/var/www/onlyoffice/documentserver/sdkjs
+      ${lndir}/bin/lndir -silent ${x2t.components.sdkjs} $out/var/www/onlyoffice/documentserver/sdkjs
+      ln -s ${x2t-with-fonts-and-themes}/web/AllFonts.js $out/var/www/onlyoffice/documentserver/sdkjs/common/AllFonts.js
+      ${lndir}/bin/lndir -silent ${x2t-with-fonts-and-themes}/images $out/var/www/onlyoffice/documentserver/sdkjs/common/Images
+
+      # we don't currently support sdkjs plugins in NixOS
+      # https://github.com/ONLYOFFICE/build_tools/blob/master/scripts/deploy_server.py#L130
+      mkdir -p $out/var/www/onlyoffice/documentserver/sdkjs-plugins
+      echo "[]" > $out/var/www/onlyoffice/documentserver/sdkjs-plugins/plugin-list-default.json
+
+      mkdir -p $out/var/www/onlyoffice/documentserver/server/schema
+      cp -r ${server-src}/schema/* $out/var/www/onlyoffice/documentserver/server/schema
+
+      mkdir -p $out/var/lib/onlyoffice
+    '';
+
+    # stripping self extracting javascript binaries likely breaks them
+    dontStrip = true;
+
+    passthru = {
+      inherit
+        x2t-with-fonts-and-themes
+        common
+        docservice
+        fileconverter
+        ;
+      tests.onlyoffice = nixosTests.onlyoffice.passthru.override {
+        package = euro-office-documentserver;
+      };
+      fhs = buildFHSEnv {
+        name = "euro-office-wrapper";
+
+        targetPkgs = pkgs: [
+          gcc-unwrapped.lib
+          euro-office-documentserver
+          fileconverter
+        ];
+
+        extraBuildCommands = ''
+          mkdir -p $out/var/{lib/onlyoffice,www}
+          cp -ar ${euro-office-documentserver}/var/www/* $out/var/www/
+        '';
+
+        extraBwrapArgs = [
+          "--bind var/lib/onlyoffice/ var/lib/onlyoffice/"
+        ];
+      };
+    };
+
+    meta = {
+      description = "Online office suite comprising viewers and editors";
+      longDescription = ''
+        Euro-Office Document Server is an online office suite comprising viewers and editors for texts, spreadsheets and presentations,
+        fully compatible with Office Open XML formats: .docx, .xlsx, .pptx and enabling collaborative editing in real time.
+      '';
+      homepage = "https://github.com/Euro-Office/DocumentServer";
+      license = lib.licenses.agpl3Only;
+      platforms = lib.platforms.linux;
+      maintainers = with lib.maintainers; [ onny ];
+    };
+  };
+in
+euro-office-documentserver

--- a/pkgs/by-name/eu/euro-office-documentserver/package.nix
+++ b/pkgs/by-name/eu/euro-office-documentserver/package.nix
@@ -1,0 +1,226 @@
+{
+  buildFHSEnv,
+  buildNpmPackage,
+  dpkg,
+  fetchFromGitHub,
+  fetchurl,
+  gcc-unwrapped,
+  lib,
+  lndir,
+  nixosTests,
+  pkg-config,
+  runCommand,
+  stdenvNoCC,
+  vips,
+  writeScript,
+  x2t,
+
+  extra-fonts ? [ ],
+}:
+
+let
+  version = "9.3.1";
+  server-src = fetchFromGitHub {
+    owner = "Euro-Office";
+    repo = "server";
+    tag = "v9.3.1-rc.1";
+    hash = "sha256-kDMK4WUwNqOzTwruVE4SC2cyQf7mpZpabB4Ov5+4SzU=";
+  };
+  common = buildNpmPackage (finalAttrs: {
+    name = "euro-office-server-Common";
+    src = server-src;
+    sourceRoot = "${finalAttrs.src.name}/Common";
+    npmDepsHash = "sha256-zFGqDtnNFzXCwp6uvK04GDMRG6BATv6ti3Wi8ikLjBU=";
+    dontNpmBuild = true;
+    postPatch = ''
+      # https://github.com/ONLYOFFICE/build_tools/blob/ef8153c053bed41909ceb0762b124f8fe7faa0a7/scripts/build_server.py#L34
+      sed -e "s/^const buildVersion = '[0-9.]*'/const buildVersion = '${version}'/" -i sources/commondefines.js
+    '';
+    postInstall = ''
+      ln -s $out/lib/node_modules/common $out/lib/node_modules/Common
+    '';
+  });
+  docservice = buildNpmPackage (finalAttrs: {
+    name = "euro-office-server-DocService";
+    src = server-src;
+    sourceRoot = "${finalAttrs.src.name}/DocService";
+    nativeBuildInputs = [
+      pkg-config
+    ];
+    buildInputs = [
+      vips.dev
+    ];
+    npmDepsHash = "sha256-EKrMv1AIbdgMbXvZrqdSWP1j+s8UhEsXFdPTcJyCl1w=";
+    npmFlags = [ "--loglevel=verbose" ];
+    dontNpmBuild = true;
+    postInstall = ''
+      # it would be neater if this were a 'ln -s', but this is not possible
+      # because common/sources/notificationService.js has a circular dependency
+      # back on DocService
+      cp -r ${common}/lib/node_modules/common $out/lib/node_modules/Common
+      ln -s $out/lib/node_modules/coauthoring $out/lib/node_modules/DocService
+    '';
+  });
+  fileconverter = buildNpmPackage (finalAttrs: {
+    name = "euro-office-server-FileConverter";
+    src = server-src;
+
+    sourceRoot = "${finalAttrs.src.name}/FileConverter";
+
+    npmDepsHash = "sha256-zGLZBbQYV2z0HgQKISKVhclRKbMB8RYEX13H0mB6qJw=";
+
+    dontNpmBuild = true;
+
+    postInstall = ''
+      ln -s ${common}/lib/node_modules/common $out/lib/node_modules/Common
+      ln -s ${docservice}/lib/node_modules/coauthoring $out/lib/node_modules/DocService
+    '';
+  });
+
+  # https://github.com/ONLYOFFICE/document-server-package/blob/master/common/documentserver/bin/documentserver-generate-allfonts.sh.m4
+  x2t-with-fonts-and-themes = runCommand "x2t-with-fonts-and-themes" { } ''
+    mkdir -p $out/{web,converter,images,fonts}
+
+    echo "Generating fonts"
+    export CUSTOM_FONTS_PATHS=${lib.concatStringsSep ":" extra-fonts}
+    ${x2t.components.allfontsgen}/bin/allfontsgen \
+      --input=${x2t.components.core-fonts} \
+      --allfonts-web=$out/web/AllFonts.js \
+      --allfonts=$out/converter/AllFonts.js \
+      --images=$out/images \
+      --selection=$out/converter/font_selection.bin \
+      --output-web=$out/fonts \
+      --use-system=true
+
+    mkdir -p $out/bin
+    cp ${lib.getExe x2t} $out/bin
+    cat >$out/bin/DoctRenderer.config <<EOF
+      <Settings>
+        <file>${x2t.components.sdkjs}/common/Native/native.js</file>
+        <file>${x2t.components.sdkjs}/common/Native/jquery_native.js</file>
+        <allfonts>$out/converter/AllFonts.js</allfonts>
+        <file>${x2t.components.web-apps}/vendor/xregexp/xregexp-all-min.js</file>
+        <sdkjs>${x2t.components.sdkjs}</sdkjs>
+        <dictionaries>${x2t.components.dictionaries}</dictionaries>
+      </Settings>
+    EOF
+
+    echo Generating presentation themes
+    # creates temporary files next to sources...
+    mkdir working
+    cp ${x2t.components.sdkjs}/slide/themes/src/* working
+    ${x2t.components.allthemesgen}/bin/allthemesgen \
+      --converter-dir="$out/bin"\
+      --src="working"\
+      --output="$out/images"
+    ${x2t.components.allthemesgen}/bin/allthemesgen \
+      --converter-dir="$out/bin"\
+      --src="working"\
+      --output="$out/images"\
+      --postfix="ios"\
+      --params="280,224"
+    ${x2t.components.allthemesgen}/bin/allthemesgen \
+      --converter-dir="$out/bin"\
+      --src="working"\
+      --output="$out/images"\
+      --postfix="android"\
+      --params="280,224"
+  '';
+  # var/www/onlyoffice/documentserver/server/DocService/docservice
+  euro-office-documentserver = stdenvNoCC.mkDerivation {
+    pname = "euro-office-documentserver";
+    version = "9.3.1";
+
+    src = fetchFromGitHub {
+      owner = "Euro-Office";
+      repo = "document-server-package";
+      tag = "v9.3.1-rc.1";
+      hash = "sha256-373ayOQGtChBWruDGUDPl6P8eRvmxRR2dJQVstETkh8=";
+    };
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      mkdir -p $out/etc/onlyoffice/documentserver/log4js
+      cp ${server-src}/Common/config/default.json $out/etc/onlyoffice/documentserver
+      cp ${server-src}/Common/config/production-linux.json $out/etc/onlyoffice/documentserver
+      cp ${server-src}/Common/config/log4js/production.json $out/etc/onlyoffice/documentserver/log4js
+
+      mkdir -p $out/var/www/onlyoffice/documentserver-example
+      cp -r common/documentserver-example/welcome $out/var/www/onlyoffice/documentserver-example
+
+      mkdir -p $out/var/www/onlyoffice/documentserver
+
+      # equivalent of usr/bin/documentserver-flush-cache.sh,
+      # busts cache also when fonts collection changes
+      mkdir $out/var/www/onlyoffice/documentserver/web-apps
+      ${lndir}/bin/lndir -silent ${x2t.components.web-apps} $out/var/www/onlyoffice/documentserver/web-apps
+      mv $out/var/www/onlyoffice/documentserver/web-apps/apps/api/documents/api.js{,.orig}
+      sed -e "s/{{HASH_POSTFIX}}/$(basename $out | cut -d '-' -f 1)/" $out/var/www/onlyoffice/documentserver/web-apps/apps/api/documents/api.js.orig > $out/var/www/onlyoffice/documentserver/web-apps/apps/api/documents/api.js
+
+      ln -s ${x2t-with-fonts-and-themes}/fonts $out/var/www/onlyoffice/documentserver/fonts
+
+      mkdir -p $out/var/www/onlyoffice/documentserver/sdkjs
+      ${lndir}/bin/lndir -silent ${x2t.components.sdkjs} $out/var/www/onlyoffice/documentserver/sdkjs
+      ln -s ${x2t-with-fonts-and-themes}/web/AllFonts.js $out/var/www/onlyoffice/documentserver/sdkjs/common/AllFonts.js
+      ${lndir}/bin/lndir -silent ${x2t-with-fonts-and-themes}/images $out/var/www/onlyoffice/documentserver/sdkjs/common/Images
+
+      # we don't currently support sdkjs plugins in NixOS
+      # https://github.com/ONLYOFFICE/build_tools/blob/master/scripts/deploy_server.py#L130
+      mkdir -p $out/var/www/onlyoffice/documentserver/sdkjs-plugins
+      echo "[]" > $out/var/www/onlyoffice/documentserver/sdkjs-plugins/plugin-list-default.json
+
+      mkdir -p $out/var/www/onlyoffice/documentserver/server/schema
+      cp -r ${server-src}/schema/* $out/var/www/onlyoffice/documentserver/server/schema
+
+      mkdir -p $out/var/lib/onlyoffice
+    '';
+
+    # stripping self extracting javascript binaries likely breaks them
+    dontStrip = true;
+
+    passthru = {
+      inherit
+        x2t-with-fonts-and-themes
+        common
+        docservice
+        fileconverter
+        ;
+      tests.onlyoffice = nixosTests.onlyoffice.passthru.override {
+        package = euro-office-documentserver;
+      };
+      fhs = buildFHSEnv {
+        name = "euro-office-wrapper";
+
+        targetPkgs = pkgs: [
+          gcc-unwrapped.lib
+          euro-office-documentserver
+          fileconverter
+        ];
+
+        extraBuildCommands = ''
+          mkdir -p $out/var/{lib/onlyoffice,www}
+          cp -ar ${euro-office-documentserver}/var/www/* $out/var/www/
+        '';
+
+        extraBwrapArgs = [
+          "--bind var/lib/onlyoffice/ var/lib/onlyoffice/"
+        ];
+      };
+    };
+
+    meta = {
+      description = "Online office suite comprising viewers and editors";
+      longDescription = ''
+        Euro-Office Document Server is an online office suite comprising viewers and editors for texts, spreadsheets and presentations,
+        fully compatible with Office Open XML formats: .docx, .xlsx, .pptx and enabling collaborative editing in real time.
+      '';
+      homepage = "https://github.com/Euro-Office/DocumentServer";
+      license = lib.licenses.agpl3Only;
+      platforms = lib.platforms.linux;
+      maintainers = with lib.maintainers; [ onny ];
+    };
+  };
+in
+euro-office-documentserver

--- a/pkgs/by-name/x2/x2t/package.nix
+++ b/pkgs/by-name/x2/x2t/package.nix
@@ -983,5 +983,6 @@ buildCoreComponent "X2tConverter/build/Qt" {
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ raboof ];
     platforms = lib.platforms.linux;
+    mainProgram = "x2t";
   };
 }


### PR DESCRIPTION
packaging [euro-office-documentserver](https://github.com/Euro-Office/DocumentServer), a hard-fork of onlyoffice-documentserver and „an online office suite comprising viewers and editors“

run tests with:
```
nix build -L .#euro-office-documentserver.passthru.tests.onlyoffice
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
