### PR TITLE
vdrPlugins: Updates 2026-03

### DIFF
--- a/pkgs/applications/video/vdr/epgsearch/default.nix
+++ b/pkgs/applications/video/vdr/epgsearch/default.nix
@@ -10,12 +10,12 @@
 }:
 stdenv.mkDerivation rec {
   pname = "vdr-epgsearch";
-  version = "2.4.5";
+  version = "2.4.6";
 
   src = fetchFromGitHub {
     repo = "vdr-plugin-epgsearch";
     owner = "vdr-projects";
-    sha256 = "sha256-ERHy6ks5evYmOUoTXNd63ETIA2PyR67VZ7CXR6kn7x4=";
+    sha256 = "sha256-+csxlLBSIKiYIjgEPj0IUP8wZX9zuOM26cgA99uZ3EA=";
     rev = "v${version}";
   };
 

--- a/pkgs/applications/video/vdr/markad/default.nix
+++ b/pkgs/applications/video/vdr/markad/default.nix
@@ -7,12 +7,12 @@
 }:
 stdenv.mkDerivation rec {
   pname = "vdr-markad";
-  version = "4.2.17";
+  version = "4.2.19";
 
   src = fetchFromGitHub {
     repo = "vdr-plugin-markad";
     owner = "kfb77";
-    hash = "sha256-27Axgh8brG0Apq06gry7uN95GtJ74FC1RNYVcqTUbE0=";
+    hash = "sha256-ecCWf/BKUe/L5Wrj9xKMRt+zVcmdCdYQw3s4Jwi4510=";
     tag = "V${version}";
   };
 

--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -39,33 +39,6 @@ in
     buildInputs = oldAttr.buildInputs ++ [ ncurses ];
   });
 
-  femon = stdenv.mkDerivation rec {
-    pname = "vdr-femon";
-    version = "2.4.0";
-
-    buildInputs = [ vdr ];
-
-    src = fetchFromGitHub {
-      repo = "vdr-plugin-femon";
-      owner = "rofafor";
-      sha256 = "sha256-0qBMYgNKk7N9Bj8fAoOokUo+G9gfj16N5e7dhoKRBqs=";
-      rev = "v${version}";
-    };
-
-    postPatch = "substituteInPlace Makefile --replace /bin/true true";
-
-    makeFlags = [ "DESTDIR=$(out)" ];
-
-    meta = {
-      inherit (src.meta) homepage;
-      description = "DVB Frontend Status Monitor plugin for VDR";
-      maintainers = [ lib.maintainers.ck3d ];
-      license = lib.licenses.gpl2;
-      inherit (vdr.meta) platforms;
-    };
-
-  };
-
   vnsiserver = stdenv.mkDerivation rec {
     pname = "vdr-vnsiserver";
     version = "1.8.3";

--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -4,7 +4,7 @@
   vdr,
   fetchFromGitHub,
   graphicsmagick,
-  boost186,
+  boost,
   libgcrypt,
   ncurses,
   callPackage,
@@ -132,19 +132,19 @@ in
 
   fritzbox = stdenv.mkDerivation rec {
     pname = "vdr-fritzbox";
-    version = "1.5.4";
+    version = "1.5.8";
 
     src = fetchFromGitHub {
       owner = "jowi24";
       repo = "vdr-fritz";
       rev = version;
-      hash = "sha256-DGD73i+ZHFgtCo+pMj5JaMovvb5vS1x20hmc5t29//o=";
+      hash = "sha256-o+wJJCAOTg6pPScZ0iIiEWZyT2/++pLtuOppNeaXzmQ=";
       fetchSubmodules = true;
     };
 
     buildInputs = [
       vdr
-      boost186
+      boost
       libgcrypt
     ];
 


### PR DESCRIPTION
Update following vdr plugins fritzbox, markad, and epgsearch and removed unmaintained plugin femon.

This updates are needed to allow the update of vdr https://github.com/NixOS/nixpkgs/pull/368522

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
