### PR TITLE
garble: 0.14.1 -> 0.15.0

### DIFF
--- a/pkgs/by-name/ga/garble/0001-Add-version-info.patch
+++ b/pkgs/by-name/ga/garble/0001-Add-version-info.patch
@@ -1,38 +1,21 @@
-From e46a41faac008ede4acbeb18db5b3076eb206de5 Mon Sep 17 00:00:00 2001
-From: wxt <3264117476@qq.com>
-Date: Sun, 3 Nov 2024 15:11:49 +0800
-Subject: [PATCH] Add version info
-
----
- main.go                    | 1 +
- testdata/script/help.txtar | 2 +-
- 2 files changed, 2 insertions(+), 1 deletion(-)
-
-diff --git a/main.go b/main.go
-index 0de5a2f..1c830b1 100644
 --- a/main.go
 +++ b/main.go
-@@ -362,6 +362,7 @@ func mainErr(args []string) error {
- 		// manually construct something like a pseudo-version.
- 		// TODO: remove when this code is dead, hopefully in Go 1.22.
- 		if mod.Version == "(devel)" {
-+			mod.Version = "@version@"
- 			var vcsTime time.Time
- 			var vcsRevision string
- 			for _, setting := range info.Settings {
-diff --git a/testdata/script/help.txtar b/testdata/script/help.txtar
-index 8f25260..859f492 100644
+@@ -370,6 +370,7 @@
+ 			mod = mod.Replace
+ 		}
+ 
++		mod.Version = "@version@"
+ 		fmt.Printf("%s %s\n\n", mod.Path, mod.Version)
+ 		fmt.Printf("Build settings:\n")
+ 		for _, setting := range info.Settings {
 --- a/testdata/script/help.txtar
 +++ b/testdata/script/help.txtar
-@@ -91,7 +91,7 @@ stderr 'directory not found'
- # and to be able to use static VCS info, use an environment variable.
- # First, test without the information, and then with it.
+@@ -88,7 +88,7 @@
+ # Test the version command. Note that test binaries exclude VCS build info,
+ # and we reuse the test binary for garble itself, so that's missing.
  exec garble version
 -stdout -count=1 'mvdan.cc/garble \(devel\)'
 +stdout -count=1 'mvdan.cc/garble @version@'
  stdout -count=1 'Build settings'
  stdout -count=3 '-compiler|GOOS|GOARCH'
  ! stdout 'vcs'
--- 
-2.46.1
-

--- a/pkgs/by-name/ga/garble/package.nix
+++ b/pkgs/by-name/ga/garble/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  buildGoModule,
+  buildGo125Module,
   fetchFromGitHub,
   git,
   versionCheckHook,
@@ -9,15 +9,15 @@
   nix-update-script,
 }:
 
-buildGoModule (finalAttrs: {
+buildGo125Module (finalAttrs: {
   pname = "garble";
-  version = "0.14.1";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "burrowers";
     repo = "garble";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zS/K2kOpWhJmr0NuWSjEjNXV8ILt81yLIQWSPDuMwt8=";
+    hash = "sha256-9Vjv5Eis+ALUm2aaXOj4i8w3UmylPggMXqgwXtD2YA8=";
   };
 
   __darwinAllowLocalNetworking = true;
@@ -34,10 +34,10 @@ buildGoModule (finalAttrs: {
 
   checkFlags = [
     "-skip"
-    "TestScript/gogarble"
+    "TestScript/gogarble|TestScript/gotoolchain|TestScript/tiny"
   ];
 
-  vendorHash = "sha256-xxG1aQrALVuJ7oVn+Z+sH655eFQ7rcYFmymGCUZD1uU=";
+  vendorHash = "sha256-EOmAb2k9LSzsvumsCZdeJIDKQBJBeRFt15mWAyyVl1k=";
 
   # Used for some of the tests.
   nativeCheckInputs = [


### PR DESCRIPTION
- Diff: https://github.com/burrowers/garble/compare/v0.14.1...v0.15.0
- Changelog: https://github.com/burrowers/garble/releases/tag/v0.15.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
