### PR TITLE
eflite: fix build with gcc15

### DIFF
--- a/pkgs/by-name/ef/eflite/package.nix
+++ b/pkgs/by-name/ef/eflite/package.nix
@@ -30,16 +30,24 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/e/eflite/0.4.1-8/debian/patches/cvs-update";
-      sha256 = "0r631vzmky7b7qyhm152557y4fr0xqrpi3y4w66fcn6p4rj03j05";
+      url = "https://sources.debian.org/data/main/e/eflite/0.4.1-14/debian/patches/cvs-update";
+      hash = "sha256-BcgBZCbXWOaM4cSPeDPuIDviTymihAo9Puv4Wf8Ow2Q=";
     })
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/e/eflite/0.4.1-8/debian/patches/buf-overflow";
-      sha256 = "071qk133kb7n7bq6kxgh3p9bba6hcl1ixsn4lx8vp8klijgrvkmx";
+      url = "https://sources.debian.org/data/main/e/eflite/0.4.1-14/debian/patches/link";
+      hash = "sha256-zAEJl473sk1H6Ltbbeo9IhWE5/Z6QL7EUV63S24bA10=";
     })
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/e/eflite/0.4.1-8/debian/patches/link";
-      sha256 = "0p833dp4pdsya72bwh3syvkq85927pm6snxvx13lvcppisbhj0fc";
+      url = "https://sources.debian.org/data/main/e/eflite/0.4.1-14/debian/patches/buf-overflow";
+      hash = "sha256-vc6dn4x0ortRp8TqHgNl0Ki10h3w9WnwOvasOUaYOBw=";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/e/eflite/0.4.1-14/debian/patches/flags";
+      hash = "sha256-h7+OewOznlOrGNcn2zfE4kb/0rP+h9rTP3TLlyiPTJM=";
+    })
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/e/eflite/0.4.1-14/debian/patches/gcc-15";
+      hash = "sha256-hiQaEM9Rf0KV8rgkXdjj3KIF+4jMYS4J4CT4UIfydGQ=";
     })
     ./format.patch
   ];


### PR DESCRIPTION
- #475479 
- https://hydra.nixos.org/build/322285283

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
