### PR TITLE
constrict: 25.12.1 -> 26.2

### DIFF
--- a/pkgs/by-name/co/constrict/package.nix
+++ b/pkgs/by-name/co/constrict/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   python3Packages,
-  fetchFromGitHub,
+  fetchFromGitLab,
   meson,
   ninja,
   pkg-config,
@@ -16,18 +16,20 @@
   ffmpeg,
   gst-thumbnailers,
   glycin-loaders,
+  nix-update-script,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "constrict";
-  version = "25.12.1";
+  version = "26.2";
   pyproject = false; # Built with meson
 
-  src = fetchFromGitHub {
-    owner = "Wartybix";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World";
     repo = "Constrict";
     tag = finalAttrs.version;
-    hash = "sha256-ZSiBlejNFakz+/3qj3n+ekB5l9JOk3MiQ8PRZOdxtLQ=";
+    hash = "sha256-SkfutiBi0Y7gNx5PyTaSzVw/5rU/0ULxbtf2606i2wA=";
   };
 
   nativeBuildInputs = [
@@ -67,10 +69,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
     )
   '';
 
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
   meta = {
     description = "Compresses your videos to your chosen file size";
-    homepage = "https://github.com/Wartybix/Constrict";
-    changelog = "https://github.com/Wartybix/Constrict/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://gitlab.gnome.org/World/Constrict";
+    changelog = "https://gitlab.gnome.org/World/Constrict/-/releases/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Plus;
     mainProgram = "constrict";
     teams = [ lib.teams.gnome-circle ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* [Diff](https://gitlab.gnome.org/World/Constrict/-/compare/25.12.1...26.2)
* [26.2 release notes](https://gitlab.gnome.org/World/Constrict/-/releases/26.2)
* [26.1 release notes](https://gitlab.gnome.org/World/Constrict/-/releases/26.1)

Sources moved to https://gitlab.gnome.org/World/Constrict

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
