### PR TITLE
onnx: enable ONNX_ML

### DIFF
--- a/pkgs/by-name/on/onnx/package.nix
+++ b/pkgs/by-name/on/onnx/package.nix
@@ -72,10 +72,9 @@ stdenv.mkDerivation (finalAttrs: {
     BUILD_SHARED_LIBS = if stdenv.hostPlatform.isDarwin then "0" else "1";
     ONNX_BUILD_PYTHON = "1";
     ONNX_BUILD_TESTS = if finalAttrs.doCheck then "1" else "0";
-    # ONNX_ML is enabled by default, so we must explicitly disable it.
+    # ONNX_ML is enabled by default.
     # See: https://github.com/onnx/onnx/blob/b751946c3d59a3c8358abcc0569b59e6ddb08cdd/CMakeLists.txt#L66-L73
-    # NOTE: If this is `true`, onnx-tensorrt fails to build due to missing protobuf files.
-    ONNX_ML = "0";
+    ONNX_ML = "1";
     ONNX_NAMESPACE = "onnx";
     ONNX_USE_PROTOBUF_SHARED_LIBS = "1";
 

--- a/pkgs/development/python-modules/skl2onnx/default.nix
+++ b/pkgs/development/python-modules/skl2onnx/default.nix
@@ -51,6 +51,8 @@ buildPythonPackage rec {
   # Core dump
   doCheck = false;
 
+  pythonImportsCheck = [ "skl2onnx" ];
+
   meta = {
     description = "Convert scikit-learn models to ONNX";
     license = with lib.licenses; [ asl20 ];


### PR DESCRIPTION
skl2onnx fails to import 

```
ImportError: cannot import name 'OnnxArrayFeatureExtractor' from 'skl2onnx.algebra.onnx_ops'
```

cc @b-rodrigues

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
