### PR TITLE
exegol-mcp: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ex/exegol-mcp/package.nix
+++ b/pkgs/by-name/ex/exegol-mcp/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  exegol,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "exegol-mcp";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ThePorgs";
+    repo = "Exegol-MCP";
+    tag = version;
+    hash = "sha256-A8mF6EJps7IUhgrk1Y6vic6JlS0bpxTq7CL1NEuC4qk=";
+  };
+
+  build-system = with python3Packages; [ pdm-backend ];
+
+  dependencies =
+    with python3Packages;
+    [
+      mcp
+    ]
+    ++ [ exegol ];
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "exegol_mcp" ];
+
+  meta = {
+    description = "MCP server for Exegol";
+    homepage = "https://github.com/ThePorgs/Exegol-MCP";
+    changelog = "https://github.com/ThePorgs/Exegol-MCP/releases/tag/${src.tag}";
+    license = with lib.licenses; [
+      gpl3Only
+      {
+        fullName = "Exegol Software License (ESL) - Version 1.0";
+        url = "https://docs.exegol.com/legal/software-license";
+        free = false;
+        redistributable = false;
+      }
+    ];
+    mainProgram = "exegol-mcp";
+    maintainers = with lib.maintainers; [
+      macbucheron
+    ];
+  };
+}


### PR DESCRIPTION
Adds `exegol-mcp` at 1.0.0

Exegol is a cybersecurity toolkit in the form of a docker container.
This package is the mcp server for the (already packaged) package exegol. 
For cybersecurity professional & enthusiast, this package help to leverage the use of IA inside of exegol.

Homepage: https://github.com/ThePorgs/Exegol-MCP/tree/1.0.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

  Commands run:
  - `nix build -L .#exegol-mcp`
  - `export NIXPKGS_ALLOW_UNFREE=1; nix run .#exegol-mcp --impure -- --help`
  
<img width="1293" height="378" alt="image" src="https://github.com/user-attachments/assets/f8bb4132-8f02-47d7-823d-5e9010d9484f" />


- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
