### PR TITLE
organicmaps: 2026.01.26-11 -> 2026.05.27-11, devendor dependencies

### DIFF
--- a/pkgs/by-name/or/organicmaps/boost.patch
+++ b/pkgs/by-name/or/organicmaps/boost.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7d9128ce6c9..4f47afc31a3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -182,6 +182,7 @@ endif()
+ if (WITH_SYSTEM_PROVIDED_3PARTY)
+   set(GFLAGS_USE_TARGET_NAMESPACE ON)
+   find_package(gflags REQUIRED)
++  find_package(Boost CONFIG REQUIRED COMPONENTS headers)
+ 
+   find_package(expat CONFIG REQUIRED)
+   find_package(jansson CONFIG REQUIRED)

--- a/pkgs/by-name/or/organicmaps/force-vendored-protobuf.patch
+++ b/pkgs/by-name/or/organicmaps/force-vendored-protobuf.patch
@@ -1,0 +1,39 @@
+index 84fc55c511..3a006ddae2 100644
+--- i/3party/CMakeLists.txt
++++ w/3party/CMakeLists.txt
+@@ -38,32 +38,32 @@ if (NOT WITH_SYSTEM_PROVIDED_3PARTY)
+ 
+   # Add gflags library.
+   set(GFLAGS_BUILD_TESTING OFF)
+   set(GFLAGS_BUILD_PACKAGING OFF)
+   add_subdirectory(gflags)
+   target_compile_options(gflags_nothreads_static PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-subobject-linkage>)
+ 
+   # Add pugixml library.
+   add_subdirectory(pugixml)
+ 
+-  # Add protobuf library.
+-  add_subdirectory(protobuf)
+-
+   add_subdirectory(freetype)
+   add_subdirectory(icu)
+   add_subdirectory(harfbuzz)
+ 
+   add_library(utf8cpp INTERFACE)
+   add_library(utf8cpp::utf8cpp ALIAS utf8cpp)
+   target_include_directories(utf8cpp INTERFACE "${OMIM_ROOT}/3party/utfcpp/source")
+ endif()
+ 
++# Add protobuf library.
++add_subdirectory(protobuf)
++
+ add_subdirectory(agg)
+ add_subdirectory(bsdiff-courgette)
+ add_subdirectory(glaze)
+ add_subdirectory(minizip)
+ add_subdirectory(open-location-code)
+ add_subdirectory(opening_hours)
+ add_subdirectory(stb_image)
+ add_subdirectory(succinct)
+ 
+ add_subdirectory(vulkan_wrapper)

--- a/pkgs/by-name/or/organicmaps/force-vendored-protobuf.patch
+++ b/pkgs/by-name/or/organicmaps/force-vendored-protobuf.patch
@@ -1,0 +1,24 @@
+diff --git a/3party/CMakeLists.txt b/3party/CMakeLists.txt
+index c802251db8..314f4d4543 100644
+--- a/3party/CMakeLists.txt
++++ b/3party/CMakeLists.txt
+@@ -33,9 +33,6 @@ if (NOT WITH_SYSTEM_PROVIDED_3PARTY)
+   # Add pugixml library.
+   add_subdirectory(pugixml)
+ 
+-  # Add protobuf library.
+-  add_subdirectory(protobuf)
+-
+   add_subdirectory(freetype)
+   add_subdirectory(icu)
+   add_subdirectory(harfbuzz)
+@@ -45,6 +42,9 @@ if (NOT WITH_SYSTEM_PROVIDED_3PARTY)
+   target_include_directories(utf8cpp SYSTEM INTERFACE "${OMIM_ROOT}/3party/utfcpp/source")
+ endif()
+ 
++# Add protobuf library.
++add_subdirectory(protobuf)
++
+ add_subdirectory(agg)
+ add_subdirectory(bsdiff-courgette)
+ add_subdirectory(glaze)

--- a/pkgs/by-name/or/organicmaps/package.nix
+++ b/pkgs/by-name/or/organicmaps/package.nix
@@ -18,42 +18,35 @@
   libxrandr,
   libxinerama,
   libxcursor,
+  gflags,
+  expat,
+  jansson,
+  boost,
+  fast-float,
+  utfcpp,
   nix-update-script,
 }:
 
-let
-  world_feed_integration_tests_data = fetchFromGitHub {
-    owner = "organicmaps";
-    repo = "world_feed_integration_tests_data";
-    rev = "30ecb0b3fe694a582edfacc2a7425b6f01f9fec6";
-    hash = "sha256-1FF658OhKg8a5kKX/7TVmsxZ9amimn4lB6bX9i7pnI4=";
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "organicmaps";
-  version = "2026.01.26-11";
+  version = "2026.03.11-12";
 
   src = fetchFromGitHub {
     owner = "organicmaps";
     repo = "organicmaps";
     tag = "${finalAttrs.version}-android";
-    hash = "sha256-EsVPzibUta0cmKA6bYLqCKKij5FWbwPHgMmIs2THpL0=";
+    hash = "sha256-9UB/Qr+nNjNz8iDsxM7fTa6a2PDb7N90vE6cwkJ+K00=";
     fetchSubmodules = true;
   };
 
-  postPatch = ''
-    # Disable certificate check. It's dependent on time
-    echo "exit 0" > tools/unix/check_cert.sh
-
-    # crude fix for https://github.com/organicmaps/organicmaps/issues/1862
-    echo "echo ${lib.replaceStrings [ "." "-" ] [ "" "" ] finalAttrs.version}" > tools/unix/version.sh
-
-    # TODO use system boost instead, see https://github.com/organicmaps/organicmaps/issues/5345
-    patchShebangs 3party/boost/tools/build/src/engine/build.sh
-
-    # Prefetch test data, or the build system will try to fetch it with git.
-    ln -s ${world_feed_integration_tests_data} data/test_data/world_feed_integration_tests_data
-  '';
+  patches = [
+    # Adds a missing find_package
+    # https://github.com/organicmaps/organicmaps/pull/11902
+    ./boost.patch
+    # Needs the very old protobuf 3.3, so we use the vendored one
+    # https://github.com/organicmaps/organicmaps/pull/6310
+    ./force-vendored-protobuf.patch
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -65,7 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.wrapQtAppsHook
   ];
 
-  # Most dependencies are vendored
   buildInputs = [
     qt6.qtbase
     qt6.qtpositioning
@@ -80,12 +72,21 @@ stdenv.mkDerivation (finalAttrs: {
     libxrandr
     libxinerama
     libxcursor
+    gflags
+    expat
+    jansson
+    boost
+    fast-float
+    utfcpp
   ];
 
-  # Yes, this is PRE configure. The configure phase uses cmake
-  preConfigure = ''
-    bash ./configure.sh
-  '';
+  cmakeFlags = [
+    (lib.cmakeBool "WITH_SYSTEM_PROVIDED_3PARTY" true)
+    (lib.cmakeBool "SKIP_TESTS" true)
+    (lib.cmakeBool "SKIP_TOOLS" true)
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev utfcpp}/include/utf8cpp";
 
   passthru = {
     updateScript = nix-update-script {

--- a/pkgs/by-name/or/organicmaps/package.nix
+++ b/pkgs/by-name/or/organicmaps/package.nix
@@ -18,42 +18,32 @@
   libxrandr,
   libxinerama,
   libxcursor,
+  gflags,
+  expat,
+  jansson,
+  boost,
+  fast-float,
+  utf8cpp,
   nix-update-script,
 }:
 
-let
-  world_feed_integration_tests_data = fetchFromGitHub {
-    owner = "organicmaps";
-    repo = "world_feed_integration_tests_data";
-    rev = "30ecb0b3fe694a582edfacc2a7425b6f01f9fec6";
-    hash = "sha256-1FF658OhKg8a5kKX/7TVmsxZ9amimn4lB6bX9i7pnI4=";
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "organicmaps";
-  version = "2026.01.26-11";
+  version = "2026.05.27-11";
 
   src = fetchFromGitHub {
     owner = "organicmaps";
     repo = "organicmaps";
     tag = "${finalAttrs.version}-android";
-    hash = "sha256-EsVPzibUta0cmKA6bYLqCKKij5FWbwPHgMmIs2THpL0=";
+    hash = "sha256-zLNQk9CCCk3linmAyAT5qsS5GhrOrlSVOdDf5koBwrc=";
     fetchSubmodules = true;
   };
 
-  postPatch = ''
-    # Disable certificate check. It's dependent on time
-    echo "exit 0" > tools/unix/check_cert.sh
-
-    # crude fix for https://github.com/organicmaps/organicmaps/issues/1862
-    echo "echo ${lib.replaceStrings [ "." "-" ] [ "" "" ] finalAttrs.version}" > tools/unix/version.sh
-
-    # TODO use system boost instead, see https://github.com/organicmaps/organicmaps/issues/5345
-    patchShebangs 3party/boost/tools/build/src/engine/build.sh
-
-    # Prefetch test data, or the build system will try to fetch it with git.
-    ln -s ${world_feed_integration_tests_data} data/test_data/world_feed_integration_tests_data
-  '';
+  patches = [
+    # Needs the very old protobuf 3.3, so we use the vendored one
+    # https://github.com/organicmaps/organicmaps/pull/6310
+    ./force-vendored-protobuf.patch
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -65,7 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.wrapQtAppsHook
   ];
 
-  # Most dependencies are vendored
   buildInputs = [
     qt6.qtbase
     qt6.qtpositioning
@@ -80,12 +69,21 @@ stdenv.mkDerivation (finalAttrs: {
     libxrandr
     libxinerama
     libxcursor
+    gflags
+    expat
+    jansson
+    boost
+    fast-float
+    utf8cpp
   ];
 
-  # Yes, this is PRE configure. The configure phase uses cmake
-  preConfigure = ''
-    bash ./configure.sh
-  '';
+  cmakeFlags = [
+    (lib.cmakeBool "WITH_SYSTEM_PROVIDED_3PARTY" true)
+    (lib.cmakeBool "SKIP_TESTS" true)
+    (lib.cmakeBool "SKIP_TOOLS" true)
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev utf8cpp}/include/utf8cpp";
 
   passthru = {
     updateScript = nix-update-script {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
