### PR TITLE
python3Packages.pytorch-pfn-extras: 0.8.4 -> 0.9.0

### DIFF
--- a/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
+++ b/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   setuptools,
@@ -15,21 +16,21 @@
 
   # tests
   onnx,
+  pyparsing,
   pytestCheckHook,
   torchvision,
-  pythonAtLeast,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pytorch-pfn-extras";
-  version = "0.8.4";
+  version = "0.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pfnet";
     repo = "pytorch-pfn-extras";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OrUYO0V5fWqkIjHiYkhvjeFy0YX8CxeRqzrw3NfGK2A=";
+    hash = "sha256-4XS2Poa8lUQM0p3vks77e/HSlhaxbZOsORUyk4Iqvyw=";
   };
 
   build-system = [ setuptools ];
@@ -44,10 +45,13 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     onnx
     pytestCheckHook
+    pyparsing
     torchvision
   ];
 
-  pytestFlags = [
+  pytestFlags = lib.optionals (pythonAtLeast "3.14") [
+    # DeprecationWarning: `torch.jit.script` is not supported in Python 3.14+ and may break.
+    # Please switch to `torch.compile` or `torch.export`.
     "-Wignore::DeprecationWarning"
   ];
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/pfnet/pytorch-pfn-extras/compare/v0.8.4...v0.9.0
Changelog: https://github.com/pfnet/pytorch-pfn-extras/releases/tag/v0.9.0

cc @samuela

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test