### PR TITLE
ocamlPackages.miou: 0.4.0 → 0.5.5

### DIFF
--- a/pkgs/development/ocaml-modules/miou/default.nix
+++ b/pkgs/development/ocaml-modules/miou/default.nix
@@ -2,24 +2,27 @@
   lib,
   buildDunePackage,
   fetchurl,
+  dune-configurator,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "miou";
-  version = "0.4.0";
+  version = "0.5.5";
 
   minimalOCamlVersion = "5.0.0";
 
   src = fetchurl {
-    url = "https://github.com/robur-coop/miou/releases/download/v${version}/miou-${version}.tbz";
-    hash = "sha256-2a5SET2SPyQloTdcWU9KzPYRcXgK8e8hHbu6OP9R2s8=";
+    url = "https://github.com/robur-coop/miou/releases/download/v${finalAttrs.version}/miou-${finalAttrs.version}.tbz";
+    hash = "sha256-YJZ/nlqpxW77mhcamtCMx5d6/f9MVVBv1QCOz55EyuA=";
   };
+
+  buildInputs = [ dune-configurator ];
 
   meta = {
     description = "Composable concurrency primitives for OCaml";
     homepage = "https://git.robur.coop/robur/miou";
-    changelog = "https://git.robur.coop/robur/miou/src/tag/v${version}/CHANGES.md";
+    changelog = "https://git.robur.coop/robur/miou/src/tag/v${finalAttrs.version}/CHANGES.md";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
