### PR TITLE
Remove Profpatsch from most teams & maintainer fields

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -26,10 +26,10 @@
 
 # Libraries
 /lib                        @infinisil @hsjobeki
-/lib/generators.nix         @infinisil @hsjobeki @Profpatsch
-/lib/cli.nix                @infinisil @hsjobeki @Profpatsch
-/lib/debug.nix              @infinisil @hsjobeki @Profpatsch
-/lib/asserts.nix            @infinisil @hsjobeki @Profpatsch
+/lib/generators.nix         @infinisil @hsjobeki
+/lib/cli.nix                @infinisil @hsjobeki
+/lib/debug.nix              @infinisil @hsjobeki
+/lib/asserts.nix            @infinisil @hsjobeki
 /lib/path/*                 @infinisil @hsjobeki
 /lib/fileset                @infinisil @hsjobeki
 /maintainers/github-teams.json @infinisil
@@ -75,7 +75,7 @@
 /pkgs/pkgs-lib                                   @Stunkymonkey @h7x4
 
 # Nixpkgs build-support
-/pkgs/build-support/writers @lassulus @Profpatsch
+/pkgs/build-support/writers @lassulus
 
 # Nixpkgs make-disk-image
 /doc/build-helpers/images/makediskimage.section.md  @raitobezarius
@@ -335,8 +335,8 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /pkgs/build-support/dlang @jtbx @TomaSajt
 
 # Dhall
-/pkgs/development/dhall-modules      @Gabriella439 @Profpatsch
-/pkgs/development/interpreters/dhall @Gabriella439 @Profpatsch
+/pkgs/development/dhall-modules      @Gabriella439
+/pkgs/development/interpreters/dhall @Gabriella439
 
 # Agda
 /pkgs/build-support/agda                  @NixOS/agda
@@ -348,9 +348,6 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 # Idris
 /pkgs/development/idris-modules @Infinisil
 /pkgs/development/compilers/idris2 @mattpolzin
-
-# Bazel
-/pkgs/by-name/ba/bazel_7 @Profpatsch
 
 # NixOS modules for e-mail and dns services
 /nixos/modules/services/mail/mailman.nix    @peti

--- a/maintainers/github-teams.json
+++ b/maintainers/github-teams.json
@@ -41,7 +41,6 @@
     "description": "Maintenance of https://bazel.build/ and related packages",
     "id": 5468470,
     "maintainers": {
-      "Profpatsch": 3153638
     },
     "members": {
       "aherrmann": 732652,

--- a/pkgs/applications/networking/droopy/default.nix
+++ b/pkgs/applications/networking/droopy/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
     description = "Mini Web server that let others upload files to your computer";
     homepage = "http://stackp.online.fr/droopy";
     license = lib.licenses.bsd3;
-    maintainers = [ lib.maintainers.Profpatsch ];
+    maintainers = [ ];
     mainProgram = "droopy";
   };
 

--- a/pkgs/by-name/bg/bgnet/package.nix
+++ b/pkgs/by-name/bg/bgnet/package.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation {
     homepage = "https://beej.us/guide/bgnet/";
     license = lib.licenses.unfree;
 
-    maintainers = with lib.maintainers; [ Profpatsch ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/fd/fdtools/package.nix
+++ b/pkgs/by-name/fd/fdtools/package.nix
@@ -96,6 +96,6 @@ stdenv.mkDerivation {
     description = "Set of utilities for working with file descriptors";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.Profpatsch ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ge/geteltorito/package.nix
+++ b/pkgs/by-name/ge/geteltorito/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Extract the initial/default boot image from a CD image if existent";
     homepage = "https://userpages.uni-koblenz.de/~krienke/ftp/noarch/geteltorito/";
-    maintainers = [ lib.maintainers.Profpatsch ];
+    maintainers = [ ];
     license = lib.licenses.gpl2Only;
     mainProgram = "geteltorito";
   };

--- a/pkgs/by-name/mk/mktorrent/package.nix
+++ b/pkgs/by-name/mk/mktorrent/package.nix
@@ -33,7 +33,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/pobrn/mktorrent/wiki";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      Profpatsch
       winter
     ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/mp/mpv/scripts/convert.nix
+++ b/pkgs/by-name/mp/mpv/scripts/convert.nix
@@ -38,7 +38,7 @@ buildLua {
   meta = {
     description = "Convert parts of a video while you are watching it in mpv";
     homepage = "https://gist.github.com/Zehkul/25ea7ae77b30af959be0";
-    maintainers = [ lib.maintainers.Profpatsch ];
+    maintainers = [ ];
     longDescription = ''
       When this script is loaded into mpv, you can hit Alt+W to mark the beginning
       and Alt+W again to mark the end of the clip. Then a settings window opens.

--- a/pkgs/by-name/mu/mustache-spec/package.nix
+++ b/pkgs/by-name/mu/mustache-spec/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     homepage = "http://mustache.github.io/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ Profpatsch ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/ne/nettee/package.nix
+++ b/pkgs/by-name/ne/nettee/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://sourceforge.net/projects/nettee";
     description = ''Network "tee" program'';
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ Profpatsch ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "nettee";
   };

--- a/pkgs/by-name/ta/tagtime/package.nix
+++ b/pkgs/by-name/ta/tagtime/package.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation {
     '';
     homepage = "https://messymatters.com/tagtime/";
     license = lib.licenses.bsd3;
-    maintainers = [ lib.maintainers.Profpatsch ];
+    maintainers = [ ];
     mainProgram = "tagtimed";
   };
 }

--- a/pkgs/by-name/ul/ultrastardx/package.nix
+++ b/pkgs/by-name/ul/ultrastardx/package.nix
@@ -82,7 +82,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       diogotcorreia
-      Profpatsch
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/yj/yj/package.nix
+++ b/pkgs/by-name/yj/yj/package.nix
@@ -27,7 +27,7 @@ buildGoModule (finalAttrs: {
     description = "Convert YAML <=> TOML <=> JSON <=> HCL";
     license = lib.licenses.asl20;
     mainProgram = "yj";
-    maintainers = with lib.maintainers; [ Profpatsch ];
+    maintainers = [ ];
     homepage = "https://github.com/sclevine/yj";
   };
 })

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -382,8 +382,6 @@ package-maintainers:
     - cornelis
   poscat:
     - hinit
-  Profpatsch:
-    - gitit
   psibi:
     - path-pieces
     - persistent

--- a/pkgs/development/tools/database/cdb/default.nix
+++ b/pkgs/development/tools/database/cdb/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation {
   meta = {
     homepage = "https://cr.yp.to/cdb.html";
     license = lib.licenses.publicDomain;
-    maintainers = [ lib.maintainers.Profpatsch ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/development/tools/kgt/default.nix
+++ b/pkgs/development/tools/kgt/default.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/katef/kgt";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ Profpatsch ];
+    maintainers = [ ];
   };
 
 }

--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -231,7 +231,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      Profpatsch
       uncenter
       amaanq
     ];

--- a/pkgs/tools/misc/ultrastar-creator/default.nix
+++ b/pkgs/tools/misc/ultrastar-creator/default.nix
@@ -60,6 +60,6 @@ stdenv.mkDerivation {
     description = "Ultrastar karaoke song creation tool";
     homepage = "https://github.com/UltraStar-Deluxe/UltraStar-Creator";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ Profpatsch ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/tools/misc/ultrastar-manager/default.nix
+++ b/pkgs/tools/misc/ultrastar-manager/default.nix
@@ -151,6 +151,6 @@ stdenv.mkDerivation {
     mainProgram = "UltraStar-Manager";
     homepage = "https://github.com/UltraStar-Deluxe/UltraStar-Manager";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ Profpatsch ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
due to bot spam

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
