### PR TITLE
zlib: disable vectorized CRC32 when cross-compiling for s390x

### DIFF
--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -46,6 +46,10 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-uzKaCizQJ00FUZ1hxmfAYuBpkNcuEl7i36jeZPARnRY=";
     };
 
+  # https://github.com/madler/zlib/commit/60ab906ea29f4f67204c4398be4ec5af8d7e87c7
+  # Fix s390x vectorized CRC32 build by passing VGFMAFLAG through configure.
+  patches = lib.optional stdenv.hostPlatform.isS390 ./fix-s390x-vgfmaflag.patch;
+
   postPatch = ''
     substituteInPlace configure \
       --replace-fail '/usr/bin/libtool' '${stdenv.cc.targetPrefix}ar' \

--- a/pkgs/development/libraries/zlib/fix-s390x-vgfmaflag.patch
+++ b/pkgs/development/libraries/zlib/fix-s390x-vgfmaflag.patch
@@ -1,0 +1,20 @@
+diff --git a/configure b/configure
+index bc723443e..4e6c8d85b 100755
+--- a/configure
++++ b/configure
+@@ -1024,6 +1024,7 @@ sed < ${SRCDIR}Makefile.in "
+ /^LDFLAGS *=/s#=.*#=$LDFLAGS#
+ /^LDSHARED *=/s#=.*#=$LDSHARED#
+ /^CPP *=/s#=.*#=$CPP#
++/^VGFMAFLAG *=/s#=.*#=$VGFMAFLAG#
+ /^STATICLIB *=/s#=.*#=$STATICLIB#
+ /^SHAREDLIB *=/s#=.*#=$SHAREDLIB#
+ /^SHAREDLIBV *=/s#=.*#=$SHAREDLIBV#
+@@ -1054,6 +1055,7 @@ sed < ${SRCDIR}zlib.pc.in "
+ /^CC *=/s#=.*#=$CC#
+ /^CFLAGS *=/s#=.*#=$CFLAGS#
+ /^CPP *=/s#=.*#=$CPP#
++/^VGFMAFLAG *=/s#=.*#=$VGFMAFLAG#
+ /^LDSHARED *=/s#=.*#=$LDSHARED#
+ /^STATICLIB *=/s#=.*#=$STATICLIB#
+ /^SHAREDLIB *=/s#=.*#=$SHAREDLIB#


### PR DESCRIPTION
zlib 1.3.2 added `crc32_vx.c` which uses s390x vector builtins (`__builtin_s390_vec_insert`, etc.) that require the `-mvx` compiler flag. The zlib configure script sets `VGFMAFLAG` for this purpose, but during cross-compilation the flag does not get propagated correctly, causing the build to fail with:

```
error: '__builtin_s390_vec_insert' requires '-mvx'
```

This adds `--disable-crcvx` to the configure flags when cross-compiling for s390x to fix the build.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test