### PR TITLE
erlang_26, elixir_1_15, elixir_1_16: remove as EOL

### DIFF
--- a/pkgs/by-name/ak/akkoma/package.nix
+++ b/pkgs/by-name/ak/akkoma/package.nix
@@ -9,9 +9,9 @@
 }:
 
 let
-  beamPackages = beam_minimal.packages.erlang_26.extend (
+  beamPackages = beam_minimal.packages.erlang_27.extend (
     self: super: {
-      elixir = self.elixir_1_16;
+      elixir = self.elixir_1_17;
       rebar3 = self.rebar3WithPlugins {
         plugins = with self; [ pc ];
       };

--- a/pkgs/by-name/pl/pleroma/package.nix
+++ b/pkgs/by-name/pl/pleroma/package.nix
@@ -16,7 +16,7 @@
 }:
 
 let
-  beamPackages = beam.packages.erlang_26.extend (self: super: { elixir = elixir_1_17; });
+  beamPackages = beam.packages.erlang_27.extend (self: super: { elixir = elixir_1_17; });
 in
 beamPackages.mixRelease rec {
   pname = "pleroma";

--- a/pkgs/by-name/pl/pleroma/package.nix
+++ b/pkgs/by-name/pl/pleroma/package.nix
@@ -1,6 +1,5 @@
 {
   beam,
-  elixir_1_17,
   lib,
   fetchFromGitHub,
   fetchFromGitLab,
@@ -16,7 +15,7 @@
 }:
 
 let
-  beamPackages = beam.packages.erlang_27.extend (self: super: { elixir = elixir_1_17; });
+  beamPackages = beam.packages.erlang_27.extend (self: super: { elixir = self.elixir_1_18; });
 in
 beamPackages.mixRelease rec {
   pname = "pleroma";
@@ -205,6 +204,18 @@ beamPackages.mixRelease rec {
             mkdir config
             cp ${cfgFile} config/config.exs
           '';
+      };
+
+      # mochiweb is unused by still in mix.lock
+      # work around OTP 27+ incompat by forcing our build to use a newer version
+      mochiweb = prev.mochiweb.override rec {
+        version = "3.3.0";
+
+        src = fetchHex {
+          pkg = "mochiweb";
+          version = "${version}";
+          sha256 = "sha256-qoW3d/sj6ZcuvEJOQLXTUQbxm8mYhz4Cbe3Ydt+O5Qw=";
+        };
       };
     };
   };

--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -71,16 +71,6 @@ let
         debugInfo = true;
       };
 
-      elixir_1_16 = callPackage ../interpreters/elixir/1.16.nix {
-        inherit erlang;
-        debugInfo = true;
-      };
-
-      elixir_1_15 = callPackage ../interpreters/elixir/1.15.nix {
-        inherit erlang;
-        debugInfo = true;
-      };
-
       # Remove old versions of elixir, when the supports fades out:
       # https://hexdocs.pm/elixir/compatibility-and-deprecations.html
 

--- a/pkgs/development/interpreters/elixir/1.15.nix
+++ b/pkgs/development/interpreters/elixir/1.15.nix
@@ -1,7 +1,0 @@
-import ./generic-builder.nix {
-  version = "1.15.7";
-  hash = "sha256-6GfZycylh+sHIuiQk/GQr1pRQRY1uBycSQdsVJ0J13k=";
-  # https://hexdocs.pm/elixir/1.15.0/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
-  minimumOTPVersion = "24";
-  maximumOTPVersion = "26";
-}

--- a/pkgs/development/interpreters/elixir/1.16.nix
+++ b/pkgs/development/interpreters/elixir/1.16.nix
@@ -1,7 +1,0 @@
-import ./generic-builder.nix {
-  version = "1.16.3";
-  hash = "sha256-WUBqoz3aQvBlSG3pTxGBpWySY7I0NUcDajQBgq5xYTU=";
-  # https://hexdocs.pm/elixir/1.16.0/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
-  minimumOTPVersion = "24";
-  maximumOTPVersion = "26";
-}

--- a/pkgs/development/interpreters/erlang/26.nix
+++ b/pkgs/development/interpreters/erlang/26.nix
@@ -1,6 +1,0 @@
-genericBuilder:
-
-genericBuilder {
-  version = "26.2.5.18";
-  hash = "sha256-mCkJeRf6PsMsVJXBIpPoHMff5JyVXLSzPzCyLiJtgJo=";
-}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -642,6 +642,8 @@ mapAliases {
   electron_37 = throw "electron_37 has been removed in favor of newer versions"; # Added 2026-03-20
   electron_37-bin = throw "electron_37-bin has been removed in favor of newer versions"; # Added 2026-03-20
   elementsd-simplicity = throw "'elementsd-simplicity' has been removed due to lack of maintenance, consider using 'elementsd' instead"; # Added 2025-06-04
+  elixir_1_15 = throw "'elixir_1_15' has been removed, due to the removal of erlang_26 as EOL"; # added 2026-04-01
+  elixir_1_16 = throw "'elixir_1_16' has been removed, due to the removal of erlang_26 as EOL"; # added 2026-04-01
   elixir_ls = throw "'elixir_ls' has been renamed to/replaced by 'elixir-ls'"; # Converted to throw 2025-10-27
   elm-github-install = throw "'elm-github-install' has been removed as it is abandoned upstream and only supports Elm 0.18.0"; # Added 2025-08-25
   emacsMacport = throw "'emacsMacport' has been renamed to/replaced by 'emacs-macport'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -661,6 +661,7 @@ mapAliases {
   eris-go = throw "'eris-go' has been removed due to a hostile upstream moving tags and breaking src FODs"; # Added 2025-09-01
   eriscmd = throw "'eriscmd' has been removed due to a hostile upstream moving tags and breaking src FODs"; # Added 2025-09-01
   erlang-ls = throw "'erlang-ls' has been removed as it has been archived upstream. Consider using 'erlang-language-platform' instead"; # Added 2025-10-02
+  erlang_26 = throw "'erlang_26' has been removed, as it is EOL"; # added 2026-04-01
   esbuild-config = throw "'esbuild-config' has been removed as it has been unmaintained upstream since September 2022"; # Added 2026-02-07
   etBook = warnAlias "'etBook' has been renamed to 'et-book'" et-book; # Added 2026-02-08
   ethercalc = throw "'ethercalc' has been removed from nixpkgs as the project was old, unmaintained, and could not be packaged well in nixpkgs"; # Added 2025-11-28

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5013,7 +5013,6 @@ with pkgs;
     erlang
     erlang_28
     erlang_27
-    erlang_26
     ;
 
   inherit (beam.packages.erlang_28.beamPackages)
@@ -5029,11 +5028,6 @@ with pkgs;
     lfe
     ;
 
-  inherit (beam.packages.erlang_26.beamPackages)
-    elixir_1_16
-    elixir_1_15
-    ;
-
   inherit (beam.packages.erlang)
     erlfmt
     elvis-erlang
@@ -5046,12 +5040,10 @@ with pkgs;
   beamPackages = dontRecurseIntoAttrs beam.packages.erlang.beamPackages;
   beamMinimalPackages = dontRecurseIntoAttrs beam_minimal.packages.erlang.beamPackages;
 
-  beam26Packages = recurseIntoAttrs beam.packages.erlang_26.beamPackages;
   beam27Packages = recurseIntoAttrs beam.packages.erlang_27.beamPackages;
   beam28Packages = recurseIntoAttrs beam.packages.erlang_28.beamPackages;
   beam29Packages = dontRecurseIntoAttrs beam.packages.erlang_29.beamPackages;
 
-  beamMinimal26Packages = recurseIntoAttrs beam_minimal.packages.erlang_26.beamPackages;
   beamMinimal27Packages = recurseIntoAttrs beam_minimal.packages.erlang_27.beamPackages;
   beamMinimal28Packages = recurseIntoAttrs beam_minimal.packages.erlang_28.beamPackages;
   beamMinimal29Packages = dontRecurseIntoAttrs beam_minimal.packages.erlang_29.beamPackages;

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   beam,
   callPackage,
@@ -46,10 +47,6 @@ in
       inherit wxSupport systemdSupport;
     };
 
-    erlang_26 = callErlang ../development/interpreters/erlang/26.nix {
-      inherit wxSupport systemdSupport;
-    };
-
     # Other Beam languages. These are built with `beam.interpreters.erlang`. To
     # access for example elixir built with different version of Erlang, use
     # `beam.packages.erlang_27.elixir`.
@@ -76,6 +73,11 @@ in
     erlang_29 = self.packagesWith self.interpreters.erlang_29;
     erlang_28 = self.packagesWith self.interpreters.erlang_28;
     erlang_27 = self.packagesWith self.interpreters.erlang_27;
-    erlang_26 = self.packagesWith self.interpreters.erlang_26;
+  }
+  // lib.optionalAttrs config.allowAliases {
+    erlang_26 = throw "'erlang_26' has been removed, as it is EOL"; # added 2026-04-01
   };
+}
+// lib.optionalAttrs config.allowAliases {
+  erlang_26 = throw "'erlang_26' has been removed, as it is EOL"; # added 2026-04-01
 }

--- a/pkgs/top-level/beam-packages.nix
+++ b/pkgs/top-level/beam-packages.nix
@@ -56,11 +56,10 @@ in
       elixir_1_19
       elixir_1_18
       elixir_1_17
-      elixir_1_16
-      elixir_1_15
       elixir-ls
       lfe
       ;
+
   };
 
   # Helper function to generate package set with a specific Erlang version.
@@ -80,4 +79,7 @@ in
 }
 // lib.optionalAttrs config.allowAliases {
   erlang_26 = throw "'erlang_26' has been removed, as it is EOL"; # added 2026-04-01
+
+  elixir_1_16 = throw "'elixir_1_16' has been removed, due to the removal of erlang_26 as EOL"; # added 2026-04-01
+  elixir_1_15 = throw "'elixir_1_15' has been removed, due to the removal of erlang_26 as EOL"; # added 2026-04-01
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

OTP 26 will go EOL before or during 26.05. This removes this release, and the corresponding Elixir 1.15.x and 1.16.x, which are not supported on OTP 27.

Closes: #507594

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
