### PR TITLE
python3Packages.ml-dtypes: include upstream patch for numpy 2.4.3

### DIFF
--- a/pkgs/development/python-modules/ml-dtypes/default.nix
+++ b/pkgs/development/python-modules/ml-dtypes/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
 
   # build-system
   setuptools,
@@ -29,6 +30,15 @@ buildPythonPackage rec {
     # Hence, we rely on the bundled eigen library.
     fetchSubmodules = true;
   };
+
+  patches = [
+    # Fix tests for numpy 2.4.3, which changed the way testing assertions
+    # handle behaviors with NaN equivalence on the custom numeric types.
+    (fetchpatch2 {
+      url = "https://github.com/jax-ml/ml_dtypes/commit/04c4dc8b23720d9d92f3cc849ffc387d5798db84.patch?full_index=1";
+      hash = "sha256-jqqiDYcHq58JxSqtHfXcNWFbMFhvufqafDPHmORe6F0=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \


### PR DESCRIPTION
Numpy 2.4.3 (currently present on staging) changes the float equality semantics for NaN-equivalence, which breaks ml_dtypes' tests and causes build failures. We include an upstream commit to fix this: https://github.com/jax-ml/ml_dtypes/commit/04c4dc8b23720d9d92f3cc849ffc387d5798db84.

For full build logs from staging, see: [ml-dtypes-0.5.4.txt](https://github.com/user-attachments/files/26426562/ml-dtypes-0.5.4.txt)

I'm targeting master instead of staging as this fix isn't a mass rebuild and the package continues to build, but I can retarget if that's desirable.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
