### PR TITLE
coqPackages_9_1: enable aac-tactics, rewriter, unicoq, and mtac2

### DIFF
--- a/pkgs/development/coq-modules/aac-tactics/default.nix
+++ b/pkgs/development/coq-modules/aac-tactics/default.nix
@@ -36,7 +36,7 @@ mkCoqDerivation {
 
     lib.switch coq.coq-version [
       {
-        case = "9.0";
+        case = lib.versions.isGe "9.0";
         out = "9.0.0";
       }
       {

--- a/pkgs/development/coq-modules/mtac2/default.nix
+++ b/pkgs/development/coq-modules/mtac2/default.nix
@@ -15,10 +15,15 @@ mkCoqDerivation {
     with lib.versions;
     lib.switch coq.version [
       {
+        case = isEq "9.1";
+        out = "1.4-rocq${coq.coq-version}";
+      }
+      {
         case = range "8.19" "9.0";
         out = "1.4-coq${coq.coq-version}";
       }
     ] null;
+  release."1.4-rocq9.1".hash = "sha256-A+ac84ZfDMW2NhS/NrGIfdairXmzXxZIYGNmJIz0ReM=";
   release."1.4-coq9.0".sha256 = "sha256-pAPBRCW7M46UZPJ+v/0xAT8mpQURN8czMmlrfYz/MVU=";
   release."1.4-coq8.20".sha256 = "sha256-3nu/8zDvdnl6WzGtw46mVcdqgkRgc6Xy8/I+lUOrSIY=";
   release."1.4-coq8.19".sha256 = "sha256-G9eK0eLyECdT20/yf8yyz7M8Xq2WnHHaHpxVGP0yTtU=";

--- a/pkgs/development/coq-modules/rewriter/default.nix
+++ b/pkgs/development/coq-modules/rewriter/default.nix
@@ -16,7 +16,7 @@ mkCoqDerivation {
     in
     lib.switch coq.coq-version [
       {
-        case = range "8.17" "9.0";
+        case = range "8.17" "9.2";
         out = "0.0.15";
       }
     ] null;

--- a/pkgs/development/coq-modules/unicoq/default.nix
+++ b/pkgs/development/coq-modules/unicoq/default.nix
@@ -13,6 +13,10 @@ mkCoqDerivation {
     with lib.versions;
     lib.switch coq.version [
       {
+        case = isGe "9.1";
+        out = "1.6-9.1";
+      }
+      {
         case = range "8.20" "9.0";
         out = "1.6-8.20";
       }
@@ -21,6 +25,8 @@ mkCoqDerivation {
         out = "1.6-8.19";
       }
     ] null;
+  release."1.6-9.1".rev = "0cf37ef7e638bfaad6e804e17bd80e7bb0e1b717";
+  release."1.6-9.1".hash = "sha256-1EKDkj33pg3AsEpckZYqWppPUZV2OkxM2xLq2zvZGMQ=";
   release."1.6-8.20".sha256 = "sha256-zne9LB0lGdqUfrBe8cDK8fwuxfBDFU4PqNlt9nl7rNI=";
   release."1.6-8.19".sha256 = "sha256-fDk60B8AzJwiemxHGgWjNu6PTu6NcJoI9uK7Ww2AT14=";
   releaseRev = v: "v${v}";


### PR DESCRIPTION
Tested: https://github.com/rocq-community/coq-nix-toolbox/pull/449

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
