### PR TITLE
various: fix build with boost 1.89

### DIFF
--- a/pkgs/by-name/co/coloquinte/package.nix
+++ b/pkgs/by-name/co/coloquinte/package.nix
@@ -19,6 +19,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-BQg2rVYe1wJOX7YnvgDVpmN6hwBJZKH0fxm+8HC8bvY=";
   };
 
+  # boost 1.89 removed the boost_system stub library
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'FIND_PACKAGE(Boost REQUIRED COMPONENTS system filesystem iostreams program_options unit_test_framework)' \
+      'FIND_PACKAGE(Boost REQUIRED COMPONENTS filesystem iostreams program_options unit_test_framework)'
+  '';
+
   nativeBuildInputs = [
     cmake
   ];

--- a/pkgs/by-name/cp/cpp-hocon/package.nix
+++ b/pkgs/by-name/cp/cpp-hocon/package.nix
@@ -27,6 +27,11 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace CMakeLists.txt --replace-fail \
       "cmake_minimum_required(VERSION 3.2.2)" \
       "cmake_minimum_required(VERSION 3.10)"
+
+    # boost 1.89 removed the boost_system stub library
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'list(APPEND BOOST_COMPONENTS thread date_time chrono filesystem system program_options)' \
+      'list(APPEND BOOST_COMPONENTS thread date_time chrono filesystem program_options)'
   '';
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";

--- a/pkgs/by-name/fi/fileshelter/package.nix
+++ b/pkgs/by-name/fi/fileshelter/package.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     sed -i '1i #include <algorithm>' src/fileshelter/ui/ShareCreateFormView.cpp
+
+    # boost 1.89 removed the boost_system stub library
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'find_package(Boost REQUIRED COMPONENTS system program_options)' \
+      'find_package(Boost REQUIRED COMPONENTS program_options)'
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/gr/grip-search/package.nix
+++ b/pkgs/by-name/gr/grip-search/package.nix
@@ -44,6 +44,14 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace CMakeLists.txt \
       --replace-fail "cmake_minimum_required (VERSION 3.1)" "cmake_minimum_required(VERSION 3.10)"
+
+    # boost 1.89 removed the boost_system stub library
+    substituteInPlace \
+      src/general/CMakeLists.txt \
+      src/test/CMakeLists.txt \
+      src/gripgen/CMakeLists.txt \
+      src/grip/CMakeLists.txt \
+      --replace-fail ' system' ""
   '';
 
   meta = {

--- a/pkgs/by-name/gr/grive2/package.nix
+++ b/pkgs/by-name/gr/grive2/package.nix
@@ -37,6 +37,11 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace-fail 'cmake_minimum_required(VERSION 2.8)' 'cmake_minimum_required(VERSION 3.10)'
+
+    # boost 1.89 removed the boost_system stub library
+    substituteInPlace libgrive/CMakeLists.txt --replace-fail \
+      'find_package(Boost 1.40.0 COMPONENTS program_options filesystem unit_test_framework regex system REQUIRED)' \
+      'find_package(Boost 1.40.0 COMPONENTS program_options filesystem unit_test_framework regex REQUIRED)'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/le/leatherman/package.nix
+++ b/pkgs/by-name/le/leatherman/package.nix
@@ -27,6 +27,20 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace CMakeLists.txt --replace-fail \
       "cmake_minimum_required(VERSION 3.2.2)" \
       "cmake_minimum_required(VERSION 3.10)"
+
+    # boost 1.89 removed the boost_system stub library
+    substituteInPlace \
+      curl/CMakeLists.txt \
+      dynamic_library/CMakeLists.txt \
+      execution/CMakeLists.txt \
+      file_util/CMakeLists.txt \
+      locale/CMakeLists.txt \
+      logging/CMakeLists.txt \
+      ruby/CMakeLists.txt \
+      util/CMakeLists.txt \
+      windows/CMakeLists.txt \
+      --replace-fail ' system' ""
+    substituteInPlace tests/CMakeLists.txt --replace-fail 'system ' ""
   '';
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";

--- a/pkgs/by-name/li/libwhereami/package.nix
+++ b/pkgs/by-name/li/libwhereami/package.nix
@@ -25,6 +25,11 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace CMakeLists.txt --replace-fail \
       "cmake_minimum_required(VERSION 3.2.2)" \
       "cmake_minimum_required(VERSION 3.10)"
+
+    # boost 1.89 removed the boost_system stub library
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'list(APPEND BOOST_COMPONENTS filesystem regex system thread)' \
+      'list(APPEND BOOST_COMPONENTS filesystem regex thread)'
   '';
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";

--- a/pkgs/by-name/lo/localproxy/package.nix
+++ b/pkgs/by-name/lo/localproxy/package.nix
@@ -54,6 +54,9 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace ./CMakeLists.txt --replace-fail \
       "cmake_minimum_required(VERSION 3.2 FATAL_ERROR)" \
       "cmake_minimum_required(VERSION 4.0)"
+
+    # boost 1.89 removed the boost_system stub library
+    substituteInPlace CMakeLists.txt --replace-fail ' system' ""
   '';
 
   # causes redefinition of _FORTIFY_SOURCE

--- a/pkgs/by-name/op/openrw/package.nix
+++ b/pkgs/by-name/op/openrw/package.nix
@@ -34,10 +34,17 @@ stdenv.mkDerivation {
     hash = "sha256-2fQQL0JoV8YukU+VW2iWS4DpBi1j361SfiXRHRmocRg=";
   };
 
-  postPatch = lib.optional (stdenv.cc.isClang && (lib.versionAtLeast stdenv.cc.version "9")) ''
-    substituteInPlace cmake_configure.cmake \
-      --replace-fail 'target_link_libraries(rw_interface INTERFACE "stdc++fs")' ""
-  '';
+  postPatch =
+    lib.optionalString (stdenv.cc.isClang && (lib.versionAtLeast stdenv.cc.version "9")) ''
+      substituteInPlace cmake_configure.cmake \
+        --replace-fail 'target_link_libraries(rw_interface INTERFACE "stdc++fs")' ""
+    ''
+    + ''
+      # boost 1.89 removed the boost_system stub library
+      substituteInPlace CMakeLists.txt --replace-fail \
+        'find_package(Boost COMPONENTS program_options system REQUIRED)' \
+        'find_package(Boost COMPONENTS program_options REQUIRED)'
+    '';
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/sf/sfcgal/package.nix
+++ b/pkgs/by-name/sf/sfcgal/package.nix
@@ -20,6 +20,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-9caucSIEAjzc4cWShuwbBC+BLs5a3e3y58aT4aLzN5E=";
   };
 
+  # boost 1.89 removed the boost_system stub library
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'set( SFCGAL_Boost_COMPONENTS thread system serialization )' \
+      'set( SFCGAL_Boost_COMPONENTS thread serialization )'
+  '';
+
   buildInputs = [
     cgal
     boost

--- a/pkgs/by-name/sr/srsran/package.nix
+++ b/pkgs/by-name/sr/srsran/package.nix
@@ -55,6 +55,17 @@ stdenv.mkDerivation (finalAttrs: {
     zeromq
   ];
 
+  # boost 1.89 removed the boost_system stub library
+  postPatch = ''
+    substituteInPlace cmake/modules/FindUHD.cmake --replace-fail \
+      'set(CMAKE_REQUIRED_LIBRARIES uhd boost_program_options boost_system)' \
+      'set(CMAKE_REQUIRED_LIBRARIES uhd boost_program_options)'
+    substituteInPlace lib/src/phy/rf/CMakeLists.txt --replace-fail \
+      '/usr/lib/x86_64-linux-gnu/libboost_system.so' ""
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'list(APPEND BOOST_REQUIRED_COMPONENTS "system")' ""
+  '';
+
   cmakeFlags = [
     "-DENABLE_WERROR=OFF"
     (lib.cmakeBool "ENABLE_LTE_RATES" enableLteRates)


### PR DESCRIPTION
This fixes [all known issues with Boost 1.89](https://github.com/NixOS/nixpkgs/issues/485826) in the tree. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test