### PR TITLE
lomiri.morph-browser: Drop

### DIFF
--- a/nixos/tests/morph-browser.nix
+++ b/nixos/tests/morph-browser.nix
@@ -6,8 +6,9 @@ let
     }:
     makeTest (
       { pkgs, lib, ... }:
+      assert lib.assertMsg withQt6 "`lomiri.morph-browser` has been dropped, cannot test it.";
       {
-        name = "morph-browser-${if withQt6 then "qt6" else "qt5"}-standalone";
+        name = "morph-browser-qt6-standalone";
         meta.maintainers = lib.teams.lomiri.members;
 
         nodes.machine =
@@ -24,7 +25,7 @@ let
             services.xserver.enable = true;
 
             environment = {
-              systemPackages = with (if withQt6 then pkgs.lomiri-qt6 else pkgs.lomiri); [
+              systemPackages = with pkgs.lomiri-qt6; [
                 suru-icon-theme
                 morph-browser
               ];
@@ -76,6 +77,6 @@ let
     );
 in
 {
-  qt5 = generic { withQt6 = false; };
+  qt5 = throw "`lomiri.morph-browser` has been removed because it relied on the known-vulnerable `libsForQt5.qtwebengine`. For testing the Qt6 version of Morph, please use `nixosTests.morph-browser.qt6` instead."; # Added on 2026-03-31
   qt6 = generic { withQt6 = true; };
 }

--- a/pkgs/desktops/lomiri/applications/morph-browser/default.nix
+++ b/pkgs/desktops/lomiri/applications/morph-browser/default.nix
@@ -159,11 +159,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = gitUpdater { };
+  }
+  // lib.optionalAttrs withQt6 {
     tests = {
       # Test of morph-browser itself
       standalone = if withQt6 then nixosTests.morph-browser.qt6 else nixosTests.morph-browser.qt5;
-    }
-    // lib.optionalAttrs withQt6 {
+
       # Interactions between the Lomiri ecosystem and this browser
       inherit (nixosTests.lomiri) desktop-basics desktop-appinteractions;
     };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -16,12 +16,6 @@ let
       inherit (self) callPackage;
     in
     {
-      #### Core Apps
-      morph-browser = callPackage ./applications/morph-browser {
-        # get_target_property() called with non-existent target "Qt6::qdoc".
-        withDocumentation = !useQt6;
-      };
-
       #### Data
       lomiri-schemas = callPackage ./data/lomiri-schemas { };
       lomiri-sounds = callPackage ./data/lomiri-sounds { };
@@ -55,6 +49,13 @@ let
       };
       lomiri-indicator-network = callPackage ./services/lomiri-indicator-network { };
       lomiri-url-dispatcher = callPackage ./services/lomiri-url-dispatcher { };
+    }
+    // lib.optionalAttrs useQt6 {
+      #### Core Apps
+      morph-browser = callPackage ./applications/morph-browser {
+        # get_target_property() called with non-existent target "Qt6::qdoc".
+        withDocumentation = !useQt6;
+      };
     }
     // lib.optionalAttrs (!useQt6) {
       #### Core Apps
@@ -105,5 +106,6 @@ lib.makeScope qtPackages.newScope packages
   content-hub = lib.warnOnInstantiate "`content-hub` was renamed to `lomiri-content-hub`." pkgs.lomiri.lomiri-content-hub; # Added on 2024-09-11
   history-service = lib.warnOnInstantiate "`history-service` was renamed to `lomiri-history-service`." pkgs.lomiri.lomiri-history-service; # Added on 2024-11-11
   lomiri-system-settings-security-privacy = lib.warnOnInstantiate "`lomiri-system-settings-security-privacy` upstream was merged into `lomiri-system-settings`. Please use `pkgs.lomiri.lomiri-system-settings-unwrapped` if you need to directly access the plugins that belonged to this project." pkgs.lomiri.lomiri-system-settings-unwrapped; # Added on 2024-08-08
+  morph-browser = throw "`lomiri.morph-browser` has been removed because it relied on the known-vulnerable `libsForQt5.qtwebengine`. Please use `lomiri-qt6.morph-browser` instead."; # Added on 2026-03-31
   telephony-service = lib.warnOnInstantiate "`telephony-service` was renamed to `lomiri-telephony-service`." pkgs.lomiri.lomiri-telephony-service; # Adder on 2025-01-15
 }


### PR DESCRIPTION
Relies on known-insecure `libsForQt5.qtwebengine`. `lomiri-qt6.morph-browser` can be used instead.

Will help with dropping `libsForQt5.qtwebengine`: #480196 (CC @LordGrimmauld)

(I'm keeping the qt5/qt6 structure in the VM test file as a blueprint for further test porting)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
