### PR TITLE
flaca: 3.5.3 -> 3.6.1

### DIFF
--- a/pkgs/by-name/fl/flaca/package.nix
+++ b/pkgs/by-name/fl/flaca/package.nix
@@ -7,18 +7,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "flaca";
-  version = "3.5.3";
+  version = "3.6.1";
 
   lockFile = fetchurl {
     url = "https://github.com/Blobfolio/flaca/releases/download/v${finalAttrs.version}/Cargo.lock";
-    hash = "sha256-NNeq8qr+z0s98mgFYyUu9aNRqaAi2CZfQx0vQzSzOc8=";
+    hash = "sha256-GNpL51rx3na+ECHUl0JAUQJBRQQ12Ubg4RIhNfXxMRQ=";
   };
 
   src = fetchFromGitHub {
     owner = "Blobfolio";
     repo = "flaca";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Fh+nWnAG87NL3scr/y2jCNqaeJtEwi4nCYTGwnmEsIQ=";
+    hash = "sha256-LVk+2zt7Abku3bR5FnpugztMy0A3LmpO2yBkZO1jjxc=";
   };
 
   postUnpack = ''
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [ rustPlatform.bindgenHook ];
 
-  cargoHash = "sha256-yHkUsxJppHhIpgX7Vtrs8TCy43xaNpqoVkMZ0msr02k=";
+  cargoHash = "sha256-73O/h7Cuh+to9MpQ97daPFKI4ACtT0aer3h0EmKKcoA=";
 
   meta = {
     description = "CLI tool to losslessly compress JPEG and PNG images";


### PR DESCRIPTION

Diff: https://github.com/Blobfolio/flaca/compare/v3.5.3...v3.6.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
