### PR TITLE
pandoc: fix pandoc server

### DIFF
--- a/pkgs/by-name/pa/pandoc/package.nix
+++ b/pkgs/by-name/pa/pandoc/package.nix
@@ -11,12 +11,20 @@
 let
   # Since pandoc 3.0 the pandoc binary resides in the pandoc-cli package.
   static = haskell.lib.compose.justStaticExecutables pandoc-cli;
-  pandoc-cli = selectPandocCLI haskellPackages;
+  pandoc-cli = (selectPandocCLI haskellPackages).overrideScope (
+    final: prev:
+    prev
+    // {
+      pandoc = haskell.lib.compose.overrideCabal (drv: {
+        configureFlags = drv.configureFlags or [ ] ++ [ "-fembed_data_files" ];
+        buildDepends = drv.buildDepends or [ ] ++ [ prev.file-embed ];
+        enableSeparateDataOutput = false;
+      }) prev.pandoc;
+    }
+  );
 
 in
 (haskell.lib.compose.overrideCabal (drv: {
-  configureFlags = drv.configureFlags or [ ] ++ [ "-fembed_data_files" ];
-  buildDepends = drv.buildDepends or [ ] ++ [ pandoc-cli.scope.file-embed ];
   buildTools = (drv.buildTools or [ ]) ++ [
     removeReferencesTo
     installShellFiles


### PR DESCRIPTION
Flag `-fembed_data_files` was applied to a wrong package, doing nothing.

Fixes #377637
CC @maralorn @sternenseemann @larstvei

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
