### PR TITLE
whatsie: 4.16.3 -> 5.0.0

### DIFF
--- a/pkgs/by-name/wh/whatsie/package.nix
+++ b/pkgs/by-name/wh/whatsie/package.nix
@@ -2,64 +2,37 @@
   fetchFromGitHub,
   lib,
   stdenv,
-  makeDesktopItem,
-  copyDesktopItems,
+  cmake,
   libx11,
   libxcb,
-  qt5,
+  qt6,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "whatsie";
-  version = "4.16.3";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "keshavbhatt";
     repo = "whatsie";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-F6hQY3Br0iFDYkghBgRAyzLW6QhhG8UHOgkEgDjeQLg=";
+    hash = "sha256-GVXwZZFfPqAmBrP95zleHc2PpMMBj/8xZdW4JpFdYVs=";
   };
-
-  sourceRoot = "${finalAttrs.src.name}/src";
-
-  desktopItems = [
-    (makeDesktopItem {
-      name = "whatsie";
-      desktopName = "Whatsie";
-      icon = "whatsie";
-      exec = "whatsie";
-      comment = finalAttrs.meta.description;
-    })
-  ];
 
   buildInputs = [
     libx11
     libxcb
-    qt5.qtwebengine
+    qt6.qtwebengine
   ];
 
   nativeBuildInputs = [
-    copyDesktopItems
-    qt5.wrapQtAppsHook
-    qt5.qmake
+    cmake
+    qt6.wrapQtAppsHook
   ];
 
-  strictDeps = false;
+  strictDeps = true;
 
   enableParallelBuilding = true;
-
-  preBuild = ''
-    export QT_WEBENGINE_ICU_DATA_DIR=${qt5.qtwebengine.out}/resources
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm755 whatsie -t $out/bin
-    install -Dm644 $src/snap/gui/icon.svg $out/share/icons/hicolor/scalable/apps/whatsie.svg
-
-    runHook postInstall
-  '';
 
   meta = {
     homepage = "https://github.com/keshavbhatt/whatsie";


### PR DESCRIPTION
So we can get closer to dropping Qt5 WebEngine: #480196

<img width="806" height="977" alt="image" src="https://github.com/user-attachments/assets/dc582038-a4ff-4c4a-95af-10b4d7561f10" />

Have not tested any functionality beyond startup, as I do not use WhatsApp. Upstream now ships a .desktop file with desktop actions defined, so opting to drop our custom one.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
