### PR TITLE
buffybox: 3.4.2-unstable-2025-10-25 -> 3.5.1

### DIFF
--- a/pkgs/by-name/bu/buffybox/package.nix
+++ b/pkgs/by-name/bu/buffybox/package.nix
@@ -1,5 +1,6 @@
 {
   fetchFromGitLab,
+  fetchpatch,
   inih,
   lib,
   libdrm,
@@ -15,17 +16,35 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "buffybox";
-  version = "3.4.2-unstable-2025-10-25";
-  # 3.4.2 would be preferred but there are 3 commits past 3.4.2 that are really nice to have
+  version = "3.5.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.postmarketos.org";
     owner = "postmarketOS";
     repo = "buffybox";
     fetchSubmodules = true; # to use its vendored lvgl
-    rev = "437ff2cbd7fd35ba6ca2d46624e7fcf8c5f3f954";
-    hash = "sha256-1GRsntNc3byHmZKLG/ZRXvbo96DjmLrA0bVYtMAlKsQ=";
+    tag = finalAttrs.version;
+    hash = "sha256-aOPfKqnUIkJozt+DwVJjbNQEcmpjCmUgJUjTx9LV23M=";
   };
+
+  mesonFlags = [
+    (lib.mesonBool "systemd" true)
+  ];
+
+  patches = [
+    /*
+      There's a close to zero chance that anyone with a 32-bit machine will be using BuffyBox.
+      In the case that it happens, I expect no complaints whatsoever.
+
+      https://gitlab.postmarketos.org/postmarketOS/buffybox/-/merge_requests/87
+    */
+
+    (fetchpatch {
+      name = "fix-32-bit-build";
+      url = "https://gitlab.postmarketos.org/postmarketOS/buffybox/-/merge_requests/87.patch";
+      hash = "sha256-GUk+YrG07hL+0w70qvymPzHGTmUXdfzG4Cy35gg/Asw=";
+    })
+  ];
 
   depsBuildBuild = [
     pkg-config
@@ -54,6 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Suite of graphical applications for the terminal";
     homepage = "https://gitlab.postmarketos.org/postmarketOS/buffybox";
+    changelog = "https://gitlab.postmarketos.org/postmarketOS/buffybox/-/blob/main/CHANGELOG.md";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ colinsane ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Bumps unl0kr to 3.5.1. Keys dropping are supposed to not be an issue anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
