### PR TITLE
python3Packages.torch-c-dlpack-ext: init at 0.1.9

### DIFF
--- a/pkgs/development/python-modules/torch-c-dlpack-ext/default.nix
+++ b/pkgs/development/python-modules/torch-c-dlpack-ext/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  apache-tvm-ffi,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  torch,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "torch-c-dlpack-ext";
+  inherit (apache-tvm-ffi) version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/addons/torch_c_dlpack_ext";
+
+  build-system = [
+    apache-tvm-ffi
+    setuptools
+  ];
+
+  dependencies = [
+    torch
+  ];
+
+  pythonImportsCheck = [ "torch_c_dlpack_ext" ];
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    description = "Ahead-Of-Time (AOT) compiled module to support faster DLPack conversion in DLPack";
+    homepage = "https://github.com/apache/tvm-ffi/tree/main/addons/torch_c_dlpack_ext";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19451,6 +19451,8 @@ self: super: with self; {
 
   torch-bin = callPackage ../development/python-modules/torch/bin { triton = self.triton-bin; };
 
+  torch-c-dlpack-ext = callPackage ../development/python-modules/torch-c-dlpack-ext { };
+
   torch-geometric = callPackage ../development/python-modules/torch-geometric { };
 
   # Required to test triton


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds building the [torch-c-dlpack-ext](https://github.com/apache/tvm-ffi/tree/main/addons/torch_c_dlpack_ext) extension required by quack-kernels for vLLM 0.17+ CUDA support.

Superseded #504334.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
