### PR TITLE
surge-downloader: init at 0.7.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5549,6 +5549,13 @@
     githubId = 1222362;
     name = "Matías Lang";
   };
+  crispyfires = {
+    email = "junkstuff7489@gmail.com";
+    name = "Crispyfires";
+    matrix = "@ithkuilthecultist:matrix.org";
+    github = "crispyfires";
+    githubId = 152764922;
+  };
   criyle = {
     email = "i+nixos@goj.ac";
     name = "Yang Gao";

--- a/pkgs/by-name/su/surge-downloader/package.nix
+++ b/pkgs/by-name/su/surge-downloader/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  stdenv,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "surge-downloader";
+  version = "0.7.5";
+
+  src = fetchFromGitHub {
+    owner = "surge-downloader";
+    repo = "surge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zI2eCVvj+u16mQstdL9yY0eVSj2YIGRGHlmsbRHoPXA=";
+  };
+
+  vendorHash = "sha256-zaQPmtzGfdj959Mi0Zt1R097XkZFbtJspcYry4SkpEg=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/surge-downloader/surge/cmd.Version=${finalAttrs.version}"
+    "-X=github.com/surge-downloader/surge/cmd.BuildTime=1970-01-01T00:00:00Z"
+  ];
+
+  # Workaround for a test that requires the root path /homeless-shelter to be writeable
+  postPatch = ''
+    substituteInPlace internal/utils/debug_test.go \
+    --replace-fail 'logsDir := config.GetLogsDir()' 'logsDir := config.GetLogsDir(); if v := os.Getenv("TMPDIR"); v != "" { logsDir = filepath.Join(v, "surge-logs") }'
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Blazing fast TUI download manager built in Go for power users";
+    homepage = "https://github.com/surge-downloader/surge";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ crispyfires ];
+    mainProgram = "surge";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Surge](https://github.com/surge-downloader/surge) is a TUI download manager written in Go.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
