### PR TITLE
python3Packages.autoskope-client: init at 1.4.1

### DIFF
--- a/pkgs/development/python-modules/autoskope-client/default.nix
+++ b/pkgs/development/python-modules/autoskope-client/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest-asyncio,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "autoskope-client";
+  version = "1.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mcisk";
+    repo = "autoskope_client";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ThrI5BzjxVg4K1fvRZvPfDycAh4A9rm226FSpk3a/zs=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ aiohttp ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  disabledTestMarks = [
+    "integration"
+  ];
+
+  pythonImportsCheck = [ "autoskope_client" ];
+
+  meta = {
+    description = "Python client library for the Autoskope API";
+    homepage = "https://github.com/mcisk/autoskope_client";
+    changelog = "https://github.com/mcisk/autoskope_client/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -508,7 +508,8 @@
       ];
     "autoskope" =
       ps: with ps; [
-      ]; # missing inputs: autoskope_client
+        autoskope-client
+      ];
     "avea" =
       ps: with ps; [
         avea
@@ -7518,6 +7519,7 @@
     "autarco"
     "auth"
     "automation"
+    "autoskope"
     "awair"
     "aws"
     "aws_s3"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1302,6 +1302,8 @@ self: super: with self; {
 
   autopxd2 = callPackage ../development/python-modules/autopxd2 { };
 
+  autoskope-client = callPackage ../development/python-modules/autoskope-client { };
+
   autoslot = callPackage ../development/python-modules/autoslot { };
 
   av = callPackage ../development/python-modules/av { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://home-assistant.io/integrations/autoskope
- https://pypi.org/project/autoskope-client/
- https://github.com/mcisk/autoskope_client

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
