### PR TITLE
beedii: modernize

### DIFF
--- a/pkgs/by-name/be/beedii/package.nix
+++ b/pkgs/by-name/be/beedii/package.nix
@@ -2,26 +2,23 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
   gitUpdater,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "beedii";
   version = "1.0.0";
 
   src = fetchzip {
-    url = "https://github.com/webkul/beedii/releases/download/v${version}/beedii.zip";
+    url = "https://github.com/webkul/beedii/releases/download/v${finalAttrs.version}/beedii.zip";
     hash = "sha256-MefkmWl7LdhQiePpixKcatoIeOTlrRaO3QA9xWAxJ4Q=";
     stripRoot = false;
   };
 
-  installPhase = ''
-    runHook preInstall
+  sourceRoot = "${finalAttrs.src.name}/Fonts";
 
-    install -Dm444 Fonts/*.ttf -t $out/share/fonts/truetype/${pname}
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   passthru.updateScript = gitUpdater {
     url = "https://github.com/webkul/beedii";
@@ -41,4 +38,4 @@ stdenvNoCC.mkDerivation rec {
       kachick
     ];
   };
-}
+})


### PR DESCRIPTION
* Use `installFonts` as a part of https://github.com/NixOS/nixpkgs/issues/495640
* Switch to `finalAttrs`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
