### PR TITLE
duckdb: 1.4.4 -> 1.5.1, disable iejoin tests on darwin

### DIFF
--- a/pkgs/by-name/du/duckdb/package.nix
+++ b/pkgs/by-name/du/duckdb/package.nix
@@ -122,6 +122,24 @@ stdenv.mkDerivation (finalAttrs: {
           "test/sql/function/list/aggregates/skewness.test"
           "test/sql/aggregate/aggregates/histogram_table_function.test"
         ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [
+          # SIGTRAP during iejoin tests on aarch64-darwin (with and without sandbox)
+          # iejoin implementation rewritten in 1.5.x with new parallel task scheduling
+          "test/sql/join/iejoin/iejoin_issue_6861.test"
+          "test/sql/join/iejoin/iejoin_issue_7278.test"
+          "test/sql/join/iejoin/iejoin_projection_maps.test"
+          "test/sql/join/iejoin/merge_join_switch.test"
+          "test/sql/join/iejoin/predicate_expressions.test"
+          "test/sql/join/iejoin/test_countzeros.test"
+          "test/sql/join/iejoin/test_ieantijoin.test"
+          "test/sql/join/iejoin/test_iejoin.test"
+          "test/sql/join/iejoin/test_iejoin_east_west.test"
+          "test/sql/join/iejoin/test_iejoin_events.test"
+          "test/sql/join/iejoin/test_iejoin_null_keys.test"
+          "test/sql/join/iejoin/test_iejoin_overlaps.test"
+          "test/sql/join/iejoin/test_iejoin_predicate.test"
+          "test/sql/join/iejoin/test_iesemijoin.test"
+        ]
       );
       LD_LIBRARY_PATH = lib.optionalString stdenv.hostPlatform.isDarwin "DY" + "LD_LIBRARY_PATH";
     in

--- a/pkgs/by-name/du/duckdb/package.nix
+++ b/pkgs/by-name/du/duckdb/package.nix
@@ -144,6 +144,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "duckdb";
     maintainers = with lib.maintainers; [
+      cameronraysmith
       costrouc
       cpcloud
     ];

--- a/pkgs/by-name/du/duckdb/versions.json
+++ b/pkgs/by-name/du/duckdb/versions.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.4.4",
-  "rev": "6ddac802ffa9bcfbcc3f5f0d71de5dff9b0bc250",
-  "hash": "sha256-h9Mldv29u47DnFOCN28HBHWz8daFGE/Nj1JcnNhhQ5Q=",
-  "python_hash": "sha256-860KbaM7Ojp4Qwm5x5WPQg176XKOYayk8pLVaUAuC4M="
+  "version": "1.5.1",
+  "rev": "7dbb2e646fea939a89f10a55aa98c474cbb0c098",
+  "hash": "sha256-FygBpfhvezvUbI969Dta+vZOPt6BnSW2d5gO4I4oB2A=",
+  "python_hash": "sha256-ZB+Zcxg5VjBzfTkQk7TxoP9pw+hvOXpB2qqnqqmjhxM="
 }

--- a/pkgs/development/python-modules/duckdb/default.nix
+++ b/pkgs/development/python-modules/duckdb/default.nix
@@ -145,6 +145,9 @@ buildPythonPackage rec {
     description = "Python binding for DuckDB";
     homepage = "https://duckdb.org/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ cpcloud ];
+    maintainers = with lib.maintainers; [
+      cameronraysmith
+      cpcloud
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR supersedes #503288 #499655 to address https://github.com/NixOS/nixpkgs/pull/499655#issuecomment-4079249467.

- updates duckdb 1.4.4 -> 1.5.1
- excludes iejoin tests following iejoin rewrite in 1.5.x with new parallel task scheduling that crash with `SIGTRAP` on aarch64-darwin
  - https://github.com/NixOS/nixpkgs/pull/499655#issuecomment-4079249467 
- adds @cameronraysmith as a duckdb maintainer 
  - would like to at least help merge version updates following 1.3.x -> 1.4.x
    - https://github.com/NixOS/nixpkgs/pull/444225
  - and the changes to the updateScript that make maintainer merge possible
    - #474603

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
