### PR TITLE
ren-find: 0-unstable-2024-01-11 -> 0.0.4

### DIFF
--- a/pkgs/by-name/re/ren-find/package.nix
+++ b/pkgs/by-name/re/ren-find/package.nix
@@ -4,18 +4,18 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ren-find";
-  version = "0-unstable-2024-01-11";
+  version = "0.0.4";
 
   src = fetchFromGitHub {
     owner = "robenkleene";
     repo = "ren-find";
-    rev = "50c40172e354caffee48932266edd7c7a76a20f";
-    hash = "sha256-zVIt6Xp+Mvym6gySvHIZJt1QgzKVP/wbTGTubWk6kzI=";
+    tag = finalAttrs.version;
+    hash = "sha256-DipYEem+Vr6lvnsSMAePjYF3yx0qWMM7CLG9ORcehJk=";
   };
 
-  cargoHash = "sha256-lSeO/GaJPZ8zosOIJRXVIEuPXaBg1GBvKBIuXtu1xZg=";
+  cargoHash = "sha256-LeYd2FFdzW35ylghEoq6Tqrg7bUXwegmWfxfQi7/tpI=";
 
   meta = {
     description = "Command-line utility that takes find-formatted lines and batch renames them";
@@ -24,4 +24,4 @@ rustPlatform.buildRustPackage {
     maintainers = with lib.maintainers; [ philiptaron ];
     mainProgram = "ren";
   };
-}
+})


### PR DESCRIPTION
https://github.com/robenkleene/ren-find/releases/tag/0.0.4

Also moved to finalAttrs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
