### PR TITLE
system-manager: fix test sandbox failure, add latest-nix test

### DIFF
--- a/pkgs/by-name/sy/system-manager/package.nix
+++ b/pkgs/by-name/sy/system-manager/package.nix
@@ -6,8 +6,11 @@
   pkg-config,
   clippy,
   nix,
+  nixVersions,
   cargo,
   nix-update-script,
+  writableTmpDirAsHomeHook,
+  system-manager,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -32,6 +35,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     clippy
     nix
     cargo
+    writableTmpDirAsHomeHook
   ];
 
   preCheck = ''
@@ -43,7 +47,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     export NIX_STATE_DIR=$TMPDIR
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.latest-nix = system-manager.override { nix = nixVersions.latest; };
+  };
 
   meta = {
     description = "Manage system config using nix on any distro";


### PR DESCRIPTION
Add `writableTmpDirAsHomeHook` to `nativeCheckInputs` to fix the `test_try_nix_eval` test failure caused by Nix trying to create `/homeless-shelter/.cache/nix` in the sandbox.

Add `passthru.tests.latest-nix` to verify system-manager builds and passes tests with `nixVersions.latest`.

Discovered this in NixOS/nixpkgs#505121.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
