### PR TITLE
feedbackd: 0.8.5 -> 0.8.9

### DIFF
--- a/pkgs/by-name/fe/feedbackd/package.nix
+++ b/pkgs/by-name/fe/feedbackd/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitLab,
+  testers,
   docbook-xsl-nons,
   docutils,
   gi-docgen,
@@ -27,7 +28,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "feedbackd";
-  version = "0.8.5";
+  version = "0.8.9";
 
   outputs = [
     "out"
@@ -37,11 +38,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
-    owner = "agx";
+    owner = "feedbackd";
     repo = "feedbackd";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-m8jDn7gDrZOsdFl17IsIINgcpuHmmtNOCEEdQFwVj6g=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4cbH5jzbLROs/FtbiktlyZPGPYiIo3wgqgOCzyzNzzs=";
   };
+
+  postPatch = ''
+    patchShebangs run.in
+
+    substituteInPlace data/72-feedbackd.rules \
+      --replace-fail '/usr/libexec/' "$out/libexec/"
+  '';
 
   depsBuildBuild = [
     pkg-config
@@ -73,6 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "-Dgtk_doc=true"
     "-Dman=true"
+    "-Dmedia-roles=true"
     # Make compiling work when doCheck = false
     "-Dtests=${lib.boolToString finalAttrs.finalPackage.doCheck}"
   ];
@@ -83,11 +92,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
-
-  postInstall = ''
-    mkdir -p $out/lib/udev/rules.d
-    sed "s|/usr/libexec/|$out/libexec/|" < $src/data/90-feedbackd.rules > $out/lib/udev/rules.d/90-feedbackd.rules
-  '';
 
   postFixup = ''
     # Move developer documentation to devdoc output.
@@ -103,6 +107,10 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   passthru = {
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
     updateScript = nix-update-script { };
   };
 
@@ -110,7 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Theme based Haptic, Visual and Audio Feedback";
-    homepage = "https://gitlab.freedesktop.org/agx/feedbackd/";
+    homepage = "https://gitlab.freedesktop.org/feedbackd/feedbackd/";
     license = with lib.licenses; [
       # feedbackd
       gpl3Plus
@@ -122,6 +130,7 @@ stdenv.mkDerivation (finalAttrs: {
       pacman99
       Luflosi
     ];
+    pkgConfigModules = [ "libfeedback-0.0" ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
This is untested beyond "it builds", I just happened to notice that this was outdated while working on #505818.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
