### PR TITLE
kibot: init at 1.8.5

### DIFF
--- a/pkgs/by-name/bl/blender/wrapper.nix
+++ b/pkgs/by-name/bl/blender/wrapper.nix
@@ -16,14 +16,14 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   installPhase = ''
     mkdir $out/{share/applications,bin} -p
-    sed 's/Exec=blender/Exec=${finalAttrs.finalPackage.pname}/g' $src/share/applications/blender.desktop > $out/share/applications/${finalAttrs.finalPackage.pname}.desktop
+    sed 's/Exec=blender/Exec=blender/g' $src/share/applications/blender.desktop > $out/share/applications/blender.desktop
     cp -r $src/share/blender $out/share
     cp -r $src/share/doc $out/share
     cp -r $src/share/icons $out/share
 
     buildPythonPath "''${pythonPath[*]}"
 
-    makeWrapper ${blender}/bin/blender $out/bin/${finalAttrs.finalPackage.pname} \
+    makeWrapper ${blender}/bin/blender $out/bin/blender \
       --prefix PATH : $program_PATH \
       --prefix PYTHONPATH : $program_PYTHONPATH
   '';

--- a/pkgs/by-name/in/interactive-html-bom-inti-cmnb/package.nix
+++ b/pkgs/by-name/in/interactive-html-bom-inti-cmnb/package.nix
@@ -1,0 +1,64 @@
+{
+  fetchFromGitHub,
+  lib,
+  kicad,
+  python3Packages,
+  xvfb-run,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "interactive-html-bom-inti-cmnb";
+  version = "2.11.0-1";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "INTI-CMNB";
+    repo = "InteractiveHtmlBom";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1yjYkNSAuYt1H030Wg9mbmOLuufxzjgshhhWkptbomw=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = [
+    python3Packages.jsonschema
+    python3Packages.wxpython
+    python3Packages.kicad
+  ];
+
+  nativeCheckInputs = [
+    xvfb-run
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    ln -s ${kicad.base}/share/kicad/demos/stickhub/StickHub.kicad_pcb .
+    HOME=$(mktemp -d) xvfb-run $out/bin/generate_interactive_bom.py --no-browser StickHub.kicad_pcb
+
+    runHook postCheck
+  '';
+
+  buildPhase = ''
+    python setup.py build
+  '';
+
+  installPhase = ''
+    python setup.py install --prefix=$out
+  '';
+
+  postInstall = ''
+    mv $out/bin/generate_interactive_bom $out/bin/generate_interactive_bom.py
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Interactive HTML BOM generation for KiCad, EasyEDA, Eagle, Fusion360 and Allegro PCB designer";
+    homepage = "https://github.com/INTI-CMNB/InteractiveHtmlBom";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ scd31 ];
+    mainProgram = "generate_interactive_bom.py";
+  };
+})

--- a/pkgs/by-name/ki/kibot/fix-interactive-html-bom.patch
+++ b/pkgs/by-name/ki/kibot/fix-interactive-html-bom.patch
@@ -1,0 +1,28 @@
+diff --git a/kibot/out_ibom.py b/kibot/out_ibom.py
+index ac300744..37f97a1c 100644
+--- a/kibot/out_ibom.py
++++ b/kibot/out_ibom.py
+@@ -10,12 +10,7 @@ Dependencies:
+     github: INTI-CMNB/InteractiveHtmlBom
+     command: generate_interactive_bom.py
+     no_cmd_line_version_old: true
+-    plugin_dirs:
+-      - InteractiveHtmlBom
+-      - InteractiveHtmlBom/InteractiveHtmlBom
+-      - org_openscopeproject_InteractiveHtmlBom
+-      - org_openscopeproject_InteractiveHtmlBom/InteractiveHtmlBom
+-    version: 2.7.0
++    version: 2.10.0
+     downloader: pytool
+     id: ibom
+ """
+@@ -204,9 +199,6 @@ class IBoMOptions(VariantOptions):
+                 else:
+                     logger.warning(W_NONETLIST+"The file name used in `extra_data_file` doesn't exist")
+         cmd = [tool, pcb_name, '--dest-dir', output_dir, '--no-browser', ]
+-        if not which(tool) and not os.access(tool, os.X_OK):
+-            # Plugin could be installed without execute flags
+-            cmd.insert(0, 'python3')
+         # Apply variants/filters
+         to_remove = ','.join(self.get_not_fitted_refs(parent=True))
+         if self.blacklist and to_remove:

--- a/pkgs/by-name/ki/kibot/package.nix
+++ b/pkgs/by-name/ki/kibot/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  kicad9,
+  interactive-html-bom-inti-cmnb,
+  symlinkJoin,
+}:
+
+let
+  libraries = kicad9.libraries;
+
+  # KICAD9_TEMPLATE_DIR only works with a single path (it does not handle : separated paths)
+  # but it's used to find both the templates and the symbol/footprint library tables
+  # https://gitlab.com/kicad/code/kicad/-/issues/14792
+  template_dir = symlinkJoin {
+    name = "KiCad_template_dir";
+    paths = with libraries; [
+      "${templates}/share/kicad/template"
+      "${footprints}/share/kicad/template"
+      "${symbols}/share/kicad/template"
+    ];
+  };
+in
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "kibot";
+  version = "1.8.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "INTI-CMNB";
+    repo = "KiBot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9evd7zTGg0csoKGT46w0sE+Ug0Gtn2LuiOlmw4mcNcQ=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  pythonPath = with python3Packages; [
+    kiauto
+    pyyaml
+    xlsxwriter
+    colorama
+    requests
+    qrcodegen
+    markdown2
+    lark
+    kicad9
+    lxml
+    interactive-html-bom-inti-cmnb
+  ];
+
+  buildInputs = [ kicad9 ];
+
+  patches = [
+    ./fix-interactive-html-bom.patch
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/kibot \
+      --set KICAD_PATH "${kicad9}" \
+      --set KICAD9_FOOTPRINT_DIR ${libraries.footprints}/share/kicad/footprints \
+      --set KICAD9_SYMBOL_DIR ${libraries.symbols}/share/kicad/symbols \
+      --set KICAD9_TEMPLATE_DIR ${template_dir} \
+      --set KICAD9_3DMODEL_DIR ${libraries.packages3d}/share/kicad/3dmodels
+  '';
+
+  postInstall = ''
+    find $out -name '*.pyc' -delete
+    find $out -name '__pycache__' -type d -exec rm -r {} +
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Tool for generating fabrication and documentation files for KiCad";
+    homepage = "https://github.com/INTI-CMNB/KiBot";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ scd31 ];
+    mainProgram = "kibot";
+  };
+})

--- a/pkgs/by-name/ki/kicad/base.nix
+++ b/pkgs/by-name/ki/kicad/base.nix
@@ -89,7 +89,17 @@ stdenv.mkDerivation (finalAttrs: {
     ./writable.patch
     # https://gitlab.com/kicad/code/kicad/-/issues/15687
     ./runtime_stock_data_path.patch
-  ];
+  ]
+  ++ (
+    if stable && !testing then
+      [
+        # don't throw non-zero error codes when working with zipped stlZ files
+        # (upstreamed into Kicad 10: https://gitlab.com/kicad/code/kicad/-/merge_requests/2531)
+        ./uncompress.patch
+      ]
+    else
+      [ ]
+  );
 
   # tagged releases don't have "unknown"
   # kicad testing and nightlies use git describe --dirty

--- a/pkgs/by-name/ki/kicad/custom_versions.nix
+++ b/pkgs/by-name/ki/kicad/custom_versions.nix
@@ -1,0 +1,24 @@
+{
+  "kicad9" = {
+    kicadVersion = {
+      version = "9.0.8";
+      src = {
+        rev = "1b361e77008b6a38253c4d90d7c749f4aef0f07f";
+        sha256 = "1b995p0qb9cjpj0n3x3szbqr6d7fxwmrp2nbx37y7ym2bc1lpxd8";
+      };
+    };
+    libVersion = {
+      version = "9.0.8";
+      libSources = {
+        symbols.rev = "83b87ce54ef7c17da4cefe45ad99a5f8d375abe6";
+        symbols.sha256 = "08qb4rqxsyhrcvj1k200m2c06jjy7jwjmf9n1qkcm0biqqc5dba4";
+        templates.rev = "319c71222af4205673e0cab9d772a02bbb34c597";
+        templates.sha256 = "0zs29zn8qjgxv0w1vyr8yxmj02m8752zagn4vcraqgik46dwg2id";
+        footprints.rev = "384ecd066fcaef6aacdd099ca0bb7c47499a9a4b";
+        footprints.sha256 = "1w7dkb93s84ymi1syxpzacbmkxlnlh0k4z1c62nabspb901nn524";
+        packages3d.rev = "6b3a47da075011b33b6de17aa499690f8c5be4a7";
+        packages3d.sha256 = "1j26dmgz7xfixlqrzclb1wpc6zkd10n1fq7rmdrgwwx083p3c7a8";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/ki/kicad/package.nix
+++ b/pkgs/by-name/ki/kicad/package.nix
@@ -22,6 +22,7 @@
   jq,
 
   pname ? "kicad",
+  version9 ? false,
   stable ? true,
   compressStep ? true,
   testing ? false,
@@ -84,13 +85,15 @@
 
 let
   baseName =
-    if testing then
+    if version9 then
+      "kicad9"
+    else if testing then
       "kicad-testing"
     else if stable then
       "kicad"
     else
       "kicad-unstable";
-  versionsImport = import ./versions.nix;
+  versionsImport = import ./versions.nix // import ./custom_versions.nix;
 
   # versions.nix does not provide us with version, src and rev. We
   # need to turn this into appropriate fetcher calls.
@@ -314,6 +317,9 @@ stdenv.mkDerivation rec {
     ];
     supportedFeatures = [ "commit" ];
   };
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   meta = {
     description =

--- a/pkgs/by-name/ki/kicad/uncompress.patch
+++ b/pkgs/by-name/ki/kicad/uncompress.patch
@@ -1,0 +1,25 @@
+--- a/pcbnew/exporters/step/step_pcb_model.cpp
++++ b/pcbnew/exporters/step/step_pcb_model.cpp
+@@ -3365,9 +3365,7 @@ bool STEP_PCB_MODEL::getModelLabel( const wxString& aBaseName, const wxString& a
+                 }
+                 catch( ... )
+                 {
+-                    m_reporter->Report(
+-                            wxString::Format( wxT( "failed to decompress '%s'." ), aFileName ),
+-                            RPT_SEVERITY_ERROR );
++                    // ignore - we try unzipping it below
+                 }
+
+                 if( expanded.empty() )
+@@ -3382,6 +3380,11 @@ bool STEP_PCB_MODEL::getModelLabel( const wxString& aBaseName, const wxString& a
+                         izipfile.Read( ofile );
+                         success = true;
+                     }
++                    else
++                    {
++                        m_reporter->Report( wxString::Format( wxT( "failed to decompress '%s'." ), aFileName ),
++                                            RPT_SEVERITY_ERROR );
++                    }
+                 }
+                 else
+                 {

--- a/pkgs/by-name/ki/kikit/default.nix
+++ b/pkgs/by-name/ki/kikit/default.nix
@@ -6,7 +6,7 @@
   bats,
   buildPythonApplication,
   callPackage,
-  kicad,
+  kicad9,
   numpy,
   click,
   markdown2,
@@ -47,7 +47,7 @@ buildPythonApplication (finalAttrs: {
   ];
 
   dependencies = [
-    kicad
+    kicad9
     numpy
     click
     markdown2

--- a/pkgs/development/python-modules/error-helper/default.nix
+++ b/pkgs/development/python-modules/error-helper/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  hatchling,
+}:
+buildPythonPackage rec {
+  pname = "error-helper";
+  version = "1.5";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "error_helper";
+    inherit version;
+    hash = "sha256-7kbzGmidsZzhoE5p9Ddjn6oDc+HUzkN02ykS0e0JodY=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    hatchling
+  ];
+
+  pythonImportsCheck = [ "error_helper" ];
+
+  meta = {
+    description = "Minimalistic python module which helps you print colorful messages for CLI tools";
+    homepage = "https://github.com/30350n/error_helper";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ scd31 ];
+  };
+}

--- a/pkgs/development/python-modules/kiauto/default.nix
+++ b/pkgs/development/python-modules/kiauto/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  xvfbwrapper,
+  psutil,
+  kicad9Pkg,
+  kicad9,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "kiauto";
+  version = "2.3.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "INTI-CMNB";
+    repo = "KiAuto";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-iK1IlzZ29sDnxHY0gHbTr/HdADXYJWzGx33GsjUa0tE=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    xvfbwrapper
+    psutil
+    kicad9Pkg
+    kicad9
+  ];
+
+  postPatch = ''
+    substituteInPlace kiauto/misc.py \
+      --replace-fail "KICAD_SHARE = '/usr/share/kicad/'" "KICAD_SHARE = '${kicad9Pkg}'"
+  '';
+
+  pythonImportsCheck = [ "kiauto" ];
+
+  meta = {
+    description = "Automation scripts for KiCad";
+    homepage = "https://github.com/INTI-CMNB/KiAuto";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ scd31 ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11774,6 +11774,11 @@ with pkgs;
     pname = "kicad-small";
     with3d = false;
   };
+
+  kicad9 = kicad.override {
+    pname = "kicad9";
+    version9 = true;
+  };
   # this is the stable branch at whatever point update.sh last updated versions.nix
   kicad-testing = kicad.override {
     pname = "kicad-testing";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8293,6 +8293,8 @@ self: super: with self; {
 
   kicad-python = callPackage ../development/python-modules/kicad-python { };
 
+  kicad9 = toPythonModule (pkgs.kicad9.override { python3 = python; }).src;
+
   kicadcliwrapper = callPackage ../development/python-modules/kicadcliwrapper { };
 
   kinparse = callPackage ../development/python-modules/kinparse { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8291,6 +8291,10 @@ self: super: with self; {
 
   khanaa = callPackage ../development/python-modules/khanaa { };
 
+  kiauto = callPackage ../development/python-modules/kiauto {
+    kicad9Pkg = pkgs.kicad9;
+  };
+
   kicad = toPythonModule (pkgs.kicad.override { python3 = python; }).src;
 
   kicad-python = callPackage ../development/python-modules/kicad-python { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5078,6 +5078,8 @@ self: super: with self; {
 
   eradicate = callPackage ../development/python-modules/eradicate { };
 
+  error-helper = callPackage ../development/python-modules/error-helper { };
+
   es-client = callPackage ../development/python-modules/es-client { };
 
   escapism = callPackage ../development/python-modules/escapism { };


### PR DESCRIPTION
Adds Kibot! Kibot is a utility for doing automated stuff with Kicad, like generating files for a board house or cool renders.

This PR does a few things:
- patches a bug in KiCad where it throws non-zero exit codes for perfectly valid stpZ files (which Nix uses for 3D models). I have a PR up to upstream this but I expect it to take a while
- sets up kibot with the env vars it needs to run properly, including when using rendering (which requires some blender shenanigans). Blender is not a dependency, so it's possible to use kibot without pulling in blender

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
