### PR TITLE
tdarr: add missing packages to build and path

### DIFF
--- a/pkgs/tools/misc/tdarr/common.nix
+++ b/pkgs/tools/misc/tdarr/common.nix
@@ -24,6 +24,7 @@
   libxfixes,
   tesseract4,
   perl,
+  apprise,
 }:
 {
   pname,
@@ -129,6 +130,7 @@ stdenv.mkDerivation (finalAttrs: {
     libx11
     libxcursor
     libxfixes
+    apprise
   ];
 
   postPatch = ''
@@ -159,6 +161,12 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postInstall = ''
+    # Remove musl-only prebuilt Node addons on glibc systems.
+    # autoPatchelf scans all ELF files in $out and fails if musl libc is missing.
+    ${lib.optionalString (stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isMusl) ''
+      find $out/share/${pname} -type f -name '*.musl.node' -delete
+    ''}
+
     makeWrapper $out/share/${pname}/${componentName} $out/bin/${pname} ${commonWrapperArgs}
     makeWrapper $out/share/${pname}/${componentTrayName} $out/bin/${pname}-tray ${commonWrapperArgs}
   ''

--- a/pkgs/tools/misc/tdarr/node.nix
+++ b/pkgs/tools/misc/tdarr/node.nix
@@ -1,4 +1,4 @@
-{ callPackage }:
+{ callPackage, ccextractor }:
 
 callPackage ./common.nix { } {
   pname = "tdarr-node";
@@ -10,4 +10,6 @@ callPackage ./common.nix { } {
     darwin_x64 = "sha256-icgzoHqZ+P6gXJ8jQTau3O2D6uRvET4MtNoWJI/JnvM=";
     darwin_arm64 = "sha256-Rw478IpDLLe+Ek3Jt5Duaq1sHL1D3pE0HkVqk+v1ECE=";
   };
+
+  includeInPath = [ ccextractor ];
 }


### PR DESCRIPTION
Added apprise for the server notifications and ccextractor to the node 

Resolves #505669
Resolves #506001

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
