### PR TITLE
gst-thumbnailers: 1.0.alpha.1 -> 1.0.0; several improvements

### DIFF
--- a/pkgs/by-name/gs/gst-thumbnailers/package.nix
+++ b/pkgs/by-name/gs/gst-thumbnailers/package.nix
@@ -81,7 +81,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.gnome.org/GNOME/gst-thumbnailers";
     changelog = "https://gitlab.gnome.org/GNOME/gst-thumbnailers/-/blob/${finalAttrs.src.tag}/NEWS";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.aleksana ];
+    maintainers = with lib.maintainers; [
+      aleksana
+      thunze
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/gs/gst-thumbnailers/package.nix
+++ b/pkgs/by-name/gs/gst-thumbnailers/package.nix
@@ -13,6 +13,8 @@
   fontconfig,
   libglycin,
   glycin-loaders,
+  writableTmpDirAsHomeHook,
+  shared-mime-info,
   callPackage,
   nix-update-script,
 }:
@@ -53,6 +55,21 @@ stdenv.mkDerivation (finalAttrs: {
     libglycin
     glycin-loaders
   ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    # fontconfig tries to write to `~/.cache/fontconfig`
+    writableTmpDirAsHomeHook
+  ];
+
+  # Fix missing glycin loaders (glycin-loaders) and incorrectly detected
+  # MIME types (shared-mime-info).
+  preCheck = ''
+    export XDG_DATA_DIRS=${glycin-loaders}/share:${shared-mime-info}/share:$XDG_DATA_DIRS
+  '';
+
+  mesonCheckFlags = [ "-v" ];
 
   passthru = {
     tests.thumbnailers = callPackage ./tests.nix { };

--- a/pkgs/by-name/gs/gst-thumbnailers/package.nix
+++ b/pkgs/by-name/gs/gst-thumbnailers/package.nix
@@ -14,6 +14,7 @@
   libglycin,
   glycin-loaders,
   callPackage,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -55,6 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.thumbnailers = callPackage ./tests.nix { };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/gs/gst-thumbnailers/package.nix
+++ b/pkgs/by-name/gs/gst-thumbnailers/package.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Generate thumbnailer for video and audio files";
     homepage = "https://gitlab.gnome.org/GNOME/gst-thumbnailers";
+    changelog = "https://gitlab.gnome.org/GNOME/gst-thumbnailers/-/blob/${finalAttrs.src.tag}/NEWS";
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.aleksana ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gs/gst-thumbnailers/package.nix
+++ b/pkgs/by-name/gs/gst-thumbnailers/package.nix
@@ -56,6 +56,9 @@ stdenv.mkDerivation (finalAttrs: {
     glycin-loaders
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   doCheck = true;
 
   nativeCheckInputs = [

--- a/pkgs/by-name/gs/gst-thumbnailers/package.nix
+++ b/pkgs/by-name/gs/gst-thumbnailers/package.nix
@@ -19,19 +19,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gst-thumbnailers";
-  version = "1.0.alpha.1";
+  version = "1.0.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "gst-thumbnailers";
     tag = finalAttrs.version;
-    hash = "sha256-LOdD8ECSK+QuXkE8jjIg5IfZSQ5FcIi3hmZ2vAaaBKI=";
+    hash = "sha256-QxOdjtPnX4ulGsenASQzKJckbIqfSU7FeR+iW1ZL878=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-PIqEEijKe+wsX6idqoIB591h1Yj4mixwXDKDN4caO9I=";
+    hash = "sha256-irXwoGGcVeZza02Ob5HTkeTBD3PaXmfJ4vuqXk9BadA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gs/gst-thumbnailers/package.nix
+++ b/pkgs/by-name/gs/gst-thumbnailers/package.nix
@@ -13,6 +13,7 @@
   fontconfig,
   libglycin,
   glycin-loaders,
+  callPackage,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -51,6 +52,10 @@ stdenv.mkDerivation (finalAttrs: {
     libglycin
     glycin-loaders
   ];
+
+  passthru = {
+    tests.thumbnailers = callPackage ./tests.nix { };
+  };
 
   meta = {
     description = "Generate thumbnailer for video and audio files";

--- a/pkgs/by-name/gs/gst-thumbnailers/tests.nix
+++ b/pkgs/by-name/gs/gst-thumbnailers/tests.nix
@@ -1,0 +1,46 @@
+{
+  stdenv,
+  gst-thumbnailers,
+  shared-mime-info,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gst-thumbnailers-test";
+  inherit (gst-thumbnailers) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/tests";
+
+  nativeBuildInputs = [
+    # fontconfig tries to write to `~/.cache/fontconfig`
+    writableTmpDirAsHomeHook
+  ];
+
+  # Fix incorrectly detected MIME types
+  preBuild = ''
+    export XDG_DATA_DIRS=${shared-mime-info}/share:$XDG_DATA_DIRS
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p $out
+
+    for file in *.{flac,mp3,mkv,webm}; do
+      case "$file" in
+        *.flac|*.mp3) thumbnailer=gst-audio-thumbnailer ;;
+        *.mkv|*.webm) thumbnailer=gst-video-thumbnailer ;;
+      esac
+
+      for size in 128 256 512 1024; do
+        input="file://$(realpath "$file")"
+        output="$out/$(basename "$file")-$size.png"
+
+        ${gst-thumbnailers}/bin/$thumbnailer -i "$input" -o "$output" -s $size
+        file -E "$output"
+      done
+    done
+
+    runHook postBuild
+  '';
+})


### PR DESCRIPTION
- Update from 1.0.alpha.1 to 1.0.0
  - Changelog: https://gitlab.gnome.org/GNOME/gst-thumbnailers/-/blob/1.0.0/NEWS
  - Diff: https://gitlab.gnome.org/GNOME/gst-thumbnailers/-/compare/1.0.alpha.1...1.0.0
- Enable vendored tests
- Add a package test
  - I believe that's nice to have because failing thumbnailers are usually not something you immediately notice.
- Add `meta.changelog`
- Add `passthru.updateScript`
- Add myself to maintainers

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
