### PR TITLE
syncthing: patch quic-go

### DIFF
--- a/pkgs/applications/networking/syncthing/default.nix
+++ b/pkgs/applications/networking/syncthing/default.nix
@@ -8,6 +8,7 @@
   nixosTests,
   autoSignDarwinBinariesHook,
   nix-update-script,
+  fetchpatch,
 }:
 
 let
@@ -28,7 +29,7 @@ let
         hash = "sha256-bWClKODxzcSbKiKFcgDKbRGih8KaSeVpltiFDAE8sHM=";
       };
 
-      vendorHash = "sha256-Xiod2Bd+uXcOpZ0rt8my8jkNdkdUhuoz5fcce+6JMXY=";
+      vendorHash = "sha256-QTnVVsBDqnpup2PBxTMYh0UkhZ7e2Nh/lF83JU5h6K8=";
 
       nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
         # Recent versions of macOS seem to require binaries to be signed when
@@ -56,6 +57,20 @@ let
         ./build -goos ${go.GOOS} -goarch ${go.GOARCH} -no-upgrade -version v${version} build ${target}
         runHook postBuild
       '';
+
+      # https://github.com/quic-go/quic-go/pull/5462
+      modPostBuild =
+        let
+          patch = fetchpatch {
+            url = "https://github.com/quic-go/quic-go/commit/8bfbd717c8379913493f3d6a80a09eb901420030.patch";
+            hash = "sha256-ULNJ7j9/VKHpZK7m2O6jTeXk+xvpED03TE0xPdlAQZ0=";
+            stripLen = 1;
+            extraPrefix = "vendor/github.com/quic-go/quic-go/";
+          };
+        in
+        ''
+          patch -p1 <${patch}
+        '';
 
       installPhase = ''
         runHook preInstall


### PR DESCRIPTION
Apply upstream patch from quic-go/quic-go#5462 to handle QUIC change in Go 1.26.

Fixes #502836.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
