### PR TITLE
spotifyd: Use stdenvNoCC instead of stdenv

### DIFF
--- a/pkgs/by-name/sp/spotifyd/package.nix
+++ b/pkgs/by-name/sp/spotifyd/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   config,
   alsa-lib,
   cmake,
@@ -14,11 +14,11 @@
   portaudio,
   rustPlatform,
   testers,
-  withALSA ? stdenv.hostPlatform.isLinux,
-  withJack ? stdenv.hostPlatform.isLinux,
-  withMpris ? stdenv.hostPlatform.isLinux,
-  withPortAudio ? stdenv.hostPlatform.isDarwin,
-  withPulseAudio ? config.pulseaudio or stdenv.hostPlatform.isLinux,
+  withALSA ? stdenvNoCC.hostPlatform.isLinux,
+  withJack ? stdenvNoCC.hostPlatform.isLinux,
+  withMpris ? stdenvNoCC.hostPlatform.isLinux,
+  withPortAudio ? stdenvNoCC.hostPlatform.isDarwin,
+  withPulseAudio ? config.pulseaudio or stdenvNoCC.hostPlatform.isLinux,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -41,9 +41,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   buildInputs =
-    lib.optionals stdenv.hostPlatform.isLinux [ openssl ]
+    lib.optionals stdenvNoCC.hostPlatform.isLinux [ openssl ]
     # The `dbus_mpris` feature works on other platforms, but only requires `dbus` on Linux
-    ++ lib.optional (withMpris && stdenv.hostPlatform.isLinux) dbus
+    ++ lib.optional (withMpris && stdenvNoCC.hostPlatform.isLinux) dbus
     ++ lib.optional (withALSA || withJack) alsa-lib
     ++ lib.optional withJack libjack2
     ++ lib.optional withPulseAudio libpulseaudio
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ++ lib.optional withPortAudio "portaudio_backend"
     ++ lib.optional withPulseAudio "pulseaudio_backend";
 
-  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+  checkFlags = lib.optionals stdenvNoCC.hostPlatform.isDarwin [
     # `assertion failed: shell.is_some()`
     # Internally it's trying to query the user's shell through `dscl`. This is bad
     # https://github.com/Spotifyd/spotifyd/blob/8777c67988508d3623d3f6b81c9379fb071ac7dd/src/utils.rs#L45-L47


### PR DESCRIPTION
C compiler and linker are not required to build, so use stdenvNoCC.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
