### PR TITLE
nixos/cloudflare-ddns: package new options and update assertions

### DIFF
--- a/nixos/modules/services/networking/cloudflare-ddns.nix
+++ b/nixos/modules/services/networking/cloudflare-ddns.nix
@@ -23,7 +23,7 @@ in
         Path to a file containing the Cloudflare API authentication token.
         The file content should be in the format `CLOUDFLARE_API_TOKEN=YOUR_SECRET_TOKEN`.
         The service user needs read access to this file.
-        Ensure permissions are secure (e.g., `0400` or `0440`) and ownership is appropriate
+        Ensure permissions are secure (e.g., `0400` or `0440`) and ownership is appropriate.
         Using `CLOUDFLARE_API_TOKEN` is preferred over the deprecated `CF_API_TOKEN`.
       '';
       example = "/run/secrets/cloudflare-ddns-token";
@@ -33,9 +33,9 @@ in
       type = lib.types.listOf lib.types.str;
       default = [ ];
       description = ''
-        List of domain names (FQDNs) to manage. Wildcards like `*.example.com` are supported.
-        These domains will be managed for both IPv4 and IPv6 unless overridden by
-        `ip4Domains` or `ip6Domains`, or if the respective providers are disabled.
+        List of domain names (FQDNs) to manage for both IPv4 (`A`) and IPv6 (`AAAA`) records.
+        Wildcards like `*.example.com` are supported.
+        These are combined with (not overridden by) `ip4Domains` and `ip6Domains`.
         This corresponds to the `DOMAINS` environment variable.
       '';
       example = [
@@ -45,23 +45,38 @@ in
     };
 
     ip4Domains = lib.mkOption {
-      type = lib.types.nullOr (lib.types.listOf lib.types.str);
-      default = null;
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
       description = ''
-        Explicit list of domains to manage only for IPv4. If set, overrides `domains` for IPv4.
+        Additional list of domains to manage only for IPv4 (`A` records).
+        These are combined with domains listed in `domains`.
         Corresponds to the `IP4_DOMAINS` environment variable.
       '';
       example = [ "ipv4.example.com" ];
     };
 
     ip6Domains = lib.mkOption {
-      type = lib.types.nullOr (lib.types.listOf lib.types.str);
-      default = null;
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
       description = ''
-        Explicit list of domains to manage only for IPv6. If set, overrides `domains` for IPv6.
+        Additional list of domains to manage only for IPv6 (`AAAA` records).
+        These are combined with domains listed in `domains`.
         Corresponds to the `IP6_DOMAINS` environment variable.
       '';
       example = [ "ipv6.example.com" ];
+    };
+
+    managedRecordsCommentRegex = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = ''
+        Regex that selects which DNS records this updater manages by their comments.
+        Matched records are updated or deleted as needed; new records are created with comments that match.
+        Uses RE2 syntax (the Go `regexp` syntax, not Perl/PCRE).
+        When empty, the updater manages all DNS records for the configured domains.
+        Corresponds to the `MANAGED_RECORDS_COMMENT_REGEX` environment variable.
+      '';
+      example = "^managed-by-ddns$";
     };
 
     wafLists = lib.mkOption {
@@ -74,13 +89,27 @@ in
       example = [ "YOUR_ACCOUNT_ID/allowed_dynamic_ips" ];
     };
 
+    managedWafListItemsCommentRegex = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = ''
+        Regex that selects which WAF list items this updater manages by their comments.
+        Matched items are updated or deleted as needed, and new items are created with comments that match.
+        This lets multiple updater instances share one WAF list safely.
+        Uses RE2 syntax (the Go `regexp` syntax, not Perl/PCRE).
+        When empty, the updater manages all WAF list items.
+        Corresponds to the `MANAGED_WAF_LIST_ITEMS_COMMENT_REGEX` environment variable.
+      '';
+      example = "^managed-by-ddns$";
+    };
+
     provider = {
       ipv4 = lib.mkOption {
         type = lib.types.str;
         default = "cloudflare.trace";
         description = ''
-          IP detection provider for IPv4. Common values: `cloudflare.trace`, `cloudflare.doh`, `local`, `url:URL`, `none`.
-          Use `none` to disable IPv4 updates.
+          IP detection provider for IPv4. Common values: `cloudflare.trace`, `local`, `url:URL`, `none`.
+          Use `none` to disable IPv4 updates; use `static.empty` to clear managed IPv4 content.
           See cloudflare-ddns documentation for all options.
         '';
       };
@@ -88,11 +117,35 @@ in
         type = lib.types.str;
         default = "cloudflare.trace";
         description = ''
-          IP detection provider for IPv6. Common values: `cloudflare.trace`, `cloudflare.doh`, `local`, `url:URL`, `none`.
-          Use `none` to disable IPv6 updates.
+          IP detection provider for IPv6. Common values: `cloudflare.trace`, `local`, `url:URL`, `none`.
+          Use `none` to disable IPv6 updates; use `static.empty` to clear managed IPv6 content.
           See cloudflare-ddns documentation for all options.
         '';
       };
+    };
+
+    ip4DefaultPrefixLen = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 32;
+      description = ''
+        Default CIDR prefix length for detected bare IPv4 addresses.
+        WAF lists use this to determine the stored range (e.g., 24 stores each detection as a /24 range).
+        Valid range: 8–32.
+        Corresponds to the `IP4_DEFAULT_PREFIX_LEN` environment variable.
+        (Experimental feature as of cloudflare-ddns 1.16.0).
+      '';
+    };
+
+    ip6DefaultPrefixLen = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 64;
+      description = ''
+        Default CIDR prefix length for detected bare IPv6 addresses.
+        WAF lists use this to determine the stored range (e.g., 48 stores each detection as a /48 range).
+        Valid range: 12–128.
+        Corresponds to the `IP6_DEFAULT_PREFIX_LEN` environment variable.
+        (Experimental feature as of cloudflare-ddns 1.16.0).
+      '';
     };
 
     updateCron = lib.mkOption {
@@ -105,6 +158,17 @@ in
       example = "@hourly";
     };
 
+    tz = lib.mkOption {
+      type = lib.types.str;
+      default = "UTC";
+      description = ''
+        Timezone used for logging messages and parsing `updateCron`.
+        Accepts any IANA Time Zone name.
+        Corresponds to the `TZ` environment variable.
+      '';
+      example = "Asia/Kathmandu";
+    };
+
     updateOnStart = lib.mkOption {
       type = lib.types.bool;
       default = true;
@@ -115,8 +179,7 @@ in
       type = lib.types.bool;
       default = false;
       description = ''
-        Whether to delete the managed DNS records and clear WAF lists when the service is stopped gracefully.
-        Warning: Setting this to true with `updateCron = "@once"` will cause immediate deletion.
+        Whether to delete managed DNS records and managed WAF content when the service is stopped gracefully.
       '';
     };
 
@@ -133,7 +196,8 @@ in
       type = lib.types.ints.positive;
       default = 1;
       description = ''
-        Time To Live (TTL) for the DNS records in seconds.
+        Fallback TTL (in seconds) for DNS records managed by the updater.
+        The updater preserves existing TTL values when possible.
         Must be 1 (for automatic) or between 30 and 86400.
       '';
     };
@@ -142,7 +206,8 @@ in
       type = lib.types.str;
       default = "false";
       description = ''
-        Whether the managed DNS records should be proxied through Cloudflare ('orange cloud').
+        Fallback proxy setting for DNS records managed by the updater.
+        The updater preserves existing proxy statuses when possible.
         Accepts boolean values (`true`, `false`) or a domain expression.
         See cloudflare-ddns documentation for expression syntax (e.g., "is(a.com) || sub(b.org)").
       '';
@@ -152,13 +217,22 @@ in
     recordComment = lib.mkOption {
       type = lib.types.str;
       default = "";
-      description = "Comment to add to managed DNS records.";
+      description = "Fallback comment for DNS records managed by the updater.";
     };
 
     wafListDescription = lib.mkOption {
       type = lib.types.str;
       default = "";
-      description = "Description for managed WAF lists (used when creating or verifying lists).";
+      description = ''
+        Fallback description for WAF lists managed by the updater.
+        Only matters when the updater creates a new WAF list.
+      '';
+    };
+
+    wafListItemComment = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "Fallback comment for WAF list items managed by the updater.";
     };
 
     detectionTimeout = lib.mkOption {
@@ -173,23 +247,36 @@ in
       description = "Timeout for updating records via the Cloudflare API.";
     };
 
+    logging = {
+      quiet = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether to reduce logging output.";
+      };
+      emoji = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether to use emojis in logging output.";
+      };
+    };
+
     healthchecks = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
+      type = lib.types.str;
+      default = "";
       description = "URL for Healthchecks.io monitoring endpoint (optional).";
       example = "https://hc-ping.com/your-uuid";
     };
 
     uptimeKuma = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
+      type = lib.types.str;
+      default = "";
       description = "URL for Uptime Kuma push monitor endpoint (optional).";
       example = "https://status.example.com/api/push/tag?status=up&msg=OK&ping=";
     };
 
     shoutrrr = lib.mkOption {
-      type = lib.types.nullOr (lib.types.listOf lib.types.str);
-      default = null;
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
       description = "List of Shoutrrr notification service URLs (optional).";
       example = [
         "discord://token@id"
@@ -213,21 +300,45 @@ in
   config = lib.mkIf cfg.enable {
     assertions = [
       {
-        assertion = cfg.ttl == 1 || (cfg.ttl >= 30 && cfg.ttl <= 86400);
-        message = "services.cloudflare-ddns.ttl must be 1 or between 30 and 86400";
-      }
-      {
-        assertion = cfg.updateCron == "@once" -> !cfg.deleteOnStop;
-        message = "services.cloudflare-ddns.deleteOnStop cannot be true when updateCron is \"@once\"";
-      }
-      {
         assertion =
-          cfg.domains != [ ] || cfg.ip4Domains != null || cfg.ip6Domains != null || cfg.wafLists != [ ];
+          cfg.domains != [ ] || cfg.ip4Domains != [ ] || cfg.ip6Domains != [ ] || cfg.wafLists != [ ];
         message = "services.cloudflare-ddns requires at least one domain (domains, ip4Domains, ip6Domains) or WAF list (wafLists) to be specified";
       }
       {
-        assertion = cfg.provider.ipv4 != "none" || cfg.provider.ipv6 != "none";
-        message = "services.cloudflare-ddns requires at least one provider (ipv4 or ipv6) to be enabled (not 'none')";
+        assertion = cfg.updateCron == "@once" -> cfg.updateOnStart;
+        message = "services.cloudflare-ddns.updateOnStart must be true when updateCron is \"@once\", otherwise nothing will happen";
+      }
+      {
+        assertion =
+          let
+            ip4Off = cfg.provider.ipv4 == "static.empty" || cfg.provider.ipv4 == "none";
+            ip6Off = cfg.provider.ipv6 == "static.empty" || cfg.provider.ipv6 == "none";
+          in
+          cfg.updateCron == "@once" && cfg.deleteOnStop -> ip4Off && ip6Off;
+        message = "services.cloudflare-ddns.deleteOnStop cannot be true when updateCron is \"@once\" unless each provider is either 'none' or 'static.empty'";
+      }
+      {
+        assertion =
+          let
+            ip4Managed =
+              cfg.provider.ipv4 != "none" && (cfg.domains != [ ] || cfg.ip4Domains != [ ] || cfg.wafLists != [ ]);
+            ip6Managed =
+              cfg.provider.ipv6 != "none" && (cfg.domains != [ ] || cfg.ip6Domains != [ ] || cfg.wafLists != [ ]);
+          in
+          ip4Managed || ip6Managed;
+        message = "services.cloudflare-ddns requires at least one provider (ipv4 or ipv6) to be enabled (not 'none') and actively used";
+      }
+      {
+        assertion = cfg.ip4DefaultPrefixLen >= 8 && cfg.ip4DefaultPrefixLen <= 32;
+        message = "services.cloudflare-ddns.ip4DefaultPrefixLen must be between 8 and 32";
+      }
+      {
+        assertion = cfg.ip6DefaultPrefixLen >= 12 && cfg.ip6DefaultPrefixLen <= 128;
+        message = "services.cloudflare-ddns.ip6DefaultPrefixLen must be between 12 and 128";
+      }
+      {
+        assertion = cfg.ttl == 1 || (cfg.ttl >= 30 && cfg.ttl <= 86400);
+        message = "services.cloudflare-ddns.ttl must be 1 or between 30 and 86400";
       }
     ];
 
@@ -276,31 +387,44 @@ in
               lib.optionalString pred (toEnvList name value);
           in
           lib.filter (envVar: envVar != "") [
-            (toEnvList "DOMAINS" cfg.domains)
-            (toEnvMaybeList (cfg.ip4Domains != null) "IP4_DOMAINS" cfg.ip4Domains)
-            (toEnvMaybeList (cfg.ip6Domains != null) "IP6_DOMAINS" cfg.ip6Domains)
-
-            (toEnv "IP4_PROVIDER" cfg.provider.ipv4)
-            (toEnv "IP6_PROVIDER" cfg.provider.ipv6)
+            (toEnvMaybeList (cfg.domains != [ ]) "DOMAINS" cfg.domains)
+            (toEnvMaybeList (cfg.ip4Domains != [ ]) "IP4_DOMAINS" cfg.ip4Domains)
+            (toEnvMaybeList (cfg.ip6Domains != [ ]) "IP6_DOMAINS" cfg.ip6Domains)
+            (toEnvMaybe (
+              cfg.managedRecordsCommentRegex != ""
+            ) "MANAGED_RECORDS_COMMENT_REGEX" cfg.managedRecordsCommentRegex)
 
             (toEnvMaybeList (cfg.wafLists != [ ]) "WAF_LISTS" cfg.wafLists)
-            (toEnvMaybe (cfg.wafListDescription != "") "WAF_LIST_DESCRIPTION" cfg.wafListDescription)
+            (toEnvMaybe (
+              cfg.managedWafListItemsCommentRegex != ""
+            ) "MANAGED_WAF_LIST_ITEMS_COMMENT_REGEX" cfg.managedWafListItemsCommentRegex)
 
-            (toEnv "UPDATE_CRON" cfg.updateCron)
+            (toEnvMaybe (cfg.provider.ipv4 != "") "IP4_PROVIDER" cfg.provider.ipv4)
+            (toEnvMaybe (cfg.provider.ipv6 != "") "IP6_PROVIDER" cfg.provider.ipv6)
+            (toEnv "IP4_DEFAULT_PREFIX_LEN" cfg.ip4DefaultPrefixLen)
+            (toEnv "IP6_DEFAULT_PREFIX_LEN" cfg.ip6DefaultPrefixLen)
+
+            (toEnvMaybe (cfg.updateCron != "") "UPDATE_CRON" cfg.updateCron)
+            (toEnvMaybe (cfg.tz != "") "TZ" cfg.tz)
             (toEnvBool "UPDATE_ON_START" cfg.updateOnStart)
             (toEnvBool "DELETE_ON_STOP" cfg.deleteOnStop)
-            (toEnv "CACHE_EXPIRATION" cfg.cacheExpiration)
+            (toEnvMaybe (cfg.cacheExpiration != "") "CACHE_EXPIRATION" cfg.cacheExpiration)
 
             (toEnv "TTL" cfg.ttl)
-            (toEnv "PROXIED" cfg.proxied)
+            (toEnvMaybe (cfg.proxied != "") "PROXIED" cfg.proxied)
             (toEnvMaybe (cfg.recordComment != "") "RECORD_COMMENT" cfg.recordComment)
+            (toEnvMaybe (cfg.wafListDescription != "") "WAF_LIST_DESCRIPTION" cfg.wafListDescription)
+            (toEnvMaybe (cfg.wafListItemComment != "") "WAF_LIST_ITEM_COMMENT" cfg.wafListItemComment)
 
-            (toEnv "DETECTION_TIMEOUT" cfg.detectionTimeout)
-            (toEnv "UPDATE_TIMEOUT" cfg.updateTimeout)
+            (toEnvMaybe (cfg.detectionTimeout != "") "DETECTION_TIMEOUT" cfg.detectionTimeout)
+            (toEnvMaybe (cfg.updateTimeout != "") "UPDATE_TIMEOUT" cfg.updateTimeout)
 
-            (toEnvMaybe (cfg.healthchecks != null) "HEALTHCHECKS" cfg.healthchecks)
-            (toEnvMaybe (cfg.uptimeKuma != null) "UPTIMEKUMA" cfg.uptimeKuma)
-            (toEnvMaybeList (cfg.shoutrrr != null) "SHOUTRRR" (lib.concatStringsSep "\n" cfg.shoutrrr))
+            (toEnvBool "QUIET" cfg.logging.quiet)
+            (toEnvBool "EMOJI" cfg.logging.emoji)
+
+            (toEnvMaybe (cfg.healthchecks != "") "HEALTHCHECKS" cfg.healthchecks)
+            (toEnvMaybe (cfg.uptimeKuma != "") "UPTIMEKUMA" cfg.uptimeKuma)
+            (toEnvMaybe (cfg.shoutrrr != [ ]) "SHOUTRRR" (lib.concatStringsSep "\n" cfg.shoutrrr))
           ];
 
         ExecStart = lib.getExe cfg.package;
@@ -319,6 +443,7 @@ in
         RestrictAddressFamilies = [
           "AF_INET"
           "AF_INET6"
+          "AF_NETLINK"
         ];
       };
     };


### PR DESCRIPTION
Add new NixOS module options to match recent upstream additions:

- `managedRecordsCommentRegex` and `managedWafListItemsCommentRegex` for selectively managing DNS records and WAF list items by comment, enabling multiple updater instances to share resources safely
- `ip4DefaultPrefixLen` and `ip6DefaultPrefixLen` for controlling CIDR prefix lengths used in WAF list entries
- `wafListItemComment` for setting fallback comments on WAF list items

Package previously missing upstream options:

- `tz` for configuring the timezone used in logging and cron parsing
- `quiet` and `emoji` under a new logging subgroup for controlling logging verbosity and style

Improve existing option descriptions to better reflect upstream behavior:

- Clarify that `domains`, `ip4Domains`, and `ip6Domains` are combined (not overriding), matching actual upstream semantics
- Reword `ttl`, `proxied`, `recordComment`, and `wafListDescription` as "fallback" values since the updater preserves existing values
- Mention `static.empty` in provider descriptions as an option for clearing managed content
- Remove `cloudflare.doh` from provider "common values" lists
- Fix minor punctuation in `apiTokenFile` description

Change `ip4Domains`, `ip6Domains`, `healthchecks`, `uptimeKuma`, and `shoutrrr` from `nullOr` types with `null` defaults to direct types with empty defaults (`[]` or `""`), simplifying the option interface and aligning the environment variable generation to only emit values when non-empty.

Rework assertions for correctness:

- Require `updateOnStart` when `updateCron` is `@once` (otherwise nothing would run)
- Refine `deleteOnStop` + `@once` check to allow it when providers are `none` or `static.empty` (safe deletion-only runs)
- Validate that at least one provider is actively used (not just enabled), accounting for whether domains are actually configured
- Add range validation for prefix length options

Add `AF_NETLINK` to `RestrictAddressFamilies` so that the `local.iface` provider can query network interfaces via netlink.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
