### PR TITLE
smiley-sans: use installFonts hook

### DIFF
--- a/pkgs/by-name/sm/smiley-sans/package.nix
+++ b/pkgs/by-name/sm/smiley-sans/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchzip,
   nix-update-script,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -15,13 +16,12 @@ stdenvNoCC.mkDerivation rec {
     stripRoot = false;
   };
 
-  installPhase = ''
-    runHook preInstall
-    install -Dm644 -t $out/share/fonts/opentype *.otf
-    install -Dm644 -t $out/share/fonts/truetype *.ttf
-    install -Dm644 -t $out/share/fonts/woff2 *.woff2
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/sm/smiley-sans/package.nix
+++ b/pkgs/by-name/sm/smiley-sans/package.nix
@@ -30,7 +30,7 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://atelier-anchor.com/typefaces/smiley-sans/";
     changelog = "https://github.com/atelier-anchor/smiley-sans/blob/main/CHANGELOG.md";
     license = lib.licenses.ofl;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ pancaek ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/sm/smiley-sans/package.nix
+++ b/pkgs/by-name/sm/smiley-sans/package.nix
@@ -6,12 +6,12 @@
   installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "smiley-sans";
   version = "2.0.1";
 
   src = fetchzip {
-    url = "https://github.com/atelier-anchor/smiley-sans/releases/download/v${version}/smiley-sans-v${version}.zip";
+    url = "https://github.com/atelier-anchor/smiley-sans/releases/download/v${finalAttrs.version}/smiley-sans-v${finalAttrs.version}.zip";
     sha256 = "sha256-p6DwX5MBPemAfV99L9ayLkEWro31ip4tf+wBQr8mkbs=";
     stripRoot = false;
   };
@@ -33,4 +33,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with lib.maintainers; [ pancaek ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Tracking https://github.com/NixOS/nixpkgs/issues/495640
I've added `outputs = [ "webfont" ]`~~, but I wasn't able to find where they go, if anyone has the answer I'd love to know~~
Added @pancaek as maintainer as per https://github.com/NixOS/nixpkgs/issues/495640#issuecomment-3981346307

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
