### PR TITLE
python3Packages.pot: 0.9.6.post1 -> 0.9.7-unstable-2026-03-05

### DIFF
--- a/pkgs/development/python-modules/pot/default.nix
+++ b/pkgs/development/python-modules/pot/default.nix
@@ -21,14 +21,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pot";
-  version = "0.9.6.post1";
+  version = "0.9.7-unstable-2026-03-05";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "PythonOT";
     repo = "POT";
-    tag = finalAttrs.version;
-    hash = "sha256-db4fKXqvg9DEmbI/RTQWcOdw+3ccPk74ME0VDsXZlsQ=";
+    rev = "41a4d57e1ecc88d79e8ebfe825b32ba761132007";
+    # tag = finalAttrs.version;
+    hash = "sha256-xM6GEBXRo6rOjX276glNyF1EIX5eM/3RR+N9fsjTk+Q=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/pot/default.nix
+++ b/pkgs/development/python-modules/pot/default.nix
@@ -19,7 +19,7 @@
   torch,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pot";
   version = "0.9.6.post1";
   pyproject = true;
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "PythonOT";
     repo = "POT";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-db4fKXqvg9DEmbI/RTQWcOdw+3ccPk74ME0VDsXZlsQ=";
   };
 
@@ -63,7 +63,7 @@ buildPythonPackage rec {
     ];
     plot = [ matplotlib ];
     all =
-      with optional-dependencies;
+      with finalAttrs.passthru.optional-dependencies;
       (
         backend-numpy
         ++ backend-jax
@@ -137,7 +137,9 @@ buildPythonPackage rec {
   meta = {
     description = "Python Optimal Transport Library";
     homepage = "https://pythonot.github.io/";
+    changelog = "https://github.com/PythonOT/POT/blob/${finalAttrs.version}/RELEASES.md";
+    downloadPage = "https://github.com/PythonOT/POT";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yl3dy ];
   };
-}
+})


### PR DESCRIPTION
Fixes scipy compatibility (and openmp on Darwin).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
