### PR TITLE
gnucash: 5.14 -> 5.15

### DIFF
--- a/pkgs/by-name/gn/gnucash/package.nix
+++ b/pkgs/by-name/gn/gnucash/package.nix
@@ -37,12 +37,12 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnucash";
-  version = "5.14";
+  version = "5.15";
 
   # raw source code doesn't work out of box; fetchFromGitHub not usable
   src = fetchurl {
     url = "https://github.com/Gnucash/gnucash/releases/download/${finalAttrs.version}/gnucash-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-DG/SAhTahqmgRDNZ97YtmivU7YAv1oCFPaS3V6NxrJE=";
+    hash = "sha256-sL1K9Dtr3jRUIn1LOY6ex6Db1RQ0acE3P8gkw8qrCQk=";
   };
 
   nativeBuildInputs = [
@@ -134,7 +134,7 @@ stdenv.mkDerivation (finalAttrs: {
         owner = "Gnucash";
         repo = "gnucash-docs";
         tag = finalAttrs.version;
-        hash = "sha256-KaUkpqBSQnrWR/ynZC6DuUUnbCURxwFBVg+f4HVwy3Q=";
+        hash = "sha256-EI/By0Ek3qDCmi6svX96Wg78UnmsDZzQLRSqErPUuxA=";
       };
 
       nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/gn/gnucash/update.sh
+++ b/pkgs/by-name/gn/gnucash/update.sh
@@ -19,6 +19,6 @@ src_doc_hash=$(nix-prefetch-github Gnucash gnucash-docs --rev "$latest_version" 
 src_doc_hash=$(nix-hash --to-sri --type sha256 "$src_doc_hash")
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
-sed -i default.nix -e "s|$old_src_hash|$src_hash|"
-sed -i default.nix -e "s|$old_src_doc_hash|$src_doc_hash|"
-sed -i default.nix -e "/ version =/s|\"${UPDATE_NIX_OLD_VERSION}\"|\"${latest_version}\"|"
+sed -i package.nix -e "s|$old_src_hash|$src_hash|"
+sed -i package.nix -e "s|$old_src_doc_hash|$src_doc_hash|"
+sed -i package.nix -e "/ version =/s|\"${UPDATE_NIX_OLD_VERSION}\"|\"${latest_version}\"|"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Update-script broke after moving to by-name, fixed.
- Upstream release: https://github.com/Gnucash/gnucash/releases/tag/5.15

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
