### PR TITLE
pcloud: 2.0.3 -> 2.0.4

### DIFF
--- a/pkgs/by-name/pc/pcloud/package.nix
+++ b/pkgs/by-name/pc/pcloud/package.nix
@@ -40,13 +40,13 @@
 
 let
   pname = "pcloud";
-  version = "2.0.3";
-  code = "XZ8opl5ZaaYsnBeCX3fLU3v8ngqAv8VMqq7k";
+  version = "2.0.4";
+  code = "XZNttt5ZD5h5yXmbVPHHIIr4nEUwduLH837X";
 
   # Archive link's codes: https://www.pcloud.com/release-notes/linux.html
   src = fetchzip {
     url = "https://api.pcloud.com/getpubzip?code=${code}&filename=pcloud-${version}.zip";
-    hash = "sha256-Few8BsMUwL5qfdtFyezoWifZcZufAhUthxQXEQwm52w=";
+    hash = "sha256-VINx6xM8/unPC9xopV2ml64wqU0FdhZdGTnxLUpCiyY=";
   };
 
 in


### PR DESCRIPTION
[Changelog:](https://www.pcloud.com/release-notes/linux.html)

- 2.0.4 (31/03/2026)
  - This update improves overall performance and reliability. We’ve fixed issues affecting sync stability, Crypto folder crashes, and peer-to-peer connections.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
