### PR TITLE
nixos/unifi: fix stop behavior

### DIFF
--- a/nixos/modules/services/networking/unifi.nix
+++ b/nixos/modules/services/networking/unifi.nix
@@ -160,17 +160,14 @@ in
       serviceConfig = {
         Type = "notify";
         ExecStart = "${cmd} start";
-        ExecStop = "${cmd} stop";
+        ExecStop = [
+          "${cmd} stop"
+          "${lib.getExe' pkgs.util-linux "waitpid"} -t 30 -e $MAINPID"
+        ];
         Restart = "always";
-        TimeoutSec = "5min";
         User = "unifi";
         UMask = "0077";
         WorkingDirectory = "${stateDir}";
-        # the stop command exits while the main process is still running, and unifi
-        # wants to manage its own child processes. this means we have to set KillSignal
-        # to something the main process ignores, otherwise every stop will have unifi.service
-        # fail with SIGTERM status.
-        KillSignal = "SIGCONT";
 
         # Hardening
         AmbientCapabilities = "";

--- a/nixos/tests/unifi.nix
+++ b/nixos/tests/unifi.nix
@@ -21,8 +21,19 @@
 
     machine.wait_for_unit("unifi.service")
     machine.wait_for_open_port(8880)
+    machine.succeed("systemctl show unifi.service | grep -q 'ActiveState=active'")
+    machine.succeed("pgrep mongod")
 
     status = json.loads(machine.succeed("curl --silent --show-error --fail-with-body http://localhost:8880/status"))
     assert status["meta"]["rc"] == "ok"
+
+    machine.succeed("systemctl stop unifi.service")
+    machine.succeed("systemctl show unifi.service | grep -q 'ActiveState=inactive'")
+    machine.fail("pgrep mongod")
+
+    machine.succeed("systemctl start unifi.service")
+    machine.wait_for_unit("unifi.service")
+    machine.succeed("systemctl show unifi.service | grep -q 'ActiveState=active'")
+    machine.succeed("pgrep mongod")
   '';
 }


### PR DESCRIPTION
Resurrection of https://github.com/NixOS/nixpkgs/pull/330574, thanks to @B4dM4n's comment at https://github.com/NixOS/nixpkgs/issues/502333#issuecomment-4169284955. I've also improved the test to make sure the behavior is correct - the test fails on the master branch, but succeeds with the changes here.

Closes https://github.com/NixOS/nixpkgs/issues/502333.

cc @numinit 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
