### PR TITLE
python3Packages.plux: disable test incompatible with pytest 9

### DIFF
--- a/pkgs/development/python-modules/plux/default.nix
+++ b/pkgs/development/python-modules/plux/default.nix
@@ -34,6 +34,13 @@ buildPythonPackage rec {
     export HOME=$TMPDIR
   '';
 
+  disabledTests = [
+    # Fails with pytest >= 9 which uses PEP 639 License-Expression metadata
+    # instead of legacy License field. Upstream pins pytest==8.4.1 in CI.
+    # https://github.com/localstack/plux/pull/46
+    "test_resolve_distribution_information"
+  ];
+
   pythonImportsCheck = [ "plugin.core" ];
 
   meta = {


### PR DESCRIPTION
`test_resolve_distribution_information` fails with pytest >= 9.0.2 because
pytest now ships PEP 639 `License-Expression` metadata instead of the legacy
`License` field. Upstream pins `pytest==8.4.1` in CI so they never hit this.

Upstream fix: https://github.com/localstack/plux/pull/46

This unblocks `localstack` and `localstack-ext`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
