### PR TITLE
treewide: fix (some of) the ilmbase fallout

### DIFF
--- a/pkgs/by-name/ar/art/package.nix
+++ b/pkgs/by-name/ar/art/package.nix
@@ -33,7 +33,6 @@
   exiftool,
   mimalloc,
   openexr,
-  ilmbase,
   opencolorio,
   color-transformation-language,
 }:
@@ -92,7 +91,6 @@ stdenv.mkDerivation (finalAttrs: {
     libcanberra-gtk3
     mimalloc
     openexr
-    ilmbase
     opencolorio
     color-transformation-language
   ];

--- a/pkgs/by-name/ba/bambu-studio/package.nix
+++ b/pkgs/by-name/ba/bambu-studio/package.nix
@@ -25,12 +25,12 @@
   gtest,
   gtk3,
   hicolor-icon-theme,
-  ilmbase,
   libpng,
   mpfr,
   nlopt,
   opencascade-occt_7_6,
   openvdb,
+  openexr,
   opencv,
   pcre,
   systemd,
@@ -94,11 +94,11 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-good
     gtk3
     hicolor-icon-theme
-    ilmbase
     libpng
     mpfr
     nlopt
     opencascade-occt_7_6
+    openexr
     openvdb
     pcre
     onetbb

--- a/pkgs/by-name/co/color-transformation-language/package.nix
+++ b/pkgs/by-name/co/color-transformation-language/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  ilmbase,
   openexr,
   libtiff,
   aces-container,
@@ -22,7 +21,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    ilmbase
     openexr
     libtiff
     aces-container

--- a/pkgs/by-name/da/darktable/package.nix
+++ b/pkgs/by-name/da/darktable/package.nix
@@ -27,7 +27,6 @@
   graphicsmagick,
   gtk3,
   icu,
-  ilmbase,
   isocodes,
   jasper,
   json-glib,
@@ -114,7 +113,6 @@ stdenv.mkDerivation rec {
     graphicsmagick
     gtk3
     icu
-    ilmbase
     isocodes
     jasper
     json-glib
@@ -122,7 +120,7 @@ stdenv.mkDerivation rec {
     lensfun
     lerc
     libaom
-    #libavif # TODO re-enable once cmake files are fixed (#425306)
+    libavif
     libdatrie
     libepoxy
     libexif

--- a/pkgs/by-name/or/orca-slicer/package.nix
+++ b/pkgs/by-name/or/orca-slicer/package.nix
@@ -26,7 +26,6 @@
   gtest,
   gtk3,
   hicolor-icon-theme,
-  ilmbase,
   libsecret,
   libpng,
   mpfr,
@@ -111,7 +110,6 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-good
     gtk3
     hicolor-icon-theme
-    ilmbase
     libsecret
     libpng
     mpfr
@@ -141,6 +139,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/SoftFever/OrcaSlicer/commit/d10a06ae11089cd1f63705e87f558e9392f7a167.patch";
       hash = "sha256-t4own5AwPsLYBsGA15id5IH1ngM0NSuWdFsrxMRXmTk=";
     })
+
+    # Pick https://github.com/prusa3d/PrusaSlicer/pull/14207 to remove unused and insecure ilmbase dependency
+    ./patches/no-ilmbase.patch
   ];
 
   doCheck = true;

--- a/pkgs/by-name/or/orca-slicer/patches/no-ilmbase.patch
+++ b/pkgs/by-name/or/orca-slicer/patches/no-ilmbase.patch
@@ -1,0 +1,38 @@
+diff --git a/cmake/modules/FindOpenVDB.cmake b/cmake/modules/FindOpenVDB.cmake
+index 4fde5fa4a75..b62813fa663 100644
+--- a/cmake/modules/FindOpenVDB.cmake
++++ b/cmake/modules/FindOpenVDB.cmake
+@@ -347,25 +347,6 @@ macro(just_fail msg)
+   return()
+ endmacro()
+ 
+-find_package(IlmBase QUIET)
+-if(NOT IlmBase_FOUND)
+-  pkg_check_modules(IlmBase QUIET IlmBase)
+-endif()
+-if (IlmBase_FOUND AND NOT TARGET IlmBase::Half)
+-  message(STATUS "Falling back to IlmBase found by pkg-config...")
+-
+-  find_library(IlmHalf_LIBRARY NAMES Half)
+-  if(IlmHalf_LIBRARY-NOTFOUND OR NOT IlmBase_INCLUDE_DIRS)
+-    just_fail("IlmBase::Half can not be found!")
+-  endif()
+-  
+-  add_library(IlmBase::Half UNKNOWN IMPORTED)
+-  set_target_properties(IlmBase::Half PROPERTIES
+-    IMPORTED_LOCATION "${IlmHalf_LIBRARY}"
+-    INTERFACE_INCLUDE_DIRECTORIES "${IlmBase_INCLUDE_DIRS}")
+-elseif(NOT IlmBase_FOUND)
+-  just_fail("IlmBase::Half can not be found!")
+-endif()
+ find_package(TBB ${_quiet} ${_required} COMPONENTS tbb)
+ find_package(ZLIB ${_quiet} ${_required})
+ find_package(Boost ${_quiet} ${_required} COMPONENTS iostreams system )
+@@ -471,7 +452,6 @@ endif()
+ set(_OPENVDB_VISIBLE_DEPENDENCIES
+   Boost::iostreams
+   Boost::system
+-  IlmBase::Half
+ )
+ 
+ set(_OPENVDB_DEFINITIONS)

--- a/pkgs/by-name/pr/prusa-slicer/no-ilmbase.patch
+++ b/pkgs/by-name/pr/prusa-slicer/no-ilmbase.patch
@@ -1,0 +1,38 @@
+diff --git a/cmake/modules/FindOpenVDB.cmake b/cmake/modules/FindOpenVDB.cmake
+index 4fde5fa4a75..b62813fa663 100644
+--- a/cmake/modules/FindOpenVDB.cmake
++++ b/cmake/modules/FindOpenVDB.cmake
+@@ -347,25 +347,6 @@ macro(just_fail msg)
+   return()
+ endmacro()
+ 
+-find_package(IlmBase QUIET)
+-if(NOT IlmBase_FOUND)
+-  pkg_check_modules(IlmBase QUIET IlmBase)
+-endif()
+-if (IlmBase_FOUND AND NOT TARGET IlmBase::Half)
+-  message(STATUS "Falling back to IlmBase found by pkg-config...")
+-
+-  find_library(IlmHalf_LIBRARY NAMES Half)
+-  if(IlmHalf_LIBRARY-NOTFOUND OR NOT IlmBase_INCLUDE_DIRS)
+-    just_fail("IlmBase::Half can not be found!")
+-  endif()
+-  
+-  add_library(IlmBase::Half UNKNOWN IMPORTED)
+-  set_target_properties(IlmBase::Half PROPERTIES
+-    IMPORTED_LOCATION "${IlmHalf_LIBRARY}"
+-    INTERFACE_INCLUDE_DIRECTORIES "${IlmBase_INCLUDE_DIRS}")
+-elseif(NOT IlmBase_FOUND)
+-  just_fail("IlmBase::Half can not be found!")
+-endif()
+ find_package(TBB ${_quiet} ${_required} COMPONENTS tbb)
+ find_package(ZLIB ${_quiet} ${_required})
+ find_package(Boost ${_quiet} ${_required} COMPONENTS iostreams system )
+@@ -471,7 +452,6 @@ endif()
+ set(_OPENVDB_VISIBLE_DEPENDENCIES
+   Boost::iostreams
+   Boost::system
+-  IlmBase::Half
+ )
+ 
+ set(_OPENVDB_DEFINITIONS)

--- a/pkgs/by-name/pr/prusa-slicer/package.nix
+++ b/pkgs/by-name/pr/prusa-slicer/package.nix
@@ -19,7 +19,6 @@
   gmp,
   gtk3,
   hicolor-icon-theme,
-  ilmbase,
   libpng,
   mpfr,
   nanosvg,
@@ -78,6 +77,8 @@ clangStdenv.mkDerivation (finalAttrs: {
     # https://github.com/NixOS/nixpkgs/issues/415703
     # https://gitlab.archlinux.org/archlinux/packaging/packages/prusa-slicer/-/merge_requests/5
     ./allow_wayland.patch
+    # Pick https://github.com/prusa3d/PrusaSlicer/pull/14207 to remove unused and insecure ilmbase dependency
+    ./no-ilmbase.patch
   ];
 
   # (not applicable to super-slicer fork)
@@ -119,7 +120,6 @@ clangStdenv.mkDerivation (finalAttrs: {
     gmp
     gtk3
     hicolor-icon-theme
-    ilmbase
     libpng
     mpfr
     nanosvg-fltk

--- a/pkgs/by-name/su/super-slicer/no-ilmbase.patch
+++ b/pkgs/by-name/su/super-slicer/no-ilmbase.patch
@@ -1,0 +1,38 @@
+diff --git a/cmake/modules/FindOpenVDB.cmake b/cmake/modules/FindOpenVDB.cmake
+index 4fde5fa4a75..b62813fa663 100644
+--- a/cmake/modules/FindOpenVDB.cmake
++++ b/cmake/modules/FindOpenVDB.cmake
+@@ -347,25 +347,6 @@ macro(just_fail msg)
+   return()
+ endmacro()
+ 
+-find_package(IlmBase QUIET)
+-if(NOT IlmBase_FOUND)
+-  pkg_check_modules(IlmBase QUIET IlmBase)
+-endif()
+-if (IlmBase_FOUND AND NOT TARGET IlmBase::Half)
+-  message(STATUS "Falling back to IlmBase found by pkg-config...")
+-
+-  find_library(IlmHalf_LIBRARY NAMES Half)
+-  if(IlmHalf_LIBRARY-NOTFOUND OR NOT IlmBase_INCLUDE_DIRS)
+-    just_fail("IlmBase::Half can not be found!")
+-  endif()
+-  
+-  add_library(IlmBase::Half UNKNOWN IMPORTED)
+-  set_target_properties(IlmBase::Half PROPERTIES
+-    IMPORTED_LOCATION "${IlmHalf_LIBRARY}"
+-    INTERFACE_INCLUDE_DIRECTORIES "${IlmBase_INCLUDE_DIRS}")
+-elseif(NOT IlmBase_FOUND)
+-  just_fail("IlmBase::Half can not be found!")
+-endif()
+ find_package(TBB ${_quiet} ${_required} COMPONENTS tbb)
+ find_package(ZLIB ${_quiet} ${_required})
+ find_package(Boost ${_quiet} ${_required} COMPONENTS iostreams system )
+@@ -471,7 +452,6 @@ endif()
+ set(_OPENVDB_VISIBLE_DEPENDENCIES
+   Boost::iostreams
+   Boost::system
+-  IlmBase::Half
+ )
+ 
+ set(_OPENVDB_DEFINITIONS)

--- a/pkgs/by-name/su/super-slicer/package.nix
+++ b/pkgs/by-name/su/super-slicer/package.nix
@@ -21,6 +21,8 @@ let
     })
     ./super-slicer-use-boost186.patch
     ./super-slicer-fix-cereal-1.3.1.patch
+    # Pick https://github.com/prusa3d/PrusaSlicer/pull/14207 to remove unused and insecure ilmbase dependency
+    ./no-ilmbase.patch
   ];
 
   wxwidgets_3_1-prusa = wxwidgets_3_1.overrideAttrs (old: {


### PR DESCRIPTION
Fixes #501924.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
