### PR TITLE
init: nushell-custom-completion-claude at 0-unstable-2026-03-12

### DIFF
--- a/pkgs/by-name/nu/nushell-custom-completion-claude/package.nix
+++ b/pkgs/by-name/nu/nushell-custom-completion-claude/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  nushell,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nushell-custom-completion-claude";
+  version = "0-unstable-2026-03-12";
+
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/nushell/nu_scripts/196d94338d382561e7bacb29948ffcfa5ff1b2a1/custom-completions/claude/claude-completions.nu";
+    hash = "sha256-SzdCyuvCpDfuBfXbXylEYYwXf/Zg+zoK5M+73IbACiM=";
+  };
+
+  # It's a nushell script, so it doesn't need to be built
+  dontBuild = true;
+  dontUnpack = true;
+
+  runtimeDeps = [ nushell ];
+
+  doCheck = true;
+
+  checkPhase = ''
+    ${lib.getExe nushell} --no-config-file $src
+  '';
+
+  installPhase = ''
+    install -Dm644 $src $out/share/nushell/custom-completions/claude.nu
+  '';
+
+  meta = with lib; {
+    description = "Claude completion for Nushell";
+    homepage = "https://github.com/nushell/nu_scripts/tree/main/custom-completions/claude";
+    license = licenses.mit;
+    maintainers = with maintainers; [ asakura ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8750,6 +8750,10 @@ with pkgs;
         { };
   };
 
+  nushellCustomCompletions = recurseIntoAttrs {
+    claude = callPackage ../by-name/nu/nushell-custom-completion-claude/package.nix { };
+  };
+
   net-tools =
     # some platforms refer back to this from unixtools, so this is needed to
     # break the cycle


### PR DESCRIPTION
Nushell's custom completion script for Claude
https://github.com/nushell/nu_scripts/tree/main/custom-completions/claude

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
