### PR TITLE
vimPlugins.sg-nvim: skip 'sg.health' module in require check hook

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/sg-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/sg-nvim/default.nix
@@ -58,6 +58,9 @@ vimUtils.buildVimPlugin {
   nvimSkipModules = [
     # Dependent on active fuzzy search state
     "sg.cody.fuzzy"
+    # Invokes a request that fails in the check hook
+    # https://github.com/sourcegraph/sg.nvim/blob/775f22b75a9826eabf69b0094dd1d51d619fe552/lua/sg/health.lua#L2
+    "sg.health"
   ];
 
   passthru = {


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/504078#discussion_r3008908400

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
