### PR TITLE
python3Packages.psutil_7_1: init at 7.1.2, home-assistant: pin psutil to 7.1.2 for systemmonitor

### DIFF
--- a/pkgs/development/python-modules/psutil/7_1.nix
+++ b/pkgs/development/python-modules/psutil/7_1.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  python,
+}:
+
+buildPythonPackage rec {
+  pname = "psutil";
+  version = "7.1.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "giampaolo";
+    repo = "psutil";
+    tag = "release-${version}";
+    hash = "sha256-LyGnLrq+SzCQmz8/P5DOugoNEyuH0IC7uIp8UAPwH0U=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # Segfaults on darwin:
+  # https://github.com/giampaolo/psutil/issues/1715
+  doCheck = !stdenv.hostPlatform.isDarwin;
+
+  # Only test_system.py is enabled; other test files require hardware access
+  # or fail in the sandbox (e.g. process, network, memory tests).
+  enabledTestPaths = [
+    # $out is needed because psutil 7.1.x has tests inside the psutil package
+    # (not top-level like 7.2.x) and C extensions are only in the installed output
+    "${placeholder "out"}/${python.sitePackages}/psutil/tests/test_system.py"
+  ];
+
+  disabledTests = [
+    # Some of the tests have build-system hardware-based impurities (like
+    # reading temperature sensor values).  Disable them to avoid the failures
+    # that sometimes result.
+    "cpu_freq"
+    "cpu_times"
+    "disk_io_counters"
+    "sensors_battery"
+    "sensors_temperatures"
+    "user"
+    "test_disk_partitions" # problematic on Hydra's Linux builders, apparently
+  ];
+
+  pythonImportsCheck = [ "psutil" ];
+
+  meta = {
+    description = "Process and system utilization information interface";
+    homepage = "https://github.com/giampaolo/psutil";
+    changelog = "https://github.com/giampaolo/psutil/blob/${src.tag}/HISTORY.rst";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ matteopacini ];
+  };
+}

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -223,6 +223,10 @@ let
         doCheck = false;
       });
 
+      # Pinned because systemmonitor in Home Assistant 2026.3.4 still requires
+      # psutil 7.1.2 and breaks with 7.2.x (missing sbattery in psutil._common).
+      psutil = self.psutil_7_1;
+
       # internal python packages only consumed by home-assistant itself
       hass-web-proxy-lib = self.callPackage ./python-modules/hass-web-proxy-lib { };
       home-assistant-frontend = self.callPackage ./frontend.nix { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12965,6 +12965,8 @@ self: super: with self; {
 
   psutil-home-assistant = callPackage ../development/python-modules/psutil-home-assistant { };
 
+  psutil_7_1 = callPackage ../development/python-modules/psutil/7_1.nix { };
+
   psychrolib = callPackage ../development/python-modules/psychrolib { };
 
   psycopg = callPackage ../development/python-modules/psycopg { };


### PR DESCRIPTION
 Add `python3Packages.psutil_7_1` (psutil 7.1.2) as a standalone versioned package and use it in the Home Assistant python environment. 

Home Assistant's `systemmonitor` component still requires `psutil==7.1.2` and breaks at import time with psutil 7.2.x 

Supersedes #497895. Resolves #496133.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
