### PR TITLE
pomerium: 0.30.5 -> 0.32.4

### DIFF
--- a/pkgs/by-name/po/pomerium/0001-envoy-allow-specification-of-external-binary.patch
+++ b/pkgs/by-name/po/pomerium/0001-envoy-allow-specification-of-external-binary.patch
@@ -4,46 +4,41 @@ Date: Sun, 26 May 2024 12:17:01 -0500
 Subject: [PATCH] envoy: allow specification of external binary
 
 ---
- pkg/envoy/envoy.go | 20 ++++++++++++++++----
- 1 file changed, 16 insertions(+), 4 deletions(-)
+ pkg/envoy/envoy.go | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
 
 diff --git a/pkg/envoy/envoy.go b/pkg/envoy/envoy.go
 index 85c725629..4a726a44b 100644
 --- a/pkg/envoy/envoy.go
 +++ b/pkg/envoy/envoy.go
-@@ -8,9 +8,9 @@ import (
+@@ -8,10 +8,10 @@ import (
  	"errors"
  	"fmt"
  	"io"
 +	"io/fs"
+ 	"net"
+ 	"net/http"
+ 	"net/url"
  	"os"
  	"os/exec"
 -	"path"
  	"path/filepath"
- 	"regexp"
- 	"runtime"
-@@ -36,8 +36,17 @@ import (
- 
- const (
+@@ -44,6 +44,11 @@ const (
  	configFileName = "envoy-config.yaml"
-+	workingDirectoryName = ".pomerium-envoy"
-+	embeddedEnvoyPermissions     fs.FileMode = 0o700
  )
- 
+
 +var OverrideEnvoyPath = ""
 +
-+type serverOptions struct {
-+	services string
-+	logLevel config.LogLevel
-+}
++const workingDirectoryName = ".pomerium-envoy"
++const embeddedEnvoyPermissions fs.FileMode = 0o700
 +
  // A Server is a pomerium proxy implemented via envoy.
  type Server struct {
  	ServerOptions
-@@ -95,14 +104,17 @@ func NewServer(ctx context.Context, src config.Source, builder *envoyconfig.Buil
+@@ -100,14 +105,17 @@ func NewServer(
  		log.Ctx(ctx).Debug().Err(err).Msg("couldn't preserve RLIMIT_NOFILE before starting Envoy")
  	}
- 
+
 -	envoyPath, err := Extract()
 +	envoyPath := OverrideEnvoyPath
 +	wd := filepath.Join(os.TempDir(), workingDirectoryName)
@@ -53,14 +48,14 @@ index 85c725629..4a726a44b 100644
 -		return nil, fmt.Errorf("extracting envoy: %w", err)
 +		return nil, fmt.Errorf("error creating temporary working directory for envoy: %w", err)
  	}
- 
+
  	srv := &Server{
- 		ServerOptions: options,
--		wd:            path.Dir(envoyPath),
-+		wd:            wd,
- 		builder:       builder,
- 		grpcPort:      src.GetConfig().GRPCPort,
- 		httpPort:      src.GetConfig().HTTPPort,
--- 
+ 		ServerOptions:        options,
+-		wd:                   path.Dir(envoyPath),
++		wd:                   wd,
+ 		builder:              builder,
+ 		grpcPort:             src.GetConfig().GRPCPort,
+ 		httpPort:             src.GetConfig().HTTPPort,
+--
 2.49.0
 

--- a/pkgs/by-name/po/pomerium/package.nix
+++ b/pkgs/by-name/po/pomerium/package.nix
@@ -4,9 +4,8 @@
   fetchFromGitHub,
   lib,
   envoy,
-  yarnConfigHook,
-  yarnBuildHook,
-  fetchYarnDeps,
+  npmHooks,
+  fetchNpmDeps,
   nodejs,
   nixosTests,
   pomerium-cli,
@@ -22,31 +21,36 @@ let
 in
 buildGoModule rec {
   pname = "pomerium";
-  version = "0.30.5";
+  version = "0.32.4";
   src = fetchFromGitHub {
     owner = "pomerium";
     repo = "pomerium";
     rev = "v${version}";
-    hash = "sha256-3SmcuLEWqsw/B10jTIG2TKGa7tyMLa/lpkD6Iq/Fm4g=";
+    hash = "sha256-XTj0ZLPRe8I3a5be0oRTxRUuT2wHnbsms7wIvLUg9ms=";
   };
 
-  vendorHash = "sha256-mOTjBH8VqsMdyW5jTIZ76bf55WnHw9XuUSh6zsBktt0=";
+  vendorHash = "sha256-EYXmeS4jtueI9FwVQdMlsYX3CSRGH9Dft0Syf88nf7o=";
 
   ui = stdenv.mkDerivation {
     pname = "pomerium-ui";
     inherit version;
     src = "${src}/ui";
 
-    offlineCache = fetchYarnDeps {
-      yarnLock = "${src}/ui/yarn.lock";
-      hash = "sha256-V2nSSMvTCK+SYmEhTbLMArIOmNs/AgB5xfhQGx3e/x8=";
+    npmDeps = fetchNpmDeps {
+      src = "${src}/ui";
+      hash = "sha256-2fzINp3LBPHPJlzJnUggPWUZHrjuX9TYPD2XvioonSw=";
     };
 
     nativeBuildInputs = [
-      yarnConfigHook
-      yarnBuildHook
+      npmHooks.npmConfigHook
       nodejs
     ];
+
+    buildPhase = ''
+      runHook preBuild
+      npm run build
+      runHook postBuild
+    '';
 
     installPhase = ''
       runHook preInstall


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Changes

- Updated version and hashes to [v0.32.4](https://github.com/pomerium/pomerium/releases/tag/v0.32.4)
- Switched UI build from yarn to npm due to an upstream migratation
- Updated the envoy external binary patch to macth an updated function signature

### Note

Depends on the envoy `depsHash` fix in #505745.
Current `master` has a stale `x86_64-linux` hash that prevents building.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Ran `--version`:
```sh
$ /nix/store/64kicxl0ns21cv332qqyxlw6jsvni24x-pomerium-0.32.4/bin/pomerium --version
pomerium version pomerium: v0.32.4-nixpkgs
envoy: 1.36.5+429dc716720106e02a1221426742cfefe5513111de8c430ebba17e6f2b062dbf
```

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
