### PR TITLE
zinit: refactor to allow darwin builds

### DIFF
--- a/pkgs/by-name/zi/zinit/package.nix
+++ b/pkgs/by-name/zi/zinit/package.nix
@@ -20,19 +20,23 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "man"
+    "doc"
   ];
 
   strictDeps = true;
 
   nativeBuildInputs = [ installShellFiles ];
 
+  dontBuild = true;
+
   installPhase = ''
     runHook preInstall
 
     # Source files
     mkdir -p $out/share/zinit
-    install -m0644 zinit{,-side,-install,-autoload}.zsh _zinit $out/share/zinit
+    install -m0644 zinit{,-side,-install,-autoload,-additional}.zsh _zinit $out/share/zinit
     install -m0755 share/git-process-output.zsh $out/share/zinit
+    install -m0644 share/rpm2cpio.zsh $out/share/zinit
 
     # Autocompletion
     installShellCompletion --zsh _zinit
@@ -40,6 +44,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # Manpage
     mkdir -p ${placeholder "man"}/share/man/man{1..9}
     installManPage doc/zinit.1
+
+    mkdir -p $doc/share/doc/zinit
+    install -m0644 doc/zsdoc/*.adoc $doc/share/doc/zinit
+    install -m0644 doc/HACKING.md $doc/share/doc/zinit
 
     runHook postInstall
   '';
@@ -51,8 +59,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --replace-fail "ZINIT[MAN_DIR]:=\''${ZPFX}/man" "ZINIT[MAN_DIR]:=${placeholder "man"}/share/man"
   '';
 
-  #TODO: output doc through zshelldoc
-
   passthru = {
     updateScript = nix-update-script { };
   };
@@ -60,11 +66,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://github.com/zdharma-continuum/zinit";
     description = "Flexible zsh plugin manager";
+    changelog = "https://github.com/zdharma-continuum/zinit/blob/${finalAttrs.src.rev}/doc/CHANGELOG.md";
     license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       pasqui23
       sei40kr
       moraxyc
+      kaynetik
     ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
