### PR TITLE
pay-respects: fix modules not building and strip api keys

### DIFF
--- a/pkgs/by-name/pa/pay-respects/package.nix
+++ b/pkgs/by-name/pa/pay-respects/package.nix
@@ -17,6 +17,23 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-dCZGPIipSotcA7DT3VvTCYq8+DxWHi5cp/fwh/44Jwc=";
 
+  env = {
+    _DEF_PR_AI_API_KEY = "";
+    _DEF_PR_AI_URL = "";
+    _DEF_PR_AI_MODEL = "";
+  };
+
+  cargoBuildFlags = [
+    "-p pay-respects"
+    "-p pay-respects-module-runtime-rules"
+    "-p pay-respects-module-request-ai"
+  ];
+  cargoTestFlags = [
+    "-p pay-respects"
+    "-p pay-respects-module-runtime-rules"
+    "-p pay-respects-module-request-ai"
+  ];
+
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
At present, the package for https://codeberg.org/iff/pay-respects only builds the core `pay-respects` binary, but the project is composed of the core binary and two separate module binaries.

There is already support in the [`pay-respects` NixOS module](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/programs/pay-respects.nix) for functionality that requires both of the module binaries including `pay-respects.runtimeRules` and `pay-respects.aiIntegration`, and as far as I can tell this functionality has been broken since the package was initialised.

I have also set specific compile time variables to strip out [the baked in API key](https://codeberg.org/iff/pay-respects/src/commit/8180e35c3f09c6638b07fc05ec30c4b4069ba1ab/module-request-ai/src/requests.rs#L208) from the binary itself. This seems sensible for security and reproducibility, and if wanted the keys can be set manually with the NixOS module or directly with envars.

This is my first PR, so I'm not entirely sure if everything has been done correctly. As far as I can tell the variables should be fine in lieu of directly patching the source code, and while `cargoBuildFlags = [ "--workspace" ];` works the same and would be shorter, specifically setting the members felt like a better way of writing it. Please let me know if this is not the case.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
