### PR TITLE
affected: init at 0.2.2

### DIFF
--- a/pkgs/by-name/af/affected/package.nix
+++ b/pkgs/by-name/af/affected/package.nix
@@ -1,0 +1,61 @@
+{
+  fetchFromGitHub,
+  lib,
+  libgit2,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+  zlib,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "affected";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Rani367";
+    repo = "affected";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dRf1SMCIqRm4loIosakb0YO9vAe6rpAPKNdVYWvFKYA=";
+  };
+
+  cargoHash = "sha256-POXMKm2RHXdlUZbj0ESv9JWlhBQWUrnukxa7KhzIRt4=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libgit2
+    openssl
+    zlib
+  ];
+
+  env.OPENSSL_NO_VENDOR = true;
+
+  doCheck = false; # https://github.com/Rani367/affected/issues/3
+  preCheck = ''
+    RUST_BACKTRACE=full
+  '';
+
+  # https://github.com/Rani367/affected/issues/4
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/Rani367/affected/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Detect affected packages and run only what matters";
+    longDescription = ''
+      Standalone, language-agnostic CLI that detects which packages in
+      your monorepo are affected by git changes — then runs tests,
+      lints, builds, or any command on only those packages.  No
+      framework, no config files, no no lock-in.
+    '';
+    homepage = "https://github.com/Rani367/affected";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "affected";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
