### PR TITLE
smux: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -876,6 +876,12 @@
     matrix = "aiya:catgirl.cloud";
     name = "aiya";
   };
+  aietes = {
+    email = "stefan@standa.de";
+    github = "Aietes";
+    githubId = 5823770;
+    name = "Stefan Krüger";
+  };
   aij = {
     email = "aij+git@mrph.org";
     github = "aij";

--- a/pkgs/by-name/sm/smux/package.nix
+++ b/pkgs/by-name/sm/smux/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  makeWrapper,
+  tmux,
+  fzf,
+  zoxide,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "smux";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "Aietes";
+    repo = "smux";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mc7sspGN4Wf8Jn995S/jsZ0v1s5kgJ0ASn9iGbzH13U=";
+  };
+
+  cargoHash = "sha256-nUJwIOdVmZR+inDz4kYpPTFXREyZyf891ATed6UFIJo=";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    $out/bin/smux completions zsh --dir completions
+    installShellCompletion --zsh completions/_smux
+
+    $out/bin/smux man --dir man
+    installManPage man/*.1
+    installManPage man/*.5
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/smux \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          tmux
+          fzf
+          zoxide
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Tmux session manager with fzf-powered project and template selection";
+    homepage = "https://github.com/Aietes/smux";
+    license = lib.licenses.mit;
+    mainProgram = "smux";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ aietes ];
+  };
+})


### PR DESCRIPTION
Adds `smux`, a tmux session manager with fzf-powered session, project, folder, and template selection.

- Homepage: https://github.com/Aietes/smux
- Upstream release: https://github.com/Aietes/smux/releases/tag/v0.3.1

The package:
- builds from the tagged GitHub source with `rustPlatform.buildRustPackage`
- installs the `smux` binary
- installs zsh completions and man pages (generated at build time, guarded behind `stdenv.buildPlatform.canExecute stdenv.hostPlatform` so cross-compilation does not break)
- wraps the runtime PATH for `tmux`, `fzf`, and `zoxide` via `postFixup`

## Things done

- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` / `nix-build` on this PR locally (binary runs, completions, man pages, and PATH wrapper all verified).
- [x] Tested basic functionality of the binary in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
