### PR TITLE
openmpi: ensure that fortran .mod files are in dev output

### DIFF
--- a/pkgs/by-name/op/openmpi/package.nix
+++ b/pkgs/by-name/op/openmpi/package.nix
@@ -199,6 +199,10 @@ stdenv.mkDerivation (finalAttrs: {
     ''
       find $out/lib/ -name "*.la" -exec rm -f \{} \;
 
+      # Fortran .mod files end up in bin output.
+      # Force all headers into the dev output .
+      moveToOutput "include/" "''${!outputDev}"
+
       # The main wrapper that all the rest of the commonly used binaries are
       # symlinked to
       moveToOutput "bin/opal_wrapper" "''${!outputDev}"


### PR DESCRIPTION
Currently the Fortran .mod header files end up in $bin/include.
This PR forces all header files in include/ to $dev/include.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

CC @sheepforce 