### PR TITLE
[Backport release-25.11] GNOME: 49.3 → 49.4

### DIFF
--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -47,9 +47,9 @@
   xz,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "evolution";
-  version = "3.58.2";
+  version = "3.58.3";
 
   outputs = [
     "out"
@@ -57,8 +57,8 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/evolution/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-uhvDtXKKMbjJ6qDaHuiulG7dzFRO6CQtzMIJ2W3KozA=";
+    url = "mirror://gnome/sources/evolution/${lib.versions.majorMinor finalAttrs.version}/evolution-${finalAttrs.version}.tar.xz";
+    hash = "sha256-XQG3mlvr3y06mHG2E1CTnPJQH26gPCQVQ/dEqShtTXk=";
   };
 
   nativeBuildInputs = [
@@ -155,4 +155,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ev/evolution-data-server/package.nix
+++ b/pkgs/by-name/ev/evolution-data-server/package.nix
@@ -50,7 +50,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "evolution-data-server";
-  version = "3.58.2";
+  version = "3.58.3";
 
   outputs = [
     "out"
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor finalAttrs.version}/evolution-data-server-${finalAttrs.version}.tar.xz";
-    hash = "sha256-aULs/Dnrs2sLQ2Ot/wB3HBwt+jT1ToDsksO6o/6wIPs=";
+    hash = "sha256-2hNtEZDZ6LCUmUUvYFjiTu5rd/RBqMdp90pSRRvzefE=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-maps/package.nix
+++ b/pkgs/by-name/gn/gnome-maps/package.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-maps";
-  version = "49.3";
+  version = "49.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-maps/${lib.versions.major finalAttrs.version}/gnome-maps-${finalAttrs.version}.tar.xz";
-    hash = "sha256-v8jpNxGOWWNnC8Pvkcdmn6wV7b1r9rIU+K2IFxkovd8=";
+    hash = "sha256-hvqvWNQNauDy9fN8nA3TEsPuKqTlElsfSjHv5Kn4BLA=";
   };
 
   doCheck = !stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/gn/gnome-maps/package.nix
+++ b/pkgs/by-name/gn/gnome-maps/package.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-maps";
-  version = "49.2";
+  version = "49.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-maps/${lib.versions.major finalAttrs.version}/gnome-maps-${finalAttrs.version}.tar.xz";
-    hash = "sha256-dd4/kCjDInLTbgnbqhG/3myFz3USCGVdO6RIJo08PzA=";
+    hash = "sha256-v8jpNxGOWWNnC8Pvkcdmn6wV7b1r9rIU+K2IFxkovd8=";
   };
 
   doCheck = !stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/gn/gnome-sudoku/package.nix
+++ b/pkgs/by-name/gn/gnome-sudoku/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-sudoku";
-  version = "49.2";
+  version = "49.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-sudoku/${lib.versions.major version}/gnome-sudoku-${version}.tar.xz";
-    hash = "sha256-ymcPrHPZ5cPngz/aNVZxC0Ig22Qz577FCnEFYNp9uEA=";
+    hash = "sha256-ybVGyN/pcWHfXVD1U4GCp0FTYmy8NoBbB4FSjvM7xZU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-sudoku/package.nix
+++ b/pkgs/by-name/gn/gnome-sudoku/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-sudoku";
-  version = "49.3";
+  version = "49.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-sudoku/${lib.versions.major version}/gnome-sudoku-${version}.tar.xz";
-    hash = "sha256-ybVGyN/pcWHfXVD1U4GCp0FTYmy8NoBbB4FSjvM7xZU=";
+    hash = "sha256-nIzQZ6RSOHiq/zBHovvYb4izGYQkPw1CorHk8+ZFH1A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-user-docs/package.nix
+++ b/pkgs/by-name/gn/gnome-user-docs/package.nix
@@ -9,13 +9,13 @@
   yelp-tools,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-user-docs";
-  version = "49.1";
+  version = "49.4";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-user-docs/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-DlC4u0/OqpEoNnzTRY5e24YclieMGqmnOm7AQCt7xhc=";
+    url = "mirror://gnome/sources/gnome-user-docs/${lib.versions.major finalAttrs.version}/gnome-user-docs-${finalAttrs.version}.tar.xz";
+    hash = "sha256-BkRI6t1cHxW8j+tQQYpjRxFO+BXcjRXQCiDcX0iuioA=";
   };
 
   nativeBuildInputs = [
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "gnome-user-docs";
     };
   };
 
@@ -40,4 +40,4 @@ stdenv.mkDerivation rec {
     teams = [ lib.teams.gnome ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/li/libshumate/package.nix
+++ b/pkgs/by-name/li/libshumate/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libshumate";
-  version = "1.5.1";
+  version = "1.5.2";
 
   outputs = [
     "out"
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libshumate/${lib.versions.majorMinor finalAttrs.version}/libshumate-${finalAttrs.version}.tar.xz";
-    hash = "sha256-2q34twATQ4jH6TPgtiNYaqp/L76LOmJZOHUTMDuYduY=";
+    hash = "sha256-ppVlwetd2ezTkmi78UNeqlGlsCjtDGUqC2uTZ+BMk4Y=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/li/libshumate/package.nix
+++ b/pkgs/by-name/li/libshumate/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libshumate";
-  version = "1.5.2";
+  version = "1.5.3";
 
   outputs = [
     "out"
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libshumate/${lib.versions.majorMinor finalAttrs.version}/libshumate-${finalAttrs.version}.tar.xz";
-    hash = "sha256-ppVlwetd2ezTkmi78UNeqlGlsCjtDGUqC2uTZ+BMk4Y=";
+    hash = "sha256-NfATslORhW4bXD1ECaXEpkDGzLX1KW/5gux77Tn1bUw=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/li/libspelling/package.nix
+++ b/pkgs/by-name/li/libspelling/package.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libspelling";
-  version = "0.4.9";
+  version = "0.4.10";
 
   outputs = [
     "out"
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libspelling/${lib.versions.majorMinor finalAttrs.version}/libspelling-${finalAttrs.version}.tar.xz";
-    hash = "sha256-0JP9Na4PHJj7WIdlBSh/wKiF5H2p0kEdbXzVlfNNTr8=";
+    hash = "sha256-VuPwGjoYtXW+6kw0NJ+ZzaujFuH3wnGxIx97z12a9zs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Backport of 
- https://github.com/NixOS/nixpkgs/pull/485635

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
