### PR TITLE
claude-code: 2.1.89 -> 2.1.90

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -8,8 +8,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     name = "claude-code";
     publisher = "anthropic";
-    version = "2.1.89";
-    hash = "sha256-9GASgI7ifhxAj4L6Xf1MGyGsiFcC5NZb2ICCjLUf5Qw=";
+    version = "2.1.90";
+    hash = "sha256-8xHAEqxxCA0bw/4eNFL2PutMquD2H7FO1o2yycAJ4ME=";
   };
 
   postInstall = ''

--- a/pkgs/by-name/cl/claude-code-bin/manifest.json
+++ b/pkgs/by-name/cl/claude-code-bin/manifest.json
@@ -1,46 +1,46 @@
 {
-  "version": "2.1.89",
-  "buildDate": "2026-03-31T23:01:10Z",
+  "version": "2.1.90",
+  "buildDate": "2026-04-01T22:59:02Z",
   "platforms": {
     "darwin-arm64": {
       "binary": "claude",
-      "checksum": "f903a5e53f845b1ac5566296b713193827665f28da16300fdca7539cb0669a7f",
-      "size": 196886384
+      "checksum": "73c1a7570501ca743cd2d7467cb4699103534a2138052a4e6cab53c0e09d79c8",
+      "size": 197828752
     },
     "darwin-x64": {
       "binary": "claude",
-      "checksum": "1322c5eecec8047e9cd7114f7d547ef6a9596563d6bbc7e594167d0f8bc8b406",
-      "size": 198397008
+      "checksum": "9934675063ea4360665b7a43f649c92e6ba5cf93257324af7af1a6b490746395",
+      "size": 199326928
     },
     "linux-arm64": {
       "binary": "claude",
-      "checksum": "428301f56cf0139e6fbfa55e13be3f0f032ac1eb5ddb8849fbc703ee220c1cca",
-      "size": 228657728
+      "checksum": "15d5089ee7d9981faacf5463eabd427a012814d9fc02113883bb23a4f387ad4a",
+      "size": 230165056
     },
     "linux-x64": {
       "binary": "claude",
-      "checksum": "903cb3c96b314d86856632c8702f5cdf971b804d0b19ef87446573bcd1d7df1c",
-      "size": 228473472
+      "checksum": "6074e3959989b2958a9abec60adf7b441a0f6f1c7e66401abff0fe54dad04fd6",
+      "size": 229902976
     },
     "linux-arm64-musl": {
       "binary": "claude",
-      "checksum": "7cb5fd60f3d2366672857077f3bd0f93ab83dffebd8f93c70344afa58bdb91ec",
-      "size": 221776320
+      "checksum": "2508fa1c9c0575cf6fa26f2561ff7f0fd83be5fb4c6f9ec8281dfd5911d44371",
+      "size": 223218112
     },
     "linux-x64-musl": {
       "binary": "claude",
-      "checksum": "60941916f0a5656a5952a0f2f54228f574f8756ea503119f858724ad43c9b28d",
-      "size": 223099328
+      "checksum": "854746d04db11f543ed8d3836b5316366d965e6b6cfa2ac6312e6f7a5c4b5cb1",
+      "size": 224201152
     },
     "win32-x64": {
       "binary": "claude.exe",
-      "checksum": "2e312000b538f11d13f1dfc52d4131996895b9a07bd8897d8f9153635d4ea092",
-      "size": 238557856
+      "checksum": "f6be38fbdcadc373e93f751d1286845f58b032690e32be8f64799380a295a79f",
+      "size": 239622816
     },
     "win32-arm64": {
       "binary": "claude.exe",
-      "checksum": "5f1d597c542aac3a11f557e12c92d0c49220ab77e741014b0599a572d81ca679",
-      "size": 235014304
+      "checksum": "019f7210055cd7a884d13c4e6a0b6caf1a82348ee42950b7b5247a4b0484709c",
+      "size": 236335776
     }
   }
 }

--- a/pkgs/by-name/cl/claude-code/package-lock.json
+++ b/pkgs/by-name/cl/claude-code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@anthropic-ai/claude-code",
-  "version": "2.1.89",
+  "version": "2.1.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@anthropic-ai/claude-code",
-      "version": "2.1.89",
+      "version": "2.1.90",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"

--- a/pkgs/by-name/cl/claude-code/package.nix
+++ b/pkgs/by-name/cl/claude-code/package.nix
@@ -15,14 +15,14 @@
 }:
 buildNpmPackage (finalAttrs: {
   pname = "claude-code";
-  version = "2.1.89";
+  version = "2.1.90";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${finalAttrs.version}.tgz";
-    hash = "sha256-FoTm6KDr+8Dzhk4ibZUlU1QLPFdPm/OriUUWqAaFswg=";
+    hash = "sha256-4/hqWrY2fncQ8p0TxwBAI+mNH98ZDhjvFqB9us7GJK0=";
   };
 
-  npmDepsHash = "sha256-NI4F5bq0lEuMjLUdkGrml2aOzGbGkdyUckgfeVFEe8o=";
+  npmDepsHash = "sha256-kWbbIAoNAQ/BtsICmsabkfnS/1Nta5MQ4iX9+oH7WRw=";
 
   strictDeps = true;
 


### PR DESCRIPTION
Update claude-code, claude-code-bin, and vscode-extensions.anthropic.claude-code to 2.1.90.

https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
