### PR TITLE
ctx7: init at 0.3.9

### DIFF
--- a/pkgs/by-name/ct/ctx7/package.nix
+++ b/pkgs/by-name/ct/ctx7/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_10,
+  nodejs,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ctx7";
+  version = "0.3.9";
+
+  src = fetchFromGitHub {
+    owner = "upstash";
+    repo = "context7";
+    rev = "ab17551de1a3fcd088f317c01bdb000f5f3c6e21";
+    hash = "sha256-nrJCYezH9VDd1Ptpg5xATx0ByweTw8dkKT2y3rnFHd8=";
+  };
+
+  postUnpack = ''
+    chmod -R +w .
+  '';
+
+  postPatch = ''
+    cp ${./tsup.config.ts} tsup.config.ts
+  '';
+
+  sourceRoot = "${finalAttrs.src.name}/packages/cli";
+
+  pnpmRoot = "../..";
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-8RRHfCTZVC91T1Qx+ACCo2oG4ZwMNy5WYakCjmBhe3Q=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm_10
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp dist/index.js $out/bin/ctx7
+    chmod +x $out/bin/ctx7
+    cp package.json $out/package.json
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI tool for managing AI coding skills and documentation context";
+    homepage = "https://context7.com";
+    changelog = "https://github.com/upstash/context7/releases/tag/ctx7@${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "ctx7";
+    maintainers = with lib.maintainers; [ vitorpavani ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/ct/ctx7/tsup.config.ts
+++ b/pkgs/by-name/ct/ctx7/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  banner: {
+    js: "#!/usr/bin/env node\nimport { createRequire } from 'module'; const require = createRequire(import.meta.url);",
+  },
+  noExternal: [/./],
+  external: [
+    "@inquirer/core",
+    "@inquirer/type",
+    "@inquirer/prompts",
+    "mute-stream",
+    "stream",
+  ],
+});


### PR DESCRIPTION
## Summary

- Adds \`ctx7\` (version 0.3.9), a CLI tool for [Context7](https://context7.com) — manages AI coding skills and documentation context
- Source: [\`upstash/context7\`](https://github.com/upstash/context7) monorepo, \`packages/cli\` subdirectory
- Uses \`fetchPnpmDeps\` + \`pnpmConfigHook\` for the pnpm workspace
- Ships a patched \`tsup.config.ts\` alongside \`package.nix\` (see below)

## Why the patched `tsup.config.ts`

The upstream config has \`noExternal: []\`, which makes tsup treat all \`dependencies\` from \`package.json\` as external. The built \`dist/index.js\` then contains bare ESM imports:

\`\`\`js
import { Command } from "commander";
import pc from "picocolors";
\`\`\`

In Nix we only install \`dist/index.js\` into \`$out/bin/\` — there are no \`node_modules\` alongside it, so the binary crashes immediately with \`Cannot find package 'commander'\`.

The patched config fixes two things:

1. **\`noExternal: [/./]\`** — inlines all dependencies into the bundle. \`dist/index.js\` becomes a self-contained ~490 KB file with no \`node_modules\` needed at runtime. \`@inquirer/*\` packages remain external (they are already listed in the upstream \`external\` array).

2. **\`createRequire\` banner** — when tsup bundles CJS packages (like \`commander\`) into an ESM output, it wraps their \`require()\` calls in a shim that throws \`"Dynamic require of 'events' is not supported"\` because \`require\` is undefined in pure ESM. Adding \`import { createRequire } from 'module'; const require = createRequire(import.meta.url);\` to the banner defines a real \`require\` globally before any bundled code runs, so Node built-ins like \`events\` resolve correctly.

A separate file is used instead of \`substituteInPlace\` because the replacement string contains single quotes and newlines, which cannot be embedded in Nix's \`''...''\` indented strings (\`''\` is the string delimiter in Nix).

## Testing

\`\`\`
nix-build -A ctx7
result/bin/ctx7 --help
\`\`\`

---
<!-- 8<--------8<--------8<--------8<--------8<--------8<--------8<-------- -->

#### Maintainers

<!-- This is the preferred method, but there are others listed in CONTRIBUTING.md -->
@NixOS/nixpkgs-committers @r-ryantm

<!-- 8<--------8<--------8<--------8<--------8<--------8<--------8<-------- -->

#### Things done

- [ ] Built on platform(s)
  - [x] \`x86_64-linux\`
  - [ ] \`aarch64-linux\`
  - [ ] \`x86_64-darwin\`
  - [ ] \`aarch64-darwin\`
- [x] For non-Linux: tested in VM(s)
- [x] Tested compilation of all packages that depend on this change
- [x] Tested execution of all new functionality
- [x] \`nixpkgs-review\` run done
- [x] Commits are well-structured

<!-- We welcome suggestions for how to improve your contribution, but please try to be constructive, and avoid dismissive or unconstructive feedback. -->