### PR TITLE
Prometheus jellyfin exporter 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30200,6 +30200,12 @@
     githubId = 250877;
     name = "Elmar Athmer";
   };
+  zaz = {
+    name = "zaz";
+    email = "nixpkgs@rtljvp.fr";
+    github = "leafblowersama";
+    githubId = 12385515;
+  };
   zazedd = {
     name = "Leonardo Santos";
     email = "leomendesantos@gmail.com";

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -76,6 +76,7 @@ let
         "imap-mailstat"
         "influxdb"
         "ipmi"
+        "jellyfin"
         "jitsi"
         "json"
         "junos-czerwonk"

--- a/nixos/modules/services/monitoring/prometheus/exporters/jellyfin.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/jellyfin.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  pkgs,
+  options,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.jellyfin;
+in
+{
+  port = 9708;
+  extraOpts = {
+    url = lib.mkOption {
+      type = lib.types.str;
+      default = "http://127.0.0.1";
+      description = ''
+        The full URL to Jellyfin, including port and urlbase
+      '';
+      example = "https://127.0.0.1:8906/jellyfin";
+    };
+
+    collector.activity.enable = lib.mkEnableOption "activity collector";
+
+    package = lib.mkPackageOption pkgs "prometheus-jellyfin-exporter" { };
+
+    apiKeyFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        File containing the Jellyfin API key
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      LoadCredential = lib.optionalString (cfg.apiKeyFile != null) "apikey:${cfg.apiKeyFile}";
+      ExecStart = "${pkgs.writeShellScript "prometheus-jellyfin-exporter-wrapper" ''
+        export JELLYFIN_TOKEN="$(cat $1)"
+        export JELLYFIN_ADDRESS="${cfg.url}"
+        ${pkgs.prometheus-jellyfin-exporter}/bin/jellyfin_exporter ${
+          if cfg.collector.activity.enable then "--collector.activity" else ""
+        }
+      ''} \${CREDENTIALS_DIRECTORY}/apikey";
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -553,6 +553,24 @@ let
         '';
       };
 
+    jellyfin =
+      { pkgs, ... }:
+      {
+        exporterConfig = {
+          enable = true;
+          apiKeyFile = pkgs.writeText "apikey" "FAKE_KEY";
+        };
+        # Jellyfin has no EASY way of spawning the service with an existing API key, so let's
+        # just check the exporter replies with something
+        exporterTest = ''
+          wait_for_unit("prometheus-jellyfin-exporter.service")
+          wait_for_open_port(9594)
+          succeed(
+            "curl -sSf http://localhost:9594/metrics | grep 'jellyfin'"
+          )
+        '';
+      };
+
     jitsi =
       { ... }:
       {

--- a/pkgs/by-name/pr/prometheus-jellyfin-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-jellyfin-exporter/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  runCommand,
+  nixosTests,
+}:
+let
+  baseAttrs = rec {
+    pname = "prometheus-jellyfin-exporter";
+    version = "1.4.0";
+
+    src = fetchFromGitHub {
+      owner = "rebelcore";
+      repo = "jellyfin_exporter";
+      rev = "v${version}";
+      sha256 = "0pghbfqgapwx2zxf1pszryn3qwiwyqp744q0dskgix4r58l4d6f2";
+    };
+
+    vendorHash = "sha256-e08u10e/wNapNZSsD/fGVN9ybMHe3sW0yDIOqI8ZcYs=";
+    meta = {
+      description = "Prometheus exporter for Jellyfin";
+      homepage = "https://github.com/rebelcore/jellyfin_exporter";
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [ zaz ];
+      mainProgram = "jellyfin_exporter";
+    };
+  };
+  testpkg = buildGoModule (baseAttrs // { buildTestBinaries = true; });
+in
+buildGoModule (
+  baseAttrs
+  // rec {
+    # as of v1.4.0, upstream go tests don't work in the nix build sandbox, as they are actually
+    # integration tests that spawn the binary and use the network.
+    # instead of running them directly, we build them separately and run them here
+    # TODO revisit on next release if i manage to contribute more compliant upstream tests
+    doCheck = false;
+    passthru.tests = {
+      inherit (nixosTests.prometheus-exporters) jellyfin;
+      gotests =
+        runCommand "${baseAttrs.pname}-test"
+          {
+            nativeBuildInputs = [
+              testpkg
+            ];
+          }
+          ''
+            jellyfin_exporter.test > $out
+            [ "$(cat $out)" = "PASS" ] || { echo "tests failed to pass" && cat $out && exit 1; };
+          '';
+    };
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
add `prometheus-jellyfin-exporter` based on https://github.com/rebelcore/jellyfin_exporter
add appropriate bits for using it as a nixos module as well including nixos tests

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
