### PR TITLE
hyprmod: init at 0.4.0

### DIFF
--- a/pkgs/by-name/hy/hyprmod/package.nix
+++ b/pkgs/by-name/hy/hyprmod/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  fetchFromGitHub,
+  glib,
+  gnome-desktop,
+  gobject-introspection,
+  gtk4,
+  libadwaita,
+  python3Packages,
+  wrapGAppsHook4,
+  xvfb-run,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "hyprmod";
+  version = "0.4.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "BlueManCZ";
+    repo = "hyprmod";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MYxYraLMc9QecjKsoVxYO3wkeXDTgLJnBH131VVs0hI=";
+  };
+
+  build-system = with python3Packages; [ hatchling ];
+
+  nativeBuildInputs = [
+    glib # glib-compile-schemas for hatch build hook
+    gobject-introspection
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gnome-desktop
+    gtk4
+    libadwaita
+  ];
+
+  dependencies = with python3Packages; [
+    hyprland-config
+    hyprland-monitors
+    hyprland-schema
+    hyprland-socket
+    hyprland-state
+    pygobject3
+  ];
+
+  pythonRelaxDeps = [ "pygobject" ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  postInstall = ''
+    install -Dm0644 data/applications/io.github.bluemancz.hyprmod.desktop \
+      -t $out/share/applications
+    install -Dm0644 data/icons/hicolor/scalable/apps/io.github.bluemancz.hyprmod.svg \
+      -t $out/share/icons/hicolor/scalable/apps
+    install -Dm0644 data/metainfo/io.github.bluemancz.hyprmod.metainfo.xml \
+      -t $out/share/metainfo
+  '';
+
+  pythonImportsCheck = [ "hyprmod" ];
+
+  nativeCheckInputs = [
+    python3Packages.pytest
+    xvfb-run
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+    # GnomeDesktop.XkbInfo aborts without the org.gnome.desktop.* schemas, which
+    # are otherwise only wired up by the wrapper this phase runs before
+    export XDG_DATA_DIRS="$GSETTINGS_SCHEMAS_PATH''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    xvfb-run -s '-screen 0 1024x768x24' pytest
+    runHook postCheck
+  '';
+
+  meta = {
+    description = "Native GTK4/libadwaita settings application for Hyprland";
+    homepage = "https://github.com/BlueManCZ/hyprmod";
+    changelog = "https://github.com/BlueManCZ/hyprmod/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ sophronesis ];
+    platforms = lib.platforms.linux;
+    mainProgram = "hyprmod";
+  };
+})

--- a/pkgs/development/python-modules/hyprland-config/default.nix
+++ b/pkgs/development/python-modules/hyprland-config/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hypothesis,
+  lua5_4,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "hyprland-config";
+  version = "0.9.14";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "BlueManCZ";
+    repo = "hyprland-config";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Jgh/X7M+hdp0NPuA0YnfdYU/sxY9hfl/OCihnzobvm8=";
+  };
+
+  # The Lua reader shells out to an interpreter it looks up on PATH at runtime.
+  # Hyprland links Lua internally and never installs a `lua` binary, so without
+  # this every read of a Lua-mode config raises LuaReaderError.
+  postPatch = ''
+    substituteInPlace src/hyprland_config/_lua/_read/_runner.py \
+      --replace-fail '_LUA_BINARY_CANDIDATES = ("lua", "lua5.5", "lua5.4", "lua5.3", "lua5.2")' \
+                     '_LUA_BINARY_CANDIDATES = ("${lib.getExe lua5_4}",)'
+  '';
+
+  build-system = [ hatchling ];
+
+  nativeCheckInputs = [
+    hypothesis
+    lua5_4 # the test helpers probe PATH for lua/luac themselves
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "hyprland_config" ];
+
+  meta = {
+    description = "Round-trip parser and editor for Hyprland configuration files";
+    homepage = "https://github.com/BlueManCZ/hyprland-config";
+    changelog = "https://github.com/BlueManCZ/hyprland-config/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ sophronesis ];
+  };
+})

--- a/pkgs/development/python-modules/hyprland-monitors/default.nix
+++ b/pkgs/development/python-modules/hyprland-monitors/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hyprland-socket,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "hyprland-monitors";
+  version = "0.8.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "BlueManCZ";
+    repo = "hyprland-monitors";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-a7fEDPPN9XYsrpE99C9c9MZGpqg24ZlY6vvHzgvNtzc=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [ hyprland-socket ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "hyprland_monitors" ];
+
+  meta = {
+    description = "Monitor management utilities for Hyprland";
+    homepage = "https://github.com/BlueManCZ/hyprland-monitors";
+    changelog = "https://github.com/BlueManCZ/hyprland-monitors/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ sophronesis ];
+  };
+})

--- a/pkgs/development/python-modules/hyprland-schema/default.nix
+++ b/pkgs/development/python-modules/hyprland-schema/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pytestCheckHook,
+  ruff,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "hyprland-schema";
+  version = "0.7.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "BlueManCZ";
+    repo = "hyprland-schema";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5wm21kpn7Car4hntm+ZYG0xdRBpfbwI57yCBmoHmooQ=";
+  };
+
+  build-system = [ hatchling ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    # load-bearing: generate_schema.py formats the module it emits with ruff, and
+    # test_generate.py asserts on the resulting double-quote style. Without ruff on
+    # PATH that formatting is silently skipped and the test fails.
+    ruff
+  ];
+
+  pythonImportsCheck = [ "hyprland_schema" ];
+
+  meta = {
+    description = "Typed Python schema for every Hyprland configuration option";
+    homepage = "https://github.com/BlueManCZ/hyprland-schema";
+    changelog = "https://github.com/BlueManCZ/hyprland-schema/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ sophronesis ];
+  };
+})

--- a/pkgs/development/python-modules/hyprland-socket/default.nix
+++ b/pkgs/development/python-modules/hyprland-socket/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "hyprland-socket";
+  version = "0.12.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "BlueManCZ";
+    repo = "hyprland-socket";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XPVhHnIwq4Plkuk3uf/IUcg9L0OsZT76cr60x7EG1lc=";
+  };
+
+  build-system = [ hatchling ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "hyprland_socket" ];
+
+  meta = {
+    description = "Typed Python library for Hyprland IPC via Unix sockets";
+    homepage = "https://github.com/BlueManCZ/hyprland-socket";
+    changelog = "https://github.com/BlueManCZ/hyprland-socket/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ sophronesis ];
+  };
+})

--- a/pkgs/development/python-modules/hyprland-state/default.nix
+++ b/pkgs/development/python-modules/hyprland-state/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hyprland-config,
+  hyprland-monitors,
+  hyprland-schema,
+  hyprland-socket,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "hyprland-state";
+  version = "0.4.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "BlueManCZ";
+    repo = "hyprland-state";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Vb6LIH3DC/6/mbh3Bji/qpil5r0Xp+WiELQ+rL+S6UU=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    hyprland-config
+    hyprland-monitors
+    hyprland-schema
+    hyprland-socket
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "hyprland_state" ];
+
+  meta = {
+    description = "Live state interface for Hyprland - options, animations, monitors, binds, and devices";
+    homepage = "https://github.com/BlueManCZ/hyprland-state";
+    changelog = "https://github.com/BlueManCZ/hyprland-state/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ sophronesis ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7314,6 +7314,8 @@ self: super: with self; {
 
   hyprland-schema = callPackage ../development/python-modules/hyprland-schema { };
 
+  hyprland-socket = callPackage ../development/python-modules/hyprland-socket { };
+
   hyrule = callPackage ../development/python-modules/hyrule { };
 
   i-pi = callPackage ../development/python-modules/i-pi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7312,6 +7312,8 @@ self: super: with self; {
 
   hyppo = callPackage ../development/python-modules/hyppo { };
 
+  hyprland-config = callPackage ../development/python-modules/hyprland-config { };
+
   hyprland-schema = callPackage ../development/python-modules/hyprland-schema { };
 
   hyprland-socket = callPackage ../development/python-modules/hyprland-socket { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7314,6 +7314,8 @@ self: super: with self; {
 
   hyprland-config = callPackage ../development/python-modules/hyprland-config { };
 
+  hyprland-monitors = callPackage ../development/python-modules/hyprland-monitors { };
+
   hyprland-schema = callPackage ../development/python-modules/hyprland-schema { };
 
   hyprland-socket = callPackage ../development/python-modules/hyprland-socket { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7320,6 +7320,8 @@ self: super: with self; {
 
   hyprland-socket = callPackage ../development/python-modules/hyprland-socket { };
 
+  hyprland-state = callPackage ../development/python-modules/hyprland-state { };
+
   hyrule = callPackage ../development/python-modules/hyrule { };
 
   i-pi = callPackage ../development/python-modules/i-pi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7312,6 +7312,8 @@ self: super: with self; {
 
   hyppo = callPackage ../development/python-modules/hyppo { };
 
+  hyprland-schema = callPackage ../development/python-modules/hyprland-schema { };
+
   hyrule = callPackage ../development/python-modules/hyrule { };
 
   i-pi = callPackage ../development/python-modules/i-pi { };


### PR DESCRIPTION
Native GTK4/libadwaita settings application for Hyprland. Provides live configuration editing, profile management, bezier curve editor, monitor configuration, keybind editor with interactive key capture, and global search.

Homepage: https://github.com/BlueManCZ/hyprmod

Also adds five new Python library dependencies from the same author:
- `hyprland-socket` 0.12.2 - Typed Python library for Hyprland IPC via Unix sockets
- `hyprland-config` 0.9.14 - Round-trip parser and editor for Hyprland configuration files
- `hyprland-schema` 0.7.0 - Typed Python schema for every Hyprland configuration option
- `hyprland-monitors` 0.8.0 - Monitor management utilities for Hyprland
- `hyprland-state` 0.4.4 - Live state interface for Hyprland

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
