### PR TITLE
python3Packages.psptool: init at 3.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19690,6 +19690,12 @@
     githubId = 6930756;
     name = "Nicolas Mattia";
   };
+  nmetschke = {
+    email = "niclas.metschke+nix@protonmail.com";
+    github = "nmetschke";
+    githubId = 94750751;
+    name = "Niclas Metschke";
+  };
   nmishin = {
     email = "sanduku.default@gmail.com";
     github = "Nmishin";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19948,6 +19948,12 @@
     githubId = 6930756;
     name = "Nicolas Mattia";
   };
+  nmetschke = {
+    email = "niclas.metschke+nix@protonmail.com";
+    github = "nmetschke";
+    githubId = 94750751;
+    name = "Niclas Metschke";
+  };
   nmishin = {
     email = "sanduku.default@gmail.com";
     github = "Nmishin";

--- a/pkgs/development/python-modules/psptool/default.nix
+++ b/pkgs/development/python-modules/psptool/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  hatch-vcs,
+  cryptography,
+  prettytable,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "psptool";
+  version = "3.6";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-ULSSN48sIWxkvhL9afcwAHdOarBa4jJOowNaxz5kwbQ=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = [
+    cryptography
+    prettytable
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export PATH="$PATH:$out/bin"
+  '';
+
+  disabledTestPaths = [
+    # the integration test require ROM files from a private submodule
+    "tests/integration"
+  ];
+
+  meta = {
+    description = "PSPTool is a tool for dealing with AMD binary blobs";
+    homepage = "https://github.com/PSPReverse/PSPTool";
+    license = lib.licenses.gpl3;
+    mainProgram = "psptool";
+    maintainers = with lib.maintainers; [
+      nmetschke
+    ];
+  };
+})

--- a/pkgs/development/python-modules/psptool/default.nix
+++ b/pkgs/development/python-modules/psptool/default.nix
@@ -1,0 +1,59 @@
+{
+  buildPythonPackage,
+  cryptography,
+  fetchPypi,
+  hatch-vcs,
+  hatchling,
+  lib,
+  prettytable,
+  pytestCheckHook,
+  versionCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "psptool";
+  version = "3.6";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-ULSSN48sIWxkvhL9afcwAHdOarBa4jJOowNaxz5kwbQ=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = [
+    cryptography
+    prettytable
+  ];
+
+  pythonImportChecks = [ "psptool.PSPTool" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    versionCheckHook
+  ];
+
+  # needed for cli test
+  preCheck = ''
+    export PATH="$PATH:$out/bin"
+  '';
+
+  disabledTestPaths = [
+    # the integration test require ROM files from a private submodule
+    "tests/integration"
+  ];
+
+  meta = {
+    description = "PSPTool is a tool for dealing with AMD binary blobs";
+    homepage = "https://github.com/PSPReverse/PSPTool";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "psptool";
+    maintainers = with lib.maintainers; [
+      nmetschke
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13011,6 +13011,8 @@ self: super: with self; {
 
   psnawp = callPackage ../development/python-modules/psnawp { };
 
+  psptool = callPackage ../development/python-modules/psptool { };
+
   psrpcore = callPackage ../development/python-modules/psrpcore { };
 
   psutil = callPackage ../development/python-modules/psutil { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13236,6 +13236,8 @@ self: super: with self; {
 
   psnawp = callPackage ../development/python-modules/psnawp { };
 
+  psptool = callPackage ../development/python-modules/psptool { };
+
   psrpcore = callPackage ../development/python-modules/psrpcore { };
 
   psutil = callPackage ../development/python-modules/psutil { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [PSPTool](https://github.com/PSPReverse/PSPTool). From the projects README: 
>PSPTool is a Swiss Army knife for dealing with firmware of the **AMD Secure Processor (ASP)**, formerly known as *Platform Security Processor* or **PSP**. It can parse, extract, and replace AMD firmware inside  **UEFI images** as part of BIOS updates targeting **AMD platforms**.

It can be used from the command line or as a Python module. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
