### PR TITLE
python3Packages.python-ly: 0.9.9 -> 0.9.10

### DIFF
--- a/pkgs/development/python-modules/python-ly/default.nix
+++ b/pkgs/development/python-modules/python-ly/default.nix
@@ -10,22 +10,20 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "python-ly";
-  version = "0.9.9";
+  version = "0.9.10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "frescobaldi";
     repo = "python-ly";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CMMssU+qoHbhdny0sgpoYQas4ySPVHnu7GPnSthuMuE=";
+    hash = "sha256-diLg1rU+SmCutW1WJQtMJvpipU+k8GluvAqFfcv1GS4=";
   };
 
   pythonImportsCheck = [ "ly" ];
 
   build-system = [ hatchling ];
 
-  # Tests seem to be broken ATM: https://github.com/wbsoft/python-ly/issues/70
-  doCheck = false;
   nativeCheckInputs = [
     lxml
     pytestCheckHook
@@ -48,7 +46,7 @@ buildPythonPackage (finalAttrs: {
       the GNU music typesetter [LilyPond](https://lilypond.org).
     '';
     homepage = "https://pypi.org/project/python-ly";
-    license = lib.licenses.gpl2Plus;
+    license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ yiyu ];
     mainProgram = "ly";
   };


### PR DESCRIPTION
See https://github.com/frescobaldi/python-ly/issues/186 for more details.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
