### PR TITLE
libjwt: 1.18.1 -> 3.3.2

### DIFF
--- a/pkgs/by-name/li/libjwt/package.nix
+++ b/pkgs/by-name/li/libjwt/package.nix
@@ -1,34 +1,50 @@
 {
   stdenv,
   lib,
+  check,
+  cmake,
   fetchFromGitHub,
   autoreconfHook,
   pkg-config,
   jansson,
   openssl,
+  runtimeShell,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libjwt";
-  version = "1.18.1";
+  version = "3.3.2";
 
   src = fetchFromGitHub {
     owner = "benmcollins";
     repo = "libjwt";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-0gFMeSW4gfbI6MUctcN8UuKhMDswaT8BzHTV2VuwZzc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-k8478rW9ovFS0kSo1Zk/nobNgOvEOtAc/zbnw3ciEwc=";
   };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail /bin/bash "${runtimeShell}"
+  '';
 
   buildInputs = [
     jansson
     openssl
   ];
+
   nativeBuildInputs = [
-    autoreconfHook
+    cmake
     pkg-config
   ];
 
+  doCheck = true;
+
+  checkInputs = [
+    check
+  ];
+
   meta = {
+    changelog = "https://github.com/benmcollins/libjwt/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://github.com/benmcollins/libjwt";
     description = "JWT C Library";
     license = lib.licenses.mpl20;


### PR DESCRIPTION
Diff: https://github.com/benmcollins/libjwt/compare/v1.18.1...v3.3.2

fixes https://github.com/NixOS/nixpkgs/issues/505281
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
