### PR TITLE
haskellPackages.pandoc: build with -f+embed_data_files

### DIFF
--- a/pkgs/by-name/pa/pandoc/package.nix
+++ b/pkgs/by-name/pa/pandoc/package.nix
@@ -15,8 +15,6 @@ let
 
 in
 (haskell.lib.compose.overrideCabal (drv: {
-  configureFlags = drv.configureFlags or [ ] ++ [ "-fembed_data_files" ];
-  buildDepends = drv.buildDepends or [ ] ++ [ pandoc-cli.scope.file-embed ];
   buildTools = (drv.buildTools or [ ]) ++ [
     removeReferencesTo
     installShellFiles

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -325,6 +325,16 @@ builtins.intersectAttrs super {
   # Heist's test suite requires system pandoc
   heist = addTestToolDepend pkgs.pandoc super.heist;
 
+  pandoc = lib.pipe super.pandoc [
+    # pandoc can't do I/O (including reading data files). See
+    # <https://pandoc.org/pandoc-server.html#description>.
+    # It's simpler to just enable this globally rather than building multiple pandocs.
+    (enableCabalFlag "embed_data_files")
+    # pandoc still references these data files and we can't prevent their installation.
+    # pkgs.pandoc removes the reference to $out, so having everything in one place is best.
+    (overrideCabal { enableSeparateDataOutput = false; })
+  ];
+
   # Use Nixpkgs' double-conversion library
   double-conversion = disableCabalFlag "embedded_double_conversion" (
     addBuildDepends [ pkgs.double-conversion ] super.double-conversion

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -335,6 +335,16 @@ builtins.intersectAttrs super {
     (overrideCabal { enableSeparateDataOutput = false; })
   ];
 
+  # So pandoc-server can be used:
+  # https://pandoc.org/MANUAL.html#running-pandoc-as-a-web-server
+  # TODO(@sternenseemann): provide pandoc-server.cgi symlink?
+  pandoc-cli = overrideCabal (drv: {
+    postInstall = ''
+      ${drv.postInstall or ""}
+      ln -s "''${!outputBin}/bin/pandoc" "''${!outputBin}/bin/pandoc-server"
+    '';
+  }) super.pandoc-cli;
+
   # Use Nixpkgs' double-conversion library
   double-conversion = disableCabalFlag "embedded_double_conversion" (
     addBuildDepends [ pkgs.double-conversion ] super.double-conversion


### PR DESCRIPTION
This embeds the data files into the pandoc library instead of referencing the data output. This is not exactly desireable since it doesn't (necessarily) make the executable relocatable or anything, but is required for pandoc-server to work correctly (when built against pandoc) since it can't do I/O, i.e. can't read from the data output.

Previously, this was just enabled in pkgs.pandoc, but since that is no longer the same as haskellPackages.pandoc, the flag has no effect. Resolves #377637.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
