### PR TITLE
sgx-psw: 2.27 -> 2.28; nixos/aesmd: update

### DIFF
--- a/nixos/modules/services/security/aesmd.nix
+++ b/nixos/modules/services/security/aesmd.nix
@@ -1,6 +1,5 @@
 {
   config,
-  options,
   pkgs,
   lib,
   ...
@@ -20,23 +19,22 @@ let
     ;
 
   cfg = config.services.aesmd;
-  opt = options.services.aesmd;
-
   sgx-psw = cfg.package;
 
+  # See `psw/ae/aesm_service/source/utils/aesm_config.cpp` for available options
   configFile =
-    with cfg.settings;
-    pkgs.writeText "aesmd.conf" (
-      concatStringsSep "\n" (
-        optional (whitelistUrl != null) "whitelist url = ${whitelistUrl}"
-        ++ optional (proxy != null) "aesm proxy = ${proxy}"
-        ++ optional (proxyType != null) "proxy type = ${proxyType}"
-        ++ optional (defaultQuotingType != null) "default quoting type = ${defaultQuotingType}"
+    let
+      c = cfg.settings;
+      lines =
+        optional (c.defaultQuotingType != null) "default quoting type = ${c.defaultQuotingType}"
+        ++ optional (c.qplLogLevel != null) "qpl log level = ${c.qplLogLevel}"
+        ++ optional (c.proxy != null) "aesm proxy = ${c.proxy}"
+        ++ optional (c.proxyType != null) "proxy type = ${c.proxyType}"
         ++
           # Newline at end of file
-          [ "" ]
-      )
-    );
+          [ "" ];
+    in
+    pkgs.writeText "aesmd.conf" (concatStringsSep "\n" lines);
 in
 {
   imports = [
@@ -45,13 +43,19 @@ in
 
           services.aesmd.package = pkgs.sgx-psw.override { debug = true; };
     '')
+    (mkRemovedOptionModule [
+      "services"
+      "aesmd"
+      "settings"
+      "whitelistUrl"
+    ] "sgx-psw-v2.28 no longer supports Intel enclave signer cert whitelist management.")
   ];
 
   options.services.aesmd = {
     enable = mkEnableOption "Intel's Architectural Enclave Service Manager (AESM) for Intel SGX";
     package = mkPackageOption pkgs "sgx-psw" { };
     environment = mkOption {
-      type = with types; attrsOf str;
+      type = types.attrsOf types.str;
       default = { };
       description = "Additional environment variables to pass to the AESM service.";
       # Example environment variable for `sgx-azure-dcap-client` provider library
@@ -61,59 +65,55 @@ in
       };
     };
     quoteProviderLibrary = mkOption {
-      type = with types; nullOr path;
+      type = types.nullOr types.path;
       default = null;
       example = literalExpression "pkgs.sgx-azure-dcap-client";
       description = "Custom quote provider library to use.";
     };
-    settings = mkOption {
-      description = "AESM configuration";
-      default = { };
-      type = types.submodule {
-        options.whitelistUrl = mkOption {
-          type = with types; nullOr str;
-          default = null;
-          example = "http://whitelist.trustedservices.intel.com/SGX/LCWL/Linux/sgx_white_list_cert.bin";
-          description = "URL to retrieve authorized Intel SGX enclave signers.";
-        };
-        options.proxy = mkOption {
-          type = with types; nullOr str;
-          default = null;
-          example = "http://proxy_url:1234";
-          description = "HTTP network proxy.";
-        };
-        options.proxyType = mkOption {
-          type =
-            with types;
-            nullOr (enum [
-              "default"
-              "direct"
-              "manual"
-            ]);
-          default = if (cfg.settings.proxy != null) then "manual" else null;
-          defaultText = literalExpression ''
-            if (config.${opt.settings}.proxy != null) then "manual" else null
-          '';
-          example = "default";
-          description = ''
-            Type of proxy to use. The `default` uses the system's default proxy.
-            If `direct` is given, uses no proxy.
-            A value of `manual` uses the proxy from
-            {option}`services.aesmd.settings.proxy`.
-          '';
-        };
-        options.defaultQuotingType = mkOption {
-          type =
-            with types;
-            nullOr (enum [
-              "ecdsa_256"
-              "epid_linkable"
-              "epid_unlinkable"
-            ]);
-          default = null;
-          example = "ecdsa_256";
-          description = "Attestation quote type.";
-        };
+    settings = {
+      proxy = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "http://proxy_url:1234";
+        description = "HTTP network proxy.";
+      };
+      proxyType = mkOption {
+        type = types.nullOr (
+          types.enum [
+            "default"
+            "direct"
+            "manual"
+          ]
+        );
+        default = if (cfg.settings.proxy != null) then "manual" else null;
+        defaultText = literalExpression ''
+          if (cfg.settings.proxy != null) then "manual" else null
+        '';
+        example = "default";
+        description = ''
+          Type of proxy to use. The `default` uses the system's default proxy.
+          If `direct` is given, uses no proxy.
+          A value of `manual` uses the proxy from
+          {option}`services.aesmd.settings.proxy`.
+        '';
+      };
+      defaultQuotingType = mkOption {
+        # As of sgx-psw-v2.28 EPID attestation is no longer supported.
+        type = types.nullOr (types.enum [ "ecdsa_256" ]);
+        default = null;
+        example = "ecdsa_256";
+        description = "Attestation quote type.";
+      };
+      qplLogLevel = mkOption {
+        type = types.nullOr (
+          types.enum [
+            "info"
+            "error"
+          ]
+        );
+        default = null;
+        example = "error";
+        description = "Set the log level for the default quote provider library";
       };
     };
   };
@@ -131,8 +131,6 @@ in
     systemd.services.aesmd =
       let
         storeAesmFolder = "${sgx-psw}/aesm";
-        # Hardcoded path AESM_DATA_FOLDER in psw/ae/aesm_service/source/oal/linux/aesm_util.cpp
-        aesmDataFolder = "/var/opt/aesmd/data";
       in
       {
         description = "Intel Architectural Enclave Service Manager";
@@ -155,12 +153,9 @@ in
 
         serviceConfig = {
           # Run with elevated privileges to create /var/opt/aesmd/... before
-          # dropping to DynamicUser.
-          ExecStartPre = ''
-            +${lib.getExe' pkgs.coreutils "install"} -m 644 -D \
-                "${storeAesmFolder}/data/white_list_cert_to_be_verify.bin" \
-                "${aesmDataFolder}/white_list_cert_to_be_verify.bin"
-          '';
+          # dropping to DynamicUser. This is a hardcoded path `AESM_DATA_FOLDER`
+          # in `psw/ae/aesm_service/source/oal/linux/aesm_util.cpp`.
+          ExecStartPre = "+${lib.getExe' pkgs.coreutils "mkdir"} -p -m 755 /var/opt/aesmd/data";
           ExecStart = "${sgx-psw}/bin/aesm_service --no-daemon";
           ExecReload = ''${pkgs.coreutils}/bin/kill -SIGHUP "$MAINPID"'';
 
@@ -267,5 +262,11 @@ in
           UMask = "0066";
         };
       };
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [
+      phlip9
+    ];
   };
 }

--- a/nixos/tests/aesmd.nix
+++ b/nixos/tests/aesmd.nix
@@ -14,8 +14,8 @@
         enable = true;
         settings = {
           defaultQuotingType = "ecdsa_256";
+          qplLogLevel = "info";
           proxyType = "direct";
-          whitelistUrl = "http://nixos.org";
         };
       };
 
@@ -75,16 +75,16 @@
           machine.fail(f"sudo -u nosgxtest test {op} {socket_path}")
 
       with subtest("Copies white_list_cert_to_be_verify.bin"):
-        whitelist_path = "/var/opt/aesmd/data/white_list_cert_to_be_verify.bin"
-        whitelist_perms = machine.succeed(
-          f"nsenter -m -t {main_pid} ${pkgs.coreutils}/bin/stat -c '%a' {whitelist_path}"
+        data_dir = "/var/opt/aesmd/data"
+        data_dir_perms = machine.succeed(
+          f"nsenter -m -t {main_pid} ${pkgs.coreutils}/bin/stat -c '%a' {data_dir}"
         ).strip()
-        assert "644" == whitelist_perms, f"white_list_cert_to_be_verify.bin has permissions {whitelist_perms}"
+        assert data_dir_perms == "755", f"{data_dir} has permissions {data_dir_perms}"
 
       with subtest("Writes and binds aesm.conf in service namespace"):
         aesmd_config = machine.succeed(f"nsenter -m -t {main_pid} ${pkgs.coreutils}/bin/cat /etc/aesmd.conf")
-
-        assert aesmd_config == "whitelist url = http://nixos.org\nproxy type = direct\ndefault quoting type = ecdsa_256\n", "aesmd.conf differs"
+        expected = "default quoting type = ecdsa_256\nqpl log level = info\nproxy type = direct\n"
+        assert aesmd_config == expected, f"aesmd.conf\n\nactual:\n{aesmd_config}\n---\n\nexpected:\n{expected}"
 
       with subtest("aesmd.service without quote provider library has correct LD_LIBRARY_PATH"):
         status, environment = machine.systemctl("show --property Environment --value aesmd.service")

--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -17,18 +17,20 @@
   which,
   debug ? false,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sgx-psw";
   # Version as given in se_version.h
-  version = "2.27.100.1";
+  version = "2.28.100.1";
   # Version as used in the Git tag
-  versionTag = "2.27";
+  versionTag = "2.28";
+  # The Intel Data Center Attestation Primitives (DCAP) version.
+  versionDcap = "1.25";
 
   src = fetchFromGitHub {
     owner = "intel";
-    repo = "linux-sgx";
-    rev = "sgx_${versionTag}";
-    hash = "sha256-hNmh4IgNJDNqt2xF8zBnD/x+saMyMk5hZLA3aOqzqEA=";
+    repo = "confidential-computing.sgx";
+    rev = "sgx_${finalAttrs.versionTag}";
+    hash = "sha256-dRLTyIMNHnPmHb+ro2O7UtzR5EkhMXvxR5BKa6kfNhs=";
     fetchSubmodules = true;
   };
 
@@ -39,31 +41,30 @@ stdenv.mkDerivation rec {
       # run user application enclaves, verify launch policies, produce remote
       # attestation quotes, and do platform certification.
       ae.prebuilt = fetchurl {
-        url = "https://download.01.org/intel-sgx/sgx-linux/${versionTag}/prebuilt_ae_${versionTag}.tar.gz";
+        url = "https://download.01.org/intel-sgx/sgx-linux/${finalAttrs.versionTag}/prebuilt_ae_${finalAttrs.versionTag}.tar.gz";
         hash = "sha256-Hlh96rYOyml2y50d8ASKz6U97Fl0hbGYECeZiG9nMSQ=";
       };
 
       # Pre-built ipp-crypto with mitigations.
       optlib.prebuilt = fetchurl {
-        url = "https://download.01.org/intel-sgx/sgx-linux/${versionTag}/optimized_libs_${versionTag}.tar.gz";
+        url = "https://download.01.org/intel-sgx/sgx-linux/${finalAttrs.versionTag}/optimized_libs_${finalAttrs.versionTag}.tar.gz";
         hash = "sha256-7mDTaLtpOQLHQ6Fv+FWJ2k/veJZPXIcuj7kOdRtRqhg=";
       };
 
       # Fetch the Data Center Attestation Primitives (DCAP) platform enclaves
       # and pre-built sgxssl.
       dcap = rec {
-        version = "1.24";
-        filename = "prebuilt_dcap_${version}.tar.gz";
+        filename = "prebuilt_dcap_${finalAttrs.versionDcap}.tar.gz";
         prebuilt = fetchurl {
-          url = "https://download.01.org/intel-sgx/sgx-dcap/${version}/linux/${filename}";
-          hash = "sha256-sc/eYIPdhwAyDk2Zh1HU6yuFlobqVy/4++m5OnQE3Bc=";
+          url = "https://download.01.org/intel-sgx/sgx-dcap/${finalAttrs.versionDcap}/linux/${filename}";
+          hash = "sha256-TXQ8xh0q9RKPyKqjMvxoQtIH2lxbhCiwpV+HvQxACaw=";
         };
       };
     in
     ''
       # Make sure this is the right version of linux-sgx
-      grep -q '"${version}"' "$src/common/inc/internal/se_version.h" \
-        || (echo "Could not find expected version ${version} in linux-sgx source" >&2 && exit 1)
+      grep -q '"${finalAttrs.version}"' "$src/common/inc/internal/se_version.h" \
+        || (echo "Could not find expected version ${finalAttrs.version} in linux-sgx source" >&2 && exit 1)
 
       tar -xzvf ${ae.prebuilt}     -C $sourceRoot/
       tar -xzvf ${optlib.prebuilt} -C $sourceRoot/
@@ -273,10 +274,8 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/intel/linux-sgx";
     maintainers = with lib.maintainers; [
       phlip9
-      veehaitch
-      citadelcore
     ];
     platforms = [ "x86_64-linux" ];
     license = [ lib.licenses.bsd3 ];
   };
-}
+})

--- a/pkgs/os-specific/linux/sgx/psw/disable-downloads.patch
+++ b/pkgs/os-specific/linux/sgx/psw/disable-downloads.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile b/Makefile
-index 144f4e4..834c23e 100644
+index 0dd0e66..64d3715 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -50,22 +50,17 @@ tips:
+@@ -50,17 +50,13 @@ tips:
  preparation:
  # As SDK build needs to clone and patch openmp, we cannot support the mode that download the source from github as zip.
  # Only enable the download from git
@@ -11,17 +11,21 @@ index 144f4e4..834c23e 100644
  	git apply ../0001-Add-a-macro-to-disable-time-support-in-jwt-for-SGX.patch -R --check
 -	./external/dcap_source/QuoteVerification/prepare_sgxssl.sh nobuild
  	cd external/openmp/openmp_code && git apply ../0001-Enable-OpenMP-in-SGX.patch >/dev/null 2>&1 ||  git apply ../0001-Enable-OpenMP-in-SGX.patch --check -R
- 	cd external/protobuf/protobuf_code && git apply ../sgx_protobuf.patch >/dev/null 2>&1 ||  git apply ../sgx_protobuf.patch --check -R
- 	cd external/protobuf/protobuf_code && git apply ../0001-bumped-protobuf-to-1.33.0.patch >/dev/null 2>&1 ||  git apply ../0001-bumped-protobuf-to-1.33.0.patch --check -R
--	cd external/protobuf/protobuf_code && git submodule update --init --recursive && cd third_party/abseil-cpp && git apply ../../../sgx_abseil.patch>/dev/null 2>&1 || git apply ../../../sgx_abseil.patch --check -R
- 	./external/sgx-emm/create_symlink.sh
- 	cd external/cbor && cp -r libcbor sgx_libcbor
- 	cd external/cbor/libcbor && git apply ../raw_cbor.patch >/dev/null 2>&1 || git apply ../raw_cbor.patch --check -R
+ 	cd external/protobuf/protobuf_code && \
+ 		git apply ../sgx_protobuf.patch >/dev/null 2>&1 || git apply ../sgx_protobuf.patch --check -R && \
+ 		git apply ../0001-bumped-protobuf-to-1.33.0.patch >/dev/null 2>&1 || git apply ../0001-bumped-protobuf-to-1.33.0.patch --check -R && \
+-		git submodule update --init --recursive && \
+ 		cd third_party/abseil-cpp && \
+-		git reset --hard && \
+ 		git apply ../../../sgx_abseil.patch >/dev/null 2>&1 || git apply ../../../sgx_abseil.patch --check -R && \
+ 		git apply ../../../0001-fix-to-make-SGX-Linux-build-on-GCC14.patch >/dev/null 2>&1 || git apply ../../../0001-fix-to-make-SGX-Linux-build-on-GCC14.patch --check -R && \
+ 		git apply ../../../0001-abseil-fix-missing-abort.patch >/dev/null 2>&1 || git apply ../../../0001-abseil-fix-missing-abort.patch --check -R
+@@ -70,8 +66,6 @@ preparation:
  	cd external/cbor/sgx_libcbor && git apply ../sgx_cbor.patch >/dev/null 2>&1 || git apply ../sgx_cbor.patch --check -R
  	cd external/ippcp_internal/ipp-crypto && git apply ../0001-IPP-crypto-for-SGX.patch > /dev/null 2>&1 || git apply ../0001-IPP-crypto-for-SGX.patch --check -R
  	cd external/ippcp_internal/ipp-crypto && mkdir -p build
 -	./download_prebuilt.sh
 -	./external/dcap_source/QuoteGeneration/download_prebuilt.sh
+ 	cd external/libcxxrt/libcxxrt_code && git apply ../sgx_libcxxrt.patch >/dev/null 2>&1 || git apply ../sgx_libcxxrt.patch --check -R
  
  psw:
- 	$(MAKE) -C psw/ USE_OPT_LIBS=$(USE_OPT_LIBS)


### PR DESCRIPTION
### Upstream changes

Release notes: <https://github.com/intel/confidential-computing.sgx/releases/tag/sgx_2.28>
Diff: <https://github.com/intel/linux-sgx/compare/sgx_2.27..sgx_2.28>

- Starting SGX enclaves via a Launch Enclave provided "einittoken" is no longer supported. If you are running stock NixOS or any Linux kernel >5.10 (like 5 years old?), you are probably already using the in-kernel driver for starting enclaves that does not use the Launch Enclave.
- Upstream removes all code supporting EPID attestation. Note that IAS (Intel Attestation Services) already EOL'd EPID attestation a year ago, so EPID-based attestation in general has been non-functional for a while.

If you see journalctl logs like:

```
aesm_service[3341]: Malformed request received (May be forged for attack)
```

This probably means something is trying (and failing) to get a launch token.


### `sgx-psw` package

- use stdenv `finalAttrs` fixpoint so version is easier to override

### NixOS `aesmd` module

- following upstream, remove support for `services.aesmd.settings.whitelistUrl`
- following upstream, add new `services.aesmd.settings.qplLogLevel` option


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
