### PR TITLE
nushellPlugins.file: init at 0.22.0

### DIFF
--- a/pkgs/by-name/nu/nushell-plugin-file/package.nix
+++ b/pkgs/by-name/nu/nushell-plugin-file/package.nix
@@ -1,0 +1,31 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nu_plugin_file";
+  version = "0.22.0";
+
+  src = fetchFromGitHub {
+    owner = "fdncred";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    sha256 = "1bqli50sx7ldi1wvf6i622xq98y3h86lv989dsw8qvl0abbb4mm6";
+  };
+
+  cargoHash = "sha256-lGxwrkjQPK054cmMs0livc8g3MBlQex+m1XUBlDxjWs=";
+
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+
+  meta = {
+    description = "A file system plugin for Nushell";
+    mainProgram = "nu_plugin_file";
+    homepage = "https://github.com/fdncred/nu_plugin_file";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ asakura ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8748,6 +8748,7 @@ with pkgs;
     desktop_notifications =
       callPackage ../by-name/nu/nushell-plugin-desktop_notifications/package.nix
         { };
+    file = callPackage ../by-name/nu/nushell-plugin-file/package.nix { };
   };
 
   net-tools =


### PR DESCRIPTION
nu_plugin_file will open files to inspect them and report back a little information. It uses magic bytes to determine many file formats.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
