### PR TITLE
init: tmuxPlugins.smart-splits-nvim at 0-unstable-2025-03-28

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -1203,6 +1203,32 @@ in
       maintainers = with lib.maintainers; [ szaffarano ];
     };
   };
+
+  smart-splits-nvim = mkTmuxPlugin {
+    pluginName = "smart-splits-nvim";
+    version = "0-unstable-2025-03-28";
+    rtpFilePath = "smart-splits.tmux";
+    src = pkgs.fetchFromGitHub {
+      owner = "mrjones2014";
+      repo = "smart-splits.nvim";
+      rev = "b64e778448f74d6b15db10b141b82228487ce7e7";
+      hash = "sha256-e9MkKwaMHdceFQa/wIoZS4z2GtKMH+aPfDFwnXDbUhg=";
+    };
+    meta = {
+      homepage = "https://github.com/mrjones2014/smart-splits.nvim";
+      description = "Smart, seamless, directional navigation and resizing of Neovim + terminal multiplexer splits.";
+      longDescription = ''
+        Smarter and more intuitive split pane management that
+        uses a mental model of left/right/up/down instead of
+        wider/narrower/taller/shorter for resizing. Supports
+        seamless navigation between Neovim and terminal multiplexer
+        split panes.
+      '';
+      license = lib.licenses.mit;
+      platforms = lib.platforms.unix;
+      maintainers = with lib.maintainers; [ asakura ];
+    };
+  };
 }
 // lib.optionalAttrs config.allowAliases {
   mkDerivation = throw "tmuxPlugins.mkDerivation is deprecated, use tmuxPlugins.mkTmuxPlugin instead"; # added 2021-03-14


### PR DESCRIPTION
Add tmux plugin for smart-splits.nvim
Smart, seamless, directional navigation and resizing of Neovim + terminal multiplexer splits.
 https://github.com/mrjones2014/smart-splits.nvim

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
