### PR TITLE
gimp: 3.0.8 -> 3.2.4

### DIFF
--- a/pkgs/applications/graphics/gimp/2.0/default.nix
+++ b/pkgs/applications/graphics/gimp/2.0/default.nix
@@ -264,9 +264,16 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     # The declarations for `gimp-with-plugins` wrapper,
     # used for determining plug-in installation paths
-    majorVersion = "${lib.versions.major finalAttrs.version}.0";
-    targetLibDir = "lib/gimp/${finalAttrs.passthru.majorVersion}";
-    targetDataDir = "share/gimp/${finalAttrs.passthru.majorVersion}";
+    apiVersion = "${
+      toString (
+        lib.toInt (lib.versions.major finalAttrs.version)
+        + (if lib.versions.minor finalAttrs.version == "99" then 1 else 0)
+      )
+    }.0";
+    appVersion = lib.versions.majorMinor finalAttrs.version;
+    majorVersion = lib.warn "gimp2.majorVersion is deprecated in favour of gimp2.apiVersion and gimp2.appVersion" finalAttrs.passthru.apiVersion;
+    targetLibDir = "lib/gimp/${finalAttrs.passthru.apiVersion}";
+    targetDataDir = "share/gimp/${finalAttrs.passthru.apiVersion}";
     targetPluginDir = "${finalAttrs.passthru.targetLibDir}/plug-ins";
     targetScriptDir = "${finalAttrs.passthru.targetDataDir}/scripts";
 

--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -60,7 +60,7 @@
   gexiv2,
   harfbuzz,
   makeFontsConf,
-  mypaint-brushes1,
+  mypaint-brushes,
   libwebp,
   libheif,
   gjs,
@@ -71,7 +71,6 @@
   adwaita-icon-theme,
   alsa-lib,
   desktopToDarwinBundle,
-  fetchpatch,
   qoi,
 }:
 
@@ -84,7 +83,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gimp";
-  version = "3.0.8";
+  version = "3.2.2";
 
   outputs = [
     "out"
@@ -95,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://download.gimp.org/gimp/v${lib.versions.majorMinor finalAttrs.version}/gimp-${finalAttrs.version}.tar.xz";
-    hash = "sha256-/rSYrMAbJoJ8/x/5Wqj7gs3Wpg16v3c8/NGavq/KM4Y=";
+    hash = "sha256-bF+Mur4IH0BWM6LTK3mggWaut7Q8f1SDkWCNwNDecb4=";
   };
 
   patches = [
@@ -117,31 +116,6 @@ stdenv.mkDerivation (finalAttrs: {
     # so we need to pick up the one from the package.
     (replaceVars ./tests-dbus-conf.patch {
       session_conf = "${dbus.out}/share/dbus-1/session.conf";
-    })
-
-    # Allow calling tests from other directories.
-    # Required for the next patch.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gimp/-/commit/fd58ab3bee7a79cb0a7870c6858f3b64c84a7917.patch";
-      hash = "sha256-fpysKWwt5rilqp7ukdWx7kutkDquL/6YhYjR1zQfu/Q=";
-    })
-
-    # Do not go through ui for save-and-export test.
-    # https://gitlab.gnome.org/GNOME/gimp/-/issues/15763
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gimp/-/commit/608ad0a528b5b31101c021d96aeb95558d207497.patch";
-      hash = "sha256-0oA5u+uAT0l3WT90fy0RGOR8xy/fGIHevBb69oUzfGs=";
-      excludes = [
-        # Other changes would prevent deletion, removing it from build is sufficient.
-        "app/tests/test-save-and-export.c"
-      ];
-    })
-
-    # Disable broken UI tests.
-    # https://gitlab.gnome.org/GNOME/gimp/-/issues/15763
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gimp/-/commit/c34fe3e94f1019eafcb38edf1c07bff12a57431e.patch";
-      hash = "sha256-yVauEpoGEOIfCXnGnWMGWjXbIDizDhJ3hipeCy3XSBM=";
     })
   ];
 
@@ -216,7 +190,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxmu
     glib-networking
     libmypaint
-    mypaint-brushes1
+    mypaint-brushes
     qoi
 
     # New file dialogue crashes with “Icon 'image-missing' not present in theme Symbolic” without an icon theme.
@@ -285,19 +259,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     # GIMP is executed at build time so we need to fix this.
     # TODO: Look into if we can fix the interp thing.
-    chmod +x plug-ins/python/{colorxhtml,file-openraster,foggify,gradients-save-as-css,histogram-export,palette-offset,palette-sort,palette-to-gradient,python-eval,spyro-plus}.py
+    chmod +x plug-ins/python/{colorxhtml,file-openraster,foggify,gradients-save-as-css,histogram-export,palette-export-as-kpl,palette-offset,palette-sort,palette-to-gradient,python-eval,spyro-plus}.py
     patchShebangs \
-      plug-ins/python/{colorxhtml,file-openraster,foggify,gradients-save-as-css,histogram-export,palette-offset,palette-sort,palette-to-gradient,python-eval,spyro-plus}.py
-
-    # Use Python from environment not from Meson.
-    # https://gitlab.gnome.org/GNOME/gimp/-/merge_requests/2607
-    substituteInPlace meson.build \
-      --replace-fail "import('python').find_installation()" "import('python').find_installation('python3')"
-
-    # Broken test
-    # https://github.com/NixOS/nixpkgs/pull/484971#issuecomment-3846759517
-    substituteInPlace app/tests/meson.build \
-      --replace-fail "{${"\n"}    'name': 'save-and-export',${"\n"}  }${"\n"}" ""
+      plug-ins/python/{colorxhtml,file-openraster,foggify,gradients-save-as-css,histogram-export,palette-export-as-kpl,palette-offset,palette-sort,palette-to-gradient,python-eval,spyro-plus}.py
   '';
 
   preBuild =

--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -339,7 +339,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "GNU Image Manipulation Program";
     homepage = "https://www.gimp.org/";
     donationPage = "https://www.gimp.org/donating/";
-    maintainers = with lib.maintainers; [ jtojnar ];
+    maintainers = with lib.maintainers; [
+      jtojnar
+      bddvlpr
+    ];
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     # Build invokes built binary to convert assets, binary hangs during plugin loading on big-endian platforms (s390x, ppc64)

--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -60,7 +60,7 @@
   gexiv2,
   harfbuzz,
   makeFontsConf,
-  mypaint-brushes1,
+  mypaint-brushes,
   libwebp,
   libheif,
   gjs,
@@ -71,7 +71,6 @@
   adwaita-icon-theme,
   alsa-lib,
   desktopToDarwinBundle,
-  fetchpatch,
   qoi,
 }:
 
@@ -84,7 +83,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gimp";
-  version = "3.0.8";
+  version = "3.2.4";
 
   outputs = [
     "out"
@@ -95,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://download.gimp.org/gimp/v${lib.versions.majorMinor finalAttrs.version}/gimp-${finalAttrs.version}.tar.xz";
-    hash = "sha256-/rSYrMAbJoJ8/x/5Wqj7gs3Wpg16v3c8/NGavq/KM4Y=";
+    hash = "sha256-cxK8U+nG0tAFbKe5PxxrmHB5Rt2TT3FMIbh0bstgFYg=";
   };
 
   patches = [
@@ -117,31 +116,6 @@ stdenv.mkDerivation (finalAttrs: {
     # so we need to pick up the one from the package.
     (replaceVars ./tests-dbus-conf.patch {
       session_conf = "${dbus.out}/share/dbus-1/session.conf";
-    })
-
-    # Allow calling tests from other directories.
-    # Required for the next patch.
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gimp/-/commit/fd58ab3bee7a79cb0a7870c6858f3b64c84a7917.patch";
-      hash = "sha256-fpysKWwt5rilqp7ukdWx7kutkDquL/6YhYjR1zQfu/Q=";
-    })
-
-    # Do not go through ui for save-and-export test.
-    # https://gitlab.gnome.org/GNOME/gimp/-/issues/15763
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gimp/-/commit/608ad0a528b5b31101c021d96aeb95558d207497.patch";
-      hash = "sha256-0oA5u+uAT0l3WT90fy0RGOR8xy/fGIHevBb69oUzfGs=";
-      excludes = [
-        # Other changes would prevent deletion, removing it from build is sufficient.
-        "app/tests/test-save-and-export.c"
-      ];
-    })
-
-    # Disable broken UI tests.
-    # https://gitlab.gnome.org/GNOME/gimp/-/issues/15763
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gimp/-/commit/c34fe3e94f1019eafcb38edf1c07bff12a57431e.patch";
-      hash = "sha256-yVauEpoGEOIfCXnGnWMGWjXbIDizDhJ3hipeCy3XSBM=";
     })
   ];
 
@@ -216,7 +190,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxmu
     glib-networking
     libmypaint
-    mypaint-brushes1
+    mypaint-brushes
     qoi
 
     # New file dialogue crashes with “Icon 'image-missing' not present in theme Symbolic” without an icon theme.
@@ -285,19 +259,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     # GIMP is executed at build time so we need to fix this.
     # TODO: Look into if we can fix the interp thing.
-    chmod +x plug-ins/python/{colorxhtml,file-openraster,foggify,gradients-save-as-css,histogram-export,palette-offset,palette-sort,palette-to-gradient,python-eval,spyro-plus}.py
+    chmod +x plug-ins/python/{colorxhtml,file-openraster,foggify,gradients-save-as-css,histogram-export,palette-export-as-kpl,palette-offset,palette-sort,palette-to-gradient,python-eval,spyro-plus}.py
     patchShebangs \
-      plug-ins/python/{colorxhtml,file-openraster,foggify,gradients-save-as-css,histogram-export,palette-offset,palette-sort,palette-to-gradient,python-eval,spyro-plus}.py
-
-    # Use Python from environment not from Meson.
-    # https://gitlab.gnome.org/GNOME/gimp/-/merge_requests/2607
-    substituteInPlace meson.build \
-      --replace-fail "import('python').find_installation()" "import('python').find_installation('python3')"
-
-    # Broken test
-    # https://github.com/NixOS/nixpkgs/pull/484971#issuecomment-3846759517
-    substituteInPlace app/tests/meson.build \
-      --replace-fail "{${"\n"}    'name': 'save-and-export',${"\n"}  }${"\n"}" ""
+      plug-ins/python/{colorxhtml,file-openraster,foggify,gradients-save-as-css,histogram-export,palette-export-as-kpl,palette-offset,palette-sort,palette-to-gradient,python-eval,spyro-plus}.py
   '';
 
   preBuild =
@@ -354,9 +318,16 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     # The declarations for `gimp-with-plugins` wrapper,
     # used for determining plug-in installation paths
-    majorVersion = "${lib.versions.major finalAttrs.version}.0";
-    targetLibDir = "lib/gimp/${finalAttrs.passthru.majorVersion}";
-    targetDataDir = "share/gimp/${finalAttrs.passthru.majorVersion}";
+    apiVersion = "${
+      toString (
+        lib.toInt (lib.versions.major finalAttrs.version)
+        + (if lib.versions.minor finalAttrs.version == "99" then 1 else 0)
+      )
+    }.0";
+    appVersion = lib.versions.majorMinor finalAttrs.version;
+    majorVersion = lib.warn "gimp.majorVersion is deprecated in favour of gimp.apiVersion and gimp.appVersion" finalAttrs.passthru.apiVersion;
+    targetLibDir = "lib/gimp/${finalAttrs.passthru.apiVersion}";
+    targetDataDir = "share/gimp/${finalAttrs.passthru.apiVersion}";
     targetPluginDir = "${finalAttrs.passthru.targetLibDir}/plug-ins";
     targetScriptDir = "${finalAttrs.passthru.targetDataDir}/scripts";
 

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -13,12 +13,10 @@ let
     stdenv
     fetchurl
     fetchpatch
-    fetchpatch2
     pkg-config
     intltool
     glib
     fetchFromGitHub
-    fetchFromGitLab
     ;
 
   # We cannot use gimp from the arguments directly, or it would be shadowed by the one
@@ -144,7 +142,7 @@ lib.makeScope pkgs.newScope (
       installTargets = [ "install-admin" ];
 
       meta = {
-        broken = gimp.majorVersion != "2.0";
+        broken = gimp.apiVersion != "2.0";
         description = "Batch Image Manipulation Plugin for GIMP";
         homepage = "https://github.com/alessandrofrancesconi/gimp-plugin-bimp";
         license = lib.licenses.gpl2Plus;
@@ -168,7 +166,7 @@ lib.makeScope pkgs.newScope (
       '';
 
       meta = {
-        broken = gimp.majorVersion != "2.0";
+        broken = gimp.apiVersion != "2.0";
         description = "Gimp plug-in for the farbfeld image format";
         homepage = "https://github.com/ids1024/gimp-farbfeld";
         license = lib.licenses.mit;
@@ -208,7 +206,7 @@ lib.makeScope pkgs.newScope (
       '';
 
       meta = {
-        broken = gimp.majorVersion != "2.0";
+        broken = gimp.apiVersion != "2.0";
         description = "GIMP plug-in to do the fourier transform";
         homepage = "https://people.via.ecp.fr/~remi/soft/gimp/gimp_plugin_en.php3#fourier";
         license = with lib.licenses; [ gpl3Plus ];
@@ -265,7 +263,7 @@ lib.makeScope pkgs.newScope (
       ];
 
       meta = {
-        broken = gimp.majorVersion != "2.0";
+        broken = gimp.apiVersion != "2.0";
       };
     };
 
@@ -293,7 +291,7 @@ lib.makeScope pkgs.newScope (
       installPhase = "installPlugin src/wavelet-sharpen"; # TODO translations are not copied .. How to do this on nix?
 
       meta = {
-        broken = gimp.majorVersion != "2.0";
+        broken = gimp.apiVersion != "2.0";
       };
     };
 
@@ -322,7 +320,7 @@ lib.makeScope pkgs.newScope (
       ];
 
       meta = {
-        broken = gimp.majorVersion != "2.0";
+        broken = gimp.apiVersion != "2.0";
       };
     };
 
@@ -356,7 +354,7 @@ lib.makeScope pkgs.newScope (
     ";
 
       meta = {
-        broken = gimp.majorVersion != "2.0";
+        broken = gimp.apiVersion != "2.0";
         description = "GIMP plugin to correct lens distortion using the lensfun library and database";
 
         homepage = "http://lensfun.sebastiankraft.net/";

--- a/pkgs/applications/graphics/gimp/wrapper.nix
+++ b/pkgs/applications/graphics/gimp/wrapper.nix
@@ -18,8 +18,7 @@ let
     ++ lib.optionals (gimp.majorVersion == "2.0") [
       ''--prefix GTK_PATH : "${gnome-themes-extra}/lib/gtk-2.0"''
     ];
-  exeVersion =
-    if gimp.majorVersion == "2.0" then lib.versions.majorMinor gimp.version else gimp.majorVersion;
+  exeVersion = lib.versions.majorMinor gimp.version;
   majorVersion = lib.versions.major gimp.version;
 
 in

--- a/pkgs/applications/graphics/gimp/wrapper.nix
+++ b/pkgs/applications/graphics/gimp/wrapper.nix
@@ -15,11 +15,9 @@ let
   selectedPlugins = lib.filter (pkg: pkg != gimp) (if plugins == null then allPlugins else plugins);
   extraArgs =
     map (x: x.wrapArgs or "") selectedPlugins
-    ++ lib.optionals (gimp.majorVersion == "2.0") [
+    ++ lib.optionals (gimp.apiVersion == "2.0") [
       ''--prefix GTK_PATH : "${gnome-themes-extra}/lib/gtk-2.0"''
     ];
-  exeVersion =
-    if gimp.majorVersion == "2.0" then lib.versions.majorMinor gimp.version else gimp.majorVersion;
   majorVersion = lib.versions.major gimp.version;
 
 in
@@ -37,7 +35,7 @@ symlinkJoin {
   nativeBuildInputs = [ makeWrapper ];
 
   postBuild = ''
-    for each in gimp-${exeVersion} gimp-console-${exeVersion}; do
+    for each in gimp-${gimp.appVersion} gimp-console-${gimp.appVersion}; do
       wrapProgram $out/bin/$each \
         --set GIMP${majorVersion}_PLUGINDIR "$out/${gimp.targetLibDir}" \
         --set GIMP${majorVersion}_DATADIR "$out/${gimp.targetDataDir}" \
@@ -45,7 +43,7 @@ symlinkJoin {
     done
     set +x
     for each in gimp gimp-console; do
-      ln -sf "$each-${exeVersion}" $out/bin/$each
+      ln -sf "$each-${gimp.appVersion}" $out/bin/$each
     done
 
     ln -s ${gimp.man} $man

--- a/pkgs/by-name/gm/gmic-qt/package.nix
+++ b/pkgs/by-name/gm/gmic-qt/package.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "GMIC_QT_HOST" (
       if variant == "standalone" then
         "none"
-      else if variant == "gimp" && gimp.majorVersion == "3.0" then
+      else if variant == "gimp" && gimp.apiVersion == "3.0" then
         "gimp3"
       else
         variant

--- a/pkgs/by-name/gu/gutenprint/package.nix
+++ b/pkgs/by-name/gu/gutenprint/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     ''
     + lib.optionalString gimp2Support ''
       sed -i \
-        -e "s,gimp2_plug_indir=.*,gimp2_plug_indir=\"$out/lib/gimp/${gimp.majorVersion}\",g" \
+        -e "s,gimp2_plug_indir=.*,gimp2_plug_indir=\"$out/lib/gimp/${gimp.apiVersion}\",g" \
         configure
     '';
 


### PR DESCRIPTION
A plugin got added so patching those shebangs as well. I'm still confused why some paths are hardcoded to `3.0` as the major version but I hope @jtojnar knows.

Unsure if this patches the four open security issues. Nothing in the changelog states these specific CVEs, just a few ZDI ones.

Supersedes #501974.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
