### PR TITLE
matlab-language-server: 1.1.6 -> 1.3.9

### DIFF
--- a/pkgs/by-name/ma/matlab-language-server/package.nix
+++ b/pkgs/by-name/ma/matlab-language-server/package.nix
@@ -2,39 +2,29 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  fetchpatch,
 }:
 
-buildNpmPackage {
+buildNpmPackage (finalAttrs: {
   pname = "matlab-language-server";
-  version = "1.1.6";
+  version = "1.3.9";
 
   src = fetchFromGitHub {
     owner = "mathworks";
     repo = "matlab-language-server";
-    # Upstream doesn't tag commits unfortunately, but lists versions and dates
-    # in README... See complaint at:
-    # https://github.com/mathworks/MATLAB-language-server/issues/24
-    rev = "c8c901956e3bbfbd6eab440a1b60c3fe016cf567";
-    hash = "sha256-D03gXyrvPYOMkJI2YuHfPAnWdXTz5baemykQ5j9L0rs=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-V4CW7mC3F4L7yqpB4AhpLNtOAaEGIWT8AMWCJkTHepI=";
   };
-  patches = [
-    # https://github.com/mathworks/MATLAB-language-server/pull/23
-    (fetchpatch {
-      url = "https://github.com/mathworks/MATLAB-language-server/commit/56374de620b4855529c4136539f52ab6030e2c92.patch";
-      hash = "sha256-F38ATP+eap0SnxQoib1JwIvNCFfB7g8EtXI9+iK5+HA=";
-    })
-  ];
 
-  npmDepsHash = "sha256-P3MSrwk6FVt4lK58pjwy0YOg2UZI0TG8uXjqCPudgTE=";
+  npmDepsHash = "sha256-eN6Z/UhzovwJh8EoCTuDnhsYyOxY9/fxOkPf0TqIg3k=";
 
   npmBuildScript = "package";
 
   meta = {
     description = "Language Server for MATLAB® code";
     homepage = "https://github.com/mathworks/MATLAB-language-server";
+    changelog = "https://github.com/mathworks/MATLAB-language-server/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ doronbehar ];
     mainProgram = "matlab-language-server";
   };
-}
+})


### PR DESCRIPTION
https://github.com/mathworks/MATLAB-language-server/blob/v1.3.9/CHANGELOG.md
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
