### PR TITLE
k3s: update packages

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_33/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_33/chart-versions.nix
@@ -1,10 +1,10 @@
 {
   traefik-crd = {
-    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-39.0.201+up39.0.2.tgz";
-    sha256 = "0r43kny2kkrlxjniivnivzbqqbiri08cg9qjrl6mx9rjzsxfxqwg";
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-39.0.501+up39.0.5.tgz";
+    sha256 = "0h260ldykvkj9rs81ps1wnys2gqs1l7cb43djpn10g8rzpf5n966";
   };
   traefik = {
-    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-39.0.201+up39.0.2.tgz";
-    sha256 = "1ci2wns11ibgwf7x4j90vcbrsf63rrz1slsm63iayvkdq3r3ri04";
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-39.0.501+up39.0.5.tgz";
+    sha256 = "0ns3vf6c7pby28l0x6w83sx0vcfi4pibwxl04fcr36vnk38fk3c8";
   };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_33/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_33/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.9%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "93f356bfebfd647b099aed93e9754deade10c38ef081afa858f8483503d480b1"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.10%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "89b65e25a55a25ccb01cc98678e6f6aaf71a7626665c908cb71142b75de5d8e9"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.9%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "e368015a3d3b4d38b23ea2ef31b37c2bcb6e9488628954c33c7976a5f0f09290"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.10%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "0db2a423b805a92d1f637151e223277c04f6e11d66ff5096d3c15c3a8a108c76"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.9%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "4cb0a69d3c7319ee27e2c1a3a93523bbdb9c05fde4698b78187d5fb30b9df791"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.10%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "1b396d7637d58aaa47fdae21b96e546ca4c7d94e6f04d8ad7b4e1af2e5f7c793"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.9%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "b789ea7b1965d630d4d5346af7247da6645fa3b6ef32c9f27a6d44e64af9b5c0"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.10%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "e397badd49ca42bf1d8847e37b47bc1409bece6398a5a6e58331a574b7b33cc3"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.9%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "1cd8c3902f215c861d9a66602df0b28c1a70e292468f6a149b8c6299da1d7cbe"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.10%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "38d41721e1a25e51e264062ff69eda5a7351753c546facb90039bb6d44095501"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.9%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "790c4de411881c0af1d704d566d3832afc2fd91c4820423af1a3796c85b47734"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.10%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "806ccb30058b4103753bc842d819ca67eabf532a80237e3a85a1c0de1587a94c"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_33/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_33/versions.nix
@@ -1,21 +1,21 @@
 {
-  k3sVersion = "1.33.9+k3s1";
-  k3sCommit = "f93a18d13d956f6c7f1cc6101e6048766df09ebb";
-  k3sRepoSha256 = "006g6spjfqnz5w57hls4iy1b84r9y6i6h0ybfprhsphdk5fblvkn";
-  k3sVendorHash = "sha256-PKEPdSdljMOFxwh/xbfSHziRPxMgfvNGK3fQqiNC0UI=";
+  k3sVersion = "1.33.10+k3s1";
+  k3sCommit = "52978a7f01d46758c472a6f528dcc255c0797578";
+  k3sRepoSha256 = "0an56jm4lchwc2czqjs9z6sp88vacj73v06bngz4xz7v24v2ag4z";
+  k3sVendorHash = "sha256-w8pwAU0q2zYTP0vBwNjNX0XUvFkISnDOB4549tb35Nc=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
   k3sRootSha256 = "008n8xx7x36y9y4r24hx39xagf1dxbp3pqq2j53s9zkaiqc62hd0";
-  k3sCNIVersion = "1.9.0-k3s1";
-  k3sCNISha256 = "0naqf3jkxz3rd9ljd40wbm8walgi2bx6d1l9wr6mcvrgj7d5g28c";
-  containerdVersion = "2.1.5-k3s1.33";
-  containerdSha256 = "15iw6px3710rlsx7j933i07qd4a2r7caagfjbhhfcp33m9k19v7h";
-  containerdPackage = "github.com/k3s-io/containerd/v2";
+  k3sCNIVersion = "1.9.1-k3s1";
+  k3sCNISha256 = "1ggaz0p1c2k94car9d89a05smz3zx32sxn197b1l5kmjcnzdwadh";
+  containerdVersion = "2.2.2-k3s1";
+  containerdSha256 = "0lqyv4ps1nyjm8fi7znk3r2z3j4ida2h9x1nkzb7c72lz96q1jzs";
+  containerdPackage = "github.com/brandond/containerd/v2";
   criCtlVersion = "1.33.0-k3s2";
-  flannelVersion = "v0.28.0";
+  flannelVersion = "v0.28.2";
   flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s2";
-  helmJobVersion = "v0.9.14-build20260210";
+  helmJobVersion = "v0.9.14-build20260309";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_34/chart-versions.nix
@@ -1,10 +1,10 @@
 {
   traefik-crd = {
-    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-39.0.201+up39.0.2.tgz";
-    sha256 = "0r43kny2kkrlxjniivnivzbqqbiri08cg9qjrl6mx9rjzsxfxqwg";
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-39.0.501+up39.0.5.tgz";
+    sha256 = "0h260ldykvkj9rs81ps1wnys2gqs1l7cb43djpn10g8rzpf5n966";
   };
   traefik = {
-    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-39.0.201+up39.0.2.tgz";
-    sha256 = "1ci2wns11ibgwf7x4j90vcbrsf63rrz1slsm63iayvkdq3r3ri04";
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-39.0.501+up39.0.5.tgz";
+    sha256 = "0ns3vf6c7pby28l0x6w83sx0vcfi4pibwxl04fcr36vnk38fk3c8";
   };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_34/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.5%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "c4b6795a54bb193ea4b156c76a742dd4f93e03bbd03b739d8356d7298aa8a9be"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.6%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "597a061d7d2c05dac31552c3ed78bdbf3673eb56c26206f3eb488ed245d66631"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.5%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "dbc5a1a69162b37544ea7f4d04208355f57c696b98bb7ae47a3080c84d90debf"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.6%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "8d1175bf46cc4e383ce64cae82a3cd7f85f1df8bcd99b67e966b6c87c9bdf9e8"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.5%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "d5e882421ab3d31786d03dfceaa4cdda80fdf5c15e456bfdaf69b46627dce0ef"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.6%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "cd94b87eb8a474221a8d667e8558f21b4102102931aedcfb272b031a454998f2"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.5%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "d795d06766a1d5475123deef4bf4c869fe5c8dadba844241e983aa25818d1631"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.6%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "46718dbfe0caf8cc285a03f7cd66110bf4ad53741dacbba633a57091963f2fd6"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.5%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "dda519d71787bc7eed33a2a1db9015158ca58d86f23a39704b4193f3e1e1a36b"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.6%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "e8af1a6f02a309325265e8fe7d60ee62b18b527177ecb2498f4a35fb747da0e7"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.5%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "c5799a879b68adc996e9a09158d8ea7f04b46bff5241e9641c404809e687d29e"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.6%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "44bd04100b34356dbcd4ea507fcd4755dc20a667f0e33c3ba2f8cc86b10c998d"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_34/versions.nix
@@ -1,21 +1,21 @@
 {
-  k3sVersion = "1.34.5+k3s1";
-  k3sCommit = "c2661bc1e7029f4e68a02f4a9d15c7de3428d0cf";
-  k3sRepoSha256 = "07wqbj8l48nwvx59p6wrahk7acw5bgmvkv7ij24f1514xj5y6if2";
-  k3sVendorHash = "sha256-q3/KylcuuhUMC3ggpR8DsLjdWgtPnhCqa1HjM2sgHuo=";
+  k3sVersion = "1.34.6+k3s1";
+  k3sCommit = "234e61326ca4e005522be1e69645c1ca5754121f";
+  k3sRepoSha256 = "0h3x85alprdgzmsr9c1hpp0h4djh8hr34xdmm72nhb4423jzaiif";
+  k3sVendorHash = "sha256-1eTFsdTlWpXfLQAPGRLNIZj1IfavEAr039PxKFR+Nnw=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
   k3sRootSha256 = "008n8xx7x36y9y4r24hx39xagf1dxbp3pqq2j53s9zkaiqc62hd0";
-  k3sCNIVersion = "1.9.0-k3s1";
-  k3sCNISha256 = "0naqf3jkxz3rd9ljd40wbm8walgi2bx6d1l9wr6mcvrgj7d5g28c";
-  containerdVersion = "2.1.5-k3s1";
-  containerdSha256 = "0n0g58d352i8wz0bqn87vgrd7z54j268cbmbp19fz68wmifm7fl8";
-  containerdPackage = "github.com/k3s-io/containerd/v2";
+  k3sCNIVersion = "1.9.1-k3s1";
+  k3sCNISha256 = "1ggaz0p1c2k94car9d89a05smz3zx32sxn197b1l5kmjcnzdwadh";
+  containerdVersion = "2.2.2-k3s1";
+  containerdSha256 = "0lqyv4ps1nyjm8fi7znk3r2z3j4ida2h9x1nkzb7c72lz96q1jzs";
+  containerdPackage = "github.com/brandond/containerd/v2";
   criCtlVersion = "1.34.0-k3s2";
-  flannelVersion = "v0.28.0";
+  flannelVersion = "v0.28.2";
   flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s3";
-  helmJobVersion = "v0.9.14-build20260210";
+  helmJobVersion = "v0.9.14-build20260309";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_35/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_35/chart-versions.nix
@@ -1,10 +1,10 @@
 {
   traefik-crd = {
-    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-39.0.201+up39.0.2.tgz";
-    sha256 = "0r43kny2kkrlxjniivnivzbqqbiri08cg9qjrl6mx9rjzsxfxqwg";
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-39.0.501+up39.0.5.tgz";
+    sha256 = "0h260ldykvkj9rs81ps1wnys2gqs1l7cb43djpn10g8rzpf5n966";
   };
   traefik = {
-    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-39.0.201+up39.0.2.tgz";
-    sha256 = "1ci2wns11ibgwf7x4j90vcbrsf63rrz1slsm63iayvkdq3r3ri04";
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-39.0.501+up39.0.5.tgz";
+    sha256 = "0ns3vf6c7pby28l0x6w83sx0vcfi4pibwxl04fcr36vnk38fk3c8";
   };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_35/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_35/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.2%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "5714a481d7e197cc4e41070bfd8a310dc93103fc9f23bfc32fce61d24940d9a7"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.3%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "00c57623c1507d3688b17dcd61a9a4106e5c1b47d9f4e1db0de9d003a086ea73"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.2%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "a3caf6692c1495f58bbaa1411a0e2377e9f7ebd262bd33101c3cd1edade68360"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.3%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "1f929f52845623ba336de4af9b49285f6e5a4c7bbc20cab006d374fb9b75bf37"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.2%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "bd48d1aeee4e7643e796439ec95caef0e270e07744307a9b1d134e55837b868b"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.3%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "c4add6b7777d221867d826d994b4962a8a0878f2f73a1a43553ef4b8eddf293a"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.2%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "393d1de18e0ba363164d77b005d9cca045b9cd726645b9915550a429fc7920e8"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.3%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "1521713f0f0afb5ab804d5fbafb52f2ef7ad31730d70a83c5af8252f705d5b75"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.2%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "fe69ee52cf6a9b51667877e2eebda08a789b19d4fb0a0a38fde21aa5051eb24d"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.3%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "53b9881898f51aadd91b8637ee9062e2a4fe19219501bdf93cb28af7c88b9c9d"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.2%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "5ddc08b28514575c819638ee2a870b587ca4105a4465763cca276b663ce84298"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.3%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "2352fb30a98b95967ffe287018461a9a4dec4fb06862061385e4b64c40255d82"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_35/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_35/versions.nix
@@ -1,21 +1,21 @@
 {
-  k3sVersion = "1.35.2+k3s1";
-  k3sCommit = "13563febb4bd4aef9c7cda43a22c8155ac937dd4";
-  k3sRepoSha256 = "0kwk4c99bn0glhyf81cmx0ly0x97hlajhh2h658cpjr97hij2fpa";
-  k3sVendorHash = "sha256-iGtGGviYfLDmagFlWfMBZ1Gm57aNhusLFR2p70SpFMQ=";
+  k3sVersion = "1.35.3+k3s1";
+  k3sCommit = "be38e8843c3498607d41ce583bdbb0ef1e63bba6";
+  k3sRepoSha256 = "11q3nqbypiz10q07jcr7laff52rahnjsq7r91b9vf591m1m9qc6j";
+  k3sVendorHash = "sha256-X14CitVueEFdsOumIV9nL3uvuxgPUwnKW194UY6PLqg=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
   k3sRootSha256 = "008n8xx7x36y9y4r24hx39xagf1dxbp3pqq2j53s9zkaiqc62hd0";
-  k3sCNIVersion = "1.9.0-k3s1";
-  k3sCNISha256 = "0naqf3jkxz3rd9ljd40wbm8walgi2bx6d1l9wr6mcvrgj7d5g28c";
-  containerdVersion = "2.1.5-k3s1";
-  containerdSha256 = "0n0g58d352i8wz0bqn87vgrd7z54j268cbmbp19fz68wmifm7fl8";
+  k3sCNIVersion = "1.9.1-k3s1";
+  k3sCNISha256 = "1ggaz0p1c2k94car9d89a05smz3zx32sxn197b1l5kmjcnzdwadh";
+  containerdVersion = "2.2.2-k3s1";
+  containerdSha256 = "0lqyv4ps1nyjm8fi7znk3r2z3j4ida2h9x1nkzb7c72lz96q1jzs";
   containerdPackage = "github.com/k3s-io/containerd/v2";
   criCtlVersion = "1.35.0-k3s2";
-  flannelVersion = "v0.28.0";
+  flannelVersion = "v0.28.2";
   flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s3";
-  helmJobVersion = "v0.9.14-build20260210";
+  helmJobVersion = "v0.9.14-build20260309";
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- `k3s_1_33: 1.33.9+k3s1 -> 1.33.10+k3s1`
- `k3s_1_34: 1.34.5+k3s1 -> 1.34.6+k3s1`
- `k3s_1_35: 1.35.2+k3s1 -> 1.35.3+k3s1`

The containerd versions for `k3s_1_33` and `k3s_1_34` point to non-existent tags. The github release pages (https://github.com/k3s-io/k3s/releases/tag/v1.33.10%2Bk3s1 and https://github.com/k3s-io/k3s/releases/tag/v1.34.6%2Bk3s1) also list the wrong tags. I think this is a hickup in the k3s release flow, all versions should use [containerd-v2.2.2-k3s1](https://github.com/k3s-io/containerd/releases/tag/v2.2.2-k3s1). All tests pass.

`k3s_1_32` is EOL and dropped in https://github.com/NixOS/nixpkgs/pull/505211

@NixOS/k3s 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
