### PR TITLE
python3Packages: add spectral-derivatives, derivative, pysindy

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5393,6 +5393,11 @@
     githubId = 5953003;
     name = "Connor Nelson";
   };
+  conny = {
+    github = "ConstantConstantin";
+    githubId = 162139822;
+    name = "Constantin-Paul Hertel";
+  };
   conradmearns = {
     email = "conradmearns+github@pm.me";
     github = "ConradMearns";

--- a/pkgs/development/python-modules/derivative/default.nix
+++ b/pkgs/development/python-modules/derivative/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  numpy,
+  scipy,
+  scikit-learn,
+  spectral-derivatives,
+  importlib-metadata,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "derivative";
+  version = "0.6.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "andgoldschmidt";
+    repo = "derivative";
+    tag = "v${version}";
+    hash = "sha256-vsN1zlD9x0CEOtRIwr/DrtkV+OjiyrI8QL9Z8pB3wrY=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    numpy
+    scipy
+    scikit-learn
+    spectral-derivatives
+    importlib-metadata
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Numerical differentiation of noisy time series data";
+    license = lib.licenses.mit;
+    homepage = "https://derivative.readthedocs.io/en/latest/";
+    maintainers = with lib.maintainers; [ conny ];
+  };
+}

--- a/pkgs/development/python-modules/pysindy/default.nix
+++ b/pkgs/development/python-modules/pysindy/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  scikit-learn,
+  numpy,
+  derivative,
+  scipy,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "pysindy";
+  version = "2.1.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-NpZZ22MucuZwtkz9ef08C578jjo28MNfTxG4ROhjuwg=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    scikit-learn
+    numpy
+    derivative
+    scipy
+    typing-extensions
+  ];
+
+  # Tests require optional dependencies like jax
+  doCheck = false;
+
+  pythonImportsCheck = [ "pysindy" ];
+
+  meta = {
+    description = "Sparse identification of nonlinear dynamical systems";
+    license = lib.licenses.mit;
+    homepage = "https://pysindy.readthedocs.io/en/latest/";
+    maintainers = with lib.maintainers; [ conny ];
+  };
+}

--- a/pkgs/development/python-modules/spectral-derivatives/default.nix
+++ b/pkgs/development/python-modules/spectral-derivatives/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  numpy,
+  scipy,
+  matplotlib,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "spectral_derivatives";
+  version = "0.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pavelkomarov";
+    repo = "spectral-derivatives";
+    tag = "v${version}";
+    hash = "sha256-KSx3aW2DgVr1nhtGqIO85s6c5p+1rjnrpMY4e63LLiE=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+    scipy
+    matplotlib
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "specderiv" ];
+
+  meta = {
+    description = "Derivatives by spectral methods";
+    license = lib.licenses.bsd3;
+    homepage = "https://pavelkomarov.com/spectral-derivatives/specderiv.html";
+    maintainers = with lib.maintainers; [ conny ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14997,6 +14997,8 @@ self: super: with self; {
 
   pysimplesoap = callPackage ../development/python-modules/pysimplesoap { };
 
+  pysindy = callPackage ../development/python-modules/pysindy { };
+
   pysingleton = callPackage ../development/python-modules/pysingleton { };
 
   pyskyqhub = callPackage ../development/python-modules/pyskyqhub { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18090,6 +18090,8 @@ self: super: with self; {
 
   spectral-cube = callPackage ../development/python-modules/spectral-cube { };
 
+  spectral-derivatives = callPackage ../development/python-modules/spectral-derivatives { };
+
   speechbrain = callPackage ../development/python-modules/speechbrain { };
 
   speechrecognition = callPackage ../development/python-modules/speechrecognition { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3840,6 +3840,8 @@ self: super: with self; {
 
   depyf = callPackage ../development/python-modules/depyf { };
 
+  derivative = callPackage ../development/python-modules/derivative { };
+
   derpconf = callPackage ../development/python-modules/derpconf { };
 
   desktop-entry-lib = callPackage ../development/python-modules/desktop-entry-lib { };


### PR DESCRIPTION
## Description of changes

Add the following Python packages:

- spectral-derivatives: Python library for computing spectral derivatives using various bases.
- derivative: Library for numerical differentiation of noisy time series data.
- pysindy: Sparse identification of nonlinear dynamical systems.

For spectral-derivatives and derivative, the source is fetched from GitHub since the PyPI tarball does not include tests.

For pysindy, tests are disabled because the upstream test suites require optional dependencies (e.g. jax) during import, which are not part of the default dependency set.

All packages pass pythonImportsCheck.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
