### PR TITLE
codex: fix hardcoded bwrap path on NixOS

### DIFF
--- a/pkgs/by-name/co/codex/package.nix
+++ b/pkgs/by-name/co/codex/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   installShellFiles,
   cargo,
+  bubblewrap,
   clang,
   cmake,
   gitMinimal,
@@ -65,6 +66,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       ]
     );
   };
+
+  postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
+    substituteInPlace $(grep -rlF "/usr/bin/bwrap" .) \
+      --replace-fail "/usr/bin/bwrap" "${lib.getExe bubblewrap}"
+  '';
 
   # NOTE: part of the test suite requires access to networking, local shells,
   # apple system configuration, etc. since this is a very fast moving target


### PR DESCRIPTION
Codex currently embeds `/usr/bin/bwrap` in the packaged binary. On NixOS this path does not exist, so Codex warns that it could not find system bubblewrap even when `bubblewrap` is installed via Nix.

This patch replaces the hardcoded FHS path during `postPatch` with `${lib.getExe bubblewrap}` on Linux, so the packaged binary points at the Nix store path instead.

I built the package locally on NixOS, verified that the resulting binary no longer contains `/usr/bin/bwrap` and instead contains the Nix store path to `bwrap`, and confirmed the built `codex` binary runs successfully.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

### Local verification

```bash
CARGO_BUILD_JOBS=1 nix build .#codex -L --cores 1 --option max-jobs 1
out=$(nix build --print-out-paths --no-link .#codex)
strings "$out/bin/.codex-wrapped" | rg '/usr/bin/bwrap'
strings "$out/bin/.codex-wrapped" | rg -o '/nix/store/[^ ]*/bin/bwrap'
"$out/bin/codex" --version
"$out/bin/codex" sandbox linux /run/current-system/sw/bin/echo ok
```

Observed:

- `rg '/usr/bin/bwrap'` returned no output
- the binary contains a Nix store bwrap path
- `"$out/bin/codex" --version` reported codex-cli 0.116.0
- `"$out/bin/codex" sandbox linux /run/current-system/sw/bin/echo ok` printed ok

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test