### PR TITLE
 libu2f-emu: init at 0-unstable-2020-09-04, add qemu build support

### DIFF
--- a/pkgs/by-name/li/libu2f-emu/package.nix
+++ b/pkgs/by-name/li/libu2f-emu/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  openssl,
+}:
+
+stdenv.mkDerivation {
+  pname = "libu2f-emu";
+  version = "0-unstable-2020-09-04";
+
+  src = fetchFromGitHub {
+    owner = "Agnoctopus";
+    repo = "libu2f-emu";
+    rev = "d1c4b9c2e1c42e8931033912c8b609521f2a7756";
+    hash = "sha256-kDAXA/v2nb/QAiJpGs0rTjm0t6CdbonTwHHoYhDQExE=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  postPatch = ''
+    # Upstream meson.build uses error() instead of warning() for missing
+    # doxygen/dot, which fails the configure.
+    substituteInPlace meson.build \
+      --replace-fail "error('Skip doc:" "warning('Skip doc:" \
+      --replace-fail "error('Skip dot in doc:" "warning('Skip dot in doc:"
+
+    # Fix header guard typo: TRANSaCTION_H -> TRANSACTION_H
+    substituteInPlace src/usb/transaction.h \
+      --replace-fail "define TRANSaCTION_H" "define TRANSACTION_H"
+
+    # Install headers into a u2f-emu/ subdirectory so consumers can
+    # use #include <u2f-emu/u2f-emu.h> (expected by QEMU).
+    substituteInPlace src/meson.build \
+      --replace-fail "install_headers(u2f_emu_headers)" \
+                     "install_headers(u2f_emu_headers, subdir: 'u2f-emu')"
+  '';
+
+  # Disable -Werror: upstream uses OpenSSL EC_KEY APIs deprecated since 3.0.
+  mesonFlags = [ "--warnlevel=2" ];
+  env.NIX_CFLAGS_COMPILE = "-Wno-error";
+
+  meta = {
+    description = "Universal 2nd Factor (U2F) Emulation C Library";
+    homepage = "https://github.com/Agnoctopus/libu2f-emu";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ philiptaron ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/qe/qemu/package.nix
+++ b/pkgs/by-name/qe/qemu/package.nix
@@ -92,6 +92,8 @@
   fuse3,
   canokeySupport ? false,
   canokey-qemu,
+  u2fEmuSupport ? false,
+  libu2f-emu,
   capstoneSupport ? !minimal,
   capstone,
   valgrindSupport ? false,
@@ -245,6 +247,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals uringSupport [ liburing ]
   ++ lib.optionals fuseSupport [ fuse3 ]
   ++ lib.optionals canokeySupport [ canokey-qemu ]
+  ++ lib.optionals u2fEmuSupport [ libu2f-emu ]
   ++ lib.optionals capstoneSupport [ capstone ]
   ++ lib.optionals valgrindSupport [ valgrind-light ];
 
@@ -329,6 +332,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional uringSupport "--enable-linux-io-uring"
   ++ lib.optional fuseSupport "--enable-fuse"
   ++ lib.optional canokeySupport "--enable-canokey"
+  ++ lib.optional u2fEmuSupport "--enable-u2f"
   ++ lib.optional capstoneSupport "--enable-capstone"
   ++ lib.optional (!pluginsSupport) "--disable-plugins"
   ++ lib.optional (!enableBlobs) "--disable-install-blobs"


### PR DESCRIPTION
It's quite an old library, and it's a bit rough around the edges, but it let me write an actual NixOS test for #486044.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
