### PR TITLE
atuin: enable ai and hex build features

### DIFF
--- a/pkgs/by-name/at/atuin/package.nix
+++ b/pkgs/by-name/at/atuin/package.nix
@@ -29,6 +29,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "sync"
     "clipboard"
     "daemon"
+    "ai"
+    "hex"
   ];
 
   nativeBuildInputs = [ installShellFiles ];


### PR DESCRIPTION
## Summary

- Enable `ai` and `hex` build features for atuin, which were added to upstream defaults but are missing from the nixpkgs package
- Since `buildNoDefaultFeatures = true` is set (to exclude `check-update`), new default features need to be added to `buildFeatures` manually

### AI

LLM-powered English-to-shell command generation via Atuin Hub (opt-in, disabled by default in atuin config).

- [Docs: AI introduction](https://docs.atuin.sh/cli/ai/introduction/)
- [Docs: AI settings](https://docs.atuin.sh/cli/ai/settings/)

### Hex

Lightweight PTY proxy that renders the TUI search overlay on top of previous terminal output without entering fullscreen.

- [Docs: Hex reference](https://docs.atuin.sh/cli/reference/hex/)

Both features were introduced in [Atuin v18.13](https://blog.atuin.sh/atuin-v18-13/).

> **Note:** `ai` and `hex` are the only default upstream features currently missing from `buildFeatures` (beyond the intentionally excluded `check-update`). The full upstream default list is: `client`, `sync`, `clipboard`, `check-update`, `daemon`, `ai`, `hex`.

## Test plan

- [x] Built locally with nix-darwin and verified `atuin hex` and `atuin ai` subcommands are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)