### PR TITLE
stoolap: 0.3.7 -> 0.4.0, add update script

### DIFF
--- a/pkgs/by-name/st/stoolap/package.nix
+++ b/pkgs/by-name/st/stoolap/package.nix
@@ -3,25 +3,28 @@
   rustPlatform,
   fetchFromGitHub,
   stdenv,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "stoolap";
-  version = "0.3.7";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "stoolap";
     repo = "stoolap";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NfGs9TDyX+8hC2bCGJL0AWFd3C1joowT061vea5hxx0=";
+    hash = "sha256-TE16vsLzhwmqZRZrmWx8ikv2HJbB4sAXaKSPPNsMeLw=";
   };
 
-  cargoHash = "sha256-tzgxffwXd331Sz1xftXNBowqud29pKvbw+Epv01xOiQ=";
+  cargoHash = "sha256-ZWu1uu607n3wl3k7xcpS7cHbX7mifAX9gvo8KQmCB/E=";
 
   # On aarch64-darwin, dev target needs to set panic strategy to abort
   # However this must be set while the flag `-Zpanic_abort_tests` is also set,
   # which could only be done in Rust nightly toolchain.
   doCheck = !(with stdenv.hostPlatform; isDarwin && isAarch64);
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Modern Embedded SQL Database written in Rust";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
