### PR TITLE
sysboard: init at 9.9.9-unstable-2025-10-23

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28237,6 +28237,12 @@
     github = "uxodb";
     githubId = 20535246;
   };
+  uzlkav = {
+    name = "Uzlkav";
+    github = "Uzlkav";
+    githubId = 177883133;
+    matrix = "@capybara_squash:unredacted.org";
+  };
   V = {
     name = "V";
     email = "v@anomalous.eu";

--- a/pkgs/by-name/sy/sysboard/package.nix
+++ b/pkgs/by-name/sy/sysboard/package.nix
@@ -1,0 +1,75 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  makeWrapper,
+  wayland-scanner,
+  gtkmm4,
+  gtk4-layer-shell,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sysboard";
+  version = "9.9.9-unstable-2025-10-23";
+
+  src = fetchFromGitHub {
+    owner = "System64fumo";
+    repo = "sysboard";
+    rev = "1a032fb4dd76f3f5496955d293eab2ea90f7fc15";
+    hash = "sha256-wSx1YyzZvcuCscSSQi+nrvvIh0iFjLDQgnBXN80KfFU=";
+  };
+
+  # tries to use absolute paths, use relative instead
+  # this is referenced from pkg source of syshud
+  postPatch = ''
+    substituteInPlace src/main.cpp \
+      --replace-fail /usr/share/sys64/board/config.conf $out/share/sys64/board/config.conf
+    substituteInPlace src/window.cpp \
+      --replace-fail /usr/share/sys64/board/style.css $out/share/sys64/board/style.css
+  '';
+
+  # make sure we're using the nix paths
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "PREFIX="
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland-scanner
+    makeWrapper
+  ];
+
+  buildInputs = [
+    gtkmm4
+    gtk4-layer-shell
+  ];
+
+  # populate version info used by `sysboard -v`:
+  configurePhase = ''
+    runHook preConfigure
+
+    echo '#define GIT_COMMIT_MESSAGE "${finalAttrs.src.rev}\n"' >> src/git_info.hpp
+    echo '#define GIT_COMMIT_DATE "${lib.removePrefix "0-unstable-" finalAttrs.version}"' >> src/git_info.hpp
+
+    runHook postConfigure
+  '';
+
+  # sysboard tries to manually `dlopen`'s its library component
+  # again, use nix's path
+  postFixup = ''
+    wrapProgram $out/bin/sysboard --prefix LD_LIBRARY_PATH : $out/lib
+  '';
+
+  meta = {
+    description = "Simple virtual keyboard for wayland";
+    homepage = "https://github.com/System64fumo/sysboard";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      uzlkav
+    ];
+    mainProgram = "sysboard";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/sy/sysboard/package.nix
+++ b/pkgs/by-name/sy/sysboard/package.nix
@@ -1,0 +1,70 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  makeWrapper,
+  wayland-scanner,
+  gtkmm4,
+  gtk4-layer-shell,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sysboard";
+  version = "9.9.9-unstable-2025-10-23";
+
+  src = fetchFromGitHub {
+    owner = "System64fumo";
+    repo = "sysboard";
+    rev = "1a032fb4dd76f3f5496955d293eab2ea90f7fc15";
+    hash = "sha256-wSx1YyzZvcuCscSSQi+nrvvIh0iFjLDQgnBXN80KfFU=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  postPatch = ''
+    substituteInPlace src/main.cpp \
+      --replace-fail /usr/share/sys64/board/config.conf $out/share/sys64/board/config.conf
+    substituteInPlace src/window.cpp \
+      --replace-fail /usr/share/sys64/board/style.css $out/share/sys64/board/style.css
+  '';
+
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "PREFIX="
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland-scanner
+    makeWrapper
+  ];
+
+  buildInputs = [
+    gtkmm4
+    gtk4-layer-shell
+  ];
+
+  # populate version info used by `sysboard -v`:
+  postConfigure = ''
+    echo '#define GIT_COMMIT_MESSAGE "${finalAttrs.src.rev}\n"' >> src/git_info.hpp
+    echo '#define GIT_COMMIT_DATE "${lib.removePrefix "0-unstable-" finalAttrs.version}"' >> src/git_info.hpp
+  '';
+
+  # sysboard tries to manually `dlopen`'s its library component
+  postFixup = ''
+    wrapProgram $out/bin/sysboard --prefix LD_LIBRARY_PATH : $out/lib
+  '';
+
+  meta = {
+    description = "Simple virtual keyboard for wayland";
+    homepage = "https://github.com/System64fumo/sysboard";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      uzlkav
+    ];
+    mainProgram = "sysboard";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Technically also 9.9.9 but upstream doesn't use tags

sysboard: Simple virtual keyboard for wayland
https://github.com/System64fumo/sysboard
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
