### PR TITLE
nushellPlugins.parquet: init at 0.22

### DIFF
--- a/pkgs/by-name/nu/nushell-plugin-parquet/package.nix
+++ b/pkgs/by-name/nu/nushell-plugin-parquet/package.nix
@@ -1,0 +1,38 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nu_plugin_parquet";
+  version = "0.22";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "fdncred";
+    repo = finalAttrs.pname;
+    tag = finalAttrs.version;
+    hash = "sha256-TFzYa4jMy664rW+FRKYAcKo+niJg0IcEEyinGrpXbBg=";
+  };
+
+  cargoHash = "sha256-hiiddu/0vjeLTh9G0MpNCLPJ8gq7JvEAw9SLPSrCUVA=";
+
+  nativeBuildInputs = lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+
+  # there are no tests
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Nushell plugin to read and write parquet files";
+    mainProgram = "nu_plugin_parquet";
+    homepage = "https://github.com/fdncred/nu_plugin_parquet";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ asakura ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8554,6 +8554,7 @@ with pkgs;
     skim = callPackage ../by-name/nu/nushell-plugin-skim/package.nix { };
     semver = callPackage ../by-name/nu/nushell-plugin-semver/package.nix { };
     hcl = callPackage ../by-name/nu/nushell-plugin-hcl/package.nix { };
+    parquet = callPackage ../by-name/nu/nushell-plugin-parquet/package.nix { };
     desktop_notifications =
       callPackage ../by-name/nu/nushell-plugin-desktop_notifications/package.nix
         { };


### PR DESCRIPTION
A nushell plugin to read and write parquet files. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
