### PR TITLE
okapi-ed: init at 0.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27636,6 +27636,12 @@
     githubId = 74688871;
     name = "Tochukwu Ahanonu";
   };
+  toelke = {
+    name = "Philipp Riederer";
+    email = "philipp@riederer.email";
+    github = "toelke";
+    githubId = 183276;
+  };
   tom94 = {
     email = "nix@94.me";
     github = "Tom94";

--- a/pkgs/by-name/ok/okapi-ed/package.nix
+++ b/pkgs/by-name/ok/okapi-ed/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  ripgrep,
+  rustPlatform,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "okapi-ed";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "nk9";
+    repo = "okapi";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Xnckb3CMB8lE1oaEbmy8etRGJB5BuSoHts0phXm48uM=";
+  };
+
+  cargoHash = "sha256-g+JbSph5Fplq7SYKnWUpMQdoT989+qOe+kRUK3K+bDk=";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  postFixup = ''
+    wrapProgram "$out/bin/okapi" \
+      --prefix PATH : "${lib.makeBinPath [ ripgrep ]}"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Find lines across files by regex and edit them all at once with your $EDITOR";
+    homepage = "https://github.com/nk9/okapi";
+    license = lib.licenses.asl20;
+    mainProgram = "okapi";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ toelke ];
+  };
+})


### PR DESCRIPTION
see https://github.com/nk9/okapi and https://github.com/nk9/okapi/issues/8

This is a tool that hands you the output of ripgrep in an editor and thus allows changing all found lines at once.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
