### PR TITLE
imnodes: unstable-2024-03-12 -> unstable-2025-06-25

### DIFF
--- a/pkgs/by-name/im/imnodes/package.nix
+++ b/pkgs/by-name/im/imnodes/package.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation {
   pname = "imnodes";
-  version = "unstable-2024-03-12";
+  version = "unstable-2025-06-25";
   outputs = [
     "out"
     "dev"
@@ -22,8 +22,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "Nelarius";
     repo = "imnodes";
-    rev = "8563e1655bd9bb1f249e6552cc6274d506ee788b";
-    hash = "sha256-E7NNCxYq9dyVvutWbpl2a+D2Ap2ErvdYHBDqpX0kb0c=";
+    rev = "b2ec254ce576ac3d42dfb7aef61deadbff8e7211";
+    hash = "sha256-Hdde198chSm3Ii0grEB4imqp7vVu6mYxa1VPZovvb7A=";
   };
   patches = [
     # CMake install rules


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
No changelog as this is _still_ not a real version but just grab-master-and-slap-a-date-on-it
Diff (tiny): https://github.com/Nelarius/imnodes/compare/8563e1655bd9bb1f249e6552cc6274d506ee788b..b2ec254ce576ac3d42dfb7aef61deadbff8e7211

<details>
<summary>
A note on `imnodes.passthru.tests`: 
</summary>

https://github.com/NixOS/nixpkgs/blob/05cc6179cb3f0c9ef987d7ca41e575f67f2dda7e/pkgs/by-name/im/imnodes/package.nix#L47

results in

```
/build/source/example/main.cpp:4:10: fatal error: imgui_impl_sdl2.h: No such file or directory
    4 | #include <imgui_impl_sdl2.h>
```

So, you'd need to switch from `imgui` as a dependency to `imgui.override { IMGUI_BUILD_SDL2_BINDING = true; }`, only to discover

https://github.com/NixOS/nixpkgs/blob/1a994610b0a597f7c0d8e92677c88d9768bf0e87/pkgs/by-name/im/imgui/package.nix#L139-L152

And I _really_ don't feel like getting into that right now. The tests were broken before, they're still broken, and not relevant to this update (look at the upstream diff)
</details>

Maintainer ping: @SomeoneSerge 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`. <- **broken**
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
