### PR TITLE
xkcd-font: use installFonts hook

### DIFF
--- a/pkgs/by-name/xk/xkcd-font/package.nix
+++ b/pkgs/by-name/xk/xkcd-font/package.nix
@@ -29,6 +29,6 @@ stdenvNoCC.mkDerivation {
     homepage = "https://github.com/ipython/xkcd-font";
     license = lib.licenses.cc-by-nc-30;
     platforms = lib.platforms.all;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ pancaek ];
   };
 }

--- a/pkgs/by-name/xk/xkcd-font/package.nix
+++ b/pkgs/by-name/xk/xkcd-font/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation {
@@ -15,14 +16,14 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-1DgSx2L+OpXuPVSXbbl/hcZUyBK9ikPyGWuk6wNzlwc=";
   };
 
-  installPhase = ''
-    runHook preInstall
+  preInstall = "rm xkcd/build/xkcd.otf";
 
-    install -Dm444 -t $out/share/fonts/opentype/ xkcd/build/xkcd.otf
-    install -Dm444 -t $out/share/fonts/truetype/ xkcd-script/font/xkcd-script.ttf
+  nativeBuildInputs = [ installFonts ];
 
-    runHook postInstall
-  '';
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
   meta = {
     description = "Xkcd font";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Tracking https://github.com/NixOS/nixpkgs/issues/495640
Added @pancaek as maintainer as per https://github.com/NixOS/nixpkgs/issues/495640#issuecomment-3981346307

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
