### PR TITLE
vimPlugins.codediff-nvim: cleanup build files

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/codediff-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/codediff-nvim/default.nix
@@ -30,6 +30,11 @@ vimUtils.buildVimPlugin rec {
     runHook postBuild
   '';
 
+  # Cleanup
+  preInstall = ''
+    rm -rf build
+  '';
+
   # The plugin detects Nix and tries to download libgomp at runtime.
   # Symlinking it into the plugin directory fixes error message.
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''


### PR DESCRIPTION
Fix build dependency leakage by removing the `build` dir.

Tested with nixvim on x86_64-linux.

<details>
<summary>Before:</summary>
<pre>
/nix/store/p7jg95rzvfalb95k3mskk0jqxc9d724n-libunistring-1.4.1
/nix/store/1ga782ml07vy0h503ac4cin0h8d7q6yh-libidn2-2.3.8
/nix/store/vpxblivamvic1p5r5zny934jvg33m50r-xgcc-15.2.0-libgcc
/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51
/nix/store/1fvcxyhg3i5fvw0j4l8wmyml10dnvm7q-gnumake-4.4.1
/nix/store/hbnbbbx1n96v1waiiaid9fmg4li4i1kp-gcc-15.2.0-libgcc
/nix/store/ab3753m6i7isgvzphlar0a8xb84gl96i-gcc-15.2.0-lib
/nix/store/1gz9xi4281s7ma043szyhgjf5vrninwm-tree-sitter-query-neovim-0.12.0
/nix/store/29mmnqpc1p3iv8wj0lpvicajy3jsbx87-zstd-1.5.7
/nix/store/2f4ypcw5idjbqa7lpmcvjn93jypxs9jz-unibilium-2.1.2
/nix/store/2kdz3m7ic8w226pcvkz1dlg169v91p6a-zlib-1.3.2
/nix/store/p2yk6q3bhcz1d0wlmk907ysj4l95ak7y-attr-2.5.2
/nix/store/4sabfgpxkbv6w3mvk0wil50vdi37m9r8-acl-2.3.2
/nix/store/dlr3cc27i1mjkqcm9jlp5bjmb0n57q01-gmp-with-cxx-6.3.0
/nix/store/74sind1d6vf2bfwd7yklg8chsvzqxmmq-coreutils-9.10
/nix/store/355mp4ns4042sb5p51rx3ys4mlliiwc5-diffutils-3.12
/nix/store/36j4ir5ik94nb836ar2qxw5wmny9r4rl-tree-sitter-vimdoc-neovim-0.12.0
/nix/store/4zmr3iw5s719y5zz7h2dnym67x2i6n23-ncurses-6.6
/nix/store/68kslg4wrhdxz24saw62fzyqi1kjgcfs-expand-response-params
/nix/store/7yiiywqw2db840zsgjvayq204jm0m9zw-tree-sitter-0.25.10
/nix/store/zrmg8bj9lxkl7bi19k19jydk73xxk3rs-luajit-2.1.1741730670
/nix/store/8gkkzwfff7cbnrc90azjz5f2f30d1as5-luajit2.1-lpeg-1.1.0-2
/nix/store/8zgy79sw0zjwfcfp78p883hkkdw0pdzs-libffi-3.5.2
/nix/store/a6kd5v5x97jnyyzbmiild0m1ikn5yfmg-mailcap-2.1.54
/nix/store/bga5xf95jaypy385hvxm4h3yxl3m1566-openssl-3.6.1
/nix/store/cr8mzl7cj4s5mriwrqnf9cvadw1iai5m-expat-2.7.4
/nix/store/gac1a2359c62vgvy13d2i3asi6v00vfa-mpdecimal-4.0.1
/nix/store/h15ranlgwagilr6ajd7ich6d896kf9zd-tzdata-2026a
/nix/store/q9wz2k88ksbv9d90hw27hsr08b8jdc2d-gdbm-1.26-lib
/nix/store/qq90p0xx02ydaqv2gv28mx4qx2vk98fq-readline-8.3p3
/nix/store/safgshpdshpq8v8ww406szddpfws3vml-util-linux-minimal-2.41.3-lib
/nix/store/v8sa6r6q037ihghxfbwzjj4p59v2x0pv-bash-5.3p9
/nix/store/vi21p90v3kj509rx00r101xcqa6za76b-bzip2-1.0.8
/nix/store/x8x0bp6q9x80lr3lljkj7xr4lx2495si-xz-5.8.2
/nix/store/yvh4iy0ab95dq2p6cfm1xfvs6j9m0gxy-sqlite-3.51.2
/nix/store/pzdalg368npikvpq4ncz2saxnz19v53k-python3-3.13.12
/nix/store/dvh0g5qwmg3h2nanwzvcj01ip845g4il-python3.13-pyelftools-0.32
/nix/store/8qrmarrmn133gbm8i9zp23cyl4m7009w-python3-3.13.12-env
/nix/store/9hm3jdm6kk4m4ppwjcxz4s1dsdvd6fin-glibc-2.42-51-bin
/nix/store/a7ia9wiq2vzi7x0qlq8cl8xpwygb99qv-tree-sitter-c-neovim-0.12.0
/nix/store/amvbx81w5i1i6wr240l64ni22pbgphhr-expand-response-params
/nix/store/b12i37990c31a8081pg3n51lmg9qcr2r-tree-sitter-markdown-neovim-0.12.0
/nix/store/b7503a4yi4b92flv0glrav130a2xpbcf-rhash-1.4.4
/nix/store/bl3ryfm7yzf4p5ahc0vvfv69n0jb3k7q-libuv-1.52.0
/nix/store/by6npbc13ly5a1zgsqghv7wv5bklyiny-bzip2-1.0.8-bin
/nix/store/c89zz4vh8v9dbs8169wk8ahwxvrdxgm5-findutils-4.10.0
/nix/store/nvllv8vnli7kqa9vsx5r9pzchrglnj7x-ed-1.22.5
/nix/store/ca84rbhb0bhwdcci7q51dad20nkbn9xc-patch-2.8
/nix/store/cfmacw3sqfbi8v7vb239vp0srsfx3dkk-libluv-1.51.0-2
/nix/store/cynwj0s5x0c84hyi879isn8pdpf1iihm-gmp-6.3.0
/nix/store/dzp08l4bx7w4nppj9q02cc62xh3sjlw5-utf8proc-2.11.3
/nix/store/gg169kyil5vhsg5aqcpagyhs8fwl0r5r-gawk-5.3.2
/nix/store/sfvyavxai6qvzmv9p9x6mp4wwdz4v41m-bash-interactive-5.3p9
/nix/store/flz28px2b6cbgw2qm1hv6qsxbdlx6jd3-vim-9.2.0106
/nix/store/vy4nwn1qa5cm5nzfvn4zxqkrqwpm2by5-keyutils-1.6.3-lib
/nix/store/g2g1jvyldykkq49hhgvvkndbj731c676-krb5-1.22.1-lib
/nix/store/jv35gdc4dfr0h8idwicn6h1h3r7pa13v-nghttp2-1.67.1-lib
/nix/store/lq3xr8iiayj65lpwazxpqfywm98n9lsh-libssh2-1.11.1
/nix/store/g1ichmziz7inq0csl5dfw06pnnfrwjbk-curl-8.18.0
/nix/store/g6mlwdvpg92rchq352ll7jbi0pz7h43r-xz-5.8.2-bin
/nix/store/pg99pd2gbwqs9y6z0q2hmx46m3hw9bns-linux-headers-6.18.7
/nix/store/h0ip0h6qp7kc2wm7mwjaglkxxbzmjri4-glibc-2.42-51-dev
/nix/store/jg0wzzd657xyhhss3mfqqa1iv5s9r75i-binutils-2.44-lib
/nix/store/rfp8lhk4dl9syfn64rwb3h3c73426p08-binutils-2.44
/nix/store/gknk1jw10h0pswl53ps5xj06cmwza52p-binutils-wrapper-2.44
/nix/store/ygdgqjzw03k8d05zq3pigzf67b62j7vs-pcre2-10.46
/nix/store/h6hdbgkfh59np7bi7h8qa76pq27ixz8r-gnugrep-3.12
/nix/store/scabrfc47i7h73kfp4yn7vkw3qkxv8gk-isl-0.20
/nix/store/sjlfsbd2lk4a1iva4vjjgvp4r1hga1xg-mpfr-4.2.2
/nix/store/zfv59aslcf318vjkjs8zw855cdjcjdvq-libmpc-1.3.1
/nix/store/lvwga6ivl1d4lnw0zis9ajs0rqx9gp4i-gcc-15.2.0
/nix/store/x7ikkplbrv5dlihy1bqq32gp6lilkval-binutils-wrapper-2.44
/nix/store/hb2bs5fg5wkm04x565737qd5nh2hy5nk-gcc-wrapper-15.2.0
/nix/store/m5w0q8xki8ci049xfg16j6k2jzy2ib4m-luajit2.1-luabitop-1.0.2-3
/nix/store/yw8nb69n9dgykjljznc28h41d0263glr-luajit2.1-mpack-1.0.13-0
/nix/store/igsd8nvkw7m8lglsllhpf1qg2ynf9n2a-luajit-2.1.1741730670-env
/nix/store/il10nbvr9fk8ipc3p0h3lfsv63hka2q6-tree-sitter-vim-neovim-0.12.0
/nix/store/jh88jxci5iqcb13z8hzsjj91hb34vvf4-tree-sitter-lua-neovim-0.12.0
/nix/store/jpsqy47rdl0j0dvyyzb4kw8gqajw8nx0-gnused-4.9
/nix/store/kjg8z2k0zvsczaij78803g7imlfm1vfb-file-5.45
/nix/store/kvmqv1jqv4792rsihf7yjc5kwk3d8z6x-gnutar-1.35
/nix/store/v5k7aj5qfr8spbak4xnjhb9g5g3dzsar-libxml2-2.15.1
/nix/store/kxalwqav6m5zpj5yvlfw4r4vg2qaf11s-libarchive-3.8.4-lib
/nix/store/lxd1b025gdcxpc5vwn2zjfidn2qv237k-auto-patchelf-0-unstable-2024-08-14
/nix/store/pnxiz967z73a45f4x7c1icldjaaqmlcp-gzip-1.14
/nix/store/pv8nz1bdpp0xna94khk28hkskhn4dg6g-tree-sitter-markdown_inline-neovim-0.12.0
/nix/store/q800b7nrqa8csf2gcds2i83w1icsda5w-cmake-4.1.2
/nix/store/sj3f6y3j8m1831l0gqm1bsk1f46jzkfd-patchelf-0.15.2
/nix/store/z75y4avz3j5hy5p1lsxmfaw6wzpsmpqv-neovim-unwrapped-0.12.0
/nix/store/ri7ai0axjwc5z8ilmv58389br3wdmi9b-vimplugin-codediff.nvim-2.43.9
</pre>
</details>

<details>
<summary>After:</summary>
<pre>
/nix/store/p7jg95rzvfalb95k3mskk0jqxc9d724n-libunistring-1.4.1
/nix/store/1ga782ml07vy0h503ac4cin0h8d7q6yh-libidn2-2.3.8
/nix/store/vpxblivamvic1p5r5zny934jvg33m50r-xgcc-15.2.0-libgcc
/nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51
/nix/store/p2yk6q3bhcz1d0wlmk907ysj4l95ak7y-attr-2.5.2
/nix/store/4sabfgpxkbv6w3mvk0wil50vdi37m9r8-acl-2.3.2
/nix/store/hbnbbbx1n96v1waiiaid9fmg4li4i1kp-gcc-15.2.0-libgcc
/nix/store/ab3753m6i7isgvzphlar0a8xb84gl96i-gcc-15.2.0-lib
/nix/store/dlr3cc27i1mjkqcm9jlp5bjmb0n57q01-gmp-with-cxx-6.3.0
/nix/store/74sind1d6vf2bfwd7yklg8chsvzqxmmq-coreutils-9.10
/nix/store/v8sa6r6q037ihghxfbwzjj4p59v2x0pv-bash-5.3p9
/nix/store/9iv3szv4gmpdfiy9qdx5h4sl04rl2z99-vimplugin-codediff.nvim-2.43.9
</pre>
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
