### PR TITLE
nixos/sway: Added xdg package to sway module

### DIFF
--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -96,6 +96,9 @@ in
       '';
     };
 
+    enablePortals = lib.mkEnableOption "Enabled GTK and WLR xdg portals";
+
+
     xwayland.enable = lib.mkEnableOption "XWayland" // {
       default = true;
     };
@@ -185,10 +188,6 @@ in
         # https://github.com/emersion/xdg-desktop-portal-wlr/blob/master/contrib/wlroots-portals.conf
         # https://github.com/emersion/xdg-desktop-portal-wlr/pull/315
         xdg.portal = {
-          # Include the portal as a actuall package if its not already installed
-          extraPortals = [
-            pkgs.xdg-desktop-portal-gtk
-          ];
           config.sway = {
             # Use xdg-desktop-portal-gtk for every portal interface...
             default = [ "gtk" ];
@@ -206,6 +205,8 @@ in
       (import ./wayland-session.nix {
         inherit lib pkgs;
         enableXWayland = cfg.xwayland.enable;
+        enableWlrPortal = cfg.enablePortals;
+        enableGtkPortal = cfg.enablePortals;
       })
     ]
   );

--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -98,7 +98,6 @@ in
 
     enablePortals = lib.mkEnableOption "Enabled GTK and WLR xdg portals";
 
-
     xwayland.enable = lib.mkEnableOption "XWayland" // {
       default = true;
     };

--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -184,16 +184,22 @@ in
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050913
         # https://github.com/emersion/xdg-desktop-portal-wlr/blob/master/contrib/wlroots-portals.conf
         # https://github.com/emersion/xdg-desktop-portal-wlr/pull/315
-        xdg.portal.config.sway = {
-          # Use xdg-desktop-portal-gtk for every portal interface...
-          default = [ "gtk" ];
-          # ... except for the ScreenCast, Screenshot and Secret
-          "org.freedesktop.impl.portal.ScreenCast" = "wlr";
-          "org.freedesktop.impl.portal.Screenshot" = "wlr";
-          # ignore inhibit bc gtk portal always returns as success,
-          # despite sway/the wlr portal not having an implementation,
-          # stopping firefox from using wayland idle-inhibit
-          "org.freedesktop.impl.portal.Inhibit" = "none";
+        xdg.portal = {
+          # Include the portal as a actuall package if its not already installed
+          extraPortals = [
+            pkgs.xdg-desktop-portal-gtk
+          ];
+          config.sway = {
+            # Use xdg-desktop-portal-gtk for every portal interface...
+            default = [ "gtk" ];
+            # ... except for the ScreenCast, Screenshot and Secret
+            "org.freedesktop.impl.portal.ScreenCast" = "wlr";
+            "org.freedesktop.impl.portal.Screenshot" = "wlr";
+            # ignore inhibit bc gtk portal always returns as success,
+            # despite sway/the wlr portal not having an implementation,
+            # stopping firefox from using wayland idle-inhibit
+            "org.freedesktop.impl.portal.Inhibit" = "none";
+          };
         };
       }
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [] aarch64-linux
  - [] x86_64-darwin
  - [] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


Just added the extraPortal for sway's xdg gtk config to include the gtk portal package.

This is done both by niri and hyprland modules, so best add it here for consistency.