### PR TITLE
python3Packages.odfdo: init at 3.22.3

### DIFF
--- a/pkgs/development/python-modules/odfdo/default.nix
+++ b/pkgs/development/python-modules/odfdo/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  lxml,
+  pillow,
+  uv-build,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "odfdo";
+  version = "3.22.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jdum";
+    repo = "odfdo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1cOi7aAJ8jWjLuQbhd7aK5s2rJ5IvkTLIl9atKmXKMU=";
+  };
+
+  build-system = [ uv-build ];
+
+  dependencies = [ lxml ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pillow
+  ];
+
+  meta = {
+    description = "OpenDocument Format (ODF, ISO/IEC 26300) library for Python";
+    homepage = "https://github.com/jdum/odfdo";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+  };
+})

--- a/pkgs/development/python-modules/odsgenerator/default.nix
+++ b/pkgs/development/python-modules/odsgenerator/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  odfdo,
+  pyyaml,
+  uv-build,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "odsgenerator";
+  version = "1.12.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jdum";
+    repo = "odsgenerator";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FfwyqNI5Hz2Muoe/VWgQigea6D042UoRbXDV9GNV4w4=";
+  };
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    odfdo
+    pyyaml
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.9.0,<0.10.0" "uv_build"
+    substituteInPlace tests/test_cli.py \
+      --replace-fail '"odsgenerator"' "\"$out/bin/odsgenerator\""
+  '';
+
+  meta = {
+    description = "odsgenerator generates an ODF .ods file from json or yaml file";
+    homepage = "https://github.com/jdum/odsgenerator";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+  };
+})

--- a/pkgs/development/python-modules/odsparsator/default.nix
+++ b/pkgs/development/python-modules/odsparsator/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  odfdo,
+  uv-build,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "odsparsator";
+  version = "1.14.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jdum";
+    repo = "odsparsator";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DpVWkspaZYYJHGYOrLte4JevH25xRzu38M2+QdFG22M=";
+  };
+
+  build-system = [ uv-build ];
+
+  dependencies = [ odfdo ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.9.0,<0.10.0" "uv_build"
+    substituteInPlace tests/test_cli.py \
+      --replace-fail '"odsparsator"' "\"$out/bin/odsparsator\""
+  '';
+
+  meta = {
+    description = "Generate a json file from an OpenDocument Format .ods file";
+    homepage = "https://github.com/jdum/odsparsator";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11357,6 +11357,8 @@ self: super: with self; {
 
   odsgenerator = callPackage ../development/python-modules/odsgenerator { };
 
+  odsparsator = callPackage ../development/python-modules/odsparsator { };
+
   oelint-data = callPackage ../development/python-modules/oelint-data { };
 
   oelint-parser = callPackage ../development/python-modules/oelint-parser { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11349,6 +11349,8 @@ self: super: with self; {
 
   oddsprout = callPackage ../development/python-modules/oddsprout { };
 
+  odfdo = callPackage ../development/python-modules/odfdo { };
+
   odfpy = callPackage ../development/python-modules/odfpy { };
 
   odp-amsterdam = callPackage ../development/python-modules/odp-amsterdam { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11355,6 +11355,8 @@ self: super: with self; {
 
   odp-amsterdam = callPackage ../development/python-modules/odp-amsterdam { };
 
+  odsgenerator = callPackage ../development/python-modules/odsgenerator { };
+
   oelint-data = callPackage ../development/python-modules/oelint-data { };
 
   oelint-parser = callPackage ../development/python-modules/oelint-parser { };


### PR DESCRIPTION
Add a new python module for interacting with ODF files

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
