### PR TITLE
python3Packages.gpiod: rename from libgpiod

### DIFF
--- a/pkgs/development/python-modules/gpiod/default.nix
+++ b/pkgs/development/python-modules/gpiod/default.nix
@@ -2,10 +2,14 @@
   lib,
   buildPythonPackage,
   libgpiod,
+  setuptools,
 }:
 buildPythonPackage {
-  inherit (libgpiod) pname version src;
-  format = "setuptools";
+  pname = "gpiod";
+  inherit (libgpiod) version src;
+  pyproject = true;
+
+  build-system = [ setuptools ];
 
   buildInputs = [ libgpiod ];
 

--- a/pkgs/development/python-modules/gpiodevice/default.nix
+++ b/pkgs/development/python-modules/gpiodevice/default.nix
@@ -6,7 +6,7 @@
   fetchFromGitHub,
   hatchling,
   hatch-fancy-pypi-readme,
-  libgpiod,
+  gpiod,
   mock,
 }:
 buildPythonPackage (finalAttrs: {
@@ -27,7 +27,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   dependencies = [
-    libgpiod
+    gpiod
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/universal-silabs-flasher/default.nix
+++ b/pkgs/development/python-modules/universal-silabs-flasher/default.nix
@@ -12,7 +12,7 @@
   click,
   coloredlogs,
   crc,
-  libgpiod,
+  gpiod,
   pyserial-asyncio-fast,
   typing-extensions,
   zigpy,
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     typing-extensions
     zigpy
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux) [ libgpiod ];
+  ++ lib.optionals (stdenv.hostPlatform.isLinux) [ gpiod ];
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/servers/home-assistant/custom-components/gpio/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/gpio/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildHomeAssistantComponent,
   fetchFromCodeberg,
-  libgpiod,
+  gpiod,
 }:
 
 buildHomeAssistantComponent rec {
@@ -17,7 +17,7 @@ buildHomeAssistantComponent rec {
     hash = "sha256-JyyJPI0lbZLJj+016WgS1KXU5rnxUmRMafel4/wKsYk=";
   };
 
-  dependencies = [ libgpiod ];
+  dependencies = [ gpiod ];
 
   meta = {
     description = "Home Assistant GPIO custom integration";

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -287,6 +287,7 @@ mapAliases {
   lcov_cobertura = throw "'lcov_cobertura' has been renamed to/replaced by 'lcov-cobertura'"; # Converted to throw 2025-10-29
   ldap = throw "'ldap' has been renamed to/replaced by 'python-ldap'"; # Converted to throw 2025-10-29
   ledger_agent = throw "'ledger_agent' has been renamed to/replaced by 'ledger-agent'"; # Converted to throw 2025-10-29
+  libgpiod = gpiod; # added 2026-03-30
   libpyfoscam = throw "libpyfoscam was removed because Home Assistant switched to libpyfoscamcgi"; # added 2025-07-03
   line_profiler = throw "'line_profiler' has been renamed to/replaced by 'line-profiler'"; # Converted to throw 2025-10-29
   linear-garage-door = throw "'linear-garage-door' has been superseded by 'nice-go'"; # Added 2025-11-16

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6597,6 +6597,8 @@ self: super: with self; {
 
   gpib-ctypes = callPackage ../development/python-modules/gpib-ctypes { };
 
+  gpiod = callPackage ../development/python-modules/gpiod { inherit (pkgs) libgpiod; };
+
   gpiodevice = callPackage ../development/python-modules/gpiodevice { };
 
   gpiozero = callPackage ../development/python-modules/gpiozero { };
@@ -8698,8 +8700,6 @@ self: super: with self; {
   );
 
   libfive = toPythonModule (pkgs.libfive.override { python3 = python; });
-
-  libgpiod = callPackage ../development/python-modules/libgpiod { inherit (pkgs) libgpiod; };
 
   libgravatar = callPackage ../development/python-modules/libgravatar { };
 


### PR DESCRIPTION
On PyPI the package is called gpiod and that's also what's listed as its name in the METADATA file.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
