### PR TITLE
python3Packages.scalene: 2.1.4 -> 2.2.1

### DIFF
--- a/pkgs/development/python-modules/scalene/default.nix
+++ b/pkgs/development/python-modules/scalene/default.nix
@@ -12,6 +12,7 @@
   psutil,
   pydantic,
   pytestCheckHook,
+  python,
   pyyaml,
   rich,
   setuptools-scm,
@@ -34,18 +35,20 @@ let
     tag = "v4.0.0";
     hash = "sha256-tgLJNJw/dJGQMwCmfkWNBvHB76xZVyyfVVplq7aSJnI=";
   };
+
+  pythonPath = lib.getExe python;
 in
 
 buildPythonPackage (finalAttrs: {
   pname = "scalene";
-  version = "2.1.4";
+  version = "2.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "plasma-umass";
     repo = "scalene";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ISXD7QegTL0OvAGS7KYZAk9MAKTr0hMFe/9ws02Ykgk=";
+    hash = "sha256-a8laU7w6DLNIxmfhis/PvYd0iQMSqiQ2j6WURbsWPxk=";
   };
 
   patches = [
@@ -60,6 +63,15 @@ buildPythonPackage (finalAttrs: {
     cp -r ${printf-src}/* vendor/printf
     sed -i 's/^#define printf printf_/\/\/&/' vendor/printf/printf.h
     sed -i 's/^#define vsnprintf vsnprintf_/\/\/&/' vendor/printf/printf.h
+  '';
+
+  postPatch = ''
+    # Fix hash mismatch
+    rm vendor/printf/printf.c
+
+    # Set correct sys.executable
+    substituteInPlace tests/test_{multiprocessing_pool_spawn,on_off_windows}.py \
+      --replace-fail "sys.executable" "\"${pythonPath}\""
   '';
 
   build-system = [


### PR DESCRIPTION
Version bump and fix tests by injecting the python path in place of `sys.executable`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
