### PR TITLE
[25.11] teams/radicle: init

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -518,3 +518,7 @@ pkgs/by-name/wa/warp-terminal/  @emilytrau @imadnyc @FlameFlag @johnrtitor
 /pkgs/build-support/build-nim-package.nix @NixOS/nim
 /pkgs/build-support/build-nim-sbom.nix    @NixOS/nim
 /pkgs/top-level/nim-overrides.nix         @NixOS/nim
+
+# Radicle
+/pkgs/build-support/fetchradicle/      @NixOS/radicle
+/pkgs/build-support/fetchradiclepatch/ @NixOS/radicle

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -849,6 +849,10 @@ with lib.maintainers;
     enableFeatureFreezePing = true;
   };
 
+  radicle = {
+    github = "radicle";
+  };
+
   redcodelabs = {
     members = [
       unrooted

--- a/nixos/modules/services/continuous-integration/radicle/adapters/native.nix
+++ b/nixos/modules/services/continuous-integration/radicle/adapters/native.nix
@@ -15,7 +15,7 @@ let
 in
 
 {
-  meta.maintainers = with lib.maintainers; [ defelo ];
+  meta.teams = [ lib.teams.radicle ];
 
   options.services.radicle.ci.adapters.native = {
     instances = lib.mkOption {

--- a/nixos/modules/services/continuous-integration/radicle/ci-broker.nix
+++ b/nixos/modules/services/continuous-integration/radicle/ci-broker.nix
@@ -37,7 +37,7 @@ let
 in
 
 {
-  meta.maintainers = with lib.maintainers; [ defelo ];
+  meta.teams = [ lib.teams.radicle ];
 
   options.services.radicle.ci.broker = {
     enable = lib.mkEnableOption "radicle-ci-broker";

--- a/nixos/modules/services/misc/radicle.nix
+++ b/nixos/modules/services/misc/radicle.nix
@@ -406,9 +406,5 @@ in
     ]
   );
 
-  meta.maintainers = with lib.maintainers; [
-    defelo
-    julm
-    lorenzleutgeb
-  ];
+  meta.teams = [ lib.teams.radicle ];
 }

--- a/nixos/tests/radicle-ci-broker.nix
+++ b/nixos/tests/radicle-ci-broker.nix
@@ -16,7 +16,7 @@ in
 
 {
   name = "radicle-ci-broker";
-  meta.maintainers = with lib.maintainers; [ defelo ];
+  meta.maintainers = lib.teams.radicle.members;
 
   nodes.seed = {
     services.radicle = {

--- a/nixos/tests/radicle.nix
+++ b/nixos/tests/radicle.nix
@@ -2,7 +2,7 @@
 # and verifies that an alice peer can host a repository on the seed,
 # and that a bob peer can send alice a patch via the seed.
 
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 
 let
   # The Node ID depends on nodes.seed.services.radicle.privateKeyFile
@@ -63,13 +63,7 @@ in
 {
   name = "radicle";
 
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [
-      defelo
-      julm
-      lorenzleutgeb
-    ];
-  };
+  meta.maintainers = lib.teams.radicle.members;
 
   nodes = {
     seed =

--- a/pkgs/by-name/ra/radicle-ci-broker/package.nix
+++ b/pkgs/by-name/ra/radicle-ci-broker/package.nix
@@ -73,7 +73,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit
       asl20
     ];
-    maintainers = with lib.maintainers; [ defelo ];
+    teams = [ lib.teams.radicle ];
     mainProgram = "cib";
   };
 })

--- a/pkgs/by-name/ra/radicle-desktop/package.nix
+++ b/pkgs/by-name/ra/radicle-desktop/package.nix
@@ -125,11 +125,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://app.radicle.xyz/nodes/seed.radicle.xyz/rad:z4D5UCArafTzTQpDZNQRuqswh3ury/tree/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [
-      matthiasbeyer
-      defelo
-      faukah
-    ];
+    teams = [ lib.teams.radicle ];
+    maintainers = with lib.maintainers; [ faukah ];
     mainProgram = "radicle-desktop";
   };
 })

--- a/pkgs/by-name/ra/radicle-explorer/package.nix
+++ b/pkgs/by-name/ra/radicle-explorer/package.nix
@@ -111,11 +111,8 @@ lib.fix (
         homepage = "https://radicle.xyz";
         license = lib.licenses.gpl3;
 
-        maintainers = with lib.maintainers; [
-          tazjin
-          lorenzleutgeb
-          defelo
-        ];
+        teams = [ lib.teams.radicle ];
+        maintainers = with lib.maintainers; [ tazjin ];
       };
     }
   )

--- a/pkgs/by-name/ra/radicle-httpd/package.nix
+++ b/pkgs/by-name/ra/radicle-httpd/package.nix
@@ -86,11 +86,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [
-      gador
-      lorenzleutgeb
-      defelo
-    ];
+    teams = [ lib.teams.radicle ];
+    maintainers = with lib.maintainers; [ gador ];
     mainProgram = "radicle-httpd";
   };
 })

--- a/pkgs/by-name/ra/radicle-job/package.nix
+++ b/pkgs/by-name/ra/radicle-job/package.nix
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit
       asl20
     ];
-    maintainers = with lib.maintainers; [ defelo ];
+    teams = [ lib.teams.radicle ];
     mainProgram = "rad-job";
   };
 })

--- a/pkgs/by-name/ra/radicle-native-ci/package.nix
+++ b/pkgs/by-name/ra/radicle-native-ci/package.nix
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit
       asl20
     ];
-    maintainers = with lib.maintainers; [ defelo ];
+    teams = [ lib.teams.radicle ];
     mainProgram = "radicle-native-ci";
   };
 })

--- a/pkgs/by-name/ra/radicle-node/package.nix
+++ b/pkgs/by-name/ra/radicle-node/package.nix
@@ -166,11 +166,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit
     ];
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [
-      amesgen
-      lorenzleutgeb
-      defelo
-    ];
+    teams = [ lib.teams.radicle ];
     mainProgram = "rad";
   };
 })

--- a/pkgs/by-name/ra/radicle-tui/package.nix
+++ b/pkgs/by-name/ra/radicle-tui/package.nix
@@ -72,10 +72,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20 # or
       mit
     ];
-    maintainers = with lib.maintainers; [
-      matthiasbeyer
-      defelo
-    ];
+    teams = [ lib.teams.radicle ];
     mainProgram = "rad-tui";
   };
 })


### PR DESCRIPTION
Backport of #503028

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
