### PR TITLE
arnis: init at 2.6.0

### DIFF
--- a/pkgs/by-name/ar/arnis/package.nix
+++ b/pkgs/by-name/ar/arnis/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  cargo-tauri,
+  wrapGAppsHook4,
+  webkitgtk_4_1,
+  pkg-config,
+  versionCheckHook,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "arnis";
+  version = "2.6.0";
+
+  src = fetchFromGitHub {
+    owner = "louis-e";
+    repo = "arnis";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FO/8cQkw6CZWMjWgjx0/2KbfnYgIbHHWdgc4c5t4AEk=";
+  };
+
+  cargoHash = "sha256-R7dW2/7UInK3yLz5YHb6UYhLukPrv8NZ8lRYhQwsiMw=";
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    wrapGAppsHook4
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    webkitgtk_4_1
+  ];
+
+  checkFlags = [
+    # Fail to run in sandbox environment
+    "--skip=map_transformation::translate::translator::tests::test_translate_by_vector"
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram =
+    let
+      binSubdirectory =
+        if stdenv.hostPlatform.isLinux then
+          "bin"
+        else if stdenv.hostPlatform.isDarwin then
+          "Applications/Arnis.app/Contents/MacOS"
+        else
+          throw "Unsuported system";
+    in
+    "${placeholder "out"}/${binSubdirectory}/arnis";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Real world location generator for Minecraft Java Edition";
+    longDescription = ''
+      Open source project written in Rust generates any chosen location from
+      the real world in Minecraft Java Edition with a high level of detail.
+    '';
+    homepage = "https://github.com/louis-e/arnis";
+    changelog = "https://github.com/louis-e/arnis/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    inherit (cargo-tauri.hook.meta) platforms;
+    maintainers = with lib.maintainers; [ nartsiss ];
+    mainProgram = "arnis";
+  };
+})


### PR DESCRIPTION
https://github.com/louis-e/arnis
Generate any location from the real world in Minecraft Java Edition with a high level of detail.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
