### PR TITLE
debase: fix build with gcc15

### DIFF
--- a/pkgs/by-name/de/debase/package.nix
+++ b/pkgs/by-name/de/debase/package.nix
@@ -1,6 +1,5 @@
 {
   fetchFromGitHub,
-  fetchpatch, # Delete at next version bump.
   lib,
   libgit2,
   stdenv,
@@ -28,6 +27,10 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile \
       --replace-fail 'git rev-parse HEAD' 'echo aa083074d67938d50336bd3737c960b038d91134' \
       --replace-fail '$(GITHASHHEADER): .git/HEAD .git/index' '$(GITHASHHEADER):'
+
+    # fix build with gcc15
+    substituteInPlace lib/Makefile \
+      --replace-fail './configure' './configure cf_cv_type_of_bool=bool'
   '';
 
   patches = [


### PR DESCRIPTION
- #475479
- https://hydra.nixos.org/build/324214620

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
