### PR TITLE
python3Packages.discid: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/development/python-modules/discid/default.nix
+++ b/pkgs/development/python-modules/discid/default.nix
@@ -5,12 +5,20 @@
   buildPythonPackage,
   fetchPypi,
   setuptools,
+  sphinxHook,
+  sphinx-autodoc-typehints,
+  sphinx-rtd-theme,
 }:
 
 buildPythonPackage rec {
   pname = "discid";
   version = "1.4.0";
   pyproject = true;
+
+  outputs = [
+    "out"
+    "doc"
+  ];
 
   src = fetchPypi {
     inherit pname version;
@@ -30,6 +38,12 @@ buildPythonPackage rec {
         --replace "_open_library(_LIB_NAME)" \
                   "_open_library('${libdiscid}/lib/libdiscid${extension}')"
     '';
+
+  nativeBuildInputs = [
+    sphinxHook
+    sphinx-autodoc-typehints
+    sphinx-rtd-theme
+  ];
 
   meta = {
     description = "Python binding of libdiscid";

--- a/pkgs/development/python-modules/discid/default.nix
+++ b/pkgs/development/python-modules/discid/default.nix
@@ -8,6 +8,7 @@
   sphinxHook,
   sphinx-autodoc-typehints,
   sphinx-rtd-theme,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -43,6 +44,10 @@ buildPythonPackage rec {
     sphinxHook
     sphinx-autodoc-typehints
     sphinx-rtd-theme
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
   ];
 
   meta = {

--- a/pkgs/development/python-modules/discid/default.nix
+++ b/pkgs/development/python-modules/discid/default.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage rec {
   pname = "discid";
-  version = "1.3.0";
+  version = "1.4.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-cWChIRrD1qbYIT+4jdPXPjKr5eATNqWkyYWwgql9QzU=";
+    sha256 = "sha256-UP09tEXK60S593Y3d+1JaIw89GM9qZ00DCW5GUlrqLU=";
   };
 
   build-system = [


### PR DESCRIPTION
Changelog: https://python-discid.readthedocs.io/en/v1.4.0/CHANGES.html#changes-in-1-4-0-2026-03-30

Also I added the installation of the docs and running the tests.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
