### PR TITLE
buildkite-agent: 3.89.0 -> 3.121.0

### DIFF
--- a/pkgs/by-name/bu/buildkite-agent/package.nix
+++ b/pkgs/by-name/bu/buildkite-agent/package.nix
@@ -14,16 +14,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "buildkite-agent";
-  version = "3.89.0";
+  version = "3.121.0";
 
   src = fetchFromGitHub {
     owner = "buildkite";
     repo = "agent";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-5COo5vXecXLhYAy3bcaYvmluFdfEKGgiTbhat8T3AV8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QlslPoLpqzuX05bp58xz/3Vhj0imEqCleO1hhe1PPXM=";
   };
 
-  vendorHash = "sha256-iYc/TWiUFdlgoGB4r/L28yhwQG7g+tBG8usB77JJncM=";
+  vendorHash = "sha256-rv5CqNpjmXhGcZ3KQBX0Z2428upWBUVkdRjEG4QWEoY=";
 
   postPatch = ''
     substituteInPlace clicommand/agent_start.go --replace /bin/bash ${bash}/bin/bash


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/buildkite/agent/releases/tag/v3.121.0
Diff: https://github.com/buildkite/agent/compare/v3.89.0...v3.121.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result for [#505717](https://github.com/NixOS/nixpkgs/pull/505717)

Generated using [`nixpkgs-review-gha`](https://github.com/Defelo/nixpkgs-review-gha)

Command: `nixpkgs-review pr 505717`
Commit: [`2ddafdee9a2207df0ff28d1a810ee4c86d2406b4`](https://github.com/NixOS/nixpkgs/commit/2ddafdee9a2207df0ff28d1a810ee4c86d2406b4) ([subsequent changes](https://github.com/NixOS/nixpkgs/compare/2ddafdee9a2207df0ff28d1a810ee4c86d2406b4..pull/505717/head))
Merge: [`fc89378508319486bf5b75034fbdcc6326253c8f`](https://github.com/NixOS/nixpkgs/commit/fc89378508319486bf5b75034fbdcc6326253c8f)

Logs: https://github.com/cbrxyz/nixpkgs-review-gha/actions/runs/23856396506


---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>buildkite-agent</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>buildkite-agent</li>
  </ul>
</details>

---
### `x86_64-darwin` (sandbox = true)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>buildkite-agent</li>
  </ul>
</details>

---
### `aarch64-darwin` (sandbox = true)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>buildkite-agent</li>
  </ul>
</details>
