### PR TITLE
[release-25.11] keycloak-config-cli: init at 6.4.0

### DIFF
--- a/pkgs/by-name/ke/keycloak-config-cli/package.nix
+++ b/pkgs/by-name/ke/keycloak-config-cli/package.nix
@@ -1,0 +1,47 @@
+{
+  maven,
+  lib,
+  fetchFromGitHub,
+  jre_headless,
+  makeWrapper,
+  nix-update-script,
+}:
+maven.buildMavenPackage rec {
+  pname = "keycloak-config-cli";
+  version = "6.4.0";
+
+  src = fetchFromGitHub {
+    owner = "adorsys";
+    repo = "keycloak-config-cli";
+    tag = "v${version}";
+    hash = "sha256-Vg56Dz9U0eAJw+7u90MSZWmMIZttWYGXAwsXZsEfTj8=";
+  };
+
+  mvnHash = "sha256-tdh8hRqGXI3zuwy55dC3La9dm2naqeCEZT4qcw37iDI=";
+
+  # Tests use MockServer which needs to bind to a local port
+  __darwinAllowLocalNetworking = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 target/keycloak-config-cli.jar $out/share/keycloak-config-cli/keycloak-config-cli.jar
+    makeWrapper ${jre_headless}/bin/java $out/bin/keycloak-config-cli \
+      --add-flags "-jar $out/share/keycloak-config-cli/keycloak-config-cli.jar"
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/adorsys/keycloak-config-cli";
+    description = "Import YAML/JSON-formatted configuration files into Keycloak";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      anish
+    ];
+    mainProgram = "keycloak-config-cli";
+    platforms = jre_headless.meta.platforms;
+  };
+}


### PR DESCRIPTION
Backport of #504480 to `release-25.11`.

**Conflict resolution**: `all-plugins.nix` had a conflict because `release-25.11` never included `keycloak-config-cli` in the plugins list (unlike master). The resolution keeps HEAD's version of `all-plugins.nix` untouched — the only meaningful change is adding `pkgs/by-name/ke/keycloak-config-cli/package.nix` as a top-level package.

<!--
Labels: backport release-25.11
-->