### PR TITLE
datadog-agent: include integration python modules into agent python path

### DIFF
--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -111,7 +111,7 @@ buildGoModule rec {
     cp -R $src/cmd/agent/dist/{checks,utils,config.py} $out/${python.sitePackages}
 
     wrapProgram "$out/bin/agent" \
-      --set PYTHONPATH "$out/${python.sitePackages}"''
+      --set PYTHONPATH "${python}/${python.sitePackages}:$out/${python.sitePackages}"''
   + lib.optionalString withSystemd " --prefix LD_LIBRARY_PATH : ${
      lib.makeLibraryPath [
        (lib.getLib systemd)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This change-set on the `datadog-agent` package changes the agent binary `PYTHON_PATH` to include the final merged Python environment of the integration set defined by the user. Prior to this change datadog-agent was unable to run the Postgres integration.

We use the `datadog-agent` package and module in production at the company I work for, and recently when we were setting up the Postgres integration with the agent on our NixOS server fleet we ran into an check error, which noted that the specific "postgres" module under `datadog_checks` (the Python module the integration for Postgres is implemented in) was unable to be found. We eventually tracked it down to the fact that the agent package never actually links the Python runtime towards the final "merged" integration package, where all of the `datadog_checks` modules are stored together. Once the integration environment was added into the agent binary `PYTHON_PATH`, we were able to get Postgres running, and are currently using this fix in production.

Before confirming this PR it would be great to get feedback to see if the maintainers of the `datadog-agent` package know of this issue, or if they managed to get it working on their hosts in a different way! ^^ This is the only way we were able to get it to work, but I wasn't able to track down a matching issue for this, which could either point towards that no one has tried to use `datadog-agent` with Postgres on NixOS before, that they fixed it themselves, or that it's not an issue in other environments, so confirming this would be very beneficial, and I will make sure to answer any questions anyone wants to ask in regards to this fix. :) 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
