### PR TITLE
tinygo: use fixed go version

### DIFF
--- a/pkgs/by-name/ti/tinygo/package.nix
+++ b/pkgs/by-name/ti/tinygo/package.nix
@@ -1,11 +1,11 @@
 {
   stdenv,
   lib,
-  buildGoModule,
+  buildGo125Module,
   fetchFromGitHub,
   makeWrapper,
   llvmPackages_20,
-  go,
+  go_1_25,
   xar,
   binaryen,
   avrdude,
@@ -16,8 +16,10 @@
 }:
 
 let
-  # nixpkgs typically updates default llvm version faster than tinygo releases
-  # which ends up breaking this build. Use fixed version for each release.
+  # nixpkgs typically updates default llvm and go versions faster than tinygo releases
+  # which ends up breaking this build. Use fixed versions for each release.
+  buildGoModule = buildGo125Module;
+  go = go_1_25;
   llvmMajor = lib.versions.major llvm.version;
   inherit (llvmPackages_20)
     llvm
@@ -34,14 +36,14 @@ let
   '';
 in
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "tinygo";
   version = "0.40.1";
 
   src = fetchFromGitHub {
     owner = "tinygo-org";
     repo = "tinygo";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-+dLdQdq47M+HKjiMQI1/NJZqiRFuR8rnv/osCbFTpQE=";
     fetchSubmodules = true;
     # The public hydra server on `hydra.nixos.org` is configured with
@@ -134,7 +136,7 @@ buildGoModule rec {
     make build/release USE_SYSTEM_BINARYEN=1
 
     wrapProgram $out/bin/tinygo \
-      --prefix PATH : ${lib.makeBinPath runtimeDeps}
+      --prefix PATH : ${lib.makeBinPath finalAttrs.runtimeDeps}
 
     runHook postInstall
   '';
@@ -147,4 +149,4 @@ buildGoModule rec {
       muscaln
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Closes #505037

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
