### PR TITLE
osu-lazer{,-bin}: 2026.305.0 -> 2026.401.0

### DIFF
--- a/pkgs/by-name/os/osu-lazer-bin/package.nix
+++ b/pkgs/by-name/os/osu-lazer-bin/package.nix
@@ -10,23 +10,23 @@
 
 let
   pname = "osu-lazer-bin";
-  version = "2026.305.0";
+  version = "2026.401.0";
 
   src =
     {
       aarch64-darwin = fetchzip {
         url = "https://github.com/ppy/osu/releases/download/${version}-lazer/osu.app.Apple.Silicon.zip";
-        hash = "sha256-UmlqeuO5VeboR0zrxBOS5AiZl/rYw+Xb5L4tbofn6T0=";
+        hash = "sha256-nsQdU3qrsRw94hnwJum3zdKcBJl0Z7hjtC+ZAm2LkvY=";
         stripRoot = false;
       };
       x86_64-darwin = fetchzip {
         url = "https://github.com/ppy/osu/releases/download/${version}-lazer/osu.app.Intel.zip";
-        hash = "sha256-h1Z+XD0bHECmPCJrxzfwJfdLiuieq/RBg2DytKOOg+c=";
+        hash = "sha256-d6SPgVzM+be+C5kWqZdc9yT7duZPF9+UsQo8iQ57pcA=";
         stripRoot = false;
       };
       x86_64-linux = fetchurl {
         url = "https://github.com/ppy/osu/releases/download/${version}-lazer/osu.AppImage";
-        hash = "sha256-azI3PS5LIVq1H02P1Z4Bny2VFqVLUC6pwCj1UD5HA6g=";
+        hash = "sha256-FEnsFtNAI6nlaw901UVbs2H+bayefcMtu7/n4Vz7bOc=";
       };
     }
     .${stdenvNoCC.system} or (throw "osu-lazer-bin: ${stdenvNoCC.system} is unsupported.");

--- a/pkgs/by-name/os/osu-lazer/deps.json
+++ b/pkgs/by-name/os/osu-lazer/deps.json
@@ -11,13 +11,13 @@
   },
   {
     "pname": "DiffPlex",
-    "version": "1.7.2",
-    "hash": "sha256-Vsn81duAmPIPkR40h5bEz7hgtF5Kt5nAAGhQZrQbqxE="
+    "version": "1.9.0",
+    "hash": "sha256-ozj2ME8fTj3AXMUguIqI45ecLS41WnOETCxCG6bDeo4="
   },
   {
     "pname": "DiscordRichPresence",
-    "version": "1.2.1.24",
-    "hash": "sha256-oRNrlF1/yK0QvrW2+48RsmSg9h9/pDIfA56/bpoHXFU="
+    "version": "1.6.1.70",
+    "hash": "sha256-uXTNIWfZU7Gf/JpXQ5ufKA3SQdXYSkg3yLm5yCrBDd8="
   },
   {
     "pname": "FFmpeg.AutoGen",
@@ -36,8 +36,8 @@
   },
   {
     "pname": "HtmlAgilityPack",
-    "version": "1.11.72",
-    "hash": "sha256-MRt7yj6+/ORmr2WBERpQ+1gMRzIaPFKddHoB4zZmv2k="
+    "version": "1.12.4",
+    "hash": "sha256-58ohjvtRXFwfY46Hny9GWL2r6KwZzkJWHFXwIWjkaHU="
   },
   {
     "pname": "Humanizer",
@@ -296,8 +296,8 @@
   },
   {
     "pname": "JetBrains.ReSharper.GlobalTools",
-    "version": "2023.3.3",
-    "hash": "sha256-Nn3imJvnqLe02gR1GyUHYH4+XkrNnhLy9dyCjJCkB7M="
+    "version": "2025.2.3",
+    "hash": "sha256-O0391kuA/ds8C7WmtbeMYi4eNiO3DKFPDYsUDHfVFUA="
   },
   {
     "pname": "Markdig",
@@ -306,73 +306,73 @@
   },
   {
     "pname": "MessagePack",
-    "version": "3.1.3",
-    "hash": "sha256-OBn7iltr/rdE7ZKmv0MCUQSS+6OJKUYtlHdTbhEwzzE="
+    "version": "3.1.4",
+    "hash": "sha256-oju/hX+vwZFqSa9ORSa58ToM3cE7fF8x34i2oNLGNVo="
   },
   {
     "pname": "MessagePack.Annotations",
-    "version": "3.1.3",
-    "hash": "sha256-o+T3u+xaHtW1c7AeWysCmIDUfN8lRhes2LoW5iQBafs="
+    "version": "3.1.4",
+    "hash": "sha256-YZGKa20siabb4VIQri5dMuFwnDxX19Htf51nGrIPx28="
   },
   {
     "pname": "MessagePackAnalyzer",
-    "version": "3.1.3",
-    "hash": "sha256-5t4Av4CQ8HI7y9aAw+2qcOp+fsY0/3PdaFPJeCEAXQ0="
+    "version": "3.1.4",
+    "hash": "sha256-qc+mzydfbZ/0O4j7pPDjp+x8aQ4KYqMeCDRIPhb1oe8="
   },
   {
     "pname": "Microsoft.AspNetCore.Connections.Abstractions",
-    "version": "9.0.2",
-    "hash": "sha256-xmPIOJ1MgI7LRLfQBexgBRLSNUEPNjksjpUxqDrOylM="
+    "version": "10.0.5",
+    "hash": "sha256-ciMnBkc2qy6/I3qhYspbf/OHQGUBPaxHvA0+y1xCJYE="
   },
   {
     "pname": "Microsoft.AspNetCore.Http.Connections.Client",
-    "version": "9.0.2",
-    "hash": "sha256-2TOp4D4zc5qX8XeY0MyYq6s2diaKeTO0PlWvGuIUeo8="
+    "version": "10.0.5",
+    "hash": "sha256-gX/cRqxkee+v4RD0w17OdshRH0iVxx1zCyl7/G79WQs="
   },
   {
     "pname": "Microsoft.AspNetCore.Http.Connections.Common",
-    "version": "9.0.2",
-    "hash": "sha256-IGjbK3tcvlUkdoI+/6VygAwpBd0Yqn+40FbgOv0UGDU="
+    "version": "10.0.5",
+    "hash": "sha256-pM90k96qeIWJHCn9LBTHQ6ODvrRdn0GShbiH/I/RYk8="
   },
   {
     "pname": "Microsoft.AspNetCore.SignalR.Client",
-    "version": "9.0.2",
-    "hash": "sha256-hnvCWtgjKqnOO1q4xvJpZaUjS+I6wu1RkUxqS2ez96w="
+    "version": "10.0.5",
+    "hash": "sha256-avbFNCuSi4xFK8QHhQ2Bz3UfRqaEpbbl1x+LhqQvKv4="
   },
   {
     "pname": "Microsoft.AspNetCore.SignalR.Client.Core",
-    "version": "9.0.2",
-    "hash": "sha256-5EuEV8zXfbYoERlCtx7yqzEMT+SVlHfLQj4QFabEye8="
+    "version": "10.0.5",
+    "hash": "sha256-0kLjqwX7lvdDU2gjTAbHtS5KVA5uA9qeE8kh8zxDq1k="
   },
   {
     "pname": "Microsoft.AspNetCore.SignalR.Common",
-    "version": "9.0.2",
-    "hash": "sha256-lEW6uQ87Ml+XqjNHVQfzPQaEL4wERi2bOB6S763DN3w="
+    "version": "10.0.5",
+    "hash": "sha256-oVs3VUtFd8zRls5nHpX/y6SJiVcI7x+rD6xw3kJrl5M="
   },
   {
     "pname": "Microsoft.AspNetCore.SignalR.Protocols.Json",
-    "version": "9.0.2",
-    "hash": "sha256-AVBp8mGbVdRjyIpo5LNMpnmV8G5uROw4Ko+gTbtnhc4="
+    "version": "10.0.5",
+    "hash": "sha256-m3zjs4Pc9NERMkXnPaegB2ZMuLHcRRqtjmD83CXQ13g="
   },
   {
     "pname": "Microsoft.AspNetCore.SignalR.Protocols.MessagePack",
-    "version": "9.0.2",
-    "hash": "sha256-wfYf4wIJ6hwBD4tacI5dWfAMDBYM6aBohEfQUV4ary0="
+    "version": "10.0.5",
+    "hash": "sha256-9fiZVKUrsx+X9YU3l+RmUbtHucVSy32/vPwH3HDc0PU="
   },
   {
     "pname": "Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson",
-    "version": "9.0.2",
-    "hash": "sha256-g2UwkpwGu+birT76nUcJ+GlN31QN8yL02bFOP1zYWkk="
+    "version": "10.0.5",
+    "hash": "sha256-pWyollxtDu+Cz/82c6THEJWTuti+fWcvygMbiPKvP8Q="
   },
   {
     "pname": "Microsoft.Bcl.AsyncInterfaces",
-    "version": "9.0.2",
-    "hash": "sha256-D+MR5Rzxn+aFPVJWF83pc0dTWnQes658xBM4bPZ6HPc="
+    "version": "10.0.5",
+    "hash": "sha256-HLhS6ysB8lh2TRtFn1EiE2MOjd3og1uniEFFVaz96UU="
   },
   {
     "pname": "Microsoft.Bcl.TimeProvider",
-    "version": "9.0.2",
-    "hash": "sha256-qce+art6dBZTx78LwKfGULXXkwL73nCnn0x4kSGDtC4="
+    "version": "10.0.5",
+    "hash": "sha256-kkfOuLkIDFosDpC/ro4Pfh7fEHUyNwkx7GLZEftUn0Y="
   },
   {
     "pname": "Microsoft.CodeAnalysis.BannedApiAnalyzers",
@@ -386,8 +386,8 @@
   },
   {
     "pname": "Microsoft.Data.Sqlite.Core",
-    "version": "9.0.2",
-    "hash": "sha256-ZUVDe+oy7fAWcnQDRdhkVeN7YZkJewwqBNaxdZcykiM="
+    "version": "10.0.5",
+    "hash": "sha256-A69tzaD9RjkxdHPj3Jm1WizdBM9QfLQyHuhs9TGrwqA="
   },
   {
     "pname": "Microsoft.Diagnostics.NETCore.Client",
@@ -401,8 +401,13 @@
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Abstractions",
-    "version": "9.0.2",
-    "hash": "sha256-icRtfbi0nDRUYDErtKYx0z6A1gWo5xdswsSM6o4ozxc="
+    "version": "10.0.5",
+    "hash": "sha256-DNK+lL2jeHFYyd43zfgVY32UskEfQ4YsTapztuQbYwo="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "10.0.5",
+    "hash": "sha256-ofDRirUV9XLSz4oksCqErwBJFtAieHACFfyZukHKFng="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection",
@@ -410,9 +415,9 @@
     "hash": "sha256-zJQsAVTfA46hUV5q67BslsVn9yehYBclD06wg2UhyWQ="
   },
   {
-    "pname": "Microsoft.Extensions.DependencyInjection",
-    "version": "9.0.2",
-    "hash": "sha256-jNQVj2Xo7wzVdNDu27bLbYCVUOF8yDVrFtC3cZ9OsXo="
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "10.0.5",
+    "hash": "sha256-KrP+hE3gk7pATbJYZsJ1LHiXjzLA+ntHW7G/VGgHk2g="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
@@ -425,24 +430,19 @@
     "hash": "sha256-oTYhI+lMwaQ7l9CfDHeNMBAdfofv4kHC0vqBZ7oJr4U="
   },
   {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "9.0.2",
-    "hash": "sha256-WoTLgw/OlXhgN54Szip0Zpne7i/YTXwZ1ZLCPcHV6QM="
-  },
-  {
     "pname": "Microsoft.Extensions.Features",
-    "version": "9.0.2",
-    "hash": "sha256-LHvTuI3JilE9g+ODoyjDJkj4AhF0OUHRyN7mMT7bokc="
+    "version": "10.0.5",
+    "hash": "sha256-OazAQa1XfjiLGxEbmovB8UeXYHXpdxlA/58qFQmBFl8="
   },
   {
     "pname": "Microsoft.Extensions.Logging",
-    "version": "9.0.2",
-    "hash": "sha256-vPCb4ZoiwZUSGJIOhYiLwcZLnsd0ZZhny6KQkT88nI0="
+    "version": "10.0.5",
+    "hash": "sha256-4gVrKZfo/YHZKgKNsgGZZYqa79XWK9wDUuiVfguUV6U="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
-    "version": "9.0.2",
-    "hash": "sha256-mCxeuc+37XY0bmZR+z4p1hrZUdTZEg+FRcs/m6dAQDU="
+    "version": "10.0.5",
+    "hash": "sha256-e3A/l+II+n+D7/OPwjdyQM1IBtKHfHeIdlkJmuRw77w="
   },
   {
     "pname": "Microsoft.Extensions.ObjectPool",
@@ -451,23 +451,23 @@
   },
   {
     "pname": "Microsoft.Extensions.Options",
+    "version": "10.0.5",
+    "hash": "sha256-nw+m6VWXjmaBqZ1aH/l9SR9Oy62N9dmiMKloJ78kxv8="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
     "version": "6.0.0",
     "hash": "sha256-DxnEgGiCXpkrxFkxXtOXqwaiAtoIjA8VSSWCcsW0FwE="
   },
   {
-    "pname": "Microsoft.Extensions.Options",
-    "version": "9.0.2",
-    "hash": "sha256-y2jZfcWx/H6Sx7wklA248r6kPjZmzTTLGxW8ZxrzNLM="
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "10.0.5",
+    "hash": "sha256-uvrur+0dg4zAAQcpLkkhPA77ST0tA3+EpGdDlCckC+E="
   },
   {
     "pname": "Microsoft.Extensions.Primitives",
     "version": "6.0.0",
     "hash": "sha256-AgvysszpQ11AiTBJFkvSy8JnwIWTj15Pfek7T7ThUc4="
-  },
-  {
-    "pname": "Microsoft.Extensions.Primitives",
-    "version": "9.0.2",
-    "hash": "sha256-zy/YNMaY47o6yNv2WuYiAJEjtoOF8jlWgsWHqXeSm4s="
   },
   {
     "pname": "Microsoft.NET.StringTools",
@@ -535,19 +535,14 @@
     "hash": "sha256-iNan1ix7RtncGWC9AjAZ2sk70DoxOsmEOgQ10fXm4Pw="
   },
   {
-    "pname": "NETStandard.Library",
-    "version": "2.0.0",
-    "hash": "sha256-Pp7fRylai8JrE1O+9TGfIEJrAOmnWTJRLWE+qJBahK0="
-  },
-  {
     "pname": "Newtonsoft.Json",
     "version": "13.0.1",
     "hash": "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo="
   },
   {
     "pname": "Newtonsoft.Json",
-    "version": "13.0.3",
-    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+    "version": "13.0.4",
+    "hash": "sha256-8JCB1FdAW681qXP6DFDWvycu1oPyVoxaYgpJ2pUvZSk="
   },
   {
     "pname": "NuGet.Versioning",
@@ -556,13 +551,8 @@
   },
   {
     "pname": "NUnit",
-    "version": "3.14.0",
-    "hash": "sha256-CuP/q5HovPWfAW3Cty/QxRi7VpjykJ3TDLq5TENI6KY="
-  },
-  {
-    "pname": "NVika",
-    "version": "4.0.0",
-    "hash": "sha256-daeovN+AsZX0r59SKYDSbofVAsXxT2DOTV892QrgMLY="
+    "version": "4.5.1",
+    "hash": "sha256-+BO4kpkiPEvC4R2wyqV/QMjpKc6jcGwARyc3Bk9skPU="
   },
   {
     "pname": "OpenTabletDriver",
@@ -626,8 +616,8 @@
   },
   {
     "pname": "ppy.osu.Framework",
-    "version": "2026.303.0",
-    "hash": "sha256-wkbRfNuatxkweNe+62I3gkq9KYBbT/mVOPXOK7LRhPw="
+    "version": "2026.318.0",
+    "hash": "sha256-LKRgb7Qiuap13zPB14+StllK52Oz/VN35bGnymqek4s="
   },
   {
     "pname": "ppy.osu.Framework.NativeLibs",
@@ -641,8 +631,8 @@
   },
   {
     "pname": "ppy.osu.Game.Resources",
-    "version": "2026.305.0",
-    "hash": "sha256-f79dXDjW5AH+T77mP1s36kuMZ+ukjjCnn/3Wfd7d6ys="
+    "version": "2026.331.0",
+    "hash": "sha256-RsqGRsarnaTbVciOKZwhoWoeTpppXoNyJTIHOKmcvVg="
   },
   {
     "pname": "ppy.osuTK.NS20",
@@ -961,13 +951,13 @@
   },
   {
     "pname": "Sentry",
-    "version": "5.1.1",
-    "hash": "sha256-Ud0rRSJZDxxs1gQSXeiuoAdxmHqPH6mfnJ0TPTKyryg="
+    "version": "6.2.0",
+    "hash": "sha256-mGCqvgqXvCxXZcreXHDzyZqSnIkHFSwNWGaPzX5AQFY="
   },
   {
     "pname": "SharpCompress",
-    "version": "0.39.0",
-    "hash": "sha256-Me88MMn5NUiw5bugFKCKFRnFSXQKIFZJ+k97Ex6jgZE="
+    "version": "0.47.0",
+    "hash": "sha256-eeTuwUXeH9gw54bczkwrYCze2bHX22Rclx8QZm4zoxY="
   },
   {
     "pname": "SharpFNT",
@@ -990,24 +980,34 @@
     "hash": "sha256-MlRF+3SGfahbsB1pZGKMOrsfUCx//hCo7ECrXr03DpA="
   },
   {
+    "pname": "SourceGear.sqlite3",
+    "version": "3.50.4.2",
+    "hash": "sha256-NsahZ3lW1JYXMq4NOH5nM/EhdjV05sbrhjsGNIinb+M="
+  },
+  {
     "pname": "SQLitePCLRaw.bundle_e_sqlite3",
-    "version": "2.1.10",
-    "hash": "sha256-kZIWjH/TVTXRIsHPZSl7zoC4KAMBMWmgFYGLrQ15Occ="
+    "version": "3.0.2",
+    "hash": "sha256-l3LqZUP4iVNyMJuBxr1VYDJr28VqoCPUPmXX6JC2ldU="
+  },
+  {
+    "pname": "SQLitePCLRaw.config.e_sqlite3",
+    "version": "3.0.2",
+    "hash": "sha256-Q8wi2rEqnE1n53DZ1wnaM8Dr5h/Bic1/EiytK3XQzrU="
   },
   {
     "pname": "SQLitePCLRaw.core",
-    "version": "2.1.10",
-    "hash": "sha256-gpZcYwiJVCVwCyJu0R6hYxyMB39VhJDmYh9LxcIVAA8="
+    "version": "2.1.11",
+    "hash": "sha256-s/fxEoYlNf9c2C4HZueMzPCBvpiViDVlSpg7epB0GXY="
   },
   {
-    "pname": "SQLitePCLRaw.lib.e_sqlite3",
-    "version": "2.1.10",
-    "hash": "sha256-m2v2RQWol+1MNGZsx+G2N++T9BNtQGLLHXUjcwkdCnc="
+    "pname": "SQLitePCLRaw.core",
+    "version": "3.0.2",
+    "hash": "sha256-AK1Yc78ykY3H0Jq1INq3O1x278CtcWH7dF9heKhWvno="
   },
   {
     "pname": "SQLitePCLRaw.provider.e_sqlite3",
-    "version": "2.1.10",
-    "hash": "sha256-MLs3jiETLZ7k/TgkHynZegCWuAbgHaDQKTPB0iNv7Fg="
+    "version": "3.0.2",
+    "hash": "sha256-LOD39Pqx58tMjP4uc4j8BvzhnsIRFocX9e5a8I1ZgPg="
   },
   {
     "pname": "StbiSharp",
@@ -1028,11 +1028,6 @@
     "pname": "System.Buffers",
     "version": "4.5.1",
     "hash": "sha256-wws90sfi9M7kuCPWkv1CEYMJtCqx9QB/kj0ymlsNaxI="
-  },
-  {
-    "pname": "System.Buffers",
-    "version": "4.6.0",
-    "hash": "sha256-c2QlgFB16IlfBms5YLsTCFQ/QeKoS6ph1a9mdRkq/Jc="
   },
   {
     "pname": "System.Collections",
@@ -1076,13 +1071,13 @@
   },
   {
     "pname": "System.Diagnostics.DiagnosticSource",
-    "version": "4.3.0",
-    "hash": "sha256-OFJRb0ygep0Z3yDBLwAgM/Tkfs4JCDtsNhwDH9cd1Xw="
+    "version": "10.0.5",
+    "hash": "sha256-yVXEbpbQRF+B4oYUJEWUgMUmOvZTFZzK3CWrr9pynVY="
   },
   {
     "pname": "System.Diagnostics.DiagnosticSource",
-    "version": "9.0.2",
-    "hash": "sha256-vhlhNgWeEosMB3DyneAUgH2nlpHORo7vAIo5Bx5Dgrc="
+    "version": "4.3.0",
+    "hash": "sha256-OFJRb0ygep0Z3yDBLwAgM/Tkfs4JCDtsNhwDH9cd1Xw="
   },
   {
     "pname": "System.Diagnostics.Tools",
@@ -1151,13 +1146,13 @@
   },
   {
     "pname": "System.IO.Packaging",
-    "version": "9.0.2",
-    "hash": "sha256-633GG/fTf5MHhi5RrCiuD5q2JzWUUeuDashmYWIBrXo="
+    "version": "10.0.5",
+    "hash": "sha256-nR3shhnchCqZq//ypgn+/l2QDiiSbNKpSswqZ43rxoM="
   },
   {
     "pname": "System.IO.Pipelines",
-    "version": "9.0.2",
-    "hash": "sha256-uxM7J0Q/dzEsD0NGcVBsOmdHiOEawZ5GNUKBwpdiPyE="
+    "version": "10.0.5",
+    "hash": "sha256-zV+G9x2d3ugEaq7ClmZbMhQe0901hxj0WtleEEglpcE="
   },
   {
     "pname": "System.Linq",
@@ -1200,6 +1195,11 @@
     "hash": "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI="
   },
   {
+    "pname": "System.Memory",
+    "version": "4.6.3",
+    "hash": "sha256-JgeK63WMmumF6L+FH5cwJgYdpqXrSDcgTQwtIgTHKVU="
+  },
+  {
     "pname": "System.Net.Http",
     "version": "4.3.0",
     "hash": "sha256-UoBB7WPDp2Bne/fwxKF0nE8grJ6FzTMXdT/jfsphj8Q="
@@ -1221,8 +1221,8 @@
   },
   {
     "pname": "System.Net.ServerSentEvents",
-    "version": "9.0.2",
-    "hash": "sha256-XZi2duryjNRtvyFrLlX2u8WlSlBbE8ccTS6X72P/kY4="
+    "version": "10.0.5",
+    "hash": "sha256-kIFzD6o58dtrWohy2lZFAkPPJvTwAcKVDBGryke5mtM="
   },
   {
     "pname": "System.Net.Sockets",
@@ -1491,13 +1491,13 @@
   },
   {
     "pname": "System.Text.Encodings.Web",
-    "version": "9.0.2",
-    "hash": "sha256-tZhc/Xe+SF9bCplthph2QmQakWxKVjMfQJZzD1Xbpg8="
+    "version": "10.0.5",
+    "hash": "sha256-8dXorb9rjnaqD8EpGlyHkvKrwgcxZblQdzeLYDdk6lw="
   },
   {
     "pname": "System.Text.Json",
-    "version": "9.0.2",
-    "hash": "sha256-kftKUuGgZtF4APmp77U79ws76mEIi+R9+DSVGikA5y8="
+    "version": "10.0.5",
+    "hash": "sha256-Phy+3UAOvqk8U0yeCSpr4n6H7JjKMTHdrHlV2bZfiUU="
   },
   {
     "pname": "System.Text.RegularExpressions",
@@ -1516,13 +1516,13 @@
   },
   {
     "pname": "System.Threading.Channels",
-    "version": "6.0.0",
-    "hash": "sha256-klGYnsyrjvXaGeqgfnMf/dTAMNtcHY+zM4Xh6v2JfuE="
+    "version": "10.0.5",
+    "hash": "sha256-mk27zxVvlbgOSOsKl0NqV6aHbdyJkMMM8CGh5MZdTqI="
   },
   {
     "pname": "System.Threading.Channels",
-    "version": "9.0.2",
-    "hash": "sha256-Ubs57l7OtgMyC/N1qiAFcfqAxqghRVXs9tB7Jws30t8="
+    "version": "6.0.0",
+    "hash": "sha256-klGYnsyrjvXaGeqgfnMf/dTAMNtcHY+zM4Xh6v2JfuE="
   },
   {
     "pname": "System.Threading.Tasks",
@@ -1593,10 +1593,5 @@
     "pname": "Vortice.Mathematics",
     "version": "1.4.25",
     "hash": "sha256-Mr/HVvwIeeDJtMNToP6kh2hyqud2zT31913HdhB4hm4="
-  },
-  {
-    "pname": "ZstdSharp.Port",
-    "version": "0.8.4",
-    "hash": "sha256-4bFUNK++6yUOnY7bZQiibClSJUQjH0uIiUbQLBtPWbo="
   }
 ]

--- a/pkgs/by-name/os/osu-lazer/package.nix
+++ b/pkgs/by-name/os/osu-lazer/package.nix
@@ -22,13 +22,13 @@
 
 buildDotnetModule rec {
   pname = "osu-lazer";
-  version = "2026.305.0";
+  version = "2026.401.0";
 
   src = fetchFromGitHub {
     owner = "ppy";
     repo = "osu";
     tag = "${version}-lazer";
-    hash = "sha256-vUFaazcaaVRp5r/S0iAMnUa6hLHgoTauhK9KGD5/txg=";
+    hash = "sha256-cdFHPM3mhiSGhyhSrZdFlgdzgaaCsM/t0IsiJvmZGOM=";
   };
 
   projectFile = "osu.Desktop/osu.Desktop.csproj";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


[compare upstream changes on GitHub](https://github.com/ppy/osu/compare/2026.305.0-lazer...2026.401.0-lazer)

the diffs were generated using [nixpkgs-update](https://github.com/nix-community/nixpkgs-update)

<details><summary>relevant check output (click to expand)</summary>

```
- built on NixOS
- The tests defined in `passthru.tests`, if any, passed
- found 2026.401.0 with grep in /nix/store/rvz0cmw4zanvqgix26wgiy0pdirv0k58-osu-lazer-bin-2026.401.0
- found 2026.401.0 in filename of file in /nix/store/rvz0cmw4zanvqgix26wgiy0pdirv0k58-osu-lazer-bin-2026.401.0

[...]

- found 2026.401.0 with grep in /nix/store/hylj8lrwnvrz0m9ssl1l15zrhmra47ds-osu-lazer-2026.401.0
- found 2026.401.0 in filename of file in /nix/store/hylj8lrwnvrz0m9ssl1l15zrhmra47ds-osu-lazer-2026.401.0
```

</details>

<details>
<summary>
<b>Instructions to test osu-lazer</b> (click to expand)
</summary>

build the derivation with:
```
nix-build -A osu-lazer https://github.com/Walavouchey/nixpkgs/archive/fb1554b6e5f91e62d62f6c69101aa300c468a0a6.tar.gz
```
or
```
nix build github:Walavouchey/nixpkgs/fb1554b6e5f91e62d62f6c69101aa300c468a0a6#osu-lazer
```

if it complains about unfree software, set `export NIXPKGS_ALLOW_UNFREE=1` and add `--impure` to the above command

you can then run it either from the symlink:

```
./result/bin/osu!
```

or from the store path:

```
/nix/store/hylj8lrwnvrz0m9ssl1l15zrhmra47ds-osu-lazer-2026.401.0/bin/osu!
```

</details>

</summary>

<details>
<summary>
<b>Instructions to test osu-lazer-bin</b> (click to expand)
</summary>

build the derivation with:
```
nix-build -A osu-lazer-bin https://github.com/Walavouchey/nixpkgs/archive/50cbebb0bcf88724d846a19bfc3aaa5ae13a6f4d.tar.gz
```
or:
```
nix build github:Walavouchey/nixpkgs/50cbebb0bcf88724d846a19bfc3aaa5ae13a6f4d#osu-lazer-bin
```

if it complains about unfree software, set `export NIXPKGS_ALLOW_UNFREE=1` and add `--impure` to the above command

you can then run it either from the symlink:

```
./result/bin/osu!
```

or from the store path:

```
/nix/store/rvz0cmw4zanvqgix26wgiy0pdirv0k58-osu-lazer-bin-2026.401.0/bin/osu!
```

</details>

cc maintainers @gepbird @thiagokokada @Guanran928 @stepbrobd

nixpkgs-review:

```
--------- Report for 'x86_64-linux' ---------
2 packages built:
osu-lazer osu-lazer-bin
```