### PR TITLE
imgui: 1.91.4 -> 1.92.7

### DIFF
--- a/pkgs/by-name/da/dartsim/package.nix
+++ b/pkgs/by-name/da/dartsim/package.nix
@@ -73,6 +73,11 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/dartsim/dart/commit/6f3d6086780a311ef6e1928697f56a4d845ae028.patch";
       hash = "sha256-sfbTm9C74fl7lVnGPZ1h3cvKXILHhkeNYxd/BpSQvg8=";
     })
+    # ref. https://github.com/dartsim/dart/pull/2525 (for v7)
+    (fetchpatch {
+      url = "https://github.com/dartsim/dart/commit/7c3279ecef0ee27dbd76da8562b71407928996be.patch";
+      hash = "sha256-0jMy55FCN8mU3Mp2IFiczxnTCjlF3tufWqz1QHeOAyk=";
+    })
   ];
 
   # Install python bindings

--- a/pkgs/by-name/im/imgui/package.nix
+++ b/pkgs/by-name/im/imgui/package.nix
@@ -72,7 +72,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "imgui";
-  version = "1.91.4";
+  version = "1.92.7";
   outputs = [
     # Note: no "dev" because vcpkg installs include/ and imgui-config.cmake
     # into different prefixes but expects the merged layout at import time
@@ -84,7 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ocornut";
     repo = "imgui";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6j4keBOAzbBDsV0+R4zTNlsltxz2dJDGI43UIrHXDNM=";
+    hash = "sha256-wHJliNAMMLpfy2R3weHIPOtaJiZMPxk2S/n7uJPLvzM=";
   };
 
   cmakeRules = "${vcpkgSource}/ports/imgui";

--- a/pkgs/by-name/im/imtui/package.nix
+++ b/pkgs/by-name/im/imtui/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   imgui,
   ninja,
@@ -35,6 +36,13 @@ stdenv.mkDerivation rec {
     ++ lib.optional withCurl curl
     ++ lib.optional withNcurses ncurses;
 
+  patches = [
+    # update for keyboard interaction in imgui >=1.91.5
+    (fetchpatch {
+      url = "https://github.com/ggerganov/imtui/commit/54e92c15176cfe05d854ccc1d1f071111c80de7f.patch";
+      hash = "sha256-qEdprfmierPn1K2jAJkoMs1agla7Ra1Xk0MhYHnUXu0=";
+    })
+  ];
   postPatch = ''
     cp -r ${imgui.src}/* third-party/imgui/imgui
     chmod -R u+w third-party/imgui


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelog: https://github.com/ocornut/imgui/releases
Diff: https://github.com/ocornut/imgui/compare/v1.91.4..v1.92.7

Update imgui to v1.92.7 and fix any breakage caused by it. Included patch for dartsim is [merged](https://github.com/dartsim/dart/pull/2526) by upstream but still unreleased, patch for imtui is _not_ merged and so far **unreviewed**. Maybe someone from nixpkgs can take a quick look there: https://github.com/ggerganov/imtui/pull/62

Supersedes:
* https://github.com/NixOS/nixpkgs/pull/444588

Depends on (wait for merge):
* https://github.com/NixOS/nixpkgs/pull/504172
* https://github.com/NixOS/nixpkgs/pull/472954
* https://github.com/NixOS/nixpkgs/pull/505138

ignore my branch name, 1.92.7 came out while I was waiting for other things to settle / get merged

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
