### PR TITLE
graphviz: fix missing `lib/graphviz/config6`, enable strictDeps

### DIFF
--- a/pkgs/tools/graphics/graphviz/default.nix
+++ b/pkgs/tools/graphics/graphviz/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitLab,
   autoreconfHook,
   pkg-config,
+  buildPackages,
   cairo,
   expat,
   flex,
@@ -15,6 +16,7 @@
   libtool,
   makeWrapper,
   pango,
+  runCommand,
   bash,
   bison,
   libxrender,
@@ -35,14 +37,14 @@ let
     optionalAttrs
     ;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "graphviz";
   version = "12.2.1";
 
   src = fetchFromGitLab {
     owner = "graphviz";
     repo = "graphviz";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-Uxqg/7+LpSGX4lGH12uRBxukVw0IswFPfpb2EkLsaiI=";
   };
 
@@ -77,6 +79,7 @@ stdenv.mkDerivation rec {
   ++ optional false "--without-x";
 
   enableParallelBuilding = true;
+  strictDeps = true;
 
   env = optionalAttrs (withXorg && stdenv.hostPlatform.isDarwin) {
     CPPFLAGS = "-I${cairo.dev}/include/cairo";
@@ -86,6 +89,19 @@ stdenv.mkDerivation rec {
 
   preAutoreconf = ''
     ./autogen.sh
+  '';
+
+  # Invoke `dot -c` even while cross compiling else lib/graphviz/config6 will not load at runtime.
+  postPatch = ''
+    substituteInPlace cmd/dot/Makefile.am --replace-fail \
+      'if test "x$(DESTDIR)" = "x" -a "x$(build)" = "x$(host)"; then if test -x $(bindir)/dot$(EXEEXT); then if test -x /sbin/ldconfig; then /sbin/ldconfig 2>/dev/null; fi; cd $(bindir); ./dot$(EXEEXT) -c; else cd $(bindir); ./dot_static$(EXEEXT) -c; fi; fi' \
+      '${lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+        if test -x $(bindir)/dot$(EXEEXT); then \
+          cd $(bindir); ${stdenv.hostPlatform.emulator buildPackages} ./dot$(EXEEXT) -c; \
+        else \
+          cd $(bindir); ${stdenv.hostPlatform.emulator buildPackages} ./dot_static$(EXEEXT) -c; \
+        fi
+      ''}'
   '';
 
   postFixup = optionalString withXorg ''
@@ -109,6 +125,14 @@ stdenv.mkDerivation rec {
       fltk
       graphicsmagick
       ;
+    dot-can-load-plugins =
+      runCommand "dot-can-load-plugins"
+        {
+          nativeBuildInputs = [ finalAttrs.finalPackage ];
+        }
+        ''
+          dot -P -o $out
+        '';
   };
 
   meta = {
@@ -121,4 +145,4 @@ stdenv.mkDerivation rec {
       raskin
     ];
   };
-}
+})

--- a/pkgs/tools/graphics/graphviz/default.nix
+++ b/pkgs/tools/graphics/graphviz/default.nix
@@ -74,9 +74,8 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--with-ltdl-lib=${libtool.lib}/lib"
     "--with-ltdl-include=${libtool}/include"
-  ]
-  # TODO: this should probably be !withXorg instead of false, however it causes 17k rebuilds
-  ++ optional false "--without-x";
+    (lib.withFeature withXorg "x")
+  ];
 
   enableParallelBuilding = true;
   strictDeps = true;


### PR DESCRIPTION
fixes `$(nix-build -A pkgsCross.musl64.graphviz)/bin/dot < /dev/null)`

without `$out/lib/graphviz/config6`, a cross-compiled graphviz wouldn't know which plugins it had available, and so any `dot` command would fail like:
```
$ dot
There is no layout engine support for "dot"
Perhaps "dot -c" needs to be run (with installer's privileges) to register the plugins?
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
