### PR TITLE
ghostline-cursor-theme: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20751,6 +20751,12 @@
     githubId = 6931743;
     name = "pasqui23";
   };
+  passeriform = {
+    email = "bhardwajutkarsh.ub@gmail.com";
+    github = "Passeriform";
+    githubId = 32395996;
+    name = "Passeriform";
+  };
   passivelemon = {
     email = "jeremyseber@gmail.com";
     github = "PassiveLemon";

--- a/pkgs/by-name/gh/ghostline-cursor-theme/package.nix
+++ b/pkgs/by-name/gh/ghostline-cursor-theme/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ghostline-cursor-theme";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "patinhooh";
+    repo = "ghostline-cursor-theme";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-emllRxawCKiTSseCuoAARs2bG7niyvJU762Y4bDijOQ=";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/icons/Ghostline\ Dark
+    mv linux/dark/{cursors,index.theme} $out/share/icons/Ghostline\ Dark
+  '';
+
+  meta = {
+    description = "Ghostline Cursor theme";
+    homepage = "https://github.com/patinhooh/ghostline-cursor-theme";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ passeriform ];
+  };
+})


### PR DESCRIPTION
Add ghostline cursor theme for Linux desktops.

https://github.com/patinhooh/ghostline-cursor-theme

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
