### PR TITLE
haskellPackages.ihp: pin to hasql 1.10

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3905,3 +3905,39 @@ with haskellLib;
     ];
   }
 )
+
+# 2026-04-01: IHP packages need hasql >= 1.10 (via hasql-mapping).
+# The scope renames hasql-stack attrs to the 1.10 line and unmarks
+# hasql-mapping, which only builds against hasql >= 1.10 and so stays
+# broken at the top level. dontCheck for tests that need a live
+# PostgreSQL lives in configuration-nix.nix on the versioned attrs.
+// (
+  let
+    ihpHasqlScope = self: super: {
+      hasql = doDistribute super.hasql_1_10_3;
+      hasql-dynamic-statements = doDistribute super.hasql-dynamic-statements_0_5_1;
+      hasql-notifications = doDistribute super.hasql-notifications_0_2_5_0;
+      hasql-pool = doDistribute super.hasql-pool_1_4_2;
+      hasql-transaction = doDistribute super.hasql-transaction_1_2_2;
+      postgresql-binary = doDistribute super.postgresql-binary_0_15_0_1;
+      text-builder = doDistribute super.text-builder_1_0_0_5;
+      hasql-mapping = doDistribute (unmarkBroken super.hasql-mapping);
+    };
+
+    ihpPackages = [
+      "ihp"
+      "ihp-datasync"
+      "ihp-graphql"
+      "ihp-hspec"
+      "ihp-ide"
+      "ihp-job-dashboard"
+      "ihp-migrate"
+      "ihp-pglistener"
+      "ihp-ssc"
+      "ihp-typed-sql"
+    ];
+  in
+  lib.genAttrs ihpPackages (
+    name: haskellLib.doDistribute (haskellLib.unmarkBroken (super.${name}.overrideScope ihpHasqlScope))
+  )
+)

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1483,6 +1483,14 @@ builtins.intersectAttrs super {
   # only test suite is testcontainers/docker-based
   postgresql-simple-postgresql-types = dontCheck super.postgresql-simple-postgresql-types;
 
+  # hasql 1.10 stack used by IHP — tests need a live PostgreSQL / docker
+  hasql_1_10_3 = dontCheck super.hasql_1_10_3;
+  hasql-dynamic-statements_0_5_1 = dontCheck super.hasql-dynamic-statements_0_5_1;
+  hasql-notifications_0_2_5_0 = dontCheck super.hasql-notifications_0_2_5_0;
+  hasql-pool_1_4_2 = dontCheck super.hasql-pool_1_4_2;
+  hasql-transaction_1_2_2 = dontCheck super.hasql-transaction_1_2_2;
+  postgresql-binary_0_15_0_1 = dontCheck super.postgresql-binary_0_15_0_1;
+
   users-postgresql-simple = lib.pipe super.users-postgresql-simple [
     (addTestToolDepends [
       pkgs.postgresql


### PR DESCRIPTION
IHP needs hasql >= 1.10 via hasql-mapping. Use `overrideScope` to pin IHP packages to the newer hasql versions which are already available as version-suffixed extra-packages, keeping the Stackage LTS 24 defaults for the rest of the package set.

Same pattern as postgrest, which also uses `overrideScope` for version-pinned hasql dependencies.

### Scoped overrides (ihpHasqlScope)

| Package | Override | Reason |
|---|---|---|
| hasql | `hasql_1_10_3` | IHP needs >= 1.10 |
| hasql-dynamic-statements | `hasql-dynamic-statements_0_5_1` | match hasql 1.10 |
| hasql-mapping | `unmarkBroken` | works with hasql 1.10 |
| hasql-notifications | `hasql-notifications_0_2_5_0` | API compat with hasql 1.10 |
| hasql-pool | `hasql-pool_1_4_2` | match hasql 1.10 |
| hasql-postgresql-types | `doJailbreak` | [ptr-peeker <0.2 too tight](https://github.com/nikita-volkov/hasql-postgresql-types/issues/4) |
| hasql-transaction | `hasql-transaction_1_2_2` | match hasql 1.10 |
| postgresql-binary | `postgresql-binary_0_15_0_1` | match hasql 1.10 |
| postgresql-simple-postgresql-types | `dontCheck` | tests need Docker |
| postgresql-types | `dontCheck` + `doJailbreak` | [ptr-peeker ^>=0.1 too tight](https://github.com/nikita-volkov/postgresql-types/issues/67); integration tests need Docker |
| postgresql-types-algebra | `doJailbreak` | [ptr-peeker ^>=0.1 too tight](https://github.com/nikita-volkov/postgresql-types-algebra/issues/2) |
| text-builder | `text-builder_1_0_0_5` | needed by postgresql-simple-postgresql-types |

Applied via `lib.genAttrs` to: ihp, ihp-datasync, ihp-graphql, ihp-hspec, ihp-ide, ihp-job-dashboard, ihp-pglistener, ihp-ssc, ihp-typed-sql.

`dontCheck` on scoped packages: tests use testcontainers (Docker) or connect to PostgreSQL at runtime.

### Build results (aarch64-linux)

7/9 IHP packages build successfully. `ihp-ide` and `ihp-hspec` fail due to a pre-existing issue: `ihp-migrate` 1.4.0 is incompatible with `ihp` 1.5.0 (missing modules). `ihp-migrate` 1.5.0 has been [published on Hackage](https://hackage.haskell.org/package/ihp-migrate-1.5.0) and will be picked up on the next `update-package-set.sh` run.

## Things done

- Built on platform:
  - [x] aarch64-linux