### PR TITLE
brave-search-cli: init at 1.2.0

### DIFF
--- a/pkgs/by-name/br/brave-search-cli/package.nix
+++ b/pkgs/by-name/br/brave-search-cli/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "brave-search-cli";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "brave";
+    repo = "brave-search-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wcZwgCPqIy+AVxpqcCI8rOyUOWXb7aYSsHJDS2pfpnE=";
+  };
+
+  cargoHash = "sha256-qIBepW7I5meLX9V3yEq6zoIRaZWD3CVjyrN8zpTAbR0=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI for the Brave Search API with support for web, news, images, and AI answer endpoints";
+    homepage = "https://github.com/brave/brave-search-cli";
+    changelog = "https://github.com/brave/brave-search-cli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ vitorpavani ];
+    mainProgram = "bx";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description

Adds `brave-search-cli` (`bx`), a zero-dependency, token-efficient CLI for the [Brave Search API](https://brave.com/search/api/), built for AI agents and LLMs.

- Language: Rust
- Binary: `bx`
- License: MPL-2.0
- Upstream: https://github.com/brave/brave-search-cli

## Checklist

- [x] package path fits guidelines (`pkgs/by-name/br/brave-search-cli/package.nix`)
- [x] package name fits guidelines
- [x] package version fits guidelines
- [x] `meta.description` is set and fits guidelines
- [x] `meta.license` fits upstream license (MPL-2.0)
- [x] `meta.platforms` is set
- [x] `meta.maintainers` is set
- [x] `meta.mainProgram` is set (`bx`)
- [x] `nix-instantiate --eval -A brave-search-cli.name` evaluates cleanly
- [ ] package builds on x86_64-linux
- [ ] executables tested