### PR TITLE
tandoor-recipes: 2.6.0 -> 2.6.4

### DIFF
--- a/nixos/modules/services/misc/tandoor-recipes.nix
+++ b/nixos/modules/services/misc/tandoor-recipes.nix
@@ -16,6 +16,7 @@ let
     DEBUG = "0";
     DEBUG_TOOLBAR = "0";
     MEDIA_ROOT = "${stateDir}${lib.optionalString useNewMediaRoot "/media"}";
+    ALLOWED_HOSTS = cfg.address;
   }
   // lib.optionalAttrs (config.time.timeZone != null) {
     TZ = config.time.timeZone;

--- a/pkgs/by-name/ta/tandoor-recipes/common.nix
+++ b/pkgs/by-name/ta/tandoor-recipes/common.nix
@@ -1,15 +1,15 @@
 { lib, fetchFromGitHub }:
 rec {
-  version = "2.6.0";
+  version = "2.6.4";
 
   src = fetchFromGitHub {
     owner = "TandoorRecipes";
     repo = "recipes";
     tag = version;
-    hash = "sha256-tjVqHcDy+Ms1L3IuGo3aKDKcrHU22YvDE8QBEQ8Hybg=";
+    hash = "sha256-PPx7rdJREh8qVHTk3a5j1lw3OwHXejravMGBak4u8b8=";
   };
 
-  yarnHash = "sha256-yC8v/lYTL12YTJLX+/BrBLolzQ0O4kSZpcsduLHm65o=";
+  yarnHash = "sha256-9Oxp4C0iRaqsQG1e0DEdfUUAfSuZo/fiuQO0ofSJEXY=";
 
   meta = {
     homepage = "https://tandoor.dev/";


### PR DESCRIPTION
https://github.com/TandoorRecipes/recipes/releases/tag/2.6.4
Diff: https://github.com/TandoorRecipes/recipes/compare/2.6.0...2.6.4

Fixes:
[GHSA-x636-4jx6-xc4w](https://github.com/TandoorRecipes/recipes/security/advisories/GHSA-x636-4jx6-xc4w)
[GHSA-8w8h-3pv2-3554](https://github.com/TandoorRecipes/recipes/security/advisories/GHSA-8w8h-3pv2-3554)
[GHSA-xvmf-cfrq-4j8f](https://github.com/TandoorRecipes/recipes/security/advisories/GHSA-xvmf-cfrq-4j8f)
[GHSA-9hhh-g2fc-r8x2](https://github.com/TandoorRecipes/recipes/security/advisories/GHSA-9hhh-g2fc-r8x2)
[GHSA-v8x3-w674-55p5](https://github.com/TandoorRecipes/recipes/security/advisories/GHSA-v8x3-w674-55p5)

ALLOWED_HOSTS must now be set to the hostname of the server inside of `services.tandoor-recipes.extraConfig`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
