### PR TITLE
home-assistant-custom-components.frigate: fix build

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/frigate/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/frigate/package.nix
@@ -28,6 +28,11 @@ buildHomeAssistantComponent rec {
     hash = "sha256-fgsYznTqJrEh4niyGfksnflRp1PpljrlzJBvs8gKn54=";
   };
 
+  patches = [
+    # https://github.com/blakeblackshear/frigate-hass-integration/pull/1070
+    ./service-to-action.patch
+  ];
+
   dependencies = [
     hass-web-proxy-lib
     titlecase

--- a/pkgs/servers/home-assistant/custom-components/frigate/service-to-action.patch
+++ b/pkgs/servers/home-assistant/custom-components/frigate/service-to-action.patch
@@ -1,0 +1,21 @@
+index 9d3ba82..dabf566 100644
+--- a/tests/test_integration_services.py
++++ b/tests/test_integration_services.py
+@@ -137,7 +137,7 @@ async def test_review_summarize_service_version_check(
+     await setup_mock_frigate_config_entry(hass, client=client)
+ 
+     # Verify service is not available (should not be registered for version < 0.17)
+-    with pytest.raises(Exception, match="service_not_found"):
++    with pytest.raises(Exception, match="Action frigate.review_summarize not found"):
+         await hass.services.async_call(
+             "frigate",
+             SERVICE_REVIEW_SUMMARIZE,
+@@ -156,7 +156,7 @@ async def test_review_summarize_service_no_integration(
+     # Don't set up any Frigate integration
+ 
+     # When no integration is configured, the service won't exist
+-    with pytest.raises(Exception, match="service_not_found"):
++    with pytest.raises(Exception, match="Action frigate.review_summarize not found"):
+         await hass.services.async_call(
+             "frigate",
+             SERVICE_REVIEW_SUMMARIZE,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
