### PR TITLE
{forgejo,forgejo-lts,forgejo-runner}: Use stdenvNoCC instead of stdenv

### DIFF
--- a/pkgs/by-name/fo/forgejo-runner/package.nix
+++ b/pkgs/by-name/fo/forgejo-runner/package.nix
@@ -1,5 +1,5 @@
 {
-  stdenv,
+  stdenvNoCC,
   lib,
   buildGoModule,
   fetchFromGitea,
@@ -42,7 +42,7 @@ let
     "TestHandler"
     "TestHandler_gcCache"
   ]
-  ++ lib.optionals stdenv.isDarwin [
+  ++ lib.optionals stdenvNoCC.isDarwin [
     # Uses docker-specific options, unsupported on Darwin
     "TestMergeJobOptions"
   ];
@@ -100,7 +100,7 @@ buildGoModule (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
-    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    tests = lib.optionalAttrs stdenvNoCC.hostPlatform.isLinux {
       latest = nixosTests.forgejo.sqlite3;
       lts = nixosTests.forgejo-lts.sqlite3;
     };

--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -23,7 +23,7 @@
   sqliteSupport ? true,
   lndir,
   runCommand,
-  stdenv,
+  stdenvNoCC,
   fetchFromCodeberg,
   buildNpmPackage,
   writableTmpDirAsHomeHook,
@@ -195,7 +195,7 @@ buildGoModule rec {
     changelog = "https://codeberg.org/forgejo/forgejo/releases/tag/v${version}";
     license = lib.licenses.gpl3Plus;
     teams = [ lib.teams.forgejo ];
-    broken = stdenv.hostPlatform.isDarwin;
+    broken = stdenvNoCC.hostPlatform.isDarwin;
     mainProgram = "forgejo";
   };
 }


### PR DESCRIPTION
C compiler and linker are not required to build, so use stdenvNoCC.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
