### PR TITLE
python3Packages.pgvector: use lib.meta.availableOn to only run tests when supported

### DIFF
--- a/pkgs/development/python-modules/pgvector/default.nix
+++ b/pkgs/development/python-modules/pgvector/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -59,6 +60,8 @@ buildPythonPackage rec {
     sqlalchemy
     sqlmodel
   ];
+
+  doCheck = lib.meta.availableOn stdenv.buildPlatform postgresqlTestHook;
 
   env = {
     PGDATABASE = "pgvector_python_test";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Use `lib.meta.availableOn` to only run `postgresqlTestHook` test when supported, to fix `aarch64-darwin` build failing with:

```sh
error: Refusing to evaluate package 'postgresql-test-hook' in /Users/shivaraj/oss/nixpkgs/pkgs/by-name/po/postgresqlTestHook/package.nix:8 because it is not available on the requested hostPlatform:
         hostPlatform.system = "aarch64-darwin"
         package.meta.platforms = [ ]
         package.meta.badPlatforms = [
           "x86_64-darwin"
           "aarch64-darwin"
         ]
```

Closes https://github.com/NixOS/nixpkgs/issues/374254

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
