### PR TITLE
tfenv: init at 3.0.0

### DIFF
--- a/pkgs/by-name/tf/tfenv/package.nix
+++ b/pkgs/by-name/tf/tfenv/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  nix-update-script,
+  unzip,
+  curl,
+  gnugrep,
+  gnused,
+  gawk,
+  coreutils,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tfenv";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "tfutils";
+    repo = "tfenv";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-2Fpaj/UQDE7PNFX9GNr4tygvKmm/X0yWVVerJ+Y6eks=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib $out/libexec $out/share
+
+    cp -r lib/* $out/lib/
+    cp -r libexec/* $out/libexec/
+    cp -r share/* $out/share/
+
+    install -m0644 CHANGELOG.md $out/CHANGELOG.md
+
+    install -m0755 bin/tfenv $out/bin/tfenv
+    install -m0755 bin/terraform $out/bin/terraform
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    for f in $out/bin/* $out/libexec/*; do
+      [ -f "$f" ] || continue
+      wrapProgram "$f" \
+        --prefix PATH : "${
+          lib.makeBinPath [
+            unzip
+            curl
+            gnugrep
+            gnused
+            gawk
+            coreutils
+          ]
+        }"
+    done
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terraform version manager";
+    homepage = "https://github.com/tfutils/tfenv";
+    changelog = "https://github.com/tfutils/tfenv/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kaynetik ];
+    mainProgram = "tfenv";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Add [tfenv](https://github.com/tfutils/tfenv), a Terraform version manager (bash-based, similar in spirit to rbenv).

- Install layout mirrors upstream: `bin/`, `lib/`, `libexec/`, `share/`, plus `CHANGELOG.md` at the store root so `tfenv --version` works.
- Wrap `bin` and `libexec` scripts with common runtime tools (`curl`, `unzip`, GNU grep/sed/awk, `coreutils`).
- `passthru.updateScript` via `nix-update-script` for r-ryantm / manual `nix-update`.

**Usage**

- `environment.systemPackages` / `home.packages`: add `pkgs.tfenv`.
- Put `$out/bin` on `PATH` (or rely on the profile), then use `tfenv install`, `tfenv use`, and the `terraform` shim as in upstream docs. Versions and state live under tfenv’s config (e.g. `TFENV_CONFIG_DIR` / default under the user’s home), not inside the nix store for installed Terraform binaries.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
