### PR TITLE
nixVersions.stable: 2.31.4 -> 2.34.6

### DIFF
--- a/nixos/modules/installer/tools/nix-fallback-paths.nix
+++ b/nixos/modules/installer/tools/nix-fallback-paths.nix
@@ -1,8 +1,8 @@
 {
-  x86_64-linux = "/nix/store/vals1fs2rl6yn5f8gbqj9mvly4r27shs-nix-2.31.4";
-  i686-linux = "/nix/store/fyrlz8cdzvf5csdh5885wifpxc8ywdii-nix-2.31.4";
-  aarch64-linux = "/nix/store/19p3nc892m7idfg2ngd1614660xqbhnm-nix-2.31.4";
-  riscv64-linux = "/nix/store/x1isvq0xnyrg0l29qk2xlp929cgjsmqy-nix-riscv64-unknown-linux-gnu-2.31.4";
-  x86_64-darwin = "/nix/store/4gqxzd5zkxcq271wi5saml4zd92rdkws-nix-2.31.4";
-  aarch64-darwin = "/nix/store/r3gz609kdqchxcmil7dhbravbq8kwm93-nix-2.31.4";
+  x86_64-linux = "/nix/store/q7f0d4m54yj98fcjmbkscw83j82fypnd-nix-2.34.6";
+  i686-linux = "/nix/store/mlv349bmjjx34p50idp54rg0wsm44hws-nix-2.34.6";
+  aarch64-linux = "/nix/store/wlcv2ymswfgwv1cj1q29p26rh26xj3nd-nix-2.34.6";
+  riscv64-linux = "/nix/store/000b0vjlhw359rl82p8pld00g6363c78-nix-riscv64-unknown-linux-gnu-2.34.6";
+  x86_64-darwin = "/nix/store/mqvv503c5l9kgjvc7vyxj3rdx5a71c11-nix-2.34.6";
+  aarch64-darwin = "/nix/store/hcgga2smfm8lqirshrbfpk5j1my1wh4j-nix-2.34.6";
 }

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -230,7 +230,7 @@ lib.makeExtensible (
       latest = self.nix_2_34;
 
       # Read ./README.md before bumping a major release
-      stable = addFallbackPathsCheck self.nix_2_31;
+      stable = addFallbackPathsCheck self.nix_2_34;
     }
     // lib.optionalAttrs config.allowAliases (
       lib.listToAttrs (

--- a/pkgs/tools/package-management/nix/modular/src/libstore-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libstore-tests/package.nix
@@ -62,10 +62,10 @@ mkMesonExecutable (finalAttrs: {
         runCommand "${finalAttrs.pname}-run"
           {
             meta.broken = !stdenv.hostPlatform.emulatorAvailable buildPackages;
-            buildInputs = [
+            nativeBuildInputs = [
               writableTmpDirAsHomeHook
             ]
-            ++ lib.optional (lib.versionAtLeast version "2.34pre") openssl;
+            ++ lib.optional (lib.versionAtLeast version "2.34pre") (lib.getBin openssl);
           }
           ''
             export _NIX_TEST_UNIT_DATA=${data + "/src/libstore-tests/data"}


### PR DESCRIPTION
It's time to do it. 26.05 awaits. CI has been building with these quite successfully.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
