### PR TITLE
cpp-ipfs-http-client: unstable-2022-01-30 -> 0-unstable-2023-06-04

### DIFF
--- a/pkgs/by-name/cp/cpp-ipfs-http-client/package.nix
+++ b/pkgs/by-name/cp/cpp-ipfs-http-client/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation {
   pname = "cpp-ipfs-http-client";
-  version = "unstable-2022-01-30";
+  version = "0-unstable-2023-06-04";
 
   src = fetchFromGitHub {
     owner = "vasild";
     repo = "cpp-ipfs-http-client";
-    rev = "3cdfa7fc6326e49fc81b3c7ca43ce83bdccef6d9";
-    sha256 = "sha256-/oyafnk4SbrvoCh90wkZXNBjknMKA6EEUoEGo/amLUo=";
+    rev = "29a103af79ad62ef42180f54f6cd2128b4128836";
+    hash = "sha256-B57W4OqNU0M4yYxbHIZb2TyHfMaihCOD1KdvPrm6xLE=";
   };
 
   patches = [ ./unvendor-nlohmann-json.patch ];


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/324213631

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
