### PR TITLE
prowler: add updateScript

### DIFF
--- a/pkgs/by-name/pr/prowler/package.nix
+++ b/pkgs/by-name/pr/prowler/package.nix
@@ -2,40 +2,26 @@
   lib,
   python3,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
-let
-  py = python3.override {
-    packageOverrides = self: super: {
-
-      # Doesn't work with latest pydantic
-      py-ocsf-models = super.py-ocsf-models.overridePythonAttrs (oldAttrs: {
-        dependencies = [
-          python3.pkgs.pydantic_1
-          python3.pkgs.cryptography
-          python3.pkgs.email-validator
-        ];
-      });
-    };
-  };
-in
-py.pkgs.buildPythonApplication (finalAttrs: {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "prowler";
-  version = "5.12.3";
+  version = "5.14.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "prowler-cloud";
     repo = "prowler";
     tag = finalAttrs.version;
-    hash = "sha256-6RPtld95MauhCmSLrgncr4+s16z0PfmiiC6eAph8ZmI=";
+    hash = "sha256-GRVVyHqAjTsC02Ba7963xP3dutH6KmpSYvHI2eWyehE=";
   };
 
   pythonRelaxDeps = true;
 
-  build-system = with py.pkgs; [ poetry-core ];
+  build-system = with python3.pkgs; [ poetry-core ];
 
-  dependencies = with py.pkgs; [
+  dependencies = with python3.pkgs; [
     alive-progress
     awsipranges
     azure-identity
@@ -52,6 +38,7 @@ py.pkgs.buildPythonApplication (finalAttrs: {
     azure-mgmt-loganalytics
     azure-mgmt-monitor
     azure-mgmt-network
+    azure-mgmt-postgresqlflexibleservers
     azure-mgmt-rdbms
     azure-mgmt-recoveryservices
     azure-mgmt-recoveryservicesbackup
@@ -74,15 +61,18 @@ py.pkgs.buildPythonApplication (finalAttrs: {
     dulwich
     google-api-python-client
     google-auth-httplib2
+    h2
     jsonschema
     kubernetes
+    markdown
     microsoft-kiota-abstractions
     msgraph-sdk
     numpy
+    oci
     pandas
     py-iam-expand
     py-ocsf-models
-    pydantic_1
+    pydantic
     pygithub
     python-dateutil
     pytz
@@ -94,6 +84,8 @@ py.pkgs.buildPythonApplication (finalAttrs: {
   ];
 
   pythonImportsCheck = [ "prowler" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Security tool for AWS, Azure and GCP to perform Cloud Security best practices assessments";

--- a/pkgs/by-name/pr/prowler/package.nix
+++ b/pkgs/by-name/pr/prowler/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   kingfisher,
+  nix-update-script,
   python3Packages,
 }:
 
@@ -131,6 +132,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   '';
 
   pythonImportsCheck = [ "prowler" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Security tool to perform Cloud Security best practices assessments";


### PR DESCRIPTION
Add `passthru.updateScript = nix-update-script { }` to [Prowler](https://github.com/prowler-cloud/prowler) so `r-ryantm` has a `nix-update`-based path for future version bumps.

Rebased onto current master. This PR originally also bumped 5.12.3 → 5.14.2, but that was superseded by #535645 (merged), and master is now at 5.39.1 with every dependency this PR added already present and the `python3.override` / `pydantic_1` workaround already removed. The only surviving change is the `updateScript`, so the diff is now a single file, 3 added lines.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

**Verification notes:** `passthru` additions do not change the derivation, so `nix-build -A prowler` on aarch64-darwin is a cache hit against master's output; `./result/bin/prowler --version` reports `Prowler 5.39.1`. `nix-instantiate --eval -A prowler.updateScript` resolves to the `nix-update` command, and `nix fmt` on the file is a no-op. `nixpkgs-review` was not run — Prowler has no reverse dependencies in nixpkgs.

The branch name still says `5.14.2`; renaming it would close this PR, so it is left as is.
