### PR TITLE
kdotool: 0.2.2-pre -> 0.2.2

### DIFF
--- a/pkgs/by-name/kd/kdotool/package.nix
+++ b/pkgs/by-name/kd/kdotool/package.nix
@@ -8,29 +8,17 @@
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
-  version = "0.2.2-pre";
+  version = "0.2.2";
   pname = "kdotool";
 
   src = fetchFromGitHub {
     owner = "jinliu";
     repo = "kdotool";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-qx4bWAFQcoLM/r4aNzmoZdjclw8ccAW8lKLda6ON1aQ=";
+    hash = "sha256-aJRqFcKyu4/aqI3WtH9NjzjNgiI6lq0VgCXNGaNdyvE=";
   };
 
-  patches = [
-    # Remove these two on next release.
-    (fetchpatch {
-      url = "https://github.com/jinliu/kdotool/commit/049e3f5620ad8c5484241d7d06d742bc17d423ed.patch";
-      hash = "sha256-VTpHlT6XMVRgJIeLjxZPHkzaYFZCYtS8IAD0mKZ8rzs=";
-    })
-    (fetchpatch {
-      url = "https://github.com/jinliu/kdotool/commit/e0a3bff3b5d9882033dd72836e5fcff572b64135.patch";
-      hash = "sha256-6IsV9O2h9N/FxGQRHS8qAbEqdr7282ziGza5K52vpPk=";
-    })
-  ];
-
-  cargoHash = "sha256-ASR2zMwVCKeEZPYQNoO54J00eZyTn1i6FE0NBCJWSCs=";
+  cargoHash = "sha256-QrJVN2O/pDCIpD1ioFPZyj7au3DQtU3l/I440WsyYWo=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dbus ];


### PR DESCRIPTION
Closes: #484350 (technically already fixed in #485686)
Closes: #505360
Diff: https://github.com/jinliu/kdotool/compare/v0.2.2-pre...v0.2.2
Changelog: https://github.com/jinliu/kdotool/releases/tag/v0.2.2

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
