### PR TITLE
bcon: init at 1.3.0

### DIFF
--- a/pkgs/by-name/bc/bcon/package.nix
+++ b/pkgs/by-name/bc/bcon/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  makeWrapper,
+  versionCheckHook,
+
+  pkg-config,
+  fontconfig,
+  systemd,
+  seatd,
+  libxkbcommon,
+  libgbm,
+  libinput,
+  libGL,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bcon";
+  version = "1.3.0";
+  src = fetchFromGitHub {
+    owner = "sanohiro";
+    repo = "bcon";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-R5eoqlrIAnZiixvBVJYF2Hg/LcNr/KSlFOqD9BDngh8=";
+  };
+
+  cargoHash = "sha256-4dADjDaGAfnBSdz9RtHHSrBlRR2qmA993OYpvYfpCI0=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+    versionCheckHook
+  ];
+
+  buildInputs = [
+    fontconfig
+    systemd
+    seatd
+    libxkbcommon
+    libgbm
+    libinput
+    libGL
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/bcon \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs}
+  '';
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "GPU-accelerated terminal emulator for Linux console (TTY)";
+    homepage = "https://github.com/sanohiro/bcon";
+    license = [ lib.licenses.mit ];
+    maintainers = with lib.maintainers; [ haruki7049 ];
+    mainProgram = "bcon";
+    changelog = "https://github.com/sanohiro/bcon/blob/v${finalAttrs.version}/CHANGELOG.md";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/sanohiro/bcon

bcon: GPU-accelerated terminal emulator for Linux console (TTY)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
