### PR TITLE
treewide: remove redundant name attrs and parseDrvName calls

### DIFF
--- a/pkgs/development/beam-modules/rebar3-release.nix
+++ b/pkgs/development/beam-modules/rebar3-release.nix
@@ -57,7 +57,6 @@ let
       attrs
       // {
 
-        name = "${pname}-${version}";
         inherit version pname;
 
         buildInputs =

--- a/pkgs/development/idris-modules/build-builtin-package.nix
+++ b/pkgs/development/idris-modules/build-builtin-package.nix
@@ -3,12 +3,10 @@
 # deps: The dependencies of the package
 { idris, build-idris-package }:
 pname: deps:
-let
-  inherit (builtins.parseDrvName idris.name) version;
-in
 build-idris-package {
 
-  inherit pname version;
+  inherit pname;
+  inherit (idris) version;
   inherit (idris) src;
 
   noPrelude = true;

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -39,12 +39,7 @@ lib.makeOverridable (
     platform ? "ruby",
     ruby ? defs.ruby,
     stdenv ? ruby.stdenv,
-    namePrefix ? (
-      let
-        rubyName = builtins.parseDrvName ruby.name;
-      in
-      "${rubyName.name}${lib.versions.majorMinor rubyName.version}-"
-    ),
+    namePrefix ? "${ruby.pname}${lib.versions.majorMinor (toString ruby.version)}-",
     nativeBuildInputs ? [ ],
     buildInputs ? [ ],
     meta ? { },

--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -38,7 +38,6 @@
 let
   pname = "xonotic";
   version = "0.8.6";
-  name = "${pname}-${version}";
   variant =
     if withSDL && withGLX then
       ""

--- a/pkgs/tools/security/bundler-audit/default.nix
+++ b/pkgs/tools/security/bundler-audit/default.nix
@@ -6,7 +6,6 @@
 }:
 
 bundlerEnv rec {
-  name = "${pname}-${version}";
   pname = "bundler-audit";
   version = (import ./gemset.nix).bundler-audit.version;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Part of #103997.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
