### PR TITLE
cryptomator: fix GTK file chooser drawing failure due to freetype con…

### DIFF
--- a/pkgs/by-name/cr/cryptomator/package.nix
+++ b/pkgs/by-name/cr/cryptomator/package.nix
@@ -10,6 +10,7 @@
   maven,
   wrapGAppsHook3,
   nix-update-script,
+  freetype,
 }:
 
 let
@@ -86,6 +87,7 @@ maven.buildMavenPackage rec {
         lib.makeLibraryPath [
           fuse3
           libayatana-appindicator
+          freetype
         ]
       }" \
       --set JAVA_HOME "${jdk.home}"
@@ -119,6 +121,7 @@ maven.buildMavenPackage rec {
     glib
     jdk
     libayatana-appindicator
+    freetype
   ];
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
When a user selects "Open Existing Vault" the file dialog does not properly display. This PR fixes the drawing failure for widget 'GtkFileChooserDialog': error occurred in libfreetype.
Adding freetype to LD_LIBRARY_PATH ensures a consistent ABI is used.

```output
(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkLabel': error occurred in libfreetype

(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkBox': error occurred in libfreetype

(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkEventBox': error occurred in libfreetype

(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkRevealer': error occurred in libfreetype

(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkSidebarRow': error occurred in libfreetype

(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkListBox': error occurred in libfreetype

(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkViewport': error occurred in libfreetype

(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkPlacesSidebar': error occurred in libfreetype

(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkPaned': error occurred in libfreetype

(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkBox': error occurred in libfreetype

(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkFileChooserWidget': error occurred in libfreetype

(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkBox': error occurred in libfreetype

(java:5550): Gtk-WARNING **: 02:39:45.666: drawing failure for widget 'GtkFileChooserDialog': error occurred in libfreetype

```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
