### PR TITLE
nixos/nominatim: add nominatim-api to PYTHONPATH

### DIFF
--- a/nixos/modules/services/search/nominatim.nix
+++ b/nixos/modules/services/search/nominatim.nix
@@ -257,6 +257,7 @@ in
               cfg.package
               falcon
               uvicorn
+              nominatim-api
             ];
           NOMINATIM_DATABASE_DSN = nominatimApiDsn;
           NOMINATIM_DATABASE_WEBUSER = cfg.database.apiUser;


### PR DESCRIPTION
Added `python3Packages.nominatim-api` to the `nominatim` service's `PYTHONPATH`. 

I'm not sure in what situations this is necessary. In some cases everything worked fine, but when I was testing out upgrading nominatim without deleting the database and starting from scratch, I ran into an error where it seems to dynamically try to load `nominatim-api`, and crash when it can't find it. This solved the problem for me.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

```
[2026-03-30 19:50:04 +0000] [1465766] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/nix/store/v9aibhrjjw3hjv3zd0ir0gsn5c7wbqvi-python3.13-gunicorn-23.0.0/lib/python3.13/si>
    worker.init_process()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/nix/store/02q4whl559b4yzz5577xs3702i6bziyq-python3.13-uvicorn-0.35.0/lib/python3.13/sit>
    super().init_process()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "/nix/store/v9aibhrjjw3hjv3zd0ir0gsn5c7wbqvi-python3.13-gunicorn-23.0.0/lib/python3.13/si>
    self.load_wsgi()
    ~~~~~~~~~~~~~~^^
  File "/nix/store/v9aibhrjjw3hjv3zd0ir0gsn5c7wbqvi-python3.13-gunicorn-23.0.0/lib/python3.13/si>
    self.wsgi = self.app.wsgi()
                ~~~~~~~~~~~~~^^
  File "/nix/store/v9aibhrjjw3hjv3zd0ir0gsn5c7wbqvi-python3.13-gunicorn-23.0.0/lib/python3.13/si>
    self.callable = self.load()
                    ~~~~~~~~~^^
  File "/nix/store/v9aibhrjjw3hjv3zd0ir0gsn5c7wbqvi-python3.13-gunicorn-23.0.0/lib/python3.13/si>
    return self.load_wsgiapp()
           ~~~~~~~~~~~~~~~~~^^
  File "/nix/store/v9aibhrjjw3hjv3zd0ir0gsn5c7wbqvi-python3.13-gunicorn-23.0.0/lib/python3.13/si>
    return util.import_app(self.app_uri)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/nix/store/v9aibhrjjw3hjv3zd0ir0gsn5c7wbqvi-python3.13-gunicorn-23.0.0/lib/python3.13/si>
    mod = importlib.import_module(module)
  File "/nix/store/44rn0p64x92bnnh7cwn6x6ybvflybmvz-python3-3.13.12/lib/python3.13/importlib/__i>
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'nominatim_api'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
