### PR TITLE
python3Packages.onnx-asr: 0.10.2 -> 0.11.0

### DIFF
--- a/pkgs/development/python-modules/onnx-asr/default.nix
+++ b/pkgs/development/python-modules/onnx-asr/default.nix
@@ -10,11 +10,9 @@
 
   # build-time deps for the custom hatch build hook that generates
   # ONNX preprocessor models (listed in pyproject.toml [dependency-groups] build)
+  ml-dtypes,
   numpy,
-  onnx,
   onnxscript,
-  torch,
-  torchaudio,
 
   # dependencies
   onnxruntime,
@@ -25,26 +23,22 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "onnx-asr";
-  version = "0.10.2";
+  version = "0.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "istupakov";
     repo = "onnx-asr";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KumdelY9oNMAEBSGVdvbBH6SYi93n2cA/eEqaE8MmIU=";
+    hash = "sha256-gi5U56ZPSo0bJ0Fmi8nebvIXENZWwX4lofk5vKV8gag=";
   };
 
   build-system = [
-    hatchling
     hatch-vcs
-    # The custom hatch build hook (hatch_build.py) generates ONNX preprocessor
-    # models at build time using these dependencies.
+    hatchling
+    ml-dtypes
     numpy
-    onnx
     onnxscript
-    torch
-    torchaudio
   ];
 
   dependencies = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Updated onnx-asr.
This PR supercedes #505194 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
