### PR TITLE
rep-grep: 0-unstable-2024-02-06 -> 0.0.8

### DIFF
--- a/pkgs/by-name/re/rep-grep/package.nix
+++ b/pkgs/by-name/re/rep-grep/package.nix
@@ -4,18 +4,18 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rep-grep";
-  version = "0-unstable-2024-02-06";
+  version = "0.0.8";
 
   src = fetchFromGitHub {
     owner = "robenkleene";
     repo = "rep-grep";
-    rev = "10510d47e392cb9d30a861c69f702fd194b3fa88";
-    hash = "sha256-/dH+mNtNHaYFndVhoqmz4Sc3HeemoQt1HGD98mb9Qhw=";
+    tag = finalAttrs.version;
+    hash = "sha256-GJXpzqc9reFFyZWPsaiohFsPj3PseijSLn6Td8Ouidk=";
   };
 
-  cargoHash = "sha256-t4tfQaFq4EV4ZWeU+IestSFiSAIeVQslTZhLbpKVoO4=";
+  cargoHash = "sha256-ugQxJsu/U7O3S8SQwhGGDAdEIDesW7JbwFBkNYRe13w=";
 
   meta = {
     description = "Command-line utility that takes grep-formatted lines and performs a find-and-replace on them";
@@ -24,4 +24,4 @@ rustPlatform.buildRustPackage {
     maintainers = with lib.maintainers; [ philiptaron ];
     mainProgram = "rep";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/robenkleene/rep-grep/releases/tag/0.0.8

Also moved to finalAttrs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
