### PR TITLE
 datadog-agent: include data directories from integrations into configuration

### DIFF
--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -32,32 +32,39 @@ let
   }
   // cfg.extraConfig;
 
-  # Generate Datadog configuration files for each configured checks.
-  # This works because check configurations have predictable paths,
-  # and because JSON is a valid subset of YAML.
-  makeCheckConfigs =
-    entries:
-    lib.mapAttrs' (name: conf: {
-      name = "datadog-agent/conf.d/${name}.d/conf.yaml";
-      value.source = pkgs.writeText "${name}-check-conf.yaml" (builtins.toJSON conf);
-    }) entries;
-
   defaultChecks = {
     disk = cfg.diskCheck;
     network = cfg.networkCheck;
   };
 
-  # Assemble all check configurations and the top-level agent
-  # configuration.
-  etcfiles =
-    with pkgs;
-    with builtins;
-    {
-      "datadog-agent/datadog.yaml" = {
-        source = writeText "datadog.yaml" (toJSON ddConf);
-      };
-    }
-    // makeCheckConfigs (cfg.checks // defaultChecks);
+  # Assemble the configuration directory from the agent package defaults,
+  # including integration data directories, overlaid with the user's check
+  # configurations converted to JSON (as YAML subset).
+  confDir =
+    let
+      checks = cfg.checks // defaultChecks;
+    in
+    pkgs.runCommand "datadog-agent-conf.d" { } (
+      ''
+        cp -r ${datadogPkg}/share/datadog-agent/conf.d $out
+        chmod -R u+w $out
+      ''
+      + lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (name: conf: ''
+          mkdir -p $out/${name}.d
+          cp ${pkgs.writeText "${name}-check-conf.yaml" (builtins.toJSON conf)} $out/${name}.d/conf.yaml
+        '') checks
+      )
+    );
+
+  etcfiles = {
+    "datadog-agent/datadog.yaml" = {
+      source = pkgs.writeText "datadog.yaml" (builtins.toJSON ddConf);
+    };
+    "datadog-agent/conf.d" = {
+      source = confDir;
+    };
+  };
 
   # Apply the configured extraIntegrations to the provided agent
   # package. See the documentation of `dd-agent/integrations-core.nix`

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -145,6 +145,7 @@ buildGoModule rec {
     homepage = "https://www.datadoghq.com";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
+      mel
       thoughtpolice
     ];
   };

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -108,6 +108,19 @@ buildGoModule rec {
     mkdir -p $out/${python.sitePackages} $out/share/datadog-agent
     cp -R --no-preserve=mode $src/cmd/agent/dist/conf.d $out/share/datadog-agent
     rm -rf $out/share/datadog-agent/conf.d/{apm.yaml.default,process_agent.yaml.default,winproc.d,agentcrashdetect.d,myapp.d}
+
+    # install integration data directories (default configs, profiles)
+    # some integrations have behavior which depends on the data directory contents,
+    # such as the snmp integration, which defines profiles for various devices in
+    # it's data directory, without which the user will not be able to choose device
+    # profiles, or use auto-discovery.
+    for dataDir in ${python}/${python.sitePackages}/datadog_checks/*/data; do
+      [ -d "$dataDir" ] || continue
+      integrationName=$(basename "$(dirname "$dataDir")")
+      mkdir -p $out/share/datadog-agent/conf.d/$integrationName.d
+      cp -rT --no-preserve=mode "$dataDir" $out/share/datadog-agent/conf.d/$integrationName.d/
+    done
+
     cp -R $src/cmd/agent/dist/{checks,utils,config.py} $out/${python.sitePackages}
 
     wrapProgram "$out/bin/agent" \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the default Datadog integration data/configurations into the agent configuration directories.

There are Datadog integrations which have expectations about the files which are included in their respective integration directories under `/etc/datadog-agent/conf.d/<integration.d>/`, and have functionality which depends on specific files being there. For example, the integration we were trying to set up, SNMP, ships with various different profiles which SNMP can use to match devices it auto-discovers on the network to these profiles, which allows Datadog to correctly scrape these devices.

Currently, the only file within the configuration directory of a Datadog integration is our generated `conf.yaml` file, but the default installation of the agent, as well as the Python modules, ship with the default set of files already included, which we can use to fill the configuration directories, thus allowing, for example, SNMP to be used correctly. SNMP for example, stores profiles in folders `/etc/datadog-agent/conf.d/snmp.d/default_profiles` and `/etc/datadog-agent/conf.d/snmp.d/default_profiles`. Without these definitions, auto-discovery is completely unsupported.

The Datadog enterprise support team is also of the expectation that these files are there, and they offer support with that assumption in mind. When my team and I were in talks with Datadog regarding SNMP, their process explicitly included the profile listings, using them, and manipulating them, a workflow which prior to these changes was not fully possible. Though the NixOS package and module are not directly supported by them, I believe it's still valuable to make usability of `datadog-agent` within NixOS as smooth as possible, both for private users and companies.

It'd be great if someone has any feedback on this change, we've been running it in production on our NixOS server fleet, and it allowed us to use Datadog far more effectively than the current implementation within nixpkgs allows, and I believe it makes sense to upstream, as the benefit is high with practically no downside. Any help is really appreciated!! :) 

I've added myself to the maintainer list of `datadog-agent`, to help out with future integration fixing and packaging, as I already maintain this package and module in my day-job, however I can take myself back out of the list again, if you would like! ^^

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
