### PR TITLE
qt6Packages.ktactilefeedback: init at 0-unstable-2025-07-25

### DIFF
--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
@@ -12,6 +12,8 @@
   gdb,
   glib,
   kdePackages,
+  # Used on Qt6
+  ktactilefeedback ? null,
   libevdev,
   lttng-ust,
   mesa,
@@ -21,6 +23,7 @@
   qmake,
   qtbase,
   qtdeclarative,
+  # Used on Qt5
   qtfeedback ? null,
   qtgraphicaleffects ? null,
   qtpim ? null,
@@ -53,11 +56,18 @@ let
     [
       qtdeclarative
     ]
+    ++ lib.optionals withQt6 [
+      # Qt5Compat.GraphicalEffects
+      qt5compat
+
+      # Tactile feedback on Qt6
+      ktactilefeedback
+    ]
     ++ lib.optionals (!withQt6) [
       # Deprecated in Qt6
       qtgraphicaleffects
 
-      # Will prolly want this in the future, but needs porting to Qt6
+      # Tactile feedback on Qt5
       qtfeedback
     ]
   );
@@ -189,12 +199,15 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withQt6 [
     # Qt5Compat.GraphicalEffects
     qt5compat
+
+    # Tactile feedback on Qt6
+    ktactilefeedback
   ]
   ++ lib.optionals (!withQt6) [
     # Deprecated in Qt6
     qtgraphicaleffects
 
-    # Will prolly want this in the future, but needs porting to Qt6
+    # Tactile feedback on Qt5
     qtfeedback
   ];
 

--- a/pkgs/development/libraries/ktactilefeedback/default.nix
+++ b/pkgs/development/libraries/ktactilefeedback/default.nix
@@ -1,0 +1,65 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  unstableGitUpdater,
+  cmake,
+  extra-cmake-modules,
+  qtbase,
+  qtdeclarative,
+  qtmultimedia,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ktactilefeedback";
+  version = "0-unstable-2025-07-25";
+
+  src = fetchFromGitLab {
+    domain = "invent.kde.org";
+    owner = "jbbgameich";
+    repo = "ktactilefeedback";
+    rev = "da7858aaa125588d4c309f273afefff93222e8f9";
+    hash = "sha256-VEGZkA6bWuKJK6fk4u6RB5aMV8fbabD8ymm8HC/ddzg=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    extra-cmake-modules
+    qtbase
+    qtmultimedia
+  ];
+
+  # Library
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    # Need to run these post-install, so QML import path exists
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doInstallCheck)
+  ];
+
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  installCheckTarget = "test";
+  preInstallCheck = ''
+    export QML2_IMPORT_PATH=$out/${qtbase.qtQmlPrefix}:${lib.getBin qtdeclarative}/${qtbase.qtQmlPrefix}
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Tactile feedback library for Qt";
+    homepage = "https://invent.kde.org/jbbgameich/ktactilefeedback";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [
+      OPNA2608
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -67,6 +67,8 @@ makeScopeWithSplicing' {
       futuresql = callPackage ../development/libraries/futuresql { };
       kquickimageedit = callPackage ../development/libraries/kquickimageedit { };
 
+      ktactilefeedback = kdePackages.callPackage ../development/libraries/ktactilefeedback { };
+
       libiodata = callPackage ../development/libraries/libiodata { };
 
       libqaccessibilityclient = callPackage ../development/libraries/libqaccessibilityclient { };


### PR DESCRIPTION
Used in Qt6 Lomiri to interface with haptic feedback services, instead of QtFeedback.

Running `lomiri-qt6.morph-browser` and clicking on the burger menu button in the top-right:

```
QDBusMarshaller::appendVariantInternal: Found unknown D-Bus type ''
Failed to vibrate with pattern: "The name org.sigxcpu.Feedback was not provided by any .service files"
```

I don't have a supported feedback service running on my system (it's trying to talk to `feedbackd` there), so I suppose this is "correct".

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
