### PR TITLE
docstrfmt: 1.11.0 -> 2.0.2

### DIFF
--- a/pkgs/by-name/do/docstrfmt/package.nix
+++ b/pkgs/by-name/do/docstrfmt/package.nix
@@ -6,29 +6,38 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "docstrfmt";
-  version = "1.11.0";
+  version = "2.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "LilSpazJoekp";
     repo = "docstrfmt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5Yx+omXZSlpJSzA4dTY/JdfmHQshM7qI++OVvqYg1jc=";
+    hash = "sha256-N2uPFOdDvAUL9eV4kn8MYM6OTMWJm24inlyY+k9Eqm8=";
   };
 
   build-system = [
     python3.pkgs.flit-core
   ];
 
+  pythonRelaxDeps = [
+    # https://github.com/LilSpazJoekp/docstrfmt/issues/186
+    "types-docutils"
+  ];
+
   dependencies = with python3.pkgs; [
     black
     click
+    coverage
     docutils
+    docutils-stubs
     libcst
     platformdirs
+    roman
     sphinx
     tabulate
-    toml
+    tomli
+    types-docutils
   ];
 
   nativeCheckInputs = with python3.pkgs; [

--- a/pkgs/development/python-modules/docutils-stubs/default.nix
+++ b/pkgs/development/python-modules/docutils-stubs/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  docutils,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "docutils-stubs";
+  version = "0.0.22";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tk0miya";
+    repo = "docutils-stubs";
+    tag = finalAttrs.version;
+    hash = "sha256-ng/f5e8ElFGNqtpdiQsv897TNkJ4gd++HAxON2l+80s=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    docutils
+  ];
+
+  # Module doesn't have tests
+  doCheck = false;
+
+  meta = {
+    description = "PEP 561 based Type information for docutils";
+    homepage = "https://github.com/tk0miya/docutils-stubs";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ doronbehar ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4571,6 +4571,8 @@ self: super: with self; {
 
   docutils = callPackage ../development/python-modules/docutils { };
 
+  docutils-stubs = callPackage ../development/python-modules/docutils-stubs { };
+
   docx2python = callPackage ../development/python-modules/docx2python { };
 
   docx2txt = callPackage ../development/python-modules/docx2txt { };


### PR DESCRIPTION
- Diff: https://github.com/LilSpazJoekp/docstrfmt/compare/v1.11.0...v2.0.2
- Changelog: https://github.com/LilSpazJoekp/docstrfmt/releases/tag/v2.0.2

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
