### PR TITLE
caprice32: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ca/caprice32/cstdint.patch
+++ b/pkgs/by-name/ca/caprice32/cstdint.patch
@@ -1,0 +1,10 @@
+--- a/src/cartridge.cpp
++++ b/src/cartridge.cpp
+@@ -7,6 +7,7 @@
+ #include <cstring>
+ #include <algorithm>
+ #include <memory>
++#include <cstdint>
+ 
+ const uint32_t CARTRIDGE_NB_PAGES = 32;
+ const uint32_t CARTRIDGE_PAGE_SIZE = 16*1024;

--- a/pkgs/by-name/ca/caprice32/package.nix
+++ b/pkgs/by-name/ca/caprice32/package.nix
@@ -38,7 +38,10 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
-  patches = [ ./string.patch ];
+  patches = [
+    ./string.patch
+    ./cstdint.patch
+  ];
 
   makeFlags = [
     "APP_PATH=${placeholder "out"}/share/caprice32"


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324209865

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
