### PR TITLE
[Backport release-25.11] calibre: backport some CVEs and maintainer add

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23780,6 +23780,11 @@
     githubId = 33031;
     name = "Greg Pfeil";
   };
+  sempiternal-aurora = {
+    github = "sempiternal-aurora";
+    githubId = 78790545;
+    name = "Myria Sarvay";
+  };
   semtexerror = {
     email = "github@spampert.com";
     github = "SemtexError";

--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -153,6 +153,15 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://github.com/kovidgoyal/calibre/commit/b1ef6a8142b8dadeb7e72c250c65d42b36ee7118.patch";
         hash = "sha256-1uZ2c+yUilt06okc0vSgilPrmvluAodbwEMEtdd/7JE=";
       })
+      # Fix CVE-2026-33206
+      # http://tracker.security.nixos.org/issues/NIXPKGS-2026-0825
+      # https://github.com/NixOS/nixpkgs/issues/504458
+      # Fixed upstream in 9.6.0.
+      (fetchpatch {
+        name = "CVE-2026-33206.patch";
+        url = "https://github.com/kovidgoyal/calibre/commit/c43f347837dbc00d9a7b5ff15a228b6f6081e290.patch";
+        hash = "sha256-rHDMaZ/P9Or6Asr9YZO1lmvNqEpoFfil1w98t713XdI=";
+      })
     ]
     ++ lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;
 

--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -352,7 +352,10 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     changelog = "https://github.com/kovidgoyal/calibre/releases/tag/v${finalAttrs.version}";
     license = if unrarSupport then lib.licenses.unfreeRedistributable else lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ pSub ];
+    maintainers = with lib.maintainers; [
+      pSub
+      sempiternal-aurora
+    ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -139,6 +139,20 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://github.com/kovidgoyal/calibre/commit/0f8dc639337d9ace67201e15ca12d5906d05f4c8.patch";
         hash = "sha256-P/x1dsxHQ1cp/H34CIXvBvge2LCEQ1QKrTuJwpOEunY=";
       })
+      # Fix CVE-2026-33205
+      # http://tracker.security.nixos.org/issues/NIXPKGS-2026-0824
+      # https://github.com/NixOS/nixpkgs/issues/504457
+      # Fixed upstream in 9.6.0.
+      (fetchpatch {
+        name = "CVE-2026-33205.1.patch";
+        url = "https://github.com/kovidgoyal/calibre/commit/6eb7b5458f183c8a037e9d7dac428122a77204e4.patch";
+        hash = "sha256-JhMTuvqR0CZ1zNYC3pKRnu07ftl71Z/IDS3sKa3i2Ic=";
+      })
+      (fetchpatch {
+        name = "CVE-2026-33205.2.patch";
+        url = "https://github.com/kovidgoyal/calibre/commit/b1ef6a8142b8dadeb7e72c250c65d42b36ee7118.patch";
+        hash = "sha256-1uZ2c+yUilt06okc0vSgilPrmvluAodbwEMEtdd/7JE=";
+      })
     ]
     ++ lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Backport adding myself as maintainer, and also a bunch of CVE fixes included in 9.6.0 backported to stable.

Fixes: #504457 and #504458

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
