### PR TITLE
python3Packages.freud: extend comment for disabledTests

### DIFF
--- a/pkgs/development/python-modules/freud/default.nix
+++ b/pkgs/development/python-modules/freud/default.nix
@@ -80,6 +80,7 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
     sympy
   ];
+  # https://github.com/NixOS/nixpkgs/issues/255262
   preCheck = ''
     rm -rf freud
   '';

--- a/pkgs/development/python-modules/freud/default.nix
+++ b/pkgs/development/python-modules/freud/default.nix
@@ -86,7 +86,11 @@ buildPythonPackage (finalAttrs: {
   '';
 
   disabledTests = [
+    # 4 tests fail with:
+    #
     # AttributeError: module 'scipy.special' has no attribute 'sph_harm'
+    #
+    # See: https://github.com/glotzerlab/freud/issues/1408
     "test_ld"
     "test_multiple_l"
     "test_qlmi"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test