### PR TITLE
dwmblocks: fix build with gcc15

### DIFF
--- a/pkgs/by-name/dw/dwmblocks/package.nix
+++ b/pkgs/by-name/dw/dwmblocks/package.nix
@@ -28,7 +28,12 @@ stdenv.mkDerivation {
       configFile =
         if lib.isDerivation conf || builtins.isPath conf then conf else writeText "blocks.def.h" conf;
     in
-    lib.optionalString (conf != null) "cp ${configFile} blocks.def.h";
+    lib.optionalString (conf != null) "cp ${configFile} blocks.def.h"
+    + ''
+      # gcc15
+      substituteInPlace dwmblocks.c \
+        --replace-fail 'void termhandler()' 'void termhandler(int signum)'
+    '';
 
   makeFlags = [ "PREFIX=$(out)" ];
 


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324216363

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
