### PR TITLE
readest: 0.9.100 -> 0.10.6

### DIFF
--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -26,13 +26,13 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "readest";
-  version = "0.10.1";
+  version = "0.10.4";
 
   src = fetchFromGitHub {
     owner = "readest";
     repo = "readest";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nlmz3XE8SxWJ8JxBFLRfZmpRyTzYQA2l4qfSC/IsN2k=";
+    hash = "sha256-/4UyRzFALujZ98EdXxiVeLH8W+0Mqm09RZ4zEwOVyyk=";
     fetchSubmodules = true;
   };
 
@@ -49,11 +49,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-0BihRVXYRGKciBhyHd14vco34RYpKE+TUQzwXq6BkrU=";
+    hash = "sha256-7jar0aNXaBfoklGzgvC+1DwsOXgpnOcIcEbIGwWgyfw=";
   };
 
   cargoRoot = "../..";
-  cargoHash = "sha256-d8V3mdfE9LgmPtM2GMWbed3u+GBD45cuSkQ44+lToVY=";
+  cargoHash = "sha256-rxOjXhXN19w8qAEvELIh0oXuB/N80Dtzmf/i3hjRal0=";
 
   buildAndTestSubdir = "src-tauri";
 

--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   rustPlatform,
   pnpm_10,
   fetchPnpmDeps,
@@ -25,13 +26,13 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "readest";
-  version = "0.9.100";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "readest";
     repo = "readest";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GsIOMfNqjcdtVRZ0XwCkxpQoIonivLJVT4GmZyB86M0=";
+    hash = "sha256-nlmz3XE8SxWJ8JxBFLRfZmpRyTzYQA2l4qfSC/IsN2k=";
     fetchSubmodules = true;
   };
 
@@ -48,11 +49,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-/bzjOdpvuPLBMvX/q1WaO3lFg5/jLz5Ypr5OojssXUI=";
+    hash = "sha256-0BihRVXYRGKciBhyHd14vco34RYpKE+TUQzwXq6BkrU=";
   };
 
   cargoRoot = "../..";
-  cargoHash = "sha256-qYBHYjwfGkKmGXN8caamZ6/XGtnxe+lmy6dIpdMwS/I=";
+  cargoHash = "sha256-d8V3mdfE9LgmPtM2GMWbed3u+GBD45cuSkQ44+lToVY=";
 
   buildAndTestSubdir = "src-tauri";
 
@@ -64,6 +65,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     substituteInPlace src/services/constants.ts \
       --replace-fail "autoCheckUpdates: true" "autoCheckUpdates: false" \
       --replace-fail "telemetryEnabled: true" "telemetryEnabled: false"
+
+    mkdir -p src-tauri/plugins/tauri-plugin-turso/dist-js
+    cp -r ${finalAttrs.passthru.tursoPlugin} src-tauri/plugins/tauri-plugin-turso/dist-js
+    jq '.scripts.build = "true"' \
+      src-tauri/plugins/tauri-plugin-turso/package.json | \
+      sponge src-tauri/plugins/tauri-plugin-turso/package.json
   '';
 
   nativeBuildInputs = [
@@ -93,6 +100,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   preBuild = ''
     # set up pdfjs and simplecc
     pnpm setup-vendors
+
+    # `tauri-plugin-turso` expects frontend files to exist before the build, else it fails with:
+    #
+    # > > tauri-plugin-turso-api@0.1.0 build /build/source/apps/readest-app/src-tauri/plugins/tauri-plugin-turso
+    # > > true
+    # >
+    # >   Error Unable to find your web assets, did you forget to build your web app?
+    #     Your frontendDist is set to "../out" (which is `/build/source/apps/readest-app/out`).
+    pnpm --filter @readest/readest-app build
   '';
 
   preFixup = lib.optionalString withNvidiaFix ''
@@ -105,6 +121,37 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   passthru.updateScript = nix-update-script { };
+
+  passthru.tursoPluginDeps = fetchPnpmDeps {
+    pname = "tauri-plugin-turso";
+    version = finalAttrs.version;
+    src = "${finalAttrs.src}/apps/readest-app/src-tauri/plugins/tauri-plugin-turso";
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-Jf/UaEaLUg/v9ZRInBCEfkDY4d6nwyAIegCMKZe0iAQ=";
+  };
+
+  passthru.tursoPlugin = stdenv.mkDerivation {
+    pname = "tauri-plugin-turso";
+    version = finalAttrs.version;
+    src = "${finalAttrs.src}/apps/readest-app/src-tauri/plugins/tauri-plugin-turso";
+
+    nativeBuildInputs = [
+      pnpm_10
+      pnpmConfigHook
+      nodejs
+    ];
+
+    pnpmDeps = finalAttrs.passthru.tursoPluginDeps;
+
+    buildPhase = ''
+      pnpm build
+    '';
+
+    installPhase = ''
+      cp -r dist-js $out
+    '';
+  };
 
   meta = {
     description = "Modern, feature-rich ebook reader";

--- a/pkgs/by-name/re/readest/package.nix
+++ b/pkgs/by-name/re/readest/package.nix
@@ -26,13 +26,13 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "readest";
-  version = "0.10.4";
+  version = "0.10.6";
 
   src = fetchFromGitHub {
     owner = "readest";
     repo = "readest";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/4UyRzFALujZ98EdXxiVeLH8W+0Mqm09RZ4zEwOVyyk=";
+    hash = "sha256-48POUgO6torvLJLXpVzDQLF5sZ2Ws+vhiI1x84+exAw=";
     fetchSubmodules = true;
   };
 
@@ -49,11 +49,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-7jar0aNXaBfoklGzgvC+1DwsOXgpnOcIcEbIGwWgyfw=";
+    hash = "sha256-4CO0ouas6TAZDaL2J8zr9wR28QB/DVN4y1Cqe8m1FEg=";
   };
 
   cargoRoot = "../..";
-  cargoHash = "sha256-rxOjXhXN19w8qAEvELIh0oXuB/N80Dtzmf/i3hjRal0=";
+  cargoHash = "sha256-7wmqDGhtBHU9iOvLrsqGifCEuVdymdljlETkW7dThHA=";
 
   buildAndTestSubdir = "src-tauri";
 


### PR DESCRIPTION
Changelogs:
- https://github.com/readest/readest/releases/tag/v0.9.101
- https://github.com/readest/readest/releases/tag/v0.10.1

Although updating readest to `0.10.1` wasn't straightforward, I'm happy that it works. It's also worth noting that this release is more stable for me than `0.9.101` and I haven't encountered any of the previous issues.

Closes https://github.com/NixOS/nixpkgs/pull/495897

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
