### PR TITLE
python3Packages.pycrashreport: 1.2.8 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/pycrashreport/default.nix
+++ b/pkgs/development/python-modules/pycrashreport/default.nix
@@ -1,25 +1,23 @@
 {
   buildPythonPackage,
-  cached-property,
-  click,
   fetchFromGitHub,
-  la-panic,
   lib,
   pytestCheckHook,
   setuptools,
   setuptools-scm,
+  typer,
 }:
 
 buildPythonPackage rec {
   pname = "pycrashreport";
-  version = "1.2.8";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "doronz88";
     repo = "pycrashreport";
     tag = "v${version}";
-    hash = "sha256-CjFMixbnRlCT2tnBgpYjnOXg+SJgUtzsVNazPtNyfYQ=";
+    hash = "sha256-huiPTpcNwRY8IMHe4y4H/OBCdlDWhBiU9u1xTvLSDQk=";
   };
 
   build-system = [
@@ -28,9 +26,7 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    cached-property
-    click
-    la-panic
+    typer
   ];
 
   pythonImportsCheck = [ "pycrashreport" ];


### PR DESCRIPTION
Diff: https://github.com/doronz88/pycrashreport/compare/v1.2.8...v2.0.0

Changelog: https://github.com/doronz88/pycrashreport/releases/tag/v2.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
