### PR TITLE
trivial-builders: better meta.position for writeTextFile, writeShellApplication, concatTextFile

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -80,18 +80,19 @@ rec {
         inherit buildCommand name;
         passAsFile = [ "buildCommand" ] ++ (derivationArgs.passAsFile or [ ]);
       }
-      // {
-        ${if !derivationArgs ? meta then "pos" else null} =
-          let
-            args = builtins.attrNames derivationArgs;
-          in
-          if builtins.length args > 0 then
-            builtins.unsafeGetAttrPos (builtins.head args) derivationArgs
-          else
-            null;
-        ${if runLocal then "preferLocalBuild" else null} = true;
-        ${if runLocal then "allowSubstitutes" else null} = false;
-      }
+      // (
+        let
+          args = builtins.attrNames derivationArgs;
+        in
+        {
+          ${
+            if builtins.length args > 0 && derivationArgs.meta.description or null == null then "pos" else null
+          } =
+            builtins.unsafeGetAttrPos (builtins.head args) derivationArgs;
+          ${if runLocal then "preferLocalBuild" else null} = true;
+          ${if runLocal then "allowSubstitutes" else null} = false;
+        }
+      )
       // removeAttrs derivationArgs [ "passAsFile" ]
     );
 
@@ -123,7 +124,6 @@ rec {
     runCommand name
       (
         {
-          pos = builtins.unsafeGetAttrPos "name" args;
           inherit
             text
             executable
@@ -131,14 +131,14 @@ rec {
             allowSubstitutes
             preferLocalBuild
             ;
+          meta = {
+            ${if executable && matches != null then "mainProgram" else null} = lib.head matches;
+          }
+          // meta
+          // derivationArgs.meta or { };
           passAsFile = [ "text" ] ++ derivationArgs.passAsFile or [ ];
-          meta =
-            lib.optionalAttrs (executable && matches != null) {
-              mainProgram = lib.head matches;
-            }
-            // meta
-            // derivationArgs.meta or { };
           passthru = passthru // derivationArgs.passthru or { };
+          ${if meta.description or null == null then "pos" else null} = builtins.unsafeGetAttrPos "name" args;
         }
         // removeAttrs derivationArgs [
           "passAsFile"
@@ -265,7 +265,6 @@ rec {
         name
         meta
         passthru
-        derivationArgs
         ;
       executable = true;
       destination = "/bin/${name}";
@@ -321,6 +320,11 @@ rec {
           ''
         else
           checkPhase;
+
+      derivationArgs = {
+        ${if meta.description or null == null then "pos" else null} = builtins.unsafeGetAttrPos "name" args;
+      }
+      // derivationArgs;
     };
 
   # Create a C binary
@@ -380,7 +384,7 @@ rec {
       checkPhase ? "", # syntax checks, e.g. for scripts
       meta ? { },
       passthru ? { },
-    }:
+    }@args:
     runCommandLocal name
       {
         inherit
@@ -391,6 +395,7 @@ rec {
           passthru
           destination
           ;
+        ${if meta.description or null == null then "pos" else null} = builtins.unsafeGetAttrPos "name" args;
       }
       ''
         file=$out$destination


### PR DESCRIPTION
Example:

```nix
let
	pkgs = import <nixpkgs> {};
	x = pkgs.writeShellApplication {
		name = "test-position";
		text = "true";
		meta.description = "Test position";
	};
in
x.meta.position
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
