### PR TITLE
ecl: 24.5.10 -> 26.3.27

### DIFF
--- a/pkgs/development/compilers/ecl/default.nix
+++ b/pkgs/development/compilers/ecl/default.nix
@@ -24,11 +24,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "ecl";
-  version = "24.5.10";
+  version = "26.3.27";
 
   src = fetchurl {
     url = "https://common-lisp.net/project/ecl/static/files/release/ecl-${version}.tgz";
-    hash = "sha256-5Opluxhh4OSVOGv6i8ZzvQFOltPPnZHpA4+RQ1y+Yis=";
+    hash = "sha256-QW1XB78R0rPY0z1nkUGaeG5MxZrAzD7FBe5ZtRqfXJo=";
   };
 
   nativeBuildInputs = [
@@ -48,31 +48,6 @@ stdenv.mkDerivation rec {
   ++ lib.optionals useBoehmgc [
     # replaces ecl's own gc which other packages can depend on, thus propagated
     boehmgc
-  ];
-
-  patches = [
-    # https://gitlab.com/embeddable-common-lisp/ecl/-/merge_requests/1
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/sagemath/sage/9.2/build/pkgs/ecl/patches/write_error.patch";
-      sha256 = "0hfxacpgn4919hg0mn4wf4m8r7y592r4gw7aqfnva7sckxi6w089";
-    })
-  ]
-  ++ lib.optionals stdenv.cc.isGNU [
-    # Fix gcc15 compat for downstream packages e.g. sage
-    # error: ‘bool’ cannot be defined via ‘typedef’
-    (fetchpatch {
-      url = "https://gitlab.com/embeddable-common-lisp/ecl/-/commit/1aec8f741f69fd736f020b7fe4d3afc33e60ae6a.patch";
-      sha256 = "sha256-/cA6iOOob0ATViQm5EwBbdin5peqRMjLPKa7RjkrJ94=";
-    })
-    # error: too many arguments to function 'fn'; expected 0, have 1
-    (fetchpatch {
-      url = "https://gitlab.com/embeddable-common-lisp/ecl/-/commit/5b4e9c4bbd7cce4a678eecd493e56c495490e8b5.patch";
-      sha256 = "sha256-QHxswFiW2rfDAQ98Sl+VVmyP4M/eIjJWQEcR/B+m398=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.com/embeddable-common-lisp/ecl/-/commit/5ec9e02f6db9694dcdef7574036f1e320d64a8af.patch";
-      sha256 = "sha256-ZRah0IqOt6OQZGqlCq0RKiToyxsRXQEXAiSUGgqZnKU=";
-    })
   ];
 
   configureFlags = [


### PR DESCRIPTION
https://ecl.common-lisp.dev/posts/ECL-26327-release.html

- Dropped GCC 15 patches are part of the release.
- write_error.patch no longer applies, but appears to be intended to resolve an issue that has been fixed years ago according to the bug tracker.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
