### PR TITLE
objfw: 1.3.2 -> 1.5.1

### DIFF
--- a/pkgs/by-name/ob/objfw/package.nix
+++ b/pkgs/by-name/ob/objfw/package.nix
@@ -3,7 +3,8 @@
   autogen,
   automake,
   clangStdenv,
-  fetchfossil,
+  fetchFromGitea,
+  gitUpdater,
   lib,
   objfw,
   writeTextDir,
@@ -11,12 +12,14 @@
 
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "objfw";
-  version = "1.3.2";
+  version = "1.5.1";
 
-  src = fetchfossil {
-    url = "https://objfw.nil.im/home";
+  src = fetchFromGitea {
+    domain = "git.nil.im";
+    owner = "ObjFW";
+    repo = "ObjFW";
     rev = "${finalAttrs.version}-release";
-    hash = "sha256-cFYsiNG60FyDXAeiuBZn/u/1dEawVAxF7EDFBZRYt7w=";
+    hash = "sha256-5ECvNsDU3MagbS2tVq2sJCRMQHBkCuMQHqpWlB6tbR8=";
   };
 
   nativeBuildInputs = [
@@ -35,6 +38,8 @@ clangStdenv.mkDerivation (finalAttrs: {
   passthru.tests = {
     build-hello-world = (import ./test-build-and-run.nix) { inherit clangStdenv objfw writeTextDir; };
   };
+
+  passthru.updateScript = gitUpdater { rev-suffix = "-release"; };
 
   meta = {
     description = "Portable framework for the Objective-C language";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
