### PR TITLE
rofi-systemd: 1.1.0 -> 1.1.2

### DIFF
--- a/pkgs/by-name/ro/rofi-systemd/package.nix
+++ b/pkgs/by-name/ro/rofi-systemd/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchFromGitHub,
   rofi,
   systemd,
@@ -11,15 +11,15 @@
   jq,
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "rofi-systemd";
-  version = "1.1.0";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
-    owner = "IvanMalison";
-    repo = "rofi-systemd";
-    tag = "v${version}";
-    sha256 = "1zwbw119mblp5b6dj4h92fi0y2ymimlgh4bawi5ks2051hpq6c1a";
+    owner = "colonelpanic8";
+    repo = finalAttrs.pname;
+    tag = "v${finalAttrs.version}";
+    sha256 = "13dccm6wgw0gc6jgxaimcnk0rrvpml2x2khzgkjfpr2yvm2wcbj7";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -27,8 +27,11 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp -a rofi-systemd $out/bin/rofi-systemd
+    runHook preInstall
+
+    install -Dm755 rofi-systemd $out/bin/rofi-systemd
+
+    runHook postInstall
   '';
 
   wrapperPath = lib.makeBinPath [
@@ -40,18 +43,16 @@ stdenv.mkDerivation rec {
     util-linux
   ];
 
-  fixupPhase = ''
-    patchShebangs $out/bin
-
-    wrapProgram $out/bin/rofi-systemd --prefix PATH : "${wrapperPath}"
+  postFixup = ''
+    wrapProgram $out/bin/rofi-systemd --prefix PATH : "${finalAttrs.wrapperPath}"
   '';
 
   meta = {
     description = "Control your systemd units using rofi";
-    homepage = "https://github.com/IvanMalison/rofi-systemd";
-    maintainers = with lib.maintainers; [ imalison ];
+    homepage = "https://github.com/colonelpanic8/rofi-systemd";
+    maintainers = [ lib.maintainers.imalison ];
     license = lib.licenses.gpl3;
-    platforms = with lib.platforms; linux;
-    mainProgram = "rofi-systemd";
+    platforms = lib.platforms.linux;
+    mainProgram = finalAttrs.pname;
   };
-}
+})


### PR DESCRIPTION
Update rofi-systemd to the latest upstream release, and switch the fetch/homepage to the current upstream owner.

Upstream changes between `v1.1.0` and `v1.1.2` include more robust unit selection/execution, a fix so rofi stays visible while units are loading, a new status shortcut, and improved menu column formatting.

Changelog / compare:
- https://github.com/colonelpanic8/rofi-systemd/compare/v1.1.0...v1.1.2

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test