### PR TITLE
mathics-scanner: init at 2.0.0

### DIFF
--- a/pkgs/by-name/ma/mathics-scanner/package.nix
+++ b/pkgs/by-name/ma/mathics-scanner/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonPackage (finalAttrs: {
+  pname = "mathics-scanner";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Mathics3";
+    repo = "Mathics3-scanner";
+    tag = finalAttrs.version;
+    hash = "sha256-XxZ3h0BtqH+gKZDumrHa13IhZxXQ6ZI5htn6DIislMY=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    chardet
+    click
+    pyyaml
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tokenizer, operator, character tables, and conversion routines for the Wolfram Language";
+    homepage = "https://github.com/Mathics3/Mathics3-scanner";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ VZstless ];
+    mainProgram = "mathics3-tokens";
+  };
+})


### PR DESCRIPTION
This package contains binary executables while acting as the dependency for mathics-core (not packed yet) at the same time.

dependency graph: 
(mathics-scanner -> mathics-core) -> mathicsscript
In which mathics-core is the opensource Mathematica engine that could be used directly, mathicsscript (not packed yet) is a more advanced frontend for mathics-core.

This is the first time I contribute a Python package so please review it carefully, thx.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
