### PR TITLE
[Backport release-25.11] beamPackages.expert: init at 0.1.0

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -81,6 +81,7 @@ let
       };
 
       elixir-ls = callPackage ./elixir-ls { inherit elixir; };
+      expert = callPackage ./expert { };
 
       lfe = callPackage ../interpreters/lfe { inherit erlang buildRebar3 buildHex; };
 

--- a/pkgs/development/beam-modules/expert/default.nix
+++ b/pkgs/development/beam-modules/expert/default.nix
@@ -6,13 +6,13 @@
   fetchMixDeps,
 }:
 let
-  version = "0.1.0-rc.4";
+  version = "0.1.0-rc.5";
 
   src = fetchFromGitHub {
     owner = "elixir-lang";
     repo = "expert";
     tag = "v${version}";
-    hash = "sha256-DghNlNbGUTMX859Y9HYRowCXvAxZKJffodTzy94Mb5Q=";
+    hash = "sha256-7e8zi3AFHESXyxTA0/YRmzR4L4tl19L0LHKaEM1l0P4=";
   };
 
   engineDeps = fetchMixDeps {
@@ -62,7 +62,7 @@ mixRelease rec {
 
   meta = {
     homepage = "https://github.com/elixir-lang/expert";
-    changelog = "https://github.com/elixir-lang/expert/releases/tag/v${version}";
+    changelog = "https://github.com/elixir-lang/expert/blob/v${version}/CHANGELOG.md";
     description = "Official Elixir Language Server Protocol implementation";
     longDescription = ''
       Expert is the official language server implementation for the Elixir programming language.

--- a/pkgs/development/beam-modules/expert/default.nix
+++ b/pkgs/development/beam-modules/expert/default.nix
@@ -6,13 +6,13 @@
   fetchMixDeps,
 }:
 let
-  version = "0.1.0-rc.2";
+  version = "0.1.0-rc.4";
 
   src = fetchFromGitHub {
     owner = "elixir-lang";
     repo = "expert";
     tag = "v${version}";
-    hash = "sha256-5BGI0bLGCvYyMT4GNHLalin1jg9UW6qtFC7B8OssHCc=";
+    hash = "sha256-DghNlNbGUTMX859Y9HYRowCXvAxZKJffodTzy94Mb5Q=";
   };
 
   engineDeps = fetchMixDeps {

--- a/pkgs/development/beam-modules/expert/default.nix
+++ b/pkgs/development/beam-modules/expert/default.nix
@@ -1,0 +1,75 @@
+{
+  erlang,
+  fetchFromGitHub,
+  mixRelease,
+  lib,
+  fetchMixDeps,
+}:
+let
+  version = "0.1.0-rc.2";
+
+  src = fetchFromGitHub {
+    owner = "elixir-lang";
+    repo = "expert";
+    tag = "v${version}";
+    hash = "sha256-5BGI0bLGCvYyMT4GNHLalin1jg9UW6qtFC7B8OssHCc=";
+  };
+
+  engineDeps = fetchMixDeps {
+    pname = "mix-deps-expert-engine";
+
+    inherit src version;
+    hash = "sha256-PTyPLyo85N0BltX9oIRhHDGKgmNScb10N129wC8o6Q4=";
+
+    preConfigure = ''
+      cd apps/engine
+    '';
+  };
+in
+mixRelease rec {
+  pname = "expert";
+  inherit src version;
+
+  mixFodDeps = fetchMixDeps {
+    pname = "mix-deps-${pname}";
+    inherit src version;
+    hash = "sha256-T5OSjoglZfQa1lMO2lOZJ7yWoyxf6m33rKGuy4zq2AE=";
+
+    preConfigure = ''
+      cd apps/expert
+    '';
+  };
+
+  mixReleaseName = "plain";
+
+  preConfigure = ''
+    ln -sv ${engineDeps} apps/engine/deps
+
+    cd apps/expert
+  '';
+
+  postInstall = ''
+    mv $out/bin/plain $out/bin/expert
+
+    wrapProgram $out/bin/expert --add-flag "eval" --add-flag "System.no_halt(true); Application.ensure_all_started(:xp_expert)"
+  '';
+
+  removeCookie = false;
+
+  passthru = {
+    inherit engineDeps;
+  };
+
+  meta = {
+    homepage = "https://github.com/elixir-lang/expert";
+    changelog = "https://github.com/elixir-lang/expert/releases/tag/v${version}";
+    description = "Official Elixir Language Server Protocol implementation";
+    longDescription = ''
+      Expert is the official language server implementation for the Elixir programming language.
+    '';
+    license = lib.licenses.asl20;
+    inherit (erlang.meta) platforms;
+    mainProgram = "expert";
+    teams = [ lib.teams.beam ];
+  };
+}

--- a/pkgs/development/beam-modules/expert/default.nix
+++ b/pkgs/development/beam-modules/expert/default.nix
@@ -6,20 +6,20 @@
   fetchMixDeps,
 }:
 let
-  version = "0.1.0-rc.5";
+  version = "0.1.0-rc.6";
 
   src = fetchFromGitHub {
     owner = "elixir-lang";
     repo = "expert";
     tag = "v${version}";
-    hash = "sha256-7e8zi3AFHESXyxTA0/YRmzR4L4tl19L0LHKaEM1l0P4=";
+    hash = "sha256-w3jRpQLbigQVNuuPlyoOHp6wO0gPsgdR0kwHP6Zul6Y=";
   };
 
   engineDeps = fetchMixDeps {
     pname = "mix-deps-expert-engine";
 
     inherit src version;
-    hash = "sha256-PTyPLyo85N0BltX9oIRhHDGKgmNScb10N129wC8o6Q4=";
+    hash = "sha256-2QCaY4TlscRmklPQ897xjjree7N8cLl7O83syfqPmng=";
 
     preConfigure = ''
       cd apps/engine
@@ -33,7 +33,7 @@ mixRelease rec {
   mixFodDeps = fetchMixDeps {
     pname = "mix-deps-${pname}";
     inherit src version;
-    hash = "sha256-T5OSjoglZfQa1lMO2lOZJ7yWoyxf6m33rKGuy4zq2AE=";
+    hash = "sha256-Rx5O77UEIDKcCz967h/8z1MAdaw0syzvLG5JOSaqgLE=";
 
     preConfigure = ''
       cd apps/expert

--- a/pkgs/development/beam-modules/expert/default.nix
+++ b/pkgs/development/beam-modules/expert/default.nix
@@ -6,13 +6,13 @@
   fetchMixDeps,
 }:
 let
-  version = "0.1.0-rc.6";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "elixir-lang";
     repo = "expert";
     tag = "v${version}";
-    hash = "sha256-w3jRpQLbigQVNuuPlyoOHp6wO0gPsgdR0kwHP6Zul6Y=";
+    hash = "sha256-r/SovUjU12ENT6OqbYuGK7XAmoxchUgiHTswlON/WeI=";
   };
 
   engineDeps = fetchMixDeps {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Manual backport of https://github.com/NixOS/nixpkgs/pull/505026 and preceding.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
