### PR TITLE
songrec: 0.4.3 -> 0.6.7

### DIFF
--- a/pkgs/by-name/so/songrec/package.nix
+++ b/pkgs/by-name/so/songrec/package.nix
@@ -2,38 +2,51 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  gtk3,
-  openssl,
+  gtk4,
+  libadwaita,
+  libsoup_3,
+  glib-networking,
   alsa-lib,
   pkg-config,
+  wrapGAppsHook4,
   ffmpeg,
-  dbus,
+  glib,
   libpulseaudio,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "songrec";
-  version = "0.4.3";
+  version = "0.6.7";
 
   src = fetchFromGitHub {
     owner = "marin-m";
     repo = "songrec";
     rev = finalAttrs.version;
-    hash = "sha256-pTonrxlYvfuLRKMXW0Lao4KCoNFlMzE9rH+hwpa60JY=";
+    hash = "sha256-lCwFMBQ6IimNtXYMfTnFOpwOO2qbwijOEZ+oMsQKAP0=";
   };
 
-  cargoHash = "sha256-wSRn1JY067RVqGGdiox87+zRb2/2OMcvKLYZE1QUs/s=";
+  cargoHash = "sha256-BhDFGkvY6c8XbhJpFX1w8CSXK9IY/HiysNoooytFT9I=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
 
   buildInputs = [
     alsa-lib
-    dbus
-    gtk3
-    openssl
-    ffmpeg
+    glib
+    glib-networking
+    gtk4
+    libadwaita
     libpulseaudio
+    libsoup_3
   ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${lib.makeBinPath [ ffmpeg ]}"
+    )
+  '';
 
   postInstall = ''
     mv packaging/rootfs/usr/share $out/share
@@ -42,7 +55,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Open-source Shazam client for Linux, written in Rust";
     homepage = "https://github.com/marin-m/SongRec";
-    license = lib.licenses.gpl3Only;
+    license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ tcbravo ];
     mainProgram = "songrec";


### PR DESCRIPTION
Updated to https://github.com/marin-m/SongRec/releases/tag/0.6.7

Packaging changes:
- Replace gtk3 with gtk4, libadwaita, libsoup_3, gdk-pixbuf
- Add wrapGAppsHook4 for proper GLib/GTK4 environment wrapping
- Add glib-networking for TLS support via GIO modules
- Remove openssl (not used; soup3 uses glib-networking for TLS)
- Move ffmpeg from buildInputs to runtime PATH (only used via subprocess)
- Fix license: gpl3Only -> gpl3Plus (matches upstream Cargo.toml)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
