### PR TITLE
gh-gonest: init at 0-unstable-2025-12-17

### DIFF
--- a/pkgs/by-name/gh/gh-gonest/package.nix
+++ b/pkgs/by-name/gh/gh-gonest/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  makeWrapper,
+  bashInteractive,
+  gh,
+  jq,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "gh-gonest";
+  version = "0-unstable-2025-12-17";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "emmanuel-ferdman";
+    repo = "gh-gonest";
+    rev = "4be041b29e6e102b04b00f98619c818780060a60";
+    hash = "sha256-NTqq7y/6Gw1CXgmEpj7an2bT7d5ZFjjlV4zyBthC5yw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ bashInteractive ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m755 gh-gonest "$out"/bin/gh-gonest
+
+    runHook postInstall
+  '';
+
+  # Use --suffix to ensure that, if the user has a `gh` executable (e.g.
+  # because they've set `programs.gh.package` in Home Manager), then that gets
+  # picked up first.
+  postFixup =
+    let
+      pathPkgs = [
+        gh
+        jq
+      ];
+    in
+    ''
+      wrapProgram "$out"/bin/gh-gonest \
+        --suffix PATH : ${lib.makeBinPath pathPkgs}
+    '';
+
+  meta = {
+    homepage = "https://github.com/emmanuel-ferdman/gh-gonest";
+    description = "GitHub CLI extension for cleaning up ghost notifications";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.me-and ];
+    mainProgram = "gh-gonest";
+  };
+})

--- a/pkgs/by-name/gh/gh-gonest/package.nix
+++ b/pkgs/by-name/gh/gh-gonest/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  makeWrapper,
+  bashInteractive,
+  gh,
+  jq,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "gh-gonest";
+  version = "0-unstable-2025-12-17";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "emmanuel-ferdman";
+    repo = "gh-gonest";
+    rev = "4be041b29e6e102b04b00f98619c818780060a60";
+    hash = "sha256-NTqq7y/6Gw1CXgmEpj7an2bT7d5ZFjjlV4zyBthC5yw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ bashInteractive ];
+
+  # runtimeInputs is not used by mkDerivation directly, but defining it means
+  # the packages on the path at runtime can be more easily inspected and
+  # overridden.
+  runtimeInputs = [
+    gh
+    jq
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m755 gh-gonest "$out"/bin/gh-gonest
+
+    runHook postInstall
+  '';
+
+  # Use --suffix to ensure that, if the user has a `gh` executable (e.g.
+  # because they've set `programs.gh.package` in Home Manager), then that gets
+  # picked up first.
+  postFixup = ''
+    wrapProgram "$out"/bin/gh-gonest \
+      --suffix PATH : ${lib.makeBinPath finalAttrs.runtimeInputs}
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version"
+      "branch"
+    ];
+  };
+
+  meta = {
+    homepage = "https://github.com/emmanuel-ferdman/gh-gonest";
+    description = "GitHub CLI extension for cleaning up ghost notifications";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.me-and ];
+    mainProgram = "gh-gonest";
+  };
+})


### PR DESCRIPTION
[gh-gonest](https://github.com/emmanuel-ferdman/gh-gonest) is a [GitHub CLI extension](https://docs.github.com/en/github-cli/github-cli/using-github-cli-extensions) that finds and removes "ghost" GitHub notifications.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
