### PR TITLE
treewide: fix mentions for nodejs.python

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-vscode.js-debug/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vscode.js-debug/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchNpmDeps,
   nodejs,
+  nodejs-slim,
   npmHooks,
   pkg-config,
   libsecret,
@@ -38,7 +39,7 @@ let
     ];
     nativeBuildInputs = [
       nodejs
-      nodejs.python
+      nodejs-slim.python
       npmHooks.npmConfigHook
     ]
     ++ lib.optionals stdenv.isLinux [

--- a/pkgs/applications/editors/vscode/extensions/prettier.prettier-vscode/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/prettier.prettier-vscode/default.nix
@@ -5,6 +5,7 @@
   fetchNpmDeps,
   libsecret,
   nodejs,
+  nodejs-slim,
   npmHooks,
   pkg-config,
   clang_20,
@@ -37,7 +38,7 @@ let
 
     nativeBuildInputs = [
       nodejs
-      nodejs.python
+      nodejs-slim.python
       npmHooks.npmConfigHook
     ]
     ++ lib.optionals stdenv.isLinux [

--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -4,6 +4,7 @@
   fetchNpmDeps,
   buildPackages,
   nodejs,
+  nodejs-slim,
   cctools,
 }@topLevelArgs:
 
@@ -101,7 +102,7 @@ lib.extendMkDerivation {
           (if npmConfigHook != null then npmConfigHook else npmHooks.npmConfigHook)
           (if npmBuildHook != null then npmBuildHook else npmHooks.npmBuildHook)
           (if npmInstallHook != null then npmInstallHook else npmHooks.npmInstallHook)
-          nodejs.python
+          nodejs-slim.python
         ]
         ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools ];
       buildInputs = buildInputs ++ [ nodejs ];

--- a/pkgs/by-name/az/azurite/package.nix
+++ b/pkgs/by-name/az/azurite/package.nix
@@ -5,7 +5,7 @@
   clang_20,
   fetchFromGitHub,
   libsecret,
-  nodejs,
+  nodejs-slim,
   pkg-config,
 }:
 
@@ -24,7 +24,7 @@ buildNpmPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
-    nodejs.python
+    nodejs-slim.python
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ clang_20 ]; # clang_21 breaks @vscode/vsce's optional dependency keytar
 

--- a/pkgs/by-name/ch/cherry-studio/package.nix
+++ b/pkgs/by-name/ch/cherry-studio/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   electron_40,
-  nodejs,
+  nodejs-slim,
   pnpm_10_29_2,
   pnpmConfigHook,
   makeWrapper,
@@ -58,8 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    nodejs
-    (nodejs.python.withPackages (ps: with ps; [ setuptools ]))
+    nodejs-slim
+    (nodejs-slim.python.withPackages (ps: with ps; [ setuptools ]))
     pnpm
     pnpmConfigHook
     makeWrapper

--- a/pkgs/by-name/fi/firefly-iii-data-importer/package.nix
+++ b/pkgs/by-name/fi/firefly-iii-data-importer/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   stdenvNoCC,
-  nodejs,
+  nodejs-slim,
   fetchNpmDeps,
   buildPackages,
   php84,
@@ -25,8 +25,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   buildInputs = [ php84 ];
 
   nativeBuildInputs = [
-    nodejs
-    nodejs.python
+    nodejs-slim
+    nodejs-slim.npm
+    nodejs-slim.python
     buildPackages.npmHooks.npmConfigHook
     php84.composerHooks.composerInstallHook
     php84.packages.composer-local-repo-plugin

--- a/pkgs/by-name/fi/firefly-iii/package.nix
+++ b/pkgs/by-name/fi/firefly-iii/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   stdenvNoCC,
-  nodejs,
+  nodejs-slim,
   fetchNpmDeps,
   buildPackages,
   php84,
@@ -25,8 +25,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   buildInputs = [ php84 ];
 
   nativeBuildInputs = [
-    nodejs
-    nodejs.python
+    nodejs-slim
+    nodejs-slim.python
     buildPackages.npmHooks.npmConfigHook
     php84.packages.composer
     php84.composerHooks2.composerInstallHook

--- a/pkgs/by-name/ga/gancio/package.nix
+++ b/pkgs/by-name/ga/gancio/package.nix
@@ -8,7 +8,7 @@
   yarnConfigHook,
   yarnBuildHook,
   yarnInstallHook,
-  nodejs_22,
+  nodejs-slim_22,
   pkg-config,
 
   vips,
@@ -21,7 +21,7 @@
 let
   # The latest nodejs is always used in yarn, leading to build issues when it's
   # different from the pinned one.
-  nodejs = nodejs_22;
+  nodejs = nodejs-slim_22;
   yarnConfigHook' = yarnConfigHook.override {
     yarn = yarn.override { inherit nodejs; };
   };

--- a/pkgs/by-name/ko/koodo-reader/package.nix
+++ b/pkgs/by-name/ko/koodo-reader/package.nix
@@ -8,7 +8,7 @@
   copyDesktopItems,
   cctools,
   makeWrapper,
-  nodejs,
+  nodejs-slim,
   yarnConfigHook,
   yarnBuildHook,
   wrapGAppsHook3,
@@ -44,8 +44,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     makeWrapper
-    nodejs
-    (nodejs.python.withPackages (ps: [ ps.setuptools ]))
+    nodejs-slim
+    nodejs-slim.npm
+    (nodejs-slim.python.withPackages (ps: [ ps.setuptools ]))
     yarnConfigHook
     yarnBuildHook
   ]
@@ -65,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     chmod -R u+w electron-dist
 
     # we need to build cpu-features with the non-electron headers first
-    export npm_config_nodedir=${nodejs}
+    export npm_config_nodedir=${nodejs-slim}
     npm rebuild --verbose cpu-features
 
     export npm_config_nodedir=${electron.headers}

--- a/pkgs/by-name/lo/logseq/package.nix
+++ b/pkgs/by-name/lo/logseq/package.nix
@@ -15,6 +15,7 @@
   makeDesktopItem,
   makeWrapper,
   nodejs,
+  nodejs-slim,
   removeReferencesTo,
   yarnBuildHook,
   yarnConfigHook,
@@ -148,7 +149,7 @@ stdenv.mkDerivation (finalAttrs: {
       fakeGit
       makeWrapper
       nodejs
-      (nodejs.python.withPackages (ps: [ ps.setuptools ]))
+      (nodejs-slim.python.withPackages (ps: [ ps.setuptools ]))
       removeReferencesTo
       yarnBuildHook
       yarnConfigHook

--- a/pkgs/by-name/op/openvscode-server/package.nix
+++ b/pkgs/by-name/op/openvscode-server/package.nix
@@ -11,6 +11,7 @@
   pkg-config,
   runCommand,
   nodejs_22,
+  nodejs-slim_22,
   node-gyp,
   libsecret,
   libkrb5,
@@ -100,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
   nativeBuildInputs = [
     nodejs
-    nodejs.python
+    nodejs-slim_22.python
     pkg-config
     makeWrapper
     git

--- a/pkgs/by-name/re/redisinsight/package.nix
+++ b/pkgs/by-name/re/redisinsight/package.nix
@@ -9,7 +9,7 @@
   copyDesktopItems,
   dart-sass,
   makeWrapper,
-  nodejs_20,
+  nodejs-slim_20,
   pkg-config,
   yarnConfigHook,
 
@@ -19,7 +19,7 @@
 }:
 
 let
-  nodejs = nodejs_20;
+  nodejs = nodejs-slim_20;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "redisinsight";

--- a/pkgs/by-name/rs/rstudio/package.nix
+++ b/pkgs/by-name/rs/rstudio/package.nix
@@ -17,7 +17,7 @@
   git,
   jdk,
   makeWrapper,
-  nodejs,
+  nodejs-slim,
   npmHooks,
   xcbuild,
   yarn,
@@ -135,7 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
     ant
     jdk
 
-    nodejs
+    nodejs-slim
     yarn
     yarnConfigHook
     zip
@@ -145,7 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals (!server) [
     makeWrapper
-    (nodejs.python.withPackages (ps: [ ps.setuptools ]))
+    (nodejs-slim.python.withPackages (ps: [ ps.setuptools ]))
     npmHooks.npmConfigHook
   ];
 
@@ -289,8 +289,8 @@ stdenv.mkDerivation (finalAttrs: {
     RSTUDIO_INSTALLED_NODE_VERSION="22.21.1"
 
     mkdir -p dependencies/common/node
-    ln -s ${nodejs} dependencies/common/node/$RSTUDIO_NODE_VERSION
-    ln -s ${nodejs} dependencies/common/node/$RSTUDIO_INSTALLED_NODE_VERSION-installed
+    ln -s ${nodejs-slim} dependencies/common/node/$RSTUDIO_NODE_VERSION
+    ln -s ${nodejs-slim} dependencies/common/node/$RSTUDIO_INSTALLED_NODE_VERSION-installed
 
   ''
   + lib.optionalString (!server) ''

--- a/pkgs/by-name/sm/smtp4dev/package.nix
+++ b/pkgs/by-name/sm/smtp4dev/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   buildDotnetModule,
   fetchFromGitHub,
-  nodejs,
+  nodejs-slim,
   npmHooks,
   fetchNpmDeps,
   dotnetCorePackages,
@@ -23,8 +23,9 @@ buildDotnetModule (finalAttrs: {
   patches = [ ./smtp4dev-npm-packages.patch ];
 
   nativeBuildInputs = [
-    nodejs
-    nodejs.python
+    nodejs-slim
+    nodejs-slim.npm
+    nodejs-slim.python
     npmHooks.npmConfigHook
     stdenv.cc # c compiler is needed for compiling npm-deps
   ];

--- a/pkgs/by-name/vs/vsce/package.nix
+++ b/pkgs/by-name/vs/vsce/package.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   pkg-config,
   libsecret,
-  nodejs,
+  nodejs-slim,
   clang_20,
   versionCheckHook,
   nix-update-script,
@@ -30,7 +30,7 @@ buildNpmPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
-    nodejs.python
+    nodejs-slim.python
   ]
   ++ lib.optionals stdenv.isDarwin [ clang_20 ]; # clang_21 breaks @vscode/vsce's optional dependency keytar
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Follow-up to https://github.com/NixOS/nixpkgs/pull/481461, nodejs is now a simple symlink package and nodejs.python does not necessarily reflect the correct derivation

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
