### PR TITLE
img4lib: add darwin support

### DIFF
--- a/pkgs/by-name/im/img4lib/package.nix
+++ b/pkgs/by-name/im/img4lib/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   openssl,
   lzfse,
+  gcc,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "img4lib";
@@ -17,9 +18,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-xCWovBJ9cxT17u1uo+aUQnxDoYFQXYy9Qer0mD45aOU=";
   };
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
+  nativeBuildInputs =
+    [ pkg-config ]
+    ++ lib.optional stdenv.hostPlatform.isDarwin gcc;
 
   buildInputs = [
     lzfse
@@ -42,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     # No licensing information available
     # https://github.com/xerub/img4lib/issues/14
     license = lib.licenses.unfree;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ onny ];
     mainProgram = "img4";
   };

--- a/pkgs/by-name/im/img4lib/package.nix
+++ b/pkgs/by-name/im/img4lib/package.nix
@@ -18,9 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-xCWovBJ9cxT17u1uo+aUQnxDoYFQXYy9Qer0mD45aOU=";
   };
 
-  nativeBuildInputs =
-    [ pkg-config ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin gcc;
+  nativeBuildInputs = [ pkg-config ] ++ lib.optional stdenv.hostPlatform.isDarwin gcc;
 
   buildInputs = [
     lzfse


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/435847
- Added and tested `{aarch64,x86_64}-darwin` support

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test