### PR TITLE
lib.evalModules: make finalModules available like extendModules

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -247,6 +247,7 @@ let
         config = {
           _module.args = {
             inherit extendModules;
+            finalModules = regularModules;
             moduleType = type;
           };
           _module.specialArgs = specialArgs;


### PR DESCRIPTION
We already offer extendModules.

But we have no way to offer the final result in a way that is importable somewhere else.

While this is not usually all that useful for a system config, this would be very useful in making systems of separately evaluated submodules that export other modules to integrate themselves with nixos

e.g. it would allow me to remove mkInstallModule entirely from this project https://github.com/BirdeeHub/nix-wrapper-modules/discussions/370

---

What needs to be updated in the docs and such for this?

---

Should we also export specialArgs from result? Is there any harm in doing so?