### PR TITLE
tests.makeBinaryWrapper: fix broken tests

### DIFF
--- a/pkgs/test/make-binary-wrapper/combination/combination.c
+++ b/pkgs/test/make-binary-wrapper/combination/combination.c
@@ -3,31 +3,86 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 
 #define assert_success(e) do { if ((e) < 0) { perror(#e); abort(); } } while (0)
 
-void set_env_prefix(char *env, char *sep, char *prefix) {
-    char *existing = getenv(env);
-    if (existing) {
-        char *val;
-        assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing));
-        assert_success(setenv(env, val, 1));
-        free(val);
-    } else {
-        assert_success(setenv(env, prefix, 1));
+int is_surrounded_by_sep(char *env, char *ptr, unsigned long len, char *sep) {
+  unsigned long sep_len = strlen(sep);
+
+  // Check left side (if not at start)
+  if (env != ptr) {
+    if (ptr - env < sep_len)
+      return 0;
+    if (strncmp(sep, ptr - sep_len, sep_len) != 0) {
+      return 0;
     }
+  }
+  // Check right side (if not at end)
+  char *end_ptr = ptr + len;
+  if (*end_ptr != '\0') {
+    if (strncmp(sep, ptr + len, sep_len) != 0) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+void set_env_prefix(char *env, char *sep, char *prefix) {
+  char *existing_env = getenv(env);
+  if (existing_env) {
+    char *val;
+
+    char *existing_prefix = strstr(existing_env, prefix);
+    unsigned long prefix_len = strlen(prefix);
+    // If the prefix already exists, remove the original
+    if (existing_prefix && is_surrounded_by_sep(existing_env, existing_prefix, prefix_len, sep)) {
+      if (existing_env == existing_prefix) {
+        return;
+      }
+      unsigned long sep_len = strlen(sep);
+      int n_before = existing_prefix - existing_env;
+      assert_success(asprintf(&val, "%s%s%.*s%s", prefix, sep,
+                              n_before, existing_env,
+                              existing_prefix + prefix_len + sep_len));
+    } else {
+      assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing_env));
+    }
+    assert_success(setenv(env, val, 1));
+    free(val);
+  } else {
+    assert_success(setenv(env, prefix, 1));
+  }
 }
 
 void set_env_suffix(char *env, char *sep, char *suffix) {
-    char *existing = getenv(env);
-    if (existing) {
-        char *val;
-        assert_success(asprintf(&val, "%s%s%s", existing, sep, suffix));
-        assert_success(setenv(env, val, 1));
-        free(val);
+  char *existing_env = getenv(env);
+  if (existing_env) {
+    char *val;
+
+    char *existing_suffix = strstr(existing_env, suffix);
+    unsigned long suffix_len = strlen(suffix);
+    // If the suffix already exists, remove the original
+    if (existing_suffix && is_surrounded_by_sep(existing_env, existing_suffix, suffix_len, sep)) {
+      char *end_ptr = existing_suffix + suffix_len;
+      if (*end_ptr == '\0') {
+        return;
+      }
+      unsigned long sep_len = strlen(sep);
+      int n_before = existing_suffix - existing_env;
+      assert_success(asprintf(&val, "%.*s%s%s%s",
+                              n_before, existing_env,
+                              existing_suffix + suffix_len + sep_len,
+                              sep, suffix));
     } else {
-        assert_success(setenv(env, suffix, 1));
+      assert_success(asprintf(&val, "%s%s%s", existing_env, sep, suffix));
     }
+    assert_success(setenv(env, val, 1));
+    free(val);
+  } else {
+    assert_success(setenv(env, suffix, 1));
+  }
 }
 
 int main(int argc, char **argv) {

--- a/pkgs/test/make-binary-wrapper/overlength-strings/overlength-strings.c
+++ b/pkgs/test/make-binary-wrapper/overlength-strings/overlength-strings.c
@@ -3,19 +3,57 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 
 #define assert_success(e) do { if ((e) < 0) { perror(#e); abort(); } } while (0)
 
-void set_env_prefix(char *env, char *sep, char *prefix) {
-    char *existing = getenv(env);
-    if (existing) {
-        char *val;
-        assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing));
-        assert_success(setenv(env, val, 1));
-        free(val);
-    } else {
-        assert_success(setenv(env, prefix, 1));
+int is_surrounded_by_sep(char *env, char *ptr, unsigned long len, char *sep) {
+  unsigned long sep_len = strlen(sep);
+
+  // Check left side (if not at start)
+  if (env != ptr) {
+    if (ptr - env < sep_len)
+      return 0;
+    if (strncmp(sep, ptr - sep_len, sep_len) != 0) {
+      return 0;
     }
+  }
+  // Check right side (if not at end)
+  char *end_ptr = ptr + len;
+  if (*end_ptr != '\0') {
+    if (strncmp(sep, ptr + len, sep_len) != 0) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+void set_env_prefix(char *env, char *sep, char *prefix) {
+  char *existing_env = getenv(env);
+  if (existing_env) {
+    char *val;
+
+    char *existing_prefix = strstr(existing_env, prefix);
+    unsigned long prefix_len = strlen(prefix);
+    // If the prefix already exists, remove the original
+    if (existing_prefix && is_surrounded_by_sep(existing_env, existing_prefix, prefix_len, sep)) {
+      if (existing_env == existing_prefix) {
+        return;
+      }
+      unsigned long sep_len = strlen(sep);
+      int n_before = existing_prefix - existing_env;
+      assert_success(asprintf(&val, "%s%s%.*s%s", prefix, sep,
+                              n_before, existing_env,
+                              existing_prefix + prefix_len + sep_len));
+    } else {
+      assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing_env));
+    }
+    assert_success(setenv(env, val, 1));
+    free(val);
+  } else {
+    assert_success(setenv(env, prefix, 1));
+  }
 }
 
 int main(int argc, char **argv) {

--- a/pkgs/test/make-binary-wrapper/prefix/prefix.c
+++ b/pkgs/test/make-binary-wrapper/prefix/prefix.c
@@ -3,19 +3,57 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 
 #define assert_success(e) do { if ((e) < 0) { perror(#e); abort(); } } while (0)
 
-void set_env_prefix(char *env, char *sep, char *prefix) {
-    char *existing = getenv(env);
-    if (existing) {
-        char *val;
-        assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing));
-        assert_success(setenv(env, val, 1));
-        free(val);
-    } else {
-        assert_success(setenv(env, prefix, 1));
+int is_surrounded_by_sep(char *env, char *ptr, unsigned long len, char *sep) {
+  unsigned long sep_len = strlen(sep);
+
+  // Check left side (if not at start)
+  if (env != ptr) {
+    if (ptr - env < sep_len)
+      return 0;
+    if (strncmp(sep, ptr - sep_len, sep_len) != 0) {
+      return 0;
     }
+  }
+  // Check right side (if not at end)
+  char *end_ptr = ptr + len;
+  if (*end_ptr != '\0') {
+    if (strncmp(sep, ptr + len, sep_len) != 0) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+void set_env_prefix(char *env, char *sep, char *prefix) {
+  char *existing_env = getenv(env);
+  if (existing_env) {
+    char *val;
+
+    char *existing_prefix = strstr(existing_env, prefix);
+    unsigned long prefix_len = strlen(prefix);
+    // If the prefix already exists, remove the original
+    if (existing_prefix && is_surrounded_by_sep(existing_env, existing_prefix, prefix_len, sep)) {
+      if (existing_env == existing_prefix) {
+        return;
+      }
+      unsigned long sep_len = strlen(sep);
+      int n_before = existing_prefix - existing_env;
+      assert_success(asprintf(&val, "%s%s%.*s%s", prefix, sep,
+                              n_before, existing_env,
+                              existing_prefix + prefix_len + sep_len));
+    } else {
+      assert_success(asprintf(&val, "%s%s%s", prefix, sep, existing_env));
+    }
+    assert_success(setenv(env, val, 1));
+    free(val);
+  } else {
+    assert_success(setenv(env, prefix, 1));
+  }
 }
 
 int main(int argc, char **argv) {

--- a/pkgs/test/make-binary-wrapper/suffix/suffix.c
+++ b/pkgs/test/make-binary-wrapper/suffix/suffix.c
@@ -3,19 +3,59 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 
 #define assert_success(e) do { if ((e) < 0) { perror(#e); abort(); } } while (0)
 
-void set_env_suffix(char *env, char *sep, char *suffix) {
-    char *existing = getenv(env);
-    if (existing) {
-        char *val;
-        assert_success(asprintf(&val, "%s%s%s", existing, sep, suffix));
-        assert_success(setenv(env, val, 1));
-        free(val);
-    } else {
-        assert_success(setenv(env, suffix, 1));
+int is_surrounded_by_sep(char *env, char *ptr, unsigned long len, char *sep) {
+  unsigned long sep_len = strlen(sep);
+
+  // Check left side (if not at start)
+  if (env != ptr) {
+    if (ptr - env < sep_len)
+      return 0;
+    if (strncmp(sep, ptr - sep_len, sep_len) != 0) {
+      return 0;
     }
+  }
+  // Check right side (if not at end)
+  char *end_ptr = ptr + len;
+  if (*end_ptr != '\0') {
+    if (strncmp(sep, ptr + len, sep_len) != 0) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+void set_env_suffix(char *env, char *sep, char *suffix) {
+  char *existing_env = getenv(env);
+  if (existing_env) {
+    char *val;
+
+    char *existing_suffix = strstr(existing_env, suffix);
+    unsigned long suffix_len = strlen(suffix);
+    // If the suffix already exists, remove the original
+    if (existing_suffix && is_surrounded_by_sep(existing_env, existing_suffix, suffix_len, sep)) {
+      char *end_ptr = existing_suffix + suffix_len;
+      if (*end_ptr == '\0') {
+        return;
+      }
+      unsigned long sep_len = strlen(sep);
+      int n_before = existing_suffix - existing_env;
+      assert_success(asprintf(&val, "%.*s%s%s%s",
+                              n_before, existing_env,
+                              existing_suffix + suffix_len + sep_len,
+                              sep, suffix));
+    } else {
+      assert_success(asprintf(&val, "%s%s%s", existing_env, sep, suffix));
+    }
+    assert_success(setenv(env, val, 1));
+    free(val);
+  } else {
+    assert_success(setenv(env, suffix, 1));
+  }
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
0fdcb958d3e9 (makeBinaryWrapper: If prefix/suffix already exists, remove the original (#451031), 2025-12-11) changed the C code generated by makeBinaryWrapper.  The tests for makeBinaryWrapper check the exact code that's generated, so they need updating.

Fixes #505339.

This is a naïve application of the changes made in #451031 to the test code. I haven't attempted to verify that the behaviour changes are desirable.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
