### PR TITLE
static-web-server: 2.39.0 -> 2.42.0 

### DIFF
--- a/pkgs/by-name/st/static-web-server/package.nix
+++ b/pkgs/by-name/st/static-web-server/package.nix
@@ -3,29 +3,31 @@
   rustPlatform,
   fetchFromGitHub,
   nixosTests,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "static-web-server";
-  version = "2.39.0";
+  version = "2.42.0";
 
   src = fetchFromGitHub {
     owner = "static-web-server";
     repo = "static-web-server";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-iprQlSHO+ac7v1odVoS/9IU+Zov8/xh1l9pm1PJE8fs=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EWCkad2v937GPL7qeHxPp24wf3EWk+M5iQkZBhErv/Y=";
   };
 
-  cargoHash = "sha256-rNrGlgUvPezX7RnKhprRjl9DiJ/Crt4phmxnfY9tNXA=";
+  cargoHash = "sha256-RYTG54c4Q4uP4lAZpjfulP/BV4jDp5xxsa6vtSn+vOs=";
 
   # static-web-server already has special handling for files with modification
-  # time = unix epoch, but the nix store is unix epoch + 1 second.
+  # time = Unix epoch, but the nix store is Unix epoch + 1 second.
   patches = [ ./include-unix-time-plus-one.diff ];
 
-  # Some tests which implicitly relied on the above behavior now break.  Force
-  # an mtime update to fix.
+  # Some tests which implicitly relied on the above behavior now break.
+  # Force an mtime update to everything except symbolic inks to fix.
   postUnpack = ''
-    find . -exec touch -m {} +
+    find . -not -type l -exec touch -m {} +
   '';
 
   # Need to copy in the systemd units for systemd.packages to discover them
@@ -33,12 +35,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
     install -Dm444 -t $out/lib/systemd/system/ systemd/static-web-server.{service,socket}
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) static-web-server;
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      inherit (nixosTests) static-web-server;
+    };
   };
 
   meta = {
-    description = "Asynchronous web server for static files-serving";
+    description = "A cross-platform, high-performance and asynchronous web server for static files-serving";
     homepage = "https://static-web-server.net/";
     changelog = "https://github.com/static-web-server/static-web-server/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [

--- a/pkgs/by-name/st/static-web-server/package.nix
+++ b/pkgs/by-name/st/static-web-server/package.nix
@@ -47,6 +47,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ];
     maintainers = with lib.maintainers; [
       misilelab
+      progrm_jarvis
     ];
     mainProgram = "static-web-server";
   };


### PR DESCRIPTION
For `static-web-server`:
* add myself as maintainer (part of #458096);
* upgrade from `2.39.0` to `2.42.0` (resolves #493299, [CVE-2026-27480](https://nvd.nist.gov/vuln/detail/CVE-2026-27480)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
