### PR TITLE
various: use installFonts hook

### DIFF
--- a/pkgs/by-name/be/behdad-fonts/package.nix
+++ b/pkgs/by-name/be/behdad-fonts/package.nix
@@ -5,14 +5,14 @@
   installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "behdad-fonts";
   version = "0.0.3";
 
   src = fetchFromGitHub {
     owner = "font-store";
     repo = "BehdadFont";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-gKfzxo3/bCMKXl2d6SP07ahIiNrUyrk/SN5XLND2lWY=";
   };
 
@@ -25,4 +25,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ pancaek ];
   };
-}
+})

--- a/pkgs/by-name/be/behdad-fonts/package.nix
+++ b/pkgs/by-name/be/behdad-fonts/package.nix
@@ -28,6 +28,6 @@ stdenvNoCC.mkDerivation rec {
     description = "Persian/Arabic Open Source Font";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ pancaek ];
   };
 }

--- a/pkgs/by-name/be/behdad-fonts/package.nix
+++ b/pkgs/by-name/be/behdad-fonts/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -15,13 +16,7 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-gKfzxo3/bCMKXl2d6SP07ahIiNrUyrk/SN5XLND2lWY=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/behrad-fonts {} \;
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     homepage = "https://github.com/font-store/BehdadFont";

--- a/pkgs/by-name/be/besley/package.nix
+++ b/pkgs/by-name/be/besley/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
 }:
 stdenvNoCC.mkDerivation {
   pname = "besley";
@@ -14,14 +15,7 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-N6QU3Pd6EnIrdbRtDT3mW5ny683DBWo0odADJBSdA2E=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/share/fonts/truetype
-    cp fonts/*/*.otf $out/share/fonts/truetype
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     homepage = "https://indestructibletype.com/Besley.html";

--- a/pkgs/by-name/br/bront_fonts/package.nix
+++ b/pkgs/by-name/br/bront_fonts/package.nix
@@ -2,6 +2,7 @@
   stdenvNoCC,
   lib,
   fetchFromGitHub,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation {
@@ -15,9 +16,9 @@ stdenvNoCC.mkDerivation {
     sha256 = "1sx2gv19pgdyccb38sx3qnwszksmva7pqa1c8m35s6cipgjhhgb4";
   };
 
-  installPhase = ''
-    install -m444 -Dt $out/share/fonts/truetype *Bront.ttf
-  '';
+  preInstall = "rm {DejaVuSansMono,UbuntuMono}.ttf";
+
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Bront Fonts";

--- a/pkgs/by-name/br/bront_fonts/package.nix
+++ b/pkgs/by-name/br/bront_fonts/package.nix
@@ -28,6 +28,6 @@ stdenvNoCC.mkDerivation {
       ufl
     ];
     platforms = lib.platforms.all;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ pancaek ];
   };
 }

--- a/pkgs/by-name/fe/ferrum/package.nix
+++ b/pkgs/by-name/fe/ferrum/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
 let
@@ -18,13 +19,7 @@ stdenvNoCC.mkDerivation {
     stripRoot = false;
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     homepage = "https://dotcolon.net/font/ferrum/";

--- a/pkgs/by-name/ji/jigmo/package.nix
+++ b/pkgs/by-name/ji/jigmo/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Japanese Kanji font set which is the official successor to Hanazono Mincho";
     homepage = "https://kamichikoichi.github.io/jigmo/";
     license = lib.licenses.cc0;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ pancaek ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ji/jigmo/package.nix
+++ b/pkgs/by-name/ji/jigmo/package.nix
@@ -5,12 +5,12 @@
   installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "jigmo";
   version = "20250912";
 
   src = fetchzip {
-    url = "https://kamichikoichi.github.io/jigmo/Jigmo-${version}.zip";
+    url = "https://kamichikoichi.github.io/jigmo/Jigmo-${finalAttrs.version}.zip";
     hash = "sha256-Z9WYPqNjHqnYjRndxtHsQ9XhFshMR50hVkQsXgUMKE8=";
     stripRoot = false;
   };
@@ -24,4 +24,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with lib.maintainers; [ pancaek ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ji/jigmo/package.nix
+++ b/pkgs/by-name/ji/jigmo/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -14,13 +15,7 @@ stdenvNoCC.mkDerivation rec {
     stripRoot = false;
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 *.ttf -t $out/share/fonts/truetype/
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Japanese Kanji font set which is the official successor to Hanazono Mincho";

--- a/pkgs/by-name/jo/jost/package.nix
+++ b/pkgs/by-name/jo/jost/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -13,13 +14,7 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-ne81bMhmTzNZ/GGIzb7nCYh19vNLK+hJ3cP/zDxtiGM=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 fonts/otf/*.otf -t $out/share/fonts/opentype
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     homepage = "https://github.com/indestructible-type/Jost";

--- a/pkgs/by-name/jo/jost/package.nix
+++ b/pkgs/by-name/jo/jost/package.nix
@@ -5,12 +5,12 @@
   installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "jost";
   version = "3.5";
 
   src = fetchzip {
-    url = "https://github.com/indestructible-type/Jost/releases/download/${version}/Jost.zip";
+    url = "https://github.com/indestructible-type/Jost/releases/download/${finalAttrs.version}/Jost.zip";
     hash = "sha256-ne81bMhmTzNZ/GGIzb7nCYh19vNLK+hJ3cP/zDxtiGM=";
   };
 
@@ -22,4 +22,4 @@ stdenvNoCC.mkDerivation rec {
     license = lib.licenses.ofl;
     maintainers = [ lib.maintainers.ar1a ];
   };
-}
+})

--- a/pkgs/by-name/lo/lora/package.nix
+++ b/pkgs/by-name/lo/lora/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchFromGitHub,
   nix-update-script,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -21,13 +22,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   passthru.updateScript = nix-update-script { };
 
+  nativeBuildInputs = [ installFonts ];
+
+  # installFonts adds a hook to `postInstall` that installs fonts
+  # into the correct directories
   installPhase = ''
     runHook preInstall
-
-    install -Dm444 -t $out/share/fonts/truetype $src/fonts/ttf/*.ttf
-    install -Dm444 -t $out/share/fonts/opentype $src/fonts/otf/*.otf
-    install -Dm444 -t $out/share/fonts/variable $src/fonts/variable/*.ttf
-
     runHook postInstall
   '';
 

--- a/pkgs/by-name/me/medio/package.nix
+++ b/pkgs/by-name/me/medio/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
 let
@@ -18,13 +19,7 @@ stdenvNoCC.mkDerivation {
     stripRoot = false;
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     homepage = "https://dotcolon.net/font/medio/";

--- a/pkgs/by-name/me/melete/package.nix
+++ b/pkgs/by-name/me/melete/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
 let
@@ -18,13 +19,7 @@ stdenvNoCC.mkDerivation {
     stripRoot = false;
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     homepage = "https://dotcolon.net/font/melete/";

--- a/pkgs/by-name/me/merriweather-sans/package.nix
+++ b/pkgs/by-name/me/merriweather-sans/package.nix
@@ -2,9 +2,10 @@
   stdenvNoCC,
   lib,
   fetchFromGitHub,
+  installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation {
   pname = "merriweather-sans";
   version = "1.008";
 
@@ -18,12 +19,13 @@ stdenvNoCC.mkDerivation rec {
   # TODO: it would be nice to build this from scratch, but lots of
   # Python dependencies to package (fontmake, gftools)
 
-  installPhase = ''
-    install -m444 -Dt $out/share/fonts/truetype/${pname} fonts/ttfs/*.ttf
-    install -m444 -Dt $out/share/fonts/woff/${pname} fonts/woff/*.woff
-    install -m444 -Dt $out/share/fonts/woff2/${pname} fonts/woff2/*.woff2
-    # TODO: install variable version?
-  '';
+  # TODO: packaging with python allow update and usage of variable/otf fonts
+  nativeBuildInputs = [ installFonts ];
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
   meta = {
     homepage = "https://github.com/SorkinType/Merriweather-Sans";

--- a/pkgs/by-name/me/merriweather/package.nix
+++ b/pkgs/by-name/me/merriweather/package.nix
@@ -2,29 +2,29 @@
   stdenvNoCC,
   lib,
   fetchFromGitHub,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "merriweather";
-  version = "2.005";
+  version = "2.200";
 
   src = fetchFromGitHub {
     owner = "SorkinType";
     repo = "Merriweather";
-    rev = "4fd88c9299009d1c1d201e7da3ff75cf1de5153a";
-    sha256 = "1ndycja2jzhcfbqbm0p6ka2zl1i1pdbkf0crw2lp3pi4k89wlm29";
+    rev = "6e3263d6241aeb747ebfcdd4af3ff8bd1013bb49";
+    sha256 = "sha256-mpVJpxI98VxHpZMFFyTHjxTPcUTB1kK8XCGa32znMcQ=";
   };
 
   # TODO: it would be nice to build this from scratch, but lots of
   # Python dependencies to package (fontmake, gftools)
 
-  installPhase = ''
-    install -m444 -Dt $out/share/fonts/opentype/${pname} fonts/otf/*.otf
-    install -m444 -Dt $out/share/fonts/truetype/${pname} fonts/ttfs/*.ttf
-    install -m444 -Dt $out/share/fonts/woff/${pname} fonts/woff/*.woff
-    install -m444 -Dt $out/share/fonts/woff2/${pname} fonts/woff2/*.woff2
-    # TODO: install variable version?
-  '';
+  nativeBuildInputs = [ installFonts ];
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
   meta = {
     homepage = "https://github.com/SorkinType/Merriweather";

--- a/pkgs/by-name/me/merriweather/package.nix
+++ b/pkgs/by-name/me/merriweather/package.nix
@@ -5,7 +5,7 @@
   installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "merriweather";
   version = "2.200";
 
@@ -33,4 +33,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ emily ];
   };
-}
+})

--- a/pkgs/by-name/me/meslo-lgs-nf/package.nix
+++ b/pkgs/by-name/me/meslo-lgs-nf/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  installFonts,
 }:
 
 stdenv.mkDerivation {
@@ -15,10 +16,7 @@ stdenv.mkDerivation {
     sha256 = "sha256-8xwVOlOP1SresbReNh1ce2Eu12KdIwdJSg6LKM+k2ng=";
   };
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp $src/*.ttf $out/share/fonts/truetype
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Meslo Nerd Font patched for Powerlevel10k";

--- a/pkgs/by-name/mp/mph_2b_damase/package.nix
+++ b/pkgs/by-name/mp/mph_2b_damase/package.nix
@@ -1,4 +1,8 @@
-{ stdenvNoCC, fetchzip }:
+{
+  stdenvNoCC,
+  fetchzip,
+  installFonts,
+}:
 
 stdenvNoCC.mkDerivation {
   pname = "mph-2b-damase";
@@ -9,13 +13,7 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-4x78D+c3ZBxfhTQQ4+gyxvrsuztHF2ItXLh4uA0PxvU=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 *.ttf -t $out/share/fonts/truetype
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = { };
 }

--- a/pkgs/by-name/sn/sniglet/package.nix
+++ b/pkgs/by-name/sn/sniglet/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   stdenvNoCC,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation {
@@ -15,14 +16,14 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-fLT2hZT9o1Ka30EB/6oWwmalhVJ+swXLRFG99yRWd2c=";
   };
 
-  installPhase = ''
-    runHook preInstall
+  preInstall = "rm webfonts/Sniglet-webfont.ttf";
 
-    install -D -m444 -t $out/share/fonts/truetype $src/*.ttf
-    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
+  nativeBuildInputs = [ installFonts ];
 
-    runHook postInstall
-  '';
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
   meta = {
     description = "Fun rounded display face that’s great for headlines";

--- a/pkgs/by-name/su/sudo-font/package.nix
+++ b/pkgs/by-name/su/sudo-font/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation rec {
     homepage = "https://www.kutilek.de/sudo-font/";
     changelog = "https://github.com/jenskutilek/sudo-font/raw/v${version}/sudo/FONTLOG.txt";
     license = lib.licenses.ofl;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ pancaek ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/su/sudo-font/package.nix
+++ b/pkgs/by-name/su/sudo-font/package.nix
@@ -5,12 +5,12 @@
   installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "sudo-font";
   version = "3.4";
 
   src = fetchzip {
-    url = "https://github.com/jenskutilek/sudo-font/releases/download/v${version}/sudo.zip";
+    url = "https://github.com/jenskutilek/sudo-font/releases/download/v${finalAttrs.version}/sudo.zip";
     hash = "sha256-sSLY94wY9+AYAqWDq+Xy+KctUfJVS0jeS3baF8mLO9I=";
   };
 
@@ -19,9 +19,9 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Font for programmers and command line users";
     homepage = "https://www.kutilek.de/sudo-font/";
-    changelog = "https://github.com/jenskutilek/sudo-font/raw/v${version}/sudo/FONTLOG.txt";
+    changelog = "https://github.com/jenskutilek/sudo-font/raw/v${finalAttrs.version}/sudo/FONTLOG.txt";
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ pancaek ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/su/sudo-font/package.nix
+++ b/pkgs/by-name/su/sudo-font/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -13,13 +14,7 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-sSLY94wY9+AYAqWDq+Xy+KctUfJVS0jeS3baF8mLO9I=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 *.ttf -t $out/share/fonts/truetype/
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Font for programmers and command line users";

--- a/pkgs/by-name/wq/wqy_microhei/package.nix
+++ b/pkgs/by-name/wq/wqy_microhei/package.nix
@@ -5,12 +5,12 @@
   installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "wqy-microhei";
   version = "0.2.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/wqy/wqy-microhei-${version}-beta.tar.gz";
+    url = "mirror://sourceforge/wqy/wqy-microhei-${finalAttrs.version}-beta.tar.gz";
     hash = "sha256-KAKsgCOqNqZupudEWFTjoHjTd///QhaTQb0jeHH3IT4=";
   };
 
@@ -23,4 +23,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ lib.maintainers.pkmx ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/wq/wqy_microhei/package.nix
+++ b/pkgs/by-name/wq/wqy_microhei/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchurl,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -13,13 +14,7 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-KAKsgCOqNqZupudEWFTjoHjTd///QhaTQb0jeHH3IT4=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 wqy-microhei.ttc $out/share/fonts/wqy-microhei.ttc
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Chinese Unicode font optimized for screen display";

--- a/pkgs/by-name/xi/xits-math/package.nix
+++ b/pkgs/by-name/xi/xits-math/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   python3Packages,
+  installFonts,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -16,21 +17,23 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "1x3r505dylz9rz8dj98h5n9d0zixyxmvvhnjnms9qxdrz9bxy9g1";
   };
 
-  nativeBuildInputs = (
-    with python3Packages;
-    [
+  nativeBuildInputs =
+    (with python3Packages; [
       python
       fonttools
       fontforge
-    ]
-  );
+    ])
+    ++ [ installFonts ];
 
   postPatch = ''
     rm *.otf
   '';
 
+  # installFonts adds a hook to `postInstall` that installs fonts
+  # into the correct directories
   installPhase = ''
-    install -m444 -Dt $out/share/fonts/opentype *.otf
+    runHook preInstall
+    runHook postInstall
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Tracking #495640

**ferrum**
\- use `installFonts`

**wqy_microhei**
\- use `installFonts`
\- `rec` -> `finalAttrs`

**mph_2b_damase** *(note: this package does not have a `meta`)*
\- use `installFonts`

**jigmo**
\- adopt by @pancaek (https://github.com/NixOS/nixpkgs/issues/495640#issuecomment-3981346307)
\- use `installFonts`
\- `rec` -> `finalAttrs`

**behdad-fonts**
\- adopt by @pancaek (https://github.com/NixOS/nixpkgs/issues/495640#issuecomment-3981346307)
\- use `installFonts`
	(the `otf` wasn't in the outputs before)
\- `rec` -> `finalAttrs`

**besley**
\- use `installFonts` (the `otf` weren't in the outputs before)

**sniglet**
\- use `installFonts`
	(removed `Sniglet-webfont.ttf` that tried to get into `$out` output)
	(the original repo also had a webfont, added to the outputs)

**bront_fonts**
\- adopt by @pancaek (https://github.com/NixOS/nixpkgs/issues/495640#issuecomment-3981346307)
\- use `installFonts`
	(removed `{DejaVuSansMono,UbuntuMono}.ttf` that tried to get into `$out` output)

**merriweather{,-sans}**
\- update from `2.005` to `2.200` (for non `-sans`)
	(updating `-sans` causes `.woff*` files to be missing)
\- use `installFonts`
	(there's a TODO comment mentionning packaging it with python and building from source, but the repo is pretty annoying to package)

**melete**
\- use `installFonts`

**meslo-lgs-nf**
\- use `installFonts`

**sudo-font**
\- adopt by @pancaek (https://github.com/NixOS/nixpkgs/issues/495640#issuecomment-3981346307)
\- use `installFonts`
\- `rec` -> `finalAttrs`

**jost**
\- use `installFonts` (the `ttf` weren't in the outputs before)
\- `rec` -> `finalAttrs`

**xits-math**
\- use `installFonts` (the need to disable `make install` with custom installPhase)

**lora**
\- use `installFonts`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
