### PR TITLE
droid: init at 0.90.0

### DIFF
--- a/pkgs/by-name/dr/droid/package.nix
+++ b/pkgs/by-name/dr/droid/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenvNoCC,
+  stdenv,
+  fetchurl,
+  patchelf,
+  makeWrapper,
+  ripgrep,
+  xdg-utils,
+}:
+
+let
+  version = "0.90.0";
+
+  sources = {
+    x86_64-linux = {
+      url = "https://downloads.factory.ai/factory-cli/releases/${version}/linux/x64/droid";
+      hash = "sha256-1sVKOoXQh/1Wd5Pog+Mi0DCn/hh+p3Xv1bUaSrKTQKI=";
+    };
+    aarch64-linux = {
+      url = "https://downloads.factory.ai/factory-cli/releases/${version}/linux/arm64/droid";
+      hash = "sha256-LcJaH6680ZlwZ07uBUmef8JlL/BXtVIm4TttuSpmuas=";
+    };
+    x86_64-darwin = {
+      url = "https://downloads.factory.ai/factory-cli/releases/${version}/darwin/x64/droid";
+      hash = "sha256-3+rahoHqxcIxigT7i2QU/ZJqRCyYlMn7rcjbiFt88zs=";
+    };
+    aarch64-darwin = {
+      url = "https://downloads.factory.ai/factory-cli/releases/${version}/darwin/arm64/droid";
+      hash = "sha256-+IOmEw9oy76O0g/EFdhmhxhirVkOgJtEOdl0t3LR06A=";
+    };
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "droid";
+  inherit version;
+
+  src = fetchurl (
+    sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "droid: unsupported system ${stdenvNoCC.hostPlatform.system}")
+  );
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+  dontPatchELF = true;
+
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [ patchelf ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/libexec/droid
+
+    makeWrapper $out/libexec/droid $out/bin/droid \
+      --prefix PATH : ${
+        lib.makeBinPath ([ ripgrep ] ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [ xdg-utils ])
+      }
+
+    runHook postInstall
+  '';
+
+  # The droid binary has JavaScript resources appended after the ELF structure.
+  # Using autoPatchelfHook or patchelf --set-rpath corrupts this appended data.
+  # Only --set-interpreter is safe for this binary.
+  postFixup = lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
+    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} $out/libexec/droid
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Factory's AI-powered coding agent for autonomous software development";
+    homepage = "https://factory.ai";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = builtins.attrNames sources;
+    maintainers = with lib.maintainers; [ codgician ];
+    mainProgram = "droid";
+  };
+}

--- a/pkgs/by-name/dr/droid/update.sh
+++ b/pkgs/by-name/dr/droid/update.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl
+
+set -euo pipefail
+
+nixpkgs="$(git rev-parse --show-toplevel)"
+path="$nixpkgs/pkgs/by-name/dr/droid/package.nix"
+
+install_script=$(curl -fsSL "https://app.factory.ai/cli")
+new_version=$(echo "$install_script" | grep -oP 'VER="\K[0-9.]+(?=")')
+
+if [ -z "$new_version" ]; then
+  echo "Error: Could not extract version from install script" >&2
+  exit 1
+fi
+
+old_version=$(sed -nE 's/^\s*version = "(.*)".*/\1/p' "$path")
+
+if [[ "$old_version" == "$new_version" ]]; then
+  echo "Current version $old_version is up-to-date"
+  exit 0
+fi
+
+echo "Updating droid: $old_version -> $new_version"
+
+base_url="https://downloads.factory.ai/factory-cli/releases/$new_version"
+
+get_hash() {
+  curl -fsSL "$1" | xargs nix hash convert --hash-algo sha256 --to sri
+}
+
+sed -i "s/version = \"$old_version\"/version = \"$new_version\"/" "$path"
+
+for pair in "x86_64-linux:linux/x64" "aarch64-linux:linux/arm64" "x86_64-darwin:darwin/x64" "aarch64-darwin:darwin/arm64"; do
+  system="${pair%%:*}"
+  url_path="${pair#*:}"
+  hash=$(get_hash "$base_url/$url_path/droid.sha256")
+  sed -i "/$system = {/,/};/s|hash = \"sha256-[^\"]*\"|hash = \"$hash\"|" "$path"
+done
+
+echo "Updated droid: $old_version -> $new_version"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Continuation of previously closed #450797, adding Factory's Droid CLI for AI assisted code development: https://factory.ai/product/cli

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
