### PR TITLE
kwin-effect-geometry-change: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5464,6 +5464,11 @@
     githubId = 1573344;
     name = "Andrey Pavlov";
   };
+  couldbemathijs = {
+    github = "CouldBeMathijs";
+    githubId = 79464596;
+    name = "CouldBeMathijs";
+  };
   cpages = {
     email = "page@ruiec.cat";
     github = "cpages";

--- a/pkgs/by-name/kw/kwin-effect-geometry-change/package.nix
+++ b/pkgs/by-name/kw/kwin-effect-geometry-change/package.nix
@@ -37,6 +37,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/peterfajdiga/kwin4_effect_geometry_change";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ CouldBeMathijs ];
+    maintainers = with lib.maintainers; [ couldbemathijs ];
   };
 })

--- a/pkgs/by-name/kw/kwin-effect-geometry-change/package.nix
+++ b/pkgs/by-name/kw/kwin-effect-geometry-change/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  kdePackages,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "kwin-effect-geometry-change";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "peterfajdiga";
+    repo = "kwin4_effect_geometry_change";
+    tag = "v${lib.versions.majorMinor finalAttrs.version}";
+    hash = "sha256-p4FpqagR8Dxi+r9A8W5rGM5ybaBXP0gRKAuzigZ1lyA=";
+  };
+
+  nativeBuildInputs = [
+    kdePackages.kpackage
+    kdePackages.kwin
+  ];
+
+  dontBuild = true;
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    kpackagetool6 --type=KWin/Effect --install=./package --packageroot=$out/share/kwin/effects
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "KWin animation for windows moved or resized by programs or scripts";
+    homepage = "https://github.com/peterfajdiga/kwin4_effect_geometry_change";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ CouldBeMathijs ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Add couldbemathijs to maintainer list
- Add kwin-effect-geometry-change to what I hope is the right location

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
