### PR TITLE
nix-scheduler-hook: 0.7.2 -> 0.7.3, use nix 2.34

### DIFF
--- a/pkgs/by-name/ni/nix-scheduler-hook/package.nix
+++ b/pkgs/by-name/ni/nix-scheduler-hook/package.nix
@@ -1,8 +1,9 @@
 {
   fetchFromGitHub,
+  fetchFromCodeberg,
   stdenv,
   lib,
-  nix,
+  nixVersions,
   meson,
   cmake,
   ninja,
@@ -29,16 +30,17 @@ let
       slurm.dev
     ];
   };
+  nix = nixVersions.nix_2_34;
 in
 stdenv.mkDerivation rec {
   pname = "nix-scheduler-hook";
-  version = "0.7.2";
+  version = "0.7.3";
 
-  src = fetchFromGitHub {
-    owner = "lisanna-dettwyler";
+  src = fetchFromCodeberg {
+    owner = "lisanna";
     repo = "nix-scheduler-hook";
     tag = "v${version}";
-    hash = "sha256-tgZ2BZuKmaoPh4h4r/nej98tvl4PvwZfA6xbTLgNZMA=";
+    hash = "sha256-r8ybbPxQK+ohsaz4+brrsivj77fCqrrHPskfyrp6R2A=";
   };
 
   sourceRoot = "source/src";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
