### PR TITLE
DylibHijackScanner: init at 1.6.0 [objective-see]

### DIFF
--- a/pkgs/by-name/dy/dylibhijackscanner/package.nix
+++ b/pkgs/by-name/dy/dylibhijackscanner/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  unzip,
+  nix-update-script,
+  runCommand,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "dylibhijackscanner";
+  version = "1.6.0";
+
+  src = fetchurl {
+    url = "https://github.com/objective-see/DylibHijackScanner/releases/download/v${finalAttrs.version}/DHS_${finalAttrs.version}.zip";
+    hash = "sha256-PnL/pVkzKvtlqDv7w7WXMGSqyaQk3unMi8V+Y/htco8=";
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  sourceRoot = ".";
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/Applications
+    cp -R DHS.app $out/Applications/
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.has-app = runCommand "dylibhijackscanner-has-app" { } ''
+      test -d "${finalAttrs.finalPackage}/Applications/DHS.app"
+      test -x "${finalAttrs.finalPackage}/Applications/DHS.app/Contents/MacOS/DHS"
+      touch $out
+    '';
+  };
+
+  meta = {
+    description = "macOS tool that enumerates dylibs and detects hijackers per Apple guidelines";
+    homepage = "https://objective-see.org/products/dhs.html";
+    changelog = "https://github.com/objective-see/DylibHijackScanner/releases/tag/v${finalAttrs.version}";
+    downloadPage = "https://github.com/objective-see/DylibHijackScanner/releases";
+    license = lib.licenses.gpl3Plus;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ kaynetik ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+    mainProgram = "DHS";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
