### PR TITLE
python3Packages.napari-console: relax dependency, python3Packages.napari-npe2: 0.8.0 -> 0.8.1, napari: 0.6.6 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/napari-console/default.nix
+++ b/pkgs/development/python-modules/napari-console/default.nix
@@ -14,7 +14,7 @@
   qtpy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "napari-console";
   version = "0.1.4";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "napari";
     repo = "napari-console";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-z1pyG31g+fvTNLbWc2W56zDf33HCx8PvPKwIIc/x2VA=";
   };
 
@@ -31,6 +31,9 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
+  pythonRelaxDeps = [
+    "ipykernel"
+  ];
   dependencies = [
     ipykernel
     ipython
@@ -47,4 +50,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ SomeoneSerge ];
   };
-}
+})

--- a/pkgs/development/python-modules/napari-npe2/default.nix
+++ b/pkgs/development/python-modules/napari-npe2/default.nix
@@ -15,6 +15,7 @@
   pydantic-extra-types,
   pyyaml,
   rich,
+  tomli,
   tomli-w,
   typer,
 
@@ -33,14 +34,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "napari-npe2";
-  version = "0.8.0";
+  version = "0.8.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "napari";
     repo = "npe2";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-aZOs9wTYcblt9EZftYHKFWI/GvpZcC2KqVTAis15+Iw=";
+    hash = "sha256-cR7hf5v+RgcENY3rSHnOB4E/TONVYvHKS5i3Kv1Sbuc=";
   };
 
   build-system = [
@@ -56,6 +57,7 @@ buildPythonPackage (finalAttrs: {
     pydantic-extra-types
     pyyaml
     rich
+    tomli
     tomli-w
     typer
   ];

--- a/pkgs/development/python-modules/napari/default.nix
+++ b/pkgs/development/python-modules/napari/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonAtLeast,
   fetchFromGitHub,
 
   # build-system
@@ -24,12 +23,13 @@
   napari-console,
   napari-npe2,
   napari-svg,
-  numpydoc,
   pandas,
   pillow,
   pint,
   psutil,
   pydantic,
+  pydantic-extra-types,
+  pydantic-settings,
   pyopengl,
   pyyaml,
   scikit-image,
@@ -44,6 +44,7 @@
 
   # tests
   hypothesis,
+  pooch,
   pretend,
   pyautogui,
   pytest-pretty,
@@ -56,18 +57,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "napari";
-  version = "0.6.6";
+  version = "0.7.0";
   pyproject = true;
-
-  # napari uses pydantic v1 which is not compatible with python 3.14
-  # ValueError: '__slots__' in __slots__ conflicts with class variable
-  disabled = pythonAtLeast "3.14";
 
   src = fetchFromGitHub {
     owner = "napari";
     repo = "napari";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-F0l6GWyZ6n4HNZW7XyUk4ZBPQfrAW4DWixCaRHViDPI=";
+    hash = "sha256-fDt9n4+yQcA03IO7sMhcpiP3TfOWfyvbCjY7ImEj+Qg=";
   };
 
   postPatch = ''
@@ -86,11 +83,6 @@ buildPythonPackage (finalAttrs: {
     qt6.qtbase
   ];
 
-  pythonRelaxDeps = [
-    "app-model"
-    "psygnal"
-    "vispy"
-  ];
   dependencies = [
     app-model
     appdirs
@@ -104,12 +96,13 @@ buildPythonPackage (finalAttrs: {
     napari-console
     napari-npe2
     napari-svg
-    numpydoc
     pandas
     pillow
     pint
     psutil
     pydantic
+    pydantic-extra-types
+    pydantic-settings
     pyopengl
     pyyaml
     scikit-image
@@ -134,6 +127,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     hypothesis
+    pooch
     pretend
     pyautogui
     pytest-pretty
@@ -189,6 +183,7 @@ buildPythonPackage (finalAttrs: {
     # Fatal Python error: Aborted
     "test_add_layer_data_to_viewer_optional"
     "test_from_layer_data_tuple_accept_deprecating_dict"
+    "test_layer_rename_updates_combobox"
     "test_layers_populate_immediately"
     "test_magicgui_add_data"
     "test_magicgui_add_future_data"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.napari-console: relax dependency**
- **python3Packages.napari-npe2: 0.8.0 -> 0.8.1**
    - Changelog: https://github.com/napari/npe2/releases/tag/v0.8.1
    - Diff: https://github.com/napari/npe2/compare/v0.8.0...v0.8.1
- **napari: 0.6.6 -> 0.7.0**
    - Changelog: https://github.com/napari/napari/releases/tag/v0.7.0
    - Diff: Diff: https://github.com/napari/napari/compare/v0.6.6...v0.7.0

---

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
