### PR TITLE
phpstorm: 2025.3.4 -> 2026.1

### DIFF
--- a/pkgs/applications/editors/jetbrains/ides/phpstorm.nix
+++ b/pkgs/applications/editors/jetbrains/ides/phpstorm.nix
@@ -12,20 +12,20 @@ let
   # update-script-start: urls
   urls = {
     x86_64-linux = {
-      url = "https://download.jetbrains.com/webide/PhpStorm-2025.3.4.tar.gz";
-      hash = "sha256-rUFOzut21nrAoKq88W8naa61Y/ncA7pn0MO3rGmuBIY=";
+      url = "https://download.jetbrains.com/webide/PhpStorm-2026.1.tar.gz";
+      hash = "sha256-OpSc/Xg4nWh9XRpVN8FLaV1Gwz8kbM+S9WVk27jJ7gY=";
     };
     aarch64-linux = {
-      url = "https://download.jetbrains.com/webide/PhpStorm-2025.3.4-aarch64.tar.gz";
-      hash = "sha256-wjBhibJGItzDKkRtx4tXqM0Kqn4K8HNGdAVMGalm7Fw=";
+      url = "https://download.jetbrains.com/webide/PhpStorm-2026.1-aarch64.tar.gz";
+      hash = "sha256-StoSzSx4fxeeB+PnZB5PCEzPJuWCa+HeY9u6hGGlUHg=";
     };
     x86_64-darwin = {
-      url = "https://download.jetbrains.com/webide/PhpStorm-2025.3.4.dmg";
-      hash = "sha256-emlgbnHw1yaRHaiFjCL9EBYFffdWWNF7AFWyIERj0QA=";
+      url = "https://download.jetbrains.com/webide/PhpStorm-2026.1.dmg";
+      hash = "sha256-KN4OVeR7TCA+PigHemh0eIT+y3hRKAGFJlEFmRc45Xg=";
     };
     aarch64-darwin = {
-      url = "https://download.jetbrains.com/webide/PhpStorm-2025.3.4-aarch64.dmg";
-      hash = "sha256-mxrTc5v4IIDgZzwMtbvdifmetoDacGNEhyVzPiVMSSw=";
+      url = "https://download.jetbrains.com/webide/PhpStorm-2026.1-aarch64.dmg";
+      hash = "sha256-V3TQIvaYH3+NmWIDJFyTcO7Zwdd+TPP0TSFmX5pjEhM=";
     };
   };
   # update-script-end: urls
@@ -39,8 +39,8 @@ mkJetBrainsProduct {
   product = "PhpStorm";
 
   # update-script-start: version
-  version = "2025.3.4";
-  buildNumber = "253.32098.40";
+  version = "2026.1";
+  buildNumber = "261.22158.283";
   # update-script-end: version
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Updated Jetbrains PhpStorm to 2026.1 release

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
