### PR TITLE
deck-app: init at 1.4.5

### DIFF
--- a/pkgs/by-name/de/deck-app/package.nix
+++ b/pkgs/by-name/de/deck-app/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "deck-app";
+  version = "1.4.3";
+
+  src = fetchurl {
+    url = "https://github.com/yuzeguitarist/Deck/releases/download/v${finalAttrs.version}/Deck.dmg";
+    hash = "sha256-qfO4nIq6cJNNgDc0h9GCC7HiT/XqJ0jTf+ttN0NDhng=";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  dontBuild = true;
+  dontFixup = true;
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Deck is a modern, native, privacy-first clipboard manager for macOS.";
+    homepage = "https://deckclip.app/";
+    changelog = "https://github.com/yuzeguitarist/Deck/releases/tag/v${finalAttrs.version}";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = lib.platforms.darwin;
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ myzel394 ];
+    # Deck provides a CLI tool that can be enabled in the app settings.
+    mainProgram = "deckclip";
+  };
+})

--- a/pkgs/by-name/de/deck-app/package.nix
+++ b/pkgs/by-name/de/deck-app/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "deck-app";
+  version = "1.4.5";
+
+  src = fetchurl {
+    url = "https://github.com/yuzeguitarist/Deck/releases/download/v${finalAttrs.version}/Deck.dmg";
+    hash = "sha256-U5iMoQZGycwiiehxKUB3iohvzAh42gkC1sk3AJ62Ujs=";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  dontBuild = true;
+  dontFixup = true;
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Deck is a modern, native, privacy-first clipboard manager for macOS.";
+    homepage = "https://deckclip.app/";
+    changelog = "https://github.com/yuzeguitarist/Deck/releases/tag/v${finalAttrs.version}";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = lib.platforms.darwin;
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ myzel394 ];
+    # Deck provides a CLI tool that can be enabled in the app settings.
+    mainProgram = "deckclip";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/yuzeguitarist/Deck - Please note, the app is _not open source_, the README says:

> Source code is public for reference only. Please use the official compiled app from Releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
