### PR TITLE
pi-coding-agent: switch to npx tsgo to avoid version mismatch

### DIFF
--- a/pkgs/by-name/pi/pi-coding-agent/package.nix
+++ b/pkgs/by-name/pi/pi-coding-agent/package.nix
@@ -2,7 +2,6 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  typescript-go,
   nix-update-script,
   versionCheckHook,
   writableTmpDirAsHomeHook,
@@ -28,7 +27,6 @@ buildNpmPackage (finalAttrs: {
   npmRebuildFlags = [ "--ignore-scripts" ];
 
   nativeBuildInputs = [
-    typescript-go
     makeBinaryWrapper
   ];
 
@@ -39,9 +37,9 @@ buildNpmPackage (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    tsgo -p packages/ai/tsconfig.build.json
-    tsgo -p packages/tui/tsconfig.build.json
-    tsgo -p packages/agent/tsconfig.build.json
+    npx tsgo -p packages/ai/tsconfig.build.json
+    npx tsgo -p packages/tui/tsconfig.build.json
+    npx tsgo -p packages/agent/tsconfig.build.json
     npm run build --workspace=packages/coding-agent
 
     runHook postBuild


### PR DESCRIPTION
This PR prevents build errors when updating the typescript-go package.
It addresses the issue reported in https://github.com/NixOS/nixpkgs/pull/501241#issuecomment-4088333401.

Recent typescript-go updates introduce stricter regex validation that triggers TS1501 on older ES targets.
This change switches to `npx tsgo` to maintain compatibility with the package's existing tsconfig.

Refs:
- https://github.com/badlogic/pi-mono/blob/v0.62.0/package.json#L38
- https://github.com/badlogic/pi-mono/blob/v0.62.0/packages/tui/src/utils.ts#L32-L34
- https://github.com/microsoft/typescript-go/commit/880a9e9cb99d60f689a860af36f4274b78ac535e


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

cc: @Munksgaard @mbwilding