### PR TITLE
cassandra: fix

### DIFF
--- a/pkgs/servers/nosql/cassandra/generic.nix
+++ b/pkgs/servers/nosql/cassandra/generic.nix
@@ -117,7 +117,7 @@ stdenv.mkDerivation rec {
   passthru = {
     tests =
       let
-        test = nixosTests."cassandra_${generation}";
+        test = nixosTests.cassandra;
       in
       {
         nixos =

--- a/pkgs/servers/nosql/cassandra/generic.nix
+++ b/pkgs/servers/nosql/cassandra/generic.nix
@@ -17,7 +17,6 @@
   sha256,
   extraMeta ? { },
   callPackage,
-  ...
 }:
 
 let

--- a/pkgs/servers/nosql/cassandra/generic.nix
+++ b/pkgs/servers/nosql/cassandra/generic.nix
@@ -111,6 +111,8 @@ stdenv.mkDerivation rec {
     rm $out/bin/cqlsh
     # Make "cqlsh.py" accessible by invoking "cqlsh"
     ln -s $out/bin/cqlsh.py $out/bin/cqlsh
+    # Use nixpkgs Python packages instead of bundled zips
+    makeWrapperArgs+=("--set" "CQLSH_NO_BUNDLED" "1")
     wrapPythonPrograms
   '';
 

--- a/pkgs/servers/nosql/cassandra/generic.nix
+++ b/pkgs/servers/nosql/cassandra/generic.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  python311Packages,
+  python3Packages,
   makeWrapper,
   gawk,
   bash,
@@ -41,11 +41,11 @@ stdenv.mkDerivation rec {
     url = "mirror://apache/cassandra/${version}/apache-cassandra-${version}-bin.tar.gz";
   };
 
-  pythonPath = with python311Packages; [ cassandra-driver ];
+  pythonPath = with python3Packages; [ cassandra-driver ];
 
-  nativeBuildInputs = [ python311Packages.wrapPython ];
+  nativeBuildInputs = [ python3Packages.wrapPython ];
 
-  buildInputs = [ python311Packages.python ] ++ pythonPath;
+  buildInputs = [ python3Packages.python ] ++ pythonPath;
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8078,7 +8078,6 @@ with pkgs;
     # Effective Cassandra 4.0.2 there is full Java 11 support
     #  -- https://cassandra.apache.org/doc/latest/cassandra/new/java11.html
     jre = pkgs.jdk11_headless;
-    python = python3;
   };
   cassandra = cassandra_4;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

A few simple changes.
Tests pass again.

Closes #503834 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
