### PR TITLE
[25.11] {openexr_2,ilmbase}: Replace meta.insecure with meta.knownVulnerabilities

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -19,7 +19,6 @@
   gmp,
   gtk3,
   hicolor-icon-theme,
-  ilmbase,
   libpng,
   mpfr,
   nanosvg,
@@ -76,6 +75,8 @@ stdenv.mkDerivation (finalAttrs: {
     # https://github.com/NixOS/nixpkgs/issues/415703
     # https://gitlab.archlinux.org/archlinux/packaging/packages/prusa-slicer/-/merge_requests/5
     ./allow_wayland.patch
+    # Pick https://github.com/prusa3d/PrusaSlicer/pull/14207 to remove unused and insecure ilmbase dependency
+    ./no-ilmbase.patch
   ];
 
   # (not applicable to super-slicer fork)
@@ -117,7 +118,6 @@ stdenv.mkDerivation (finalAttrs: {
     gmp
     gtk3
     hicolor-icon-theme
-    ilmbase
     libpng
     mpfr
     nanosvg-fltk

--- a/pkgs/applications/misc/prusa-slicer/no-ilmbase.patch
+++ b/pkgs/applications/misc/prusa-slicer/no-ilmbase.patch
@@ -1,0 +1,38 @@
+diff --git a/cmake/modules/FindOpenVDB.cmake b/cmake/modules/FindOpenVDB.cmake
+index 4fde5fa4a75..b62813fa663 100644
+--- a/cmake/modules/FindOpenVDB.cmake
++++ b/cmake/modules/FindOpenVDB.cmake
+@@ -347,25 +347,6 @@ macro(just_fail msg)
+   return()
+ endmacro()
+ 
+-find_package(IlmBase QUIET)
+-if(NOT IlmBase_FOUND)
+-  pkg_check_modules(IlmBase QUIET IlmBase)
+-endif()
+-if (IlmBase_FOUND AND NOT TARGET IlmBase::Half)
+-  message(STATUS "Falling back to IlmBase found by pkg-config...")
+-
+-  find_library(IlmHalf_LIBRARY NAMES Half)
+-  if(IlmHalf_LIBRARY-NOTFOUND OR NOT IlmBase_INCLUDE_DIRS)
+-    just_fail("IlmBase::Half can not be found!")
+-  endif()
+-  
+-  add_library(IlmBase::Half UNKNOWN IMPORTED)
+-  set_target_properties(IlmBase::Half PROPERTIES
+-    IMPORTED_LOCATION "${IlmHalf_LIBRARY}"
+-    INTERFACE_INCLUDE_DIRECTORIES "${IlmBase_INCLUDE_DIRS}")
+-elseif(NOT IlmBase_FOUND)
+-  just_fail("IlmBase::Half can not be found!")
+-endif()
+ find_package(TBB ${_quiet} ${_required} COMPONENTS tbb)
+ find_package(ZLIB ${_quiet} ${_required})
+ find_package(Boost ${_quiet} ${_required} COMPONENTS iostreams system )
+@@ -471,7 +452,6 @@ endif()
+ set(_OPENVDB_VISIBLE_DEPENDENCIES
+   Boost::iostreams
+   Boost::system
+-  IlmBase::Half
+ )
+ 
+ set(_OPENVDB_DEFINITIONS)

--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -21,6 +21,8 @@ let
     })
     ./super-slicer-use-boost186.patch
     ./super-slicer-fix-cereal-1.3.1.patch
+    # Pick https://github.com/prusa3d/PrusaSlicer/pull/14207 to remove unused and insecure ilmbase dependency
+    ./no-ilmbase.patch
   ];
 
   wxGTK31-prusa = wxGTK31.overrideAttrs (old: {

--- a/pkgs/by-name/ar/art/package.nix
+++ b/pkgs/by-name/ar/art/package.nix
@@ -33,7 +33,6 @@
   exiftool,
   mimalloc,
   openexr,
-  ilmbase,
   opencolorio,
   color-transformation-language,
 }:
@@ -92,7 +91,6 @@ stdenv.mkDerivation rec {
     libcanberra-gtk3
     mimalloc
     openexr
-    ilmbase
     opencolorio
     color-transformation-language
   ];

--- a/pkgs/by-name/ba/bambu-studio/package.nix
+++ b/pkgs/by-name/ba/bambu-studio/package.nix
@@ -25,12 +25,12 @@
   gtest,
   gtk3,
   hicolor-icon-theme,
-  ilmbase,
   libpng,
   mpfr,
   nlopt,
   opencascade-occt_7_6,
   openvdb,
+  openexr,
   opencv,
   pcre,
   systemd,
@@ -94,11 +94,11 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-good
     gtk3
     hicolor-icon-theme
-    ilmbase
     libpng
     mpfr
     nlopt
     opencascade-occt_7_6
+    openexr
     openvdb
     pcre
     onetbb

--- a/pkgs/by-name/co/color-transformation-language/package.nix
+++ b/pkgs/by-name/co/color-transformation-language/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  ilmbase,
   openexr,
   libtiff,
   aces-container,
@@ -22,7 +21,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    ilmbase
     openexr
     libtiff
     aces-container

--- a/pkgs/by-name/da/darktable/package.nix
+++ b/pkgs/by-name/da/darktable/package.nix
@@ -27,7 +27,6 @@
   graphicsmagick,
   gtk3,
   icu,
-  ilmbase,
   isocodes,
   jasper,
   json-glib,
@@ -112,7 +111,6 @@ stdenv.mkDerivation rec {
     graphicsmagick
     gtk3
     icu
-    ilmbase
     isocodes
     jasper
     json-glib
@@ -120,7 +118,7 @@ stdenv.mkDerivation rec {
     lensfun
     lerc
     libaom
-    #libavif # TODO re-enable once cmake files are fixed (#425306)
+    libavif
     libdatrie
     libepoxy
     libexif

--- a/pkgs/by-name/il/ilmbase/package.nix
+++ b/pkgs/by-name/il/ilmbase/package.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation {
     homepage = "https://www.openexr.com/";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
-    insecure = true;
+    inherit (openexr_2.meta) knownVulnerabilities;
   };
 }

--- a/pkgs/by-name/kr/krita/generic.nix
+++ b/pkgs/by-name/kr/krita/generic.nix
@@ -39,7 +39,6 @@
   xsimd,
   poppler,
   curl,
-  ilmbase,
   immer,
   kseexpr,
   lager,
@@ -118,7 +117,6 @@ mkDerivation rec {
     xsimd
     poppler
     curl
-    ilmbase
     immer
     kseexpr
     libmypaint

--- a/pkgs/by-name/or/orca-slicer/package.nix
+++ b/pkgs/by-name/or/orca-slicer/package.nix
@@ -26,7 +26,6 @@
   gtest,
   gtk3,
   hicolor-icon-theme,
-  ilmbase,
   libsecret,
   libpng,
   mpfr,
@@ -111,7 +110,6 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-good
     gtk3
     hicolor-icon-theme
-    ilmbase
     libsecret
     libpng
     mpfr
@@ -141,6 +139,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/SoftFever/OrcaSlicer/commit/d10a06ae11089cd1f63705e87f558e9392f7a167.patch";
       hash = "sha256-t4own5AwPsLYBsGA15id5IH1ngM0NSuWdFsrxMRXmTk=";
     })
+
+    # Pick https://github.com/prusa3d/PrusaSlicer/pull/14207 to remove unused and insecure ilmbase dependency
+    ./patches/no-ilmbase.patch
   ];
 
   doCheck = true;

--- a/pkgs/by-name/or/orca-slicer/patches/no-ilmbase.patch
+++ b/pkgs/by-name/or/orca-slicer/patches/no-ilmbase.patch
@@ -1,0 +1,38 @@
+diff --git a/cmake/modules/FindOpenVDB.cmake b/cmake/modules/FindOpenVDB.cmake
+index 4fde5fa4a75..b62813fa663 100644
+--- a/cmake/modules/FindOpenVDB.cmake
++++ b/cmake/modules/FindOpenVDB.cmake
+@@ -347,25 +347,6 @@ macro(just_fail msg)
+   return()
+ endmacro()
+ 
+-find_package(IlmBase QUIET)
+-if(NOT IlmBase_FOUND)
+-  pkg_check_modules(IlmBase QUIET IlmBase)
+-endif()
+-if (IlmBase_FOUND AND NOT TARGET IlmBase::Half)
+-  message(STATUS "Falling back to IlmBase found by pkg-config...")
+-
+-  find_library(IlmHalf_LIBRARY NAMES Half)
+-  if(IlmHalf_LIBRARY-NOTFOUND OR NOT IlmBase_INCLUDE_DIRS)
+-    just_fail("IlmBase::Half can not be found!")
+-  endif()
+-  
+-  add_library(IlmBase::Half UNKNOWN IMPORTED)
+-  set_target_properties(IlmBase::Half PROPERTIES
+-    IMPORTED_LOCATION "${IlmHalf_LIBRARY}"
+-    INTERFACE_INCLUDE_DIRECTORIES "${IlmBase_INCLUDE_DIRS}")
+-elseif(NOT IlmBase_FOUND)
+-  just_fail("IlmBase::Half can not be found!")
+-endif()
+ find_package(TBB ${_quiet} ${_required} COMPONENTS tbb)
+ find_package(ZLIB ${_quiet} ${_required})
+ find_package(Boost ${_quiet} ${_required} COMPONENTS iostreams system )
+@@ -471,7 +452,6 @@ endif()
+ set(_OPENVDB_VISIBLE_DEPENDENCIES
+   Boost::iostreams
+   Boost::system
+-  IlmBase::Half
+ )
+ 
+ set(_OPENVDB_DEFINITIONS)

--- a/pkgs/development/libraries/openexr/2.nix
+++ b/pkgs/development/libraries/openexr/2.nix
@@ -75,6 +75,20 @@ stdenv.mkDerivation rec {
     homepage = "https://www.openexr.com/";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
-    insecure = true;
+    knownVulnerabilities = [
+      "CVE-2021-3598: ImfDeepScanLineInputFile Out-of-Bounds Read"
+      "CVE-2021-3605: rleUncompress Out-of-Bounds Read"
+      "CVE-2021-3933: Integer Overflow Vulnerability in File Processing on 32-bit Systems"
+      "CVE-2021-23169: copyIntoFrameBuffer Heap Buffer Overflow Leading to Arbitrary Code Execution"
+      "CVE-2021-23215: DwaCompressor Integer Overflow Leads to Heap Buffer Overflow"
+      "CVE-2021-26260: DwaCompressor Integer Overflow Leading to Heap Buffer Overflow"
+      "CVE-2021-26945: Integer Overflow Leading to Heap Buffer Overflow"
+      "CVE-2023-5841: Heap Overflow in Scanline Deep Data Parsing"
+      "CVE-2024-31047: convert Function Denial of Service"
+      "CVE-2025-12495: EXR File Parsing Heap-based Buffer Overflow Remote Code Execution"
+      "CVE-2025-12839: EXR File Parsing Heap-based Buffer Overflow Remote Code Execution"
+      "CVE-2025-12840: EXR File Parsing Heap-based Buffer Overflow Remote Code Execution"
+      "CVE-2026-27622: CompositeDeepScanLine integer-overflow leads to heap OOB write"
+    ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7167,9 +7167,7 @@ with pkgs;
   gecode_6 = qt5.callPackage ../development/libraries/gecode { };
   gecode = gecode_6;
 
-  gegl = callPackage ../development/libraries/gegl {
-    openexr = openexr_2;
-  };
+  gegl = callPackage ../development/libraries/gegl { };
 
   geoclue2-with-demo-agent = geoclue2.override { withDemoAgent = true; };
 


### PR DESCRIPTION
Backport of #501924, #505464 and #505471. `gegl` commit was done manually, as it's still handled via `all-packages.nix` on stable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
