### PR TITLE
lib.options.renderOptionValue: show multi-line strings as plain code blocks

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -664,12 +664,23 @@ rec {
     if v ? _type && v ? text then
       v
     else
-      literalExpression (
-        lib.generators.toPretty {
-          multiline = true;
-          allowPrettyValues = true;
-        } v
-      );
+      let
+        lines = lib.splitString "\n" v;
+        displayLines = if isString v && last lines == "" then take (length lines - 1) lines else lines;
+        # Multi-line strings would be wrapped in `''...''` by `toPretty`,
+        # which adds escape sequences (`''` → `'''`, `${` → `''${`) we don't want in docs.
+        # Show all multi-line strings as plain Nix code blocks instead.
+        useRawBlock = isString v && length lines > 1;
+      in
+      if useRawBlock then
+        literalMD ("```nix\n" + concatStringsSep "\n" displayLines + "\n```")
+      else
+        literalExpression (
+          lib.generators.toPretty {
+            multiline = true;
+            allowPrettyValues = true;
+          } v
+        );
 
   /**
     For use in the `defaultText` and `example` option attributes. Causes the

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2949,7 +2949,7 @@ runTests {
 
   testRenderOptionValueMultilineStringWithQuotes = {
     # `''` would produce `'''` in `''...''` form
-    expr = lib.options.renderOptionValue ("line with '' quotes\nmore\n");
+    expr = lib.options.renderOptionValue "line with '' quotes\nmore\n";
     expected = {
       _type = "literalMD";
       text = "```nix\nline with '' quotes\nmore\n```";

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2936,6 +2936,53 @@ runTests {
     expected = "«foo»";
   };
 
+  # renderOptionValue shows all multi-line raw strings as plain Nix code blocks to avoid
+  # both the `''...''` wrapper noise and confusing escape sequences (`''` → `'''`,
+  # `${` → `''${`) that `toPretty` would produce.
+  testRenderOptionValueMultilineString = {
+    expr = lib.options.renderOptionValue "line one\nline two\n";
+    expected = {
+      _type = "literalMD";
+      text = "```nix\nline one\nline two\n```";
+    };
+  };
+
+  testRenderOptionValueMultilineStringWithQuotes = {
+    # `''` would produce `'''` in `''...''` form
+    expr = lib.options.renderOptionValue ("line with '' quotes\nmore\n");
+    expected = {
+      _type = "literalMD";
+      text = "```nix\nline with '' quotes\nmore\n```";
+    };
+  };
+
+  testRenderOptionValueMultilineStringWithInterpolation = {
+    # `${` would produce `''${` in `''...''` form
+    expr = lib.options.renderOptionValue ("has $" + "{interpolation}\nmore\n");
+    expected = {
+      _type = "literalMD";
+      text = "```nix\nhas $" + "{interpolation}\nmore\n```";
+    };
+  };
+
+  testRenderOptionValueSingleContentLineWithTrailingNewline = {
+    # A single content line with trailing newline (e.g. `programs.npm.npmrc`) is still
+    # multi-line per `lib.splitString "\n"` and must use the plain code block form.
+    expr = lib.options.renderOptionValue ("prefix = $" + "{HOME}/.npm\n");
+    expected = {
+      _type = "literalMD";
+      text = "```nix\nprefix = $" + "{HOME}/.npm\n```";
+    };
+  };
+
+  testRenderOptionValueSinglelineString = {
+    expr = lib.options.renderOptionValue "just a string";
+    expected = {
+      _type = "literalExpression";
+      text = "\"just a string\"";
+    };
+  };
+
   testToPlistUnescaped = {
     expr = mapAttrs (const (generators.toPlist { })) {
       value = {


### PR DESCRIPTION
Fixes a bug in option documentation rendering that showed escaping sequences in renderings of multi-line string definitions for `example` and `defaultText`.

These stemmed from rendering by Nix `''...''` syntax in `toPretty`, yielding escape sequences:

- `''` -> `'''`
- `${` -> `''${`

This changes fixes this by detecting multi-line strings in `renderOptionValue`, and using `literalMD` with a plain code block instead of `literalExpression` with `toPretty` output. This shows the string content directly without any Nix-specific escaping.

Single-line strings continue to use `literalExpression` (producing a double-quoted Nix string), which already handles `''` and `${` correctly without confusing escapes.

closes #503758.

disclaimer: this fix involved vibe-coding.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
